### PR TITLE
Rewrite NegativeTable with watched literals

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -54,7 +54,8 @@ add_library(glasgow_constraint_solver
         constraints/regular.cc
         constraints/seq_precede_chain.cc
         constraints/smart_table.cc
-        constraints/table.cc
+        constraints/table/negative_table.cc
+        constraints/table/table.cc
         constraints/value_precede.cc
         innards/extensional_utils.cc
         innards/integer_overflow.cc
@@ -139,6 +140,7 @@ if(GCS_BUILD_TESTS)
     add_executable(regular_test constraints/regular_test.cc)
     add_executable(seq_precede_chain_test constraints/seq_precede_chain_test.cc)
     add_executable(smart_table_test constraints/smart_table_test.cc)
+    add_executable(negative_table_test constraints/table/negative_table_test.cc)
     add_executable(symmetric_all_different_test constraints/all_different/symmetric_all_different_test.cc)
     add_executable(table_test constraints/table_test.cc)
     add_executable(value_precede_test constraints/value_precede_test.cc)
@@ -147,7 +149,8 @@ if(GCS_BUILD_TESTS)
             abs_test all_different_test all_different_except_test among_test arithmetic_test at_most_one_test comparison_test
             count_test element_test equals_test in_test increasing_test inverse_test knapsack_test lex_test linear_test
             logical_test min_max_test mult_bc_test n_value_test parity_test
-            plus_minus_test regular_test seq_precede_chain_test smart_table_test symmetric_all_different_test table_test value_precede_test)
+            plus_minus_test regular_test seq_precede_chain_test smart_table_test symmetric_all_different_test
+            negative_table_test table_test value_precede_test)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
     endforeach()
 
@@ -190,6 +193,7 @@ if(GCS_BUILD_TESTS)
         add_test(NAME smart_table_constraint_${mode}
             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:smart_table_test> ${mode})
     endforeach()
+    add_test(NAME negative_table_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:negative_table_test>)
     add_test(NAME symmetric_all_different_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:symmetric_all_different_test>)
     add_test(NAME table_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:table_test>)
     add_test(NAME value_precede_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:value_precede_test>)

--- a/gcs/constraints/table.hh
+++ b/gcs/constraints/table.hh
@@ -1,63 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_HH
 
