### PR TITLE
Refactor reasons to allow ProofLiterals and ProofFlags.

### DIFF
--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -52,16 +52,16 @@ auto Abs::install(Propagators & propagators, State & initial_state,
         // remove from v1 any value whose absolute value isn't in v2's domain.
         for (const auto & val : state.each_value_mutable(v1))
             if (! state.in_domain(v2, abs(val))) {
-                inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{}, Reason{[=]() { return Literals{v2 != abs(val)}; }});
+                inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{v2 != abs(val)}; }});
             }
 
         // now remove from v2 any value whose +/-value isn't in v1's domain.
         for (const auto & val : state.each_value_mutable(v2)) {
             if (! state.in_domain(v1, val) && ! state.in_domain(v1, -val) && state.in_domain(v2, val)) {
-                auto just = [v1, v2, val, logger](const Reason & reason) {
+                auto just = [v1, v2, val, logger](const ReasonFunction & reason) {
                     justify_abs_hole(*logger, reason, v1, v2, val);
                 };
-                inference.infer_not_equal(logger, v2, val, JustifyExplicitly{just}, Reason{[=]() { return Literals{{v1 != val, v1 != -val}}; }});
+                inference.infer_not_equal(logger, v2, val, JustifyExplicitly{just}, ReasonFunction{[=]() { return Reason{{v1 != val, v1 != -val}}; }});
             }
         }
 
@@ -70,7 +70,7 @@ auto Abs::install(Propagators & propagators, State & initial_state,
         triggers, "abs");
 
     if (optional_model) {
-        optional_model->add_constraint("Abs", "non-negative", WeightedPseudoBooleanSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-        optional_model->add_constraint("Abs", "negative", WeightedPseudoBooleanSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
+        optional_model->add_constraint("Abs", "non-negative", WeightedPseudoBooleanSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, Reason{_v1 >= 0_i});
+        optional_model->add_constraint("Abs", "negative", WeightedPseudoBooleanSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, Reason{_v1 < 0_i});
     }
 }

--- a/gcs/constraints/abs/justify.cc
+++ b/gcs/constraints/abs/justify.cc
@@ -5,7 +5,7 @@ using namespace gcs::innards;
 
 auto gcs::innards::justify_abs_hole(
     ProofLogger & logger,
-    const Reason & reason,
+    const ReasonFunction & reason,
     IntegerVariableID v1,
     IntegerVariableID v2,
     Integer val) -> void

--- a/gcs/constraints/abs/justify.hh
+++ b/gcs/constraints/abs/justify.hh
@@ -7,7 +7,7 @@ namespace gcs::innards
 {
     auto justify_abs_hole(
         ProofLogger & logger,
-        const Reason & reason,
+        const ReasonFunction & reason,
         IntegerVariableID v1,
         IntegerVariableID v2,
         Integer val) -> void;

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -181,7 +181,7 @@ namespace
         ProofLogger & logger,
         const vector<pair<Left, Right>> & edges,
         const vector<uint8_t> & left_covered,
-        const vector<optional<Right>> & matching) -> pair<JustifyExplicitly, Reason>
+        const vector<optional<Right>> & matching) -> pair<JustifyExplicitly, ReasonFunction>
     {
         vector<optional<Left>> inverse_matching(vals.size(), nullopt);
         for (const auto & [l, r] : enumerate(matching))
@@ -238,7 +238,7 @@ namespace
                 hall_value_nrs.push_back(vals[v.offset]);
 
         return pair{JustifyExplicitly{
-                        [vars, &logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](const Reason &) -> void {
+                        [vars, &logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](const ReasonFunction &) -> void {
                             justify_all_different_hall_set_or_violator(logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
                         }},
             generic_reason(state, hall_variable_ids)};
@@ -266,7 +266,7 @@ namespace
         const vector<vector<Right>> & edges_out_from_variable,
         const vector<vector<Left>> & edges_out_from_value,
         const Right delete_value,
-        const vector<int> & components) -> pair<Justification, Reason>
+        const vector<int> & components) -> pair<Justification, ReasonFunction>
     {
         // we know a hall set exists, but we have to find it. starting
         // from but not including the end of the edge we're deleting,
@@ -324,7 +324,7 @@ namespace
             if (edges_out_from_value[delete_value.offset].empty())
                 throw UnexpectedException{"missing edge out from value in trivial scc"};
             else
-                return pair{JustifyUsingRUP{}, Reason{[=]() { return Literals{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}; }}};
+                return pair{JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}; }}};
         }
         else {
             // a hall set is at work
@@ -335,7 +335,7 @@ namespace
 
             return pair{JustifyExplicitly{
                             [vars, &logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](
-                                const Reason &) -> void {
+                                const ReasonFunction &) -> void {
                                 justify_all_different_hall_set_or_violator(logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
                             }},
                 generic_reason(state, hall_variable_ids)};

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -66,14 +66,14 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
             if (other.second == val) {
                 // we're already in a contradicting state
                 inference.infer_not_equal(logger, var, val, JustifyUsingRUP{},
-                    Reason{[var = other.first, val = val]() { return Literals{{var == val}}; }});
+                    ReasonFunction{[var = other.first, val = val]() { return Reason{{var == val}}; }});
             }
         }
 
         while (i != unassigned.end()) {
             auto other = *i;
             if (other != var) {
-                inference.infer_not_equal(logger, other, val, JustifyUsingRUP{}, Reason{[var = var, val = val]() { return Literals{{var == val}}; }});
+                inference.infer_not_equal(logger, other, val, JustifyUsingRUP{}, ReasonFunction{[var = var, val = val]() { return Reason{{var == val}}; }});
                 if (auto other_val = state.optional_single_value(other)) {
                     to_propagate.emplace_back(other, *other_val);
                     unassigned.erase(i++);

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -125,7 +125,7 @@ auto Among::install(Propagators & propagators, State &, ProofModel * const optio
             auto vars_reason = generic_reason(state, vars);
             inference.infer(logger, how_many >= must_match_count, JustifyUsingRUP{}, vars_reason);
             auto less_than_this_many = Integer(vars.size()) - must_not_match_count + 1_i;
-            inference.infer(logger, how_many < less_than_this_many, JustifyExplicitly{[&](const Reason &) -> void {
+            inference.infer(logger, how_many < less_than_this_many, JustifyExplicitly{[&](const ReasonFunction &) -> void {
                 // for any variable that isn't ruled out, show that it can contribute at
                 // most one to the count.
                 if (sum_line.second && ! empty(can_be_either_or_must_vars) && values_of_interest.size() > 1) {
@@ -171,7 +171,7 @@ auto Among::install(Propagators & propagators, State &, ProofModel * const optio
                         for (const auto & val : values_of_interest)
                             inferences.push_back(var != val);
 
-                        inference.infer_all(logger, inferences, JustifyExplicitly{[&](const Reason &) -> void {
+                        inference.infer_all(logger, inferences, JustifyExplicitly{[&](const ReasonFunction &) -> void {
                             // for any variable that is forced, show that it can contribute at
                             // most one to the count
                             if (sum_line.second && ! empty(must_match_vars) && values_of_interest.size() > 1) {
@@ -215,7 +215,7 @@ auto Among::install(Propagators & propagators, State &, ProofModel * const optio
                         if (might_match)
                             for (const auto & val : state.each_value_mutable(var))
                                 if (values_of_interest.end() == find(values_of_interest.begin(), values_of_interest.end(), val)) {
-                                    inference.infer(logger, var != val, JustifyExplicitly{[&](const Reason &) {
+                                    inference.infer(logger, var != val, JustifyExplicitly{[&](const ReasonFunction &) {
                                         // need to point out that if var == val then var != voi for each voi
                                         for (const auto & voi : values_of_interest)
                                             logger->emit(RUPProofRule{}, WeightedPseudoBooleanSum{} + 1_i * (var != val) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -131,7 +131,7 @@ auto gcs::innards::circuit::prevent_small_cycles(
         auto length = chain_lengths.back();
         chain_lengths.pop_back();
         if (cmp_less(length, succ.size() - 1)) {
-            auto justf = [&](const Reason &) {
+            auto justf = [&](const ReasonFunction &) {
                 output_cycle_to_proof(succ, i, length, pos_var_data, state, *logger, Integer{end[i]}, Integer{i});
             };
             inference.infer(logger, succ[end[i]] != Integer{i}, JustifyExplicitly{justf}, generic_reason(state, succ));

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -456,7 +456,7 @@ namespace
         return line;
     }
 
-    auto prove_mid_is_at_least(auto &, ProofLogger & logger, const Reason & reason,
+    auto prove_mid_is_at_least(auto &, ProofLogger & logger, const ReasonFunction & reason,
         const long & root, const OrderingAssumption & ordering, const long & val, const Literal & assumption,
         ShiftedPosDataMaps & flag_data_for_root,
         const PosVarDataMap & pos_var_data, PosAllDiffData & pos_alldiff_data,
@@ -488,7 +488,7 @@ namespace
         }
     }
 
-    auto prove_pos_and_node_implies_next_node(auto &, ProofLogger & logger, const Reason & reason,
+    auto prove_pos_and_node_implies_next_node(auto &, ProofLogger & logger, const ReasonFunction & reason,
         const long & root, const long & node, const long & next_node, const long & count,
         ShiftedPosDataMaps & flag_data_for_root, const PosVarDataMap & pos_var_data, PosAllDiffData & pos_alldiff_data,
         const vector<IntegerVariableID> & succ)
@@ -590,7 +590,7 @@ namespace
         return successor_implies_line;
     }
 
-    auto prove_not_same_val(auto &, ProofLogger & logger, const Reason & reason,
+    auto prove_not_same_val(auto &, ProofLogger & logger, const ReasonFunction & reason,
         const long & root, const long & middle, const long & next_node, const long & count,
         map<long, ShiftedPosDataMaps> & flag_data, const PosVarDataMap & pos_var_data, PosAllDiffData & pos_alldiff_data,
         const vector<IntegerVariableID> & succ)
@@ -707,7 +707,7 @@ namespace
         return succesor_implies_not_mid_line;
     }
 
-    auto prove_exclude_last_based_on_ordering(auto &, ProofLogger & logger, const Reason & reason,
+    auto prove_exclude_last_based_on_ordering(auto &, ProofLogger & logger, const ReasonFunction & reason,
         const OrderingAssumption & ordering, const long & root, const long & count, const Literal & assumption,
         map<long, ShiftedPosDataMaps> & flag_data, const PosVarDataMap & pos_var_data, PosAllDiffData & pos_alldiff_data,
         const vector<IntegerVariableID> & succ) -> ProofLine
@@ -750,7 +750,7 @@ namespace
         return exclusion_line;
     }
 
-    auto prove_reachable_set_too_small(const State & state, auto & inference, ProofLogger & logger, const Reason & reason,
+    auto prove_reachable_set_too_small(const State & state, auto & inference, ProofLogger & logger, const ReasonFunction & reason,
         const vector<IntegerVariableID> & succ, const long & root, SCCProofData & proof_data,
         const Literal & assumption = TrueLiteral{}, const optional<OrderingAssumption> & ordering = nullopt) -> void
     {
@@ -932,7 +932,7 @@ namespace
         logger.emit_proof_line(contradiction_line.str(), ProofLevel::Current);
     }
 
-    auto prove_skipped_subtree(const State & state, auto & inference, ProofLogger & logger, const Reason & reason,
+    auto prove_skipped_subtree(const State & state, auto & inference, ProofLogger & logger, const ReasonFunction & reason,
         const vector<IntegerVariableID> & succ, const long & node, const long & next_node, const long & root, const long & skipped_subroot,
         SCCProofData & proof_data)
     {
@@ -1008,7 +1008,7 @@ namespace
             WeightedPseudoBooleanSum{} + 1_i * (succ[node] != Integer{next_node}) >= 1_i, ProofLevel::Current);
     }
 
-    auto explore(const State & state, auto & inference, ProofLogger * const logger, const Reason & reason,
+    auto explore(const State & state, auto & inference, ProofLogger * const logger, const ReasonFunction & reason,
         const long & node, const vector<IntegerVariableID> & succ, SCCPropagatorData & data, SCCProofData & proof_data,
         const SCCOptions & options)
         -> vector<pair<long, long>>
@@ -1047,7 +1047,7 @@ namespace
                         }
                     }
 
-                    inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, Reason{});
+                    inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, ReasonFunction{});
                 }
                 data.lowlink[node] = pos_min(data.lowlink[node], data.visit_number[next_node]);
             }
@@ -1068,7 +1068,7 @@ namespace
         const State & state,
         auto & inference,
         ProofLogger * const logger,
-        const Reason & reason,
+        const ReasonFunction & reason,
         const vector<IntegerVariableID> & succ,
         const SCCOptions & options,
         SCCProofData & proof_data)
@@ -1098,7 +1098,7 @@ namespace
                             prove_reachable_set_too_small(state, inference, *logger, reason, succ, from_node, proof_data,
                                 succ[from_node] != Integer{to_node});
                         }
-                        inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, Reason{});
+                        inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, ReasonFunction{});
                     }
                 }
                 data.start_prev_subtree = data.end_prev_subtree + 1;
@@ -1132,7 +1132,7 @@ namespace
         const State & state,
         auto & inference,
         ProofLogger * const logger,
-        const Reason & reason,
+        const ReasonFunction & reason,
         const vector<IntegerVariableID> & succ,
         const SCCOptions & scc_options,
         const ConstraintStateHandle & pos_var_data_handle,

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -53,11 +53,11 @@ auto Count::install(Propagators & propagators, State &, ProofModel * const optio
 
             // var_minus_val_gt_0 -> var - val > 0
             optional_model->add_constraint("Count", "var bigger",
-                    WeightedPseudoBooleanSum{} + 1_i * var + -1_i * _value_of_interest >= 1_i, HalfReifyOnConjunctionOf{{var_minus_val_gt_0}});
+                WeightedPseudoBooleanSum{} + 1_i * var + -1_i * _value_of_interest >= 1_i, HalfReifyOnConjunctionOf{{var_minus_val_gt_0}});
 
             // ! var_minus_val_gt_0 -> var - val <= 0
             optional_model->add_constraint("Count", "var not bigger",
-                    WeightedPseudoBooleanSum{} + 1_i * var + -1_i * _value_of_interest <= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_gt_0}});
+                WeightedPseudoBooleanSum{} + 1_i * var + -1_i * _value_of_interest <= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_gt_0}});
 
             // var_minus_val_lt_0 -> var - val <= -1
             optional_model->add_constraint("Count", "var smaller", WeightedPseudoBooleanSum{} + 1_i * var + -1_i * _value_of_interest <= -1_i, HalfReifyOnConjunctionOf{{var_minus_val_lt_0}});
@@ -109,7 +109,7 @@ auto Count::install(Propagators & propagators, State &, ProofModel * const optio
 
             // can't have more that this many occurrences of the value of interest
             auto how_many_is_less_than = Integer(vars.size() - how_many_definitely_do_not) + 1_i;
-            auto justf = [&](const Reason & reason) -> void {
+            auto justf = [&](const ReasonFunction & reason) -> void {
                 for (const auto & [idx, var] : enumerate(vars)) {
                     bool seen_any = false;
                     state.for_each_value_while_immutable(var, [&](const Integer & val) -> bool {
@@ -159,7 +159,7 @@ auto Count::install(Propagators & propagators, State &, ProofModel * const optio
                 }
 
                 if (how_many_might < state.lower_bound(how_many)) {
-                    auto justf = [&](const Reason & reason) -> void {
+                    auto justf = [&](const ReasonFunction & reason) -> void {
                         for (const auto & [idx, var] : enumerate(vars)) {
                             if (! state.in_domain(var, voi)) {
                                 // need to help the checker see that the equality flag must be zero
@@ -188,7 +188,7 @@ auto Count::install(Propagators & propagators, State &, ProofModel * const optio
             // what are the supports on possible values we've seen?
             if (lowest_how_many_must) {
                 auto just = JustifyExplicitly{
-                    [&](const Reason & reason) -> void {
+                    [&](const ReasonFunction & reason) -> void {
                         state.for_each_value_while_immutable(value_of_interest, [&](Integer voi) -> bool {
                             logger->emit_rup_proof_line_under_reason(reason,
                                 WeightedPseudoBooleanSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i,
@@ -201,7 +201,7 @@ auto Count::install(Propagators & propagators, State &, ProofModel * const optio
 
             if (highest_how_many_might) {
                 auto just = JustifyExplicitly{
-                    [&](const Reason & reason) -> void {
+                    [&](const ReasonFunction & reason) -> void {
                         state.for_each_value_while_immutable(value_of_interest, [&](Integer voi) -> bool {
                             for (const auto & [idx, var] : enumerate(vars)) {
                                 if (! state.in_domain(var, voi)) {

--- a/gcs/constraints/equals.hh
+++ b/gcs/constraints/equals.hh
@@ -4,9 +4,10 @@
 #include <gcs/constraint.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/reification.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
-
 #include <string>
 
 namespace gcs
@@ -14,7 +15,7 @@ namespace gcs
     namespace innards
     {
         auto enforce_equality(ProofLogger * const logger, const auto & v1, const auto & v2, const State & state,
-            auto & inference, const Literals & reason) -> PropagatorState;
+            auto & inference, const Reason & reason) -> PropagatorState;
     }
 
     /**

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -114,7 +114,7 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
                 if (! state.in_domain(y.at((x_i_value - y_start).raw_value), Integer(i) + x_start))
                     inf.infer(logger, x_i != x_i_value,
                         JustifyUsingRUP{},
-                        [&]() { return Literals{y.at((x_i_value - y_start).raw_value) != Integer(i) + x_start}; });
+                        [&]() { return Reason{y.at((x_i_value - y_start).raw_value) != Integer(i) + x_start}; });
         }
 
         for (const auto & [i, y_i] : enumerate(y)) {
@@ -122,7 +122,7 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
                 if (! state.in_domain(x.at((y_i_value - x_start).raw_value), Integer(i) + y_start))
                     inf.infer(logger, y_i != y_i_value,
                         JustifyUsingRUP{},
-                        [&]() { return Literals{x.at((y_i_value - x_start).raw_value) != Integer(i) + y_start}; });
+                        [&]() { return Reason{x.at((y_i_value - x_start).raw_value) != Integer(i) + y_start}; });
         }
 
         propagate_gac_all_different(x, x_values, *x_value_am1s.get(), state, inf, logger);

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -532,7 +532,7 @@ namespace
         }
 
         if (undetermined_vars.empty()) {
-            Literals all_vars_assigned;
+            Reason all_vars_assigned;
             for (auto & v : vars)
                 all_vars_assigned.push_back(v == state(v));
 

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -176,7 +176,7 @@ auto LinearEqualityIff::install(Propagators & propagators, State & state, ProofM
         // condition is definitely true, an empty sum matches iff the modifiers sum to the value
         if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier != _value) {
             propagators.install_initialiser([cond = _cond](const State &, auto & inference, ProofLogger * const logger) {
-                inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, Reason{[=]() { return Literals{{cond}}; }});
+                inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{cond}}; }});
             });
         }
 
@@ -223,7 +223,7 @@ auto LinearEqualityIff::install(Propagators & propagators, State & state, ProofM
         // condition is definitely false, an empty sum matches iff the modifiers sum to something other than the value
         if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier == _value) {
             propagators.install_initialiser([cond = _cond](const State &, auto & inference, ProofLogger * const logger) {
-                inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, Reason{[=]() { return Literals{{cond}}; }});
+                inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{cond}}; }});
             });
         }
 
@@ -249,12 +249,12 @@ auto LinearEqualityIff::install(Propagators & propagators, State & state, ProofM
         if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv)) {
             if (modifier == _value) {
                 propagators.install_initialiser([cond = _cond](const State &, auto & inference, ProofLogger * const logger) {
-                    inference.infer(logger, cond, NoJustificationNeeded{}, Reason{});
+                    inference.infer(logger, cond, NoJustificationNeeded{}, ReasonFunction{});
                 });
             }
             else {
                 propagators.install_initialiser([cond = _cond](const State &, auto & inference, ProofLogger * const logger) {
-                    inference.infer(logger, ! cond, NoJustificationNeeded{}, Reason{});
+                    inference.infer(logger, ! cond, NoJustificationNeeded{}, ReasonFunction{});
                 });
             }
         }

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -107,7 +107,7 @@ auto LinearInequalityIff::install(Propagators & propagators, State & state, Proo
     if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv)) {
         propagators.install_initialiser([modifier = modifier, value = _value, cond = _cond](
                                             const State &, auto & inference, ProofLogger * const logger) -> void {
-            inference.infer(logger, 0_i <= value + modifier ? cond : ! cond, JustifyUsingRUP{}, Reason{});
+            inference.infer(logger, 0_i <= value + modifier ? cond : ! cond, JustifyUsingRUP{}, ReasonFunction{});
         });
     }
 
@@ -199,12 +199,12 @@ auto LinearInequalityIff::install(Propagators & propagators, State & state, Proo
                     }
 
                     if (min_possible > value + modifier) {
-                        auto just = [&](const Reason &) { return justify_cond(state, sanitised_cv, *logger, *proof_line); };
+                        auto just = [&](const ReasonFunction &) { return justify_cond(state, sanitised_cv, *logger, *proof_line); };
                         inference.infer(logger, ! cond, JustifyExplicitly{just}, generic_reason(state, vars));
                         return PropagatorState::Enable;
                     }
                     else if (max_possible <= value + modifier) {
-                        auto just = [&](const Reason &) { return justify_cond(state, sanitised_neg_cv, *logger, *proof_line + 1); };
+                        auto just = [&](const ReasonFunction &) { return justify_cond(state, sanitised_neg_cv, *logger, *proof_line + 1); };
                         inference.infer(logger, cond, JustifyExplicitly{just}, generic_reason(state, vars));
                         return PropagatorState::Enable;
                     }

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -56,9 +56,9 @@ namespace
         const auto & coeff_vars,
         const vector<pair<Integer, Integer>> & bounds,
         const SimpleIntegerVariableID & var, bool invert,
-        const optional<Literal> & add_to_reason) -> Reason
+        const optional<Literal> & add_to_reason) -> ReasonFunction
     {
-        Literals reason;
+        Reason reason;
         for (const auto & [idx, cv] : enumerate(coeff_vars.terms)) {
             if (get_var(cv) != var) {
                 if ((get_coeff(cv) < 0_i) != invert) {
@@ -93,7 +93,7 @@ namespace
                 .visit(*add_to_reason);
         }
 
-        return Reason{[=]() { return reason; }};
+        return ReasonFunction{[=]() { return reason; }};
     }
 
     auto infer(auto & inference, ProofLogger * const logger,
@@ -103,7 +103,7 @@ namespace
     {
         if (coeff) {
             if (bounds[p].second >= (1_i + remainder)) {
-                auto justf = [&](const Reason &) {
+                auto justf = [&](const ReasonFunction &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf},
@@ -112,7 +112,7 @@ namespace
         }
         else {
             if (bounds[p].first < -remainder) {
-                auto justf = [&](const Reason &) {
+                auto justf = [&](const ReasonFunction &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf},
@@ -129,7 +129,7 @@ namespace
         // lots of conditionals to get the rounding right...
         if (coeff > 0_i && remainder >= 0_i) {
             if (bounds[p].second >= (1_i + remainder / coeff)) {
-                auto justf = [&](const Reason &) {
+                auto justf = [&](const ReasonFunction &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf},
@@ -139,7 +139,7 @@ namespace
         else if (coeff > 0_i && remainder < 0_i) {
             auto div_with_rounding = -((-remainder + coeff - 1_i) / coeff);
             if (bounds[p].second >= 1_i + div_with_rounding) {
-                auto justf = [&](const Reason &) {
+                auto justf = [&](const ReasonFunction &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf},
@@ -148,7 +148,7 @@ namespace
         }
         else if (coeff < 0_i && remainder >= 0_i) {
             if (bounds[p].first < remainder / coeff) {
-                auto justf = [&](const Reason &) {
+                auto justf = [&](const ReasonFunction &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf},
@@ -158,7 +158,7 @@ namespace
         else if (coeff < 0_i && remainder < 0_i) {
             auto div_with_rounding = (-remainder + -coeff - 1_i) / -coeff;
             if (bounds[p].first < div_with_rounding) {
-                auto justf = [&](const Reason &) {
+                auto justf = [&](const ReasonFunction &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf},

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -65,7 +65,7 @@ namespace
         WeightedPseudoBooleanSum sum = WeightedPseudoBooleanSum{};
         Integer rhs = 0_i;
         HalfReifyOnConjunctionOf half_reif = HalfReifyOnConjunctionOf{};
-        optional<Reason> reason = nullopt;
+        optional<ReasonFunction> reason = nullopt;
         ProofLine line = 0;
     };
 
@@ -154,7 +154,7 @@ namespace
     };
 
     auto result_of_deriving(ProofLogger & logger, ProofRule rule, const WeightedPseudoBooleanLessEqual & ineq,
-        const HalfReifyOnConjunctionOf & reif, const ProofLevel & proof_level, const Reason & reason) -> DerivedPBConstraint
+        const HalfReifyOnConjunctionOf & reif, const ProofLevel & proof_level, const ReasonFunction & reason) -> DerivedPBConstraint
     {
         // Have to flip it again to store in the form lhs >= rhs
         WeightedPseudoBooleanSum ge_lhs{};
@@ -208,7 +208,7 @@ namespace
         const DerivedPBConstraint & constr,
         const map<SimpleIntegerVariableID, ChannellingData> & channelling_constraints,
         const map<SimpleIntegerVariableID, ProofOnlySimpleIntegerVariableID> & mag_var,
-        const Reason & reason,
+        const ReasonFunction & reason,
         const optional<HalfReifyOnConjunctionOf> & assumption = nullopt) -> DerivedPBConstraint
     {
         if (constr.sum.terms.size() != 1 || abs(constr.sum.terms[0].coefficient) != 1_i)
@@ -284,7 +284,7 @@ namespace
         DerivedPBConstraint & constr,
         const SimpleIntegerVariableID & z,
         const map<SimpleIntegerVariableID, ChannellingData> & channelling_constraints,
-        const Reason & reason)
+        const ReasonFunction & reason)
         -> DerivedPBConstraint
     {
         auto channel_reif = HalfReifyOnConjunctionOf{constr.half_reif};
@@ -464,7 +464,7 @@ namespace
             auto negation_line = -2;
             for (const auto & p : premises) {
                 weakened_premises.emplace_back(result_of_deriving(logger, RUPProofRule{}, // implies?
-                    want_to_derive, p.half_reif, ProofLevel::Temporary, Reason{}));
+                    want_to_derive, p.half_reif, ProofLevel::Temporary, ReasonFunction{}));
                 negation_line--;
             }
 
@@ -504,7 +504,7 @@ namespace
         const map<SimpleIntegerVariableID, ProofOnlySimpleIntegerVariableID> & mag_var,
         const pair<ProofLine, ProofLine> z_eq_product_lines,
         vector<vector<BitProductData>> & bit_products,
-        const Reason & reason)
+        const ReasonFunction & reason)
         -> DerivedPBConstraint
     {
         // logger.emit_proof_comment("Prove Conditional Product Lower Bound:");
@@ -560,7 +560,7 @@ namespace
         const map<SimpleIntegerVariableID, ProofOnlySimpleIntegerVariableID> & mag_var,
         const pair<ProofLine, ProofLine> z_eq_product_lines,
         vector<vector<BitProductData>> & bit_products,
-        const Reason & reason)
+        const ReasonFunction & reason)
         -> DerivedPBConstraint
     {
         auto mag_z_sum = WeightedPseudoBooleanSum{};
@@ -660,7 +660,7 @@ namespace
             ProofLevel::Temporary, reason);
     }
 
-    auto prove_product_bounds(const Reason & reason, ProofLogger & logger,
+    auto prove_product_bounds(const ReasonFunction & reason, ProofLogger & logger,
         vector<vector<BitProductData>> & bit_products,
         const SimpleIntegerVariableID x, const SimpleIntegerVariableID y, const SimpleIntegerVariableID z,
         const map<IntegerVariableID, pair<Integer, Integer>> & var_bounds,
@@ -774,7 +774,7 @@ namespace
     }
 
     auto prove_quotient_bounds(
-        const Reason & reason,
+        const ReasonFunction & reason,
         ProofLogger & logger,
         vector<vector<BitProductData>> & bit_products,
         const SimpleIntegerVariableID x, const SimpleIntegerVariableID y, const SimpleIntegerVariableID z,
@@ -958,7 +958,7 @@ namespace
         }
         else if (y_min == 0_i && y_max == 0_i) {
             // y == 0 and 0 not in bounds of z => no possible values for x
-            inference.contradiction(logger, JustifyUsingRUP{}, [y_var, z_var]() { return Literals{y_var == 0_i, z_var != 0_i}; });
+            inference.contradiction(logger, JustifyUsingRUP{}, [y_var, z_var]() { return Reason{y_var == 0_i, z_var != 0_i}; });
         }
         else if (y_min < 0_i && y_max > 0_i && (z_min > 0_i || z_max < 0_i)) {
             // y contains -1, 0, 1 and z has either all positive or all negative values
@@ -966,7 +966,7 @@ namespace
             auto smallest_possible_quotient = -largest_possible_quotient;
 
             auto var_bounds = map<IntegerVariableID, pair<Integer, Integer>>{{x_var, state.bounds(x_var)}, {y_var, state.bounds(y_var)}, {z_var, state.bounds(z_var)}};
-            auto lower_justf = [&](const Reason & reason) {
+            auto lower_justf = [&](const ReasonFunction & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, false);
@@ -976,10 +976,10 @@ namespace
 
             inference.infer(logger, x_var < largest_possible_quotient + 1_i,
                 JustifyExplicitly{lower_justf},
-                [lits = Literals{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i, y_var >= var_bounds.at(y_var).first, y_var < var_bounds.at(y_var).second + 1_i}]() { return lits; });
+                [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i, y_var >= var_bounds.at(y_var).first, y_var < var_bounds.at(y_var).second + 1_i}]() { return lits; });
 
             var_bounds.at(x_var).first = min(var_bounds.at(x_var).first, largest_possible_quotient);
-            auto upper_justf = [&](const Reason & reason) {
+            auto upper_justf = [&](const ReasonFunction & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, true);
@@ -989,7 +989,7 @@ namespace
 
             inference.infer(logger, x_var >= smallest_possible_quotient,
                 JustifyExplicitly{upper_justf},
-                [lits = Literals{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i, y_var >= var_bounds.at(y_var).first, y_var < var_bounds.at(y_var).second + 1_i}]() { return lits; });
+                [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i, y_var >= var_bounds.at(y_var).first, y_var < var_bounds.at(y_var).second + 1_i}]() { return lits; });
         }
         else if (y_min == 0_i && y_max != 0_i && (z_min > 0_i || z_max < 0_i)) {
             // y is either 0 or strictly positive and z has either all positive or all negative values
@@ -1006,7 +1006,7 @@ namespace
             auto largest_possible_quotient = max({div_floor(z_min, y_min), div_floor(z_min, y_max), div_floor(z_max, y_min), div_floor(z_max, y_max)});
 
             auto var_bounds = map<IntegerVariableID, pair<Integer, Integer>>{{x_var, state.bounds(x_var)}, {y_var, state.bounds(y_var)}, {z_var, state.bounds(z_var)}};
-            auto upper_justf = [&](const Reason & reason) {
+            auto upper_justf = [&](const ReasonFunction & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, false);
@@ -1014,7 +1014,7 @@ namespace
                     WeightedPseudoBooleanSum{} + 1_i * (x_var < largest_possible_quotient + 1_i) >= 1_i, ProofLevel::Current);
             };
 
-            auto lower_justf = [&](const Reason & reason) {
+            auto lower_justf = [&](const ReasonFunction & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, true);
@@ -1022,24 +1022,24 @@ namespace
                     WeightedPseudoBooleanSum{} + 1_i * (x_var >= smallest_possible_quotient) >= 1_i, ProofLevel::Current);
             };
 
-            auto both_justf = [&](const Reason & reason) {
+            auto both_justf = [&](const ReasonFunction & reason) {
                 upper_justf(reason);
                 lower_justf(reason);
             };
 
             if (smallest_possible_quotient > largest_possible_quotient) {
                 inference.infer(logger, FalseLiteral{}, JustifyExplicitly{both_justf},
-                    [lits = Literals{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i,
+                    [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i,
                          y_var >= var_bounds.at(y_var).first, y_var < var_bounds.at(y_var).second + 1_i}]() { return lits; });
             }
             else {
                 inference.infer(logger, x_var < largest_possible_quotient + 1_i,
                     JustifyExplicitly{upper_justf},
-                    [lits = Literals{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i,
+                    [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i,
                          y_var >= var_bounds.at(y_var).first, y_var < var_bounds.at(y_var).second + 1_i}]() { return lits; });
                 inference.infer(logger, x_var >= smallest_possible_quotient,
                     JustifyExplicitly{lower_justf},
-                    [lits = Literals{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i,
+                    [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var < var_bounds.at(z_var).second + 1_i,
                          y_var >= var_bounds.at(y_var).first, y_var < var_bounds.at(y_var).second + 1_i}]() { return lits; });
             }
         }
@@ -1178,7 +1178,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
             auto [smallest_product, largest_product] = get_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second);
             auto & bit_products = any_cast<vector<vector<BitProductData>> &>(state.get_constraint_state(bit_products_h));
 
-            auto justf = [&](const Reason & reason) {
+            auto justf = [&](const ReasonFunction & reason) {
                 prove_product_bounds(reason, *logger, bit_products, v1, v2, v3, var_bounds,
                     smallest_product, largest_product, channelling_constraints, mag_var, v3_eq_product_lines);
                 logger->emit_rup_proof_line_under_reason(reason,
@@ -1189,7 +1189,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
 
             inference.infer_all(logger, {v3 < largest_product + 1_i, v3 >= smallest_product},
                 JustifyExplicitly{justf},
-                [lits = Literals{v1 >= var_bounds.at(v1).first, v1 < var_bounds.at(v1).second + 1_i,
+                [lits = Reason{v1 >= var_bounds.at(v1).first, v1 < var_bounds.at(v1).second + 1_i,
                      v2 >= var_bounds.at(v2).first, v2 < var_bounds.at(v2).second + 1_i}]() { return lits; });
 
             auto bounds3 = state.bounds(v3);

--- a/gcs/constraints/not_equals.cc
+++ b/gcs/constraints/not_equals.cc
@@ -49,13 +49,13 @@ auto NotEquals::install(Propagators & propagators, State & initial_state, ProofM
     else if (v1_is_constant) {
         propagators.install_initialiser([v1_is_constant = v1_is_constant, v1 = _v1, v2 = _v2](
                                             const State &, auto & inference, ProofLogger * const logger) -> void {
-            inference.infer_not_equal(logger, v2, *v1_is_constant, JustifyUsingRUP{}, Reason{[=]() { return Literals{{v1 == *v1_is_constant}}; }});
+            inference.infer_not_equal(logger, v2, *v1_is_constant, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{v1 == *v1_is_constant}}; }});
         });
     }
     else if (v2_is_constant) {
         propagators.install_initialiser([v2_is_constant = v2_is_constant, v1 = _v1, v2 = _v2](
                                             const State &, auto & inference, ProofLogger * const logger) -> void {
-            inference.infer_not_equal(logger, v1, *v2_is_constant, JustifyUsingRUP{}, Reason{[=]() { return Literals{{v2 == *v2_is_constant}}; }});
+            inference.infer_not_equal(logger, v1, *v2_is_constant, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{v2 == *v2_is_constant}}; }});
         });
     }
     else {
@@ -71,23 +71,23 @@ auto NotEquals::install(Propagators & propagators, State & initial_state, ProofM
                 auto value1 = state.optional_single_value(v1);
                 if (value1) {
                     if (convert_to_values_ne) {
-                        inference.infer_not_equal(logger, v2, *value1, NoJustificationNeeded{}, Reason{});
+                        inference.infer_not_equal(logger, v2, *value1, NoJustificationNeeded{}, ReasonFunction{});
                         return PropagatorState::DisableUntilBacktrack;
                     }
                     else {
                         inference.infer_not_equal(logger, v2, *value1,
-                            JustifyUsingRUP{}, Reason{[=]() { return Literals{{v1 == *value1}}; }});
+                            JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{v1 == *value1}}; }});
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }
                 auto value2 = state.optional_single_value(v2);
                 if (value2) {
                     if (convert_to_values_ne) {
-                        inference.infer_not_equal(logger, v1, *value2, NoJustificationNeeded{}, Reason{});
+                        inference.infer_not_equal(logger, v1, *value2, NoJustificationNeeded{}, ReasonFunction{});
                         return PropagatorState::DisableUntilBacktrack;
                     }
                     else {
-                        inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{}, Reason{[=]() { return Literals{{v2 == *value2}}; }});
+                        inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{v2 == *value2}}; }});
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -88,7 +88,7 @@ auto ParityOdd::install(Propagators & propagators, State &, ProofModel * const o
                             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         long how_many_0 = 0, how_many_1 = 0, how_many_unknown = 0;
         optional<Literal> an_unknown;
-        Literals reason;
+        HalfReifyOnConjunctionOf reason;
         for (const auto & l : lits) {
             switch (state.test_literal(l)) {
             case LiteralIs::DefinitelyTrue:
@@ -114,15 +114,15 @@ auto ParityOdd::install(Propagators & propagators, State &, ProofModel * const o
             if (how_many_1 % 2 == 1)
                 return PropagatorState::DisableUntilBacktrack;
             else
-                inference.contradiction(logger, JustifyUsingRUP{}, Reason{[=]() { return reason; }});
+                inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{[=]() { return reason; }});
         }
         else {
             if (how_many_1 % 2 == 1) {
-                inference.infer(logger, ! *an_unknown, JustifyUsingRUP{}, Reason{[=]() { return reason; }});
+                inference.infer(logger, ! *an_unknown, JustifyUsingRUP{}, ReasonFunction{[=]() { return reason; }});
                 return PropagatorState::DisableUntilBacktrack;
             }
             else {
-                inference.infer(logger, *an_unknown, JustifyUsingRUP{}, Reason{[=]() { return reason; }});
+                inference.infer(logger, *an_unknown, JustifyUsingRUP{}, ReasonFunction{[=]() { return reason; }});
                 return PropagatorState::DisableUntilBacktrack;
             }
         }

--- a/gcs/constraints/regular.cc
+++ b/gcs/constraints/regular.cc
@@ -63,7 +63,7 @@ namespace
     };
 
     auto log_additional_inference(ProofLogger * const logger, const vector<Literal> & literals, const vector<ProofFlag> & proof_flags,
-        const State &, const Reason & reason, string comment = "") -> void
+        const State &, const ReasonFunction & reason, string comment = "") -> void
     {
         if (logger) {
             // Trying to cut down on repeated code
@@ -82,7 +82,7 @@ namespace
     auto initialise_graph(RegularGraph & graph, const vector<IntegerVariableID> & vars,
         const long num_states, vector<unordered_map<Integer, long>> & transitions,
         const vector<long> & final_states, const vector<vector<ProofFlag>> & state_at_pos_flags,
-        const State & state, const Reason & reason, ProofLogger * const logger)
+        const State & state, const ReasonFunction & reason, ProofLogger * const logger)
     {
         auto num_vars = vars.size();
 
@@ -170,7 +170,7 @@ namespace
     }
 
     auto decrement_outdeg(RegularGraph & graph, const long i, const long k, const vector<IntegerVariableID> & vars,
-        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const Reason & reason, ProofLogger * const logger) -> void
+        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonFunction & reason, ProofLogger * const logger) -> void
     {
         graph.out_deg[i][k]--;
         if (graph.out_deg[i][k] == 0 && i > 0) {
@@ -193,7 +193,7 @@ namespace
 
     auto decrement_indeg(RegularGraph & graph, const long i, const long k,
         const vector<IntegerVariableID> & vars, const vector<vector<ProofFlag>> & state_at_pos_flags,
-        const State & state, const Reason & reason, ProofLogger * const logger) -> void
+        const State & state, const ReasonFunction & reason, ProofLogger * const logger) -> void
     {
         graph.in_deg[i][k]--;
         if (graph.in_deg[i][k] == 0 && cmp_less(i, graph.in_deg.size() - 1)) {

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -110,14 +110,14 @@ namespace
     }
 
     auto log_filtering_inference(ProofLogger * const logger, const ProofFlag & tuple_selector, const Literal & lit,
-        const State &, auto &, const Reason & reason)
+        const State &, auto &, const ReasonFunction & reason)
     {
         logger->emit_rup_proof_line_under_reason(reason,
             WeightedPseudoBooleanSum{} + 1_i * (! tuple_selector) + 1_i * lit >= 1_i, ProofLevel::Current);
     }
 
     auto filter_edge(const SmartEntry & edge, VariableDomainMap & supported_by_tree, const ProofFlag & tuple_selector,
-        const State & state, auto & inference, const Reason & reason, ProofLogger * const logger) -> void
+        const State & state, auto & inference, const ReasonFunction & reason, ProofLogger * const logger) -> void
     {
         // Currently filter both domains - might be overkill
         // If the tree was in a better form, think this can be optimised to do less redundant filtering.
@@ -305,7 +305,7 @@ namespace
 
     [[nodiscard]] auto filter_and_check_valid(const TreeEdges & tree, VariableDomainMap & supported_by_tree,
         const ProofFlag & tuple_selector, const State & state, auto & inference,
-        const Reason & reason, ProofLogger * const logger) -> bool
+        const ReasonFunction & reason, ProofLogger * const logger) -> bool
     {
         for (int l = tree.size() - 1; l >= 0; --l) {
             for (const auto & edge : tree[l]) {
@@ -348,7 +348,7 @@ namespace
 
     auto filter_again_and_remove_supported(const TreeEdges & tree, VariableDomainMap & supported_by_tree,
         VariableDomainMap & unsupported, const ProofFlag & tuple_selector, const State & state,
-        auto & inference, const Reason & reason, ProofLogger * const logger) -> void
+        auto & inference, const ReasonFunction & reason, ProofLogger * const logger) -> void
     {
         for (int l = tree.size() - 1; l >= 0; --l) {
             for (const auto & edge : tree[l]) {
@@ -404,7 +404,7 @@ namespace
     }
 
     auto propagate_using_smart_str(const vector<IntegerVariableID> & selectors, const vector<IntegerVariableID> & vars,
-        const SmartTuples & tuples, const vector<Forest> & forests, const State & state, auto & inference, const Reason & reason,
+        const SmartTuples & tuples, const vector<Forest> & forests, const State & state, auto & inference, const ReasonFunction & reason,
         vector<ProofFlag> pb_selectors, ProofLogger * const logger) -> void
     {
         VariableDomainMap unsupported{};
@@ -434,7 +434,7 @@ namespace
                 // First pass of filtering supported_by_tree and check of validity
                 if (! filter_and_check_valid(tree, supported_by_tree, pb_selectors[tuple_idx], state, inference, reason, logger)) {
                     // Not feasible
-                    inference.infer_equal(logger, selectors[tuple_idx], 0_i, NoJustificationNeeded{}, Reason{});
+                    inference.infer_equal(logger, selectors[tuple_idx], 0_i, NoJustificationNeeded{}, ReasonFunction{});
                     break;
                 }
 
@@ -460,7 +460,7 @@ namespace
 
         for (const auto & var : vars) {
             for (const auto & value : unsupported[var]) {
-                auto justf = [&](const Reason & reason) -> void {
+                auto justf = [&](const ReasonFunction & reason) -> void {
                     for (unsigned int tuple_idx = 0; tuple_idx < tuples.size(); ++tuple_idx) {
                         logger->emit_rup_proof_line_under_reason(reason,
                             WeightedPseudoBooleanSum{} + 1_i * (var != value) + 1_i * (! pb_selectors[tuple_idx]) >= 1_i,

--- a/gcs/innards/extensional_utils.cc
+++ b/gcs/innards/extensional_utils.cc
@@ -70,7 +70,7 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                 }
 
             if (! is_feasible)
-                inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, Reason{});
+                inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, ReasonFunction{});
         }
     },
         table.tuples);

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -31,7 +31,7 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
 
-        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason) -> void
+        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
         {
             return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason);
         }
@@ -48,12 +48,12 @@ namespace gcs::innards
 
         auto operator=(const InferenceTrackerBase &) -> InferenceTrackerBase & = delete;
 
-        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const Reason & reason) -> void
+        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason) -> void
         {
             track(logger, _state.infer(lit), lit, why, reason);
         }
 
-        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const Reason & reason) -> void
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason) -> void
         {
             if (logger)
                 logger->infer(FalseLiteral{}, why, reason);
@@ -61,42 +61,42 @@ namespace gcs::innards
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const Reason & reason) -> void
+        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const ReasonFunction & reason) -> void
         {
             track(logger, _state.infer(lit), lit, why, reason);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason) -> void
+        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
         {
             track(logger, _state.infer_equal(var, value), var == value, why, reason);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason) -> void
+        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
         {
             track(logger, _state.infer_not_equal(var, value), var != value, why, reason);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason) -> void
+        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
         {
             track(logger, _state.infer_less_than(var, value), var < value, why, reason);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason) -> void
+        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
         {
             track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, reason);
         }
 
-        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const Reason & reason) -> void
+        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const ReasonFunction & reason) -> void
         {
             // only do explicit justifications once, but note that infer might not
             // actually call the justification if nothing is inferred
             auto just = visit([&](const auto & j) -> Justification {
                 if constexpr (std::is_same_v<std::decay_t<decltype(j)>, JustifyExplicitly>)
-                    return JustifyExplicitly{[done = false, &j](const Reason & reason) mutable -> void {
+                    return JustifyExplicitly{[done = false, &j](const ReasonFunction & reason) mutable -> void {
                         if (! done) {
                             j.add_proof_steps(reason);
                             done = true;
@@ -142,7 +142,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const Reason &) -> void
+        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -184,7 +184,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason) -> void
+        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
         {
             switch (inf) {
             case Inference::NoChange:

--- a/gcs/innards/justification.hh
+++ b/gcs/innards/justification.hh
@@ -23,7 +23,7 @@ namespace gcs::innards
      * \ingroup Innards
      * \sa JustifyExplicitly
      */
-    using ExplicitJustificationFunction = std::function<auto(const Reason & reason)->void>;
+    using ExplicitJustificationFunction = std::function<auto(const ReasonFunction & reason)->void>;
 
     /**
      * \brief Specify that an inference requires an explicit justification in

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -109,7 +109,7 @@ namespace gcs::innards
         /**
          * Log, if necessary, that we have inferred a particular literal.
          */
-        auto infer(const Literal & lit, const Justification & why, const Reason & reason) -> void;
+        auto infer(const Literal & lit, const Justification & why, const ReasonFunction & reason) -> void;
 
         /**
          * What is our current proof level?
@@ -140,7 +140,7 @@ namespace gcs::innards
         /**
          * Given a reason, return the vector of literals in the conjunction.
          */
-        auto reason_to_lits(const Reason & reason) -> std::vector<ProofLiteralOrFlag>;
+        auto reason_to_lits(const ReasonFunction & reason) -> std::vector<ProofLiteralOrFlag>;
 
         /**
          * Given a PB constraint C and a conjunction of literals L, return the native
@@ -152,7 +152,7 @@ namespace gcs::innards
          * Given a PB constraint C and a reason R, return the native
          * PB constraint encoding R => C
          */
-        auto reify(const WeightedPseudoBooleanLessEqual &, const Reason &) -> WeightedPseudoBooleanLessEqual;
+        auto reify(const WeightedPseudoBooleanLessEqual &, const ReasonFunction &) -> WeightedPseudoBooleanLessEqual;
 
         /**
          * Emit the specified text as a proof line.
@@ -177,7 +177,7 @@ namespace gcs::innards
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit_under_reason(const ProofRule & rule, const SumLessEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const Reason &
+        auto emit_under_reason(const ProofRule & rule, const SumLessEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &
 #ifdef GCS_TRACK_ALL_PROPAGATIONS
             ,
             const std::source_location & w = std::source_location::current()
@@ -199,7 +199,7 @@ namespace gcs::innards
          * Emit a RUP proof step for the specified expression, subject to a
          * given reason.
          */
-        auto emit_rup_proof_line_under_reason(const Reason &, const SumLessEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level
+        auto emit_rup_proof_line_under_reason(const ReasonFunction &, const SumLessEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level
 #ifdef GCS_TRACK_ALL_PROPAGATIONS
             ,
             const std::source_location & w = std::source_location::current()

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -33,7 +33,7 @@ namespace
 {
     struct TriggerIDs
     {
-        vector<pair<int, int> > ids_and_masks;
+        vector<pair<int, int>> ids_and_masks;
     };
 }
 
@@ -71,7 +71,7 @@ auto Propagators::model_contradiction(const State &, ProofModel * const optional
         optional_model->add_constraint({});
 
     install([explain_yourself = explain_yourself](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        inference.contradiction(logger, JustifyUsingRUP{}, Reason{[=]() { return Literals{}; }});
+        inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }});
     },
         Triggers{}, "model contradiction");
 }
@@ -83,7 +83,7 @@ auto Propagators::trim_lower_bound(const State & state, ProofModel * const optio
             if (optional_model)
                 optional_model->add_constraint({var >= val});
             install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-                inference.infer(logger, var >= val, JustifyUsingRUP{}, Reason{});
+                inference.infer(logger, var >= val, JustifyUsingRUP{}, ReasonFunction{});
             });
         }
         else
@@ -98,7 +98,7 @@ auto Propagators::trim_upper_bound(const State & state, ProofModel * const optio
             if (optional_model)
                 optional_model->add_constraint({var < val + 1_i});
             install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-                inference.infer(logger, var < val + 1_i, JustifyUsingRUP{}, Reason{});
+                inference.infer(logger, var < val + 1_i, JustifyUsingRUP{}, ReasonFunction{});
             });
         }
         else

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -4,9 +4,9 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::generic_reason(const State & state, const std::vector<IntegerVariableID> & vars) -> Reason
+auto gcs::innards::generic_reason(const State & state, const std::vector<IntegerVariableID> & vars) -> ReasonFunction
 {
-    Literals reason;
+    Reason reason;
     for (const auto & var : vars) {
         auto bounds = state.bounds(var);
         if (bounds.first == bounds.second)

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_REASON_HH
 
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/variable_id.hh>
 
@@ -10,9 +11,10 @@
 
 namespace gcs::innards
 {
-    using Reason = std::function<auto()->Literals>;
+    using Reason = std::vector<ProofLiteralOrFlag>;
+    using ReasonFunction = std::function<auto()->Reason>;
 
-    [[nodiscard]] auto generic_reason(const State & state, const std::vector<IntegerVariableID> & vars) -> Reason;
+    [[nodiscard]] auto generic_reason(const State & state, const std::vector<IntegerVariableID> & vars) -> ReasonFunction;
 }
 
 #endif


### PR DESCRIPTION
I'm not sure if this overlaps with #54 or #75, but I think we've mentioned before that it would be useful to allow ProofLiterals and ProofFlags in reasons. Among other things this will make my thesis experiments nicer by making it easy to turn on and off the "short reasons" idea that introduces a fresh literal to stand for the generic reason. 

I took the liberty of renaming the current `Reason` type to `ReasonFunction` and reserving `Reason` for 
a vector<ProofLiteralOfFlag> (the same as `HalfReifyOnConjunctionOf`). Maybe this isn't the best but open to discussion.

Mostly the actual changes are just find and replace. The only places where it introduced minor awkwardness
- In plus.cc now need to do some nested `get<>`s https://github.com/ciaranm/glasgow-constraint-solver/blob/fa78c3c69ac483473d9494dd9068076985b6a734/gcs/constraints/plus.cc#L74-L75
- In logical.cc need to cast `Literals` to `Reason` by emplacing back a new vector (can't think of a better way) https://github.com/ciaranm/glasgow-constraint-solver/blob/fa78c3c69ac483473d9494dd9068076985b6a734/gcs/constraints/logical.cc#L160-L165

