### PR TITLE
Use different seed each time and run less tests.

### DIFF
--- a/examples/smart_table_random/smart_table_random.cc
+++ b/examples/smart_table_random/smart_table_random.cc
@@ -23,6 +23,7 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
 using std::shuffle;
 using std::ssize;
 using std::string;
@@ -124,9 +125,9 @@ auto test_smart_table(const int & n, mt19937 & rng)
         sort(split_points.begin(), split_points.end());
 
         for (int i = 0; i < ssize(split_points) - 1; i++) {
-            string_rep << "Tree " << i << "(";
+            // string_rep << "Tree " << i << "(";
             auto num_nodes_in_tree = split_points[i + 1] - split_points[i];
-            string_rep << num_nodes_in_tree << " nodes): ";
+            // string_rep << num_nodes_in_tree << " nodes): ";
             if (num_nodes_in_tree == 1) {
                 // Create random unary Smart Entry
                 auto constraint_type = static_cast<innards::SmartEntryConstraint>(rand0_to_7(rng));
@@ -137,13 +138,13 @@ auto test_smart_table(const int & n, mt19937 & rng)
                     }
                     shuffle(random_set.begin(), random_set.end(), rng);
                     int how_many = rand1_to_n(rng);
-                    string_rep << "x[" << index_of(copy_x[split_points[i]], x) << "] ";
-                    string_rep << constraint_type_str(constraint_type);
-                    string_rep << " {";
+                    // string_rep << "x[" << index_of(copy_x[split_points[i]], x) << "] ";
+                    // string_rep << constraint_type_str(constraint_type);
+                    // string_rep << " {";
                     for (int j = 0; j < how_many - 1; j++) {
-                        string_rep << random_set[j].raw_value << ", ";
+                        // string_rep << random_set[j].raw_value << ", ";
                     }
-                    string_rep << random_set[how_many - 1].raw_value << "};  ";
+                    // string_rep << random_set[how_many - 1].raw_value << "};  ";
                     tuple.emplace_back(innards::UnarySetEntry{
                         copy_x[split_points[i]],
                         vector<Integer>(random_set.begin(), random_set.begin() + how_many),
@@ -151,9 +152,9 @@ auto test_smart_table(const int & n, mt19937 & rng)
                 }
                 else {
                     int random_val = rand1_to_n(rng) - 1;
-                    string_rep << "x[" << index_of(copy_x[split_points[i]], x) << "] ";
-                    string_rep << constraint_type_str(constraint_type);
-                    string_rep << " " << random_val << ";  ";
+                    // string_rep << "x[" << index_of(copy_x[split_points[i]], x) << "] ";
+                    // string_rep << constraint_type_str(constraint_type);
+                    // string_rep << " " << random_val << ";  ";
                     tuple.emplace_back(innards::UnaryValueEntry{
                         copy_x[split_points[i]],
                         Integer{random_val},
@@ -162,9 +163,9 @@ auto test_smart_table(const int & n, mt19937 & rng)
             }
             else if (num_nodes_in_tree == 2) {
                 auto constraint_type = static_cast<innards::SmartEntryConstraint>(rand0_to_5(rng));
-                string_rep << "x[" << index_of(copy_x[split_points[i]], x) << "] ";
-                string_rep << constraint_type_str(constraint_type);
-                string_rep << " x[" << index_of(copy_x[split_points[i] + 1], x) << "];  ";
+                // string_rep << "x[" << index_of(copy_x[split_points[i]], x) << "] ";
+                // string_rep << constraint_type_str(constraint_type);
+                // string_rep << " x[" << index_of(copy_x[split_points[i] + 1], x) << "];  ";
                 tuple.emplace_back(innards::BinaryEntry{
                     copy_x[split_points[i]],
                     copy_x[split_points[i] + 1],
@@ -175,9 +176,9 @@ auto test_smart_table(const int & n, mt19937 & rng)
                 for (const auto & edge : tree_edges) {
                     // Create binary Smart Entry with specified variables
                     auto constraint_type = static_cast<innards::SmartEntryConstraint>(rand0_to_5(rng));
-                    string_rep << "x[" << index_of(copy_x[edge.first], x) << "] ";
-                    string_rep << constraint_type_str(constraint_type);
-                    string_rep << " x[" << index_of(copy_x[edge.second], x) << "];  ";
+                    // string_rep << "x[" << index_of(copy_x[edge.first], x) << "] ";
+                    // string_rep << constraint_type_str(constraint_type);
+                    // string_rep << " x[" << index_of(copy_x[edge.second], x) << "];  ";
                     tuple.emplace_back(innards::BinaryEntry{
                         copy_x[edge.first],
                         copy_x[edge.second],
@@ -197,13 +198,13 @@ auto test_smart_table(const int & n, mt19937 & rng)
                 }
                 shuffle(random_set.begin(), random_set.end(), rng);
                 int how_many = rand1_to_n(rng);
-                string_rep << "x[" << index_of(copy_x[var_idx], x) << "] ";
-                string_rep << constraint_type_str(constraint_type);
-                string_rep << " {";
+                // string_rep << "x[" << index_of(copy_x[var_idx], x) << "] ";
+                // string_rep << constraint_type_str(constraint_type);
+                // string_rep << " {";
                 for (int j = 0; j < how_many - 1; j++) {
-                    string_rep << random_set[j].raw_value << ", ";
+                    // string_rep << random_set[j].raw_value << ", ";
                 }
-                string_rep << random_set[how_many - 1].raw_value << "};  ";
+                // string_rep << random_set[how_many - 1].raw_value << "};  ";
                 tuple.emplace_back(innards::UnarySetEntry{
                     copy_x[var_idx],
                     vector<Integer>(random_set.begin(), random_set.begin() + how_many),
@@ -211,9 +212,9 @@ auto test_smart_table(const int & n, mt19937 & rng)
             }
             else {
                 int random_val = rand1_to_n(rng) - 1;
-                string_rep << "x[" << index_of(copy_x[var_idx], x) << "] ";
-                string_rep << constraint_type_str(constraint_type);
-                string_rep << " " << random_val << ";  ";
+                // string_rep << "x[" << index_of(copy_x[var_idx], x) << "] ";
+                // string_rep << constraint_type_str(constraint_type);
+                // string_rep << " " << random_val << ";  ";
                 tuple.emplace_back(innards::UnaryValueEntry{
                     copy_x[var_idx],
                     Integer{random_val},
@@ -222,7 +223,7 @@ auto test_smart_table(const int & n, mt19937 & rng)
         }
 
         tuples.emplace_back(tuple);
-        string_rep << "\n";
+        // string_rep << "\n";
     }
 
     p.post(SmartTable{x, tuples});
@@ -240,22 +241,23 @@ auto test_smart_table(const int & n, mt19937 & rng)
             }},
         ProofOptions{"random_table.opb", "random_table.veripb"});
 
-    cout << "Num solutions: " << stats.solutions << endl;
+    //    cout << "Num solutions: " << stats.solutions << endl;
     if (0 != system("veripb random_table.opb random_table.veripb")) {
-
         return false;
     }
-    cout << string_rep.str() << endl;
+    // cout << string_rep.str() << endl;
     return true;
 }
 auto main(int, char *[]) -> int
 {
+    random_device rand_dev;
+    auto seed = rand_dev();
+    std::mt19937 rng(seed);
+    cout << "Seed for random smart tables: " << seed << endl;
+    //    mt19937 rng(0); // Switch to this to have it the same every time.
 
-    // random_device rand_dev;
-    // std::mt19937 rng(rand_dev());
-    mt19937 rng(0); // Would rather have it the same every time, for now
     for (int n = 3; n < 6; n++) {
-        for (int r = 0; r < 240 / n; r++) {
+        for (int r = 0; r < 60 / n; r++) {
             if (! test_smart_table(n, rng)) {
                 return EXIT_FAILURE;
             }


### PR DESCRIPTION
Should be faster now. Can decrease `r` variables in: https://github.com/ciaranm/glasgow-constraint-solver/blob/7091a87b2bcff49ebb09cd52f361f8851eba19a9/examples/smart_table_random/smart_table_random.cc#L260

and

https://github.com/ciaranm/glasgow-constraint-solver/blob/7091a87b2bcff49ebb09cd52f361f8851eba19a9/examples/random_regular/random_regular.cc#L113

to get them even faster if you like. Currently I think it's down to around 20s for smart table / 70s for regular although obviously it varies based on the seed. 