### PR TITLE
IntervalSet: small-buffer optimisation with gch::small_vector (issue #134, phase 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,15 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(json)
 FetchContent_GetProperties(json)  # sets json_SOURCE_DIR in this scope (inherited by subdirs)
 
+set(GCH_SMALL_VECTOR_ENABLE_TESTS OFF CACHE INTERNAL "")
+set(GCH_SMALL_VECTOR_ENABLE_BENCHMARKS OFF CACHE INTERNAL "")
+FetchContent_Declare(
+        gch_small_vector
+        GIT_REPOSITORY https://github.com/gharveymn/small_vector.git
+        GIT_TAG f0725471b273245a5aa6855612079fbdc40f532b # v0.9.2
+)
+FetchContent_MakeAvailable(gch_small_vector)
+
 add_library(gcs_fmt INTERFACE)
 
 try_compile(GCS_COMPILER_HAS_FORMAT ${CMAKE_CURRENT_BINARY_DIR}/cmake_compile_tests ${CMAKE_CURRENT_SOURCE_DIR}/cmake_compile_tests/has_format.cc)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Compiling
   compiler's standard library lacks ``<format>`` (e.g. Clang with libc++ on macOS)
 - A ``<generator>`` polyfill, fetched only when the compiler's standard library lacks
   ``std::generator`` (e.g. Clang with libc++ on macOS)
+- [gch::small_vector](https://github.com/gharveymn/small_vector) — small-buffer-optimised
+  vector container, used internally for variable domain storage
 
 **Optional external tools:**
 - [VeriPB](https://gitlab.com/MIAOresearch/software/VeriPB) — proof checker, required

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -98,6 +98,10 @@ endif()
 
 target_link_libraries(glasgow_constraint_solver PUBLIC gcs_fmt)
 
+# gch::small_vector is used in interval_set.hh which is transitively reached
+# through state.hh, so the include directories must propagate to consumers.
+target_link_libraries(glasgow_constraint_solver PUBLIC gch::small_vector)
+
 # nlohmann_json is header-only and used only in .cc files (not public headers), so we
 # pull in its include directory directly rather than linking the CMake target.  Linking
 # the target would create a reference in the installed export set that consumers can't

--- a/gcs/innards/interval_set.hh
+++ b/gcs/innards/interval_set.hh
@@ -3,8 +3,10 @@
 
 #include <gcs/innards/interval_set-fwd.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <cstdlib>
-#include <vector>
+#include <utility>
 #include <version>
 
 #ifdef __cpp_lib_generator
@@ -34,7 +36,13 @@ namespace gcs::innards
     class IntervalSet
     {
     private:
-        using Intervals = std::vector<std::pair<Int_, Int_>>;
+        // Inline capacity tuned for the dominant case in the solver: variable
+        // domains usually start as a single contiguous interval, and after a
+        // handful of != assertions still have ≤ 2 intervals. Bigger values pay
+        // for unused inline storage on every variable and on every snapshot
+        // copy at new_epoch().
+        static constexpr std::size_t inline_intervals = 2;
+        using Intervals = gch::small_vector<std::pair<Int_, Int_>, inline_intervals>;
         Intervals intervals;
 
     public:


### PR DESCRIPTION
## Summary

Phase 3 of issue #134, building on PR #136 (Phase 1). Switches `IntervalSet`'s underlying storage from `std::vector<std::pair<Int_, Int_>>` to `gch::small_vector<std::pair<Int_, Int_>, 2>`. The dominant case in the solver is a single contiguous interval per variable; the fallback to heap allocation only kicks in for genuinely fragmented domains.

Three-way Phase 4 benchmark sweep (3 trials per build, 2 for `n_queens_88`, median solve time):

| Benchmark           | baseline   | phase1    | sbo (this) | sbo vs base | sbo vs phase1 |
|---------------------|-----------:|----------:|-----------:|------------:|--------------:|
| `magic_series_300`  | 7.226 s    | 6.072 s   | 5.147 s    | **−28.8 %** | −15.2 %       |
| `magic_square_5`    | 41.069 s   | 32.745 s  | 31.785 s   | **−22.6 %** | −2.9 %        |
| `langford_11`       | 12.642 s   | 11.510 s  | 10.597 s   | **−16.2 %** | −7.9 %        |
| `n_queens_14_all`   | 21.759 s   | 17.178 s  | 17.120 s   | **−21.3 %** | −0.3 %        |
| `ortho_latin_6_all` | 20.440 s   | 20.160 s  | 18.473 s   | **−9.6 %**  | −8.4 %        |
| `qap_12`            | 6.333 s    | 7.310 s   | 6.786 s    | **+7.2 %**  | −7.2 %        |
| `tsp_default`       | 72.945 s   | 62.129 s  | 59.361 s   | **−18.6 %** | −4.5 %        |
| `n_queens_88`       | 377.174 s  | 314.565 s | 249.196 s  | **−33.9 %** | −20.8 %       |

Recursion and propagation counts identical across all three builds (semantics preserved).

### Decisions worth flagging

**Library choice:** `gch::small_vector` (https://github.com/gharveymn/small_vector). Considered `martinus/svector`, `sfl::small_vector`, `alandefreitas/small`, `absl::InlinedVector`. `gch` won on the established criteria: MIT, single-header, FetchContent-friendly, full `std::vector`-shaped API with allocator support, mature (v0.9.2). The decision criteria are recorded in the project's auto-memory; happy to expand on any of the rejected options if useful.

**Inline capacity N:** Settled on N=2 after spot-checking N=4 on three benchmarks. N=4 reduces the QAP regression a bit further (+3.7 % vs +7.2 %) but hurts `magic_series_300` by ~17 % vs N=2 — the larger inline footprint costs more on `new_epoch` deep-copies in propagation-heavy workloads. N=2 keeps the dominant single-interval and one-hole cases inline while keeping the per-variable footprint small.

**Why QAP doesn't fully recover.** With N=2 the per-variable inline footprint is 32 bytes plus the small_vector header — bigger than the original `IntegerVariableRangeState`'s 16 bytes. QAP's tight inner loop pays for that on every `new_epoch` copy. Closing the last 7.2 % would need either dropping below N=2 (N=1 with one inline interval, but that loses the one-hole case) or a more sophisticated representation. Not worth pursuing as part of this PR.

### Phase 5 / 6 implications

Phase 5 (apply SBO to `Reason` / `HalfReifyOnConjunctionOf` / similar) is now trivially supportable via the same `gch::small_vector` dependency. Phase 6 (algorithmic wins from the unified IntervalSet) is independent of the SBO choice and can proceed separately.

### Test plan

- [x] `state_test`, `interval_set_test` pass (release + sanitize/asan+ubsan)
- [x] Full `ctest --preset release` 168/168 with VeriPB proof verification
- [ ] Full sanitize ctest skipped this round (the dev-machine ran out of disk during the three-way bench — release ctest + sanitize state/interval_set is enough to land, full sanitize will run as part of CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)