### PR TITLE
Fix file I/O error handling in proof output (issue #111)

### DIFF
--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -7,6 +7,8 @@
 #include <gcs/innards/variable_id_utils.hh>
 
 #include <algorithm>
+#include <cstdlib>
+#include <exception>
 #include <fstream>
 #include <list>
 #include <map>
@@ -29,6 +31,7 @@ using std::any_of;
 using std::fstream;
 using std::function;
 using std::ios;
+using std::ios_base;
 using std::list;
 using std::map;
 using std::max;
@@ -69,7 +72,9 @@ struct NamesAndIDsTracker::Imp
     long long next_xliteral_nr = 0;
 
     optional<fstream> variables_map_file;
+    string variables_map_file_name;
     bool first_varmap_entry = true;
+    bool finalised = false;
     bool verbose_names;
 };
 
@@ -79,18 +84,35 @@ NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) :
     _imp->verbose_names = proof_options.verbose_names;
 
     if (proof_options.proof_file_names.variables_map_file) {
+        _imp->variables_map_file_name = *proof_options.proof_file_names.variables_map_file;
         _imp->variables_map_file.emplace();
-        _imp->variables_map_file->open(*proof_options.proof_file_names.variables_map_file, ios::out);
-        if (! *_imp->variables_map_file)
-            throw ProofError{"Error writing proof variables mapping file to '" + *proof_options.proof_file_names.variables_map_file + "'"};
-        *_imp->variables_map_file << "{\n";
+        try {
+            _imp->variables_map_file->exceptions(ios::failbit | ios::badbit);
+            _imp->variables_map_file->open(_imp->variables_map_file_name, ios::out);
+            *_imp->variables_map_file << "{\n";
+        } catch (const ios_base::failure &) {
+            throw ProofError{"Error writing proof variables mapping file to '" + _imp->variables_map_file_name + "'"};
+        }
     }
 }
 
 NamesAndIDsTracker::~NamesAndIDsTracker()
 {
-    if (_imp->variables_map_file && *_imp->variables_map_file) {
-        *_imp->variables_map_file << "\n}\n";
+    if (_imp->variables_map_file && ! _imp->finalised && std::uncaught_exceptions() == 0) {
+        fmt::print(stderr, "NamesAndIDsTracker destroyed without calling finalise()\n");
+        std::abort();
+    }
+}
+
+auto NamesAndIDsTracker::finalise() -> void
+{
+    _imp->finalised = true;
+    if (_imp->variables_map_file) {
+        try {
+            *_imp->variables_map_file << "\n}\n";
+        } catch (const ios_base::failure &) {
+            throw ProofError{"Error writing proof variables mapping file to '" + _imp->variables_map_file_name + "'"};
+        }
     }
 }
 
@@ -567,24 +589,28 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
     }
 
     if (_imp->variables_map_file) {
-        nlohmann::json data;
-        data["type"] = "condition";
-        overloaded{
-            [&](const SimpleIntegerVariableID & id) -> void {
-                data["cpvartype"] = "intvar";
-                data["cpvarid"] = id.index;
-            },
-            [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
-                data["cpvartype"] = "proofintvar";
-                data["cpvarid"] = id.index;
-            }}
-            .visit(id);
+        try {
+            nlohmann::json data;
+            data["type"] = "condition";
+            overloaded{
+                [&](const SimpleIntegerVariableID & id) -> void {
+                    data["cpvartype"] = "intvar";
+                    data["cpvarid"] = id.index;
+                },
+                [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
+                    data["cpvartype"] = "proofintvar";
+                    data["cpvarid"] = id.index;
+                }}
+                .visit(id);
 
-        data["name"] = name_of(id);
-        data["operator"] = (op == EqualsOrGreaterEqual::Equals ? "=" : ">=");
-        data["value"] = value.raw_value;
+            data["name"] = name_of(id);
+            data["operator"] = (op == EqualsOrGreaterEqual::Equals ? "=" : ">=");
+            data["value"] = value.raw_value;
 
-        write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+            write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+        } catch (const ios_base::failure &) {
+            throw ProofError{"Error writing proof variables mapping file to '" + _imp->variables_map_file_name + "'"};
+        }
     }
 
     return result;
