### PR TITLE
test utils: random_bounds_or_constant actually mixes constants

### DIFF
--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -496,6 +496,14 @@ namespace gcs::test_innards
     template <typename Random_>
     auto generate_random_data_item(Random_ & rand, const RandomBoundsOrConstant & bounds)
     {
+        // One in three calls produces a constant in the support of the
+        // bounds-pair shape; the rest produce the pair, matching the spirit
+        // of equals_test's 2:1 var-to-constant ratio.
+        std::uniform_int_distribution<int> choice{0, 2};
+        if (choice(rand) == 0) {
+            std::uniform_int_distribution<int> const_dist{bounds.lower_min, bounds.lower_max + bounds.add_max};
+            return std::variant<int, std::pair<int, int>>{const_dist(rand)};
+        }
         std::uniform_int_distribution<int> lower_dist{bounds.lower_min, bounds.lower_max}, add_dist{bounds.add_min, bounds.add_max};
         auto lower = lower_dist(rand);
         auto upper = lower + add_dist(rand);


### PR DESCRIPTION
## Summary

`random_bounds_or_constant` promised mixed const/pair output but always returned a pair-form variant. `among_test.cc` (its only caller) was already calling it expecting some array entries to come out as constants — they never did. Fixes the helper so 1 in 3 calls produces a constant in the support `[lower_min, lower_max + add_max]`, matching the 2:1 var-to-constant ratio `equals_test` achieves by interleaving `random_bounds` and `random_constant` separately.

This is the smallest first step in the constraint-test coverage sweep; other test files will adopt `random_bounds_or_constant` for argument slots that should mix const/var, separately.

## Test plan

- [x] `among_test` passes (16/16 cases verified by VeriPB), and 4 of the 16 random cases now have at least one constant in the array — the gap the audit flagged
- [x] Sanitizer-clean (ASan + UBSan)
- [x] No other consumers of `random_bounds_or_constant` in tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)