### PR TITLE
More constraint names

### DIFF
--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -142,7 +142,7 @@ auto ElementConstantArray::install(Propagators & propagators, State & initial_st
     if (optional_model) {
         for (const auto & [idx, v] : enumerate(*_vals))
             if (initial_state.in_domain(_idx, Integer(idx)))
-                optional_model->add_constraint({_idx != Integer(idx), _var == v});
+                optional_model->add_constraint("ElementConstantArray", "equality", {_idx != Integer(idx), _var == v});
     }
 
     Triggers triggers{
@@ -235,7 +235,7 @@ auto Element2DConstantArray::install(Propagators & propagators, State & initial_
             if (initial_state.in_domain(_idx1, Integer(idx1)))
                 for (const auto & [idx2, v] : enumerate(vv))
                     if (initial_state.in_domain(_idx2, Integer(idx2)))
-                        optional_model->add_constraint({_idx1 != Integer(idx1), _idx2 != Integer(idx2), _var == v});
+                        optional_model->add_constraint("Element2DConstantArray", "equality", {_idx1 != Integer(idx1), _idx2 != Integer(idx2), _var == v});
     }
 
     Triggers triggers{

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -138,7 +138,7 @@ auto Equals::install(Propagators & propagators, State & initial_state, ProofMode
     }
 
     if (optional_model)
-        optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * _v1 + -1_i * _v2 == 0_i, nullopt);
+        optional_model->add_constraint("Equals", "equality", WeightedPseudoBooleanSum{} + 1_i * _v1 + -1_i * _v2 == 0_i, nullopt);
 }
 
 EqualsIf::EqualsIf(const IntegerVariableID v1, const IntegerVariableID v2, Literal cond) :
@@ -242,7 +242,7 @@ auto EqualsIf::install(Propagators & propagators, State & initial_state, ProofMo
                 _v1, _v2);
 
             if (optional_model) {
-                optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * _v1 + -1_i * _v2 == 0_i,
+                optional_model->add_constraint("EqualsIf", "conditional equality", WeightedPseudoBooleanSum{} + 1_i * _v1 + -1_i * _v2 == 0_i,
                     HalfReifyOnConjunctionOf{{cond}});
             }
         }}

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -68,11 +68,11 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
         for (const auto & [i, x_i] : enumerate(_x))
             for (const auto & [j, y_j] : enumerate(_y)) {
                 // x[i] = j -> y[j] = i
-                optional_model->add_constraint(WeightedPseudoBooleanSum{} +
+                optional_model->add_constraint("Inverse", "x_i = j -> y[j] = i", WeightedPseudoBooleanSum{} +
                         1_i * (x_i != Integer(j) + _y_start) + 1_i * (y_j == Integer(i) + _x_start) >=
                     1_i);
                 // y[j] = i -> x[i] = j
-                optional_model->add_constraint(WeightedPseudoBooleanSum{} +
+                optional_model->add_constraint("Inverse", "y_j = i -> x[i] = j", WeightedPseudoBooleanSum{} +
                         1_i * (y_j != Integer(i) + _x_start) + 1_i * (x_i == Integer(j) + _y_start) >=
                     1_i);
             }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -164,25 +164,25 @@ auto LinearEqualityIff::install(Propagators & propagators, State & state, ProofM
         overloaded{
             [&](const TrueLiteral &) {
                 // condition is definitely true, it's just an inequality
-                proof_line = optional_model->add_constraint(terms == _value, nullopt).first.value();
+                proof_line = optional_model->add_constraint("LinearEqualityIff", "unconditional sum", terms == _value, nullopt).first.value();
             },
             [&](const FalseLiteral &) {
                 // condition is definitely false, the flag implies either greater or less
                 auto neflag = optional_model->create_proof_flag("linne");
-                optional_model->add_constraint(terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
-                optional_model->add_constraint(terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
+                optional_model->add_constraint("LinearEqualityIff", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
+                optional_model->add_constraint("LinearEqualityIff", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
             },
             [&](const IntegerVariableCondition & cond) {
                 // condition unknown, the condition implies it is neither greater nor less
-                proof_line = optional_model->add_constraint(terms == _value, HalfReifyOnConjunctionOf{{cond}}).first.value();
+                proof_line = optional_model->add_constraint("LinearEqualityIff", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond}}).first.value();
 
                 gtflag = optional_model->create_proof_flag("lineqgt");
-                optional_model->add_constraint(terms >= _value + 1_i, HalfReifyOnConjunctionOf{{*gtflag}});
+                optional_model->add_constraint("LinearEqualityIff", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{*gtflag}});
                 ltflag = optional_model->create_proof_flag("lineqlt");
-                optional_model->add_constraint(terms <= _value - 1_i, HalfReifyOnConjunctionOf{{*ltflag}});
+                optional_model->add_constraint("LinearEqualityIff", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{*ltflag}});
 
                 // lt + eq + gt = 1
-                optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * *ltflag + 1_i * *gtflag + 1_i * cond == 1_i);
+                optional_model->add_constraint("LinearEqualityIff", "one of less than, equals, greater than", WeightedPseudoBooleanSum{} + 1_i * *ltflag + 1_i * *gtflag + 1_i * cond == 1_i);
             }}
             .visit(_cond);
     }

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -118,14 +118,14 @@ auto LinearInequalityIff::install(Propagators & propagators, State & state, Proo
             terms += c * v;
         overloaded{
             [&](const TrueLiteral &) {
-                proof_line = optional_model->add_constraint(terms <= _value, nullopt);
+                proof_line = optional_model->add_constraint("LinearInequalityIff", "unconditional less than", terms <= _value, nullopt);
             },
             [&](const FalseLiteral &) {
-                proof_line = optional_model->add_constraint(terms >= _value + 1_i, nullopt);
+                proof_line = optional_model->add_constraint("LinearInequalityIff", "unconditional greater than", terms >= _value + 1_i, nullopt);
             },
             [&](const IntegerVariableCondition & cond) {
-                proof_line = optional_model->add_constraint(terms <= _value, HalfReifyOnConjunctionOf{cond});
-                optional_model->add_constraint(terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond});
+                proof_line = optional_model->add_constraint("LinearInequalityIff", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond});
+                optional_model->add_constraint("LinearInequalityIff", "greater than option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond});
             }}
             .visit(_cond);
     }

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -47,7 +47,7 @@ namespace
 
             if (optional_model) {
                 for (auto & l : _lits)
-                    optional_model->add_constraint(Literals{l});
+                    optional_model->add_constraint("Logical", "cnf", Literals{l});
             }
         }
         else {
@@ -83,7 +83,7 @@ namespace
                 });
 
                 if (optional_model) {
-                    optional_model->add_constraint(Literals{! _full_reif});
+                    optional_model->add_constraint("Logical", "saw reif false", Literals{! _full_reif});
                 }
             }
             else {
@@ -174,14 +174,14 @@ namespace
                         WeightedPseudoBooleanSum forward;
                         for (auto & l : _lits)
                             forward += 1_i * PseudoBooleanTerm{l};
-                        optional_model->add_constraint(forward >= Integer(_lits.size()), HalfReifyOnConjunctionOf{_full_reif});
+                        optional_model->add_constraint("Logical", "if condition", forward >= Integer(_lits.size()), HalfReifyOnConjunctionOf{_full_reif});
                     }
 
                     Literals reverse;
                     for (auto & l : _lits)
                         reverse.push_back(! l);
                     reverse.push_back(_full_reif);
