### PR TITLE
Fix Power constraint precision and overflow bugs

### DIFF
--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/arithmetic.hh>
+#include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
@@ -14,15 +15,14 @@
 #include <fmt/ostream.h>
 #endif
 
-#include <cmath>
+#include <optional>
 #include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
-using std::llroundl;
 using std::move;
-using std::pow;
+using std::optional;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -63,17 +63,17 @@ auto GACArithmetic<op_>::prepare(Propagators & propagators, State & initial_stat
     for (const auto & v1 : initial_state.each_value_immutable(_v1)) {
         for (const auto & v2 : initial_state.each_value_immutable(_v2)) {
             if ((v2_zero_is_ok || v2 != 0_i) && initial_state.in_domain(_v2, v2)) {
-                Integer r = 0_i;
+                optional<Integer> r;
                 switch (op_) {
                 case ArithmeticOperator::Plus: r = v1 + v2; break;
                 case ArithmeticOperator::Minus: r = v1 - v2; break;
                 case ArithmeticOperator::Times: r = v1 * v2; break;
                 case ArithmeticOperator::Div: r = v1 / v2; break;
                 case ArithmeticOperator::Mod: r = v1 % v2; break;
-                case ArithmeticOperator::Power: r = Integer{llroundl(pow(v1.raw_value, v2.raw_value))}; break;
+                case ArithmeticOperator::Power: r = checked_integer_power(v1, v2); break;
                 }
-                if (initial_state.in_domain(_result, r))
-                    permitted.push_back(vector{v1, v2, r});
+                if (r && initial_state.in_domain(_result, *r))
+                    permitted.push_back(vector{v1, v2, *r});
             }
         }
     }

--- a/gcs/constraints/arithmetic.hh
+++ b/gcs/constraints/arithmetic.hh
@@ -22,6 +22,12 @@ namespace gcs
         /**
          * \brief Arithmetic constraint, constraints that `v1 op v2 = result`.
          *
+         * \warning This is a last-resort implementation: it materialises the
+         * full list of permitted (v1, v2, result) tuples in memory, so it is
+         * O(|domain(v1)| * |domain(v2)|) in space and will exhaust memory for
+         * even moderately wide domains.  Prefer one of the dedicated
+         * propagators where one exists (see the typedef-specific notes below).
+         *
          * \ingroup Constraints
          * \ingroup Innards
          * \sa gcs::Plus
@@ -52,28 +58,47 @@ namespace gcs
     }
 
     /**
-     * \brief Constrain that `v1 + v2 = result`.
+     * \brief Constrain that `v1 + v2 = result` via a materialised tuple table.
+     *
+     * \warning Memory usage is O(|domain(v1)| * |domain(v2)|).  Under normal
+     * circumstances you should use gcs::Plus, which propagates without
+     * enumerating tuples.
      *
      * \ingroup Constraints
+     * \sa gcs::Plus
      */
     using PlusGAC = innards::GACArithmetic<innards::ArithmeticOperator::Plus>;
 
     /**
-     * \brief Constrain that `v1 - v2 = result`.
+     * \brief Constrain that `v1 - v2 = result` via a materialised tuple table.
+     *
+     * \warning Memory usage is O(|domain(v1)| * |domain(v2)|).  Under normal
+     * circumstances you should use gcs::Minus, which propagates without
+     * enumerating tuples.
      *
      * \ingroup Constraints
+     * \sa gcs::Minus
      */
     using MinusGAC = innards::GACArithmetic<innards::ArithmeticOperator::Minus>;
 
     /**
-     * \brief Constrain that `v1 * v2 = result`.
+     * \brief Constrain that `v1 * v2 = result` via a materialised tuple table.
+     *
+     * \warning Memory usage is O(|domain(v1)| * |domain(v2)|).  Under normal
+     * circumstances you should use gcs::LinearEquality if one of the operands
+     * is a constant, or gcs::MultBC otherwise.
      *
      * \ingroup Constraints
+     * \sa gcs::LinearEquality
+     * \sa gcs::MultBC
      */
     using Times = innards::GACArithmetic<innards::ArithmeticOperator::Times>;
 
     /**
      * \brief Constrain that `v1 / v2 = result`.
+     *
+     * \warning Memory usage is O(|domain(v1)| * |domain(v2)|): the full tuple
+     * table is materialised, so wide variable domains will exhaust memory.
      *
      * \ingroup Constraints
      */
@@ -82,12 +107,18 @@ namespace gcs
     /**
      * \brief Constrain that `v1 % v2 = result`.
      *
+     * \warning Memory usage is O(|domain(v1)| * |domain(v2)|): the full tuple
+     * table is materialised, so wide variable domains will exhaust memory.
+     *
      * \ingroup Constraints
      */
     using Mod = innards::GACArithmetic<innards::ArithmeticOperator::Mod>;
 
     /**
      * \brief Constrain that `power(v1, v2) = result`.
+     *
+     * \warning Memory usage is O(|domain(v1)| * |domain(v2)|): the full tuple
+     * table is materialised, so wide variable domains will exhaust memory.
      *
      * \ingroup Constraints
      */

--- a/gcs/constraints/arithmetic_test.cc
+++ b/gcs/constraints/arithmetic_test.cc
@@ -28,6 +28,7 @@ using std::function;
 using std::make_optional;
 using std::mt19937;
 using std::nullopt;
+using std::optional;
 using std::pair;
 using std::random_device;
 using std::set;
@@ -80,6 +81,27 @@ namespace
     {
         static const constexpr auto name = "mod";
     };
+
+    template <>
+    struct NameOf<Power>
+    {
+        static const constexpr auto name = "power";
+    };
+
+    auto power_is_satisfying = [](int a, int b, int c) -> bool {
+        if (b == 0) return c == 1;
+        if (a == 1) return c == 1;
+        if (a == -1) return c == ((b % 2 == 0) ? 1 : -1);
+        if (b < 0) return false;
+        if (a == 0) return c == 0;
+        long long r = 1;
+        for (int i = 0; i < b; ++i) {
+            long long next;
+            if (__builtin_mul_overflow(r, static_cast<long long>(a), &next)) return false;
+            r = next;
+        }
+        return r == c;
+    };
 }
 
 template <typename Arithmetic_>
