### PR TITLE
Move table install logic into Table constraint

### DIFF
--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -45,12 +45,23 @@ auto GACArithmetic<op_>::clone() const -> unique_ptr<Constraint>
 template <ArithmeticOperator op_>
 auto GACArithmetic<op_>::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+template <ArithmeticOperator op_>
+auto GACArithmetic<op_>::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    vector<vector<Integer>> permitted;
     bool v2_zero_is_ok = (op_ != ArithmeticOperator::Div && op_ != ArithmeticOperator::Mod);
 
-    vector<vector<Integer>> permitted;
-
-    for (const auto & v1 : initial_state.each_value_immutable(_v1))
-        for (const auto & v2 : initial_state.each_value_immutable(_v2))
+    for (const auto & v1 : initial_state.each_value_immutable(_v1)) {
+        for (const auto & v2 : initial_state.each_value_immutable(_v2)) {
             if ((v2_zero_is_ok || v2 != 0_i) && initial_state.in_domain(_v2, v2)) {
                 Integer r = 0_i;
                 switch (op_) {
@@ -64,8 +75,22 @@ auto GACArithmetic<op_>::install(Propagators & propagators, State & initial_stat
                 if (initial_state.in_domain(_result, r))
                     permitted.push_back(vector{v1, v2, r});
             }
+        }
+    }
+    _table = std::make_unique<Table>(vector{_v1, _v2, _result}, move(permitted));
+    return _table->prepare(propagators, initial_state, optional_model);
+}
 
-    propagators.define_and_install_table(initial_state, optional_model, vector{_v1, _v2, _result}, move(permitted), "arithmetic");
+template <ArithmeticOperator op_>
+auto GACArithmetic<op_>::define_proof_model(ProofModel & model) -> void
+{
+    _table->define_proof_model(model);
+}
+
+template <ArithmeticOperator op_>
+auto GACArithmetic<op_>::install_propagators(Propagators & propagators) -> void
+{
+    _table->install_propagators(propagators);
 }
 
 namespace gcs::innards

--- a/gcs/constraints/arithmetic.hh
+++ b/gcs/constraints/arithmetic.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ARITHMETIC_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/table.hh>
 #include <gcs/variable_id.hh>
 
 namespace gcs
@@ -35,6 +36,11 @@ namespace gcs
         {
         private:
             IntegerVariableID _v1, _v2, _result;
+            std::unique_ptr<Table> _table;
+
+            virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+            virtual auto define_proof_model(innards::ProofModel &) -> void override;
+            virtual auto install_propagators(innards::Propagators &) -> void override;
 
         public:
             explicit GACArithmetic(const IntegerVariableID v1, const IntegerVariableID v2, const IntegerVariableID result);

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -23,6 +23,7 @@ using namespace gcs::innards;
 
 using std::erase_if;
 using std::move;
+using std::optional;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -62,6 +63,17 @@ auto In::clone() const -> unique_ptr<Constraint>
 
 auto In::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto In::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
     erase_if(_var_vals, [&](const IntegerVariableID & v) -> bool {
         auto const_val = initial_state.optional_single_value(v);
         if (const_val)
@@ -82,11 +94,23 @@ auto In::install(Propagators & propagators, State & initial_state, ProofModel * 
         for (auto & v : _val_vals)
             tuples.emplace_back(vector{{v}});
 
-        propagators.define_and_install_table(initial_state, optional_model, move(vars), move(tuples), "in");
+        _table = std::make_unique<Table>(move(vars), move(tuples));
+        return _table->prepare(propagators, initial_state, optional_model);
     }
     else {
         throw UnimplementedException{};
     }
+    return false;
+}
+
+auto In::define_proof_model(ProofModel & model) -> void
+{
+    _table->define_proof_model(model);
+}
+
+auto In::install_propagators(Propagators & propagators) -> void
+{
+    _table->install_propagators(propagators);
 }
 
 auto In::s_exprify(const string & name, const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/in.hh
+++ b/gcs/constraints/in.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_IN_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/table.hh>
 #include <gcs/variable_id.hh>
 
 #include <vector>
@@ -19,6 +20,11 @@ namespace gcs
         IntegerVariableID _var;
         std::vector<IntegerVariableID> _var_vals;
         std::vector<Integer> _val_vals;
+        std::unique_ptr<Table> _table;
+        
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
 
     public:
         explicit In(IntegerVariableID var, std::vector<IntegerVariableID> vars, std::vector<Integer> vals);

--- a/gcs/constraints/table.cc
+++ b/gcs/constraints/table.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/table.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -55,6 +56,36 @@ auto Table::clone() const -> unique_ptr<Constraint>
 
 namespace
 {
+    auto is_immediately_infeasible(const IntegerVariableID & var, const Integer & val) -> bool
+    {
+        return is_literally_false(var == val);
+    }
+
+    auto is_immediately_infeasible(const IntegerVariableID &, const Wildcard &) -> bool
+    {
+        return false;
+    }
+
+    auto is_immediately_infeasible(const IntegerVariableID & var, const IntegerOrWildcard & val) -> bool
+    {
+        return visit([&](const auto & val) { return is_immediately_infeasible(var, val); }, val);
+    }
+
+    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const Integer & val) -> void
+    {
+        if (! is_literally_true(var == val))
+            lits += 1_i * (var == val);
+    }
+
+    auto add_lit_unless_immediately_true(WPBSum &, const IntegerVariableID &, const Wildcard &) -> void
+    {
+    }
+
+    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const IntegerOrWildcard & val) -> void
+    {
+        return visit([&](const auto & val) { add_lit_unless_immediately_true(lits, var, val); }, val);
+    }
+
     template <typename T_>
     auto depointinate(const std::shared_ptr<const T_> & t) -> const T_ &
     {
@@ -85,14 +116,79 @@ namespace
 
 auto Table::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Table::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    bool continue_installation = true;
     visit([&](auto & tuples) {
+        if (depointinate(tuples).empty()) {
+            propagators.model_contradiction(initial_state, optional_model, "Empty table constraint from table");
+            // throw UnexpectedException{"Empty table constraint from table"};
+            continue_installation = false;
+
+            return;
+        }
         for (auto & tuple : depointinate(tuples))
             if (tuple.size() != _vars.size())
                 throw UnexpectedException{"table size mismatch"};
+        _selector = initial_state.allocate_integer_variable_with_state(0_i, Integer(depointinate(tuples).size() - 1));
     },
         _tuples);
 
-    propagators.define_and_install_table(initial_state, optional_model, vector<IntegerVariableID>{_vars}, move(_tuples), "table");
+    return continue_installation;
+}
+
+auto Table::define_proof_model(ProofModel & model) -> void
+{
+    visit([&](auto && tuples) {
+        model.set_up_integer_variable(_selector, 0_i, Integer(depointinate(tuples).size() - 1),
+            "aux_table" + to_string(_selector.index),
+            IntegerVariableProofRepresentation::DirectOnly);
+
+        // pb encoding, if necessary
+        for (const auto & [tuple_idx, tuple] : enumerate(depointinate(tuples))) {
+            // selector == tuple_idx -> /\_i vars[i] == tuple[i]
+            bool infeasible = false;
+            WPBSum lits;
+            lits += Integer(tuple.size()) * (_selector != Integer(tuple_idx));
+            for (const auto & [var_idx, var] : enumerate(_vars)) {
+                if (is_immediately_infeasible(var, tuple[var_idx]))
+                    infeasible = true;
+                else
+                    add_lit_unless_immediately_true(lits, var, tuple[var_idx]);
+            }
+            if (infeasible)
+                model.add_constraint({_selector != Integer(tuple_idx)});
+            else
+                model.add_constraint(lits >= Integer(lits.terms.size() - 1));
+        }
+    },
+        move(_tuples));
+}
+
+auto Table::install_propagators(Propagators & propagators) -> void
+{
+    visit([&](auto && tuples) {
+        Triggers triggers;
+        for (auto & v : _vars)
+            triggers.on_change.push_back(v);
+        triggers.on_change.push_back(_selector);
+
+        propagators.install([table = ExtensionalData{_selector, move(_vars), move(tuples)}](
+                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            return propagate_extensional(table, state, inference, logger);
+        },
+            triggers, "extenstional");
+    },
+        move(_tuples));
 }
 
 auto Table::s_exprify(const string & name, const innards::ProofModel * const model) const -> std::string

--- a/gcs/constraints/table.hh
+++ b/gcs/constraints/table.hh
@@ -21,11 +21,15 @@ namespace gcs
     private:
         const std::vector<IntegerVariableID> _vars;
         ExtensionalTuples _tuples;
+        SimpleIntegerVariableID _selector{0};
 
     public:
         explicit Table(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
 
         [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -18,11 +18,11 @@ using namespace gcs::innards;
 using std::atomic;
 using std::move;
 using std::optional;
-using std::to_underlying;
 using std::pair;
 using std::string;
 using std::swap;
 using std::to_string;
+using std::to_underlying;
 using std::vector;
 using std::visit;
 
@@ -127,100 +127,6 @@ auto Propagators::install(PropagationFunction && f, const Triggers & triggers, c
 auto Propagators::install_initialiser(InitialisationFunction && f) -> void
 {
     _imp->initialisation_functions.emplace_back(move(f));
-}
-
-namespace
-{
-    auto is_immediately_infeasible(const IntegerVariableID & var, const Integer & val) -> bool
-    {
-        return is_literally_false(var == val);
-    }
-
-    auto is_immediately_infeasible(const IntegerVariableID &, const Wildcard &) -> bool
-    {
-        return false;
-    }
-
-    auto is_immediately_infeasible(const IntegerVariableID & var, const IntegerOrWildcard & val) -> bool
-    {
-        return visit([&](const auto & val) { return is_immediately_infeasible(var, val); }, val);
-    }
-
-    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const Integer & val) -> void
-    {
-        if (! is_literally_true(var == val))
-            lits += 1_i * (var == val);
-    }
-
-    auto add_lit_unless_immediately_true(WPBSum &, const IntegerVariableID &, const Wildcard &) -> void
-    {
-    }
-
-    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const IntegerOrWildcard & val) -> void
-    {
-        return visit([&](const auto & val) { add_lit_unless_immediately_true(lits, var, val); }, val);
-    }
-
-    template <typename T_>
-    auto depointinate(const std::shared_ptr<const T_> & t) -> const T_ &
-    {
-        return *t;
-    }
-
-    template <typename T_>
-    auto depointinate(const T_ & t) -> const T_ &
-    {
-        return t;
-    }
-}
-
-auto Propagators::define_and_install_table(State & state, ProofModel * const optional_model, const vector<IntegerVariableID> & vars,
-    ExtensionalTuples permitted, const string & x) -> void
-{
-    visit([&](auto && permitted) {
-        if (depointinate(permitted).empty()) {
-            model_contradiction(state, optional_model, "Empty table constraint from " + x);
-            return;
-        }
-
-        auto selector = state.allocate_integer_variable_with_state(0_i, Integer(depointinate(permitted).size() - 1));
-        if (optional_model)
-            optional_model->set_up_integer_variable(selector, 0_i, Integer(depointinate(permitted).size() - 1),
-                "aux_table" + to_string(selector.index),
-                IntegerVariableProofRepresentation::DirectOnly);
-
-        // pb encoding, if necessary
-        if (optional_model) {
-            for (const auto & [tuple_idx, tuple] : enumerate(depointinate(permitted))) {
-                // selector == tuple_idx -> /\_i vars[i] == tuple[i]
-                bool infeasible = false;
-                WPBSum lits;
-                lits += Integer(tuple.size()) * (selector != Integer(tuple_idx));
-                for (const auto & [var_idx, var] : enumerate(vars)) {
-                    if (is_immediately_infeasible(var, tuple[var_idx]))
-                        infeasible = true;
-                    else
-                        add_lit_unless_immediately_true(lits, var, tuple[var_idx]);
-                }
-                if (infeasible)
-                    optional_model->add_constraint({selector != Integer(tuple_idx)});
-                else
-                    optional_model->add_constraint(lits >= Integer(lits.terms.size() - 1));
-            }
-        }
-
-        Triggers triggers;
-        for (auto & v : vars)
-            triggers.on_change.push_back(v);
-        triggers.on_change.push_back(selector);
-
-        install([table = ExtensionalData{selector, move(vars), move(permitted)}](
-                    const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return propagate_extensional(table, state, inference, logger);
-        },
-            triggers, "extenstional");
-    },
-        move(permitted));
 }
 
 auto Propagators::initialise(State & state, ProofLogger * const logger) const -> bool

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -184,8 +184,8 @@ namespace gcs::innards
          *
          * \sa gcs::innards::propagate_extensional()
          */
-        auto define_and_install_table(State &, innards::ProofModel * const, const std::vector<IntegerVariableID> &,
-            ExtensionalTuples, const std::string & name) -> void;
+        // auto define_and_install_table(State &, innards::ProofModel * const, const std::vector<IntegerVariableID> &,
+        //     ExtensionalTuples, const std::string & name) -> void;
 
         ///@}
 

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -176,17 +176,6 @@ namespace gcs::innards
          */
         auto install_initialiser(InitialisationFunction &&) -> void;
 
-        /**
-         * Install a propagator for the provided table constraint, and take
-         * care of definitions if want_definitions() is true. This is used by
-         * Table, but also by various other constraints that turn themselves
-         * into table-like constraints.
-         *
-         * \sa gcs::innards::propagate_extensional()
-         */
-        // auto define_and_install_table(State &, innards::ProofModel * const, const std::vector<IntegerVariableID> &,
-        //     ExtensionalTuples, const std::string & name) -> void;
-
         ///@}
 
         /**


### PR DESCRIPTION
This code removes table-specific code from propagators and puts it into table.cc.  It uses that to do a proper split of prepare -> define proof model -> install propagators.  With  that done, we can use a table to model the `In` and `GACArithmetic` constraints.