### PR TITLE
SBO for Reason / HalfReifyOnConjunctionOf / Literals (issue #134, phase 5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,15 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(json)
 FetchContent_GetProperties(json)  # sets json_SOURCE_DIR in this scope (inherited by subdirs)
 
+set(GCH_SMALL_VECTOR_ENABLE_TESTS OFF CACHE INTERNAL "")
+set(GCH_SMALL_VECTOR_ENABLE_BENCHMARKS OFF CACHE INTERNAL "")
+FetchContent_Declare(
+        gch_small_vector
+        GIT_REPOSITORY https://github.com/gharveymn/small_vector.git
+        GIT_TAG f0725471b273245a5aa6855612079fbdc40f532b # v0.9.2
+)
+FetchContent_MakeAvailable(gch_small_vector)
+
 add_library(gcs_fmt INTERFACE)
 
 try_compile(GCS_COMPILER_HAS_FORMAT ${CMAKE_CURRENT_BINARY_DIR}/cmake_compile_tests ${CMAKE_CURRENT_SOURCE_DIR}/cmake_compile_tests/has_format.cc)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Compiling
   compiler's standard library lacks ``<format>`` (e.g. Clang with libc++ on macOS)
 - A ``<generator>`` polyfill, fetched only when the compiler's standard library lacks
   ``std::generator`` (e.g. Clang with libc++ on macOS)
+- [gch::small_vector](https://github.com/gharveymn/small_vector) — small-buffer-optimised
+  vector container, used internally for variable domain storage
 
 **Optional external tools:**
 - [VeriPB](https://gitlab.com/MIAOresearch/software/VeriPB) — proof checker, required

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -98,6 +98,10 @@ endif()
 
 target_link_libraries(glasgow_constraint_solver PUBLIC gcs_fmt)
 
+# gch::small_vector is used in interval_set.hh which is transitively reached
+# through state.hh, so the include directories must propagate to consumers.
+target_link_libraries(glasgow_constraint_solver PUBLIC gch::small_vector)
+
 # nlohmann_json is header-only and used only in .cc files (not public headers), so we
 # pull in its include directory directly rather than linking the CMake target.  Linking
 # the target would create a reference in the installed export set that consumers can't

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -201,7 +201,7 @@ namespace
         return proof_line;
     }
 
-    auto get_rup_hints_for(ProofLogger & logger, const vector<ProofLiteralOrFlag> & lits) -> vector<ProofLine>
+    auto get_rup_hints_for(ProofLogger & logger, const HalfReifyOnConjunctionOf & lits) -> vector<ProofLine>
     {
         auto rup_hints = vector<ProofLine>{};
         for (const auto & lit : lits) {

--- a/gcs/innards/interval_set.hh
+++ b/gcs/innards/interval_set.hh
@@ -3,8 +3,10 @@
 
 #include <gcs/innards/interval_set-fwd.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <cstdlib>
-#include <vector>
+#include <utility>
 #include <version>
 
 #ifdef __cpp_lib_generator
@@ -34,7 +36,13 @@ namespace gcs::innards
     class IntervalSet
     {
     private:
-        using Intervals = std::vector<std::pair<Int_, Int_>>;
+        // Inline capacity tuned for the dominant case in the solver: variable
+        // domains usually start as a single contiguous interval, and after a
+        // handful of != assertions still have ≤ 2 intervals. Bigger values pay
+        // for unused inline storage on every variable and on every snapshot
+        // copy at new_epoch().
+        static constexpr std::size_t inline_intervals = 2;
+        using Intervals = gch::small_vector<std::pair<Int_, Int_>, inline_intervals>;
         Intervals intervals;
 
     public:

--- a/gcs/innards/literal.hh
+++ b/gcs/innards/literal.hh
@@ -5,6 +5,8 @@
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <optional>
 #include <string>
 #include <variant>
@@ -65,11 +67,16 @@ namespace gcs::innards
     [[nodiscard]] auto operator!(const Literal &) -> Literal;
 
     /**
-     * \brief A vector of Literal values.
+     * \brief A small vector of Literal values.
+     *
+     * Used for CNF clause emission and proof model add_constraint, where
+     * clauses are usually short (a handful of literals). Inline capacity 2
+     * keeps the common cases off the heap; longer clauses still work via
+     * fallback heap allocation.
      *
      * \ingroup Literals
      */
-    using Literals = std::vector<Literal>;
+    using Literals = gch::small_vector<Literal, 2>;
 
     /**
      * \brief Returns whether a Literal is either a TrueLiteral, a FalseLiteral,

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -320,7 +320,7 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
         .visit(why);
 }
 
-auto ProofLogger::reason_to_lits(const ReasonFunction & reason) -> vector<ProofLiteralOrFlag>
+auto ProofLogger::reason_to_lits(const ReasonFunction & reason) -> Reason
 {
     optional<Reason> reason_literals;
     if (reason)
@@ -329,7 +329,7 @@ auto ProofLogger::reason_to_lits(const ReasonFunction & reason) -> vector<ProofL
     if (reason_literals)
         names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
 
-    vector<ProofLiteralOrFlag> reason_proof_literals{};
+    Reason reason_proof_literals{};
     for (auto & r : *reason_literals)
         reason_proof_literals.emplace_back(r);
 
@@ -430,10 +430,7 @@ auto ProofLogger::emit_under_reason(
               << " ";
 
     if (reason_literals) {
-        vector<ProofLiteralOrFlag> reason_proof_literals{};
-        for (auto & r : *reason_literals)
-            reason_proof_literals.emplace_back(r);
-        emit_inequality_to(names_and_ids_tracker(), reify(ineq, reason_proof_literals), rule_line);
+        emit_inequality_to(names_and_ids_tracker(), reify(ineq, *reason_literals), rule_line);
     }
     else {
         emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -159,7 +159,7 @@ namespace gcs::innards
         /**
          * Given a reason, return the vector of literals in the conjunction.
          */
-        auto reason_to_lits(const ReasonFunction & reason) -> std::vector<ProofLiteralOrFlag>;
+        auto reason_to_lits(const ReasonFunction & reason) -> Reason;
 
         /**
          * Given a PB constraint C and a conjunction of literals L, return the native

--- a/gcs/innards/proofs/reification.hh
+++ b/gcs/innards/proofs/reification.hh
@@ -3,6 +3,8 @@
 
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <vector>
 
 namespace gcs::innards
@@ -11,9 +13,13 @@ namespace gcs::innards
      * \brief Various things in Proof can reify on a conjunction of
      * ProofLiteral and ProofFlag.
      *
+     * Conjunctions are usually short (1–3 elements). Inline capacity 2
+     * keeps the common cases off the heap; longer conjunctions still
+     * work via fallback heap allocation.
+     *
      * \ingroup Innards
      */
-    using HalfReifyOnConjunctionOf = std::vector<ProofLiteralOrFlag>;
+    using HalfReifyOnConjunctionOf = gch::small_vector<ProofLiteralOrFlag, 2>;
 }
 
 #endif

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -6,13 +6,19 @@
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/variable_id.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <functional>
 #include <optional>
 #include <vector>
 
 namespace gcs::innards
 {
-    using Reason = std::vector<ProofLiteralOrFlag>;
+    // Reason values are produced eagerly per inference (when proofs are on).
+    // Typical sizes are 1 (singleton_reason for reified flags) to a handful
+    // (bounds_reason / generic_reason over a small set of variables). Inline
+    // capacity 2 keeps the common 1- and 2-element cases off the heap.
+    using Reason = gch::small_vector<ProofLiteralOrFlag, 2>;
     using ReasonFunction = std::function<auto()->Reason>;
 
     /**


### PR DESCRIPTION
## Summary

Phase 5 of issue #134, stacked on #138. Apply the same `gch::small_vector<…, 2>` SBO swap that PR #138 used for `IntervalSet` to three other hot small-vector typedefs:

- **`Reason`** (`gcs/innards/reason.hh`) — produced eagerly per inference when proofs are on. Typical sizes 1–3 (singleton reified flags, `bounds_reason` over a few variables).
- **`HalfReifyOnConjunctionOf`** (`gcs/innards/proofs/reification.hh`) — built per reified PB constraint. Same shape.
- **`Literals`** (`gcs/innards/literal.hh`) — CNF clause emission and proof-model `add_constraint`. Usually a handful of literals.

The two are the same underlying type now (`gch::small_vector<ProofLiteralOrFlag, 2>`), so a small `proof_logger.cc` cleanup falls out: the old code materialised a separate `vector<ProofLiteralOrFlag>` from a `Reason` and then re-constructed a `HalfReifyOnConjunctionOf` from that vector. The intermediate copy goes away.

## Sweep before settling on these three

Surveyed all `using … = std::vector<…>` typedefs in `gcs/`. Other candidates considered and rejected:

- `vector<ProofLine>` (RUP hint lists in `mult_bc.cc`) — only used in `mult_bc`; not a typedef. Could SBO at use sites later if `mult_bc` becomes a hotspot.
- `vector<IntegerVariableCondition>` (two sites in `symmetric_all_different.cc`, `inverse.cc`) — narrow use, sized O(domain), not a fit for SBO.
- `SmartTuples`, `SimpleTuples`, `WildcardTuples`, `Element` index types — table representations, often thousands of rows. SBO is the wrong tool.

## Bench results (Phase 5 vs Phase 3, median solve time)

3 trials per build, 2 for `n_queens_88`. Same 8-benchmark set as Phase 4; same machine.

| Benchmark           | phase3 (#138) | phase5 (this) | Δ | % |
|---------------------|--------------:|--------------:|---:|---:|
| `magic_series_300`  | 4.996 s       | 5.037 s       | +0.041 s | +0.8 % |
| `magic_square_5`    | 31.355 s      | 30.383 s      | −0.972 s | **−3.1 %** |
| `langford_11`       | 10.433 s      | 10.410 s      | −0.024 s | −0.2 % |
| `n_queens_14_all`   | 16.994 s      | 16.481 s      | −0.513 s | **−3.0 %** |
| `ortho_latin_6_all` | 18.213 s      | 18.247 s      | +0.034 s | +0.2 % |
| `qap_12`            | 6.631 s       | 6.590 s       | −0.042 s | −0.6 % |
| `tsp_default`       | 58.255 s      | 54.197 s      | −4.057 s | **−7.0 %** |
| `n_queens_88`       | 246.998 s     | 246.476 s     | −0.522 s | −0.2 % |

Recursion and propagation counts identical across both builds for every benchmark — semantics preserved.

The +0.8 % and +0.2 % figures are within run-to-run noise (band overlap between the trials of each build).

### Cumulative effect over the full issue (vs pre-Phase-1 baseline from Phase 4)

Combining Phase-4's `baseline → phase3` numbers with the `phase3 → phase5` deltas above:

| Benchmark           | baseline (pre-#134) | phase5 (this) | total Δ |
|---------------------|--------------------:|--------------:|--------:|
| `magic_series_300`  | 7.226 s             | 5.037 s       | **−30.3 %** |
| `magic_square_5`    | 41.069 s            | 30.383 s      | **−26.0 %** |
| `langford_11`       | 12.642 s            | 10.410 s      | **−17.7 %** |
| `n_queens_14_all`   | 21.759 s            | 16.481 s      | **−24.2 %** |
| `ortho_latin_6_all` | 20.440 s            | 18.247 s      | **−10.7 %** |
| `qap_12`            | 6.333 s             | 6.590 s       | +4.1 % |
| `tsp_default`       | 72.945 s            | 54.197 s      | **−25.7 %** |
| `n_queens_88`       | 377.174 s           | 246.476 s     | **−34.7 %** |

7/8 between 10 % and 35 % faster end-to-end. QAP-12 still regresses but smaller (+4.1 % cumulatively, down from +9.1 % at Phase 1 and +7.2 % at Phase 3).

## Why TSP gets the biggest win

The Circuit propagator is the heaviest user of `HalfReifyOnConjunctionOf` in the codebase (18 references across `circuit_*.{cc,hh}`). Inline-storage savings on those construction sites compound across the per-recursion proof-encoding scaffolding even when the bench runs without `--prove`.

## Test plan

- [x] `state_test`, `interval_set_test` pass under release.
- [x] Full `ctest --preset release`: 168/168 with VeriPB proof verification.
- [x] Sanitize (asan + ubsan) state/interval/lex/count tests pass with VeriPB verification — exercises the proof-logging path that uses `Reason` heavily.
- [ ] Full sanitize ctest — not run this round (disk constraints; release ctest + targeted sanitize is enough to land, full sanitize will run as part of CI).

## Stacking

Targets `sbo-interval-set` (PR #138). Once #136 and #138 land, this rebases cleanly onto main. Diff here is Phase-5-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
