### PR TITLE
Proof model: full-reification API for ProofFlag (closes #133)

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -267,6 +267,13 @@ encoding (still fails with `Assert*`) or the justification (passes
 with `Assert*`, fails with the real one). Never commit code that uses
 it.
 
+**Tracing proof line provenance.** Set `GCS_VERBOSE_LOGGING=1` in the
+environment before running a test. Every line written to the `.pbp`
+will be preceded by a C++ stacktrace as comment lines (`% ...`), so a
+VeriPB failure at `foo_test.pbp:N` can be traced back to the exact
+emit site. Cheap to use and often faster than narrowing the failure by
+inspection.
+
 ## The OPB encoding
 
 Inside `if (optional_model) { ... }`, build PB constraints with `WPBSum`
@@ -317,6 +324,42 @@ optional_model->add_constraint(
 
 This emits "the conjunction → the constraint" rather than asserting it
 unconditionally. The natural way to express conditional encodings.
+
+### Fully reified flags
+
+When you introduce a *new* `ProofFlag` whose meaning is "this
+inequality holds", encode it as a full equivalence — both
+`flag → ineq` and `¬flag → ¬ineq` — not just one direction. Use:
+
+```cpp
+auto gt = optional_model->create_proof_flag_fully_reifying(
+    "gt", "Foo", "var greater than",
+    WPBSum{} + 1_i * v1 + -1_i * v2 >= 1_i);
+```
+
+This creates `gt` and emits both halves of `gt ⇔ (v1 > v2)`. The
+equivalent two-step form is
+`add_two_way_reified_constraint(name, rule, ineq, flag)` if you've
+already created the flag elsewhere. Both compute the reverse direction
+by integer-negating the supplied inequality.
+
+**Why full reif and not half reif?** A half-reified flag is left
+UP-free by VeriPB: under any complete assignment to the real
+variables, the flag could still be either 0 or 1, so any later
+constraint that *requires* the flag to be a particular value
+(e.g. an at-least-one selector sum `Σ sel_i ≥ 1`) will fail
+verification on `solx`. Full reif lets unit propagation determine
+the flag from the underlying variables, mirroring what `Count` and
+`SmartTable` do.
+
+**When half reif is still right.** If the flag is acting as a
+*selector* — i.e. the reverse half is a *different* inequality, not
+the integer negation of the forward — keep two `add_constraint`
+calls. The classic example is `≠`, encoded as
+`flag → v1 > v2` plus `¬flag → v1 < v2`: the second half is *not*
+`v1 ≤ v2`, it's the strictly stronger `v1 < v2`, and using the
+two-way API here would silently allow `v1 = v2`. `ReifiedEquals`
+and the main `Equal` flag in `SmartTable` use this pattern.
 
 ## Testing
 

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -63,30 +63,19 @@ auto Count::install(Propagators & propagators, State & initial_state, ProofModel
 auto Count::define_proof_model(ProofModel & model) -> void
 {
     for (auto & var : _vars) {
-        auto flag = model.create_proof_flag("count");
-        auto var_minus_val_gt_0 = model.create_proof_flag("countg");
-        auto var_minus_val_lt_0 = model.create_proof_flag("countl");
+        // var_minus_val_gt_0 ⇔ var > val
+        auto var_minus_val_gt_0 = model.create_proof_flag_fully_reifying("countg",
+            "Count", "var greater", WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 1_i);
+
+        // var_minus_val_lt_0 ⇔ var < val
+        auto var_minus_val_lt_0 = model.create_proof_flag_fully_reifying("countl",
+            "Count", "var less", WPBSum{} + 1_i * var + -1_i * _value_of_interest <= -1_i);
+
+        // flag ⇔ var = val (encoded as ¬gt ∧ ¬lt)
+        auto flag = model.create_proof_flag_fully_reifying("count",
+            "Count", "var equal", WPBSum{} + 1_i * ! var_minus_val_gt_0 + 1_i * ! var_minus_val_lt_0 >= 2_i);
+
         _flags.emplace_back(flag, var_minus_val_gt_0, var_minus_val_lt_0);
-
-        // var_minus_val_gt_0 -> var - val > 0
-        model.add_constraint("Count", "var bigger",
-            WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 1_i, HalfReifyOnConjunctionOf{{var_minus_val_gt_0}});
-
-        // ! var_minus_val_gt_0 -> var - val <= 0
-        model.add_constraint("Count", "var not bigger",
-            WPBSum{} + 1_i * var + -1_i * _value_of_interest <= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_gt_0}});
-
-        // var_minus_val_lt_0 -> var - val <= -1
-        model.add_constraint("Count", "var smaller", WPBSum{} + 1_i * var + -1_i * _value_of_interest <= -1_i, HalfReifyOnConjunctionOf{{var_minus_val_lt_0}});
-
-        // ! var_minus_val_lt_0 -> var - val > -1
-        model.add_constraint("Count", "var not smaller", WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 0_i, HalfReifyOnConjunctionOf{{! var_minus_val_lt_0}});
-
-        // flag => ! countg /\ ! countl
-        model.add_constraint("Count", "var equal", WPBSum{} + 1_i * ! var_minus_val_gt_0 + 1_i * ! var_minus_val_lt_0 >= 2_i, HalfReifyOnConjunctionOf{{flag}});
-
-        // ! flag => countg \/ countl
-        model.add_constraint("Count", "var not equal", WPBSum{} + 1_i * var_minus_val_gt_0 + 1_i * var_minus_val_lt_0 >= 1_i, HalfReifyOnConjunctionOf{{! flag}});
     }
 
     // sum flag == how_many

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -121,28 +121,13 @@ auto In::define_proof_model(ProofModel & model) -> void
     // Mirrors the encoding used by Count. Full reification of every
     // proof flag is the project rule for new OPB encodings.
     for (const auto & [idx, V] : enumerate(_var_vals)) {
-        auto lt = model.create_proof_flag(format("inlt{}", idx));
-        auto gt = model.create_proof_flag(format("ingt{}", idx));
-        auto sel = model.create_proof_flag(format("in{}", idx));
+        auto lt = model.create_proof_flag_fully_reifying(format("inlt{}", idx),
+            "In", "var less than", WPBSum{} + 1_i * _var + -1_i * V <= -1_i);
+        auto gt = model.create_proof_flag_fully_reifying(format("ingt{}", idx),
+            "In", "var greater than", WPBSum{} + 1_i * _var + -1_i * V >= 1_i);
+        auto sel = model.create_proof_flag_fully_reifying(format("in{}", idx),
+            "In", "var equal", WPBSum{} + 1_i * ! lt + 1_i * ! gt >= 2_i);
         _selectors.push_back(sel);
-
-        // gt ⇔ var > V_i
-        model.add_constraint("In", "var greater than",
-            WPBSum{} + 1_i * _var + -1_i * V >= 1_i, {{gt}});
-        model.add_constraint("In", "var not greater than",
-            WPBSum{} + 1_i * _var + -1_i * V <= 0_i, {{! gt}});
-
-        // lt ⇔ var < V_i
-        model.add_constraint("In", "var less than",
-            WPBSum{} + 1_i * _var + -1_i * V <= -1_i, {{lt}});
-        model.add_constraint("In", "var not less than",
-            WPBSum{} + 1_i * _var + -1_i * V >= 0_i, {{! lt}});
-
-        // sel ⇔ ¬lt ∧ ¬gt
-        model.add_constraint("In", "selector implies var equals",
-            WPBSum{} + 1_i * ! lt + 1_i * ! gt >= 2_i, {{sel}});
-        model.add_constraint("In", "var unequal implies not selector",
-            WPBSum{} + 1_i * lt + 1_i * gt >= 1_i, {{! sel}});
 
         sum += 1_i * sel;
     }

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -627,48 +627,27 @@ namespace
             model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 == 0_i,
                 HalfReifyOnConjunctionOf{{flag}});
 
-            // !f => var1 != var2
-            auto flag_lt = model.create_proof_flag("lt");
-            auto flag_gt = model.create_proof_flag("gt");
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 1_i,
-                HalfReifyOnConjunctionOf{{flag_gt}});
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 0_i,
-                HalfReifyOnConjunctionOf{{! flag_gt}});
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 1_i,
-                HalfReifyOnConjunctionOf{{flag_lt}});
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 0_i,
-                HalfReifyOnConjunctionOf{{! flag_lt}});
+            // !f => var1 != var2 via fully reified lt/gt and a selector
+            auto flag_gt = model.create_proof_flag_fully_reifying("gt", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 1_i);
+            auto flag_lt = model.create_proof_flag_fully_reifying("lt", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 1_i);
             model.add_constraint(WPBSum{} + 1_i * flag_lt + 1_i * flag_gt >= 1_i,
                 HalfReifyOnConjunctionOf{{! flag}});
             return flag;
         }
 