@@ -104,6 +126,50 @@ auto run_arithmetic_test(bool proofs, pair<int, int> v1_range, pair<int, int> v2
     check_results(proof_name, expected, actual);
 }
 
+auto run_power_pinned_test(bool proofs, Integer base, Integer exp, pair<long long, long long> result_range, optional<Integer> expected_result) -> void
+{
+    print(cerr, "arithmetic power pinned base={} exp={} result_range={} expected={} {}",
+        base, exp, result_range, expected_result ? std::to_string(expected_result->raw_value) : "<none>",
+        proofs ? "with proofs:" : ":");
+    cerr << flush;
+
+    Problem p;
+    auto v1 = p.create_integer_variable(base, base);
+    auto v2 = p.create_integer_variable(exp, exp);
+    auto v3 = p.create_integer_variable(Integer(result_range.first), Integer(result_range.second));
+    p.post(Power{v1, v2, v3});
+
+    auto proof_name = proofs ? make_optional<string>("arithmetic_test") : nullopt;
+
+    set<long long> actual_results;
+    solve_with(p,
+        SolveCallbacks{
+            .solution = [&](const CurrentState & s) -> bool {
+                actual_results.insert(s(v3).raw_value);
+                return true;
+            }},
+        proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}, true, false) : nullopt);
+
+    println(cerr, " got {} solutions", actual_results.size());
+
+    if (expected_result) {
+        if (actual_results.size() != 1 || *actual_results.begin() != expected_result->raw_value) {
+            println(cerr, "expected solution {}, got {}", expected_result->raw_value, actual_results);
+            throw UnexpectedException{"power pinned test produced wrong result"};
+        }
+    }
+    else {
+        if (! actual_results.empty()) {
+            println(cerr, "expected no solutions, got {}", actual_results);
+            throw UnexpectedException{"power pinned test produced unexpected solutions"};
+        }
+    }
+
+    if (proof_name)
+        if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
+            throw UnexpectedException{"veripb verification failed"};
+}
+
 auto main(int, char *[]) -> int
 {
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> data = {
@@ -113,6 +179,15 @@ auto main(int, char *[]) -> int
         {{1, 3}, {1, 3}, {1, 3}},
         {{1, 5}, {6, 8}, {-10, 10}},
         {{1, 1}, {2, 4}, {-5, 5}}};
+
+    vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> power_data = {
+        {{0, 3}, {0, 5}, {-1, 250}},
+        {{2, 4}, {0, 4}, {0, 260}},
+        {{-3, 3}, {0, 4}, {-30, 90}},
+        {{1, 1}, {-3, 3}, {-2, 2}},
+        {{-1, 1}, {-3, 3}, {-2, 2}},
+        {{0, 1}, {-2, 3}, {-1, 2}},
+        {{2, 5}, {-1, 4}, {-5, 700}}};
 
     random_device rand_dev;
     mt19937 rand(rand_dev());
@@ -129,6 +204,28 @@ auto main(int, char *[]) -> int
             run_arithmetic_test<Div>(proofs, r1, r2, r3, [](int a, int b, int c) { return 0 != b && a / b == c; });
             run_arithmetic_test<Mod>(proofs, r1, r2, r3, [](int a, int b, int c) { return 0 != b && a % b == c; });
         }
