### PR TITLE
dev_docs: document the Phase 6 IntervalSet / State APIs

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -207,6 +207,10 @@ Inside the propagator body, the `State` parameter exposes:
 - `state.each_value_immutable(v)` / `state.each_value_mutable(v)` →
   ranges over the current domain. Use `_immutable` if you only read;
   `_mutable` if you might infer a removal mid-iteration.
+- `state.domains_intersect(v1, v2)` → bool. Does the variables' domains
+  share any value? Walks both stored interval sets in merge order
+  without copying for the common case. Use this instead of
+  `for (auto val : state.each_value_immutable(v1)) if (state.in_domain(v2, val))`.
 
 These are read-only — modifying the state goes through `inference`.
 

--- a/dev_docs/state-and-variables.md
+++ b/dev_docs/state-and-variables.md
@@ -139,6 +139,11 @@ The class has the operations propagators care about: `lower()`, `upper()`,
 `empty()`, plus mutators `erase(value)`, `erase_less_than(value)`,
 `erase_greater_than(value)`, `clear()`, `insert_at_end(value)`. Iteration
 is via `each()` (per-value) and `each_interval()` (per-interval pair).
+For set-difference idioms (yield each maximal interval present in
+`*this` and absent from another set), there's
+`each_interval_minus(other)` — a merge walk that's strictly cheaper
+than per-value membership testing. Yielded `(l, u)` pairs are *closed*
+intervals, matching `each_interval()`'s convention.
 
 `has_holes()` is allowed to over-approximate: a `false` return guarantees
 no holes, but a `true` return doesn't guarantee any. The current
@@ -290,8 +295,18 @@ constants:
   the `IntervalSet` into the coroutine frame), so they are
   behaviourally interchangeable today — but `_immutable` callers must
   not rely on that, since it is allowed to be optimised in future to
-  avoid the copy.
+  avoid the copy. `CurrentState` exposes a single `each_value` (forward)
+  and `each_value_reversed` (descending) for callback-time consumers.
 - `copy_of_values(var)` — full snapshot as an `IntervalSet<Integer>`.
+- `domain_intersects_with(var, IntervalSet)` — does the variable's
+  domain share any value with the given set? The common case
+  (SimpleIntegerVariableID, no view offset) walks the stored interval
+  set against the given set without copying either side. Cheaper than
+  `set.contains_any_of(state.copy_of_values(var))`.
+- `domains_intersect(var1, var2)` — same shape, but for two variables.
+  The common case of two SimpleIntegerVariableIDs with no offsets walks
+  both stored interval sets in merge order — no copy of either side.
+  Useful in overlap-detection propagators (`Equals`, `Count`).
 
 Each one applies the view offset (and bound-swap for `negate_first`)
 after computing the answer in the actual variable's coordinate system.


### PR DESCRIPTION
## Summary

Doc-only follow-up for PR #141 (Phase 6). Documents the three new APIs that PR introduced:

- `IntervalSet::each_interval_minus(other)` — set-difference iteration, yields each maximal closed interval of values in `*this` absent from `other`.
- `State::domain_intersects_with(var, IntervalSet)` — does the variable's domain share any value with the given set?
- `State::domains_intersect(var1, var2)` — the two-variable analog, used by overlap-detection propagators (`Equals`, `Count`).

Mentioned in:

- `dev_docs/state-and-variables.md` — `each_interval_minus` in the "IntervalSet representation" section (with the closed-interval convention spelled out, matching `each_interval()` and distinct from the half-open `each_gap_interval()`); both new `State` methods in the "Public read-only queries" section.
- `dev_docs/constraints.md` — `domains_intersect` in the "Querying state" section, since constraint authors will reach for it whenever they catch themselves writing `for (auto val : state.each_value_immutable(v1)) if (state.in_domain(v2, val))`.

Pure additions, ~18 lines across two files. No rewrites.

## Stacking

Built on top of `phase-6-interval-set-ops` (#141) plus `state-and-variables-doc` (#139, cherry-picked) since the doc file lives on the latter. Once #139 and #141 land in either order, this PR rebases cleanly. If you'd prefer a different stacking arrangement (e.g. close #139 and let this PR carry the doc forward), happy to restructure.

## Test plan

- [x] Doc-only — no tests required.
- [x] All claimed APIs cross-checked against the source on `phase-6-interval-set-ops`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
