### PR TITLE
xcsp: phase 0 — bump parser, FetchContent, support matrix (#150)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -33,6 +33,10 @@ library. For an introduction to *using* the solver, start with the top-level
   measuring the wall-time impact of a performance-sensitive change, the
   rationale for each pick, the harness pattern for comparing two builds,
   and what to capture. Use when quantifying a refactor's perf impact.
+- [Frontend support matrix](frontend-support-matrix.md) — single source of
+  truth for which gcs propagators each frontend (MiniZinc, XCSP3, CPMpy)
+  exposes, plus where the solver-side gaps are tracked. Update when adding
+  a propagator or a frontend binding.
 
 More documents will be added here as we build up coverage of other parts of
 the codebase.

--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -1,0 +1,91 @@
+# Frontend support matrix
+
+The same constraint shows up under three frontends — FlatZinc/MiniZinc
+(`minizinc/`), XCSP3 (`xcsp/`), and (planned) CPMpy. This document is the
+single source of truth for "which gcs propagator do we have, and which
+frontends expose it".
+
+When you add a propagator or a frontend binding, update the relevant row.
+Cells contain one of:
+
+- **✓** — fully supported
+- **decompose** — supported by translating to other primitives at parse time
+  (note in a footnote how, if non-obvious)
+- **unsupported** — frontend deliberately does not handle this shape
+- **solver gap (#NNN)** — propagator does not yet exist; tracked under the
+  given issue number
+- **frontend gap (#NNN)** — propagator exists but the frontend has not yet
+  been wired up to it
+- **n/a** — concept does not apply to this frontend
+- **?** — not yet investigated
+
+This is a working document; a `?` is fine and signals a row that needs
+attention.
+
+## Constraints in XCSP3-core
+
+These are the rows defined by [XCSP3-core
+v3.2](https://arxiv.org/abs/2009.00514). MiniZinc and CPMpy column entries
+record whether each frontend reaches the same gcs propagator (or its natural
+equivalent for that frontend's vocabulary).
+
+| Constraint family | gcs propagator | MiniZinc | XCSP3 | CPMpy |
+|---|---|---|---|---|
+| intension (algebraic exprs) | various via tree walk | ✓ | frontend gap (#150) | ? |
+| extension (table) | `Table` / `NegativeTable` | ✓ | ✓ | ? |
+| regular | `Regular` | ✓ | frontend gap (#150) | ? |
+| mdd | solver gap (#149) | ? | solver gap (#149) | ? |
+| allDifferent | `AllDifferent` | ✓ | ✓ | ? |
+| allDifferent-list / -matrix | various decompositions | ? | frontend gap (#150) | ? |
+| allEqual | `Equals` chain (decompose) | ✓ | frontend gap (#150) | ? |
+| ordered (increasing/decreasing) | `Increasing` / `Decreasing` | ✓ | frontend gap (#150) | ? |
+| precedence (value precedence) | `ValuePrecedeChain` | ✓ | frontend gap (#150) | ? |
+| sum (linear) | `WeightedSum` | ✓ | ✓ | ? |
+| count | `Count` | ✓ | frontend gap (#150) | ? |
+| nValues | `NValue` | ✓ | frontend gap (#150) | ? |
+| cardinality (GCC) | decompose to `Count` | ? | frontend gap (#150) | ? |
+| maximum / minimum (constraint) | `ArrayMax` / `ArrayMin` | ✓ | frontend gap (#150) | ? |
+| element | `Element` | ✓ | frontend gap (#150) (matrix form) | ? |
+| channel (inverse) | `Inverse` | ✓ | frontend gap (#150) | ? |
+| noOverlap (Disjunctive) | solver gap (#146) | ? | solver gap (#146) | ? |
+| cumulative | solver gap (#147) | ? | solver gap (#147) | ? |
+| binPacking | solver gap (#148) | ? | solver gap (#148) | ? |
+| knapsack | `Knapsack` | ✓ | frontend gap (#150) | ? |
+| circuit | `Circuit` | ✓ | frontend gap (#150) | ? |
+| instantiation | `Equals` to constant | ✓ | frontend gap (#150) | ? |
+| lex (ordered list) | `Lex` | ✓ | frontend gap (#150) | ? |
+| slide (meta-constraint) | apply template per window | ? | frontend gap (#150) | ? |
+
+The MiniZinc column is best-effort: see `minizinc/fzn_glasgow.cc` for the
+authoritative list of `fzn_*` builtins handled there.
+
+## Constraints outside XCSP3-core
+
+XCSP3-core deliberately omits some constraints that MiniZinc and CPMpy
+expect. These get their own rows. CPMpy-specific gaps (half-reified `And`/`Or`,
+`LessThanEqualIf`, etc.) are tracked under
+[#61](https://github.com/ciaranm/glasgow-constraint-solver/issues/61) — link
+each row here to the relevant sub-bullet there as those features are
+addressed.
+
+| Constraint family | gcs propagator | MiniZinc | XCSP3 | CPMpy | Notes |
+|---|---|---|---|---|---|
+| half-reified comparisons (`LessThanEqualIf`, …) | partially via `Comparison` + reif | ? | n/a | gap (#61) | |
+| half-reified `And` / `Or` | – | ? | n/a | gap (#61) | |
+| `Among` | `Among` | ? | n/a (use count) | ? | |
+| `SmartTable` | `SmartTable` | ✓ | n/a | ? | Glasgow-specific extension |
+
+## Solver gaps tracked elsewhere
+
+- [#146](https://github.com/ciaranm/glasgow-constraint-solver/issues/146) — `Disjunctive` (covers XCSP3 `noOverlap`, MiniZinc `fzn_disjunctive`)
+- [#147](https://github.com/ciaranm/glasgow-constraint-solver/issues/147) — `Cumulative`
+- [#148](https://github.com/ciaranm/glasgow-constraint-solver/issues/148) — `BinPacking`
+- [#149](https://github.com/ciaranm/glasgow-constraint-solver/issues/149) — `MDD`
+
+## Related documents
+
+- [`constraints.md`](constraints.md) — the structural pattern for adding a propagator
+- [`minizinc.md`](minizinc.md) — how the MiniZinc binding works
+- The XCSP3 binding is documented in [`../xcsp/README.md`](../xcsp/README.md)
+
+<!-- vim: set tw=100 spell spelllang=en : -->

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -1,21 +1,19 @@
-include(ExternalProject)
-ExternalProject_Add(XCSP3-CPP-Parser
-    PREFIX ${CMAKE_SOURCE_DIR}/XCSP3-CPP-Parser
-    GIT_REPOSITORY https://github.com/xcsp3team/XCSP3-CPP-Parser.git
-    GIT_TAG 807f475c5b705d085215de61b811c1fbf0152398
-    INSTALL_COMMAND "")
+include(FetchContent)
 
-add_executable(xcsp_glasgow_constraint_solver xcsp_glasgow_constraint_solver.cc)
-target_include_directories(xcsp_glasgow_constraint_solver PRIVATE
-    ${CMAKE_SOURCE_DIR}/XCSP3-CPP-Parser/src/XCSP3-CPP-Parser/include/)
+FetchContent_Declare(xcsp3_cpp_parser
+    GIT_REPOSITORY https://github.com/xcsp3team/XCSP3-CPP-Parser.git
+    GIT_TAG 179670dd97cd2b87cdeb93aa7268b57bba719490
+    EXCLUDE_FROM_ALL)
+FetchContent_MakeAvailable(xcsp3_cpp_parser)
 
 find_package(LibXml2 REQUIRED)
 
+add_executable(xcsp_glasgow_constraint_solver xcsp_glasgow_constraint_solver.cc)
 target_link_libraries(xcsp_glasgow_constraint_solver PRIVATE
-    ${CMAKE_SOURCE_DIR}/XCSP3-CPP-Parser/src/XCSP3-CPP-Parser/lib/libxcsp3parser.a
+    xcsp3parser
+    LibXml2::LibXml2
     glasgow_constraint_solver
-    cxxopts
-    LibXml2::LibXml2)
+    cxxopts)
 
 add_test(NAME xcsp_sum_not_equals COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ sum_not_equals "^d FOUND SOLUTIONS 8$")
 set_tests_properties(xcsp_sum_not_equals PROPERTIES RESOURCE_LOCK xcsp)

--- a/xcsp/README.md
+++ b/xcsp/README.md
@@ -1,8 +1,51 @@
-XCSP Support
-============
+XCSP3 Support
+=============
 
-The contents of the ``XCSP3-CPP-Parser/`` directory is a ``git subtree`` of
-``https://github.com/xcsp3team/XCSP3-CPP-Parser``, which is separately
-licenced.
+This directory provides an XCSP3 frontend for the Glasgow Constraint Solver.
+It parses XCSP3 instances using the upstream
+[XCSP3-CPP-Parser](https://github.com/xcsp3team/XCSP3-CPP-Parser), fetched via
+CMake `FetchContent` into the build directory — no separate checkout needed.
+
+Build the binary with:
+
+```shell
+cmake --build build --target xcsp_glasgow_constraint_solver
+```
+
+Disable the XCSP frontend at configure time with `-DGCS_ENABLE_XCSP=OFF`.
+
+Testing
+-------
+
+Tests cross-check our solver against [ACE](https://github.com/xcsp3team/ACE),
+the reference XCSP3 solver, by comparing the full set of solutions on small
+hand-written instances. The expected solution set for each test is cached in
+this repository, so day-to-day testing does not require ACE — the runner just
+diffs our output against the cache. ACE is needed only when *adding* a new
+test, or to *regenerate* the cache if a test instance changes.
+
+The test infrastructure that consumes these tools is being added under
+[#150](https://github.com/ciaranm/glasgow-constraint-solver/issues/150)
+(Phase 4); the install recipes below are recorded here so contributors can
+set up the environment ahead of time.
+
+### Optional dependencies for adding new tests
+
+- **JDK 11+** (required by ACE):
+  ```shell
+  sudo apt install -y openjdk-21-jdk-headless
+  ```
+- **ACE 2.6+**:
+  ```shell
+  git clone https://github.com/xcsp3team/ACE.git
+  cd ACE && ./gradlew build
+  # Resulting fat JAR: build/libs/ACE-2.6.jar
+  ```
+- **pycsp3 2.5+** (for instance generation and the official solution
+  checker; install into a virtualenv, since `pipx` rejects pure libraries):
+  ```shell
+  python3 -m venv ~/.venvs/pycsp3
+  ~/.venvs/pycsp3/bin/pip install pycsp3
+  ```
 
 <!-- vim: set tw=100 spell spelllang=en : -->

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -499,6 +499,7 @@ struct ParserCallbacks : XCSP3CoreCallbacks
             problem.post(NotEquals{diff, 0_c});
         } break;
         case OrderType::IN:
+        case OrderType::NOTIN:
             throw UnimplementedException{"order type"};
         }
     }


### PR DESCRIPTION
## Summary

Phase 0 of #150. Three things:

- Bump the `XCSP3-CPP-Parser` pin from `807f475c` (~2 years old) to `179670d`, the current upstream master. 18 commits' worth of bug fixes plus the typed `Tree*` intension callback we'll start using in Phase 1.
- Replace `ExternalProject_Add` with `FetchContent_Declare` / `FetchContent_MakeAvailable`. The parser is now a regular CMake target (`xcsp3parser`), so we no longer point at a hand-built `.a`. `EXCLUDE_FROM_ALL` suppresses the parser's unused dynamic-lib and `samplesXcsp3` targets. We have to find LibXml2 ourselves on the consumer side because the parser's `target_link_libraries` is plain-style and doesn't propagate include paths via the imported target.
- Add `dev_docs/frontend-support-matrix.md` as the single source of truth for which gcs propagators each frontend (MiniZinc, XCSP3, CPMpy) exposes, plus the four solver-gap issues (#146-#149). Also rewrite `xcsp/README.md` with optional ACE / pycsp3 / OpenJDK install recipes for the Phase 4 test infrastructure.

The parser bump introduced a new `OrderType::NOTIN` enum value; acknowledged with a matching `UnimplementedException` throw alongside the existing `IN` case, no real handling yet (Phase 2 territory).

No behavioural changes to the binding's existing capabilities — same callbacks supported, same constraints handled.

## Test plan

- [x] Cold-start `cmake --preset release` configures cleanly
- [x] `cmake --build build --target xcsp_glasgow_constraint_solver` builds cleanly (only third-party warnings remain)
- [x] `ctest --preset release -R xcsp` — `xcsp_sum_not_equals` passes including VeriPB verification
- [ ] Reviewer to double-check that the upstream parser's `xcsp3parser_dynamic` and `samplesXcsp3` targets really do stay unbuilt under `EXCLUDE_FROM_ALL` on their machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)