### PR TITLE
Added a stack to check bracket balance + catch2 tests

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -83,6 +83,10 @@ add_executable(solve_test solve_test.cc)
 target_link_libraries(solve_test PRIVATE Catch2::Catch2WithMain)
 add_test(NAME solve_test COMMAND $<TARGET_FILE:solve_test>)
 
+add_executable(problem_test problem_test.cc)
+target_link_libraries(problem_test PRIVATE Catch2::Catch2WithMain)
+add_test(NAME problem_test COMMAND $<TARGET_FILE:problem_test>)
+
 add_executable(abs_test constraints/abs_test.cc)
 add_executable(all_different_test constraints/all_different_test.cc)
 add_executable(among_test constraints/among_test.cc)

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -67,13 +67,34 @@ Problem::~Problem() = default;
 
 auto Problem::check_name(const string & name) -> const string &
 {
-    if (! _imp->names.insert(name).second)
-        throw NamingError{"duplicate variable name '" + name + "'"};
+    // Basic regex to check valid characters
+    regex allowed{R"(_*[a-zA-Z][a-zA-Z0-9\[\]_\-\{\}]*)"};
 
-    regex allowed{R"(_*[a-zA-Z][a-zA-Z0-9\[\]_\-]*)"};
     smatch m;
     if (! regex_match(name, m, allowed))
-        throw NamingError{"illegal variable name '" + name + "'"};
+        throw NamingError{"Illegal variable name '" + name + "'"};
+
+    // Use a stack to check for balanced brackets
+    deque<char> stack;
+    for (char c : name) {
+        if (c == '[' || c == '{') {
+            stack.push_back(c);
+        }
+        else if (c == ']' || c == '}') {
+            if (stack.empty())
+                throw NamingError{"Unbalanced brackets in variable name '" + name + "'"};
+            char open = stack.back();
+            stack.pop_back();
+            if ((c == ']' && open != '[') || (c == '}' && open != '{'))
+                throw NamingError{"Mismatched brackets in variable name '" + name + "'"};
+        }
+    }
+    if (!stack.empty())
+        throw NamingError{"Unbalanced brackets in variable name '" + name + "'"};
+
+    // The name is valid, but check for duplicates
+    if (! _imp->names.insert(name).second)
+        throw NamingError{"Duplicate variable name '" + name + "'"};
 
     return name;
 }

--- a/gcs/problem_test.cc
+++ b/gcs/problem_test.cc
@@ -1,0 +1,53 @@
+#include <gcs/problem.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+using namespace gcs;
+using namespace std::string_literals;
+
+// For now, these are an indirect way of testing the name-checking code in (private) Problem::check_name
+
+TEST_CASE("Problem accepts valid variable names")
+{
+    Problem p;
+
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "_x"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x_1"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x[0]"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x[0][1]"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x[0]{y}[1]"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x[0]{y[1]}"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x[y[0{1}]]"s));
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "x{row}"s));
+}
+
+TEST_CASE("Problem rejects illegal variable names")
+{
+    Problem p;
+
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, ""s), NamingError);
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "1x"s), NamingError);
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "x y"s), NamingError);
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "x()"s), NamingError);
+}
+
+TEST_CASE("Problem rejects unbalanced or mismatched brackets")
+{
+    Problem p;
+
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "x["s), NamingError);
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "x}"s), NamingError);
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "x[}"s), NamingError);
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "x{]"s), NamingError);
+}
+
+TEST_CASE("Problem rejects duplicate variable names")
+{
+    Problem p;
+
+    CHECK_NOTHROW(p.create_integer_variable(0_i, 1_i, "dup"s));
+    CHECK_THROWS_AS(p.create_integer_variable(0_i, 1_i, "dup"s), NamingError);
+}


### PR DESCRIPTION
- I moved the duplicate test to the end as there's no point inserting a bad var name into the list of names
- I kept the regex as-is because it handles character-level validity
- I added a stack mechanism to check for balanced brackets (square and curly)
- I added (indirect) unit tests for this function.  Problem::check_name is private but called by the public Problem::create_integer_variable, so I used that instead