### PR TITLE
xcsp: use native AllEqual constraint instead of Equals-chain decomposition

### DIFF
--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -37,7 +37,7 @@ equivalent for that frontend's vocabulary).
 | mdd | solver gap (#149) | ? | solver gap (#149) | ? |
 | allDifferent | `AllDifferent` | ✓ | ✓ | ? |
 | allDifferent-list / -matrix | various decompositions | ? | matrix ✓ (rows + columns `AllDifferent`); list `s UNSUPPORTED` | ? |
-| allEqual | `Equals` chain (decompose; native propagator tracked in #61) | ✓ | ✓ via decompose (#150) | ? |
+| allEqual | `AllEqual` | ✓ | ✓ | ? |
 | ordered (increasing/decreasing) | `Increasing` / `Decreasing` | ✓ | ✓ (basic + lengths form) | ? |
 | precedence (value precedence) | `ValuePrecede` | ✓ | ✓ (with explicit values, `covered=false`) | ? |
 | sum (linear) | `WeightedSum` | ✓ | ✓ | ? |

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -256,12 +256,7 @@ namespace
 
         auto buildConstraintAllEqual(string, vector<XVariable *> & x_vars) -> void override
         {
-            // Decomposition into a chain of pairwise Equals. A native
-            // AllEqual propagator would be a small win in propagation and
-            // proof size: tracked alongside the other globals in #61.
-            auto vars = need_variables(x_vars);
-            for (size_t i = 1; i < vars.size(); ++i)
-                _problem.post(Equals{vars[0], vars[i]});
+            _problem.post(AllEqual{need_variables(x_vars)});
         }
 
         auto buildConstraintOrdered(string, vector<XVariable *> & x_vars,


### PR DESCRIPTION
## Summary

The XCSP3 binding's \`buildConstraintAllEqual\` (introduced in Phase 2b, #155) decomposed \`<allEqual>\` into a chain of pairwise \`Equals\` posts because there was no native \`AllEqual\` propagator at the time. A native \`AllEqual\` landed in #162 between when the XCSP3 stack was opened and when it merged. Switching to the native form is a small win in propagation and proof size.

\`dev_docs/frontend-support-matrix.md\` updated: the allEqual row drops the "decompose" caveat.

## Test plan

- [x] \`ctest --preset release -R xcsp\` — all 26 xcsp tests pass with VeriPB verification, including \`xcsp_all_equal\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)