### PR TITLE
plus: skip pol terms over constant reason literals (closes #166)

### DIFF
--- a/gcs/constraints/plus.cc
+++ b/gcs/constraints/plus.cc
@@ -20,6 +20,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::holds_alternative;
 using std::optional;
 using std::pair;
 using std::string;
@@ -105,25 +106,29 @@ auto gcs::innards::propagate_plus(IntegerVariableID a, IntegerVariableID b, Inte
     auto justify = [&](Conclude c) -> JustifyExplicitlyThenRUP {
         return JustifyExplicitlyThenRUP{
             [c, sum_line, logger](const ReasonFunction & reason) {
-                if (! (c == Conclude::LE ? sum_line.first : sum_line.second))
+                auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
+                if (! sum_line_value)
                     return;
 
                 stringstream pol;
-                pol << "pol " << (c == Conclude::LE ? sum_line.first.value() : sum_line.second.value()) << " ";
+                pol << "pol " << *sum_line_value;
 
-                auto first_reason_lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason().at(0))));
-                auto second_reason_lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason().at(1))));
-                overloaded{
-                    [&](const XLiteral & x) { pol << logger->names_and_ids_tracker().pb_file_string_for(x) << " +"; },
-                    [&](const ProofLine & x) { pol << x << " +"; }}
-                    .visit(logger->names_and_ids_tracker().need_pol_item_defining_literal(first_reason_lit));
-
-                pol << " ";
-
-                overloaded{
-                    [&](const XLiteral & x) { pol << logger->names_and_ids_tracker().pb_file_string_for(x) << " +;"; },
-                    [&](const ProofLine & x) { pol << x << " +;"; }}
-                    .visit(logger->names_and_ids_tracker().need_pol_item_defining_literal(second_reason_lit));
+                // Constants in WPBSum are baked into the OPB sum_line directly
+                // (see emit_inequality_to.cc:58–60), so a reason literal whose
+                // variable is a ConstantIntegerVariableID already contributes
+                // to sum_line and doesn't need (or have) a pol-side defining
+                // line — need_pol_item_defining_literal would throw on it.
+                // Issue #166.
+                for (size_t i = 0; i < 2; ++i) {
+                    auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason().at(i))));
+                    if (holds_alternative<ConstantIntegerVariableID>(lit.var))
+                        continue;
+                    overloaded{
+                        [&](const XLiteral & x) { pol << " " << logger->names_and_ids_tracker().pb_file_string_for(x) << " +"; },
+                        [&](const ProofLine & x) { pol << " " << x << " +"; }}
+                        .visit(logger->names_and_ids_tracker().need_pol_item_defining_literal(lit));
+                }
+                pol << ";";
 
                 logger->emit_proof_line(pol.str(), ProofLevel::Temporary);
             }};

--- a/gcs/constraints/plus_minus_test.cc
+++ b/gcs/constraints/plus_minus_test.cc
@@ -69,18 +69,8 @@ namespace
 template <typename Constraint_, typename V1_, typename V2_, typename V3_>
 auto run_plus_minus_test(bool proofs, V1_ v1_range, V2_ v2_range, V3_ v3_range, const function<auto(int, int, int)->bool> & is_satisfying) -> void
 {
-    // Issue #166: Plus/Minus's hand-built `pol` justification calls
-    // need_pol_item_defining_literal, which crashes on constant arguments.
-    // The propagator itself works fine, so we still exercise constant
-    // arguments end-to-end — just not the proof leg. Remove the skip once
-    // #166 lands.
-    auto holds_int = [](const auto & v) { return std::holds_alternative<int>(v); };
-    bool any_constant = holds_int(v1_range) || holds_int(v2_range) || holds_int(v3_range);
-    bool effective_proofs = proofs && ! any_constant;
-
     visit([&](const auto & v1, const auto & v2, const auto & v3) {
-        print(cerr, "{} {} {} {} {}", NameOf<Constraint_>::name, v1, v2, v3,
-            effective_proofs ? " with proofs:" : (proofs ? " (no-proofs: constant arg):" : ":"));
+        print(cerr, "{} {} {} {} {}", NameOf<Constraint_>::name, v1, v2, v3, proofs ? " with proofs:" : ":");
     },
         v1_range, v2_range, v3_range);
     cerr << flush;
@@ -98,7 +88,7 @@ auto run_plus_minus_test(bool proofs, V1_ v1_range, V2_ v2_range, V3_ v3_range, 
     auto v3 = visit([&](const auto & r) { return create_integer_variable_or_constant(p, r); }, v3_range);
     p.post(Constraint_{v1, v2, v3});
 
-    auto proof_name = effective_proofs ? make_optional("plus_minus_test") : nullopt;
+    auto proof_name = proofs ? make_optional("plus_minus_test") : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual, tuple{pair{v1, CheckConsistency::None}, pair{v2, CheckConsistency::None}, pair{v3, CheckConsistency::None}});
 
     check_results(proof_name, expected, actual);


### PR DESCRIPTION
Closes #166.

## Summary

Plus's bound-tightening justifications hand-build a `pol` line that calls `need_pol_item_defining_literal` for each reason literal. The constant alternative throws `UnimplementedException`, crashing the proof leg whenever Plus or Minus is posted with any constant argument. Constants are short-circuited in `State` and don't get an OPB defining line — but they're already baked into the sum_line directly by `WPBSum`'s constant handling, so the pol polynomial doesn't need a separate term for them. The fix is to skip the per-reason emit for `ConstantIntegerVariableID` literals.

If both reasons are over constants, the pol degrades to `pol <sum_line>;` — a single-element no-op step that VeriPB accepts; the JustifyExplicitlyThenRUP closure then RUP-derives the inference. Minus is fixed transitively (it delegates to `propagate_plus(a, -b, result)`, and unary minus on a constant produces another constant which the new check catches).

## Test plan

- [x] `plus_minus_test`'s `holds_alternative<int>` skip-gate (added pre-emptively when #166 was filed) is removed; 50/50 cases now run under VeriPB (was 30/50 with the gate)
- [x] Sanitizer-clean (ASan + UBSan)
- [x] Wider ctest (`plus_minus`, `linear_*`, `knapsack`, `mult_bc`) all pass — the other constraints that call the same tracker entry point are unaffected (they hit it on different reason shapes; tracked separately if any of them turns out to need a similar fix)

## Out of scope

- The same `need_pol_item_defining_literal`-throws-on-constants pattern likely affects `linear/justify.cc:42`, `linear/linear_inequality.cc:67`, `knapsack.cc:92`, `mult_bc.cc:191`. They aren't covered here; if they hit it under future const-mixing tests, they'll need their own audit (the right fix may differ — those constructions assemble more complex polynomials than Plus's `sum + lit + lit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)