### PR TITLE
Constraint test coverage sweep: 11 tests + 2 propagator fixes + 2 issues filed

### DIFF
--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -44,6 +44,12 @@ auto AtMostOneSmartTable::clone() const -> unique_ptr<Constraint>
 auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_state,
     ProofModel * const optional_model) && -> void
 {
+    // 0 or 1 vars: "at most 1 of n equals val" is vacuously true. The
+    // SmartTable below would build empty tuples for n == 0, which means
+    // "no row matches" i.e. UNSAT — wrong for the trivial case. Skip.
+    if (_vars.size() < 2)
+        return;
+
     // Build the constraint as smart table
     // Question: Do we trust this encoding as a smart table?
     // Should we morally have a simpler PB encoding and reformulate?

--- a/gcs/constraints/at_most_one_test.cc
+++ b/gcs/constraints/at_most_one_test.cc
@@ -5,6 +5,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <random>
 #include <set>
 #include <tuple>
 #include <utility>
@@ -16,15 +17,19 @@
 #else
 #include <fmt/core.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #endif
 
 using std::cerr;
 using std::flush;
 using std::make_optional;
+using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
 using std::set;
 using std::tuple;
+using std::uniform_int_distribution;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -38,91 +43,96 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_at_most_one_test_3(bool proofs,
-    pair<int, int> r1, pair<int, int> r2, pair<int, int> r3,
-    pair<int, int> r_val) -> void
+auto run_at_most_one_test(bool proofs,
+    const vector<pair<int, int>> & ranges, pair<int, int> val_range) -> void
 {
-    print(cerr, "at_most_one 3 {} {} {} val={}{}", r1, r2, r3, r_val, proofs ? " with proofs:" : ":");
+    print(cerr, "at_most_one {} val={}{}", ranges, val_range, proofs ? " with proofs:" : ":");
     cerr << flush;
 
-    set<tuple<int, int, int, int>> expected, actual;
-    build_expected(expected, [](int a, int b, int c, int v) {
-        return (a == v) + (b == v) + (c == v) <= 1;
-    }, r1, r2, r3, r_val);
+    set<tuple<vector<int>, int>> expected, actual;
+    build_expected(expected,
+        [](const vector<int> & vs, int v) {
+            int matches = 0;
+            for (auto x : vs)
+                matches += (x == v);
+            return matches <= 1;
+        },
+        ranges, val_range);
     println(cerr, " expecting {} solutions", expected.size());
 
     Problem p;
-    auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
-    auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
-    auto v3 = p.create_integer_variable(Integer(r3.first), Integer(r3.second));
-    auto val = p.create_integer_variable(Integer(r_val.first), Integer(r_val.second));
-    p.post(AtMostOne{{v1, v2, v3}, val});
+    vector<IntegerVariableID> vars;
+    for (const auto & [l, u] : ranges)
+        vars.push_back(p.create_integer_variable(Integer(l), Integer(u)));
+    auto val = p.create_integer_variable(Integer(val_range.first), Integer(val_range.second));
+    p.post(AtMostOne{vars, val});
 
     auto proof_name = proofs ? make_optional("at_most_one_test") : nullopt;
-    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3, val});
-    check_results(proof_name, expected, actual);
-}
-
-auto run_at_most_one_test_4(bool proofs,
-    pair<int, int> r1, pair<int, int> r2, pair<int, int> r3, pair<int, int> r4,
-    pair<int, int> r_val) -> void
-{
-    print(cerr, "at_most_one 4 {} {} {} {} val={}{}", r1, r2, r3, r4, r_val, proofs ? " with proofs:" : ":");
-    cerr << flush;
-
-    set<tuple<int, int, int, int, int>> expected, actual;
-    build_expected(expected, [](int a, int b, int c, int d, int v) {
-        return (a == v) + (b == v) + (c == v) + (d == v) <= 1;
-    }, r1, r2, r3, r4, r_val);
-    println(cerr, " expecting {} solutions", expected.size());
-
-    Problem p;
-    auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
-    auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
-    auto v3 = p.create_integer_variable(Integer(r3.first), Integer(r3.second));
-    auto v4 = p.create_integer_variable(Integer(r4.first), Integer(r4.second));
-    auto val = p.create_integer_variable(Integer(r_val.first), Integer(r_val.second));
-    p.post(AtMostOne{{v1, v2, v3, v4}, val});
-
-    auto proof_name = proofs ? make_optional("at_most_one_test") : nullopt;
-    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3, v4, val});
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars, val});
     check_results(proof_name, expected, actual);
 }
 
 auto run_all_tests(bool proofs) -> void
 {
+    // Boundary: empty / singleton — both vacuously true.
+    run_at_most_one_test(proofs, {}, {1, 3});
+    run_at_most_one_test(proofs, {{1, 3}}, {1, 3});
+
+    // Two vars: smallest meaningful case.
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}}, {1, 3});
+
     // 3-variable tests, fixed val (single-point range)
-    run_at_most_one_test_3(proofs, {1, 3}, {1, 3}, {1, 3}, {2, 2});          // basic, val=2
-    run_at_most_one_test_3(proofs, {1, 3}, {1, 3}, {1, 3}, {5, 5});          // val outside all domains: all trivially satisfy
-    run_at_most_one_test_3(proofs, {1, 3}, {1, 3}, {1, 3}, {1, 1});          // val at domain boundary
-    run_at_most_one_test_3(proofs, {-2, 2}, {-2, 2}, {-2, 2}, {0, 0});       // negative domain, val=0
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {2, 2});          // basic, val=2
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {5, 5});          // val outside all domains
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {1, 1});          // val at domain boundary
+    run_at_most_one_test(proofs, {{-2, 2}, {-2, 2}, {-2, 2}}, {0, 0});       // negative domain, val=0
 
-    // 3-variable tests, variable val: val itself can change
-    run_at_most_one_test_3(proofs, {1, 3}, {1, 3}, {1, 3}, {1, 3});          // val same range as vars
-    run_at_most_one_test_3(proofs, {1, 3}, {1, 3}, {1, 3}, {2, 4});          // val range overlaps vars
+    // 3-variable tests, variable val
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {1, 3});
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {2, 4});
 
