### PR TITLE
recover_am1: handle ≥2 always-false atoms (closes #171)

### DIFF
--- a/gcs/constraints/all_different/justify.cc
+++ b/gcs/constraints/all_different/justify.cc
@@ -55,20 +55,25 @@ auto gcs::innards::justify_all_different_hall_set_or_violator(
         at_least_one_constraints.push_back(logger.names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(var));
 
     // each variable in the violator has to take at least one value that is
-    // left in its domain...
+    // left in its domain, and each value in the component can only be used
+    // once. Both kinds of summand share a single `first` flag — the leading
+    // "+" is omitted only on the very first push, since the `+` operator
+    // requires two stack elements. If at_least_one_constraints is empty
+    // (every Hall variable filtered out as a constant) the first AM1 line
+    // becomes the initial push.
     stringstream proof_step;
     proof_step << "pol";
     bool first = true;
-    for (auto & c : at_least_one_constraints) {
-        proof_step << " " << c;
+    auto add = [&](ProofLine line) {
+        proof_step << " " << line;
         if (! first)
             proof_step << " +";
         first = false;
-    }
-
-    // and each value in the component can only be used once
+    };
+    for (auto & c : at_least_one_constraints)
+        add(c);
     for (const auto & val : hall_values)
-        proof_step << " " << value_am1_constraint_numbers.at(val) << " +";
+        add(value_am1_constraint_numbers.at(val));
 
     proof_step << ';';
     logger.emit_proof_line(proof_step.str(), ProofLevel::Current);

--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -1,14 +1,19 @@
 #include <gcs/constraints/innards/recover_am1.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/proofs/simplify_literal.hh>
 
 #include <util/enumerate.hh>
 
 #include <sstream>
+#include <type_traits>
+#include <variant>
 
 using namespace gcs;
 using namespace gcs::innards;
 
 using std::function;
+using std::holds_alternative;
+using std::is_same_v;
 using std::stringstream;
 using std::vector;
 
@@ -21,6 +26,30 @@ template <typename Literal_>
 {
     if (atoms.size() < 2)
         throw UnexpectedException{"recover_am1 requires at least 2 atoms"};
+
+    if constexpr (is_same_v<Literal_, IntegerVariableCondition>) {
+        // If ≥2 atoms simplify to FalseLiteral (e.g. literals over constants
+        // that don't satisfy the condition), the AM1 they're meant to
+        // capture is genuinely violated by the input: literal-as-PB gives
+        // ≥2 of them as 0, so Σ atoms ≥ n - 1 fails. Folding pair_ne lines
+        // via the usual pol expression doesn't recover a valid line —
+        // pair_ne over two false atoms emits a direct `0 ≥ 1` contradiction,
+        // and the pol summation embeds it in a malformed expression that
+        // VeriPB rejects at parse. Short-circuit: emit a `0 ≥ 1`
+        // contradiction at the caller-supplied level directly (RUP-derivable
+        // because the OPB has unit clauses forcing the same variable to
+        // multiple values) and return that as the "AM1" line. Downstream
+        // consumers fold this into further pol expressions to derive a
+        // stronger contradiction — the correct outcome, since the input is
+        // infeasible. Issue #171.
+        unsigned n_false = 0;
+        for (const auto & atom : atoms) {
+            if (holds_alternative<FalseLiteral>(simplify_literal(atom))) {
+                if (++n_false >= 2)
+                    return logger.emit(RUPProofRule{}, WPBSum{} >= 1_i, level);
+            }
+        }
+    }
 
     auto temporary_proof_level = logger.temporary_proof_level();
 

--- a/gcs/constraints/inverse_test.cc
+++ b/gcs/constraints/inverse_test.cc
@@ -7,7 +7,6 @@
 
 #include <cstdlib>
 #include <iostream>
-#include <map>
 #include <optional>
 #include <random>
 #include <set>
@@ -52,32 +51,9 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-// Issue #171: Inverse's per-value AM1 reconstruction calls recover_am1
-// over the atoms `x[i] != v` (resp. `y[j] != v`). When two array entries
-// are constants pinned to the same value, two atoms in the AM1 are
-// always-false and pair_ne emits PB lines that the resulting `pol`
-// expression can't sum cleanly — VeriPB rejects it with a parse error
-// at the truncated `pol N +;` line. The propagator itself handles
-// duplicate-value constants fine (the instance is just infeasible);
-// only the proof leg breaks.
-template <typename Range_>
-auto has_duplicate_constants(const Range_ & range) -> bool
-{
-    std::map<int, int> counts;
-    for (const auto & entry : range)
-        if (std::holds_alternative<int>(entry))
-            ++counts[std::get<int>(entry)];
-    for (const auto & [_, c] : counts)
-        if (c >= 2) return true;
-    return false;
-}
-
 auto run_inverse_test(bool proofs, const vector<variant<int, pair<int, int>>> & x_range, const vector<variant<int, pair<int, int>>> & y_range) -> void
 {
-    bool effective_proofs = proofs && ! has_duplicate_constants(x_range) && ! has_duplicate_constants(y_range);
-
-    print(cerr, "inverse {} {} {}", x_range, y_range,
-        effective_proofs ? " with proofs:" : (proofs ? " (no-proofs: dup const, issue #171):" : ":"));
+    print(cerr, "inverse {} {} {}", x_range, y_range, proofs ? " with proofs:" : ":");
     cerr << flush;
 
     set<tuple<vector<int>, vector<int>>> expected, actual;
@@ -113,7 +89,7 @@ auto run_inverse_test(bool proofs, const vector<variant<int, pair<int, int>>> & 
         y.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     p.post(Inverse{x, y});
 
-    auto proof_name = effective_proofs ? make_optional("inverse_test") : nullopt;
+    auto proof_name = proofs ? make_optional("inverse_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{x, y});
 
     check_results(proof_name, expected, actual);
@@ -135,10 +111,11 @@ auto main(int, char *[]) -> int
         // Constant entries pin one inverse pair.
         {{1, pair{0, 2}, pair{0, 2}}, {pair{0, 2}, 0, pair{0, 2}}},
         {{pair{0, 3}, pair{0, 3}, 0, pair{0, 3}}, {2, pair{0, 3}, pair{0, 3}, pair{0, 3}}},
-        // Issue #171 regression: two x-positions pinned to the same constant
-        // makes the constraint infeasible (Inverse forces a permutation), but
-        // the propagator handles it correctly. The proof leg is skipped via
-        // has_duplicate_constants until #171 is fixed.
+        // Issue #171 regression: two array positions pinned to the same constant
+        // makes the constraint infeasible (Inverse forces a permutation). The
+        // recovered "AM1" line for the duplicate-pinned value is now a direct
+        // `0 ≥ 1` contradiction, which downstream pol expressions sum into a
+        // valid contradiction proof.
         {{3, 2, 3, pair{0, 3}}, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}},
         {{pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, {1, pair{0, 3}, 1, pair{0, 3}}}};
 


### PR DESCRIPTION
Closes #171.

## Summary

`recover_am1` folds pairwise `pair_ne` constraints into a `pol` expression to reconstruct an at-most-1 line over the supplied atoms. When ≥2 atoms simplify to `FalseLiteral` (typically literals over `ConstantIntegerVariableID` arguments not satisfying the condition), the AM1 is genuinely violated — Σ atoms ≥ n − 1 fails because ≥2 atoms contribute 0 — and folding pair_ne lines via the usual polynomial doesn't recover a valid line. VeriPB rejected the resulting expression at parse.

Short-circuit: detect the case at the top of `recover_am1` and emit a direct `0 ≥ 1` contradiction at the caller-supplied level via RUP. The contradiction is RUP-derivable whenever the input is genuinely infeasible (e.g. Inverse with two array entries pinned to the same constant value: the OPB's bidirectional implications, with constants substituted, force one variable to multiple values). Downstream consumers fold the contradiction into further pol expressions, deriving a stronger contradiction — the correct semantic outcome.

The check is gated on `if constexpr (Literal_ == IntegerVariableCondition)`. That's the only instantiation in tree, and `FalseLiteral` has concrete meaning only for that type; if a future `Literal_` ever appears, that's the right time to generalise.

## Second bug fixed in passing

The Inverse path also exposed a structural issue in `justify_all_different_hall_set_or_violator` (`gcs/constraints/all_different/justify.cc:60-71`): when the Hall set contained zero non-constant variables — the duplicate-pinned-constants shape — `at_least_one_constraints` was empty and the pol assembly emitted ` <am1> +` without a prior push, leaving `+` with a single stack element. Restructured to use a shared `first` flag across both at-least-one and AM1 contributions so the leading `+` is omitted only on the very first push.

## Test plan

- [x] `inverse_test` — `has_duplicate_constants` gate removed; the two explicit regression cases that previously skipped proof verification now verify under VeriPB (one as `s VERIFIED UNSATISFIABLE`)
- [x] Stable across 10 random-seed runs (was intermittently failing on the dup-const random shape before)
- [x] Sanitizer-clean (ASan + UBSan)
- [x] Wider ctest sweep — `inverse_constraint`, `among_constraint`, `symmetric_all_different_constraint`, `all_different_constraint`, `minizinc-{inverses,among}` (7/7 tests) — all pass; the if-constexpr branch is invisible to non-`IntegerVariableCondition` callers

## Note

The OPB encoding `Inverse` generates is sane for constants without this fix — `simplify_literal` substitutes constant values into `WPBSum` correctly, so duplicate-pinned-constant cases produce an OPB that derives infeasibility via straightforward PB reasoning. The bug was purely in the runtime AM1 reconstruction proof step (and its downstream pol assembly), not the OPB encoding. No `model_contradiction` bypass needed; the proof now flows through the OPB-encoded semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)