### PR TITLE
xcsp: phase 2b — allEqual, ordered, precedence (#150)

### DIFF
--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -37,9 +37,9 @@ equivalent for that frontend's vocabulary).
 | mdd | solver gap (#149) | ? | solver gap (#149) | ? |
 | allDifferent | `AllDifferent` | ✓ | ✓ | ? |
 | allDifferent-list / -matrix | various decompositions | ? | frontend gap (#150) | ? |
-| allEqual | `Equals` chain (decompose) | ✓ | frontend gap (#150) | ? |
-| ordered (increasing/decreasing) | `Increasing` / `Decreasing` | ✓ | frontend gap (#150) | ? |
-| precedence (value precedence) | `ValuePrecedeChain` | ✓ | frontend gap (#150) | ? |
+| allEqual | `Equals` chain (decompose; native propagator tracked in #61) | ✓ | ✓ via decompose (#150) | ? |
+| ordered (increasing/decreasing) | `Increasing` / `Decreasing` | ✓ | ✓ (basic + lengths form) | ? |
+| precedence (value precedence) | `ValuePrecede` | ✓ | ✓ (with explicit values, `covered=false`) | ? |
 | sum (linear) | `WeightedSum` | ✓ | ✓ | ? |
 | count | `Count` | ✓ | frontend gap (#150) | ? |
 | nValues | `NValue` | ✓ | frontend gap (#150) | ? |

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -29,3 +29,15 @@ set_tests_properties(xcsp_intension_boolean PROPERTIES RESOURCE_LOCK xcsp)
 
 add_test(NAME xcsp_intension_reified COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ intension_reified "^d FOUND SOLUTIONS 2$")
 set_tests_properties(xcsp_intension_reified PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_all_equal COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ all_equal "^d FOUND SOLUTIONS 3$")
+set_tests_properties(xcsp_all_equal PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_ordered_strict COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ ordered_strict "^d FOUND SOLUTIONS 4$")
+set_tests_properties(xcsp_ordered_strict PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_ordered_lengths COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ ordered_lengths "^d FOUND SOLUTIONS 10$")
+set_tests_properties(xcsp_ordered_lengths PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_precedence COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ precedence "^d FOUND SOLUTIONS 14$")
+set_tests_properties(xcsp_precedence PROPERTIES RESOURCE_LOCK xcsp)

--- a/xcsp/tests/all_equal.xml
+++ b/xcsp/tests/all_equal.xml
@@ -1,0 +1,12 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="x"> 0..2 </var>
+        <var id="y"> 0..2 </var>
+        <var id="z"> 0..2 </var>
+    </variables>
+    <constraints>
+        <allEqual>
+            <list> x y z </list>
+        </allEqual>
+    </constraints>
+</instance>

--- a/xcsp/tests/ordered_lengths.xml
+++ b/xcsp/tests/ordered_lengths.xml
@@ -1,0 +1,14 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="a"> 0..5 </var>
+        <var id="b"> 0..5 </var>
+        <var id="c"> 0..5 </var>
+    </variables>
+    <constraints>
+        <ordered>
+            <list> a b c </list>
+            <lengths> 2 1 </lengths>
+            <operator> le </operator>
+        </ordered>
+    </constraints>
+</instance>

--- a/xcsp/tests/ordered_strict.xml
+++ b/xcsp/tests/ordered_strict.xml
@@ -1,0 +1,13 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="x"> 0..3 </var>
+        <var id="y"> 0..3 </var>
+        <var id="z"> 0..3 </var>
+    </variables>
+    <constraints>
+        <ordered>
+            <list> x y z </list>
+            <operator> lt </operator>
+        </ordered>
+    </constraints>
+</instance>

--- a/xcsp/tests/precedence.xml
+++ b/xcsp/tests/precedence.xml
@@ -1,0 +1,13 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="a"> 0..2 </var>
+        <var id="b"> 0..2 </var>
+        <var id="c"> 0..2 </var>
+    </variables>
+    <constraints>
+        <precedence>
+            <list> a b c </list>
+            <values> 1 2 </values>
+        </precedence>
+    </constraints>
+</instance>

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -186,6 +186,97 @@ namespace
             _problem.post(AllDifferent{need_variables(x_vars)});
         }
 
+        auto buildConstraintAllEqual(string, vector<XVariable *> & x_vars) -> void override
+        {
+            // Decomposition into a chain of pairwise Equals. A native
+            // AllEqual propagator would be a small win in propagation and
+            // proof size: tracked alongside the other globals in #61.
+            auto vars = need_variables(x_vars);
+            for (size_t i = 1; i < vars.size(); ++i)
+                _problem.post(Equals{vars[0], vars[i]});
+        }
+
+        auto buildConstraintOrdered(string, vector<XVariable *> & x_vars,
+            OrderType order) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            switch (order) {
+                using enum OrderType;
+            case LE:
+                _problem.post(Increasing{vars});
+                break;
+            case LT:
+                _problem.post(StrictlyIncreasing{vars});
+                break;
+            case GE:
+                _problem.post(Decreasing{vars});
+                break;
+            case GT:
+                _problem.post(StrictlyDecreasing{vars});
+                break;
+            case EQ:
+            case NE:
+            case IN:
+            case NOTIN:
+                report_unsupported("ordered", "non-ordering order type");
+            }
+        }
+
+        auto buildConstraintOrdered(string, vector<XVariable *> & x_vars,
+            vector<int> & lengths, OrderType order) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            if (lengths.size() + 1 != vars.size())
+                report_unsupported("ordered", "lengths size must be |vars| - 1");
+            for (size_t i = 0; i + 1 < vars.size(); ++i) {
+                auto len = Integer{lengths[i]};
+                switch (order) {
+                    using enum OrderType;
+                case LE:
+                    // vars[i] + len <= vars[i+1]
+                    _problem.post(WeightedSum{} + 1_i * vars[i] + -1_i * vars[i + 1] <= -len);
+                    break;
+                case LT:
+                    _problem.post(WeightedSum{} + 1_i * vars[i] + -1_i * vars[i + 1] <= -len - 1_i);
+                    break;
+                case GE:
+                    // vars[i] + len >= vars[i+1]
+                    _problem.post(WeightedSum{} + -1_i * vars[i] + 1_i * vars[i + 1] <= len);
+                    break;
+                case GT:
+                    _problem.post(WeightedSum{} + -1_i * vars[i] + 1_i * vars[i + 1] <= len - 1_i);
+                    break;
+                case EQ:
+                case NE:
+                case IN:
+                case NOTIN:
+                    report_unsupported("ordered", "non-ordering order type");
+                }
+            }
+        }
+
+        auto buildConstraintPrecedence(string, vector<XVariable *> & x_vars, bool) -> void override
+        {
+            // The form without an explicit value list requires us to derive
+            // the value chain from the union of vars' domains; not yet
+            // implemented (issue #150 phase 2b).
+            (void)x_vars;
+            report_unsupported("precedence", "without explicit value list");
+        }
+
+        auto buildConstraintPrecedence(string, vector<XVariable *> & x_vars,
+            vector<int> values, bool covered) -> void override
+        {
+            if (covered)
+                report_unsupported("precedence", "covered=true");
+            auto vars = need_variables(x_vars);
+            vector<Integer> chain;
+            chain.reserve(values.size());
+            for (auto v : values)
+                chain.emplace_back(Integer{v});
+            _problem.post(ValuePrecede{std::move(chain), vars});
+        }
+
         auto buildConstraintSum(string, vector<XVariable *> & x_vars, vector<int> & coeffs,
             XCondition & cond) -> void override
         {


### PR DESCRIPTION
## Summary

Phase 2b of #150. Stacked on #154; rebase base as upstream PRs land.

Adds the comparison-based XCSP3-core constraints we have propagators for:

- **allEqual** — pairwise `Equals` chain. A native `AllEqual` propagator would be a small win in propagation and proof size; flagged in code, tracked alongside the other globals in #61.
- **ordered (basic)** — dispatch on `OrderType` to `Increasing` / `StrictlyIncreasing` / `Decreasing` / `StrictlyDecreasing`.
- **ordered (with lengths)** — chain of `WeightedSum` less-equal between `vars[i] + lengths[i]` and `vars[i+1]`, one per pair.
- **precedence (with explicit values, `covered=false`)** — `ValuePrecede`.

Forms not yet handled (clean `s UNSUPPORTED`):
- `precedence` without an explicit value list (would need to derive the value chain from the union of variable domains).
- `precedence` with `covered=true` (additionally requires every value in the chain to occur).

Both can be added when a benchmark actually needs them.

Four new ctests, all green through VeriPB:

- `all_equal` — 3 solutions
- `ordered_strict` — 4 solutions
- `ordered_lengths` — 10 solutions
- `precedence` — 14 solutions

Frontend-support matrix updated to flip the ordered / precedence / allEqual rows from "frontend gap" to ✓.

## Test plan

- [x] Cold-start `cmake --preset release` configures cleanly
- [x] `cmake --build build --target xcsp_glasgow_constraint_solver` is warning-free in our code
- [x] `clang-format --dry-run --Werror xcsp/xcsp_glasgow_constraint_solver.cc` is clean
- [x] `ctest --preset release -R xcsp` — nine tests pass with VeriPB verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)