@@ -601,11 +627,15 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(ProofFlag flag) -> XLiteral
     }
 
     if (_imp->variables_map_file) {
-        nlohmann::json data;
-        data["type"] = "proofflag";
-        data["name"] = name_of(flag);
+        try {
+            nlohmann::json data;
+            data["type"] = "proofflag";
+            data["name"] = name_of(flag);
 
-        write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+            write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+        } catch (const ios_base::failure &) {
+            throw ProofError{"Error writing proof variables mapping file to '" + _imp->variables_map_file_name + "'"};
+        }
     }
 
     return result;
@@ -631,22 +661,26 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning_negative_bit_of(SimpleOrProof
     }
 
     if (_imp->variables_map_file) {
-        nlohmann::json data;
-        data["type"] = "intvarnegbit";
-        overloaded{
-            [&](const SimpleIntegerVariableID & id) -> void {
-                data["cpvartype"] = "intvar";
-                data["cpvarid"] = id.index;
-            },
-            [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
-                data["cpvartype"] = "proofintvar";
-                data["cpvarid"] = id.index;
-            }}
-            .visit(id);
-        data["name"] = name_of(id);
-        data["power"] = power.raw_value;
+        try {
+            nlohmann::json data;
+            data["type"] = "intvarnegbit";
+            overloaded{
+                [&](const SimpleIntegerVariableID & id) -> void {
+                    data["cpvartype"] = "intvar";
+                    data["cpvarid"] = id.index;
+                },
+                [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
+                    data["cpvartype"] = "proofintvar";
+                    data["cpvarid"] = id.index;
+                }}
+                .visit(id);
+            data["name"] = name_of(id);
+            data["power"] = power.raw_value;
 
-        write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+            write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+        } catch (const ios_base::failure &) {
+            throw ProofError{"Error writing proof variables mapping file to '" + _imp->variables_map_file_name + "'"};
+        }
     }
 
     return result;
@@ -672,23 +706,27 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning_bit_of(SimpleOrProofOnlyInteg
     }
 
     if (_imp->variables_map_file) {
-        nlohmann::json data;
-        data["type"] = "intvarbit";
-        overloaded{
-            [&](const SimpleIntegerVariableID & id) -> void {
-                data["cpvartype"] = "intvar";
-                data["cpvarid"] = id.index;
-            },
-            [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
-                data["cpvartype"] = "proofintvar";
-                data["cpvarid"] = id.index;
-            }}
-            .visit(id);
+        try {
+            nlohmann::json data;
+            data["type"] = "intvarbit";
+            overloaded{
+                [&](const SimpleIntegerVariableID & id) -> void {
+                    data["cpvartype"] = "intvar";
+                    data["cpvarid"] = id.index;
+                },
+                [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
+                    data["cpvartype"] = "proofintvar";
+                    data["cpvarid"] = id.index;
+                }}
+                .visit(id);
 
-        data["name"] = name_of(id);
-        data["power"] = power.raw_value;
+            data["name"] = name_of(id);
+            data["power"] = power.raw_value;
 
-        write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+            write_vardata(*_imp->variables_map_file, _imp->first_varmap_entry, pb_file_string_for(result), data);
+        } catch (const ios_base::failure &) {
+            throw ProofError{"Error writing proof variables mapping file to '" + _imp->variables_map_file_name + "'"};
+        }
     }
 
     return result;

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -72,6 +72,13 @@ namespace gcs::innards
         explicit NamesAndIDsTracker(const ProofOptions &);
         ~NamesAndIDsTracker();
 
