### PR TITLE
Detect overflow in Integer arithmetic operations (#109)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(glasgow_constraint_solver
         constraints/table.cc
         constraints/value_precede.cc
         innards/extensional_utils.cc
+        innards/integer_overflow.cc
         innards/integer_variable_state.cc
         innards/literal.cc
         innards/power.cc
@@ -220,6 +221,10 @@ if(GCS_BUILD_TESTS)
     add_executable(interval_set_test innards/interval_set_test.cc)
     target_link_libraries(interval_set_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME interval_set_test COMMAND $<TARGET_FILE:interval_set_test>)
+
+    add_executable(integer_test integer_test.cc)
+    target_link_libraries(integer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME integer_test COMMAND $<TARGET_FILE:integer_test>)
 
     add_executable(state_test innards/state_test.cc)
     target_link_libraries(state_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/innards/integer_overflow.cc
+++ b/gcs/innards/integer_overflow.cc
@@ -1,0 +1,34 @@
+#include <gcs/innards/integer_overflow.hh>
+
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/core.h>
+using fmt::format;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+IntegerOverflow::IntegerOverflow(const char * op, long long a, long long b) :
+    UnexpectedException{format("Integer overflow: {} {} {}", a, op, b)}
+{
+}
+
+IntegerOverflow::IntegerOverflow(const char * op, long long a) :
+    UnexpectedException{format("Integer overflow: {}{}", op, a)}
+{
+}
+
+auto innards::throw_integer_overflow(const char * op, long long a, long long b) -> void
+{
+    throw IntegerOverflow{op, a, b};
+}
+
+auto innards::throw_integer_overflow(const char * op, long long a) -> void
+{
+    throw IntegerOverflow{op, a};
+}

--- a/gcs/innards/integer_overflow.hh
+++ b/gcs/innards/integer_overflow.hh
@@ -1,0 +1,23 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_INTEGER_OVERFLOW_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_INTEGER_OVERFLOW_HH
+
+#include <gcs/exception.hh>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Thrown when an Integer arithmetic operation would overflow,
+     * divide by zero, or otherwise produce an undefined result.
+     */
+    class IntegerOverflow : public UnexpectedException
+    {
+    public:
+        IntegerOverflow(const char * op, long long a, long long b);
+        IntegerOverflow(const char * op, long long a);
+    };
+
+    [[noreturn]] auto throw_integer_overflow(const char * op, long long a, long long b) -> void;
+    [[noreturn]] auto throw_integer_overflow(const char * op, long long a) -> void;
+}
+
+#endif

--- a/gcs/integer.hh
+++ b/gcs/integer.hh
@@ -1,7 +1,10 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INTEGER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INTEGER_HH
 
+#include <gcs/innards/integer_overflow.hh>
+
 #include <cstddef>
+#include <cstdlib>
 #include <functional>
 #include <limits>
 #include <ostream>
@@ -63,26 +66,30 @@ namespace gcs
 
         [[nodiscard]] constexpr auto operator<=>(const Integer &) const = default;
 
-        auto operator++() -> Integer &
+        constexpr auto operator++() -> Integer &
         {
+            if (raw_value == std::numeric_limits<long long>::max())
+                innards::throw_integer_overflow("++", raw_value);
             ++raw_value;
             return *this;
         }
 
-        auto operator++(int) -> Integer
+        constexpr auto operator++(int) -> Integer
         {
             Integer old = *this;
             operator++();
             return old;
         }
 
-        auto operator--() -> Integer &
+        constexpr auto operator--() -> Integer &
         {
+            if (raw_value == std::numeric_limits<long long>::min())
+                innards::throw_integer_overflow("--", raw_value);
             --raw_value;
             return *this;
         }
 
-        auto operator--(int) -> Integer
+        constexpr auto operator--(int) -> Integer
         {
             Integer old = *this;
             operator--();
@@ -112,43 +119,64 @@ namespace gcs
 
     [[nodiscard]] constexpr inline auto operator+(Integer a, Integer b) -> Integer
     {
-        return Integer{a.raw_value + b.raw_value};
+        long long r;
+        if (__builtin_add_overflow(a.raw_value, b.raw_value, &r))
+            innards::throw_integer_overflow("+", a.raw_value, b.raw_value);
+        return Integer{r};
     }
 
     constexpr inline auto operator+=(Integer & a, Integer b) -> Integer &
     {
-        a.raw_value += b.raw_value;
+        if (__builtin_add_overflow(a.raw_value, b.raw_value, &a.raw_value))
+            innards::throw_integer_overflow("+=", a.raw_value, b.raw_value);
         return a;
     }
 
     [[nodiscard]] constexpr inline auto operator-(Integer a, Integer b) -> Integer
     {
-        return Integer{a.raw_value - b.raw_value};
+        long long r;
+        if (__builtin_sub_overflow(a.raw_value, b.raw_value, &r))
+            innards::throw_integer_overflow("-", a.raw_value, b.raw_value);
+        return Integer{r};
     }
 
     constexpr inline auto operator-=(Integer & a, Integer b) -> Integer &
     {
-        a.raw_value -= b.raw_value;
+        if (__builtin_sub_overflow(a.raw_value, b.raw_value, &a.raw_value))
+            innards::throw_integer_overflow("-=", a.raw_value, b.raw_value);
         return a;
     }
 
     [[nodiscard]] constexpr inline auto operator*(Integer a, Integer b) -> Integer
     {
-        return Integer{a.raw_value * b.raw_value};
+        long long r;
+        if (__builtin_mul_overflow(a.raw_value, b.raw_value, &r))
+            innards::throw_integer_overflow("*", a.raw_value, b.raw_value);
+        return Integer{r};
     }
 
     [[nodiscard]] constexpr inline auto operator/(Integer a, Integer b) -> Integer
     {
+        if (b.raw_value == 0)
+            innards::throw_integer_overflow("/", a.raw_value, b.raw_value);
+        if (a.raw_value == std::numeric_limits<long long>::min() && b.raw_value == -1)
+            innards::throw_integer_overflow("/", a.raw_value, b.raw_value);
         return Integer{a.raw_value / b.raw_value};
     }
 
     [[nodiscard]] constexpr inline auto operator%(Integer a, Integer b) -> Integer
     {
+        if (b.raw_value == 0)
+            innards::throw_integer_overflow("%", a.raw_value, b.raw_value);
+        if (a.raw_value == std::numeric_limits<long long>::min() && b.raw_value == -1)
+            innards::throw_integer_overflow("%", a.raw_value, b.raw_value);
         return Integer{a.raw_value % b.raw_value};
     }
 
     [[nodiscard]] constexpr inline auto operator-(Integer a) -> Integer
     {
+        if (a.raw_value == std::numeric_limits<long long>::min())
+            innards::throw_integer_overflow("-", a.raw_value);
         return Integer{-a.raw_value};
     }
 
@@ -181,6 +209,8 @@ namespace gcs
      */
     inline auto abs(Integer i) -> Integer
     {
+        if (i.raw_value == std::numeric_limits<long long>::min())
+            innards::throw_integer_overflow("abs", i.raw_value);
         return Integer{std::llabs(i.raw_value)};
     }
 

--- a/gcs/integer_test.cc
+++ b/gcs/integer_test.cc
@@ -1,0 +1,90 @@
+#include <gcs/innards/integer_overflow.hh>
+#include <gcs/integer.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <climits>
+
+using namespace gcs;
+using gcs::innards::IntegerOverflow;
+
+TEST_CASE("Integer arithmetic on normal values")
+{
+    REQUIRE((3_i + 4_i).raw_value == 7);
+    REQUIRE((10_i - 4_i).raw_value == 6);
+    REQUIRE((6_i * 7_i).raw_value == 42);
+    REQUIRE((20_i / 3_i).raw_value == 6);
+    REQUIRE((20_i % 3_i).raw_value == 2);
+    REQUIRE((-5_i).raw_value == -5);
+    REQUIRE(abs(Integer{-7}).raw_value == 7);
+
+    Integer x{5};
+    x += 3_i;
+    REQUIRE(x.raw_value == 8);
+    x -= 2_i;
+    REQUIRE(x.raw_value == 6);
+
+    Integer y{0};
+    REQUIRE((++y).raw_value == 1);
+    REQUIRE((y++).raw_value == 1);
+    REQUIRE(y.raw_value == 2);
+    REQUIRE((--y).raw_value == 1);
+    REQUIRE((y--).raw_value == 1);
+    REQUIRE(y.raw_value == 0);
+}
+
+TEST_CASE("Integer overflow on addition")
+{
+    REQUIRE_THROWS_AS(Integer::max_value() + 1_i, IntegerOverflow);
+    REQUIRE_THROWS_AS(Integer::min_value() + Integer{-1}, IntegerOverflow);
+
+    Integer x = Integer::max_value();
+    REQUIRE_THROWS_AS(x += 1_i, IntegerOverflow);
+}
+
+TEST_CASE("Integer overflow on subtraction")
+{
+    REQUIRE_THROWS_AS(Integer::min_value() - 1_i, IntegerOverflow);
+    REQUIRE_THROWS_AS(Integer::max_value() - Integer{-1}, IntegerOverflow);
+
+    Integer x = Integer::min_value();
+    REQUIRE_THROWS_AS(x -= 1_i, IntegerOverflow);
+}
+
+TEST_CASE("Integer overflow on multiplication")
+{
+    REQUIRE_THROWS_AS(Integer::max_value() * 2_i, IntegerOverflow);
+    REQUIRE_THROWS_AS(Integer::min_value() * 2_i, IntegerOverflow);
+    REQUIRE_THROWS_AS(Integer::min_value() * Integer{-1}, IntegerOverflow);
+}
+
+TEST_CASE("Integer division edge cases")
+{
+    REQUIRE_THROWS_AS(7_i / 0_i, IntegerOverflow);
+    REQUIRE_THROWS_AS(0_i / 0_i, IntegerOverflow);
+    REQUIRE_THROWS_AS(Integer::min_value() / Integer{-1}, IntegerOverflow);
+
+    REQUIRE_THROWS_AS(7_i % 0_i, IntegerOverflow);
+    REQUIRE_THROWS_AS(Integer::min_value() % Integer{-1}, IntegerOverflow);
+}
+
+TEST_CASE("Integer unary minus and abs edge cases")
+{
+    REQUIRE_THROWS_AS(-Integer::min_value(), IntegerOverflow);
+    REQUIRE_THROWS_AS(abs(Integer::min_value()), IntegerOverflow);
+}
+
+TEST_CASE("Integer increment and decrement at limits")
+{
+    Integer at_max = Integer::max_value();
+    REQUIRE_THROWS_AS(++at_max, IntegerOverflow);
+
+    Integer also_at_max = Integer::max_value();
+    REQUIRE_THROWS_AS(also_at_max++, IntegerOverflow);
+
+    Integer at_min = Integer::min_value();
+    REQUIRE_THROWS_AS(--at_min, IntegerOverflow);
+
+    Integer also_at_min = Integer::min_value();
+    REQUIRE_THROWS_AS(also_at_min--, IntegerOverflow);
+}


### PR DESCRIPTION
## Summary

Closes #109. `Integer` previously delegated arithmetic to a raw `long long` with no overflow detection, so silent wrap-around produced wrong answers instead of a clear error.

- Wrap `+`, `-`, `*`, `+=`, `-=` with `__builtin_{add,sub,mul}_overflow`
- Add explicit edge-case checks for `/`, `%`, unary `-`, `abs`, `++`, `--` (divide-by-zero, `LLONG_MIN / -1`, `-LLONG_MIN`, `abs(LLONG_MIN)`, increment/decrement at the limits)
- On any overflow, throw a new `gcs::innards::IntegerOverflow` exception (modelled on `UnexpectedException`) carrying the operator and operands in `what()`
- New `gcs/integer_test.cc` (Catch2, 35 assertions across 7 test cases) covers normal arithmetic plus every overflow site

## Performance

Three deterministic benchmarks, three runs each, average:

| Benchmark | Baseline | Instrumented | Δ |
|---|---|---|---|
| `qap` | 6.356s | 6.377s | +0.32% |
| `langford 11` | 12.843s | 12.845s | +0.02% |
| `skyscrapers` | 41.376s | 41.098s | −0.67% |

Within run-to-run noise — branch prediction hides the checks on the hot path.

## Out of scope (follow-up)

Two sites currently bypass `Integer`'s operators by reaching into `raw_value` directly:

- `gcs/innards/power.cc:15` — `(1_i).raw_value << i.raw_value`; the existing `i >= digits` guard prevents UB but the shift itself isn't overflow-checked
- `gcs/constraints/arithmetic.cc:73` — `pow(v1.raw_value, v2.raw_value)` then `llroundl`; floating-point pow with int operands can overflow silently

Both should move to checked integer operations in a separate change.

## Test plan

- [x] `ctest -j 32` — all 160 tests pass
- [x] `integer_test` — 35 assertions across 7 test cases, all overflow paths exercised
- [x] Sanitize preset still clean (UBSan no longer fires on signed-overflow because the throws happen first)
- [x] Performance regression check — within noise on three benchmarks