+        for (auto & [r1, r2, r3] : power_data) {
+            run_arithmetic_test<Power>(proofs, r1, r2, r3, power_is_satisfying);
+        }
+
+        // 9^19 = 1350851717672992089 is exactly representable in long long but is
+        // off-by-89 when computed via double-precision pow(); the previous bug
+        // produced 1350851717672992000.  Pin the result variable to a 90-value
+        // window bracketing both, so this exercises the bug without expanding
+        // GACArithmetic's tuple table.
+        run_power_pinned_test(proofs, 9_i, 19_i, {1350851717672992000LL, 1350851717672992089LL}, make_optional(Integer{1350851717672992089LL}));
+
+        // 10^20 overflows long long.  Constraint must be UNSAT.
+        run_power_pinned_test(proofs, 10_i, 20_i, {0, 100}, nullopt);
+
+        // Negative exponent with |base| != 1: no integer answer, so UNSAT.
+        run_power_pinned_test(proofs, 2_i, Integer{-3}, {-2, 2}, nullopt);
+
+        // 1^n = 1 for all integer n, including negative.
+        run_power_pinned_test(proofs, 1_i, Integer{-5}, {-2, 2}, make_optional(1_i));
+
+        // 0^0 = 1 by convention.
+        run_power_pinned_test(proofs, 0_i, 0_i, {-2, 2}, make_optional(1_i));
     }
 
     return EXIT_SUCCESS;

--- a/gcs/innards/power.cc
+++ b/gcs/innards/power.cc
@@ -2,15 +2,46 @@
 #include <gcs/innards/power.hh>
 
 #include <limits>
+#include <optional>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::nullopt;
 using std::numeric_limits;
+using std::optional;
 
 auto gcs::innards::power2(Integer i) -> Integer
 {
     if (i < 0_i || i.raw_value >= numeric_limits<decltype(i.raw_value)>::digits)
         throw UnimplementedException{"Would get overflow on power2"};
     return Integer{(1_i).raw_value << i.raw_value};
+}
+
+auto gcs::innards::checked_integer_power(Integer base, Integer exp) -> optional<Integer>
+{
+    if (exp == 0_i)
+        return 1_i;
+    if (base == 1_i)
+        return 1_i;
+    if (base == -1_i)
+        return ((exp.raw_value & 1) == 0) ? 1_i : -1_i;
+    if (exp < 0_i)
+        return nullopt;
+    if (base == 0_i)
+        return 0_i;
+
+    long long result = 1;
+    long long b = base.raw_value;
+    long long e = exp.raw_value;
+    while (e > 0) {
+        if (e & 1)
+            if (__builtin_mul_overflow(result, b, &result))
+                return nullopt;
+        e >>= 1;
+        if (e > 0)
+            if (__builtin_mul_overflow(b, b, &b))
+                return nullopt;
+    }
+    return Integer{result};
 }

--- a/gcs/innards/power.hh
+++ b/gcs/innards/power.hh
@@ -3,9 +3,21 @@
 
 #include <gcs/integer.hh>
 
