### PR TITLE
Add add_trigger_for helper and adopt it at four call sites

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(glasgow_constraint_solver
         constraints/increasing.cc
         constraints/innards/recover_am1.cc
         constraints/innards/reified_state.cc
+        constraints/innards/triggers.cc
         constraints/inverse.cc
         constraints/knapsack.cc
         constraints/lex.cc

--- a/gcs/constraints/innards/reified_dispatcher.hh
+++ b/gcs/constraints/innards/reified_dispatcher.hh
@@ -3,6 +3,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_REIFIED_DISPATCHER_HH
 
 #include <gcs/constraints/innards/reified_state.hh>
+#include <gcs/constraints/innards/triggers.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
@@ -113,7 +114,7 @@ namespace gcs::innards
             return;
         if (std::holds_alternative<evaluated_reif::Undecided>(initial_evaluated)) {
             const auto & undecided = std::get<evaluated_reif::Undecided>(initial_evaluated);
-            triggers.on_change.push_back(undecided.cond.var);
+            add_trigger_for(triggers, undecided.cond);
         }
 
         propagators.install(

--- a/gcs/constraints/innards/triggers.cc
+++ b/gcs/constraints/innards/triggers.cc
@@ -1,0 +1,27 @@
+#include <gcs/constraints/innards/triggers.hh>
+
+#include <util/overloaded.hh>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+auto gcs::innards::add_trigger_for(Triggers & triggers, const Literal & lit) -> void
+{
+    overloaded{
+        [&](const IntegerVariableCondition & cond) {
+            switch (cond.op) {
+                using enum VariableConditionOperator;
+            case Equal:
+            case NotEqual:
+                triggers.on_change.push_back(cond.var);
+                break;
+            case Less:
+            case GreaterEqual:
+                triggers.on_bounds.push_back(cond.var);
+                break;
+            }
+        },
+        [](const TrueLiteral &) {},
+        [](const FalseLiteral &) {}}
+        .visit(lit);
+}

--- a/gcs/constraints/innards/triggers.hh
+++ b/gcs/constraints/innards/triggers.hh
@@ -1,0 +1,21 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_TRIGGERS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_TRIGGERS_HH
+
+#include <gcs/innards/literal.hh>
+#include <gcs/innards/propagators.hh>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Register the most precise wake-up trigger for the given Literal.
+     *
+     * - `Equal` / `NotEqual`     -> `triggers.on_change`
+     * - `Less` / `GreaterEqual`  -> `triggers.on_bounds`
+     * - `TrueLiteral` / `FalseLiteral` -> no-op
+     *
+     * \ingroup Innards
+     */
+    auto add_trigger_for(Triggers & triggers, const Literal & lit) -> void;
+}
+
+#endif

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/linear/linear_equality.hh>
 #include <gcs/constraints/innards/reified_state.hh>
+#include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/exception.hh>
@@ -309,7 +310,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 Triggers triggers;
                 for (auto & [_, v] : _coeff_vars.terms)
                     triggers.on_change.push_back(v);
-                triggers.on_change.push_back(reif.cond.var);
+                add_trigger_for(triggers, reif.cond);
 
                 visit([&, modifier = modifier](const auto & sanitised_cv) {
                     propagators.install([sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line, all_vars = move(all_vars)](

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/logical.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -64,27 +65,11 @@ namespace
 
         Triggers triggers;
         bool saw_false = false;
-        for (auto & l : lits)
-            overloaded{
-                [&](const IntegerVariableCondition & cond) {
-                    switch (cond.op) {
-                        using enum VariableConditionOperator;
-                    case Equal:
-                    case NotEqual:
-                        triggers.on_change.push_back(cond.var);
-                        break;
-                    case Less:
-                    case GreaterEqual:
-                        triggers.on_bounds.push_back(cond.var);
-                        break;
-                    }
-                },
-                [&](const TrueLiteral &) {
-                },
-                [&](const FalseLiteral &) {
-                    saw_false = true;
-                }}
-                .visit(l);
+        for (auto & l : lits) {
+            add_trigger_for(triggers, l);
+            if (holds_alternative<FalseLiteral>(l))
+                saw_false = true;
+        }
 
         if (saw_false) {
             // we saw a false literal, the reif variable must be forced off and

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/parity.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -6,8 +7,6 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
-
-#include <util/overloaded.hh>
 
 #include <optional>
 #include <sstream>
@@ -93,25 +92,8 @@ auto ParityOdd::define_proof_model(ProofModel & model) -> void
 auto ParityOdd::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
-    for (const auto & l : _lits) {
-        overloaded{
-            [&](const TrueLiteral &) {},
-            [&](const FalseLiteral &) {},
-            [&](const IntegerVariableCondition & cond) {
-                switch (cond.op) {
-                    using enum VariableConditionOperator;
-                case NotEqual:
-                case Equal:
-                    triggers.on_change.push_back(cond.var);
-                    break;
-                case Less:
-                case GreaterEqual:
-                    triggers.on_bounds.push_back(cond.var);
-                    break;
-                }
-            }}
-            .visit(l);
-    }
+    for (const auto & l : _lits)
+        add_trigger_for(triggers, l);
 
     propagators.install([lits = _lits](
                             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {


### PR DESCRIPTION
## Summary
- New helper `gcs::innards::add_trigger_for(Triggers &, const Literal &)` in `gcs/constraints/innards/triggers.hh` that registers the most precise wake-up trigger for a literal: `Equal`/`NotEqual` → `on_change`, `Less`/`GreaterEqual` → `on_bounds`, `TrueLiteral`/`FalseLiteral` no-op.
- Adopted at the two existing inline dispatches (`logical.cc`, `parity.cc`) — straight refactor, identical behaviour.
- Adopted in `install_reified_dispatcher` (`reified_dispatcher.hh`) and the `Undecided` branch of `ReifiedLinearEquality` (`linear_equality.cc`), which previously pushed `cond.var` onto `on_change` regardless of the operator. Behaviour change: bounds-only reification operators (`<`, `>=`) will now wake the propagator only when bounds change rather than on any domain change. Sound; potentially a small perf win.

The single `Literal` overload covers `IntegerVariableCondition` arguments via the implicit variant conversion.

Closes #115.

## Test plan
- [x] `cmake --build --preset release` clean.
- [x] `ctest` 138/138 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)