### PR TITLE
Split install() into prepare/define_proof_model/install_propagators (rebased from #106)

### DIFF
--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -28,6 +28,14 @@ namespace gcs
      */
     class [[nodiscard]] Constraint
     {
+    protected:
+        virtual auto define_proof_model(innards::ProofModel &) -> void {};
+        virtual auto install_propagators(innards::Propagators &) -> void {};
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool
+        {
+            return true;
+        };
+
     public:
         virtual ~Constraint() = 0;
 

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -47,8 +47,18 @@ auto Abs::clone() const -> unique_ptr<Constraint>
     return make_unique<Abs>(_v1, _v2);
 }
 
-auto Abs::install(Propagators & propagators, State & initial_state,
-    ProofModel * const optional_model) && -> void
+auto Abs::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Abs::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     // _v2 >= 0
     propagators.trim_lower_bound(initial_state, optional_model, _v2, 0_i, "Abs");
@@ -63,6 +73,17 @@ auto Abs::install(Propagators & propagators, State & initial_state,
     auto v2u = max(initial_state.upper_bound(_v1), -initial_state.lower_bound(_v1));
     propagators.trim_upper_bound(initial_state, optional_model, _v2, v2u, "Abs");
 
+    return true;
+}
+
+auto Abs::define_proof_model(ProofModel & model) -> void
+{
+    model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
+    model.add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
+}
+
+auto Abs::install_propagators(Propagators & propagators) -> void
+{
     // _v2 = abs(_v1)
     Triggers triggers{.on_change = {_v1, _v2}};
     propagators.install([v1 = _v1, v2 = _v2](
@@ -86,11 +107,6 @@ auto Abs::install(Propagators & propagators, State & initial_state,
         return PropagatorState::Enable;
     },
         triggers, "abs");
-
-    if (optional_model) {
-        optional_model->add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-        optional_model->add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
-    }
 }
 
 auto Abs::s_exprify(const string & name, const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/abs.hh
+++ b/gcs/constraints/abs.hh
@@ -17,6 +17,10 @@ namespace gcs
     private:
         IntegerVariableID _v1, _v2;
 
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
     public:
         explicit Abs(const IntegerVariableID v1, const IntegerVariableID v2);
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -548,32 +548,46 @@ auto gcs::innards::propagate_gac_all_different(
 
 auto GACAllDifferent::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    shared_ptr<map<Integer, ProofLine>> value_am1_constraint_numbers;
-
-    auto sanitised_vars = move(_vars);
-    sort(sanitised_vars);
-    if (adjacent_find(sanitised_vars) != sanitised_vars.end()) {
-        propagators.model_contradiction(initial_state, optional_model, "AllDifferent with duplicate variables");
+    if (! prepare(propagators, initial_state, optional_model))
         return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto GACAllDifferent::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    _sanitised_vars = move(_vars);
+    sort(_sanitised_vars);
+    if (adjacent_find(_sanitised_vars) != _sanitised_vars.end()) {
+        propagators.model_contradiction(initial_state, optional_model, "AllDifferent with duplicate variables");
+        return false;
     }
 
-    if (optional_model) {
-        value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
-        define_clique_not_equals_encoding(*optional_model, sanitised_vars);
-    }
-
-    Triggers triggers;
-    triggers.on_change = {sanitised_vars.begin(), sanitised_vars.end()};
-    vector<Integer> compressed_vals;
-
-    for (auto & var : sanitised_vars)
+    for (auto & var : _sanitised_vars)
         for (const auto & val : initial_state.each_value_immutable(var))
-            if (compressed_vals.end() == find(compressed_vals.begin(), compressed_vals.end(), val))
-                compressed_vals.push_back(val);
+            if (_compressed_vals.end() == find(_compressed_vals.begin(), _compressed_vals.end(), val))
+                _compressed_vals.push_back(val);
 
+    return true;
+}
+
+auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
+{
+    define_clique_not_equals_encoding(model, _sanitised_vars);
+}
+
+auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
+
+    auto value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
     propagators.install(
-        [vars = move(sanitised_vars),
-            vals = move(compressed_vals),
+        [vars = move(_sanitised_vars),
+            vals = move(_compressed_vals),
             value_am1_constraint_numbers = move(value_am1_constraint_numbers)](const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState {
             propagate_gac_all_different(vars, vals, *value_am1_constraint_numbers.get(), state, inference, logger);

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -32,6 +32,12 @@ namespace gcs
     {
     private:
         const std::vector<IntegerVariableID> _vars;
+        std::vector<IntegerVariableID> _sanitised_vars;
+        std::vector<Integer> _compressed_vals;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit GACAllDifferent(std::vector<IntegerVariableID> vars);

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -103,36 +103,49 @@ auto VCAllDifferent::clone() const -> unique_ptr<Constraint>
     return make_unique<VCAllDifferent>(_vars);
 }
 
-auto VCAllDifferent::install(innards::Propagators & propagators, innards::State & initial_state,
-    innards::ProofModel * const model) && -> void
+auto VCAllDifferent::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    if (model) {
-        define_clique_not_equals_encoding(*model, _vars);
-    }
-
-    auto sanitised_vars = move(_vars);
-    sort(sanitised_vars);
-    if (adjacent_find(sanitised_vars) != sanitised_vars.end()) {
-        propagators.model_contradiction(initial_state, model, "AllDifferent with duplicate variables");
+    if (! prepare(propagators, initial_state, optional_model))
         return;
-    }
 
-    Triggers triggers;
-    triggers.on_change = {sanitised_vars.begin(), sanitised_vars.end()};
-    vector<Integer> compressed_vals;
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto VCAllDifferent::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    _sanitised_vars = move(_vars);
+    sort(_sanitised_vars);
+    if (adjacent_find(_sanitised_vars) != _sanitised_vars.end()) {
+        propagators.model_contradiction(initial_state, optional_model, "AllDifferent with duplicate variables");
+        return false;
+    }
 
     // Keep track of unassigned vars
     // Might want a more centralised way of doing this in future.
     list<IntegerVariableID> unassigned{};
-    for (auto & var : sanitised_vars)
+    for (auto & var : _sanitised_vars)
         if (! initial_state.has_single_value(var))
             unassigned.push_back(var);
 
-    auto unassigned_handle = initial_state.add_constraint_state(unassigned);
+    _unassigned_handle = initial_state.add_constraint_state(unassigned);
+    return true;
+}
+
+auto VCAllDifferent::define_proof_model(ProofModel & model) -> void
+{
+    define_clique_not_equals_encoding(model, _sanitised_vars);
+}
+
+auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 
     propagators.install(
-        [vars = move(sanitised_vars), unassigned_handle = unassigned_handle,
-            vals = move(compressed_vals)](const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
+        [unassigned_handle = _unassigned_handle](const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
             propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger);
             return PropagatorState::Enable;
         },

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -31,6 +31,12 @@ namespace gcs
     {
     private:
         const std::vector<IntegerVariableID> _vars;
+        std::vector<IntegerVariableID> _sanitised_vars;
+        innards::ConstraintStateHandle _unassigned_handle;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit VCAllDifferent(std::vector<IntegerVariableID> vars);

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -72,24 +72,35 @@ auto Among::clone() const -> unique_ptr<Constraint>
     return make_unique<Among>(_vars, _values_of_interest, _how_many);
 }
 
-auto Among::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto Among::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Among::define_proof_model(ProofModel & model) -> void
+{
+    // very easy PB encoding: sum up over the condition that each variable equals one of the
+    // value of interest options, and make that equal the how many variable.
+    WPBSum sum;
+    for (auto & var : _vars)
+        for (auto & val : _values_of_interest)
+            sum += 1_i * (var == val);
+    _sum_line = model.add_constraint("Among", "how many", sum == 1_i * _how_many);
+}
+
+auto Among::install_propagators(Propagators & propagators) -> void
 {
     // we only care about the bounds for how_many, but we care about any deletions for the
     // rest of the variables
     Triggers triggers;
     triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
     triggers.on_bounds.emplace_back(_how_many);
-
-    pair<optional<ProofLine>, optional<ProofLine>> sum_line;
-    if (optional_model) {
-        // very easy PB encoding: sum up over the condition that each variable equals one of the
-        // value of interest options, and make that equal the how many variable.
-        WPBSum sum;
-        for (auto & var : _vars)
-            for (auto & val : _values_of_interest)
-                sum += 1_i * (var == val);
-        sum_line = optional_model->add_constraint("Among", "how many", sum == 1_i * _how_many);
-    }
 
     // for proof logging, we're going to need at-most-one constraints over the
     // values of interest for each variable. compute these once and remember
@@ -111,7 +122,7 @@ auto Among::install(Propagators & propagators, State &, ProofModel * const optio
     });
 
     propagators.install(
-        [vars = _vars, values_of_interest = _values_of_interest, how_many = _how_many, sum_line = sum_line, am1_lines = am1_lines](
+        [vars = _vars, values_of_interest = _values_of_interest, how_many = _how_many, sum_line = _sum_line, am1_lines = am1_lines](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // partition variables to be 1) those that must not match, 2) those that must match, and 3) those
             // where they might match but don't have to.

--- a/gcs/constraints/among.hh
+++ b/gcs/constraints/among.hh
@@ -2,8 +2,11 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_AMONG_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/variable_id.hh>
 
+#include <optional>
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -20,6 +23,10 @@ namespace gcs
         const std::vector<IntegerVariableID> _vars;
         const std::vector<Integer> _values_of_interest;
         IntegerVariableID _how_many;
+        std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
+
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Among(std::vector<IntegerVariableID>, const std::vector<Integer> & values_of_interest, const IntegerVariableID & how_many);

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -53,72 +53,88 @@ auto ReifiedCompareLessThanOrMaybeEqual::clone() const -> unique_ptr<Constraint>
     return make_unique<ReifiedCompareLessThanOrMaybeEqual>(_v1, _v2, _reif_cond, _or_equal, _vars_swapped);
 }
 
-auto ReifiedCompareLessThanOrMaybeEqual::install(Propagators & propagators, State & initial_state,
-    ProofModel * const optional_model) && -> void
+auto ReifiedCompareLessThanOrMaybeEqual::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    if (optional_model) {
-        auto do_less = [&](IntegerVariableID v1, IntegerVariableID v2, optional<HalfReifyOnConjunctionOf> cond, bool or_equal, const StringLiteral & rule) {
-            optional_model->add_constraint("ReifiedCompareLessThanOrMaybeEqual", rule, WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i), cond);
-        };
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-        overloaded{
-            [&](const reif::MustHold &) {
-                do_less(_v1, _v2, nullopt, _or_equal, "condition true");
-            },
-            [&](const reif::MustNotHold &) {
-                do_less(_v2, _v1, nullopt, ! _or_equal, "condition false");
-            },
-            [&](const reif::If & cond) {
-                do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
-            },
-            [&](const reif::NotIf & cond) {
-                do_less(_v2, _v1, HalfReifyOnConjunctionOf{{cond.cond}}, ! _or_equal, "if condition");
-            },
-            [&](const reif::Iff & cond) {
-                do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
-                do_less(_v2, _v1, HalfReifyOnConjunctionOf{{! cond.cond}}, ! _or_equal, "if not condition");
-            }}
-            .visit(_reif_cond);
-    }
+    if (optional_model)
+        define_proof_model(*optional_model);
 
-    auto v1_is_constant = initial_state.optional_single_value(_v1);
-    auto v2_is_constant = initial_state.optional_single_value(_v2);
+    install_propagators(propagators);
+}
 
-    if (v1_is_constant && v2_is_constant) {
+auto ReifiedCompareLessThanOrMaybeEqual::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _v1_is_constant = initial_state.optional_single_value(_v1);
+    _v2_is_constant = initial_state.optional_single_value(_v2);
+    _evaluated_cond = initial_state.test_reification_condition(_reif_cond);
+    return true;
+}
+
+auto ReifiedCompareLessThanOrMaybeEqual::define_proof_model(ProofModel & model) -> void
+{
+    auto do_less = [&](IntegerVariableID v1, IntegerVariableID v2, optional<HalfReifyOnConjunctionOf> cond, bool or_equal, const StringLiteral & rule) {
+        model.add_constraint("ReifiedCompareLessThanOrMaybeEqual", rule, WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i), cond);
+    };
+
+    overloaded{
+        [&](const reif::MustHold &) {
+            do_less(_v1, _v2, nullopt, _or_equal, "condition true");
+        },
+        [&](const reif::MustNotHold &) {
+            do_less(_v2, _v1, nullopt, ! _or_equal, "condition false");
+        },
+        [&](const reif::If & cond) {
+            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
+        },
+        [&](const reif::NotIf & cond) {
+            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{cond.cond}}, ! _or_equal, "if condition");
+        },
+        [&](const reif::Iff & cond) {
+            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
+            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{! cond.cond}}, ! _or_equal, "if not condition");
+        }}
+        .visit(_reif_cond);
+}
+
+auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propagators) -> void
+{
+    if (_v1_is_constant && _v2_is_constant) {
         /* special case: both values are constant, so we're potentially forcing
          * the reification condition, or just giving contradiction, but will never
          * propagate beyond that. */
-        bool holds = (_or_equal ? *v1_is_constant <= *v2_is_constant : *v1_is_constant < *v2_is_constant);
+        bool holds = (_or_equal ? *_v1_is_constant <= *_v2_is_constant : *_v1_is_constant < *_v2_is_constant);
         overloaded{
             [&](const evaluated_reif::MustHold & reif) {
                 if (! holds)
-                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = v1_is_constant, v2_is_constant = v2_is_constant, cond = reif.cond](
+                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
                         inference.infer(logger, ! cond, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}; }});
                     });
             },
             [&](const evaluated_reif::MustNotHold & reif) {
                 if (holds)
-                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = v1_is_constant, v2_is_constant = v2_is_constant, cond = reif.cond](
+                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
                         inference.infer(logger, ! cond, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}; }});
                     });
             },
             [&](const evaluated_reif::Undecided & reif) {
                 if (holds && reif.set_cond_if_must_hold)
-                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = v1_is_constant, v2_is_constant = v2_is_constant, cond = reif.cond](
+                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
                         inference.infer(logger, cond, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{v1 == *v1_is_constant, v2 == *v2_is_constant}}; }});
                     });
                 else if ((holds && reif.set_not_cond_if_must_hold) || (! holds && reif.set_not_cond_if_must_not_hold))
