### PR TITLE
gcspy: expose post_not_equals_reif

### DIFF
--- a/python/gcspy.cc
+++ b/python/gcspy.cc
@@ -500,6 +500,26 @@ auto Python::post_not_equals(const string & var_id_1, const string & var_id_2) -
     p.post(NotEquals(get_var(var_id_1), get_var(var_id_2)));
 }
 
+auto Python::post_not_equals_reif(const string & var_id_1, const string & var_id_2, const string & reif_id, bool fully_reify) -> void
+{
+    if (fully_reify) {
+#ifdef WRITE_API_CALLS
+        api_calls << "p.post(NotEqualsIff{v" << var_id_1 << ", "
+                  << "v" << var_id_2 << ", v" << reif_id << " != 0_i"
+                  << "});" << endl;
+#endif
+        p.post(NotEqualsIff(get_var(var_id_1), get_var(var_id_2), get_var(reif_id) != 0_i));
+    }
+    else {
+#ifdef WRITE_API_CALLS
+        api_calls << "p.post(NotEqualsIf{v" << var_id_1 << ", "
+                  << "v" << var_id_2 << ", v" << reif_id << " != 0_i"
+                  << "});" << endl;
+#endif
+        p.post(NotEqualsIf(get_var(var_id_1), get_var(var_id_2), get_var(reif_id) != 0_i));
+    }
+}
+
 auto Python::post_in(const string & var_id, const vector<long long int> & domain) -> void
 {
 #ifdef WRITE_API_CALLS
@@ -802,6 +822,7 @@ PYBIND11_MODULE(gcspy, m)
         .def("post_equals_reif", &Python::post_equals_reif)
 
         .def("post_not_equals", &Python::post_not_equals)
+        .def("post_not_equals_reif", &Python::post_not_equals_reif)
         .def("post_in", &Python::post_in)
         .def("post_in_vars", &Python::post_in_vars)
         .def("post_linear_equality", &Python::post_linear_equality)

--- a/python/gcspy.hh
+++ b/python/gcspy.hh
@@ -82,6 +82,7 @@ public:
     auto post_greater_than_reif(const string & var_id_1, const string & var_id_2, const string & reif, bool fully_reify) -> void;
     auto post_greater_than_equal_reif(const string & var_id_1, const string & var_id_2, const string & reif, const bool fully_reify) -> void;
     auto post_equals_reif(const string & var_id_1, const string & var_id_2, const string & reif_id, bool fully_reify) -> void;
+    auto post_not_equals_reif(const string & var_id_1, const string & var_id_2, const string & reif_id, bool fully_reify) -> void;
 
     // Linear
     auto post_linear_equality(const vector<string> & var_ids, const vector<long long int> & coeffs, long long int value) -> void;


### PR DESCRIPTION
## Summary

Stacked on #172 (rebase base when that lands).

Adds \`post_not_equals_reif(var_id_1, var_id_2, reif_id, fully_reify)\` to \`gcspy\`, mirroring the existing \`post_equals_reif\`. Posts \`NotEqualsIff\` when fully reified, \`NotEqualsIf\` otherwise. Both classes are already in gcs's public C++ API in \`gcs/constraints/equals.hh\` — this just plumbs them through pybind11.

## Why

Upstream \`cpmpy/solvers/gcs.py\` currently decomposes \`bv == (x != y)\` into \`bv == OR(x < y, x > y)\` because the native reified-NotEquals form wasn't exposed. The decomposition introduces extra Boolean variables and is the trigger for the \`State::domains_intersect\` negated-views bug (fixed separately in #175). Once a \`gcspy\` release containing this is on PyPI, the CPMpy backend can drop the workaround.

## Test plan

- [x] \`pip install ./python/\` builds cleanly
- [x] Smoke test: \`g.post_not_equals_reif(x, y, r, True)\` and \`g.post_not_equals_reif(x, y, r, False)\` post without errors
- [x] \`ctest --preset release -R equals\` — existing equals tests still pass (this PR doesn't touch the C++ propagators, but worth confirming the rebuild is clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)