### PR TITLE
Potential issue spotted

### DIFF
--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -177,8 +177,8 @@ namespace
     }
 }
 
-auto Propagators::define_and_install_table(State & state, ProofModel * const optional_model, const vector<IntegerVariableID> & vars,
-    ExtensionalTuples permitted, const string & x) -> void
+auto Propagators::define_and_install_table(State & state, ProofModel * const optional_model, const vector<IntegerVariableID> && vars,
+    ExtensionalTuples && permitted, const string & x) -> void
 {
     visit([&](auto && permitted) {
         if (depointinate(permitted).empty()) {

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -184,8 +184,8 @@ namespace gcs::innards
          *
          * \sa gcs::innards::propagate_extensional()
          */
-        auto define_and_install_table(State &, innards::ProofModel * const, const std::vector<IntegerVariableID> &,
-            ExtensionalTuples, const std::string & name) -> void;
+        auto define_and_install_table(State &, innards::ProofModel * const, const std::vector<IntegerVariableID> &&,
+            ExtensionalTuples &&, const std::string & name) -> void;
 
         ///@}
 


### PR DESCRIPTION
`Propagators::define_and_install_table` uses a lambda that captures an `ExtensionalData` with members move-constructed with objects, one of which this function only received as a reference.
https://github.com/ciaranm/glasgow-constraint-solver/blob/84dc072e12fefbe06dc99ab9fb82a59bbde0e7c3/gcs/innards/propagators.cc#L218

I believe there is a potential for a hidden undefined behaviour (including SIGSEGV) if `vars` is used outside the function after it is called, and the lambda gets deconstructed, along with the underlying data moved into it. This does not currently happen but it would be good to enforce this 'contract' with the compiler to protect from future changes, by only accepting rvalue references for objects which are to be moved into the lambda.

The alternative would be for `ExtensionalData` to only hold references, with some thought about the guarantees for the underlying objects not being deconstructed before the `ExtensionalData`.