-                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = v1_is_constant, v2_is_constant = v2_is_constant, cond = reif.cond](
+                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
                         inference.infer(logger, ! cond, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{v1 == *v1_is_constant, v2 == *v2_is_constant}}; }});
                     });
             },
             [](const evaluated_reif::Deactivated &) {
             }}
-            .visit(initial_state.test_reification_condition(_reif_cond));
+            .visit(_evaluated_cond);
     }
     else {
         overloaded{
@@ -195,7 +211,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::install(Propagators & propagators, Stat
             },
             [](const evaluated_reif::Deactivated &) {
             }}
-            .visit(initial_state.test_reification_condition(_reif_cond));
+            .visit(_evaluated_cond);
     }
 }
 

--- a/gcs/constraints/comparison.hh
+++ b/gcs/constraints/comparison.hh
@@ -3,9 +3,13 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/integer.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
+
+#include <optional>
 
 namespace gcs
 {
@@ -31,6 +35,12 @@ namespace gcs
         ReificationCondition _reif_cond;
         bool _or_equal;
         bool _vars_swapped;
+        std::optional<Integer> _v1_is_constant, _v2_is_constant;
+        innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit ReifiedCompareLessThanOrMaybeEqual(const IntegerVariableID v1, const IntegerVariableID v2, ReificationCondition cond, bool or_equal, bool vars_swapped = false);

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -49,57 +49,68 @@ auto Count::clone() const -> unique_ptr<Constraint>
     return make_unique<Count>(_vars, _value_of_interest, _how_many);
 }
 
-auto Count::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto Count::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Count::define_proof_model(ProofModel & model) -> void
+{
+    for (auto & var : _vars) {
+        auto flag = model.create_proof_flag("count");
+        auto var_minus_val_gt_0 = model.create_proof_flag("countg");
+        auto var_minus_val_lt_0 = model.create_proof_flag("countl");
+        _flags.emplace_back(flag, var_minus_val_gt_0, var_minus_val_lt_0);
+
+        // var_minus_val_gt_0 -> var - val > 0
+        model.add_constraint("Count", "var bigger",
+            WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 1_i, HalfReifyOnConjunctionOf{{var_minus_val_gt_0}});
+
+        // ! var_minus_val_gt_0 -> var - val <= 0
+        model.add_constraint("Count", "var not bigger",
+            WPBSum{} + 1_i * var + -1_i * _value_of_interest <= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_gt_0}});
+
+        // var_minus_val_lt_0 -> var - val <= -1
+        model.add_constraint("Count", "var smaller", WPBSum{} + 1_i * var + -1_i * _value_of_interest <= -1_i, HalfReifyOnConjunctionOf{{var_minus_val_lt_0}});
+
+        // ! var_minus_val_lt_0 -> var - val > -1
+        model.add_constraint("Count", "var not smaller", WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_lt_0}});
+
+        // flag => ! countg /\ ! countl
+        model.add_constraint("Count", "var equal", WPBSum{} + 1_i * ! var_minus_val_gt_0 + 1_i * ! var_minus_val_lt_0 >= 2_i, HalfReifyOnConjunctionOf{{flag}});
+
+        // ! flag => countg \/ countl
+        model.add_constraint("Count", "var not equal", WPBSum{} + 1_i * var_minus_val_gt_0 + 1_i * var_minus_val_lt_0 >= 1_i, HalfReifyOnConjunctionOf{{! flag}});
+    }
+
+    // sum flag == how_many
+    WPBSum how_many_sum;
+    for (auto & [flag, _1, _2] : _flags)
+        how_many_sum += 1_i * flag;
+    how_many_sum += -1_i * _how_many;
+
+    model.add_constraint("Count", "sum of flags", how_many_sum == 0_i);
+}
+
+auto Count::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
     triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
     triggers.on_change.emplace_back(_value_of_interest);
     triggers.on_bounds.emplace_back(_how_many);
 