-    // Propagation: one var forced to equal val, so all others must differ
-    run_at_most_one_test_3(proofs, {2, 2}, {1, 3}, {1, 3}, {2, 2});          // v1 forced to val=2, v2/v3 must != 2
-    run_at_most_one_test_3(proofs, {2, 2}, {2, 2}, {1, 3}, {1, 3});          // v1=v2=2, val must move away from 2
+    // Propagation: one var forced to equal val, others must differ
+    run_at_most_one_test(proofs, {{2, 2}, {1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(proofs, {{2, 2}, {2, 2}, {1, 3}}, {1, 3});
 
     // Unsatisfiable: two vars forced to equal a fixed val
-    run_at_most_one_test_3(proofs, {2, 2}, {2, 2}, {1, 3}, {2, 2});
+    run_at_most_one_test(proofs, {{2, 2}, {2, 2}, {1, 3}}, {2, 2});
 
-    // 4-variable tests, fixed val
-    run_at_most_one_test_4(proofs, {1, 3}, {1, 3}, {1, 3}, {1, 3}, {2, 2});
-    run_at_most_one_test_4(proofs, {2, 2}, {1, 3}, {1, 3}, {1, 3}, {2, 2});  // propagation with 4 vars
-
-    // 4-variable tests, variable val
-    run_at_most_one_test_4(proofs, {1, 3}, {1, 3}, {1, 3}, {1, 3}, {1, 3});
-    run_at_most_one_test_4(proofs, {2, 2}, {2, 2}, {1, 3}, {1, 3}, {1, 3}); // v1=v2=2, val can't be 2
+    // 4-variable tests
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(proofs, {{2, 2}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}, {1, 3}}, {1, 3});
+    run_at_most_one_test(proofs, {{2, 2}, {2, 2}, {1, 3}, {1, 3}}, {1, 3});
 }
 
 auto main(int, char *[]) -> int
 {
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         run_all_tests(proofs);
+
+        // Small random sweep: 2..5 vars, modest domains so the solution
+        // space stays small. Solution count is O(|val| * prod(|vars|))
+        // worst case, which on these bounds is at most ~5^5 = 3125 even
+        // before the at-most-one filter, so VeriPB stays fast.
+        uniform_int_distribution n_vars_dist{2, 5};
+        uniform_int_distribution lo_dist{-2, 4};
+        uniform_int_distribution width_dist{0, 4};
+        for (int x = 0; x < 10; ++x) {
+            int n_vars = n_vars_dist(rand);
+            vector<pair<int, int>> ranges;
+            for (int i = 0; i < n_vars; ++i) {
+                int lo = lo_dist(rand);
+                ranges.emplace_back(lo, lo + width_dist(rand));
+            }
+            int v_lo = lo_dist(rand);
+            run_at_most_one_test(proofs, ranges, {v_lo, v_lo + width_dist(rand)});
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/count_test.cc
+++ b/gcs/constraints/count_test.cc
@@ -47,7 +47,7 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_count_test(bool proofs, variant<int, pair<int, int>> result_range, variant<int, pair<int, int>> voi_range, const vector<pair<int, int>> & array_range) -> void
+auto run_count_test(bool proofs, variant<int, pair<int, int>> result_range, variant<int, pair<int, int>> voi_range, const vector<variant<int, pair<int, int>>> & array_range) -> void
 {
     visit([&](auto result, auto voi) { print(cerr, "count {} {} {} {}", result, voi, array_range, proofs ? " with proofs:" : ":"); }, result_range, voi_range);
     cerr << flush;
@@ -64,8 +64,8 @@ auto run_count_test(bool proofs, variant<int, pair<int, int>> result_range, vari
     auto result = visit([&](auto r) { return create_integer_variable_or_constant(p, r); }, result_range);
     auto voi = visit([&](auto v) { return create_integer_variable_or_constant(p, v); }, voi_range);
     vector<IntegerVariableID> array;
-    for (const auto & [l, u] : array_range)
-        array.push_back(p.create_integer_variable(Integer(l), Integer(u)));
+    for (const auto & entry : array_range)
+        array.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     p.post(Count{array, voi, result});
 
     auto proof_name = proofs ? make_optional("count_test") : nullopt;
@@ -76,19 +76,23 @@ auto run_count_test(bool proofs, variant<int, pair<int, int>> result_range, vari
 
 auto main(int, char *[]) -> int
 {
-    vector<tuple<variant<int, pair<int, int>>, variant<int, pair<int, int>>, vector<pair<int, int>>>> data = {
-        {pair{1, 2}, pair{1, 2}, {{1, 2}, {1, 2}}},
-        {pair{1, 2}, pair{0, 3}, {{1, 2}, {1, 2}}},
-        {pair{1, 2}, pair{1, 2}, {{1, 2}, {1, 2}, {1, 2}}},
-        {pair{0, 3}, pair{1, 2}, {{1, 2}, {1, 2}, {1, 2}}},
-        {pair{0, 4}, pair{0, 4}, {{1, 2}, {1, 2}, {1, 2}}},
-        {pair{1, 3}, pair{1, 6}, {{0, 4}, {0, 5}, {0, 6}}},
-        {pair{-1, 3}, pair{0, 5}, {{-1, 2}, {1, 3}, {4, 5}}},
-        {pair{1, 4}, pair{-3, 8}, {{1, 4}, {2, 3}, {0, 5}, {-2, 0}, {5, 7}}},
-        {pair{0, 4}, pair{-5, 2}, {{7, 14}, {7, 11}}},
-        {pair{3, 10}, pair{3, 8}, {{-2, 2}, {3, 7}, {5, 9}, {0, 6}}},
-        {pair{1, 9}, pair{-5, 5}, {{2, 6}, {8, 11}, {6, 12}, {-3, 0}}},
-        {pair{2, 2}, pair{3, 6}, {{5, 9}, {-5, 3}, {2, 6}}}};
+    using ArrayEntry = variant<int, pair<int, int>>;
+    vector<tuple<variant<int, pair<int, int>>, variant<int, pair<int, int>>, vector<ArrayEntry>>> data = {
+        {pair{1, 2}, pair{1, 2}, {pair{1, 2}, pair{1, 2}}},
+        {pair{1, 2}, pair{0, 3}, {pair{1, 2}, pair{1, 2}}},
+        {pair{1, 2}, pair{1, 2}, {pair{1, 2}, pair{1, 2}, pair{1, 2}}},
+        {pair{0, 3}, pair{1, 2}, {pair{1, 2}, pair{1, 2}, pair{1, 2}}},
+        {pair{0, 4}, pair{0, 4}, {pair{1, 2}, pair{1, 2}, pair{1, 2}}},
+        {pair{1, 3}, pair{1, 6}, {pair{0, 4}, pair{0, 5}, pair{0, 6}}},
+        {pair{-1, 3}, pair{0, 5}, {pair{-1, 2}, pair{1, 3}, pair{4, 5}}},
+        {pair{1, 4}, pair{-3, 8}, {pair{1, 4}, pair{2, 3}, pair{0, 5}, pair{-2, 0}, pair{5, 7}}},
+        {pair{0, 4}, pair{-5, 2}, {pair{7, 14}, pair{7, 11}}},
+        {pair{3, 10}, pair{3, 8}, {pair{-2, 2}, pair{3, 7}, pair{5, 9}, pair{0, 6}}},
+        {pair{1, 9}, pair{-5, 5}, {pair{2, 6}, pair{8, 11}, pair{6, 12}, pair{-3, 0}}},
+        {pair{2, 2}, pair{3, 6}, {pair{5, 9}, pair{-5, 3}, pair{2, 6}}},
+        // Constant array entries: voi seen N times where some array slots are fixed.
+        {pair{0, 3}, pair{0, 3}, {1, 2, pair{1, 3}}},
+        {pair{0, 3}, 2, {pair{1, 4}, 2, pair{1, 4}, 2}}};
 
     random_device rand_dev;
     mt19937 rand(rand_dev());
@@ -96,21 +100,21 @@ auto main(int, char *[]) -> int
         uniform_int_distribution n_values_dist(1, 4);
         auto n_values = n_values_dist(rand);
         generate_random_data(rand, data, random_bounds(-7, 7, 5, 10), random_bounds(-7, 7, 5, 10),
-            vector{size_t(n_values), random_bounds(-5, 8, 3, 8)});
+            vector{size_t(n_values), random_bounds_or_constant(-5, 8, 3, 8)});
     }
 
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 4);
         auto n_values = n_values_dist(rand);
         generate_random_data(rand, data, random_constant(-7, 7), random_bounds(-7, 7, 5, 10),
-            vector{size_t(n_values), random_bounds(-5, 8, 3, 8)});
+            vector{size_t(n_values), random_bounds_or_constant(-5, 8, 3, 8)});
     }
 
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 4);
         auto n_values = n_values_dist(rand);
         generate_random_data(rand, data, random_constant(-7, 7), random_constant(-7, 7),
-            vector{size_t(n_values), random_bounds(-5, 8, 3, 8)});
+            vector{size_t(n_values), random_bounds_or_constant(-5, 8, 3, 8)});
     }
 
     for (bool proofs : {false, true}) {

--- a/gcs/constraints/in_test.cc
+++ b/gcs/constraints/in_test.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <random>
 #include <set>
 #include <tuple>
 #include <utility>
@@ -23,10 +24,13 @@
 using std::cerr;
 using std::flush;
 using std::make_optional;
+using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
 using std::set;
 using std::tuple;
+using std::uniform_int_distribution;
 using std::vector;
 using std::ranges::find;
 
@@ -228,12 +232,62 @@ auto run_all_tests(bool proofs) -> void
     run_in_self_reference_test(proofs, {-2, 2});
 }
 
