### PR TITLE
AllEqual constraint + IntervalSet::intersect_with + MiniZinc bridge

### DIFF
--- a/dev_docs/state-and-variables.md
+++ b/dev_docs/state-and-variables.md
@@ -143,7 +143,9 @@ For set-difference idioms (yield each maximal interval present in
 `*this` and absent from another set), there's
 `each_interval_minus(other)` — a merge walk that's strictly cheaper
 than per-value membership testing. Yielded `(l, u)` pairs are *closed*
-intervals, matching `each_interval()`'s convention.
+intervals, matching `each_interval()`'s convention. The corresponding
+in-place set-intersection is `intersect_with(other)`, which retains
+exactly the values present in both sets via the same merge walk.
 
 `has_holes()` is allowed to over-approximate: a `false` return guarantees
 no holes, but a `true` return doesn't guarantee any. The current

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(glasgow_constraint_solver
         constraints/all_different/justify.cc
         constraints/all_different/symmetric_all_different.cc
         constraints/all_different/vc_all_different.cc
+        constraints/all_equal.cc
         constraints/among.cc
         constraints/arithmetic.cc
         constraints/at_most_one.cc
@@ -121,6 +122,7 @@ if(GCS_BUILD_TESTS)
     add_executable(abs_test constraints/abs_test.cc)
     add_executable(all_different_test constraints/all_different_test.cc)
     add_executable(all_different_except_test constraints/all_different/all_different_except_test.cc)
+    add_executable(all_equal_test constraints/all_equal_test.cc)
     add_executable(among_test constraints/among_test.cc)
     add_executable(arithmetic_test constraints/arithmetic_test.cc)
     add_executable(at_most_one_test constraints/at_most_one_test.cc)
@@ -149,7 +151,7 @@ if(GCS_BUILD_TESTS)
     add_executable(value_precede_test constraints/value_precede_test.cc)
 
     foreach(test_target
-            abs_test all_different_test all_different_except_test among_test arithmetic_test at_most_one_test comparison_test
+            abs_test all_different_test all_different_except_test all_equal_test among_test arithmetic_test at_most_one_test comparison_test
             count_test element_test equals_test in_test increasing_test inverse_test knapsack_test lex_test linear_test
             logical_test min_max_test mult_bc_test n_value_test parity_test
             plus_minus_test regular_test seq_precede_chain_test smart_table_test symmetric_all_different_test
@@ -160,6 +162,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME abs_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:abs_test>)
     add_test(NAME all_different_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_different_test>)
     add_test(NAME all_different_except_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_different_except_test>)
+    add_test(NAME all_equal_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_equal_test>)
     add_test(NAME among_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:among_test>)
     add_test(NAME arithmetic_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:arithmetic_test>)
     add_test(NAME at_most_one_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:at_most_one_test>)

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -1,0 +1,160 @@
+#include <gcs/constraints/all_equal.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state.hh>
+
+#include <memory>
+#include <sstream>
+#include <utility>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/ostream.h>
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_unique;
+using std::move;
+using std::string;
+using std::stringstream;
+using std::unique_ptr;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+#else
+using fmt::print;
+#endif
+
+AllEqual::AllEqual(vector<IntegerVariableID> vars) :
+    _vars(move(vars))
+{
+}
+
+auto AllEqual::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<AllEqual>(_vars);
+}
+
+auto AllEqual::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto AllEqual::prepare(Propagators &, State &, ProofModel * const) -> bool
+{
+    return _vars.size() > 1;
+}
+
+auto AllEqual::define_proof_model(ProofModel & model) -> void
+{
+    for (size_t i = 0; i + 1 < _vars.size(); ++i)
+        model.add_constraint("AllEqual", "chain step",
+            WPBSum{} + 1_i * _vars[i] + -1_i * _vars[i + 1] == 0_i);
+}
+
+auto AllEqual::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
+
+    propagators.install([vars = move(_vars)](
+                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        auto n = vars.size();
+
+        // Tighten each var to [lo, hi] where lo is the largest lower bound
+        // and hi is the smallest upper bound across all vars. Use a fixed
+        // witness var per direction so RUP only has to chain through the
+        // OPB equalities.
+        auto [lo, hi] = state.bounds(vars[0]);
+        auto argmax_lo = vars[0];
+        auto argmin_hi = vars[0];
+        for (size_t i = 1; i < n; ++i) {
+            auto [lbi, ubi] = state.bounds(vars[i]);
+            if (lbi > lo) {
+                lo = lbi;
+                argmax_lo = vars[i];
+            }
+            if (ubi < hi) {
+                hi = ubi;
+                argmin_hi = vars[i];
+            }
+        }
+
+        for (size_t i = 0; i < n; ++i) {
+            if (state.lower_bound(vars[i]) < lo)
+                inference.infer_greater_than_or_equal(logger, vars[i], lo,
+                    JustifyUsingRUP{},
+                    ReasonFunction{[w = argmax_lo, lo = lo]() { return Reason{{w >= lo}}; }});
+            if (state.upper_bound(vars[i]) > hi)
+                inference.infer_less_than(logger, vars[i], hi + 1_i,
+                    JustifyUsingRUP{},
+                    ReasonFunction{[w = argmin_hi, hi = hi]() { return Reason{{w < hi + 1_i}}; }});
+        }
+
+        // If any domain has holes, prune every var to the intersection of
+        // all domains. Reason for "vars[i] != val" is "witness != val" for
+        // any var whose domain doesn't contain val.
+        bool any_holes = false;
+        for (const auto & v : vars)
+            if (state.domain_has_holes(v)) {
+                any_holes = true;
+                break;
+            }
+
+        if (any_holes) {
+            auto common = state.copy_of_values(vars[0]);
+            for (size_t i = 1; i < n; ++i)
+                common.intersect_with(state.copy_of_values(vars[i]));
+
+            for (size_t i = 0; i < n; ++i) {
+                auto vi_set = state.copy_of_values(vars[i]);
+                for (auto [l, u] : vi_set.each_interval_minus(common)) {
+                    for (Integer val = l; val <= u; ++val) {
+                        IntegerVariableID witness = vars[0];
+                        for (size_t j = 0; j < n; ++j)
+                            if (! state.in_domain(vars[j], val)) {
+                                witness = vars[j];
+                                break;
+                            }
+                        inference.infer_not_equal(logger, vars[i], val,
+                            JustifyUsingRUP{},
+                            ReasonFunction{[w = witness, val]() { return Reason{{w != val}}; }});
+                    }
+                }
+            }
+        }
+
+        // Entailed once any var is single-valued: the chain equalities will
+        // have propagated that value to every other var (or contradicted),
+        // so further calls have nothing to do.
+        if (state.has_single_value(vars[0]))
+            return PropagatorState::DisableUntilBacktrack;
+
+        return PropagatorState::Enable;
+    },
+        triggers);
+}
+
+auto AllEqual::s_exprify(const string & name, const ProofModel * const model) const -> string
+{
+    stringstream s;
+    print(s, "{} all_equal", name);
+    for (const auto & v : _vars)
+        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
+    return s.str();
+}