+#include <optional>
+
 namespace gcs::innards
 {
     [[nodiscard]] auto power2(Integer i) -> Integer;
+
+    /**
+     * \brief Integer base raised to integer exponent, with overflow checking.
+     *
+     * Returns std::nullopt if the result would overflow Integer's range, or if
+     * no integer value exists for the operands (i.e. negative exponent with
+     * |base| != 1, or 0 raised to a negative power). 0^0 is taken to be 1 by
+     * convention.
+     */
+    [[nodiscard]] auto checked_integer_power(Integer base, Integer exp) -> std::optional<Integer>;
 }
 
 #endif


### PR DESCRIPTION
## Summary

Follow-up to #125 (was flagged as out-of-scope there). Fixes three pre-existing correctness bugs in `gcs::Power`.

`GACArithmetic<Power>::prepare` previously computed each tuple via `Integer{llroundl(pow(v1.raw_value, v2.raw_value))}`. Going through double-precision \`pow()\` caused:

1. **Silent precision loss above 2^53.** \`9^19 = 1350851717672992089\` fits exactly in \`long long\`, but \`pow(9.0, 19.0)\` is off by 89. The constraint propagated the wrong value, *excluding correct solutions*.
2. **UB on overflow.** \`pow(10, 20)\` returns an out-of-range double; \`llroundl\` of it is implementation-defined. On my machine it yields \`LLONG_MIN\`, allowing absurd assignments to satisfy the constraint.
3. **Wrong semantics for negative exponents.** \`pow(2, -3) = 0.125 → llroundl → 0\`, so the constraint claimed \`2^-3 == 0\`.

Despite these, \`Power\` had **no test coverage at all** (\`grep power gcs/constraints/arithmetic_test.cc\` returned nothing). It is exposed in the public API via \`gcs::Power\`, used by MiniZinc (\`fzn_glasgow.cc:484\`) and Python bindings (\`gcspy.cc:308\`).

## Changes

- New \`gcs::innards::checked_integer_power(base, exp) -> std::optional<Integer>\` in \`gcs/innards/power.{hh,cc}\`. Exponentiation by squaring using \`__builtin_mul_overflow\`; returns \`nullopt\` on overflow or when no integer answer exists.
- \`arithmetic.cc:73\` switches from \`pow()/llroundl()\` to the helper. The \`r\` slot is now \`optional<Integer>\` so unrepresentable tuples are skipped instead of producing junk.
- New tests in \`arithmetic_test.cc\`:
  - Enumerated coverage with \`run_arithmetic_test<Power>\` over small ranges, including negative bases, zero base, negative exponents, and \`0^0\`.
  - Five pinned tests with single-value \`v1\`/\`v2\` and small \`v3\` domains: \`9^19 = 1350851717672992089\` (precision regression guard, range pins to a 90-value window bracketing the buggy and correct values), \`10^20\` UNSAT, \`2^-3\` UNSAT, \`1^-5 = 1\`, \`0^0 = 1\`. All five also verified end-to-end by VeriPB.

The pinned tests use small result-domain ranges deliberately: \`GACArithmetic\` materialises one tuple per cross-product entry, so a wide bracket on the result variable would explode memory.

## Semantics for negative exponents

\`Power\` now treats \`base^exp\` for \`exp < 0\` as having an integer answer only when \`|base| == 1\`. For other bases the constraint is UNSAT for that pair (no integer satisfies it). This is a behaviour change, but the previous behaviour silently returned 0 — consistent with neither integer nor floating-point semantics.

## Out of scope

Site 1 from the #125 discussion (\`gcs/innards/power.cc:15\`'s direct \`raw_value\` shift in \`power2\`) is unchanged: the existing guard at \`i < 63\` already prevents overflow. It's a style nit, not a bug.

## Test plan

- [x] \`ctest -j 32\` — 159/159 pass
- [x] \`./build/arithmetic_test\` standalone — Power section passes including all 5 pinned regression cases
- [x] VeriPB verifies all proof outputs (\`VERIFIED COMPLETE ENUMERATION OF 1 SOLUTIONS\` / \`VERIFIED UNSATISFIABLE\` for each pinned test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)