-                    optional_model->add_constraint(move(reverse));
+                    optional_model->add_constraint("Logical", "if not condition", move(reverse));
                 }
             }
         }

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -119,7 +119,7 @@ auto ArrayMinMax::install(Propagators & propagators, State & initial_state, Proo
     if (optional_model) {
         // result <= each var
         for (const auto & v : _vars) {
-            optional_model->add_constraint(WeightedPseudoBooleanSum{} + (_min ? -1_i : 1_i) * v + (_min ? 1_i : -1_i) * _result <= 0_i, nullopt);
+            optional_model->add_constraint("ArrayMinMax", "result compared to value", WeightedPseudoBooleanSum{} + (_min ? -1_i : 1_i) * v + (_min ? 1_i : -1_i) * _result <= 0_i, nullopt);
         }
 
         // result == i -> i in vars
@@ -128,7 +128,7 @@ auto ArrayMinMax::install(Propagators & propagators, State & initial_state, Proo
             for (auto & v : _vars)
                 if (initial_state.in_domain(v, val))
                     lits.emplace_back(v == val);
-            optional_model->add_constraint(move(lits));
+            optional_model->add_constraint("ArrayMinMax", "result is in vars", move(lits));
         }
     }
 }

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -79,13 +79,13 @@ auto NValue::install(Propagators & propagators, State & initial_state, ProofMode
             for (auto & var : vars)
                 forward += 1_i * (var == v);
             forward += 1_i * ! flag;
-            optional_model->add_constraint(forward >= 1_i);
+            optional_model->add_constraint("NValue", "forward sum", forward >= 1_i);
 
             WeightedPseudoBooleanSum reverse;
             for (auto & var : vars)
                 reverse += 1_i * (var != v);
             reverse += Integer(vars.size()) * flag;
-            optional_model->add_constraint(reverse >= Integer(vars.size()));
+            optional_model->add_constraint("NValue", "reverse sum", reverse >= Integer(vars.size()));
 
             flags.push_back(flag);
         }