+        /**
+         * Must be called after all proof writing is complete to flush and
+         * close any supplementary output files (e.g. the variables map).
+         * Must not be called from a destructor.
+         */
+        auto finalise() -> void;
+
         auto operator=(const NamesAndIDsTracker &) -> NamesAndIDsTracker & = delete;
         NamesAndIDsTracker(const NamesAndIDsTracker &) = delete;
 

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -19,6 +19,7 @@ using std::deque;
 using std::flush;
 using std::fstream;
 using std::ios;
+using std::ios_base;
 using std::map;
 using std::max;
 using std::nullopt;
@@ -514,17 +515,15 @@ auto ProofLogger::forget_proof_level(int depth) -> void
 
 auto ProofLogger::start_proof(const ProofModel & model) -> void
 {
-    _imp->proof.open(_imp->proof_file, ios::out);
-
-    _imp->proof << "pseudo-Boolean proof version 3.0\n";
-
-    _imp->proof << "f " << model.number_of_constraints() << " ;\n";
+    try {
+        _imp->proof.exceptions(ios::failbit | ios::badbit);
+        _imp->proof.open(_imp->proof_file, ios::out);
+        _imp->proof << "pseudo-Boolean proof version 3.0\n";
+        _imp->proof << "f " << model.number_of_constraints() << " ;\n";
+    } catch (const ios_base::failure &) {
+        throw ProofError{"Error writing proof file to '" + _imp->proof_file + "'"};
+    }
     _imp->proof_line.number += model.number_of_constraints().number;
-
-    if (! _imp->proof)
-        throw ProofError{"Error writing proof file to "
-                         " + _imp->proof_file + "
-                         ""};
 }
 
 auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level) -> ProofLineNumber

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -10,7 +10,9 @@
 #include <gcs/innards/proofs/simplify_literal.hh>
 
 #include <algorithm>
+#include <cstdlib>
 #include <deque>
+#include <exception>
 #include <fstream>
 #include <iterator>
 #include <map>
@@ -26,6 +28,8 @@ using namespace gcs::innards;
 
 using std::deque;
 using std::fstream;
+using std::ios;
+using std::ios_base;
 using std::istreambuf_iterator;
 using std::map;
 using std::nullopt;
@@ -59,6 +63,7 @@ struct ProofModel::Imp
     stringstream opb;
 
     bool always_use_full_encoding = false;
+    bool finalised = false;
 
     explicit Imp(NamesAndIDsTracker & t) :
         tracker(t)
@@ -73,7 +78,13 @@ ProofModel::ProofModel(const ProofOptions & proof_options, NamesAndIDsTracker & 
     _imp->always_use_full_encoding = proof_options.always_use_full_encoding;
 }
 