-#include <gcs/constraint.hh>
-#include <gcs/extensional.hh>
-#include <gcs/variable_id.hh>
-
-#include <vector>
-
-namespace gcs
-{
-    /**
-     * \brief Constrain that the specified variables are equal to one of the specified
-     * tuples.
-     *
-     * \ingroup Constraints
-     * \see SmartTable
-     */
-    class Table : public Constraint
-    {
-    private:
-        const std::vector<IntegerVariableID> _vars;
-        ExtensionalTuples _tuples;
-        SimpleIntegerVariableID _selector{0};
-
-    public:
-        explicit Table(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
-
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto clone() const -> std::unique_ptr<Constraint> override;
-
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
-    };
-
-    /**
-     * \brief Constrain that the specified variables are not equal to one of the specified
-     * tuples.
-     *
-     * \ingroup Constraints
-     */
-    class NegativeTable : public Constraint
-    {
-    private:
-        const std::vector<IntegerVariableID> _vars;
-        ExtensionalTuples _tuples;
-
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
-
-    public:
-        explicit NegativeTable(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
-
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-        virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
-    };
-}
+#include <gcs/constraints/table/negative_table.hh>
+#include <gcs/constraints/table/table.hh>
 
 #endif

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -9,6 +9,9 @@
 
 #include <util/enumerate.hh>
 
+#include <cstddef>
+#include <limits>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <utility>
@@ -25,7 +28,12 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_shared;
+using std::nullopt;
 using std::optional;
+using std::pair;
+using std::shared_ptr;
+using std::size_t;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -69,21 +77,7 @@ namespace
     {
         return visit([](auto v) { return tuple_entry_as_string(v); }, v);
     }
-}
 
-NegativeTable::NegativeTable(vector<IntegerVariableID> v, ExtensionalTuples t) :
-    _vars(move(v)),
-    _tuples(move(t))
-{
-}
-
-auto NegativeTable::clone() const -> unique_ptr<Constraint>
-{
-    return make_unique<NegativeTable>(_vars, ExtensionalTuples{_tuples});
-}
-
-namespace
-{
     auto add_literal(Literals & lits, const IntegerVariableID & var, const Integer & val)
     {
         lits.emplace_back(var != val);
@@ -97,10 +91,7 @@ namespace
     {
         visit([&](const auto & val) { add_literal(lits, var, val); }, val);
     }
-}
 
-namespace
-{
     auto operator==(const IntegerVariableID &, const Wildcard &) -> Literal
     {
         return TrueLiteral{};
@@ -126,6 +117,17 @@ namespace gcs
 {
     using ::operator==;
     using ::operator!=;
+}
+
+NegativeTable::NegativeTable(vector<IntegerVariableID> v, ExtensionalTuples t) :
+    _vars(move(v)),
+    _tuples(move(t))
+{
+}
+
+auto NegativeTable::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<NegativeTable>(_vars, ExtensionalTuples{_tuples});
 }
 
 auto NegativeTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
@@ -163,43 +165,139 @@ auto NegativeTable::define_proof_model(ProofModel & model) -> void
         _tuples);
 }
 
+namespace
+{
+    constexpr size_t no_watch = std::numeric_limits<size_t>::max();
+}
+
 auto NegativeTable::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
     for (auto & v : _vars)
         triggers.on_change.emplace_back(v);
 
-    visit([&](const auto & tuples) {
-        propagators.install([vars = move(_vars), tuples = move(tuples)](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            for (auto & t : depointinate(tuples)) {
-                bool falsified = false;
-                optional<Literal> l1, l2;
-                for (const auto & [idx, v] : enumerate(vars)) {
-                    switch (state.test_literal(v == t[idx])) {
-                        using enum LiteralIs;
-                    case DefinitelyFalse:
-                        falsified = true;
-                        break;
-                    case DefinitelyTrue:
-                        break;
-                    case Undecided:
-                        if (! l1)
-                            l1 = (v != t[idx]);
-                        else if (! l2)
-                            l2 = (v != t[idx]);
+    // Watches are non-backtrackable: when a watch moves during search, leaving it moved
+    // after backtrack is sound (the new position is still a valid watch — its literal
+    // can only become "more not-false" as the state relaxes) and avoids restoration
+    // overhead. Using shared_ptr so the initialiser and main propagator share storage.
+    auto watches = make_shared<vector<pair<size_t, size_t>>>();
+
+    visit([&, this](auto && tuples) {
+        // Init: walk every tuple, find two watch positions, propagate units, raise
+        // contradictions. A position is unusable as a watch iff `var == t[pos]` is
+        // currently DefinitelyTrue — this captures both the "var is forced to t[pos]"
+        // case and the "t[pos] is a wildcard" case (since `var == Wildcard` overloads
+        // to TrueLiteral, which tests as DefinitelyTrue).
+        propagators.install_initialiser(
+            [vars = _vars, tuples = tuples, watches = watches](
+                const State & state, auto & inference, ProofLogger * const logger) -> void {
+                const auto & tuple_data = depointinate(tuples);
+                watches->reserve(tuple_data.size());
+
+                for (size_t ti = 0; ti < tuple_data.size(); ++ti) {
+                    const auto & t = tuple_data[ti];
+
+                    auto find_unbroken = [&](size_t skip) -> optional<size_t> {
+                        for (size_t p = 0; p < vars.size(); ++p) {
+                            if (p == skip)
+                                continue;
+                            if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
+                                return p;
+                        }
+                        return nullopt;
+                    };
+
+                    auto w1 = find_unbroken(no_watch);
+                    if (! w1) {
+                        inference.contradiction(logger, JustifyUsingRUP{},
+                            generic_reason(state, vars));
+                    }
+
+                    auto w2 = find_unbroken(*w1);
+                    if (! w2) {
+                        // Unit clause: vars[*w1] != t[*w1] is the only possibly-true
+                        // disjunct, so it must hold.
+                        inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{},
+                            generic_reason(state, vars));
+                        // Mark the tuple as already handled — both watches at the same
+                        // position will read as broken on every subsequent fire, and
+                        // any rescue search will discover the inference is now redundant.
+                        watches->emplace_back(*w1, *w1);
+                    }
+                    else {
+                        watches->emplace_back(*w1, *w2);
                     }
                 }
+            });
 
-                if (! falsified) {
-                    if (! l1)
-                        inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, vars));
-                    else if (! l2)
-                        inference.infer(logger, *l1, JustifyUsingRUP{}, generic_reason(state, vars));
+        propagators.install(
+            [vars = move(_vars), tuples = move(tuples), watches = watches](
+                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                const auto & tuple_data = depointinate(tuples);
+
+                auto is_broken = [&](const auto & t, size_t p) -> bool {
+                    return state.test_literal(vars[p] == t[p]) == LiteralIs::DefinitelyTrue;
+                };
+
+                auto find_unbroken = [&](const auto & t, size_t skip1, size_t skip2) -> optional<size_t> {
+                    for (size_t p = 0; p < vars.size(); ++p) {
+                        if (p == skip1 || p == skip2)
+                            continue;
+                        if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
+                            return p;
+                    }
+                    return nullopt;
+                };
+
+                for (size_t ti = 0; ti < tuple_data.size(); ++ti) {
+                    auto & w = (*watches)[ti];
+                    const auto & t = tuple_data[ti];
+
+                    bool b1 = is_broken(t, w.first);
+                    bool b2 = is_broken(t, w.second);
+
+                    if (! b1 && ! b2)
+                        continue;
+
+                    if (b1 && b2) {
+                        auto new1 = find_unbroken(t, no_watch, no_watch);
+                        if (! new1) {
+                            inference.contradiction(logger, JustifyUsingRUP{},
+                                generic_reason(state, vars));
+                        }
+                        auto new2 = find_unbroken(t, *new1, no_watch);
+                        if (! new2) {
+                            inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{},
+                                generic_reason(state, vars));
+                        }
+                        else {
+                            w.first = *new1;
+                            w.second = *new2;
+                        }
+                    }
+                    else if (b1) {
+                        auto new1 = find_unbroken(t, w.second, no_watch);
+                        if (! new1) {
+                            inference.infer(logger, vars[w.second] != t[w.second], JustifyUsingRUP{},
+                                generic_reason(state, vars));
+                        }
+                        else {
+                            w.first = *new1;
+                        }
+                    }
+                    else {
+                        auto new2 = find_unbroken(t, w.first, no_watch);
+                        if (! new2) {
+                            inference.infer(logger, vars[w.first] != t[w.first], JustifyUsingRUP{},
+                                generic_reason(state, vars));
+                        }
+                        else {
+                            w.second = *new2;
+                        }
+                    }
                 }
-            }
-            return PropagatorState::Enable;
-        },
+                return PropagatorState::Enable;
+            },
             triggers);
     },
         _tuples);

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -1,6 +1,5 @@
-#include <gcs/constraints/table.hh>
+#include <gcs/constraints/table/negative_table.hh>
 #include <gcs/exception.hh>
-#include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -29,7 +28,6 @@ using namespace gcs::innards;
 using std::optional;
 using std::string;
 using std::stringstream;
-using std::to_string;
 using std::unique_ptr;
 using std::variant;
 using std::vector;
@@ -43,49 +41,8 @@ using fmt::print;
 using fmt::println;
 #endif
 
-Table::Table(vector<IntegerVariableID> v, ExtensionalTuples t) :
-    _vars(move(v)),
-    _tuples(move(t))
-{
-}
-
-auto Table::clone() const -> unique_ptr<Constraint>
-{
-    return make_unique<Table>(_vars, ExtensionalTuples{_tuples});
-}
-
 namespace
 {
-    auto is_immediately_infeasible(const IntegerVariableID & var, const Integer & val) -> bool
-    {
-        return is_literally_false(var == val);
-    }
-
-    auto is_immediately_infeasible(const IntegerVariableID &, const Wildcard &) -> bool
-    {
-        return false;
-    }
-
-    auto is_immediately_infeasible(const IntegerVariableID & var, const IntegerOrWildcard & val) -> bool
-    {
-        return visit([&](const auto & val) { return is_immediately_infeasible(var, val); }, val);
-    }
-
-    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const Integer & val) -> void
-    {
-        if (! is_literally_true(var == val))
-            lits += 1_i * (var == val);
-    }
-
-    auto add_lit_unless_immediately_true(WPBSum &, const IntegerVariableID &, const Wildcard &) -> void
-    {
-    }
-
-    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const IntegerOrWildcard & val) -> void
-    {
-        return visit([&](const auto & val) { add_lit_unless_immediately_true(lits, var, val); }, val);
-    }
-
     template <typename T_>
     auto depointinate(const std::shared_ptr<const T_> & t) -> const T_ &
     {
@@ -112,113 +69,6 @@ namespace
     {
         return visit([](auto v) { return tuple_entry_as_string(v); }, v);
     }
-}
-
-auto Table::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model);
-
-    install_propagators(propagators);
-}
-
-auto Table::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
-{
-    bool continue_installation = true;
-    visit([&](auto & tuples) {
-        if (depointinate(tuples).empty()) {
-            propagators.model_contradiction(initial_state, optional_model, "Empty table constraint from table");
-            // throw UnexpectedException{"Empty table constraint from table"};
-            continue_installation = false;
-
-            return;
-        }
-        for (auto & tuple : depointinate(tuples))
-            if (tuple.size() != _vars.size())
-                throw UnexpectedException{"table size mismatch"};
-        _selector = initial_state.allocate_integer_variable_with_state(0_i, Integer(depointinate(tuples).size() - 1));
-    },
-        _tuples);
-
-    return continue_installation;
-}
-
-auto Table::define_proof_model(ProofModel & model) -> void
-{
-    visit([&](auto && tuples) {
-        model.set_up_integer_variable(_selector, 0_i, Integer(depointinate(tuples).size() - 1),
-            "aux_table" + to_string(_selector.index),
-            IntegerVariableProofRepresentation::DirectOnly);
-
-        // pb encoding, if necessary
-        for (const auto & [tuple_idx, tuple] : enumerate(depointinate(tuples))) {
-            // selector == tuple_idx -> /\_i vars[i] == tuple[i]
-            bool infeasible = false;
-            WPBSum lits;
-            lits += Integer(tuple.size()) * (_selector != Integer(tuple_idx));
-            for (const auto & [var_idx, var] : enumerate(_vars)) {
-                if (is_immediately_infeasible(var, tuple[var_idx]))
-                    infeasible = true;
-                else
-                    add_lit_unless_immediately_true(lits, var, tuple[var_idx]);
-            }
-            if (infeasible)
-                model.add_constraint({_selector != Integer(tuple_idx)});
-            else
-                model.add_constraint(lits >= Integer(lits.terms.size() - 1));
-        }
-    },
-        move(_tuples));
-}
-
-auto Table::install_propagators(Propagators & propagators) -> void
-{
-    visit([&](auto && tuples) {
-        Triggers triggers;
-        for (auto & v : _vars)
-            triggers.on_change.push_back(v);
-        triggers.on_change.push_back(_selector);
-
-        propagators.install([table = ExtensionalData{_selector, move(_vars), move(tuples)}](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return propagate_extensional(table, state, inference, logger);
-        },
-            triggers);
-    },
-        move(_tuples));
-}
-
-auto Table::s_exprify(const string & name, const innards::ProofModel * const model) const -> std::string
-{
-    stringstream s;
-
-    print(s, "{} table", name);
-    println(s, "(");
-
-    println(s, "    (");
-    visit([&](const auto & tuples) {
-        for (const auto & t : depointinate(tuples)) {
-            println(s, "        (");
-            for (const auto & v : t) {
-                println(s, "            {}", tuple_entry_as_string(v));
-            }
-            println(s, "        )");
-        }
-    },
-        _tuples);
-    println(s, "    )");
-
-    println(s, "    (");
-    for (const auto & var : _vars)
-        println(s, "        {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    println(s, "    )");
-
-    println(s, ")");
-
-    return s.str();
 }
 
 NegativeTable::NegativeTable(vector<IntegerVariableID> v, ExtensionalTuples t) :

