### PR TITLE
xcsp: phase 2c — count, nValues, cardinality (#150)

### DIFF
--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -41,9 +41,9 @@ equivalent for that frontend's vocabulary).
 | ordered (increasing/decreasing) | `Increasing` / `Decreasing` | ✓ | ✓ (basic + lengths form) | ? |
 | precedence (value precedence) | `ValuePrecede` | ✓ | ✓ (with explicit values, `covered=false`) | ? |
 | sum (linear) | `WeightedSum` | ✓ | ✓ | ? |
-| count | `Count` | ✓ | frontend gap (#150) | ? |
-| nValues | `NValue` | ✓ | frontend gap (#150) | ? |
-| cardinality (GCC) | decompose to `Count` | ? | frontend gap (#150) | ? |
+| count | `Count` (single value) / `Among` (multi-value set) | ✓ | ✓ (incl. atMost/atLeast/exactlyK/among special-cases) | ? |
+| nValues | `NValue` | ✓ | ✓ (basic; without-`except` form) | ? |
+| cardinality (GCC) | decompose to `Count` | ? | ✓ via decompose (constant values + constant occurs; closed flag) | ? |
 | maximum / minimum (constraint) | `ArrayMax` / `ArrayMin` | ✓ | frontend gap (#150) | ? |
 | element | `Element` | ✓ | frontend gap (#150) (matrix form) | ? |
 | channel (inverse) | `Inverse` | ✓ | frontend gap (#150) | ? |

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -41,3 +41,15 @@ set_tests_properties(xcsp_ordered_lengths PROPERTIES RESOURCE_LOCK xcsp)
 
 add_test(NAME xcsp_precedence COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ precedence "^d FOUND SOLUTIONS 14$")
 set_tests_properties(xcsp_precedence PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_count COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ count "^d FOUND SOLUTIONS 24$")
+set_tests_properties(xcsp_count PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_count_among COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ count_among "^d FOUND SOLUTIONS 24$")
+set_tests_properties(xcsp_count_among PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_n_values COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ n_values "^d FOUND SOLUTIONS 2$")
+set_tests_properties(xcsp_n_values PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_cardinality COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ cardinality "^d FOUND SOLUTIONS 12$")
+set_tests_properties(xcsp_cardinality PROPERTIES RESOURCE_LOCK xcsp)

--- a/xcsp/tests/cardinality.xml
+++ b/xcsp/tests/cardinality.xml
@@ -1,0 +1,15 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="a"> 0..2 </var>
+        <var id="b"> 0..2 </var>
+        <var id="c"> 0..2 </var>
+        <var id="d"> 0..2 </var>
+    </variables>
+    <constraints>
+        <cardinality>
+            <list> a b c d </list>
+            <values> 0 1 </values>
+            <occurs> 2 1 </occurs>
+        </cardinality>
+    </constraints>
+</instance>

--- a/xcsp/tests/count.xml
+++ b/xcsp/tests/count.xml
@@ -1,0 +1,15 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="a"> 0..2 </var>
+        <var id="b"> 0..2 </var>
+        <var id="c"> 0..2 </var>
+        <var id="d"> 0..2 </var>
+    </variables>
+    <constraints>
+        <count>
+            <list> a b c d </list>
+            <values> 1 </values>
+            <condition> (eq, 2) </condition>
+        </count>
+    </constraints>
+</instance>

--- a/xcsp/tests/count_among.xml
+++ b/xcsp/tests/count_among.xml
@@ -1,0 +1,14 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="a"> 0..3 </var>
+        <var id="b"> 0..3 </var>
+        <var id="c"> 0..3 </var>
+    </variables>
+    <constraints>
+        <count>
+            <list> a b c </list>
+            <values> 1 2 </values>
+            <condition> (eq, 2) </condition>
+        </count>
+    </constraints>
+</instance>

--- a/xcsp/tests/n_values.xml
+++ b/xcsp/tests/n_values.xml
@@ -1,0 +1,13 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <var id="a"> 0..1 </var>
+        <var id="b"> 0..1 </var>
+        <var id="c"> 0..1 </var>
+    </variables>
+    <constraints>
+        <nValues>
+            <list> a b c </list>
+            <condition> (eq, 1) </condition>
+        </nValues>
+    </constraints>
+</instance>

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -119,6 +119,7 @@ namespace
         {
             intensionUsingString = false;
             recognizeSpecialIntensionCases = false;
+            recognizeSpecialCountCases = true;
         }
 
         // Public so main() can read these after parsing.
@@ -288,6 +289,105 @@ namespace
             build_sum_common(x_vars, nullopt, cond);
         }
 
+        auto buildConstraintCount(string, vector<XVariable *> & x_vars, vector<int> & values,
+            XCondition & cond) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            auto how_many = _problem.create_integer_variable(0_i,
+                Integer{static_cast<long long>(vars.size())}, "countresult");
+            if (values.size() == 1)
+                _problem.post(Count{vars, constant_variable(Integer{values[0]}), how_many});
+            else {
+                vector<Integer> ivals;
+                ivals.reserve(values.size());
+                for (auto v : values)
+                    ivals.emplace_back(Integer{v});
+                _problem.post(Among{vars, ivals, how_many});
+            }
+            apply_count_condition(how_many, cond, "count");
+        }
+
+        auto buildConstraintAmong(string, vector<XVariable *> & x_vars,
+            vector<int> & values, int k) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            auto how_many = _problem.create_integer_variable(Integer{k}, Integer{k}, "amongresult");
+            vector<Integer> ivals;
+            ivals.reserve(values.size());
+            for (auto v : values)
+                ivals.emplace_back(Integer{v});
+            _problem.post(Among{vars, ivals, how_many});
+        }
+
+        auto buildConstraintAtMost(string, vector<XVariable *> & x_vars,
+            int value, int k) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            auto how_many = _problem.create_integer_variable(0_i, Integer{k}, "atmost");
+            _problem.post(Count{vars, constant_variable(Integer{value}), how_many});
+        }
+
+        auto buildConstraintAtLeast(string, vector<XVariable *> & x_vars,
+            int value, int k) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            auto how_many = _problem.create_integer_variable(Integer{k},
+                Integer{static_cast<long long>(vars.size())}, "atleast");
+            _problem.post(Count{vars, constant_variable(Integer{value}), how_many});
+        }
+
+        auto buildConstraintExactlyK(string, vector<XVariable *> & x_vars,
+            int value, int k) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            auto how_many = _problem.create_integer_variable(Integer{k}, Integer{k}, "exactlyk");
+            _problem.post(Count{vars, constant_variable(Integer{value}), how_many});
+        }
+
+        auto buildConstraintExactlyVariable(string, vector<XVariable *> & x_vars,
+            int value, XVariable * x) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            _problem.post(Count{vars, constant_variable(Integer{value}), need_variable(x->id)});
+        }
+
+        auto buildConstraintNValues(string, vector<XVariable *> & x_vars,
+            XCondition & cond) -> void override
+        {
+            auto vars = need_variables(x_vars);
+            auto n_values = _problem.create_integer_variable(1_i,
+                Integer{static_cast<long long>(vars.size())}, "nvalues");
+            _problem.post(NValue{n_values, vars});
+            apply_count_condition(n_values, cond, "nValues");
+        }
+
+        auto buildConstraintCardinality(string, vector<XVariable *> & x_vars,
+            vector<int> values, vector<int> & occurs, bool closed) -> void override
+        {
+            // Decomposition: one Count per (value, occurrence) pair. A
+            // native GCC propagator would be a future improvement (see the
+            // CPMpy globals list in #61).
+            if (values.size() != occurs.size())
+                report_unsupported("cardinality", "values/occurs size mismatch");
+            auto vars = need_variables(x_vars);
+            for (size_t i = 0; i != values.size(); ++i)
+                _problem.post(Count{vars, constant_variable(Integer{values[i]}),
+                    constant_variable(Integer{occurs[i]})});
+            if (closed) {
+                // Every var must take a value from the given list.
+                vector<Integer> ivals;
+                ivals.reserve(values.size());
+                for (auto v : values)
+                    ivals.emplace_back(Integer{v});
+                vector<vector<Integer>> tuples;
+                tuples.reserve(ivals.size());
+                for (auto v : ivals)
+                    tuples.emplace_back(vector{v});
+                for (auto v : vars)
+                    _problem.post(Table{vector<IntegerVariableID>{v}, tuples});
+            }
+        }
+
         auto buildConstraintIntension(string, Tree * tree) -> void override
         {
             post_intension_top_level(tree->root);
@@ -409,6 +509,55 @@ namespace
                 report_unsupported("element", "non-zero start index");
             if (rank != RankType::ANY)
                 report_unsupported("element", "non-any rank");
+        }
+
+        // Apply a count-style XCondition to a single result variable:
+        // posts `result <op> rhs` directly, where rhs is either a variable
+        // or a constant. Used by count, nValues, etc.
+        auto apply_count_condition(IntegerVariableID result, XCondition & xc,
+            const string & ctx) -> void
+        {
+            IntegerVariableID rhs = constant_variable(0_i);
+            switch (xc.operandType) {
+                using enum OperandType;
+            case VARIABLE:
+                rhs = need_variable(xc.var);
+                break;
+            case INTEGER:
+                rhs = constant_variable(Integer{xc.val});
+                break;
+            case INTERVAL:
+                _problem.post(WeightedSum{} + 1_i * result >= Integer{xc.min});
+                _problem.post(WeightedSum{} + 1_i * result <= Integer{xc.max});
+                return;
+            case SET:
+                report_unsupported(ctx, "set condition");
+            }
+
+            switch (xc.op) {
+                using enum OrderType;
+            case LE:
+                _problem.post(LessThanEqual{result, rhs});
+                break;
+            case LT:
+                _problem.post(LessThan{result, rhs});
+                break;
+            case EQ:
+                _problem.post(Equals{result, rhs});
+                break;
+            case GT:
+                _problem.post(GreaterThan{result, rhs});
+                break;
+            case GE:
+                _problem.post(GreaterThanEqual{result, rhs});
+                break;
+            case NE:
+                _problem.post(NotEquals{result, rhs});
+                break;
+            case IN:
+            case NOTIN:
+                report_unsupported(ctx, "set membership condition");
+            }
         }
 
         auto build_sum_common(vector<XVariable *> & x_vars, const optional<vector<int>> & coeffs,


### PR DESCRIPTION
## Summary

Phase 2c of #150. Stacked on #155.

Adds the counting-family XCSP3-core constraints:

- **count** — generic `XCondition` path; single-value-of-interest goes to `Count`, multi-value to `Among`.
- **atMost / atLeast / exactlyK / exactlyVariable / among** — XCSP3 parser special-cases of `<count>`. `recognizeSpecialCountCases = true` so these dispatch to dedicated callbacks that bound `how_many` tightly rather than posting an extra inequality.
- **nValues** — `NValue` plus a count-style condition. The form with `<except>` is `s UNSUPPORTED` for now (would need to filter the var list before posting `NValue`).
- **cardinality (GCC)** — decompose to one `Count` per `(value, occurs)` pair, plus a single-tuple `Table` per variable when `closed = true`. Variants with variable occurs / variable values / interval occurs aren't yet handled.

A small `apply_count_condition` helper centralises the `"result <op> rhs"` `XCondition` shape used by count, nValues, and the other count-family callbacks.

## Tests

Four new ctests, all green through VeriPB:

- `count` — 4 vars in 0..2, exactly 2 equal 1: **24 solutions**
- `count_among` — 3 vars in 0..3, exactly 2 in `{1,2}`: **24 solutions** (exercises the parser's "among" special case)
- `n_values` — 3 vars in 0..1, 1 distinct value across them: **2 solutions**
- `cardinality` — 4 vars in 0..2, 0 occurs 2 times and 1 occurs 1 time: **12 solutions**

## Test plan

- [x] Cold-start configure + build is warning-free in our code
- [x] `clang-format --dry-run --Werror` is clean
- [x] All 13 xcsp ctests pass with VeriPB verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)