### PR TITLE
xcsp: phase 2g + 2h — slide, round out objectives (#150)

### DIFF
--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -54,7 +54,7 @@ equivalent for that frontend's vocabulary).
 | circuit | `Circuit` | ✓ | ✓ (basic; sub-circuit with size param `s UNSUPPORTED`) | ? |
 | instantiation | `Equals` to constant | ✓ | ✓ | ? |
 | lex (ordered list) | `LexLessThan` / `LexLessThanEqual` / `LexGreaterThan` / `LexGreaterEqual` | ✓ | ✓ (lists; matrix as lex² over rows + columns) | ? |
-| slide (meta-constraint) | apply template per window | ? | frontend gap (#150) | ? |
+| slide (meta-constraint) | apply template per window | ? | ✓ (parser unfolds into per-window constraints) | ? |
 
 The MiniZinc column is best-effort: see `minizinc/fzn_glasgow.cc` for the
 authoritative list of `fzn_*` builtins handled there.

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -80,3 +80,6 @@ set_tests_properties(xcsp_lex_matrix PROPERTIES RESOURCE_LOCK xcsp)
 
 add_test(NAME xcsp_all_different_matrix COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ all_different_matrix "^d FOUND SOLUTIONS 2$")
 set_tests_properties(xcsp_all_different_matrix PROPERTIES RESOURCE_LOCK xcsp)
+
+add_test(NAME xcsp_slide COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash $<TARGET_FILE:xcsp_glasgow_constraint_solver> ${CMAKE_SOURCE_DIR}/xcsp/tests/ slide "^d FOUND SOLUTIONS 48$")
+set_tests_properties(xcsp_slide PROPERTIES RESOURCE_LOCK xcsp)

--- a/xcsp/tests/slide.xml
+++ b/xcsp/tests/slide.xml
@@ -1,0 +1,11 @@
+<instance format="XCSP3" type="CSP">
+    <variables>
+        <array id="x" size="[5]"> 0..2 </array>
+    </variables>
+    <constraints>
+        <slide>
+            <list> x[] </list>
+            <intension> ne(%0,%1) </intension>
+        </slide>
+    </constraints>
+</instance>

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -623,6 +623,36 @@ namespace
             build_objective_common(type, x_vars, coeffs, true);
         }
 
+        auto buildObjectiveMinimize(ExpressionObjective type,
+            vector<XVariable *> & x_vars) -> void override
+        {
+            vector<int> coefs(x_vars.size(), 1);
+            build_objective_common(type, x_vars, coefs, false);
+        }
+
+        auto buildObjectiveMaximize(ExpressionObjective type,
+            vector<XVariable *> & x_vars) -> void override
+        {
+            vector<int> coefs(x_vars.size(), 1);
+            build_objective_common(type, x_vars, coefs, true);
+        }
+
+        auto buildObjectiveMinimizeVariable(XVariable * x) -> void override
+        {
+            is_optimisation = true;
+            auto var = need_variable(x->id);
+            objective_variable = var;
+            _problem.minimise(var);
+        }
+
+        auto buildObjectiveMaximizeVariable(XVariable * x) -> void override
+        {
+            is_optimisation = true;
+            auto var = need_variable(x->id);
+            objective_variable = var;
+            _problem.maximise(var);
+        }
+
     private:
         Problem & _problem;
         map<string, ManagedVariable> _variables;


### PR DESCRIPTION
## Summary

Phases 2g + 2h of #150, bundled (small finishing pieces). Stacked on #159.

- **slide** is a parser-level unfold: `<slide>` with `<intension> ne(%0,%1) </intension>` expands into a series of regular `<intension>` constraints over each consecutive window pair, which our existing tree-form intension handler picks up unchanged. **No code change**, only a new ctest.
- **Objective overrides**:
  - `buildObjectiveMinimizeVariable` / `MaximizeVariable` — single-variable objective, post `Problem::minimise` / `maximise` directly.
  - `buildObjectiveMinimize` / `Maximize` without explicit `coefs` — forward to the existing `build_objective_common` with a 1-vector of coefs.
  - The string-expression and `Tree*`/variable-coefs variants stay at the parser's default (clean `s UNSUPPORTED`); add when a benchmark needs them.

## Tests

- `slide` — 5 vars in `0..2`, no two consecutive equal: **48 solutions** (3 × 2⁴)

No new COP test for the objectives — the current `run_xcsp_test.bash` only checks `^d FOUND SOLUTIONS N$` regexes, which doesn't apply to optimisation runs. COP regression coverage will land with the Phase 4 test infrastructure.

This **completes Phase 2** of the umbrella plan. Remaining open Phase-2 items in the umbrella checklist are now all crossed off.

## Test plan

- [x] Cold-start configure + build is warning-free in our code
- [x] `clang-format --dry-run --Werror` is clean
- [x] All 23 xcsp ctests pass with VeriPB verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)