### PR TITLE
xcsp: phase 4a — stream --all solutions, prep for cache-based testing (#150)

### DIFF
--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -1619,15 +1619,28 @@ auto main(int argc, char * argv[]) -> int
     auto stats = solve_with(problem,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
-                saved_solution.emplace(s.clone());
                 if (callbacks.is_optimisation) {
+                    saved_solution.emplace(s.clone());
                     cout << "o " << s(*callbacks.objective_variable) << endl;
                     return true;
                 }
-                else if (options_vars.contains("all"))
+                else if (options_vars.contains("all")) {
+                    // Stream each solution as a compact tuple line. The
+                    // test runner sorts and diffs these against the cached
+                    // expected output.
+                    cout << "ENUMSOL:";
+                    for (const auto & [n, v] : callbacks.variables())
+                        if (v.id)
+                            cout << " " << n << "=" << s(*v.id);
+                        else
+                            cout << " " << n << "=*";
+                    cout << endl;
                     return true;
-                else
+                }
+                else {
+                    saved_solution.emplace(s.clone());
                     return false;
+                }
             }},
         options_vars.contains("prove") ? make_optional<ProofOptions>("xcsp") : nullopt,
         &abort_flag);
@@ -1644,12 +1657,12 @@ auto main(int argc, char * argv[]) -> int
     bool actually_aborted = actually_timed_out || was_terminated.load();
 
     if (actually_aborted) {
-        if (callbacks.is_optimisation && saved_solution)
+        if (stats.solutions > 0)
             cout << "s SATISFIABLE" << endl;
         else
             cout << "s UNKNOWN" << endl;
     }
-    else if (! saved_solution) {
+    else if (stats.solutions == 0) {
         cout << "s UNSATISFIABLE" << endl;
     }
     else if (callbacks.is_optimisation)


### PR DESCRIPTION
## Summary

Phase 4a of #150. First slice of the cache-based testing infrastructure: get the binding to emit a stream of every solution so the test runner has something to diff against.

In CSP `--all` mode, the solution callback now emits one line per solution as the search runs:

```
ENUMSOL: x=2 y=1
ENUMSOL: x=2 y=3
...
```

Variable order is alphabetic (the `std::map` iteration order); unused variables print as `name=*`.

Other behaviour changes:

- The post-search `<instantiation>` `v` block no longer prints in `--all` mode — it only ever showed the *last* solution, which is redundant with the stream and confusing.
- The `s SATISFIABLE` / `s UNSATISFIABLE` / `s OPTIMUM FOUND` status check now uses `stats.solutions` instead of `saved_solution`, since the latter isn't populated in enumerate mode.
- COP mode (`o <val>` lines + final `v` block + `s OPTIMUM FOUND`) is unchanged.
- `d FOUND SOLUTIONS N` is unchanged, so the existing count-regex tests keep passing.

## Phase 4 plan

- **4a (this PR)**: stream solutions.
- **4b**: hand-write cache for one test, write `run_xcsp_test.bash` v2 that sorts the stream and diffs against the cache. End-to-end without ACE in the loop.
- **4c**: `regenerate_expected.bash <name>` using ACE; populate caches for the 24 existing tests; switch all tests off the count-regex framework.
- **4d**: COP test handling (cache the optimum value; no assignment).

## Test plan

- [x] `ctest --preset release -R xcsp` — all 24 existing tests still pass with VeriPB verification (the count-regex check still finds `d FOUND SOLUTIONS N`).
- [x] `--all` on `intension_basic.xml` produces the expected 5 ENUMSOL lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)