+auto run_random_tests(bool proofs, mt19937 & rand) -> void
+{
+    // Small random sweep. Each shape gets 5 instances. Brute-force cost is
+    // O(|dom(var)| * prod(|dom(V_i)|)) per case; on these bounds (var up to
+    // width 5, var list up to 3 entries width 4) that's well under 1k
+    // combinations per case, so VeriPB stays fast.
+    uniform_int_distribution lo_dist{-3, 5};
+    uniform_int_distribution width_dist{1, 4};
+    uniform_int_distribution count_dist{1, 4};
+    uniform_int_distribution val_dist{-3, 8};
+    uniform_int_distribution n_vars_dist{1, 3};
+
+    auto random_pair = [&]() {
+        int lo = lo_dist(rand);
+        return pair{lo, lo + width_dist(rand)};
+    };
+    auto random_vals = [&](int n) {
+        vector<int> vs;
+        for (int i = 0; i < n; ++i)
+            vs.push_back(val_dist(rand));
+        return vs;
+    };
+
+    for (int x = 0; x < 5; ++x)
+        run_in_integer_vals_test(proofs, random_pair(), random_vals(count_dist(rand)));
+
+    for (int x = 0; x < 5; ++x)
+        run_in_const_vars_test(proofs, random_pair(), random_vals(count_dist(rand)));
+
+    for (int x = 0; x < 5; ++x) {
+        vector<pair<int, int>> ranges;
+        int n = n_vars_dist(rand);
+        for (int i = 0; i < n; ++i)
+            ranges.push_back(random_pair());
+        run_in_var_list_test(proofs, random_pair(), ranges);
+    }
+
+    for (int x = 0; x < 5; ++x) {
+        vector<pair<int, int>> ranges;
+        int n = n_vars_dist(rand);
+        for (int i = 0; i < n; ++i)
+            ranges.push_back(random_pair());
+        run_in_var_list_mixed_test(proofs, random_pair(), ranges, random_vals(count_dist(rand)));
+    }
+}
+
 auto main(int, char *[]) -> int
 {
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         run_all_tests(proofs);
+        run_random_tests(proofs, rand);
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/increasing_test.cc
+++ b/gcs/constraints/increasing_test.cc
@@ -5,9 +5,11 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <random>
 #include <set>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 #include <version>
 
@@ -16,15 +18,20 @@
 #else
 #include <fmt/core.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #endif
 
 using std::cerr;
 using std::flush;
 using std::make_optional;
+using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
 using std::set;
 using std::tuple;
+using std::uniform_int_distribution;
+using std::variant;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -89,7 +96,7 @@ auto variant_name() -> const char *
 }
 
 template <IncVariant V>