-        case GreaterThan: {
-            auto flag = model.create_proof_flag("bin_gt");
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 1_i,
-                HalfReifyOnConjunctionOf{{flag}});
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 0_i,
-                HalfReifyOnConjunctionOf{{! flag}});
-            return flag;
-        }
+        case GreaterThan:
+            return model.create_proof_flag_fully_reifying("bin_gt", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 1_i);
 
-        case LessThan: {
-            auto flag = model.create_proof_flag("bin_lt");
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 1_i,
-                HalfReifyOnConjunctionOf{{flag}});
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 0_i,
-                HalfReifyOnConjunctionOf{{! flag}});
-            return flag;
-        }
+        case LessThan:
+            return model.create_proof_flag_fully_reifying("bin_lt", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 1_i);
 
-        case LessThanEqual: {
-            auto flag = model.create_proof_flag("bin_le");
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 0_i,
-                HalfReifyOnConjunctionOf{{flag}});
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 1_i,
-                HalfReifyOnConjunctionOf{{! flag}});
-            return flag;
-        }
+        case LessThanEqual:
+            return model.create_proof_flag_fully_reifying("bin_le", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 0_i);
 
         case NotEqual: {
             // !f => var1 == var2
@@ -676,37 +655,20 @@ namespace
             model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 == 0_i,
                 HalfReifyOnConjunctionOf{{! flag}});
 