--- a/gcs/constraints/all_equal.hh
+++ b/gcs/constraints/all_equal.hh
@@ -1,0 +1,42 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_EQUAL_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_EQUAL_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/variable_id.hh>
+
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief Constrain that vars[0] = vars[1] = ... = vars[n-1].
+     *
+     * Achieves GAC in a single propagator pass by intersecting every
+     * variable's domain and pruning each variable to that intersection.
+     * This is strictly stronger per pass than the equivalent chain of
+     * binary Equals constraints, where bound and hole removals would
+     * have to ripple along the chain via the propagation queue, one
+     * step at a time.
+     *
+     * \ingroup Constraints
+     */
+    class AllEqual : public Constraint
+    {
+    private:
+        std::vector<IntegerVariableID> _vars;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit AllEqual(std::vector<IntegerVariableID> vars);
+
+        virtual auto install(innards::Propagators &, innards::State &,
+            innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/all_equal_test.cc
+++ b/gcs/constraints/all_equal_test.cc
@@ -1,0 +1,156 @@
+#include <gcs/constraints/all_equal.hh>
+#include <gcs/constraints/in.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::mt19937;
+using std::nullopt;
+using std::pair;
+using std::random_device;
+using std::set;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+auto run_test(bool proofs, const vector<pair<int, int>> & domains) -> void
+{
+    print(cerr, "all_equal domains={}{}",
+        domains, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [](const vector<int> & vs) {
+        for (size_t i = 1; i < vs.size(); ++i)
+            if (vs[i] != vs[0])
+                return false;
+        return true;
+    },
+        domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> vars;
+    for (const auto & d : domains)
+        vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    p.post(AllEqual{vars});
+
+    auto proof_name = proofs ? make_optional("all_equal_test") : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_holes_test(bool proofs) -> void
+{
+    // Each var is restricted to a fragmented value list via In, so AllEqual
+    // sees multi-interval inputs and exercises the hole-elimination path.
+    print(cerr, "all_equal with holes{}", proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    vector<int> dx{1, 3, 5, 7, 9};
+    vector<int> dy{2, 3, 5, 6, 9};
+    vector<int> dz{3, 4, 5, 8, 9};
+
+    set<tuple<int, int, int>> expected, actual;
+    build_expected(
+        expected,
+        [&](int x, int y, int z) -> bool {
+            auto in = [](int v, const vector<int> & s) {
+                for (auto u : s)
+                    if (u == v) return true;
+                return false;
+            };
+            return x == y && y == z && in(x, dx) && in(y, dy) && in(z, dz);
+        },
+        pair{1, 10}, pair{1, 10}, pair{1, 10});
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto x = p.create_integer_variable(1_i, 10_i);
+    auto y = p.create_integer_variable(1_i, 10_i);
+    auto z = p.create_integer_variable(1_i, 10_i);
+
+    auto to_integers = [](const vector<int> & vs) {
+        vector<Integer> out;
+        for (auto v : vs)
+            out.emplace_back(v);
+        return out;
+    };
+    p.post(In{x, to_integers(dx)});
+    p.post(In{y, to_integers(dy)});
+    p.post(In{z, to_integers(dz)});
+    p.post(AllEqual{vector<IntegerVariableID>{x, y, z}});
+
+    auto proof_name = proofs ? make_optional("all_equal_test_holes") : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{x, y, z});
+    check_results(proof_name, expected, actual);
+}
+
+auto main(int, char *[]) -> int
+{
+    vector<vector<pair<int, int>>> data = {
+        {{1, 5}, {3, 8}},
+        {{1, 3}, {5, 8}},
+        {{1, 4}, {1, 4}},
+        {{1, 5}, {2, 6}, {3, 7}},
+        {{2, 4}, {2, 4}, {2, 4}},
+        {{1, 6}, {2, 5}, {3, 4}, {4, 7}},
+    };
+
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+    auto random_run = [&](int n_vars) {
+        vector<pair<int, int>> doms;
+        std::uniform_int_distribution<int> lo_dist{-3, 5};
+        std::uniform_int_distribution<int> width_dist{0, 5};
+        for (int i = 0; i < n_vars; ++i) {
+            int lo = lo_dist(rand);
+            doms.emplace_back(lo, lo + width_dist(rand));
+        }
+        data.push_back(doms);
+    };
+    for (int i = 0; i < 5; ++i) random_run(2);
+    for (int i = 0; i < 5; ++i) random_run(3);
+    for (int i = 0; i < 3; ++i) random_run(4);
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        for (const auto & doms : data)
+            run_test(proofs, doms);
+        run_holes_test(proofs);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/gcs.hh
+++ b/gcs/gcs.hh
@@ -17,6 +17,7 @@
 
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/all_equal.hh>
 #include <gcs/constraints/among.hh>
 #include <gcs/constraints/arithmetic.hh>
 #include <gcs/constraints/circuit.hh>

--- a/gcs/innards/interval_set.hh
+++ b/gcs/innards/interval_set.hh
@@ -318,6 +318,39 @@ namespace gcs::innards
                 intervals.emplace_back(lower, upper);
         }
 
+        /**
+         * \brief Removes from this set every value not present in \p other.
+         *
+         * In-place set intersection: after the call, this set contains exactly
+         * the values that were in both <code>*this</code> and \p other.
+         *
+         * Walks both interval lists via merge in
+         * <code>O(intervals(this) + intervals(other) + intervals(output))</code>,
+         * without copying either input.
+         *
+         * \sa contains_any_of(), each_interval_minus()
+         */
+        auto intersect_with(const IntervalSet & other) -> void
+        {
+            Intervals result;
+            auto j = other.intervals.begin();
+            for (auto i = intervals.begin(); i != intervals.end(); ++i) {
+                while (j != other.intervals.end() && j->second < i->first)
+                    ++j;
+                auto k = j;
+                while (k != other.intervals.end() && k->first <= i->second) {
+                    Int_ lo = i->first > k->first ? i->first : k->first;
+                    Int_ hi = i->second < k->second ? i->second : k->second;
+                    result.emplace_back(lo, hi);
+                    if (k->second > i->second)
+                        break;
+                    ++k;
+                }
+                j = k;
+            }
+            intervals = std::move(result);
+        }
+
         ///@}
 
         /**

--- a/gcs/innards/interval_set_test.cc
+++ b/gcs/innards/interval_set_test.cc
@@ -698,3 +698,154 @@ TEST_CASE("each_interval_minus brute-force cross-check with multi-interval sets"
         for (const auto & b : {s0, s1, s2, s3, s4, s5})
             CHECK(expand(intervals_minus(a, b)) == brute_force(a, b));
 }
+
+namespace
+{
+    auto intersected_with(IntervalSet<int> a, const IntervalSet<int> & b) -> vector<pair<int, int>>
+    {
+        a.intersect_with(b);
+        return intervals_of(a);
+    }
+}
+
+TEST_CASE("intersect_with: empty other empties this")
+{
+    IntervalSet<int> a, b;
+    a.insert_at_end(1, 5);
+    a.insert_at_end(10, 15);
+    CHECK(intersected_with(a, b).empty());
+}
+
+TEST_CASE("intersect_with: empty this stays empty")
+{
+    IntervalSet<int> a, b(1, 10);
+    CHECK(intersected_with(a, b).empty());
+}
+
+TEST_CASE("intersect_with: disjoint sets yield empty")
+{
+    IntervalSet<int> a(1, 5), b(10, 15);
+    CHECK(intersected_with(a, b).empty());
+    CHECK(intersected_with(b, a).empty());
+}
+
+TEST_CASE("intersect_with: other entirely covers this yields this")
+{
+    IntervalSet<int> a(3, 5), b(1, 10);
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{3, 5}});
+}
+
+TEST_CASE("intersect_with: this entirely contains other yields other")
+{
+    IntervalSet<int> a(1, 10), b(3, 5);
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{3, 5}});
+}
+
+TEST_CASE("intersect_with: single-value overlap")
+{
+    IntervalSet<int> a(1, 5), b(5, 10);
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{5, 5}});
+    CHECK(intersected_with(b, a) == vector<pair<int, int>>{{5, 5}});
+}
+
+TEST_CASE("intersect_with: other touches lower bound")
+{
+    IntervalSet<int> a(1, 5), b(1, 2);
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{1, 2}});
+}
+
+TEST_CASE("intersect_with: other touches upper bound")
+{
+    IntervalSet<int> a(1, 5), b(4, 5);
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{4, 5}});
+}
+
+TEST_CASE("intersect_with: other extends beyond this on both sides")
+{
+    IntervalSet<int> a(3, 7), b(1, 10);
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{3, 7}});
+}
+
+TEST_CASE("intersect_with: multiple other intervals punching one this interval")
+{
+    IntervalSet<int> a(1, 20);
+    IntervalSet<int> b;
+    b.insert_at_end(3, 5);
+    b.insert_at_end(8, 10);
+    b.insert_at_end(15, 17);
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{3, 5}, {8, 10}, {15, 17}});
+}
+
+TEST_CASE("intersect_with: other spans multiple this-intervals")
+{
+    IntervalSet<int> a;
+    a.insert_at_end(1, 3);
+    a.insert_at_end(7, 9);
+    a.insert_at_end(13, 15);
+    IntervalSet<int> b(2, 14);
+    // a = {1..3, 7..9, 13..15}, b = {2..14}
+    // a ∩ b = {2..3, 7..9, 13..14}
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{2, 3}, {7, 9}, {13, 14}});
+}
+
+TEST_CASE("intersect_with: a == b yields a")
+{
+    IntervalSet<int> a;
+    a.insert_at_end(1, 3);
+    a.insert_at_end(8, 10);
+    CHECK(intersected_with(a, a) == vector<pair<int, int>>{{1, 3}, {8, 10}});
+}
+
+TEST_CASE("intersect_with: an other-interval shared by two this-intervals")
+{
+    // an other-interval that overlaps two consecutive this-intervals must not
+    // be consumed prematurely after the first hit
+    IntervalSet<int> a;
+    a.insert_at_end(1, 5);
+    a.insert_at_end(7, 10);
+    IntervalSet<int> b(3, 8);
+    // a ∩ b = {3..5, 7..8}
+    CHECK(intersected_with(a, b) == vector<pair<int, int>>{{3, 5}, {7, 8}});
+}
+
+TEST_CASE("intersect_with brute-force cross-check with multi-interval sets")
+{
+    // For every pair drawn from a small library of multi-interval sets,
+    // intersect_with must produce exactly the values that a brute-force
+    // per-value test reports as in both a and b.
+    auto brute_force = [](const IntervalSet<int> & x, const IntervalSet<int> & y) {
+        vector<int> result;
+        for (auto v : x.each())
+            if (y.contains(v))
+                result.push_back(v);
+        return result;
+    };
+
+    auto expand = [](const vector<pair<int, int>> & intervals) {
+        vector<int> result;
+        for (auto [l, u] : intervals)
+            for (int v = l; v <= u; ++v)
+                result.push_back(v);
+        return result;
+    };
+
+    IntervalSet<int> s0;
+    IntervalSet<int> s1, s2, s3, s4, s5;
+    s1.insert_at_end(1, 3);
+    s1.insert_at_end(8, 10);
+    s1.insert_at_end(15, 17);
+
+    s2.insert_at_end(4, 7);
+    s2.insert_at_end(11, 14);
+
+    s3.insert_at_end(3, 5);
+    s3.insert_at_end(9, 11);
+
+    s4.insert_at_end(18, 20);
+
+    s5.insert_at_end(1, 20);
+
+    for (const auto & a : {s0, s1, s2, s3, s4, s5})
+        for (const auto & b : {s0, s1, s2, s3, s4, s5})
+            CHECK(expand(intersected_with(a, b)) == brute_force(a, b));
+}

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -591,6 +591,10 @@ auto main(int argc, char * argv[]) -> int
                     excluded.push_back(v);
                 problem.post(AllDifferentExcept{vars, excluded});
             }
+            else if (id == "glasgow_all_equal_int") {
+                const auto & vars = arg_as_array_of_var(data, args, 0);
+                problem.post(AllEqual{vars});
+            }
             else if (id == "glasgow_among") {
                 const auto & varcount = arg_as_var(data, args, 0);
                 const auto & vars = arg_as_array_of_var(data, args, 1);

--- a/minizinc/mznlib/fzn_all_equal_int.mzn
+++ b/minizinc/mznlib/fzn_all_equal_int.mzn
@@ -1,2 +1,2 @@
-predicate fzn_all_equal_int(array[int] of var int: x) =
-    forall (i in index_set(x) where i + 1 in index_set(x)) (x[i] = x[i + 1]);
+predicate glasgow_all_equal_int(array[int] of var int: x);
+predicate fzn_all_equal_int(array[int] of var int: x) = glasgow_all_equal_int(x);


### PR DESCRIPTION
## Summary

- **`IntervalSet::intersect_with(other)`** — in-place set intersection via the same merge-walk shape as `each_interval_minus`. O(intervals(this) + intervals(other) + intervals(output)), no copy of either input. 14 new TEST_CASEs cover the edge cases plus a brute-force cross-check against per-value membership.
- **`AllEqual`** — native single-pass GAC propagator for `vars[0] = ... = vars[n-1]`. Bounds tightening (max-of-lbs / min-of-ubs with a fixed witness var per direction) followed by intersection-and-prune via the new `intersect_with`. Strictly stronger per pass than the chain of binary `Equals` that the MiniZinc bridge previously decomposed to. All justifications are `JustifyUsingRUP{}`; VeriPB chains through the n-1 chain equalities in the OPB without explicit help. Hole-elimination is gated on a post-bounds any-holes check, so contiguous-domain workloads pay only the bounds pass.
- **MiniZinc bridge** — replaces the `fzn_all_equal_int` decomposition (`forall (i) x[i] = x[i+1]`) with a `glasgow_all_equal_int` redefinition that fzn-glasgow lowers to `AllEqual`. MiniZinc `all_equal` calls now produce a single named OPB block instead of n-1 pair encodings, and reach GAC in one pass.

## Test plan

- [x] `all_equal_test` passes (random + hand-picked 2/3/4-var domain shapes; `In{}`-seeded fragmented-domain holes test) under `solve_for_tests_checking_gac`
- [x] All `all_equal_test` cases verified by VeriPB end-to-end
- [x] `interval_set_test` — 14 new TEST_CASEs for `intersect_with`, all passing (335 assertions across 64 test cases)
- [x] Sanitizer-clean (ASan + UBSan) for both new test binaries
- [x] Existing `minizinc-allequal` still passes (now via the native AllEqual path); 3 solutions enumerated, VeriPB verifies
- [x] Full release ctest passes 169/169 (was 168, +1 for `all_equal_constraint`)

## Out of scope

- Reified variants (`AllEqualIf`, `AllEqualIff`) — no caller demand visible; punted

🤖 Generated with [Claude Code](https://claude.com/claude-code)