-auto run_inc_test(bool proofs, const vector<pair<int, int>> & domains) -> void
+auto run_inc_test(bool proofs, const vector<variant<int, pair<int, int>>> & domains) -> void
 {
     print(cerr, "{} {}{}", variant_name<V>(), domains, proofs ? " with proofs:" : ":");
     cerr << flush;
@@ -100,8 +107,8 @@ auto run_inc_test(bool proofs, const vector<pair<int, int>> & domains) -> void
 
     Problem p;
     vector<IntegerVariableID> vars;
-    for (const auto & d : domains)
-        vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    for (const auto & entry : domains)
+        vars.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     post_inc<V>(p, vars);
 
     auto proof_name = proofs ? make_optional("increasing_test") : nullopt;
@@ -114,28 +121,47 @@ auto run_all_for_variant(bool proofs) -> void
 {
     // Trivial cases.
     run_inc_test<V>(proofs, {});
-    run_inc_test<V>(proofs, {{0, 3}});
+    run_inc_test<V>(proofs, {pair{0, 3}});
 
     // Pairs.
-    run_inc_test<V>(proofs, {{0, 3}, {0, 3}});
-    run_inc_test<V>(proofs, {{2, 5}, {0, 3}});
+    run_inc_test<V>(proofs, {pair{0, 3}, pair{0, 3}});
+    run_inc_test<V>(proofs, {pair{2, 5}, pair{0, 3}});
 
     // Triples — exercise both forward and backward sweeps.
-    run_inc_test<V>(proofs, {{0, 3}, {0, 3}, {0, 3}});
-    run_inc_test<V>(proofs, {{1, 2}, {0, 5}, {3, 4}});
+    run_inc_test<V>(proofs, {pair{0, 3}, pair{0, 3}, pair{0, 3}});
+    run_inc_test<V>(proofs, {pair{1, 2}, pair{0, 5}, pair{3, 4}});
 
     // A negative-domain case.
-    run_inc_test<V>(proofs, {{-2, 1}, {-1, 2}, {0, 3}});
+    run_inc_test<V>(proofs, {pair{-2, 1}, pair{-1, 2}, pair{0, 3}});
 
     // Tight infeasible / nearly-infeasible for strict variants.
-    run_inc_test<V>(proofs, {{0, 2}, {0, 2}, {0, 2}, {0, 2}});
+    run_inc_test<V>(proofs, {pair{0, 2}, pair{0, 2}, pair{0, 2}, pair{0, 2}});
 
     // Length 5 to exercise the propagator on a longer chain.
-    run_inc_test<V>(proofs, {{0, 4}, {0, 4}, {0, 4}, {0, 4}, {0, 4}});
+    run_inc_test<V>(proofs, {pair{0, 4}, pair{0, 4}, pair{0, 4}, pair{0, 4}, pair{0, 4}});
+
+    // Constant entries pinning the chain at a fixed value.
+    run_inc_test<V>(proofs, {pair{0, 5}, 3, pair{0, 5}});
+    run_inc_test<V>(proofs, {2, pair{0, 5}, 4});
 }
 
 auto main(int, char *[]) -> int
 {
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+
+    auto random_run = [&]<IncVariant V>(bool proofs) {
+        // Sizes 2..5 with modest domains. For Increasing and 5 vars over a
+        // 6-value domain the worst case is C(6+5-1, 5) = 252 solutions; the
+        // strict variants are smaller. VeriPB stays fast on these.
+        uniform_int_distribution n_vars_dist{2, 5};
+        int n_vars = n_vars_dist(rand);
+        vector<variant<int, pair<int, int>>> doms;
+        for (int i = 0; i < n_vars; ++i)
+            doms.emplace_back(generate_random_data_item(rand, random_bounds_or_constant(-3, 3, 2, 4)));
+        run_inc_test<V>(proofs, doms);
+    };
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
@@ -143,6 +169,13 @@ auto main(int, char *[]) -> int
         run_all_for_variant<IncVariant::StrictlyIncreasing>(proofs);
         run_all_for_variant<IncVariant::Decreasing>(proofs);
         run_all_for_variant<IncVariant::StrictlyDecreasing>(proofs);
+
+        for (int x = 0; x < 5; ++x) {
+            random_run.template operator()<IncVariant::Increasing>(proofs);
+            random_run.template operator()<IncVariant::StrictlyIncreasing>(proofs);
+            random_run.template operator()<IncVariant::Decreasing>(proofs);
+            random_run.template operator()<IncVariant::StrictlyDecreasing>(proofs);
+        }
     }
     return EXIT_SUCCESS;
 }

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -496,6 +496,14 @@ namespace gcs::test_innards
     template <typename Random_>
     auto generate_random_data_item(Random_ & rand, const RandomBoundsOrConstant & bounds)
     {
+        // One in three calls produces a constant in the support of the
+        // bounds-pair shape; the rest produce the pair, matching the spirit
+        // of equals_test's 2:1 var-to-constant ratio.
+        std::uniform_int_distribution<int> choice{0, 2};
+        if (choice(rand) == 0) {
+            std::uniform_int_distribution<int> const_dist{bounds.lower_min, bounds.lower_max + bounds.add_max};
+            return std::variant<int, std::pair<int, int>>{const_dist(rand)};
+        }
         std::uniform_int_distribution<int> lower_dist{bounds.lower_min, bounds.lower_max}, add_dist{bounds.add_min, bounds.add_max};
         auto lower = lower_dist(rand);
         auto upper = lower + add_dist(rand);

--- a/gcs/constraints/inverse_test.cc
+++ b/gcs/constraints/inverse_test.cc
@@ -7,11 +7,13 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <map>
 #include <optional>
 #include <random>
 #include <set>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <version>
@@ -31,9 +33,12 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
+using std::uniform_int_distribution;
+using std::variant;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -47,21 +52,53 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_inverse_test(bool proofs, const vector<pair<int, int>> & x_range, const vector<pair<int, int>> & y_range) -> void
+// Issue #171: Inverse's per-value AM1 reconstruction calls recover_am1
+// over the atoms `x[i] != v` (resp. `y[j] != v`). When two array entries
+// are constants pinned to the same value, two atoms in the AM1 are
+// always-false and pair_ne emits PB lines that the resulting `pol`
+// expression can't sum cleanly — VeriPB rejects it with a parse error
+// at the truncated `pol N +;` line. The propagator itself handles
+// duplicate-value constants fine (the instance is just infeasible);
+// only the proof leg breaks.
+template <typename Range_>
+auto has_duplicate_constants(const Range_ & range) -> bool
 {
-    print(cerr, "inverse {} {} {}", x_range, y_range, proofs ? " with proofs:" : ":");
+    std::map<int, int> counts;
+    for (const auto & entry : range)
+        if (std::holds_alternative<int>(entry))
+            ++counts[std::get<int>(entry)];
+    for (const auto & [_, c] : counts)
+        if (c >= 2) return true;
+    return false;
+}
+
+auto run_inverse_test(bool proofs, const vector<variant<int, pair<int, int>>> & x_range, const vector<variant<int, pair<int, int>>> & y_range) -> void
+{
+    bool effective_proofs = proofs && ! has_duplicate_constants(x_range) && ! has_duplicate_constants(y_range);
+
+    print(cerr, "inverse {} {} {}", x_range, y_range,
+        effective_proofs ? " with proofs:" : (proofs ? " (no-proofs: dup const, issue #171):" : ":"));
     cerr << flush;
 
     set<tuple<vector<int>, vector<int>>> expected, actual;
     build_expected(
         expected, [&](const vector<int> & x, const vector<int> & y) {
-            for (const auto & [i, _] : enumerate(x))
+            // Random sweeps may pick domains that include out-of-range
+            // values; the propagator's prepare() trims them but the
+            // brute-force predicate runs over raw enumerated values, so
+            // we need explicit bounds checks before the .at() calls.
+            for (const auto & [i, _] : enumerate(x)) {
+                if (x.at(i) < 0 || std::cmp_greater_equal(x.at(i), y.size()))
+                    return false;
                 if (cmp_not_equal(y.at(x.at(i)), i))
                     return false;
-            for (const auto & [i, _] : enumerate(y))
+            }
+            for (const auto & [i, _] : enumerate(y)) {
+                if (y.at(i) < 0 || std::cmp_greater_equal(y.at(i), x.size()))
+                    return false;
                 if (cmp_not_equal(x.at(y.at(i)), i))
                     return false;
-
+            }
             return true;
         },
         x_range, y_range);
@@ -70,13 +107,13 @@ auto run_inverse_test(bool proofs, const vector<pair<int, int>> & x_range, const
 
     Problem p;
     vector<IntegerVariableID> x, y;
-    for (const auto & [l, u] : x_range)
-        x.push_back(p.create_integer_variable(Integer(l), Integer(u)));
-    for (const auto & [l, u] : y_range)
-        y.push_back(p.create_integer_variable(Integer(l), Integer(u)));
+    for (const auto & entry : x_range)
+        x.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
+    for (const auto & entry : y_range)
+        y.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     p.post(Inverse{x, y});
 
-    auto proof_name = proofs ? make_optional("inverse_test") : nullopt;
+    auto proof_name = effective_proofs ? make_optional("inverse_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{x, y});
 
     check_results(proof_name, expected, actual);
@@ -84,10 +121,45 @@ auto run_inverse_test(bool proofs, const vector<pair<int, int>> & x_range, const
 
 auto main(int, char *[]) -> int
 {
-    vector<tuple<vector<pair<int, int>>, vector<pair<int, int>>>> var_data = {
-        {{{0, 2}, {0, 2}, {0, 2}}, {{0, 2}, {0, 2}, {0, 2}}},
-        {{{0, 2}, {1, 3}, {0, 2}, {0, 3}}, {{0, 3}, {1, 2}, {1, 3}, {0, 3}}},
-        {{{0, 2}, {0, 2}, {0, 2}, {0, 4}, {0, 4}}, {{0, 4}, {0, 4}, {0, 4}, {3, 4}, {3, 4}}}};
+    using Entry = variant<int, pair<int, int>>;
+    vector<tuple<vector<Entry>, vector<Entry>>> var_data = {
+        // Boundary: empty arrays — vacuously satisfied.
+        {{}, {}},
+        // Boundary: singleton — forces both to 0.
+        {{pair{0, 0}}, {pair{0, 0}}},
+        {{pair{0, 5}}, {pair{0, 5}}},
+        // Existing hand-rolled cases.
+        {{pair{0, 2}, pair{0, 2}, pair{0, 2}}, {pair{0, 2}, pair{0, 2}, pair{0, 2}}},
+        {{pair{0, 2}, pair{1, 3}, pair{0, 2}, pair{0, 3}}, {pair{0, 3}, pair{1, 2}, pair{1, 3}, pair{0, 3}}},
+        {{pair{0, 2}, pair{0, 2}, pair{0, 2}, pair{0, 4}, pair{0, 4}}, {pair{0, 4}, pair{0, 4}, pair{0, 4}, pair{3, 4}, pair{3, 4}}},
+        // Constant entries pin one inverse pair.
+        {{1, pair{0, 2}, pair{0, 2}}, {pair{0, 2}, 0, pair{0, 2}}},
+        {{pair{0, 3}, pair{0, 3}, 0, pair{0, 3}}, {2, pair{0, 3}, pair{0, 3}, pair{0, 3}}},
+        // Issue #171 regression: two x-positions pinned to the same constant
+        // makes the constraint infeasible (Inverse forces a permutation), but
+        // the propagator handles it correctly. The proof leg is skipped via
+        // has_duplicate_constants until #171 is fixed.
+        {{3, 2, 3, pair{0, 3}}, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}},
+        {{pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, {1, pair{0, 3}, 1, pair{0, 3}}}};
+
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+
+    // Random sweep: equal-length arrays of length 2..4 with domains over
+    // {0..n-1} (occasionally const). Inverse forces a permutation matching,
+    // so the constraint is selective — but the brute-force enumerator runs
+    // n^n × n^n combinations before filtering, which is 4^4 × 4^4 = 65 536
+    // for n=4. Stays sub-second.
+    uniform_int_distribution n_dist{2, 4};
+    for (int x_count = 0; x_count < 8; ++x_count) {
+        int n = n_dist(rand);
+        vector<Entry> x_doms, y_doms;
+        for (int i = 0; i < n; ++i) {
+            x_doms.emplace_back(generate_random_data_item(rand, random_bounds_or_constant(0, 0, n - 1, n - 1)));
+            y_doms.emplace_back(generate_random_data_item(rand, random_bounds_or_constant(0, 0, n - 1, n - 1)));
+        }
+        var_data.emplace_back(x_doms, y_doms);
+    }
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())

--- a/gcs/constraints/min_max_test.cc
+++ b/gcs/constraints/min_max_test.cc
@@ -48,7 +48,7 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_min_max_test(bool proofs, bool min, variant<int, pair<int, int>> result_range, const vector<pair<int, int>> & array_range) -> void
+auto run_min_max_test(bool proofs, bool min, variant<int, pair<int, int>> result_range, const vector<variant<int, pair<int, int>>> & array_range) -> void
 {
     visit([&](auto r) { print(cerr, "{} {} {} {}", min ? "min" : "max", r, array_range, proofs ? " with proofs:" : ":"); }, result_range);
     cerr << flush;
@@ -64,8 +64,8 @@ auto run_min_max_test(bool proofs, bool min, variant<int, pair<int, int>> result
     Problem p;
     auto result = visit([&](auto r) { return create_integer_variable_or_constant(p, r); }, result_range);
     vector<IntegerVariableID> array;
-    for (const auto & [l, u] : array_range)
-        array.push_back(p.create_integer_variable(Integer(l), Integer(u)));
+    for (const auto & entry : array_range)
+        array.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     if (min)
         p.post(ArrayMin{array, result});
     else
@@ -79,31 +79,38 @@ auto run_min_max_test(bool proofs, bool min, variant<int, pair<int, int>> result
 
 auto main(int, char *[]) -> int
 {
-    vector<tuple<variant<int, pair<int, int>>, vector<pair<int, int>>>> data = {
-        {pair{1, 2}, {{1, 2}, {1, 2}}},
-        {pair{1, 2}, {{1, 2}, {1, 2}, {1, 2}}},
-        {pair{0, 4}, {{1, 2}, {1, 2}, {1, 2}}},
-        {pair{1, 3}, {{0, 4}, {0, 5}, {0, 6}}},
-        {pair{-1, 3}, {{-1, 2}, {1, 3}, {4, 5}}},
-        {pair{1, 4}, {{1, 4}, {2, 3}, {0, 5}, {-2, 0}, {5, 7}}},
-        {pair{-5, 5}, {{-8, 0}, {4, 4}, {10, 10}, {2, 11}, {4, 10}}},
-        {pair{0, 5}, {{4, 12}}},
-        {pair{2, 9}, {{-2, 3}, {-4, -1}, {-3, 5}}},
-        {pair{2, 5}, {{2, 4}, {3, 7}, {1, 4}}},
-        {pair{-3, 2}, {{-1, 7}, {-2, 6}, {1, 8}, {4, 11}}}};
+    using ArrayEntry = variant<int, pair<int, int>>;
+    vector<tuple<variant<int, pair<int, int>>, vector<ArrayEntry>>> data = {
+        // Singleton: result must equal the sole element.
+        {pair{1, 5}, {pair{2, 4}}},
+        {3, {pair{0, 5}}},
+        {pair{1, 2}, {pair{1, 2}, pair{1, 2}}},
+        {pair{1, 2}, {pair{1, 2}, pair{1, 2}, pair{1, 2}}},
+        {pair{0, 4}, {pair{1, 2}, pair{1, 2}, pair{1, 2}}},
+        {pair{1, 3}, {pair{0, 4}, pair{0, 5}, pair{0, 6}}},
+        {pair{-1, 3}, {pair{-1, 2}, pair{1, 3}, pair{4, 5}}},
+        {pair{1, 4}, {pair{1, 4}, pair{2, 3}, pair{0, 5}, pair{-2, 0}, pair{5, 7}}},
+        {pair{-5, 5}, {pair{-8, 0}, pair{4, 4}, pair{10, 10}, pair{2, 11}, pair{4, 10}}},
+        {pair{0, 5}, {pair{4, 12}}},
+        {pair{2, 9}, {pair{-2, 3}, pair{-4, -1}, pair{-3, 5}}},
+        {pair{2, 5}, {pair{2, 4}, pair{3, 7}, pair{1, 4}}},
+        {pair{-3, 2}, {pair{-1, 7}, pair{-2, 6}, pair{1, 8}, pair{4, 11}}},
+        // Constant array entries: forced winner / fixed pivot.
+        {pair{-5, 10}, {3, pair{0, 7}, 5}},
+        {pair{-5, 10}, {pair{0, 4}, 7, pair{1, 6}, pair{2, 9}}}};
 
     random_device rand_dev;
     mt19937 rand(rand_dev());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 5);
         auto n_values = n_values_dist(rand);
-        generate_random_data(rand, data, random_bounds(-5, 5, 3, 7), vector(n_values, random_bounds(-5, 5, 3, 8)));
+        generate_random_data(rand, data, random_bounds(-5, 5, 3, 7), vector(n_values, random_bounds_or_constant(-5, 5, 3, 8)));
     }
 
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 5);
         auto n_values = n_values_dist(rand);
-        generate_random_data(rand, data, random_constant(-5, 5), vector(n_values, random_bounds(-5, 5, 3, 8)));
+        generate_random_data(rand, data, random_constant(-5, 5), vector(n_values, random_bounds_or_constant(-5, 5, 3, 8)));
     }
 
     for (bool proofs : {false, true}) {

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -126,7 +126,10 @@ auto NValue::install_propagators(Propagators & propagators) -> void
                 all_definite_values.insert(*val);
         }
 
-        inference.infer(logger, n_values >= max(1_i, Integer(all_definite_values.size())), JustifyUsingRUP{}, generic_reason(state, all_vars));
+        // The "at least 1" floor only applies when the array is non-empty;
+        // an empty array contributes 0 distinct values.
+        auto distinct_floor = vars.empty() ? 0_i : 1_i;
+        inference.infer(logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{}, generic_reason(state, all_vars));
 
         return PropagatorState::Enable;
     },

--- a/gcs/constraints/n_value_test.cc
+++ b/gcs/constraints/n_value_test.cc
@@ -38,7 +38,7 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_n_value_test(bool proofs, variant<int, pair<int, int>> result_range, const vector<pair<int, int>> & array_range) -> void
+auto run_n_value_test(bool proofs, variant<int, pair<int, int>> result_range, const vector<variant<int, pair<int, int>>> & array_range) -> void
 {
     visit([&](auto r) { print(cerr, "nvalue {} {} {}", r, array_range, proofs ? " with proofs:" : ":"); }, result_range);
     cerr << flush;
@@ -54,8 +54,8 @@ auto run_n_value_test(bool proofs, variant<int, pair<int, int>> result_range, co
     Problem p;
     auto result = visit([&](auto r) { return create_integer_variable_or_constant(p, r); }, result_range);
     vector<IntegerVariableID> array;
-    for (const auto & [l, u] : array_range)
-        array.push_back(p.create_integer_variable(Integer(l), Integer(u)));
+    for (const auto & entry : array_range)
+        array.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     p.post(NValue{result, array});
 
     auto proof_name = proofs ? make_optional("n_value_test") : nullopt;
@@ -66,27 +66,37 @@ auto run_n_value_test(bool proofs, variant<int, pair<int, int>> result_range, co
 
 auto main(int, char *[]) -> int
 {
-    vector<tuple<variant<int, pair<int, int>>, vector<pair<int, int>>>> data = {
-        {pair{1, 2}, {{1, 2}, {1, 2}}},
-        {pair{1, 2}, {{1, 2}, {1, 2}, {1, 2}}},
-        {pair{0, 4}, {{1, 2}, {1, 2}, {1, 2}}},
-        {pair{1, 3}, {{0, 4}, {0, 5}, {0, 6}}},
-        {pair{-1, 3}, {{-1, 2}, {1, 3}, {4, 5}}},
-        {pair{1, 4}, {{1, 4}, {2, 3}, {0, 5}, {-2, 0}, {5, 7}}},
-        {pair{-5, 5}, {{-8, 0}, {4, 4}, {10, 10}, {2, 11}, {4, 10}}}};
+    using ArrayEntry = variant<int, pair<int, int>>;
+    vector<tuple<variant<int, pair<int, int>>, vector<ArrayEntry>>> data = {
+        // Boundary: empty array forces result == 0.
+        {pair{0, 3}, {}},
+        {0, {}},
+        // Boundary: singleton forces result == 1.
+        {pair{0, 3}, {pair{2, 5}}},
+        {1, {pair{0, 9}}},
+        {pair{1, 2}, {pair{1, 2}, pair{1, 2}}},
+        {pair{1, 2}, {pair{1, 2}, pair{1, 2}, pair{1, 2}}},
+        {pair{0, 4}, {pair{1, 2}, pair{1, 2}, pair{1, 2}}},
+        {pair{1, 3}, {pair{0, 4}, pair{0, 5}, pair{0, 6}}},
+        {pair{-1, 3}, {pair{-1, 2}, pair{1, 3}, pair{4, 5}}},
+        {pair{1, 4}, {pair{1, 4}, pair{2, 3}, pair{0, 5}, pair{-2, 0}, pair{5, 7}}},
+        {pair{-5, 5}, {pair{-8, 0}, pair{4, 4}, pair{10, 10}, pair{2, 11}, pair{4, 10}}},
+        // Constant array entries: pinned values count toward distinct.
+        {pair{0, 5}, {3, pair{1, 4}, 3}},
+        {pair{0, 5}, {1, 2, 3, pair{0, 5}}}};
 
     random_device rand_dev;
     mt19937 rand(rand_dev());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 5);
         auto n_values = n_values_dist(rand);
-        generate_random_data(rand, data, random_bounds(-5, 5, 2, 7), vector(n_values, random_bounds(-5, 5, 2, 7)));
+        generate_random_data(rand, data, random_bounds(-5, 5, 2, 7), vector(n_values, random_bounds_or_constant(-5, 5, 2, 7)));
     }
 
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 5);
         auto n_values = n_values_dist(rand);
-        generate_random_data(rand, data, random_constant(-5, 5), vector(n_values, random_bounds(-5, 5, 2, 7)));
+        generate_random_data(rand, data, random_constant(-5, 5), vector(n_values, random_bounds_or_constant(-5, 5, 2, 7)));
     }
 
     for (bool proofs : {false, true}) {

--- a/gcs/constraints/parity_test.cc
+++ b/gcs/constraints/parity_test.cc
@@ -11,7 +11,17 @@
 #include <set>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
 
 using std::cerr;
 using std::count_if;
@@ -22,9 +32,9 @@ using std::nullopt;
 using std::pair;
 using std::random_device;
 using std::set;
-using std::string;
 using std::tuple;
 using std::uniform_int_distribution;
+using std::variant;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -38,7 +48,7 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_parity_test(bool proofs, const vector<pair<int, int>> & array_range) -> void
+auto run_parity_test(bool proofs, const vector<variant<int, pair<int, int>>> & array_range) -> void
 {
     print(cerr, "parity odd {} {}", array_range, proofs ? " with proofs:" : ":");
     cerr << flush;
@@ -53,8 +63,8 @@ auto run_parity_test(bool proofs, const vector<pair<int, int>> & array_range) ->
 
     Problem p;
     vector<IntegerVariableID> array;
-    for (const auto & [l, u] : array_range)
-        array.push_back(p.create_integer_variable(Integer(l), Integer(u)));
+    for (const auto & entry : array_range)
+        array.push_back(visit([&](const auto & e) { return create_integer_variable_or_constant(p, e); }, entry));
     p.post(ParityOdd{array});
 
     auto proof_name = proofs ? make_optional("parity_test") : nullopt;
@@ -65,18 +75,42 @@ auto run_parity_test(bool proofs, const vector<pair<int, int>> & array_range) ->
 
 auto main(int, char *[]) -> int
 {
-    vector<vector<pair<int, int>>> data = {
-        {{{0, 1}}},
-        {{{0, 1}, {0, 1}}},
-        {{{0, 1}, {0, 1}, {0, 1}}},
-        {{{0, 1}, {0, 1}, {0, 1}, {0, 1}}}};
+    using Entry = variant<int, pair<int, int>>;
+    vector<vector<Entry>> data = {
+        // Boundary: empty array — UNSAT (0 is even, not odd).
+        {},
+        // Singleton over {0, 1} — only x=1 satisfies.
+        {pair{0, 1}},
+        // Existing tight {0,1} cases.
+        {pair{0, 1}, pair{0, 1}},
+        {pair{0, 1}, pair{0, 1}, pair{0, 1}},
+        {pair{0, 1}, pair{0, 1}, pair{0, 1}, pair{0, 1}},
+        // Wider non-binary domains — predicate is "nonzero count is odd",
+        // so any nonzero value contributes.
+        {pair{0, 4}, pair{0, 4}, pair{0, 4}},
+        {pair{-3, 3}, pair{-3, 3}},
+        // Domains that don't include 0 — every entry is nonzero.
+        {pair{1, 5}, pair{1, 5}, pair{1, 5}},
+        {pair{-3, -1}, pair{1, 3}},
+        // Constant entries: a fixed nonzero contributes 1 to the count;
+        // a fixed 0 contributes nothing.
+        {1, pair{0, 3}, pair{0, 3}},
+        {0, pair{0, 3}, pair{0, 3}},
+        {3, 0, pair{0, 3}, pair{0, 3}},
+        // All-constant infeasible (count = 2, even).
+        {1, 1, 0},
+        // All-constant feasible (count = 1, odd).
+        {1, 0, 0}};
 
     random_device rand_dev;
     mt19937 rand(rand_dev());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 4);
         auto n_values = n_values_dist(rand);
-        generate_random_data(rand, data, vector{size_t(n_values), random_bounds(-1, 1, 0, 1)});
+        // random_bounds_or_constant occasionally produces a constant entry,
+        // mixing with bounds-pairs over {-1..2}..{1..4}. Predicate handles
+        // any int value — only zero/non-zero matters — so wide ranges are safe.
+        generate_random_data(rand, data, vector{size_t(n_values), random_bounds_or_constant(-1, 2, 1, 4)});
     }
 
     for (bool proofs : {false, true}) {

--- a/gcs/constraints/plus_minus_test.cc
+++ b/gcs/constraints/plus_minus_test.cc
@@ -69,10 +69,20 @@ namespace
 template <typename Constraint_, typename V1_, typename V2_, typename V3_>
 auto run_plus_minus_test(bool proofs, V1_ v1_range, V2_ v2_range, V3_ v3_range, const function<auto(int, int, int)->bool> & is_satisfying) -> void
 {
-    visit([&](const auto & v1, const auto & v2) {
-        print(cerr, "{} {} {} {} {}", NameOf<Constraint_>::name, v1, v2, v3_range, proofs ? " with proofs:" : ":");
+    // Issue #166: Plus/Minus's hand-built `pol` justification calls
+    // need_pol_item_defining_literal, which crashes on constant arguments.
+    // The propagator itself works fine, so we still exercise constant
+    // arguments end-to-end — just not the proof leg. Remove the skip once
+    // #166 lands.
+    auto holds_int = [](const auto & v) { return std::holds_alternative<int>(v); };
+    bool any_constant = holds_int(v1_range) || holds_int(v2_range) || holds_int(v3_range);
+    bool effective_proofs = proofs && ! any_constant;
+
+    visit([&](const auto & v1, const auto & v2, const auto & v3) {
+        print(cerr, "{} {} {} {} {}", NameOf<Constraint_>::name, v1, v2, v3,
+            effective_proofs ? " with proofs:" : (proofs ? " (no-proofs: constant arg):" : ":"));
     },
-        v1_range, v2_range);
+        v1_range, v2_range, v3_range);
     cerr << flush;
     set<tuple<int, int, int>> expected, actual;
 
@@ -85,10 +95,10 @@ auto run_plus_minus_test(bool proofs, V1_ v1_range, V2_ v2_range, V3_ v3_range, 
     Problem p;
     auto v1 = visit([&](const auto & r) { return create_integer_variable_or_constant(p, r); }, v1_range);
     auto v2 = visit([&](const auto & r) { return create_integer_variable_or_constant(p, r); }, v2_range);
-    auto v3 = create_integer_variable_or_constant(p, v3_range);
+    auto v3 = visit([&](const auto & r) { return create_integer_variable_or_constant(p, r); }, v3_range);
     p.post(Constraint_{v1, v2, v3});
 
-    auto proof_name = proofs ? make_optional("plus_minus_test") : nullopt;
+    auto proof_name = effective_proofs ? make_optional("plus_minus_test") : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual, tuple{pair{v1, CheckConsistency::None}, pair{v2, CheckConsistency::None}, pair{v3, CheckConsistency::None}});
 
     check_results(proof_name, expected, actual);
@@ -96,25 +106,42 @@ auto run_plus_minus_test(bool proofs, V1_ v1_range, V2_ v2_range, V3_ v3_range, 
 
 auto main(int, char *[]) -> int
 {
-    vector<tuple<variant<pair<int, int>, vector<int>>, variant<pair<int, int>, vector<int>>, pair<int, int>>> data = {
-        {pair{2, 5}, pair{1, 6}, {1, 12}},
-        {pair{1, 6}, pair{2, 5}, {5, 8}},
-        {pair{1, 3}, pair{1, 3}, {0, 10}},
-        {pair{1, 3}, pair{1, 3}, {1, 3}},
-        {pair{1, 5}, pair{6, 8}, {-10, 10}},
-        {pair{1, 1}, pair{2, 4}, {-5, 5}},
-        {pair{10, 15}, pair{60, 80}, {-100, 100}},
-        {pair{-10, 0}, pair{-4, 2}, {4, 9}},
-        {pair{1, 100}, pair{1, 3}, {1, 100}},
-        {pair{1, 10}, pair{1, 3}, {1, 10}},
-        {pair{1, 10}, pair{1, 10}, {1, 20}},
-        {vector{1, 5, 10}, vector{1, 5, 10}, {1, 20}},
-        {vector{1, 2, 3, 5, 6, 10}, vector{1, 2, 3, 5, 8, 9, 10}, {1, 20}}};
+    using V12 = variant<int, pair<int, int>, vector<int>>;
+    using V3 = variant<int, pair<int, int>>;
+    vector<tuple<V12, V12, V3>> data = {
+        {pair{2, 5}, pair{1, 6}, pair{1, 12}},
+        {pair{1, 6}, pair{2, 5}, pair{5, 8}},
+        {pair{1, 3}, pair{1, 3}, pair{0, 10}},
+        {pair{1, 3}, pair{1, 3}, pair{1, 3}},
+        {pair{1, 5}, pair{6, 8}, pair{-10, 10}},
+        {pair{1, 1}, pair{2, 4}, pair{-5, 5}},
+        {pair{10, 15}, pair{60, 80}, pair{-100, 100}},
+        {pair{-10, 0}, pair{-4, 2}, pair{4, 9}},
+        {pair{1, 100}, pair{1, 3}, pair{1, 100}},
+        {pair{1, 10}, pair{1, 3}, pair{1, 10}},
+        {pair{1, 10}, pair{1, 10}, pair{1, 20}},
+        {vector{1, 5, 10}, vector{1, 5, 10}, pair{1, 20}},
+        {vector{1, 2, 3, 5, 6, 10}, vector{1, 2, 3, 5, 8, 9, 10}, pair{1, 20}},
+        // Constant-result regression: x + y == 6 over [1,5] × [1,5].
+        {pair{1, 5}, pair{1, 5}, 6},
+        // Constant-operand: x + 2 == z over [1,5] × [3,8].
+        {pair{1, 5}, 2, pair{3, 8}}};
 
+    // The random sweep mixes constants and bounds-pairs across all three slots
+    // via random_bounds_or_constant. v1/v2's variant is wider than the helper's
+    // return type (because hand-rolled cases include hole-y vector<int> domains
+    // that the random sweep doesn't produce), so visit-widen at insertion.
+    auto widen_v12 = [](variant<int, pair<int, int>> v) -> V12 {
+        return visit([](auto x) -> V12 { return x; }, v);
+    };
     random_device rand_dev;
     mt19937 rand(rand_dev());
-    for (int x = 0; x < 10; ++x)
-        generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15));
+    for (int x = 0; x < 10; ++x) {
+        auto r1 = generate_random_data_item(rand, random_bounds_or_constant(-10, 10, 5, 15));
+        auto r2 = generate_random_data_item(rand, random_bounds_or_constant(-10, 10, 5, 15));
+        auto r3 = generate_random_data_item(rand, random_bounds_or_constant(-10, 10, 5, 15));
+        data.emplace_back(widen_v12(r1), widen_v12(r2), r3);
+    }
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())

--- a/gcs/constraints/seq_precede_chain_test.cc
+++ b/gcs/constraints/seq_precede_chain_test.cc
@@ -8,9 +8,11 @@
 #include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <random>
 #include <set>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 #include <version>
 
@@ -25,10 +27,14 @@
 using std::cerr;
 using std::flush;
 using std::make_optional;
+using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
 using std::set;
 using std::tuple;
+using std::uniform_int_distribution;
+using std::variant;
 using std::vector;
 using std::chrono::duration;
 using std::chrono::steady_clock;
@@ -64,7 +70,7 @@ namespace
     }
 }
 
-auto run_test(bool proofs, const vector<pair<int, int>> & domains) -> void
+auto run_test(bool proofs, const vector<variant<int, pair<int, int>>> & domains) -> void
 {
     print(cerr, "seq_precede_chain domains={}{}",
         domains, proofs ? " with proofs:" : ":");
@@ -78,8 +84,8 @@ auto run_test(bool proofs, const vector<pair<int, int>> & domains) -> void
 
     Problem p;
     vector<IntegerVariableID> vars;
-    for (const auto & d : domains)
-        vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    for (const auto & entry : domains)
+        vars.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     p.post(SeqPrecedeChain{vars});
 
     auto proof_name = proofs ? make_optional("seq_precede_chain_test") : nullopt;
@@ -123,37 +129,60 @@ auto run_scale_test(bool proofs) -> void
 auto run_all_tests(bool proofs) -> void
 {
     // Length-2: smallest meaningful chain.
-    run_test(proofs, {{1, 2}, {1, 2}});
-    run_test(proofs, {{1, 5}, {1, 5}});
+    run_test(proofs, {pair{1, 2}, pair{1, 2}});
+    run_test(proofs, {pair{1, 5}, pair{1, 5}});
 
     // Length-3 with domain == array length, no truncation needed.
-    run_test(proofs, {{1, 3}, {1, 3}, {1, 3}});
+    run_test(proofs, {pair{1, 3}, pair{1, 3}, pair{1, 3}});
 
     // Length-3 with domain > array length, exercises truncation.
-    run_test(proofs, {{1, 6}, {1, 6}, {1, 6}});
+    run_test(proofs, {pair{1, 6}, pair{1, 6}, pair{1, 6}});
 
     // Length-5 with domain 2x array length: the headline case scaled
     // down enough for build_expected.
-    run_test(proofs, {{1, 10}, {1, 10}, {1, 10}, {1, 10}, {1, 10}});
+    run_test(proofs, {pair{1, 10}, pair{1, 10}, pair{1, 10}, pair{1, 10}, pair{1, 10}});
 
     // Negative and zero values: unconstrained by the chain.
-    run_test(proofs, {{-2, 3}, {-2, 3}, {-2, 3}});
+    run_test(proofs, {pair{-2, 3}, pair{-2, 3}, pair{-2, 3}});
 
     // Non-uniform domains, one var with a wildly larger upper bound.
     // Catches any "compute max from initial_state" bug.
-    run_test(proofs, {{1, 4}, {1, 4}, {1, 100}, {1, 4}});
+    run_test(proofs, {pair{1, 4}, pair{1, 4}, pair{1, 100}, pair{1, 4}});
 
     // Empty array: trivially satisfied.
     run_test(proofs, {});
+
+    // Constant entries pinning specific positions in the chain.
+    run_test(proofs, {1, pair{1, 4}, 2, pair{1, 4}});
+    run_test(proofs, {pair{1, 4}, 1, pair{1, 4}, 2});
+    // Constant zero / negative entries are unconstrained by the chain.
+    run_test(proofs, {0, pair{1, 3}, -1, pair{1, 3}});
 }
 
 auto main(int, char *[]) -> int
 {
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         run_all_tests(proofs);
         run_scale_test(proofs);
+
+        // Random sweep: length 2..5 with domains 1..5. SeqPrecedeChain on
+        // length n with values 1..n yields B(n) (Bell number) solutions
+        // when domains permit. B(5) = 52, comfortably bounded for VeriPB.
+        // random_bounds_or_constant means each entry is occasionally a
+        // constant, which the chain handles via clamping at min(max, n).
+        uniform_int_distribution n_dist{2, 5};
+        for (int x = 0; x < 8; ++x) {
+            int n = n_dist(rand);
+            vector<variant<int, pair<int, int>>> doms;
+            for (int i = 0; i < n; ++i)
+                doms.emplace_back(generate_random_data_item(rand, random_bounds_or_constant(0, 3, 1, 3)));
+            run_test(proofs, doms);
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/value_precede_test.cc
+++ b/gcs/constraints/value_precede_test.cc
@@ -3,12 +3,16 @@
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <iterator>
 #include <optional>
+#include <random>
 #include <set>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 #include <version>
 
@@ -20,13 +24,19 @@
 #include <fmt/ranges.h>
 #endif
 
+using std::back_inserter;
 using std::cerr;
 using std::flush;
 using std::make_optional;
+using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
+using std::sample;
 using std::set;
 using std::tuple;
+using std::uniform_int_distribution;
+using std::variant;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -63,7 +73,7 @@ namespace
     }
 }
 
-auto run_value_precede_test(bool proofs, const vector<int> & chain, const vector<pair<int, int>> & domains) -> void
+auto run_value_precede_test(bool proofs, const vector<int> & chain, const vector<variant<int, pair<int, int>>> & domains) -> void
 {
     print(cerr, "value_precede chain={} domains={}{}",
         chain, domains, proofs ? " with proofs:" : ":");
@@ -77,8 +87,8 @@ auto run_value_precede_test(bool proofs, const vector<int> & chain, const vector
 
     Problem p;
     vector<IntegerVariableID> vars;
-    for (const auto & d : domains)
-        vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    for (const auto & entry : domains)
+        vars.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     vector<Integer> chain_i;
     for (const auto & v : chain)
         chain_i.push_back(Integer(v));
@@ -92,51 +102,77 @@ auto run_value_precede_test(bool proofs, const vector<int> & chain, const vector
 auto run_all_tests(bool proofs) -> void
 {
     // Length-2 chain — basic value_precede.
-    run_value_precede_test(proofs, {1, 2}, {{1, 2}, {1, 2}});
-    run_value_precede_test(proofs, {1, 2}, {{1, 2}, {1, 2}, {1, 2}});
-    run_value_precede_test(proofs, {1, 2}, {{1, 3}, {1, 3}, {1, 3}});
+    run_value_precede_test(proofs, {1, 2}, {pair{1, 2}, pair{1, 2}});
+    run_value_precede_test(proofs, {1, 2}, {pair{1, 2}, pair{1, 2}, pair{1, 2}});
+    run_value_precede_test(proofs, {1, 2}, {pair{1, 3}, pair{1, 3}, pair{1, 3}});
 
     // Length-2 with values not present in any domain → trivially satisfied.
-    run_value_precede_test(proofs, {5, 6}, {{1, 3}, {1, 3}, {1, 3}});
-    run_value_precede_test(proofs, {1, 5}, {{1, 3}, {1, 3}});
+    run_value_precede_test(proofs, {5, 6}, {pair{1, 3}, pair{1, 3}, pair{1, 3}});
+    run_value_precede_test(proofs, {1, 5}, {pair{1, 3}, pair{1, 3}});
 
     // Length-2 with t reachable only after positions that can be s.
-    run_value_precede_test(proofs, {1, 2}, {{2, 3}, {1, 2}, {1, 2}});
+    run_value_precede_test(proofs, {1, 2}, {pair{2, 3}, pair{1, 2}, pair{1, 2}});
 
     // Length-2 with the first position forced to t (unsat).
-    run_value_precede_test(proofs, {1, 2}, {{2, 2}, {1, 2}});
+    run_value_precede_test(proofs, {1, 2}, {pair{2, 2}, pair{1, 2}});
 
     // Length-3 chain — value_precede_chain.
-    run_value_precede_test(proofs, {1, 2, 3}, {{1, 3}, {1, 3}, {1, 3}});
-    run_value_precede_test(proofs, {1, 2, 3}, {{1, 3}, {1, 3}, {1, 3}, {1, 3}});
+    run_value_precede_test(proofs, {1, 2, 3}, {pair{1, 3}, pair{1, 3}, pair{1, 3}});
+    run_value_precede_test(proofs, {1, 2, 3}, {pair{1, 3}, pair{1, 3}, pair{1, 3}, pair{1, 3}});
 
     // Chain values out of order in domains.
-    run_value_precede_test(proofs, {3, 1, 2}, {{1, 3}, {1, 3}, {1, 3}});
+    run_value_precede_test(proofs, {3, 1, 2}, {pair{1, 3}, pair{1, 3}, pair{1, 3}});
 
     // Length-4 chain.
-    run_value_precede_test(proofs, {1, 2, 3, 4}, {{1, 4}, {1, 4}, {1, 4}, {1, 4}});
+    run_value_precede_test(proofs, {1, 2, 3, 4}, {pair{1, 4}, pair{1, 4}, pair{1, 4}, pair{1, 4}});
 
     // Repeated chain values: {1, 2, 1} requires 1≺2 AND 2≺1, only satisfiable
     // when no 1 or 2 appears.
-    run_value_precede_test(proofs, {1, 2, 1}, {{1, 3}, {1, 3}, {1, 3}});
+    run_value_precede_test(proofs, {1, 2, 1}, {pair{1, 3}, pair{1, 3}, pair{1, 3}});
 
     // Repeated adjacent values: {1, 1} is a no-op pair.
-    run_value_precede_test(proofs, {1, 1}, {{1, 2}, {1, 2}, {1, 2}});
+    run_value_precede_test(proofs, {1, 1}, {pair{1, 2}, pair{1, 2}, pair{1, 2}});
 
     // Empty chain and length-1 chain — trivially satisfied (no propagator).
-    run_value_precede_test(proofs, {}, {{1, 2}, {1, 2}});
-    run_value_precede_test(proofs, {7}, {{1, 2}, {1, 2}});
+    run_value_precede_test(proofs, {}, {pair{1, 2}, pair{1, 2}});
+    run_value_precede_test(proofs, {7}, {pair{1, 2}, pair{1, 2}});
 
     // Negative values.
-    run_value_precede_test(proofs, {-1, 1}, {{-1, 1}, {-1, 1}, {-1, 1}});
+    run_value_precede_test(proofs, {-1, 1}, {pair{-1, 1}, pair{-1, 1}, pair{-1, 1}});
+
+    // Constant entries: a position pinned to a chain value.
+    run_value_precede_test(proofs, {1, 2}, {1, pair{1, 3}, pair{1, 3}});
+    run_value_precede_test(proofs, {1, 2}, {pair{1, 3}, 2, pair{1, 3}});  // unsat: forces 2 in pos 1 with no preceding 1
+    run_value_precede_test(proofs, {1, 2, 3}, {1, pair{1, 3}, 2, pair{1, 3}});
 }
 
 auto main(int, char *[]) -> int
 {
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         run_all_tests(proofs);
+
+        // Random sweep: chain length 1..3 of distinct values from {1..4},
+        // domains length 2..5 over {1..4}. With domain 4 and length 5 the
+        // unconstrained space is 4^5 = 1024 — VeriPB stays well under
+        // a second per case, and value_precede is selective in practice.
+        uniform_int_distribution chain_len_dist{1, 3};
+        uniform_int_distribution n_vars_dist{2, 5};
+        for (int x = 0; x < 8; ++x) {
+            int chain_len = chain_len_dist(rand);
+            vector<int> chain_pool{1, 2, 3, 4};
+            vector<int> chain;
+            sample(chain_pool.begin(), chain_pool.end(), back_inserter(chain), chain_len, rand);
+            int n_vars = n_vars_dist(rand);
+            vector<variant<int, pair<int, int>>> doms;
+            for (int i = 0; i < n_vars; ++i)
+                doms.emplace_back(generate_random_data_item(rand, random_bounds_or_constant(1, 2, 1, 2)));
+            run_value_precede_test(proofs, chain, doms);
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Per-constraint sweep across the audit's flagged gaps. Each test grows boundary cases, constant-mixing in argument slots, and/or random sweeps following a shared shape. Two propagator bugs found and fixed inline; two proof-logging bugs filed as issues with proof-disabled regression cases committed alongside.

**Stacked on PR #164** (`random-bounds-or-constant` helper fix). The first commits in this branch use `random_bounds_or_constant` for const-mixing, so this branch can't land cleanly until #164 does. After #164 merges, the diff against main will narrow to exactly this branch's contents.

## Per-constraint changes

- `plus_minus_test` — variant widen + const-mixing; **skips proof leg when any arg is a constant** pending #166.
- `count_test` — const-mixing in array entries.
- `min_max_test` — singleton + const-mixing in array entries.
- `n_value_test` — empty/singleton + const-mixing **+ inline propagator fix**: the unconditional `n_values >= 1` floor was wrong for empty arrays.
- `at_most_one_test` — refactor to vector-based, empty/1-var/2-var + small random **+ inline propagator fix**: empty-array SmartTable lowered to UNSAT instead of vacuously true.
- `increasing_test` — small random sweep + constant entries (boundaries already present).
- `seq_precede_chain_test` — random sweep + constant entries (boundaries already present).
- `value_precede_test` — random sweep + constant entries (boundaries already present).
- `inverse_test` — random sweep + boundaries + const-mixing; **skips proof leg when an array has duplicate-value constants** pending #171.
- `parity_test` — wider domains, constants, boundaries, plus const-mixing in random sweep.
- `in_test` — random sweep across each of the four interesting posting shapes.

## Bugs surfaced

| # | constraint | nature | status |
|---|---|---|---|
| #166 | Plus/Minus | proof logging crashes on constant args (hand-built `pol` line) | filed; test gates proof leg |
| #171 | Inverse | proof logging crashes when 2+ entries pin same constant value (AM1 reconstruction over always-false atoms) | filed; test gates proof leg |
| — | NValue | unconditional `n_values >= 1` floor → empty-array UNSAT | fixed inline (one-line) |
| — | AtMostOne | empty-array → SmartTable UNSAT | fixed inline (`_vars.size() < 2` short-circuit) |

The two filed bugs are exclusively in proof logging — the propagators themselves handle constants. Each issue body includes the reproducer, the cause, and a suggested fix; each test contains explicit deterministic regressions plus a runtime gate that skips the proof leg for the affected shape until the fix lands.

## Test plan

- [x] All 11 test binaries pass under release ctest, sanitiser-clean
- [x] All proof-leg cases (i.e. those not gated by a `#166` / `#171` skip) verified by VeriPB end-to-end
- [x] Random-seed stability: every test re-run multiple times with no flakes
- [x] Two new propagator fixes verified by the regression cases that motivated them

## Review notes

- The two proof-bug skip-gates (`plus_minus_test`'s `holds_alternative<int>` check, `inverse_test`'s `has_duplicate_constants`) are explicitly reversible — once #166 / #171 land they come out and the proof leg runs for those cases.
- For tests where I touched the data table, I mechanically rewrote brace-init `{lo, hi}` to `pair{lo, hi}` to fit the wider variant. No semantic change to existing cases.
- I avoided touching `gcs/constraints/innards/constraints_test_utils.hh` further beyond the `random_bounds_or_constant` fix in #164 — there's a missing 3-alternative variant overload (`vector<variant<int, pair, vector<int>>>`) that I worked around in `parity_test` rather than adding more depth there. Happy to add that as a follow-up if it'd be useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)