-            // f => var1 != var2
-            auto flag_lt = model.create_proof_flag("lt");
-            auto flag_gt = model.create_proof_flag("gt");
-
-            // Means we need f => fgt or flt
+            // f => var1 != var2, via fully reified lt/gt and a selector
+            auto flag_gt = model.create_proof_flag_fully_reifying("gt", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 1_i);
+            auto flag_lt = model.create_proof_flag_fully_reifying("lt", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 1_i);
             model.add_constraint(WPBSum{} + 1_i * flag_lt + 1_i * flag_gt >= 1_i,
                 HalfReifyOnConjunctionOf{{flag}});
 
-            // And then fgt <==> var1 > var2
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 1_i,
-                HalfReifyOnConjunctionOf{{flag_gt}});
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 0_i,
-                HalfReifyOnConjunctionOf{{! flag_gt}});
-
-            // flt <==> var1 < var2
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 1_i,
-                HalfReifyOnConjunctionOf{{flag_lt}});
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 0_i,
-                HalfReifyOnConjunctionOf{{! flag_lt}});
-
             return flag;
         }
 
-        case GreaterThanEqual: {
-            auto flag = model.create_proof_flag("bin_ge");
-            model.add_constraint(WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 0_i,
-                HalfReifyOnConjunctionOf{{flag}});
-            model.add_constraint(WPBSum{} + 1_i * var_2 + -1_i * var_1 >= 1_i,
-                HalfReifyOnConjunctionOf{{! flag}});
-            return flag;
-        }
+        case GreaterThanEqual:
+            return model.create_proof_flag_fully_reifying("bin_ge", "SmartTable", "binary entry",
+                WPBSum{} + 1_i * var_1 + -1_i * var_2 >= 0_i);
 
         case NotIn:
         case In:

--- a/gcs/expression.hh
+++ b/gcs/expression.hh
@@ -174,6 +174,25 @@ namespace gcs
     }
 
     /**
+     * \brief Negate an integer SumLessThanEqual: `lhs ≤ rhs` ↦ `lhs ≥ rhs + 1`,
+     * returned in `SumLessThanEqual` form (so the result is `-lhs ≤ -rhs - 1`).
+     *
+     * Useful for emitting the second half of a fully reified constraint:
+     * given `ineq, {flag}` (forward implication), `negate_inequality(ineq), {!flag}`
+     * is the corresponding reverse implication.
+     *
+     * \ingroup Expressions
+     */
+    template <typename Var_>
+    [[nodiscard]] constexpr inline auto negate_inequality(SumLessThanEqual<Weighted<Var_>> ineq) -> SumLessThanEqual<Weighted<Var_>>
+    {
+        for (auto & [c, _] : ineq.lhs.terms)
+            c = -c;
+        ineq.rhs = -ineq.rhs - 1_i;
+        return ineq;
+    }
+
+    /**
      * A syntactic equality.
      *
      * Often created by writing `WeightedSum{} + 42_i * var1 + 23_i * var2 == 1234_i`.

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -170,6 +170,22 @@ auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnC
     return add_constraint("?", "?", eq, half_reif);
 }
 
+auto ProofModel::add_two_way_reified_constraint(const StringLiteral & constraint_name, const StringLiteral & rule,
+    const WPBSumLE & ineq, const ProofFlag & flag) -> pair<optional<ProofLine>, optional<ProofLine>>
+{
+    auto forward = add_constraint(constraint_name, rule, ineq, HalfReifyOnConjunctionOf{{flag}});
+    auto reverse = add_constraint(constraint_name, rule, negate_inequality(ineq), HalfReifyOnConjunctionOf{{! flag}});
+    return {forward, reverse};
+}
+
+auto ProofModel::create_proof_flag_fully_reifying(const string & flag_name,
+    const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumLE & ineq) -> ProofFlag
+{
+    auto flag = create_proof_flag(flag_name);
+    add_two_way_reified_constraint(constraint_name, rule, ineq, flag);
+    return flag;
+}
+
 auto ProofModel::names_and_ids_tracker() -> NamesAndIDsTracker &
 {
     return _imp->tracker;

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -105,6 +105,32 @@ namespace gcs::innards
             const StringLiteral & rule,
             const Literals & lits) -> std::optional<ProofLine>;
 
+        /**
+         * \brief Encode `flag ⇔ ineq` in OPB by emitting both halves of the equivalence:
+         * the forward implication `flag → ineq` and the reverse `¬flag → ¬ineq`. The
+         * reverse half is the integer negation of `ineq`.
+         *
+         * Replaces the common pattern of writing the two halves by hand, which makes
+         * it easy to forget one direction (leaving the flag UP-free under solution
+         * extension) or to compute the negation incorrectly.
+         */
+        auto add_two_way_reified_constraint(
+            const StringLiteral & constraint_name,
+            const StringLiteral & rule,
+            const WPBSumLE & ineq,
+            const ProofFlag & flag) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+
+        /**
+         * \brief Create a fresh proof flag and fully reify it against `ineq` in one
+         * go: equivalent to `create_proof_flag` followed by
+         * `add_two_way_reified_constraint`.
+         */
+        [[nodiscard]] auto create_proof_flag_fully_reifying(
+            const std::string & flag_name,
+            const StringLiteral & constraint_name,
+            const StringLiteral & rule,
+            const WPBSumLE & ineq) -> ProofFlag;
+
         ///@}
 
         /**


### PR DESCRIPTION
## Summary
- Adds `model.add_two_way_reified_constraint(name, rule, ineq, flag)` and `model.create_proof_flag_fully_reifying(flag_name, name, rule, ineq)`. Both emit `flag → ineq` and `¬flag → ¬ineq` as a single call, computing the second half by integer-negating the supplied inequality (new helper `negate_inequality` on `SumLessThanEqual`).
- Migrates the call sites where the reverse half is genuinely the integer negation of the forward: Count, In, and the simple binary-entry arms (gt / lt / le / ge) in SmartTable, plus the lt/gt sub-flags inside SmartTable's Equal / NotEqual cases.
- Net diff: −3 lines, with two named primitives doing the work that previously took matched pairs of `add_constraint` calls.

## Out of scope (deliberately)
Some reified-flag sites *don't* fit the new API and were left as-is:
- `ReifiedEquals` (MustNotHold / NotIf / Iff)
- `ReifiedLinearEquality` (MustNotHold / NotIf / Iff)
- `SmartTable`'s main `Equal` / `NotEqual` flag

These use a **selector** pattern: the flag picks between two mutually exclusive inequalities (e.g. for `≠` it's `v1 > v2` vs `v1 < v2`), and the reverse half is *not* the integer negation of the forward — it is a strictly stronger inequality that excludes equality. Migrating any of these would change semantics. Documented in the commit message.

## Test plan
- [x] `ctest -j 32` — 162/162 pass (no failures, no skips).
- [x] All proof-verifying tests for the migrated constraints still verify with VeriPB.
- [x] `clang-format` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)