### PR TITLE
xcsp: phase 2f — lex, lexMatrix, allDifferentMatrix (#150)

### DIFF
--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -36,7 +36,7 @@ equivalent for that frontend's vocabulary).
 | regular | `Regular` | ✓ | frontend gap (#150) | ? |
 | mdd | solver gap (#149) | ? | solver gap (#149) | ? |
 | allDifferent | `AllDifferent` | ✓ | ✓ | ? |
-| allDifferent-list / -matrix | various decompositions | ? | frontend gap (#150) | ? |
+| allDifferent-list / -matrix | various decompositions | ? | matrix ✓ (rows + columns `AllDifferent`); list `s UNSUPPORTED` | ? |
 | allEqual | `Equals` chain (decompose; native propagator tracked in #61) | ✓ | ✓ via decompose (#150) | ? |
 | ordered (increasing/decreasing) | `Increasing` / `Decreasing` | ✓ | ✓ (basic + lengths form) | ? |
 | precedence (value precedence) | `ValuePrecede` | ✓ | ✓ (with explicit values, `covered=false`) | ? |
@@ -53,7 +53,7 @@ equivalent for that frontend's vocabulary).
 | knapsack | `Knapsack` | ✓ | ✓ (basic with two `XCondition`s; not yet exercised by a test) | ? |
 | circuit | `Circuit` | ✓ | ✓ (basic; sub-circuit with size param `s UNSUPPORTED`) | ? |
 | instantiation | `Equals` to constant | ✓ | ✓ | ? |
-| lex (ordered list) | `Lex` | ✓ | frontend gap (#150) | ? |
+| lex (ordered list) | `LexLessThan` / `LexLessThanEqual` / `LexGreaterThan` / `LexGreaterEqual` | ✓ | ✓ (lists; matrix as lex² over rows + columns) | ? |
 | slide (meta-constraint) | apply template per window | ? | frontend gap (#150) | ? |
 
 The MiniZinc column is best-effort: see `minizinc/fzn_glasgow.cc` for the

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -71,3 +71,12 @@ set_tests_properties(xcsp_circuit PROPERTIES RESOURCE_LOCK xcsp)
 
 add_test(NAME xcsp_instantiation COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ instantiation "^d FOUND SOLUTIONS 1$")
 set_tests_properties(xcsp_instantiation PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_lex COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ lex "^d FOUND SOLUTIONS 6$")
+set_tests_properties(xcsp_lex PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_lex_matrix COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ lex_matrix "^d FOUND SOLUTIONS 7$")
+set_tests_properties(xcsp_lex_matrix PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_all_different_matrix COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ all_different_matrix "^d FOUND SOLUTIONS 2$")
+set_tests_properties(xcsp_all_different_matrix PROPERTIES RESOURCE_LOCK xcsp)

--- a/xcsp/tests/all_different_matrix.xml
+++ b/xcsp/tests/all_different_matrix.xml
@@ -1,0 +1,10 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <array id="m" size="[2][2]"> 0..1 </array>
+    </variables>
+    <constraints>
+        <allDifferent>
+            <matrix> m[][] </matrix>
+        </allDifferent>
+    </constraints>
+</instance>

--- a/xcsp/tests/lex.xml
+++ b/xcsp/tests/lex.xml
@@ -1,0 +1,13 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <array id="a" size="[2]"> 0..1 </array>
+        <array id="b" size="[2]"> 0..1 </array>
+    </variables>
+    <constraints>
+        <lex>
+            <list> a[] </list>
+            <list> b[] </list>
+            <operator> lt </operator>
+        </lex>
+    </constraints>
+</instance>

--- a/xcsp/tests/lex_matrix.xml
+++ b/xcsp/tests/lex_matrix.xml
@@ -1,0 +1,11 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <array id="m" size="[2][2]"> 0..1 </array>
+    </variables>
+    <constraints>
+        <lex>
+            <matrix> m[][] </matrix>
+            <operator> le </operator>
+        </lex>
+    </constraints>
+</instance>

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -187,6 +187,70 @@ namespace
             _problem.post(AllDifferent{need_variables(x_vars)});
         }
 
+        auto buildConstraintAlldifferentMatrix(string,
+            vector<vector<XVariable *>> & matrix) -> void override
+        {
+            if (matrix.empty())
+                return;
+            // Rows: each row's vars are pairwise distinct.
+            vector<vector<IntegerVariableID>> rows;
+            rows.reserve(matrix.size());
+            for (auto & r : matrix) {
+                rows.emplace_back(need_variables(r));
+                _problem.post(AllDifferent{rows.back()});
+            }
+            // Columns: each column's vars are pairwise distinct.
+            auto ncols = matrix[0].size();
+            for (size_t c = 0; c < ncols; ++c) {
+                vector<IntegerVariableID> col;
+                col.reserve(rows.size());
+                for (auto & r : rows)
+                    col.emplace_back(r[c]);
+                _problem.post(AllDifferent{col});
+            }
+        }
+
+        auto buildConstraintLex(string, vector<vector<XVariable *>> & lists,
+            OrderType order) -> void override
+        {
+            if (lists.size() < 2)
+                return;
+            vector<vector<IntegerVariableID>> ilists;
+            ilists.reserve(lists.size());
+            for (auto & l : lists)
+                ilists.emplace_back(need_variables(l));
+            for (size_t i = 0; i + 1 < ilists.size(); ++i)
+                post_lex_pair(ilists[i], ilists[i + 1], order);
+        }
+
+        auto buildConstraintLexMatrix(string, vector<vector<XVariable *>> & matrix,
+            OrderType order) -> void override
+        {
+            if (matrix.empty())
+                return;
+            vector<vector<IntegerVariableID>> rows;
+            rows.reserve(matrix.size());
+            for (auto & r : matrix)
+                rows.emplace_back(need_variables(r));
+            // Each consecutive row pair lex-ordered.
+            for (size_t i = 0; i + 1 < rows.size(); ++i)
+                post_lex_pair(rows[i], rows[i + 1], order);
+            // Each consecutive column pair lex-ordered.
+            if (rows[0].empty())
+                return;
+            auto ncols = rows[0].size();
+            for (size_t c = 0; c + 1 < ncols; ++c) {
+                vector<IntegerVariableID> col1, col2;
+                col1.reserve(rows.size());
+                col2.reserve(rows.size());
+                for (auto & r : rows) {
+                    col1.emplace_back(r[c]);
+                    col2.emplace_back(r[c + 1]);
+                }
+                post_lex_pair(col1, col2, order);
+            }
+        }
+
         auto buildConstraintAllEqual(string, vector<XVariable *> & x_vars) -> void override
         {
             // Decomposition into a chain of pairwise Equals. A native
@@ -693,6 +757,31 @@ namespace
         {
             if (rank != RankType::ANY)
                 report_unsupported("element", "non-any rank");
+        }
+
+        auto post_lex_pair(const vector<IntegerVariableID> & a,
+            const vector<IntegerVariableID> & b, OrderType order) -> void
+        {
+            switch (order) {
+                using enum OrderType;
+            case LT:
+                _problem.post(LexLessThan{a, b});
+                break;
+            case LE:
+                _problem.post(LexLessThanEqual{a, b});
+                break;
+            case GT:
+                _problem.post(LexGreaterThan{a, b});
+                break;
+            case GE:
+                _problem.post(LexGreaterEqual{a, b});
+                break;
+            case EQ:
+            case NE:
+            case IN:
+            case NOTIN:
+                report_unsupported("lex", "non-ordering order type");
+            }
         }
 
         auto build_min_max_common(vector<XVariable *> & x_vars, XCondition & cond,


### PR DESCRIPTION
## Summary

Phase 2f of #150. Stacked on #158.

Adds the lifted XCSP3-core constraints we have propagators for:

- **lex (lists)** — post the appropriate `Lex*` variant (`LessThan`, `LessThanEqual`, `GreaterThan`, `GreaterEqual`) on each consecutive pair of lists. EQ/NE/IN orders → `s UNSUPPORTED`.
- **lex matrix** (≡ `lex²` / `ordered-matrix`) — apply lex pairwise to consecutive rows AND consecutive columns. Reuses the same `post_lex_pair` helper. XCSP3 doesn't surface a separate `ordered-matrix` parser callback; it routes through `lexMatrix`.
- **allDifferent matrix** — post `AllDifferent` for each row and each column. The `allDifferent-list` form (tuples must be pairwise distinct) is harder to decompose cleanly and is left out of scope for now.
- `element-matrix` already landed in #157.

## Tests

Three new ctests, all green through VeriPB:

- `lex` — two `[2]` arrays in `{0,1}` with `a <_lex b`: **6 solutions**
- `lex_matrix` — `2×2` matrix of `{0,1}` with rows and columns `le_lex`: **7 solutions** (verified by hand-enumeration)
- `all_different_matrix` — `2×2` Latin-square-style: **2 solutions**

## Test plan

- [x] Cold-start configure + build is warning-free in our code
- [x] `clang-format --dry-run --Werror` is clean
- [x] All 22 xcsp ctests pass with VeriPB verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)