--- a/gcs/constraints/table/negative_table.hh
+++ b/gcs/constraints/table/negative_table.hh
@@ -10,8 +10,9 @@
 namespace gcs
 {
     /**
-     * \brief Constrain that the specified variables are not equal to one of the specified
-     * tuples.
+     * \brief Constrain that the assignment to the specified variables does not match
+     * any of the specified tuples — equivalently, for every tuple `t`, at least one
+     * `vars[i]` differs from `t[i]`.
      *
      * \ingroup Constraints
      */

--- a/gcs/constraints/table/negative_table.hh
+++ b/gcs/constraints/table/negative_table.hh
@@ -1,0 +1,37 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_NEGATIVE_TABLE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_NEGATIVE_TABLE_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/extensional.hh>
+#include <gcs/variable_id.hh>
+
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief Constrain that the specified variables are not equal to one of the specified
+     * tuples.
+     *
+     * \ingroup Constraints
+     */
+    class NegativeTable : public Constraint
+    {
+    private:
+        const std::vector<IntegerVariableID> _vars;
+        ExtensionalTuples _tuples;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit NegativeTable(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/table/negative_table_test.cc
+++ b/gcs/constraints/table/negative_table_test.cc
@@ -1,0 +1,88 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/table/negative_table.hh>
+#include <gcs/extensional.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <set>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::nullopt;
+using std::pair;
+using std::set;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+auto run_negative_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, SimpleTuples forbidden) -> void
+{
+    print(cerr, "negative table [{},{}] [{},{}] [{},{}] {} tuples{}",
+        r1.first, r1.second, r2.first, r2.second, r3.first, r3.second, forbidden.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int, int, int>> expected, actual;
+    build_expected(expected, [&](int a, int b, int c) -> bool {
+        for (const auto & t : forbidden)
+            if (t[0].raw_value == a && t[1].raw_value == b && t[2].raw_value == c)
+                return false;
+        return true;
+    }, r1, r2, r3);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
+    auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
+    auto v3 = p.create_integer_variable(Integer(r3.first), Integer(r3.second));
+    p.post(NegativeTable{{v1, v2, v3}, forbidden});
+
+    auto proof_name = proofs ? make_optional("negative_table_test") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_all_tests(bool proofs) -> void
+{
+    run_negative_table_test(proofs, {1, 3}, {1, 3}, {1, 3},
+        {{1_i, 1_i, 1_i}, {2_i, 2_i, 2_i}, {3_i, 3_i, 3_i}});  // exclude diagonal
+    run_negative_table_test(proofs, {1, 2}, {1, 2}, {1, 2},
+        {{1_i, 1_i, 1_i}, {1_i, 1_i, 2_i}, {1_i, 2_i, 1_i}, {1_i, 2_i, 2_i},
+            {2_i, 1_i, 1_i}, {2_i, 1_i, 2_i}, {2_i, 2_i, 1_i}, {2_i, 2_i, 2_i}});  // all forbidden: unsatisfiable
+    run_negative_table_test(proofs, {1, 3}, {2, 4}, {1, 2},
+        {{1_i, 2_i, 1_i}, {3_i, 4_i, 2_i}});
+}
+
+auto main(int, char *[]) -> int
+{
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        run_all_tests(proofs);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/table/negative_table_test.cc
+++ b/gcs/constraints/table/negative_table_test.cc
@@ -4,6 +4,8 @@
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
+#include <util/overloaded.hh>
+
 #include <cstdlib>
 #include <iostream>
 #include <set>
@@ -39,9 +41,33 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_negative_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, SimpleTuples forbidden) -> void
+auto run_negative_table_test_2(bool proofs, pair<int, int> r1, pair<int, int> r2, SimpleTuples forbidden) -> void
 {
-    print(cerr, "negative table [{},{}] [{},{}] [{},{}] {} tuples{}",
+    print(cerr, "negative table 2var [{},{}] [{},{}] {} tuples{}",
+        r1.first, r1.second, r2.first, r2.second, forbidden.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int, int>> expected, actual;
+    build_expected(expected, [&](int a, int b) -> bool {
+        for (const auto & t : forbidden)
+            if (t[0].raw_value == a && t[1].raw_value == b)
+                return false;
+        return true; }, r1, r2);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
+    auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
+    p.post(NegativeTable{{v1, v2}, forbidden});
+
+    auto proof_name = proofs ? make_optional("negative_table_test") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{v1, v2});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_negative_table_test_3(bool proofs, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, SimpleTuples forbidden) -> void
+{
+    print(cerr, "negative table 3var [{},{}] [{},{}] [{},{}] {} tuples{}",
         r1.first, r1.second, r2.first, r2.second, r3.first, r3.second, forbidden.size(), proofs ? " with proofs:" : ":");
     cerr << flush;
 
@@ -50,8 +76,39 @@ auto run_negative_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, 
         for (const auto & t : forbidden)
             if (t[0].raw_value == a && t[1].raw_value == b && t[2].raw_value == c)
                 return false;
-        return true;
-    }, r1, r2, r3);
+        return true; }, r1, r2, r3);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
+    auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
+    auto v3 = p.create_integer_variable(Integer(r3.first), Integer(r3.second));
+    p.post(NegativeTable{{v1, v2, v3}, forbidden});
+
+    auto proof_name = proofs ? make_optional("negative_table_test") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_negative_wildcard_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, WildcardTuples forbidden) -> void
+{
+    print(cerr, "negative wildcard table [{},{}] [{},{}] [{},{}] {} tuples{}",
+        r1.first, r1.second, r2.first, r2.second, r3.first, r3.second, forbidden.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto entry_matches = [](const IntegerOrWildcard & entry, int val) -> bool {
+        return overloaded{
+            [val](Integer i) { return i.raw_value == val; },
+            [](Wildcard) { return true; }}
+            .visit(entry);
+    };
+
+    set<tuple<int, int, int>> expected, actual;
+    build_expected(expected, [&](int a, int b, int c) -> bool {
+        for (const auto & t : forbidden)
+            if (entry_matches(t[0], a) && entry_matches(t[1], b) && entry_matches(t[2], c))
+                return false;
+        return true; }, r1, r2, r3);
     println(cerr, " expecting {} solutions", expected.size());
 
     Problem p;
@@ -67,13 +124,46 @@ auto run_negative_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, 
 
 auto run_all_tests(bool proofs) -> void
 {
-    run_negative_table_test(proofs, {1, 3}, {1, 3}, {1, 3},
-        {{1_i, 1_i, 1_i}, {2_i, 2_i, 2_i}, {3_i, 3_i, 3_i}});  // exclude diagonal
-    run_negative_table_test(proofs, {1, 2}, {1, 2}, {1, 2},
+    // Two-variable cases.
+    run_negative_table_test_2(proofs, {1, 3}, {1, 3},
+        {{1_i, 1_i}}); // single forbidden
+    run_negative_table_test_2(proofs, {1, 3}, {1, 3},
+        {{1_i, 1_i}, {2_i, 2_i}, {3_i, 3_i}}); // exclude diagonal
+    run_negative_table_test_2(proofs, {1, 2}, {1, 2},
+        {{1_i, 1_i}, {1_i, 2_i}, {2_i, 1_i}, {2_i, 2_i}}); // all forbidden: unsat at root
+    run_negative_table_test_2(proofs, {1, 3}, {2, 2},
+        {{1_i, 2_i}}); // singleton domain forces v1!=1 at root (unit at init)
+    run_negative_table_test_2(proofs, {1, 3}, {1, 3},
+        {{4_i, 4_i}, {1_i, 1_i}}); // first tuple already infeasible (4 not in dom): satisfied automatically
+    run_negative_table_test_2(proofs, {1, 3}, {1, 3},
+        {{1_i, 1_i}, {1_i, 1_i}, {2_i, 2_i}}); // duplicates in forbidden list
+
+    // Three-variable cases.
+    run_negative_table_test_3(proofs, {1, 3}, {1, 3}, {1, 3},
+        {{1_i, 1_i, 1_i}, {2_i, 2_i, 2_i}, {3_i, 3_i, 3_i}}); // exclude diagonal
+    run_negative_table_test_3(proofs, {1, 2}, {1, 2}, {1, 2},
         {{1_i, 1_i, 1_i}, {1_i, 1_i, 2_i}, {1_i, 2_i, 1_i}, {1_i, 2_i, 2_i},
-            {2_i, 1_i, 1_i}, {2_i, 1_i, 2_i}, {2_i, 2_i, 1_i}, {2_i, 2_i, 2_i}});  // all forbidden: unsatisfiable
-    run_negative_table_test(proofs, {1, 3}, {2, 4}, {1, 2},
+            {2_i, 1_i, 1_i}, {2_i, 1_i, 2_i}, {2_i, 2_i, 1_i}, {2_i, 2_i, 2_i}}); // all forbidden: unsat
+    run_negative_table_test_3(proofs, {1, 3}, {2, 4}, {1, 2},
         {{1_i, 2_i, 1_i}, {3_i, 4_i, 2_i}});
+    run_negative_table_test_3(proofs, {1, 3}, {1, 3}, {1, 3},
+        {{1_i, 1_i, 1_i}, {1_i, 1_i, 2_i}, {1_i, 1_i, 3_i}}); // (1,1,*) all forbidden: forces v1!=1 OR v2!=1 (cascade)
+    run_negative_table_test_3(proofs, {-2, 2}, {-2, 2}, {-2, 2},
+        {{-2_i, 0_i, 2_i}, {0_i, 0_i, 0_i}, {2_i, 0_i, -2_i}});
+
+    // Larger forbidden tables to exercise watched-literal scaling.
+    run_negative_table_test_3(proofs, {1, 4}, {1, 4}, {1, 4},
+        {{1_i, 1_i, 1_i}, {1_i, 2_i, 3_i}, {2_i, 1_i, 4_i}, {2_i, 3_i, 2_i},
+            {3_i, 4_i, 1_i}, {4_i, 2_i, 3_i}, {4_i, 4_i, 4_i}, {1_i, 3_i, 2_i},
+            {2_i, 2_i, 2_i}, {3_i, 3_i, 3_i}});
+
+    // Wildcard cases.
+    run_negative_wildcard_table_test(proofs, {1, 3}, {1, 3}, {1, 3},
+        {{{Wildcard{}, 2_i, Wildcard{}}}}); // forbid all tuples with v2=2
+    run_negative_wildcard_table_test(proofs, {1, 3}, {1, 3}, {1, 3},
+        {{{1_i, Wildcard{}, 3_i}, {2_i, 2_i, Wildcard{}}}}); // mixed wildcard forbids
+    run_negative_wildcard_table_test(proofs, {1, 3}, {1, 3}, {1, 3},
+        {{{Wildcard{}, Wildcard{}, Wildcard{}}}}); // all-wildcard tuple: unsat at root
 }
 
 auto main(int, char *[]) -> int

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -1,0 +1,222 @@
+#include <gcs/constraints/table/table.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/extensional_utils.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+
+#include <util/enumerate.hh>
+
+#include <optional>
+#include <sstream>
+#include <utility>
+#include <variant>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::optional;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::unique_ptr;
+using std::variant;
+using std::vector;
+using std::visit;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+Table::Table(vector<IntegerVariableID> v, ExtensionalTuples t) :
+    _vars(move(v)),
+    _tuples(move(t))
+{
+}
+
+auto Table::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<Table>(_vars, ExtensionalTuples{_tuples});
+}
+
+namespace
+{
+    auto is_immediately_infeasible(const IntegerVariableID & var, const Integer & val) -> bool
+    {
+        return is_literally_false(var == val);
+    }
+
+    auto is_immediately_infeasible(const IntegerVariableID &, const Wildcard &) -> bool
+    {
+        return false;
+    }
+
+    auto is_immediately_infeasible(const IntegerVariableID & var, const IntegerOrWildcard & val) -> bool
+    {
+        return visit([&](const auto & val) { return is_immediately_infeasible(var, val); }, val);
+    }
+
+    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const Integer & val) -> void
+    {
+        if (! is_literally_true(var == val))
+            lits += 1_i * (var == val);
+    }
+
+    auto add_lit_unless_immediately_true(WPBSum &, const IntegerVariableID &, const Wildcard &) -> void
+    {
+    }
+
+    auto add_lit_unless_immediately_true(WPBSum & lits, const IntegerVariableID & var, const IntegerOrWildcard & val) -> void
+    {
+        return visit([&](const auto & val) { add_lit_unless_immediately_true(lits, var, val); }, val);
+    }
+
+    template <typename T_>
+    auto depointinate(const std::shared_ptr<const T_> & t) -> const T_ &
+    {
+        return *t;
+    }
+
+    template <typename T_>
+    auto depointinate(const T_ & t) -> const T_ &
+    {
+        return t;
+    }
+
+    auto tuple_entry_as_string(Integer i) -> string
+    {
+        return i.to_string();
+    }
+
+    auto tuple_entry_as_string(Wildcard) -> string
+    {
+        return "*";
+    }
+
+    auto tuple_entry_as_string(const variant<Integer, Wildcard> & v) -> string
+    {
+        return visit([](auto v) { return tuple_entry_as_string(v); }, v);
+    }
+}
+
+auto Table::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Table::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    bool continue_installation = true;
+    visit([&](auto & tuples) {
+        if (depointinate(tuples).empty()) {
+            propagators.model_contradiction(initial_state, optional_model, "Empty table constraint from table");
+            // throw UnexpectedException{"Empty table constraint from table"};
+            continue_installation = false;
+
+            return;
+        }
+        for (auto & tuple : depointinate(tuples))
+            if (tuple.size() != _vars.size())
+                throw UnexpectedException{"table size mismatch"};
+        _selector = initial_state.allocate_integer_variable_with_state(0_i, Integer(depointinate(tuples).size() - 1));
+    },
+        _tuples);
+
+    return continue_installation;
+}
+
+auto Table::define_proof_model(ProofModel & model) -> void
+{
+    visit([&](auto && tuples) {
+        model.set_up_integer_variable(_selector, 0_i, Integer(depointinate(tuples).size() - 1),
+            "aux_table" + to_string(_selector.index),
+            IntegerVariableProofRepresentation::DirectOnly);
+
+        // pb encoding, if necessary
+        for (const auto & [tuple_idx, tuple] : enumerate(depointinate(tuples))) {
+            // selector == tuple_idx -> /\_i vars[i] == tuple[i]
+            bool infeasible = false;
+            WPBSum lits;
+            lits += Integer(tuple.size()) * (_selector != Integer(tuple_idx));
+            for (const auto & [var_idx, var] : enumerate(_vars)) {
+                if (is_immediately_infeasible(var, tuple[var_idx]))
+                    infeasible = true;
+                else
+                    add_lit_unless_immediately_true(lits, var, tuple[var_idx]);
+            }
+            if (infeasible)
+                model.add_constraint({_selector != Integer(tuple_idx)});
+            else
+                model.add_constraint(lits >= Integer(lits.terms.size() - 1));
+        }
+    },
+        move(_tuples));
+}
+
+auto Table::install_propagators(Propagators & propagators) -> void
+{
+    visit([&](auto && tuples) {
+        Triggers triggers;
+        for (auto & v : _vars)
+            triggers.on_change.push_back(v);
+        triggers.on_change.push_back(_selector);
+
+        propagators.install([table = ExtensionalData{_selector, move(_vars), move(tuples)}](
+                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            return propagate_extensional(table, state, inference, logger);
+        },
+            triggers);
+    },
+        move(_tuples));
+}
+
+auto Table::s_exprify(const string & name, const innards::ProofModel * const model) const -> std::string
+{
+    stringstream s;
+
+    print(s, "{} table", name);
+    println(s, "(");
+
+    println(s, "    (");
+    visit([&](const auto & tuples) {
+        for (const auto & t : depointinate(tuples)) {
+            println(s, "        (");
+            for (const auto & v : t) {
+                println(s, "            {}", tuple_entry_as_string(v));
+            }
+            println(s, "        )");
+        }
+    },
+        _tuples);
+    println(s, "    )");
+
+    println(s, "    (");
+    for (const auto & var : _vars)
+        println(s, "        {}", model->names_and_ids_tracker().s_expr_name_of(var));
+    println(s, "    )");
+
+    println(s, ")");
+
+    return s.str();
+}

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -1,0 +1,39 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_TABLE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_TABLE_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/extensional.hh>
+#include <gcs/variable_id.hh>
+
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief Constrain that the specified variables are equal to one of the specified
+     * tuples.
+     *
+     * \ingroup Constraints
+     * \see SmartTable
+     */
+    class Table : public Constraint
+    {
+    private:
+        const std::vector<IntegerVariableID> _vars;
+        ExtensionalTuples _tuples;
+        SimpleIntegerVariableID _selector{0};
+
+    public:
+        explicit Table(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+
+        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/table_test.cc
+++ b/gcs/constraints/table_test.cc
@@ -125,32 +125,6 @@ auto run_wildcard_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, 
     check_results(proof_name, expected, actual);
 }
 
-auto run_negative_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, SimpleTuples forbidden) -> void
-{
-    print(cerr, "negative table [{},{}] [{},{}] [{},{}] {} tuples{}",
-        r1.first, r1.second, r2.first, r2.second, r3.first, r3.second, forbidden.size(), proofs ? " with proofs:" : ":");
-    cerr << flush;
-
-    set<tuple<int, int, int>> expected, actual;
-    build_expected(expected, [&](int a, int b, int c) -> bool {
-        for (const auto & t : forbidden)
-            if (t[0].raw_value == a && t[1].raw_value == b && t[2].raw_value == c)
-                return false;
-        return true;
-    }, r1, r2, r3);
-    println(cerr, " expecting {} solutions", expected.size());
-
-    Problem p;
-    auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
-    auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
-    auto v3 = p.create_integer_variable(Integer(r3.first), Integer(r3.second));
-    p.post(NegativeTable{{v1, v2, v3}, forbidden});
-
-    auto proof_name = proofs ? make_optional("table_test") : nullopt;
-    solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3});
-    check_results(proof_name, expected, actual);
-}
-
 auto run_all_tests(bool proofs) -> void
 {
     // Table, 2 variables
@@ -180,15 +154,6 @@ auto run_all_tests(bool proofs) -> void
         {{{1_i, Wildcard{}, 3_i}, {Wildcard{}, 2_i, Wildcard{}}}});
     run_wildcard_table_test(proofs, {1, 3}, {1, 3}, {1, 3},
         {{{Wildcard{}, Wildcard{}, Wildcard{}}}});  // all wildcards: all tuples allowed
