### PR TITLE
gcspy: fix build break referencing renamed innards::CompareLessThanReif

### DIFF
--- a/python/gcspy.cc
+++ b/python/gcspy.cc
@@ -402,11 +402,11 @@ auto Python::post_less_than_equal_reif(const string & var_id_1, const string & v
     }
     else {
 #ifdef WRITE_API_CALLS
-        api_calls << "p.post(innards::CompareLessThanReif{v" << var_id_1 << ", "
+        api_calls << "p.post(LessThanEqualIf{v" << var_id_1 << ", "
                   << "v" << var_id_2 << ", v" << reif << " != 0_i"
-                  << ", false, true});" << endl;
+                  << "});" << endl;
 #endif
-        p.post(innards::CompareLessThanReif{get_var(var_id_1), get_var(var_id_2), get_var_as_cond(reif), false, true});
+        p.post(LessThanEqualIf{get_var(var_id_1), get_var(var_id_2), get_var_as_cond(reif)});
     }
 }
 
@@ -422,11 +422,11 @@ auto Python::post_greater_than_reif(const string & var_id_1, const string & var_
     }
     else {
 #ifdef WRITE_API_CALLS
-        api_calls << "p.post(innards::CompareLessThanReif{v" << var_id_2 << ", "
-                  << "v" << var_id_1 << ", v" << reif << " != 0_i"
-                  << ", false, false});" << endl;
+        api_calls << "p.post(GreaterThanIf{v" << var_id_1 << ", "
+                  << "v" << var_id_2 << ", v" << reif << " != 0_i"
+                  << "});" << endl;
 #endif
-        p.post(innards::CompareLessThanReif{get_var(var_id_2), get_var(var_id_1), get_var_as_cond(reif), false, false});
+        p.post(GreaterThanIf{get_var(var_id_1), get_var(var_id_2), get_var_as_cond(reif)});
     }
 }
 
@@ -442,11 +442,11 @@ auto Python::post_greater_than_equal_reif(const string & var_id_1, const string 
     }
     else {
 #ifdef WRITE_API_CALLS
-        api_calls << "p.post(innards::CompareLessThanReif{v" << var_id_1 << ", "
+        api_calls << "p.post(GreaterThanEqualIf{v" << var_id_1 << ", "
                   << "v" << var_id_2 << ", v" << reif << " != 0_i"
-                  << ", false, true});" << endl;
+                  << "});" << endl;
 #endif
-        p.post(innards::CompareLessThanReif{get_var(var_id_2), get_var(var_id_1), get_var_as_cond(reif), false, true});
+        p.post(GreaterThanEqualIf{get_var(var_id_1), get_var(var_id_2), get_var_as_cond(reif)});
     }
 }
 


### PR DESCRIPTION
## Summary

Independent of the XCSP3 stack. Found while trying to install \`gcspy\` locally to exercise the existing CPMpy backend.

The half-reified variants of \`post_less_than_equal_reif\`, \`post_greater_than_reif\`, and \`post_greater_than_equal_reif\` still poke at \`innards::CompareLessThanReif\`, which was renamed to \`ReifiedCompareLessThanOrMaybeEqual\` some time ago. \`pip install ./python/\` against current source fails with:

```
error: 'CompareLessThanReif' is not a member of 'gcs::innards'
```

Each call site is replaced with the appropriate public wrapper class (\`LessThanEqualIf\`, \`GreaterThanIf\`, \`GreaterThanEqualIf\`), which all wrap \`ReifiedCompareLessThanOrMaybeEqual\` with the right \`or_equal\`/\`vars_swapped\` flags internally. The fully-reified branches already used the public \`*Iff\` classes; this just brings the \`else\` branches into line.

\`post_less_than_reif\` was already correct.

## Test plan

- [x] \`pip install ./python/\` (in a fresh Python 3.14 venv) now succeeds
- [x] \`python -c 'import gcspy; g = gcspy.GCS(); ...'\` smoke test runs
- [x] CPMpy 0.9.28's gcs backend — installed via \`pip install cpmpy\` then driven against this build — passes 11493 / 11940 \`test_constraints.py\` parametrisations and 128 / 134 across the next four test files. The 447+1 failures are pre-existing issues (\`State::domains_intersect\` doesn't yet handle negated views; \`gcspy.create_integer_variable\` rejects \`,\` in variable names) — not regressions from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)