-    vector<tuple<ProofFlag, ProofFlag, ProofFlag>> flags;
-    if (optional_model) {
-        for (auto & var : _vars) {
-            auto flag = optional_model->create_proof_flag("count");
-            auto var_minus_val_gt_0 = optional_model->create_proof_flag("countg");
-            auto var_minus_val_lt_0 = optional_model->create_proof_flag("countl");
-            flags.emplace_back(flag, var_minus_val_gt_0, var_minus_val_lt_0);
-
-            // var_minus_val_gt_0 -> var - val > 0
-            optional_model->add_constraint("Count", "var bigger",
-                WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 1_i, HalfReifyOnConjunctionOf{{var_minus_val_gt_0}});
-
-            // ! var_minus_val_gt_0 -> var - val <= 0
-            optional_model->add_constraint("Count", "var not bigger",
-                WPBSum{} + 1_i * var + -1_i * _value_of_interest <= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_gt_0}});
-
-            // var_minus_val_lt_0 -> var - val <= -1
-            optional_model->add_constraint("Count", "var smaller", WPBSum{} + 1_i * var + -1_i * _value_of_interest <= -1_i, HalfReifyOnConjunctionOf{{var_minus_val_lt_0}});
-
-            // ! var_minus_val_lt_0 -> var - val > -1
-            optional_model->add_constraint("Count", "var not smaller", WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_lt_0}});
-
-            // flag => ! countg /\ ! countl
-            optional_model->add_constraint("Count", "var equal", WPBSum{} + 1_i * ! var_minus_val_gt_0 + 1_i * ! var_minus_val_lt_0 >= 2_i, HalfReifyOnConjunctionOf{{flag}});
-
-            // ! flag => countg \/ countl
-            optional_model->add_constraint("Count", "var not equal", WPBSum{} + 1_i * var_minus_val_gt_0 + 1_i * var_minus_val_lt_0 >= 1_i, HalfReifyOnConjunctionOf{{! flag}});
-        }
-
-        // sum flag == how_many
-        WPBSum how_many_sum;
-        for (auto & [flag, _1, _2] : flags)
-            how_many_sum += 1_i * flag;
-        how_many_sum += -1_i * _how_many;
-
-        optional_model->add_constraint("Count", "sum of flags", how_many_sum == 0_i);
-    }
-
     vector<IntegerVariableID> all_vars = _vars;
     all_vars.push_back(_value_of_interest);
     all_vars.push_back(_how_many);
 
     propagators.install(
-        [vars = _vars, value_of_interest = _value_of_interest, how_many = _how_many, flags = flags, all_vars = move(all_vars)](
+        [vars = _vars, value_of_interest = _value_of_interest, how_many = _how_many, flags = _flags, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // check support for how many by seeing how many array values
             // intersect with a potential value of interest

--- a/gcs/constraints/count.hh
+++ b/gcs/constraints/count.hh
@@ -2,8 +2,10 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_COUNT_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/variable_id.hh>
 
+#include <tuple>
 #include <vector>
 
 namespace gcs
@@ -19,6 +21,10 @@ namespace gcs
     private:
         const std::vector<IntegerVariableID> _vars;
         IntegerVariableID _value_of_interest, _how_many;
+        std::vector<std::tuple<innards::ProofFlag, innards::ProofFlag, innards::ProofFlag>> _flags;
+
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Count(std::vector<IntegerVariableID>, const IntegerVariableID & value_of_interest, const IntegerVariableID & how_many);

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -141,45 +141,71 @@ namespace
 }
 
 template <typename EntryType_, unsigned dimensions_>
-auto NDimensionalElement<EntryType_, dimensions_>::install(innards::Propagators & propagators, innards::State & initial_state, innards::ProofModel * const optional_model) && -> void
+auto NDimensionalElement<EntryType_, dimensions_>::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+template <typename EntryType_, unsigned dimensions_>
+auto NDimensionalElement<EntryType_, dimensions_>::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    // First pass: any zero-sized dimension means the constraint is unsatisfiable; signal
+    // model contradiction without trimming bounds (which could reference variables we're
+    // about to flag inconsistent).
+    for (const auto & [i, _] : enumerate(_index_vars)) {
+        if (0_i == Integer(get_dimension_size<dimensions_>(i, *_array))) {
+            propagators.model_contradiction(initial_state, optional_model, "NDimensionalElement constraint with no values");
+            return false;
+        }
+    }
+
     for (const auto & [i, var] : enumerate(_index_vars)) {
         auto s = Integer(get_dimension_size<dimensions_>(i, *_array));
-        if (0_i == s) {
-            propagators.model_contradiction(initial_state, optional_model, "NDimensionalElement constraint with no values");
-            return;
-        }
-
         propagators.trim_lower_bound(initial_state, optional_model, var, _index_starts.at(i), "NDimensionalElement");
         propagators.trim_upper_bound(initial_state, optional_model, var, _index_starts.at(i) + s - 1_i, "NDimensionalElement");
     }
 
-    if (optional_model) {
-        HalfReifyOnConjunctionOf reif;
-        vector<size_t> elem;
+    _array_has_nonconstants = any_array_variable_is_nonconstant(initial_state, *_array);
+    return true;
+}
 
-        function<auto(unsigned)->void> build_implication_constraints = [&](unsigned d) {
-            auto s = get_dimension_size<dimensions_>(d, *_array);
-            for (size_t x = 0; x != s; ++x) {
-                reif.push_back(_index_vars.at(d) == Integer(x) + _index_starts.at(d));
-                elem.push_back(x);
-                if (elem.size() == dimensions_) {
-                    // this still works out fine if the variable is actually a constant
-                    auto array_var = get_array_var<dimensions_>(elem, *_array);
-                    optional_model->add_constraint("NDimensionalElement", "equality",
-                        WPBSum{} + (1_i * _result_var) + (-1_i * array_var) == 0_i, reif);
-                }
-                else {
-                    build_implication_constraints(d + 1);
-                }
-                elem.pop_back();
-                reif.pop_back();
+template <typename EntryType_, unsigned dimensions_>
+auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel & model) -> void
+{
+    HalfReifyOnConjunctionOf reif;
+    vector<size_t> elem;
+
+    function<auto(unsigned)->void> build_implication_constraints = [&](unsigned d) {
+        auto s = get_dimension_size<dimensions_>(d, *_array);
+        for (size_t x = 0; x != s; ++x) {
+            reif.push_back(_index_vars.at(d) == Integer(x) + _index_starts.at(d));
+            elem.push_back(x);
+            if (elem.size() == dimensions_) {
+                // this still works out fine if the variable is actually a constant
+                auto array_var = get_array_var<dimensions_>(elem, *_array);
+                model.add_constraint("NDimensionalElement", "equality",
+                    WPBSum{} + (1_i * _result_var) + (-1_i * array_var) == 0_i, reif);
             }
-        };
-        build_implication_constraints(0);
-    }
+            else {
+                build_implication_constraints(d + 1);
+            }
+            elem.pop_back();
+            reif.pop_back();
+        }
+    };
+    build_implication_constraints(0);
+}
 
-    auto array_has_nonconstants = any_array_variable_is_nonconstant(initial_state, *_array);
+template <typename EntryType_, unsigned dimensions_>
+auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagators & propagators) -> void
+{
+    auto array_has_nonconstants = _array_has_nonconstants;
 
     vector<IntegerVariableID> all_array_vars;
     {

--- a/gcs/constraints/element.hh
+++ b/gcs/constraints/element.hh
@@ -40,6 +40,12 @@ namespace gcs
         IndexStarts _index_starts;
         Array * _array;
         bool _bounds_only;
+        bool _array_has_nonconstants = false;
+
+    private:
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     protected:
         explicit NDimensionalElement(IntegerVariableID result_var, IndexVariables, IndexStarts, Array *, bool bounds_only);

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -116,49 +116,67 @@ auto ReifiedEquals::clone() const -> unique_ptr<Constraint>
 
 auto ReifiedEquals::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    if (optional_model) {
-        overloaded{
-            [&](const reif::MustHold &) {
-                optional_model->add_constraint("ReifiedEquals", "equals option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i);
-            },
-            [&](const reif::MustNotHold &) {
-                auto gtflag = optional_model->create_proof_flag("gt");
-                optional_model->add_constraint("ReifiedEquals", "greater option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
-                optional_model->add_constraint("ReifiedEquals", "less option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! gtflag}});
-            },
-            [&](const reif::If & reif) {
-                optional_model->add_constraint("ReifiedEquals", "equals option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
-            },
-            [&](const reif::NotIf & reif) {
-                auto gtflag = optional_model->create_proof_flag("gt");
-                optional_model->add_constraint("ReifiedEquals", "greater option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{reif.cond, gtflag}});
-                optional_model->add_constraint("ReifiedEquals", "less option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{reif.cond, ! gtflag}});
-            },
-            [&](const reif::Iff & reif) {
-                // condition unknown, the condition implies it is neither greater nor less
-                optional_model->add_constraint("ReifiedEquals", "equals option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-                auto gtflag = optional_model->create_proof_flag("gt");
-                optional_model->add_constraint("ReifiedEquals", "greater option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
-                auto ltflag = optional_model->create_proof_flag("lt");
-                optional_model->add_constraint("ReifiedEquals", "less option",
-                    WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{ltflag}});
+    if (optional_model)
+        define_proof_model(*optional_model);
 
-                // lt + eq + gt >= 1
-                optional_model->add_constraint("ReifiedEquals", "one of less than, equals, greater than",
-                    WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * reif.cond >= 1_i);
-            }}
-            .visit(_cond);
-    }
+    install_propagators(propagators);
+}
 
+auto ReifiedEquals::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _evaluated_cond = initial_state.test_reification_condition(_cond);
+    return true;
+}
+
+auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
+{
+    overloaded{
+        [&](const reif::MustHold &) {
+            model.add_constraint("ReifiedEquals", "equals option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i);
+        },
+        [&](const reif::MustNotHold &) {
+            auto gtflag = model.create_proof_flag("gt");
+            model.add_constraint("ReifiedEquals", "greater option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
+            model.add_constraint("ReifiedEquals", "less option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! gtflag}});
+        },
+        [&](const reif::If & reif) {
+            model.add_constraint("ReifiedEquals", "equals option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
+        },
+        [&](const reif::NotIf & reif) {
+            auto gtflag = model.create_proof_flag("gt");
+            model.add_constraint("ReifiedEquals", "greater option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{reif.cond, gtflag}});
+            model.add_constraint("ReifiedEquals", "less option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{reif.cond, ! gtflag}});
+        },
+        [&](const reif::Iff & reif) {
+            // condition unknown, the condition implies it is neither greater nor less
+            model.add_constraint("ReifiedEquals", "equals option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
+
+            auto gtflag = model.create_proof_flag("gt");
+            model.add_constraint("ReifiedEquals", "greater option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
+            auto ltflag = model.create_proof_flag("lt");
+            model.add_constraint("ReifiedEquals", "less option",
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{ltflag}});
+
+            // lt + eq + gt >= 1
+            model.add_constraint("ReifiedEquals", "one of less than, equals, greater than",
+                WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * reif.cond >= 1_i);
+        }}
+        .visit(_cond);
+}
+
+auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
+{
     overloaded{
         [&](const evaluated_reif::MustHold & reif) {
             Triggers triggers;
@@ -287,7 +305,7 @@ auto ReifiedEquals::install(Propagators & propagators, State & initial_state, Pr
         [&](const evaluated_reif::Deactivated &) {
         },
     }
-        .visit(initial_state.test_reification_condition(_cond));
+        .visit(_evaluated_cond);
 }
 
 Equals::Equals(const IntegerVariableID v1, const IntegerVariableID v2) :

--- a/gcs/constraints/equals.hh
+++ b/gcs/constraints/equals.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
@@ -29,6 +30,11 @@ namespace gcs
         IntegerVariableID _v1, _v2;
         ReificationCondition _cond;
         bool _neq;
+        innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         ReifiedEquals(const IntegerVariableID v1, const IntegerVariableID v2, ReificationCondition cond, bool neq = false);

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -58,9 +58,20 @@ auto Inverse::clone() const -> unique_ptr<Constraint>
 
 auto Inverse::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Inverse::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
     if (_x.size() != _y.size()) {
         propagators.model_contradiction(initial_state, optional_model, "Inverse constraint on different sized arrays");
-        return;
+        return false;
     }
 
     for (const auto & [idx, v] : enumerate(_x)) {
@@ -73,22 +84,32 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
         propagators.trim_upper_bound(initial_state, optional_model, v, Integer(_x.size()) + _x_start - 1_i, "Inverse");
     }
 
-    if (optional_model) {
-        for (const auto & [i, x_i] : enumerate(_x))
-            for (const auto & [j, y_j] : enumerate(_y)) {
-                // x[i] = j -> y[j] = i
-                optional_model->add_constraint("Inverse", "x_i = j -> y[j] = i", WPBSum{} + 1_i * (x_i != Integer(j) + _y_start) + 1_i * (y_j == Integer(i) + _x_start) >= 1_i);
-                // y[j] = i -> x[i] = j
-                optional_model->add_constraint("Inverse", "y_j = i -> x[i] = j", WPBSum{} + 1_i * (y_j != Integer(i) + _x_start) + 1_i * (x_i == Integer(j) + _y_start) >= 1_i);
-            }
-    }
+    return true;
+}
 
+auto Inverse::define_proof_model(ProofModel & model) -> void
+{
+    for (const auto & [i, x_i] : enumerate(_x))
+        for (const auto & [j, y_j] : enumerate(_y)) {
+            // x[i] = j -> y[j] = i
+            model.add_constraint("Inverse", "x_i = j -> y[j] = i", WPBSum{} + 1_i * (x_i != Integer(j) + _y_start) + 1_i * (y_j == Integer(i) + _x_start) >= 1_i);
+            // y[j] = i -> x[i] = j
+            model.add_constraint("Inverse", "y_j = i -> x[i] = j", WPBSum{} + 1_i * (y_j != Integer(i) + _x_start) + 1_i * (x_i == Integer(j) + _y_start) >= 1_i);
+        }
+
+    // Set up the AM1 map only when proof logging is on; the propagator captures it
+    // by value, so it must always be non-null but stays empty when define_proof_model
+    // wasn't called.
+    _x_value_am1s = make_shared<map<Integer, ProofLine>>();
+}
+
+auto Inverse::install_propagators(Propagators & propagators) -> void
+{
     Triggers triggers;
     triggers.on_change.insert(triggers.on_change.end(), _x.begin(), _x.end());
     triggers.on_change.insert(triggers.on_change.end(), _y.begin(), _y.end());
 
-    shared_ptr<map<Integer, ProofLine>> x_value_am1s;
-    if (optional_model) {
+    if (_x_value_am1s) {
         auto build_am1s = [](const vector<IntegerVariableID> & x, Integer x_start, const State &,
                               auto &, ProofLogger * const logger, const auto & map) {
             for (Integer v = x_start; v < x_start + Integer(x.size()); ++v) {
@@ -102,11 +123,14 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
             }
         };
 
-        x_value_am1s = make_shared<map<Integer, ProofLine>>();
-        propagators.install_initialiser([x = _x, x_start = _x_start, x_value_am1s = x_value_am1s, build_am1s = build_am1s](
+        propagators.install_initialiser([x = _x, x_start = _x_start, x_value_am1s = _x_value_am1s, build_am1s = build_am1s](
                                             const State & state, auto & inference, ProofLogger * const logger) -> void {
             build_am1s(x, x_start, state, inference, logger, x_value_am1s);
         });
+    }
+    else {
+        // No proof model: propagator still captures this map (must be non-null), but it stays empty.
+        _x_value_am1s = make_shared<map<Integer, ProofLine>>();
     }
 
     vector<Integer> x_values;
@@ -114,7 +138,7 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
         x_values.push_back(Integer(i) + _x_start);
 
     propagators.install([x = _x, y = _y, x_start = _x_start, y_start = _y_start,
-                            x_values = move(x_values), x_value_am1s = x_value_am1s](
+                            x_values = move(x_values), x_value_am1s = _x_value_am1s](
                             const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
         for (const auto & [i, x_i] : enumerate(x)) {
             for (auto x_i_value : state.each_value_mutable(x_i))

--- a/gcs/constraints/inverse.hh
+++ b/gcs/constraints/inverse.hh
@@ -2,8 +2,11 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INVERSE_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/variable_id.hh>
 
+#include <map>
+#include <memory>
 #include <vector>
 
 namespace gcs
@@ -20,6 +23,11 @@ namespace gcs
     private:
         const std::vector<IntegerVariableID> _x, _y;
         const Integer _x_start, _y_start;
+        std::shared_ptr<std::map<Integer, innards::ProofLine>> _x_value_am1s;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Inverse(std::vector<IntegerVariableID> x, std::vector<IntegerVariableID> y,

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -593,6 +593,17 @@ namespace
 
 auto Knapsack::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Knapsack::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
     if (_coeffs.size() != _totals.size())
         throw UnexpectedException{"mismatch between coefficients and totals sizes for knapsack"};
 
@@ -617,23 +628,28 @@ auto Knapsack::install(Propagators & propagators, State & initial_state, ProofMo
         if (initial_state.lower_bound(t) < 0_i)
             throw UnexpectedException{"not sure what to do about negative permitted totals for knapsack"};
 
-    vector<pair<ProofLine, ProofLine>> eqns_lines;
-    if (optional_model) {
-        for (const auto & [cc_idx, cc] : enumerate(_coeffs)) {
-            WPBSum sum_eq;
-            for (const auto & [idx, v] : enumerate(_vars))
-                sum_eq += cc.at(idx) * v;
-            auto [eq1, eq2] = optional_model->add_constraint(sum_eq == 1_i * _totals.at(cc_idx));
-            eqns_lines.emplace_back(eq1.value(), eq2.value());
-        }
-    }
+    return true;
+}
 
+auto Knapsack::define_proof_model(ProofModel & model) -> void
+{
+    for (const auto & [cc_idx, cc] : enumerate(_coeffs)) {
+        WPBSum sum_eq;
+        for (const auto & [idx, v] : enumerate(_vars))
+            sum_eq += cc.at(idx) * v;
+        auto [eq1, eq2] = model.add_constraint(sum_eq == 1_i * _totals.at(cc_idx));
+        _eqns_lines.emplace_back(eq1.value(), eq2.value());
+    }
+}
+
+auto Knapsack::install_propagators(Propagators & propagators) -> void
+{
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
     triggers.on_change.insert(triggers.on_change.end(), _totals.begin(), _totals.end());
 
     propagators.install(
-        [coeffs = move(_coeffs), vars = move(_vars), totals = move(_totals), eqns_lines = move(eqns_lines)](
+        [coeffs = move(_coeffs), vars = move(_vars), totals = move(_totals), eqns_lines = move(_eqns_lines)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             return knapsack(state, logger, inference, coeffs, vars, totals, eqns_lines);
         },

--- a/gcs/constraints/knapsack.hh
+++ b/gcs/constraints/knapsack.hh
@@ -2,8 +2,10 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_KNAPSACK_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/variable_id.hh>
 
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -20,6 +22,11 @@ namespace gcs
         const std::vector<std::vector<Integer>> _coeffs;
         const std::vector<IntegerVariableID> _vars;
         const std::vector<IntegerVariableID> _totals;
+        std::vector<std::pair<innards::ProofLine, innards::ProofLine>> _eqns_lines;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Knapsack(std::vector<Integer> weights, std::vector<Integer> profits,

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -146,49 +146,66 @@ namespace
     }
 }
 
-auto ReifiedLinearEquality::install(Propagators & propagators, State & state, ProofModel * const optional_model) && -> void
+auto ReifiedLinearEquality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    optional<pair<optional<ProofLine>, optional<ProofLine>>> proof_line;
-    if (optional_model) {
-        WPBSum terms;
-        for (auto & [c, v] : _coeff_vars.terms)
-            terms += c * v;
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-        overloaded{
-            [&](const reif::MustHold &) {
-                // condition is definitely true, it's just an inequality
-                proof_line = optional_model->add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
-            },
-            [&](const reif::MustNotHold &) {
-                // condition is definitely false, the flag implies either greater or less
-                auto neflag = optional_model->create_proof_flag("linne");
-                optional_model->add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
-                optional_model->add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
-            },
-            [&](const reif::If & cond) {
-                proof_line = optional_model->add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
-            },
-            [&](const reif::NotIf & cond) {
-                // condition is definitely false, the flag implies either greater or less
-                auto neflag = optional_model->create_proof_flag("linne");
-                optional_model->add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
-                optional_model->add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
-            },
-            [&](const reif::Iff & cond) {
-                // condition unknown, the condition implies it is neither greater nor less
-                proof_line = optional_model->add_constraint("ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+    if (optional_model)
+        define_proof_model(*optional_model);
 
-                auto gtflag = optional_model->create_proof_flag("lineqgt");
-                optional_model->add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});
-                auto ltflag = optional_model->create_proof_flag("lineqlt");
-                optional_model->add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{ltflag}});
+    install_propagators(propagators);
+}
 
-                // lt + eq + gt >= 1
-                optional_model->add_constraint("ReifiedLinearEquality", "one of less than, equals, greater than", WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * cond.cond >= 1_i);
-            }}
-            .visit(_reif_cond);
-    }
+auto ReifiedLinearEquality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _evaluated_cond = initial_state.test_reification_condition(_reif_cond);
+    return true;
+}
 
+auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
+{
+    WPBSum terms;
+    for (auto & [c, v] : _coeff_vars.terms)
+        terms += c * v;
+
+    overloaded{
+        [&](const reif::MustHold &) {
+            // condition is definitely true, it's just an inequality
+            _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
+        },
+        [&](const reif::MustNotHold &) {
+            // condition is definitely false, the flag implies either greater or less
+            auto neflag = model.create_proof_flag("linne");
+            model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
+            model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
+        },
+        [&](const reif::If & cond) {
+            _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+        },
+        [&](const reif::NotIf & cond) {
+            // condition is definitely false, the flag implies either greater or less
+            auto neflag = model.create_proof_flag("linne");
+            model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
+            model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
+        },
+        [&](const reif::Iff & cond) {
+            // condition unknown, the condition implies it is neither greater nor less
+            _proof_line = model.add_constraint("ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+
+            auto gtflag = model.create_proof_flag("lineqgt");
+            model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});
+            auto ltflag = model.create_proof_flag("lineqlt");
+            model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{ltflag}});
+
+            // lt + eq + gt >= 1
+            model.add_constraint("ReifiedLinearEquality", "one of less than, equals, greater than", WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * cond.cond >= 1_i);
+        }}
+        .visit(_reif_cond);
+}
+
+auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> void
+{
     auto [sanitised_cv, modifier] = tidy_up_linear(_coeff_vars);
 
     vector<IntegerVariableID> all_vars;
@@ -248,7 +265,7 @@ auto ReifiedLinearEquality::install(Propagators & propagators, State & state, Pr
 
                 visit(
                     [&, modifier = modifier](const auto & lin) {
-                        propagators.install([modifier = modifier, lin = lin, value = _value, proof_line = proof_line, reason_from_cond = reif.cond](
+                        propagators.install([modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](
                                                 const State & state, auto & inference, ProofLogger * const logger) {
                             return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond);
                         },
@@ -294,7 +311,7 @@ auto ReifiedLinearEquality::install(Propagators & propagators, State & state, Pr
                 triggers.on_change.push_back(reif.cond.var);
 
                 visit([&, modifier = modifier](const auto & sanitised_cv) {
-                    propagators.install([sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = proof_line, all_vars = move(all_vars)](
+                    propagators.install([sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line, all_vars = move(all_vars)](
                                             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                         return overloaded{
                             [&](const evaluated_reif::MustHold & reif) {
@@ -379,7 +396,7 @@ auto ReifiedLinearEquality::install(Propagators & propagators, State & state, Pr
                 },
                     sanitised_cv);
             }}
-            .visit(state.test_reification_condition(_reif_cond));
+            .visit(_evaluated_cond);
     }
 }
 

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -4,7 +4,12 @@
 #include <gcs/constraint.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/reification.hh>
+
+#include <optional>
+#include <utility>
 
 namespace gcs
 {
@@ -29,6 +34,12 @@ namespace gcs
         ReificationCondition _reif_cond;
         bool _gac;
         bool _flipped_cond;
+        std::optional<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _proof_line;
+        innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition reif_cond, bool gac = false, bool flipped_cond = false);

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -95,36 +95,54 @@ namespace
     }
 }
 
-auto ReifiedLinearInequality::install(Propagators & propagators, State & state, ProofModel * const optional_model) && -> void
+auto ReifiedLinearInequality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    optional<pair<optional<ProofLine>, optional<ProofLine>>> proof_lines, proof_lines_swapped;
-    if (optional_model) {
-        WPBSum terms;
-        for (auto & [c, v] : _coeff_vars.terms)
-            terms += c * v;
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-        overloaded{
-            [&](const reif::MustHold &) {
-                proof_lines = pair{*optional_model->add_constraint("ReifiedLinearInequality", "unconditional less than", terms <= _value, nullopt), nullopt};
-            },
-            [&](const reif::MustNotHold &) {
-                proof_lines = pair{*optional_model->add_constraint("ReifiedLinearInequality", "unconditional greater than", terms >= _value + 1_i, nullopt), nullopt};
-            },
-            [&](const reif::If & cond) {
-                proof_lines = pair{*optional_model->add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
-            },
-            [&](const reif::NotIf & cond) {
-                proof_lines = pair{*optional_model->add_constraint("ReifiedLinearInequality", "greater than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
-            },
-            [&](const reif::Iff & cond) {
-                proof_lines = pair{
-                    *optional_model->add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
-                    optional_model->add_constraint("ReifiedLinearInequality", "greater than option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
-            }}
-            .visit(_reif_cond);
+    if (optional_model)
+        define_proof_model(*optional_model);
 
-        proof_lines_swapped = pair{proof_lines->second, proof_lines->first};
-    }
+    install_propagators(propagators);
+}
+
+auto ReifiedLinearInequality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _evaluated_cond = initial_state.test_reification_condition(_reif_cond);
+    return true;
+}
+
+auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
+{
+    WPBSum terms;
+    for (auto & [c, v] : _coeff_vars.terms)
+        terms += c * v;
+
+    overloaded{
+        [&](const reif::MustHold &) {
+            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional less than", terms <= _value, nullopt), nullopt};
+        },
+        [&](const reif::MustNotHold &) {
+            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional greater than", terms >= _value + 1_i, nullopt), nullopt};
+        },
+        [&](const reif::If & cond) {
+            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+        },
+        [&](const reif::NotIf & cond) {
+            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "greater than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+        },
+        [&](const reif::Iff & cond) {
+            _proof_lines = pair{
+                *model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
+                model.add_constraint("ReifiedLinearInequality", "greater than option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
+        }}
+        .visit(_reif_cond);
+}
+
+auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> void
+{
+    auto proof_lines = _proof_lines;
+    auto proof_lines_swapped = pair{_proof_lines.second, _proof_lines.first};
 
     auto [sanitised_cv, modifier] = tidy_up_linear(_coeff_vars);
 
@@ -228,14 +246,14 @@ auto ReifiedLinearInequality::install(Propagators & propagators, State & state, 
 
                             if (min_possible > value + modifier) {
                                 // cannot possibly hold
-                                auto just = [&](const ReasonFunction &) { return justify_cond(state, sanitised_cv, *logger, proof_lines.value()); };
+                                auto just = [&](const ReasonFunction &) { return justify_cond(state, sanitised_cv, *logger, proof_lines); };
                                 if (reif.set_not_cond_if_must_not_hold)
                                     inference.infer(logger, ! reif.cond, JustifyExplicitlyThenRUP{just}, generic_reason(state, vars));
                                 return PropagatorState::DisableUntilBacktrack;
                             }
                             else if (max_possible <= value + modifier) {
                                 // must definitely hold
-                                auto just = [&](const ReasonFunction &) { return justify_cond(state, sanitised_neg_cv, *logger, proof_lines_swapped.value()); };
+                                auto just = [&](const ReasonFunction &) { return justify_cond(state, sanitised_neg_cv, *logger, proof_lines_swapped); };
                                 if (reif.set_cond_if_must_hold)
                                     inference.infer(logger, reif.cond, JustifyExplicitlyThenRUP{just}, generic_reason(state, vars));
                                 else if (reif.set_not_cond_if_must_hold)
@@ -253,7 +271,7 @@ auto ReifiedLinearInequality::install(Propagators & propagators, State & state, 
             },
                 sanitised_cv, sanitised_neg_cv);
         }}
-        .visit(state.test_reification_condition(_reif_cond));
+        .visit(_evaluated_cond);
 }
 
 auto ReifiedLinearInequality::s_exprify(const std::string & name, const ProofModel * const model) const -> std::string

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -4,11 +4,14 @@
 #include <gcs/constraint.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/propagators-fwd.hh>
-#include <gcs/innards/state-fwd.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/reification.hh>
 
 #include <memory>
+#include <optional>
+#include <utility>
 
 namespace gcs
 {
@@ -27,6 +30,12 @@ namespace gcs
         WeightedSum _coeff_vars;
         Integer _value;
         ReificationCondition _reif_cond;
+        std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _proof_lines;
+        innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit ReifiedLinearInequality(WeightedSum coeff_vars, Integer value, ReificationCondition cond);

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -47,168 +47,178 @@ namespace
         return result;
     }
 
-    auto install_and_or_or(Propagators & propagators, const State & initial_state,
-        ProofModel * const optional_model,
-        const Literals & _lits, const Literal & _full_reif,
-        const string & name) -> void
+    auto install_propagators_logical(Propagators & propagators, const Literals & lits,
+        const Literal & full_reif, LiteralIs reif_state, const string & name) -> void
     {
-        auto reif_state = initial_state.test_literal(_full_reif);
         using enum LiteralIs;
 
         if (reif_state == DefinitelyTrue) {
             // definitely true, just force all the literals
-            propagators.install_initialiser([full_reif = _full_reif, lits = _lits](
+            propagators.install_initialiser([full_reif = full_reif, lits = lits](
                                                 const State &, auto & inference, ProofLogger * const logger) {
                 for (auto & l : lits)
                     inference.infer(logger, l, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{full_reif}}; }});
             });
-
-            if (optional_model) {
-                for (auto & l : _lits)
-                    optional_model->add_constraint("Logical", "cnf", Literals{l});
-            }
+            return;
         }
-        else {
-            Triggers triggers;
-            bool saw_false = false;
-            for (auto & l : _lits)
-                overloaded{
-                    [&](const IntegerVariableCondition & cond) {
-                        switch (cond.op) {
-                            using enum VariableConditionOperator;
-                        case Equal:
-                        case NotEqual:
-                            triggers.on_change.push_back(cond.var);
-                            break;
-                        case Less:
-                        case GreaterEqual:
-                            triggers.on_bounds.push_back(cond.var);
-                            break;
-                        }
-                    },
-                    [&](const TrueLiteral &) {
-                    },
-                    [&](const FalseLiteral &) {
-                        saw_false = true;
-                    }}
-                    .visit(l);
 
-            if (saw_false) {
-                // we saw a false literal, the reif variable must be forced off and
-                // then we don't do anything else
-                propagators.install_initialiser([full_reif = _full_reif](
-                                                    const State &, auto & inference, ProofLogger * const logger) -> void {
-                    inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ReasonFunction{});
-                });
-
-                if (optional_model) {
-                    optional_model->add_constraint("Logical", "saw reif false", Literals{! _full_reif});
-                }
-            }
-            else {
-                propagators.install([lits = _lits, full_reif = _full_reif](
-                                        const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                    switch (state.test_literal(full_reif)) {
-                    case DefinitelyTrue: {
-                        for (auto & l : lits)
-                            inference.infer(logger, l, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{full_reif}}; }});
-                        return PropagatorState::DisableUntilBacktrack;
+        Triggers triggers;
+        bool saw_false = false;
+        for (auto & l : lits)
+            overloaded{
+                [&](const IntegerVariableCondition & cond) {
+                    switch (cond.op) {
+                        using enum VariableConditionOperator;
+                    case Equal:
+                    case NotEqual:
+                        triggers.on_change.push_back(cond.var);
+                        break;
+                    case Less:
+                    case GreaterEqual:
+                        triggers.on_bounds.push_back(cond.var);
+                        break;
                     }
-
-                    case DefinitelyFalse: {
-                        bool any_false = false;
-                        optional<Literal> undecided1;
-
-                        for (auto & l : lits)
-                            switch (state.test_literal(l)) {
-                            case DefinitelyTrue: break;
-                            case DefinitelyFalse: any_false = true; break;
-                            case Undecided:
-                                if (undecided1)
-                                    return PropagatorState::Enable;
-                                else
-                                    undecided1 = l;
-                            }
-
-                        if (any_false)
-                            return PropagatorState::DisableUntilBacktrack;
-                        else if (! undecided1) {
-                            // literals are all true, but reif is false
-                            Reason why;
-                            for (auto & lit : lits)
-                                why.push_back(lit);
-                            why.push_back(! full_reif);
-                            inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return why; }});
-                            return PropagatorState::Enable;
-                        }
-                        else {
-                            Reason why;
-                            for (auto & l : lits)
-                                if (l != *undecided1)
-                                    why.push_back(l);
-                            why.push_back(! full_reif);
-                            inference.infer(logger, ! *undecided1, JustifyUsingRUP{}, ReasonFunction{[=]() { return why; }});
-                            return PropagatorState::DisableUntilBacktrack;
-                        }
-                    }
-
-                    case Undecided: {
-                        optional<Literal> any_false;
-                        bool all_true = true;
-
-                        for (auto & l : lits)
-                            switch (state.test_literal(l)) {
-                            case DefinitelyTrue: break;
-                            case DefinitelyFalse:
-                                any_false = l;
-                                all_true = false;
-                                break;
-                            case Undecided: all_true = false; break;
-                            }
-
-                        if (any_false) {
-                            inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{! *any_false}}; }});
-                            return PropagatorState::DisableUntilBacktrack;
-                        }
-                        else if (all_true) {
-                            auto justf = [&](const ReasonFunction & reason) {
-                                for (auto & l : lits)
-                                    logger->emit_rup_proof_line_under_reason(reason,
-                                        WPBSum{} + 1_i * l >= 1_i, ProofLevel::Temporary);
-                            };
-                            inference.infer(logger, full_reif, JustifyExplicitlyThenRUP{justf}, ReasonFunction{[=]() {
-                                vector<ProofLiteral> reason_lits{};
-                                for (auto & l : lits)
-                                    reason_lits.emplace_back(l);
-                                return Reason(reason_lits.begin(), reason_lits.end());
-                            }});
-                            return PropagatorState::DisableUntilBacktrack;
-                        }
-                        else
-                            return PropagatorState::Enable;
-                    }
-                    }
-
-                    throw NonExhaustiveSwitch{};
                 },
-                    triggers, name);
+                [&](const TrueLiteral &) {
+                },
+                [&](const FalseLiteral &) {
+                    saw_false = true;
+                }}
+                .visit(l);
 
-                if (optional_model) {
-                    if (DefinitelyFalse != reif_state) {
-                        WPBSum forward;
-                        for (auto & l : _lits)
-                            forward += 1_i * PseudoBooleanTerm{l};
-                        optional_model->add_constraint("Logical", "if condition", forward >= Integer(_lits.size()), HalfReifyOnConjunctionOf{_full_reif});
+        if (saw_false) {
+            // we saw a false literal, the reif variable must be forced off and
+            // then we don't do anything else
+            propagators.install_initialiser([full_reif = full_reif](
+                                                const State &, auto & inference, ProofLogger * const logger) -> void {
+                inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ReasonFunction{});
+            });
+            return;
+        }
+
+        propagators.install([lits = lits, full_reif = full_reif](
+                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            switch (state.test_literal(full_reif)) {
+            case DefinitelyTrue: {
+                for (auto & l : lits)
+                    inference.infer(logger, l, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{full_reif}}; }});
+                return PropagatorState::DisableUntilBacktrack;
+            }
+
+            case DefinitelyFalse: {
+                bool any_false = false;
+                optional<Literal> undecided1;
+
+                for (auto & l : lits)
+                    switch (state.test_literal(l)) {
+                    case DefinitelyTrue: break;
+                    case DefinitelyFalse: any_false = true; break;
+                    case Undecided:
+                        if (undecided1)
+                            return PropagatorState::Enable;
+                        else
+                            undecided1 = l;
                     }
 
-                    Literals reverse;
-                    for (auto & l : _lits)
-                        reverse.push_back(! l);
-                    reverse.push_back(_full_reif);
-                    optional_model->add_constraint("Logical", "if not condition", move(reverse));
+                if (any_false)
+                    return PropagatorState::DisableUntilBacktrack;
+                else if (! undecided1) {
+                    // literals are all true, but reif is false
+                    Reason why;
+                    for (auto & lit : lits)
+                        why.push_back(lit);
+                    why.push_back(! full_reif);
+                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return why; }});
+                    return PropagatorState::Enable;
+                }
+                else {
+                    Reason why;
+                    for (auto & l : lits)
+                        if (l != *undecided1)
+                            why.push_back(l);
+                    why.push_back(! full_reif);
+                    inference.infer(logger, ! *undecided1, JustifyUsingRUP{}, ReasonFunction{[=]() { return why; }});
+                    return PropagatorState::DisableUntilBacktrack;
                 }
             }
+
+            case Undecided: {
+                optional<Literal> any_false;
+                bool all_true = true;
+
+                for (auto & l : lits)
+                    switch (state.test_literal(l)) {
+                    case DefinitelyTrue: break;
+                    case DefinitelyFalse:
+                        any_false = l;
+                        all_true = false;
+                        break;
+                    case Undecided: all_true = false; break;
+                    }
+
+                if (any_false) {
+                    inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{! *any_false}}; }});
+                    return PropagatorState::DisableUntilBacktrack;
+                }
+                else if (all_true) {
+                    auto justf = [&](const ReasonFunction & reason) {
+                        for (auto & l : lits)
+                            logger->emit_rup_proof_line_under_reason(reason,
+                                WPBSum{} + 1_i * l >= 1_i, ProofLevel::Temporary);
+                    };
+                    inference.infer(logger, full_reif, JustifyExplicitlyThenRUP{justf}, ReasonFunction{[=]() {
+                        vector<ProofLiteral> reason_lits{};
+                        for (auto & l : lits)
+                            reason_lits.emplace_back(l);
+                        return Reason(reason_lits.begin(), reason_lits.end());
+                    }});
+                    return PropagatorState::DisableUntilBacktrack;
+                }
+                else
+                    return PropagatorState::Enable;
+            }
+            }
+
+            throw NonExhaustiveSwitch{};
+        },
+            triggers, name);
+    }
+
+    auto define_proof_model_logical(ProofModel & model, const Literals & lits,
+        const Literal & full_reif, LiteralIs reif_state) -> void
+    {
+        using enum LiteralIs;
+
+        if (reif_state == DefinitelyTrue) {
+            for (auto & l : lits)
+                model.add_constraint("Logical", "cnf", Literals{l});
+            return;
         }
+
+        bool saw_false = false;
+        for (auto & l : lits)
+            overloaded{
+                [&](const FalseLiteral &) { saw_false = true; },
+                [&](const auto &) {}}
+                .visit(l);
+
+        if (saw_false) {
+            model.add_constraint("Logical", "saw reif false", Literals{! full_reif});
+            return;
+        }
+
+        if (DefinitelyFalse != reif_state) {
+            WPBSum forward;
+            for (auto & l : lits)
+                forward += 1_i * PseudoBooleanTerm{l};
+            model.add_constraint("Logical", "if condition", forward >= Integer(lits.size()), HalfReifyOnConjunctionOf{full_reif});
+        }
+
+        Literals reverse;
+        for (auto & l : lits)
+            reverse.push_back(! l);
+        reverse.push_back(full_reif);
+        model.add_constraint("Logical", "if not condition", move(reverse));
     }
 }
 
@@ -235,7 +245,29 @@ auto And::clone() const -> unique_ptr<Constraint>
 
 auto And::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    install_and_or_or(propagators, initial_state, optional_model, _lits, _full_reif, "and");
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto And::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _reif_state = initial_state.test_literal(_full_reif);
+    return true;
+}
+
+auto And::define_proof_model(ProofModel & model) -> void
+{
+    define_proof_model_logical(model, _lits, _full_reif, _reif_state);
+}
+
+auto And::install_propagators(Propagators & propagators) -> void
+{
+    install_propagators_logical(propagators, _lits, _full_reif, _reif_state, "and");
 }
 
 auto And::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
@@ -274,11 +306,35 @@ auto Or::clone() const -> unique_ptr<Constraint>
 
 auto Or::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    auto lits = _lits;
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Or::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _reif_state = initial_state.test_literal(! _full_reif);
+    return true;
+}
+
+auto Or::define_proof_model(ProofModel & model) -> void
+{
+    Literals lits = _lits;
     for (auto & l : lits)
         l = ! l;
+    define_proof_model_logical(model, move(lits), ! _full_reif, _reif_state);
+}
 
-    install_and_or_or(propagators, initial_state, optional_model, lits, ! _full_reif, "or");
+auto Or::install_propagators(Propagators & propagators) -> void
+{
+    Literals lits = _lits;
+    for (auto & l : lits)
+        l = ! l;
+    install_propagators_logical(propagators, move(lits), ! _full_reif, _reif_state, "or");
 }
 
 auto Or::s_exprify(const string & name, const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/logical.hh
+++ b/gcs/constraints/logical.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
@@ -21,6 +22,11 @@ namespace gcs
     private:
         const innards::Literals _lits;
         const innards::Literal _full_reif;
+        innards::LiteralIs _reif_state = innards::LiteralIs::Undecided;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         // Equivalent to And([var != 0 : var in vars], full_reif != 0)
@@ -47,6 +53,11 @@ namespace gcs
     private:
         const innards::Literals _lits;
         const innards::Literal _full_reif;
+        innards::LiteralIs _reif_state = innards::LiteralIs::Undecided;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         // Equivalent to Or([var != 0 : var in vars], full_reif != 0)

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -56,38 +56,53 @@ auto ArrayMinMax::clone() const -> unique_ptr<Constraint>
     return make_unique<ArrayMinMax>(_vars, _result, _min);
 }
 
-auto ArrayMinMax::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto ArrayMinMax::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto ArrayMinMax::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     if (_vars.empty())
         throw UnexpectedException{"not sure how min and max are defined over an empty array"};
+    return true;
+}
 
+auto ArrayMinMax::define_proof_model(ProofModel & model) -> void
+{
+    // (for min) each var >= result, i.e. var - result >= 0
+    for (const auto & v : _vars) {
+        model.add_constraint("ArrayMinMax", "result compared to value", WPBSum{} + (_min ? 1_i : -1_i) * v + (_min ? -1_i : 1_i) * _result >= 0_i, nullopt);
+    }
+
+    WPBSum al1_selector;
+
+    // (for min) f_i <-> var[i] <= result, i.e. var - result <= 0
+    for (const auto & [id, var] : enumerate(_vars)) {
+        auto selector = model.create_proof_flag(format("arrayminmax{}", id));
+        _selectors.push_back(selector);
+        model.add_constraint("ArrayMinMax", "result is this value", WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result <= 0_i, {{selector}});
+        model.add_constraint("ArrayMinMax", "result is this value", WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result >= 1_i, {{! selector}});
+        al1_selector += 1_i * selector;
+    }
+
+    // sum f_i >= 1
+    model.add_constraint("ArrayMinMax", "result is one of the values", al1_selector >= 1_i);
+}
+
+auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
+{
     Triggers triggers{.on_change = {_result}};
     for (const auto & v : _vars)
         triggers.on_change.emplace_back(v);
 
-    vector<ProofFlag> selectors;
-    if (optional_model) {
-        // (for min) each var >= result, i.e. var - result >= 0
-        for (const auto & v : _vars) {
-            optional_model->add_constraint("ArrayMinMax", "result compared to value", WPBSum{} + (_min ? 1_i : -1_i) * v + (_min ? -1_i : 1_i) * _result >= 0_i, nullopt);
-        }
-
-        WPBSum al1_selector;
-
-        // (for min) f_i <-> var[i] <= result, i.e. var - result <= 0
-        for (const auto & [id, var] : enumerate(_vars)) {
-            auto selector = optional_model->create_proof_flag(format("arrayminmax{}", id));
-            selectors.push_back(selector);
-            optional_model->add_constraint("ArrayMinMax", "result is this value", WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result <= 0_i, {{selector}});
-            optional_model->add_constraint("ArrayMinMax", "result is this value", WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result >= 1_i, {{! selector}});
-            al1_selector += 1_i * selector;
-        }
-
-        // sum f_i >= 1
-        optional_model->add_constraint("ArrayMinMax", "result is one of the values", al1_selector >= 1_i);
-    }
-
-    propagators.install([vars = _vars, result = _result, min = _min, selectors = selectors](
+    propagators.install([vars = _vars, result = _result, min = _min, selectors = _selectors](
                             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         // result <= upper bound of each vars
         for (auto & var : vars) {

--- a/gcs/constraints/min_max.hh
+++ b/gcs/constraints/min_max.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MIN_MAX_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/variable_id.hh>
 
 #include <vector>
@@ -27,6 +28,11 @@ namespace gcs
             const std::vector<IntegerVariableID> _vars;
             IntegerVariableID _result;
             bool _min;
+            std::vector<innards::ProofFlag> _selectors;
+
+            virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+            virtual auto define_proof_model(innards::ProofModel &) -> void override;
+            virtual auto install_propagators(innards::Propagators &) -> void override;
 
         public:
             explicit ArrayMinMax(std::vector<IntegerVariableID> vars, const IntegerVariableID result, bool min);

--- a/gcs/constraints/minus.cc
+++ b/gcs/constraints/minus.cc
@@ -44,18 +44,29 @@ auto Minus::clone() const -> unique_ptr<Constraint>
     return make_unique<Minus>(_a, _b, _result);
 }
 
-auto Minus::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto Minus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Minus::define_proof_model(ProofModel & model) -> void
+{
+    _sum_line = model.add_constraint("Minus", "sum", WPBSum{} + 1_i * _a + -1_i * _b == 1_i * _result);
+}
+
+auto Minus::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
     triggers.on_bounds.insert(triggers.on_change.end(), {_a, _b, _result});
 
-    pair<optional<ProofLine>, optional<ProofLine>> sum_line;
-    if (optional_model) {
-        sum_line = optional_model->add_constraint("Minus", "sum", WPBSum{} + 1_i * _a + -1_i * _b == 1_i * _result);
-    }
-
     propagators.install(
-        [a = _a, b = _b, result = _result, sum_line = sum_line](
+        [a = _a, b = _b, result = _result, sum_line = _sum_line](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             return propagate_plus(a, -b, result, state, inference, logger, sum_line);
         },

--- a/gcs/constraints/minus.hh
+++ b/gcs/constraints/minus.hh
@@ -2,7 +2,11 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MINUS_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/variable_id.hh>
+
+#include <optional>
+#include <utility>
 
 namespace gcs
 {
@@ -15,6 +19,10 @@ namespace gcs
     {
     private:
         IntegerVariableID _a, _b, _result;
+        std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
+
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Minus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result);

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -50,6 +50,57 @@ auto NValue::clone() const -> unique_ptr<Constraint>
 
 auto NValue::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto NValue::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    for (const auto & var : _vars) {
+        for (auto v : initial_state.each_value_immutable(var))
+            _possible_values.emplace(v, list<IntegerVariableID>{}).first->second.push_back(var);
+    }
+    return true;
+}
+
+auto NValue::define_proof_model(ProofModel & model) -> void
+{
+    list<ProofFlag> flags;
+    for (auto [v, vars] : _possible_values) {
+        auto flag = model.create_proof_flag("nvalue");
+        WPBSum forward;
+        for (auto & var : vars)
+            forward += 1_i * (var == v);
+        forward += 1_i * ! flag;
+        model.add_constraint("NValue", "forward sum", forward >= 1_i);
+
+        WPBSum reverse;
+        for (auto & var : vars)
+            reverse += 1_i * (var != v);
+        reverse += Integer(vars.size()) * flag;
+        model.add_constraint("NValue", "reverse sum", reverse >= Integer(vars.size()));
+
+        flags.push_back(flag);
+    }
+
+    WPBSum forward, reverse;
+    for (auto & flag : flags) {
+        forward += 1_i * flag;
+        reverse += -1_i * flag;
+    }
+    forward += -1_i * _n_values;
+    reverse += 1_i * _n_values;
+    model.add_constraint("NValue", "forward total", forward >= 0_i);
+    model.add_constraint("NValue", "reverse total", reverse >= 0_i);
+}
+
+auto NValue::install_propagators(Propagators & propagators) -> void
+{
     Triggers triggers;
     triggers.on_bounds.emplace_back(_n_values);
     triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
@@ -80,42 +131,6 @@ auto NValue::install(Propagators & propagators, State & initial_state, ProofMode
         return PropagatorState::Enable;
     },
         triggers, "nvalue");
-
-    if (optional_model) {
-        map<Integer, list<IntegerVariableID>> all_possible_values;
-        for (const auto & var : _vars) {
-            for (auto v : initial_state.each_value_immutable(var))
-                all_possible_values.emplace(v, list<IntegerVariableID>{}).first->second.push_back(var);
-        }
-
-        list<ProofFlag> flags;
-        for (auto [v, vars] : all_possible_values) {
-            auto flag = optional_model->create_proof_flag("nvalue");
-            WPBSum forward;
-            for (auto & var : vars)
-                forward += 1_i * (var == v);
-            forward += 1_i * ! flag;
-            optional_model->add_constraint("NValue", "forward sum", forward >= 1_i);
-
-            WPBSum reverse;
-            for (auto & var : vars)
-                reverse += 1_i * (var != v);
-            reverse += Integer(vars.size()) * flag;
-            optional_model->add_constraint("NValue", "reverse sum", reverse >= Integer(vars.size()));
-
-            flags.push_back(flag);
-        }
-
-        WPBSum forward, reverse;
-        for (auto & flag : flags) {
-            forward += 1_i * flag;
-            reverse += -1_i * flag;
-        }
-        forward += -1_i * _n_values;
-        reverse += 1_i * _n_values;
-        optional_model->add_constraint("NValue", "forward total", forward >= 0_i);
-        optional_model->add_constraint("NValue", "reverse total", reverse >= 0_i);
-    }
 }
 
 auto NValue::s_exprify(const string & name, const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/n_value.hh
+++ b/gcs/constraints/n_value.hh
@@ -4,6 +4,8 @@
 #include <gcs/constraint.hh>
 #include <gcs/variable_id.hh>
 
+#include <list>
+#include <map>
 #include <vector>
 
 namespace gcs
@@ -20,6 +22,11 @@ namespace gcs
     private:
         IntegerVariableID _n_values;
         const std::vector<IntegerVariableID> _vars;
+        std::map<Integer, std::list<IntegerVariableID>> _possible_values;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit NValue(const IntegerVariableID &, std::vector<IntegerVariableID>);

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -62,24 +62,36 @@ auto ParityOdd::clone() const -> unique_ptr<Constraint>
     return make_unique<ParityOdd>(_lits);
 }
 
-auto ParityOdd::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto ParityOdd::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    if (optional_model) {
-        PseudoBooleanTerm acc = FalseLiteral{}, not_acc = TrueLiteral{};
-        for (const auto & l : _lits) {
-            auto new_acc = optional_model->create_proof_flag("xor");
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-            optional_model->add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
-            optional_model->add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
-            optional_model->add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
-            optional_model->add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
+    if (optional_model)
+        define_proof_model(*optional_model);
 
-            acc = new_acc;
-            not_acc = ! new_acc;
-        }
-        optional_model->add_constraint("ParityOdd", "result", WPBSum{} + 1_i * acc >= 1_i);
+    install_propagators(propagators);
+}
+
+auto ParityOdd::define_proof_model(ProofModel & model) -> void
+{
+    PseudoBooleanTerm acc = FalseLiteral{}, not_acc = TrueLiteral{};
+    for (const auto & l : _lits) {
+        auto new_acc = model.create_proof_flag("xor");
+
+        model.add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
+        model.add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
+        model.add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
+        model.add_constraint("ParityOdd", "xor", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
+
+        acc = new_acc;
+        not_acc = ! new_acc;
     }
+    model.add_constraint("ParityOdd", "result", WPBSum{} + 1_i * acc >= 1_i);
+}
 
+auto ParityOdd::install_propagators(Propagators & propagators) -> void
+{
     Triggers triggers;
     for (const auto & l : _lits) {
         overloaded{

--- a/gcs/constraints/parity.hh
+++ b/gcs/constraints/parity.hh
@@ -20,6 +20,9 @@ namespace gcs
     private:
         const innards::Literals _lits;
 
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
     public:
         // Equivalent to ParityOdd([var != 0 : var in vars])
         explicit ParityOdd(const std::vector<IntegerVariableID> & vars);

--- a/gcs/constraints/plus.cc
+++ b/gcs/constraints/plus.cc
@@ -44,18 +44,29 @@ auto Plus::clone() const -> unique_ptr<Constraint>
     return make_unique<Plus>(_a, _b, _result);
 }
 
-auto Plus::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto Plus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Plus::define_proof_model(ProofModel & model) -> void
+{
+    _sum_line = model.add_constraint("Plus", "sum", WPBSum{} + 1_i * _a + 1_i * _b == 1_i * _result);
+}
+
+auto Plus::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
     triggers.on_bounds.insert(triggers.on_change.end(), {_a, _b, _result});
 
-    pair<optional<ProofLine>, optional<ProofLine>> sum_line;
-    if (optional_model) {
-        sum_line = optional_model->add_constraint("Plus", "sum", WPBSum{} + 1_i * _a + 1_i * _b == 1_i * _result);
-    }
-
     propagators.install(
-        [a = _a, b = _b, result = _result, sum_line = sum_line](
+        [a = _a, b = _b, result = _result, sum_line = _sum_line](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             return propagate_plus(a, b, result, state, inference, logger, sum_line);
         },

--- a/gcs/constraints/plus.hh
+++ b/gcs/constraints/plus.hh
@@ -20,6 +20,10 @@ namespace gcs
     {
     private:
         IntegerVariableID _a, _b, _result;
+        std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
+
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Plus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result);

--- a/gcs/constraints/regular.cc
+++ b/gcs/constraints/regular.cc
@@ -373,55 +373,70 @@ auto Regular::clone() const -> unique_ptr<Constraint>
 
 auto Regular::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    vector<vector<ProofFlag>> state_at_pos_flags;
-    if (optional_model) {
-        // Make 2D array of flags: state_at_pos_flags[i][q] means the DFA is in state q when it receives the
-        // input value from vars[i], with an extra row of flags for the state after the last transition.
-        // NB: Might be easier to have a 1D array of ProofOnlyIntegerVariables, but making literals of these is
-        // awkward currently. (TODO ?)
-        for (size_t idx = 0; idx <= _vars.size(); ++idx) {
-            WPBSum exactly_1_true{};
-            state_at_pos_flags.emplace_back();
-            for (long q = 0; q < _num_states; ++q) {
-                state_at_pos_flags[idx].emplace_back(optional_model->create_proof_flag(format("state{}is{}", idx, q)));
-                exactly_1_true += 1_i * state_at_pos_flags[idx][q];
-            }
-            optional_model->add_constraint(move(exactly_1_true) == 1_i);
-        }
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-        // State at pos 0 is 0
-        optional_model->add_constraint(WPBSum{} + 1_i * state_at_pos_flags[0][0] >= 1_i);
-        // State at pos n is one of the final states
-        WPBSum pos_n_states;
-        for (const auto & f : _final_states) {
-            pos_n_states += 1_i * state_at_pos_flags[_vars.size()][f];
-        }
-        optional_model->add_constraint(move(pos_n_states) >= 1_i);
+    if (optional_model)
+        define_proof_model(*optional_model);
 
-        for (size_t idx = 0; idx < _vars.size(); ++idx) {
-            for (long q = 0; q < _num_states; ++q) {
-                for (const auto & val : symbols()) {
-                    auto new_q = find_transition(_transitions[q], val);
-                    if (new_q == -1) {
-                        // No transition for q, v, so constrain ~(state_i = q /\ X_i = val)
-                        optional_model->add_constraint(
-                            WPBSum{} + 1_i * (_vars[idx] != val) + (1_i * ! state_at_pos_flags[idx][q]) >= 1_i);
-                    }
-                    else {
-                        optional_model->add_constraint(
-                            WPBSum{} + 1_i * ! state_at_pos_flags[idx][q] + 1_i * (_vars[idx] != val) + 1_i * state_at_pos_flags[idx + 1][new_q] >= 1_i);
-                    }
+    install_propagators(propagators);
+}
+
+auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _graph_idx = initial_state.add_constraint_state(RegularGraph(_vars.size(), _num_states));
+    return true;
+}
+
+auto Regular::define_proof_model(ProofModel & model) -> void
+{
+    // Make 2D array of flags: state_at_pos_flags[i][q] means the DFA is in state q when it receives the
+    // input value from vars[i], with an extra row of flags for the state after the last transition.
+    // NB: Might be easier to have a 1D array of ProofOnlyIntegerVariables, but making literals of these is
+    // awkward currently. (TODO ?)
+    for (size_t idx = 0; idx <= _vars.size(); ++idx) {
+        WPBSum exactly_1_true{};
+        _state_at_pos_flags.emplace_back();
+        for (long q = 0; q < _num_states; ++q) {
+            _state_at_pos_flags[idx].emplace_back(model.create_proof_flag(format("state{}is{}", idx, q)));
+            exactly_1_true += 1_i * _state_at_pos_flags[idx][q];
+        }
+        model.add_constraint(move(exactly_1_true) == 1_i);
+    }
+
+    // State at pos 0 is 0
+    model.add_constraint(WPBSum{} + 1_i * _state_at_pos_flags[0][0] >= 1_i);
+    // State at pos n is one of the final states
+    WPBSum pos_n_states;
+    for (const auto & f : _final_states) {
+        pos_n_states += 1_i * _state_at_pos_flags[_vars.size()][f];
+    }
+    model.add_constraint(move(pos_n_states) >= 1_i);
+
+    for (size_t idx = 0; idx < _vars.size(); ++idx) {
+        for (long q = 0; q < _num_states; ++q) {
+            for (const auto & val : symbols()) {
+                auto new_q = find_transition(_transitions[q], val);
+                if (new_q == -1) {
+                    // No transition for q, v, so constrain ~(state_i = q /\ X_i = val)
+                    model.add_constraint(
+                        WPBSum{} + 1_i * (_vars[idx] != val) + (1_i * ! _state_at_pos_flags[idx][q]) >= 1_i);
+                }
+                else {
+                    model.add_constraint(
+                        WPBSum{} + 1_i * ! _state_at_pos_flags[idx][q] + 1_i * (_vars[idx] != val) + 1_i * _state_at_pos_flags[idx + 1][new_q] >= 1_i);
                 }
             }
         }
     }
+}
 
+auto Regular::install_propagators(Propagators & propagators) -> void
+{
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
 
-    RegularGraph graph = RegularGraph(_vars.size(), _num_states);
-    auto graph_idx = initial_state.add_constraint_state(graph);
-    propagators.install([v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = graph_idx, flags = state_at_pos_flags, sr = _short_reasons](
+    propagators.install([v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = _graph_idx, flags = move(_state_at_pos_flags), sr = _short_reasons](
                             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         propagate_regular(v, n, t, f, flags, g, state, inference, logger, sr);
         return PropagatorState::Enable;

--- a/gcs/constraints/regular.hh
+++ b/gcs/constraints/regular.hh
@@ -3,6 +3,8 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/extensional.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
 #include <unordered_map>
 #include <vector>
@@ -26,8 +28,14 @@ namespace gcs
         const std::vector<long> _final_states;
         const bool _short_reasons;
         std::vector<Integer> _symbols;
+        std::vector<std::vector<innards::ProofFlag>> _state_at_pos_flags;
+        innards::ConstraintStateHandle _graph_idx;
 
         [[nodiscard]] auto symbols() const -> const std::vector<Integer> &;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Regular(std::vector<IntegerVariableID> vars,

--- a/gcs/constraints/table.cc
+++ b/gcs/constraints/table.cc
@@ -182,24 +182,43 @@ namespace gcs
     using ::operator!=;
 }
 
-auto NegativeTable::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto NegativeTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto NegativeTable::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     visit([&](auto & tuples) {
         for (auto & tuple : depointinate(tuples))
             if (tuple.size() != _vars.size())
                 throw UnexpectedException{"table size mismatch"};
+    },
+        _tuples);
+    return true;
+}
 
-        if (optional_model) {
-            for (auto & t : depointinate(tuples)) {
-                Literals lits;
-                for (const auto & [idx, v] : enumerate(_vars))
-                    add_literal(lits, v, t[idx]);
-                optional_model->add_constraint("NegativeTable", "forbidden", move(lits));
-            }
+auto NegativeTable::define_proof_model(ProofModel & model) -> void
+{
+    visit([&](auto & tuples) {
+        for (auto & t : depointinate(tuples)) {
+            Literals lits;
+            for (const auto & [idx, v] : enumerate(_vars))
+                add_literal(lits, v, t[idx]);
+            model.add_constraint("NegativeTable", "forbidden", move(lits));
         }
     },
         _tuples);
+}
 
+auto NegativeTable::install_propagators(Propagators & propagators) -> void
+{
     Triggers triggers;
     for (auto & v : _vars)
         triggers.on_change.emplace_back(v);

--- a/gcs/constraints/table.hh
+++ b/gcs/constraints/table.hh
@@ -43,6 +43,10 @@ namespace gcs
         const std::vector<IntegerVariableID> _vars;
         ExtensionalTuples _tuples;
 
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
     public:
         explicit NegativeTable(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
 


### PR DESCRIPTION
Rebase of #106 onto current main, with bug fixes and skip list.

Original PR (#106) was 48 commits behind main and had several issues from
stale conflict resolution. This branch replays the splits onto fresh main,
preserving Phil's per-constraint commit structure and authorship.

## Changes vs #106

### Constraints split (20)
Abs, Among, ReifiedCompareLessThanOrMaybeEqual, Count, NDimensionalElement,
ReifiedEquals, Inverse, Knapsack, Logical (And/Or), ArrayMinMax, Minus,
NValue, ParityOdd, Plus, Regular, GACAllDifferent, VCAllDifferent,
ReifiedLinearEquality, ReifiedLinearInequality, NegativeTable.

### Constraints intentionally NOT split (option 7A)
Pure delegators and tightly-coupled constraints whose installation can't
be cleanly partitioned: GACArithmetic, AtMostOneSmartTable, LexSmartTable,
Table, In, MultBC, SmartTable, CircuitPrevent, CircuitSCC. These keep
their original install() — adding the split for them either creates dead
code or pushes everything into prepare(), neither of which serves the
goal of eventually collapsing install() to a base-class one-liner.

### Bug fixes vs #106
- VCAllDifferent: define_proof_model now uses _sanitised_vars (the
  original used the moved-from _vars and would have produced an empty
  encoding).
- abs.cc / logical.cc: carried over the main-side
  Reason → HalfReifyOnConjunctionOf change (218b76d) that #106's conflict
  resolution silently dropped.
- regular.cc: removed stale unused \`using std::cmp_not_equal/getline/rename\`
  declarations from #106's bad merge.

### Style cleanups vs #106
- All new private members use the _ prefix consistently
- Reified constraints use header default-init for _evaluated_cond
  (= innards::evaluated_reif::Deactivated{}) rather than constructor-body
- Method order in .cc is install → prepare → define_proof_model →
  install_propagators (execution order)
- Missing <optional>/<utility>/<map> includes added explicitly

## What is intentionally NOT carried over from #106

For full transparency, the following changes from #106 are absent here.
None are bug-for-bug regressions — each was either a deliberate skip or
already on main via a different route.

### Skipped per option 7A (8 constraints, 7 commits)
The install() splits for these constraints exist on Phil's branch but
are not replayed here:
- GACArithmetic (33077c5)
- AtMostOneSmartTable (5c11863)
- In (7d030dd)
- LexSmartTable (6f55af3)
- CircuitPrevent + CircuitSCC (7bd9ec2)
- Table (the Table half of f1a0f0e — NegativeTable is split)
- MultBC (c4d2568) — including the public-promoted MultBC::ChannellingData
- SmartTable (cb087ad)

If we want to split these constraints in future, the helpers they delegate
to (define_and_install_table, CircuitBase::set_up, SmartTable::install)
need to be refactored into define + install halves first.

### Python test runner change dropped
Commit c0210c0 wrapped each test invocation in test/capture_encodings.py
to optionally pass per-test arg sets, specifically so linear_test could
be run four times (le/eq/ne/ge). proper-lex-propagator already splits
linear_test into per-operator ctest entries (commit bf9b780), which
makes the runner-side change unnecessary. Dropped to keep the runner
simpler.

### Squashed / folded into other commits
- 7ff89bf \"ReifiedCompareLessThanOrMaybeEqual::install()\" — added only
  a comment lampshading the deactivated-default workaround. Our version
  uses header default-init so the workaround isn't needed.
- 886e571 \"clang format\" — its fixes are folded into the individual
  per-constraint commits.
- 79d5874 \"Repositioning s_sxprify()\" — folded into the Plus split.
- f44753d \"NDimensionalElement::prepare() testing for contradiction
  first\" — folded into the NDimensionalElement split.

### Merge bookkeeping not replayed
ffec93e, 347b9e7, b22ccdd, 6202e96 (conflict-resolution fixup) — pure
git plumbing or already-on-main pulls.

## Test results
ctest --preset release: 92/92 passed (~119s)