-
-    // Negative Table
-    run_negative_table_test(proofs, {1, 3}, {1, 3}, {1, 3},
-        {{1_i, 1_i, 1_i}, {2_i, 2_i, 2_i}, {3_i, 3_i, 3_i}});  // exclude diagonal
-    run_negative_table_test(proofs, {1, 2}, {1, 2}, {1, 2},
-        {{1_i, 1_i, 1_i}, {1_i, 1_i, 2_i}, {1_i, 2_i, 1_i}, {1_i, 2_i, 2_i},
-            {2_i, 1_i, 1_i}, {2_i, 1_i, 2_i}, {2_i, 2_i, 1_i}, {2_i, 2_i, 2_i}});  // all forbidden: unsatisfiable
-    run_negative_table_test(proofs, {1, 3}, {2, 4}, {1, 2},
-        {{1_i, 2_i, 1_i}, {3_i, 4_i, 2_i}});
 }
 
 auto main(int, char *[]) -> int


### PR DESCRIPTION
## Summary
- **Commit 1:** moves Table and NegativeTable into a `gcs/constraints/table/` family directory mirroring `all_different/`. Pure restructure, no behavioural changes.
- **Commit 2:** rewrites `NegativeTable` with 2-watched-literals. Each tuple has two watch positions; each propagator fire just rechecks those. Replacement search only when a watch breaks (a variable is instantiated to its tuple value). Same propagation strength as before (unit propagation per clause), but O(forbidden_tuples) per fire in the common case instead of O(forbidden_tuples × n_vars).
- Wildcards fall out for free — `var == Wildcard` returns `TrueLiteral` via the existing operator overloads, which tests as `DefinitelyTrue`, so wildcard positions naturally fail the watch-validity check.
- Watches are non-backtrackable (`shared_ptr`); leaving them moved across backtracks is sound and skips restoration overhead.
- Root-level contradictions (e.g. all-wildcard tuple) and unit-at-init propagations are handled in `install_initialiser`.

Tests expanded: two- and three-variable cases, larger forbidden tables, dedicated wildcard tests, root-level contradictions (all-forbidden + all-wildcard), and a unit-at-init case.

Closes #117.

## Test plan
- [x] `ctest -j 32` — 161/161 pass.
- [x] Proof verification on every NegativeTable test case (including new ones) under VeriPB.
- [x] Confirmed sanitize-build failures in `smart_table`/`count`/`at_most_one` are pre-existing on `main` (libstdc++ debug-mode `vector::operator[]` assertions, unrelated to this work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)