### PR TITLE
Disable downloading range-v3  gh-pages submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ FetchContent_Declare(
         range-v3
         GIT_REPOSITORY https://github.com/ericniebler/range-v3.git
         GIT_TAG a81477931a8aa2ad025c6bda0609f38e09e4d7ec # v0.12.0
+        GIT_SUBMODULES "" # Disable submodule installation
 )
 FetchContent_MakeAvailable(range-v3)
 


### PR DESCRIPTION
Causes 'Filename too long' on Windows, see #66.

Test pull request to see if integration tests might fail.