### PR TITLE
Fix out-of-bounds access on pb_selectors when proofs disabled

### DIFF
--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -127,14 +127,18 @@ namespace
             .visit(v);
     }
 
-    auto log_filtering_inference(ProofLogger * const logger, const ProofFlag & tuple_selector, const Literal & lit,
+    auto log_filtering_inference(ProofLogger * const logger, const ProofFlag * tuple_selector, const Literal & lit,
         const State &, auto &, const ReasonFunction & reason)
     {
         logger->emit_rup_proof_line_under_reason(reason,
-            WPBSum{} + 1_i * (! tuple_selector) + 1_i * lit >= 1_i, ProofLevel::Current);
+            WPBSum{} + 1_i * (! *tuple_selector) + 1_i * lit >= 1_i, ProofLevel::Current);
     }
 
-    auto filter_edge(const SmartEntry & edge, VariableDomainMap & supported_by_tree, const ProofFlag & tuple_selector,
+    // tuple_selector may be null when proofs are disabled; the body only uses it inside
+    // `if (logger)` branches (which are also the only branches that actually need it),
+    // so passing nullptr is safe in that case and avoids forming a reference into an
+    // empty pb_selectors vector at the call site.
+    auto filter_edge(const SmartEntry & edge, VariableDomainMap & supported_by_tree, const ProofFlag * tuple_selector,
         const State & state, auto & inference, const ReasonFunction &, ProofLogger * const logger) -> void
     {
         // Currently filter both domains - might be overkill
@@ -307,7 +311,7 @@ namespace
     }
 
     [[nodiscard]] auto filter_and_check_valid(const TreeEdges & tree, VariableDomainMap & supported_by_tree,
-        const ProofFlag & tuple_selector, const State & state, auto & inference,
+        const ProofFlag * tuple_selector, const State & state, auto & inference,
         const ReasonFunction & reason, ProofLogger * const logger) -> bool
     {
         for (int l = tree.size() - 1; l >= 0; --l) {
@@ -348,7 +352,7 @@ namespace
     }
 
     auto filter_again_and_remove_supported(const TreeEdges & tree, VariableDomainMap & supported_by_tree,
-        VariableDomainMap & unsupported, const ProofFlag & tuple_selector, const State & state,
+        VariableDomainMap & unsupported, const ProofFlag * tuple_selector, const State & state,
         auto & inference, const ReasonFunction & reason, ProofLogger * const logger) -> void
     {
         for (int l = tree.size() - 1; l >= 0; --l) {
@@ -422,6 +426,10 @@ namespace
                 continue;
             }
 
+            // pb_selectors is only populated when proof logging is enabled; index it
+            // only in that case to avoid out-of-bounds access on an empty vector.
+            const auto * pb_selector = logger ? &pb_selectors[tuple_idx] : nullptr;
+
             for (const auto & tree : forests[tuple_idx]) {
                 // Initialise supported by tree to current variable domains
                 VariableDomainMap supported_by_tree{};
@@ -431,13 +439,13 @@ namespace
                         supported_by_tree[var].emplace_back(value);
 
                 // First pass of filtering supported_by_tree and check of validity
-                if (! filter_and_check_valid(tree, supported_by_tree, pb_selectors[tuple_idx], state, inference, reason, logger)) {
+                if (! filter_and_check_valid(tree, supported_by_tree, pb_selector, state, inference, reason, logger)) {
                     // Not feasible
                     inference.infer_equal(logger, selectors[tuple_idx], 0_i, NoJustificationNeeded{}, ReasonFunction{});
                     break;
                 }
 
-                filter_again_and_remove_supported(tree, supported_by_tree, unsupported, pb_selectors[tuple_idx],
+                filter_again_and_remove_supported(tree, supported_by_tree, unsupported, pb_selector,
                     state, inference, reason, logger);
             }
 


### PR DESCRIPTION
## Summary
`SmartTable::install` only populates `pb_selectors` inside the `if (optional_model)` block — when proofs are off, the captured vector is empty, but the propagator was unconditionally indexing it (`pb_selectors[tuple_idx]`) to form a `const ProofFlag &` argument for `filter_and_check_valid` / `filter_again_and_remove_supported`. The callees only actually use the flag inside their own `if (logger)` branches, so the dangling reference was never read in release — but it's UB, and libstdc++ debug `operator[]` catches it as an out-of-bounds access in sanitize builds.

This was the cause of the sanitize-build failures in `smart_table_constraint_*` (all 12 modes) and `at_most_one_constraint` (thin wrapper that posts a `SmartTable`).

Fix: change the four anonymous-namespace helpers (`log_filtering_inference`, `filter_edge`, `filter_and_check_valid`, `filter_again_and_remove_supported`) to take `const ProofFlag *` instead of `const ProofFlag &`, and at the call site compute it as `logger ? &pb_selectors[tuple_idx] : nullptr`. The only dereference is in `log_filtering_inference`, which is itself only called inside `if (logger)` branches, so the nullptr case is never reached.

## Test plan
- [x] Sanitize ctest: 114/114 pass (was 14 failing before).
- [x] Release ctest: 160/160 pass.
- [x] Proof verification on smart_table_test still works (VeriPB happy on every mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)