-ProofModel::~ProofModel() = default;
+ProofModel::~ProofModel()
+{
+    if (! _imp->finalised && std::uncaught_exceptions() == 0) {
+        fmt::print(stderr, "ProofModel destroyed without calling finalise()\n");
+        std::abort();
+    }
+}
 
 auto ProofModel::advance_constraint_counter() -> ProofLineNumber
 {
@@ -308,60 +319,63 @@ auto ProofModel::create_proof_flag(const string & name) -> ProofFlag
 
 auto ProofModel::finalise() -> void
 {
-    ofstream full_opb{_imp->opb_file};
-    full_opb << "* #variable= " << _imp->model_variables << " #constraint= " << _imp->number_of_constraints.number << '\n';
+    _imp->finalised = true;
+    try {
+        ofstream full_opb;
+        full_opb.exceptions(ios::failbit | ios::badbit);
+        full_opb.open(_imp->opb_file);
+        full_opb << "* #variable= " << _imp->model_variables << " #constraint= " << _imp->number_of_constraints.number << '\n';
 
-    if (_imp->optional_minimise_variable) {
-        full_opb << "min: ";
-        overloaded{
-            [&](const SimpleIntegerVariableID & v) {
-                names_and_ids_tracker().for_each_bit(v, [&](Integer bit_value, const XLiteral & bit_name) {
-                    full_opb << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
-                });
-            },
-            [&](const ConstantIntegerVariableID &) {
-                throw UnimplementedException{};
-            },
-            [&](const ViewOfIntegerVariableID & v) {
-                // the "then add" bit is irrelevant for the objective function
-                names_and_ids_tracker().for_each_bit(v.actual_variable, [&](Integer bit_value, const XLiteral & bit_name) {
-                    full_opb << (v.negate_first ? -bit_value : bit_value) << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
-                });
-            }}
-            .visit(*_imp->optional_minimise_variable);
-
-        full_opb << ";\n";
-    }
-
-    if (_imp->preserved_variables) {
-        full_opb << "preserved: ";
-        for (const auto & var : *_imp->preserved_variables) {
+        if (_imp->optional_minimise_variable) {
+            full_opb << "min: ";
             overloaded{
                 [&](const SimpleIntegerVariableID & v) {
-                    names_and_ids_tracker().for_each_bit(v, [&](Integer, const XLiteral & bit_name) {
-                        full_opb << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                    names_and_ids_tracker().for_each_bit(v, [&](Integer bit_value, const XLiteral & bit_name) {
+                        full_opb << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
                     });
                 },
                 [&](const ConstantIntegerVariableID &) {
+                    throw UnimplementedException{};
                 },
                 [&](const ViewOfIntegerVariableID & v) {
                     // the "then add" bit is irrelevant for the objective function
-                    names_and_ids_tracker().for_each_bit(v.actual_variable, [&](Integer, const XLiteral & bit_name) {
-                        full_opb << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                    names_and_ids_tracker().for_each_bit(v.actual_variable, [&](Integer bit_value, const XLiteral & bit_name) {
+                        full_opb << (v.negate_first ? -bit_value : bit_value) << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
                     });
                 }}
-                .visit(var);
+                .visit(*_imp->optional_minimise_variable);
+
+            full_opb << ";\n";
         }
 
-        full_opb << ";\n";
-    }
+        if (_imp->preserved_variables) {
+            full_opb << "preserved: ";
+            for (const auto & var : *_imp->preserved_variables) {
+                overloaded{
+                    [&](const SimpleIntegerVariableID & v) {
+                        names_and_ids_tracker().for_each_bit(v, [&](Integer, const XLiteral & bit_name) {
+                            full_opb << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                        });
+                    },
+                    [&](const ConstantIntegerVariableID &) {
+                    },
+                    [&](const ViewOfIntegerVariableID & v) {
+                        // the "then add" bit is irrelevant for the objective function
+                        names_and_ids_tracker().for_each_bit(v.actual_variable, [&](Integer, const XLiteral & bit_name) {
+                            full_opb << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                        });
+                    }}
+                    .visit(var);
+            }
 
-    copy(istreambuf_iterator<char>{_imp->opb}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{full_opb});
-    _imp->opb = stringstream{};
+            full_opb << ";\n";
+        }
 
-    if (! full_opb)
+        copy(istreambuf_iterator<char>{_imp->opb}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{full_opb});
+        _imp->opb = stringstream{};
+    } catch (const ios_base::failure &) {
         throw ProofError{"Error writing opb file to '" + _imp->opb_file + "'"};
-    full_opb.close();
+    }
 }
 
 auto ProofModel::number_of_constraints() const -> ProofLineNumber

--- a/gcs/innards/proofs/reification_test.cc
+++ b/gcs/innards/proofs/reification_test.cc
@@ -41,4 +41,5 @@ auto main() -> int
     logger.emit_proof_line("pol -1 s;", ProofLevel::Current);
     logger.emit_proof_line("e >= -35 : -1;", ProofLevel::Current);
     logger.conclude_none();
+    tracker.finalise();
 }

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -21,6 +21,8 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::atomic;
+using std::ios;
+using std::ios_base;
 using std::max;
 using std::nullopt;
 using std::ofstream;
@@ -160,25 +162,26 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
         optional_proof->model()->names_and_ids_tracker().emit_delayed_proof_steps();
 
         if (auto & fn = optional_proof_options->proof_file_names.s_expr_file) {
-            ofstream s_expr{*fn};
-            if (! s_expr)
+            try {
+                ofstream s_expr;
+                s_expr.exceptions(ios::failbit | ios::badbit);
+                s_expr.open(*fn);
+                println(s_expr, "(");
+                println(s_expr, "    (");
+                for (const auto & [_, l, u, n] : problem.each_variable_with_bounds_and_name()) {
+                    println(s_expr, "        ({} {} {})", n, l.raw_value, u.raw_value);
+                }
+                println(s_expr, "    )");
+                println(s_expr, "    (");
+                unsigned n = 1;
+                for (const auto & c : problem.each_constraint()) {
+                    println(s_expr, "        ({})", c.s_exprify("c" + to_string(n++), optional_proof->model()));
+                }
+                println(s_expr, "    )");
+                println(s_expr, ")");
+            } catch (const ios_base::failure &) {
                 throw ProofError{"Error writing proof s-expr file to '" + *fn + "'"};
-
-            println(s_expr, "(");
-            println(s_expr, "    (");
-            for (const auto & [_, l, u, n] : problem.each_variable_with_bounds_and_name()) {
-                println(s_expr, "        ({} {} {})", n, l.raw_value, u.raw_value);
             }
-            println(s_expr, "    )");
-
-            println(s_expr, "    (");
-            unsigned n = 1;
-            for (const auto & c : problem.each_constraint()) {
-                println(s_expr, "        ({})", c.s_exprify("c" + to_string(n++), optional_proof->model()));
-            }
-            println(s_expr, "    )");
-
-            println(s_expr, ")");
         }
     }
 
@@ -241,6 +244,9 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
         if (callbacks.completed)
             callbacks.completed();
     }
+
+    if (optional_proof)
+        optional_proof->model()->names_and_ids_tracker().finalise();
 
     stats.solve_time = duration_cast<microseconds>(steady_clock::now() - start_time);
     propagators.fill_in_constraint_stats(stats);


### PR DESCRIPTION
## Summary

- `ProofLogger::start_proof` had a broken error message — the intended string concatenation `" + _imp->proof_file + "` was accidentally quoted, so the filename never appeared in the exception text
- File I/O failures were detected with manual `if (!stream)` checks that missed write errors between open and check, and in some cases missed the open failure itself
- `NamesAndIDsTracker` wrote its closing `"\n}\n"` in the destructor, making it impossible to propagate a write failure as a `ProofError`

All file I/O in the proof output path (`proof_logger.cc`, `proof_model.cc`, `names_and_ids_tracker.cc`, `solve.cc`) now uses `stream.exceptions(ios::failbit | ios::badbit)` before `open()`, with each I/O section wrapped in `try/catch(const ios_base::failure &)` that rethrows as `ProofError` with the filename included.

The closing write in `NamesAndIDsTracker` is moved out of the destructor into a new `finalise()` method (matching `ProofModel::finalise()`), called explicitly at the end of `solve_with()`. To catch any future code that forgets to call `finalise()`, both `ProofModel` and `NamesAndIDsTracker` now set a `bool finalised` flag in their `finalise()` methods and abort with a diagnostic message in their destructors if the flag is unset — guarded by `std::uncaught_exceptions() == 0` so it does not fire during stack unwinding from an unrelated exception.

## Test plan

- [ ] CI passes (sanitize build exercises proof output paths with ASan + UBSan)
- [ ] `reification_test` passes (directly constructs `NamesAndIDsTracker` and `ProofModel`, now calls `tracker.finalise()` explicitly)
- [ ] `tutorial_proof` passes (end-to-end proof generation and VeriPB verification)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)