@@ -97,7 +97,7 @@ auto NValue::install(Propagators & propagators, State & initial_state, ProofMode
         }
         forward += -1_i * _n_values;
         reverse += 1_i * _n_values;
-        optional_model->add_constraint(forward >= 0_i);
-        optional_model->add_constraint(reverse >= 0_i);
+        optional_model->add_constraint("NValue", "forward total", forward >= 0_i);
+        optional_model->add_constraint("NValue", "reverse total", reverse >= 0_i);
     }
 }

--- a/gcs/constraints/not_equals.cc
+++ b/gcs/constraints/not_equals.cc
@@ -111,9 +111,9 @@ auto NotEquals::install(Propagators & propagators, State & initial_state, ProofM
 
     if (optional_model) {
         auto selector = optional_model->create_proof_flag("notequals");
-        optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * _v1 + -1_i * _v2 <= -1_i,
+        optional_model->add_constraint("NotEquals", "less than option", WeightedPseudoBooleanSum{} + 1_i * _v1 + -1_i * _v2 <= -1_i,
             HalfReifyOnConjunctionOf{{selector}});
-        optional_model->add_constraint(WeightedPseudoBooleanSum{} + -1_i * _v1 + 1_i * _v2 <= -1_i,
+        optional_model->add_constraint("NotEquals", "greater than option", WeightedPseudoBooleanSum{} + -1_i * _v1 + 1_i * _v2 <= -1_i,
             HalfReifyOnConjunctionOf{{! selector}});
     }
 }

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -53,15 +53,15 @@ auto ParityOdd::install(Propagators & propagators, State &, ProofModel * const o
         for (const auto & l : _lits) {
             auto new_acc = optional_model->create_proof_flag("xor");
 
-            optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
-            optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
-            optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
-            optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
+            optional_model->add_constraint("ParityOdd", "xor", WeightedPseudoBooleanSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
+            optional_model->add_constraint("ParityOdd", "xor", WeightedPseudoBooleanSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
+            optional_model->add_constraint("ParityOdd", "xor", WeightedPseudoBooleanSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
+            optional_model->add_constraint("ParityOdd", "xor", WeightedPseudoBooleanSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
 
             acc = new_acc;
             not_acc = ! new_acc;
         }
-        optional_model->add_constraint(WeightedPseudoBooleanSum{} + 1_i * acc >= 1_i);
+        optional_model->add_constraint("ParityOdd", "result", WeightedPseudoBooleanSum{} + 1_i * acc >= 1_i);
     }
 
     Triggers triggers;

--- a/gcs/constraints/table.cc
+++ b/gcs/constraints/table.cc
@@ -136,7 +136,7 @@ auto NegativeTable::install(Propagators & propagators, State &, ProofModel * con
                 Literals lits;
                 for (const auto & [idx, v] : enumerate(_vars))
                     add_literal(lits, v, t[idx]);
-                optional_model->add_constraint(move(lits));
+                optional_model->add_constraint("NegativeTable", "forbidden", move(lits));
             }
         }
     },


### PR DESCRIPTION
Not sure what I think of this and whether it might benefit from more indirection. But:

```
{
"1": {"type":"variable_lower_bounds","variables":["i0_s_b0","i0_s_b1","i0_s_b2","i0_s_b3"]},
"2": {"type":"variable_upper_bounds","variables":["i0_s_b0","i0_s_b1","i0_s_b2","i0_s_b3"]},
"3": {"type":"variable_lower_bounds","variables":["i1_e_b0","i1_e_b1","i1_e_b2","i1_e_b3"]},
// ...
"17": {"name":"AllDifferent","role":"not equals because lower","type":"constraint_definition"},
"18": {"name":"AllDifferent","role":"not equals because higher","type":"constraint_definition"},
"19": {"name":"AllDifferent","role":"not equals because lower","type":"constraint_definition"},
"20": {"name":"AllDifferent","role":"not equals because higher","type":"constraint_definition"},
// ...
}
```

For example, is it worth trying to group together constraints from the same "instantiation" of, e.g. AllDifferent? We'd have to have a way of giving constraints unique IDs then, which is doable, and possibly have yet another mapping from those IDs to constraint names.