### PR TITLE
deleting State::add_proof_steps

### DIFF
--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -282,7 +282,7 @@ auto Element2DConstantArray::install(Propagators & propagators, State & initial_
             if (*idxsel != state.allocate_integer_variable_with_state(0_i, Integer(vals->size() * vals->begin()->size())))
                 throw UnexpectedException{"something went horribly wrong with variable IDs"};
 
-            state.add_proof_steps(JustifyExplicitly{[&](Proof & proof, vector<ProofLine> & to_delete) {
+            state.infer_true(JustifyExplicitly{[&](Proof & proof, vector<ProofLine> & to_delete) {
                 state.for_each_value_immutable(idx1, [&](Integer i1) {
                     state.for_each_value_immutable(idx2, [&](Integer i2) {
                         Integer idx = i1 * Integer(vals->size()) + i2;

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -436,7 +436,7 @@ auto NotEquals::install(Propagators & propagators, State & initial_state) && -> 
 
         if (convert_to_values_ne && propagators.want_definitions()) {
             propagators.install([v1 = _v1, v2 = _v2](State & state) -> pair<Inference, PropagatorState> {
-                state.add_proof_steps(JustifyExplicitly{[&](Proof & proof, vector<ProofLine> &) -> void {
+                state.infer_true(JustifyExplicitly{[&](Proof & proof, vector<ProofLine> &) -> void {
                     proof.emit_proof_comment("converting not equals to value encoding");
                     state.for_each_value(v1, [&](Integer val1) {
                         if (state.in_domain(v2, val1)) {

--- a/gcs/constraints/linear_equality.cc
+++ b/gcs/constraints/linear_equality.cc
@@ -156,7 +156,7 @@ namespace
         };
 
         if (state.maybe_proof()) {
-            state.add_proof_steps(JustifyExplicitly{[&](Proof & proof, vector<ProofLine> & to_delete) {
+            state.infer_true(JustifyExplicitly{[&](Proof & proof, vector<ProofLine> & to_delete) {
                 proof.emit_proof_comment("building GAC table for linear equality");
                 search(&proof, &to_delete);
             }});

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -1143,15 +1143,6 @@ auto State::log_inferences_to(Proof & p) -> void
     _imp->maybe_proof = &p;
 }
 
-auto State::add_proof_steps(JustifyExplicitly why) -> void
-{
-    if (_imp->maybe_proof) {
-        vector<ProofLine> to_delete;
-        _imp->maybe_proof->add_proof_steps(why, to_delete);
-        _imp->maybe_proof->delete_proof_lines(to_delete);
-    }
-}
-
 auto State::test_literal(const Literal & lit) const -> LiteralIs
 {
     return overloaded{

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -249,13 +249,6 @@ namespace gcs::innards
         ///@{
 
         /**
-         * Output these proof steps, as if we were carrying out an explicit
-         * justification. Used by some Constraint implementations that do some
-         * non-inference reasoning upon startup.
-         */
-        auto add_proof_steps(JustifyExplicitly why) -> void;
-
-        /**
          * The Proof, if we are proof logging, or nullptr if we are not.
          */
         [[nodiscard]] auto maybe_proof() const -> Proof *;


### PR DESCRIPTION
Getting rid of State::add_proof_steps. And replacing it by State::infer_true