### PR TITLE
AtMostOne: native propagator + proof, keep SmartTable for benchmarking (closes #174)

### DIFF
--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -1,8 +1,14 @@
-#include <algorithm>
 #include <gcs/constraints/at_most_one.hh>
 #include <gcs/constraints/smart_table.hh>
+#include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+
+#include <algorithm>
+#include <optional>
 #include <sstream>
 #include <utility>
 
@@ -15,9 +21,12 @@
 #endif
 
 using std::cmp_less;
+using std::get;
+using std::make_optional;
 using std::move;
 using std::string;
 using std::stringstream;
+using std::tuple;
 using std::unique_ptr;
 using std::vector;
 
@@ -29,6 +38,124 @@ using std::print;
 #else
 using fmt::print;
 #endif
+
+// ----- Native AtMostOne -----------------------------------------------------
+
+AtMostOne::AtMostOne(vector<IntegerVariableID> vars, IntegerVariableID val) :
+    _vars(move(vars)),
+    _val(val)
+{
+}
+
+auto AtMostOne::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<AtMostOne>(_vars, _val);
+}
+
+auto AtMostOne::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (_vars.size() < 2)
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto AtMostOne::define_proof_model(ProofModel & model) -> void
+{
+    // For each var_i: define flag_i ⇔ (var_i = _val) via a Count-style
+    // gt/lt/eq triple, then post sum_i flag_i ≤ 1.
+    for (auto & var : _vars) {
+        auto var_minus_val_gt_0 = model.create_proof_flag_fully_reifying("am1g",
+            "AtMostOne", "var greater", WPBSum{} + 1_i * var + -1_i * _val >= 1_i);
+
+        auto var_minus_val_lt_0 = model.create_proof_flag_fully_reifying("am1l",
+            "AtMostOne", "var less", WPBSum{} + 1_i * var + -1_i * _val <= -1_i);
+
+        auto eq = model.create_proof_flag_fully_reifying("am1eq",
+            "AtMostOne", "var equal val", WPBSum{} + 1_i * ! var_minus_val_gt_0 + 1_i * ! var_minus_val_lt_0 >= 2_i);
+
+        _flags.emplace_back(eq, var_minus_val_gt_0, var_minus_val_lt_0);
+    }
+
+    WPBSum sum;
+    for (auto & [flag, _gt, _lt] : _flags)
+        sum += 1_i * flag;
+    model.add_constraint("AtMostOne", "at most one match", sum <= 1_i);
+}
+
+auto AtMostOne::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
+    triggers.on_change.emplace_back(_val);
+
+    vector<IntegerVariableID> all_vars = _vars;
+    all_vars.push_back(_val);
+
+    propagators.install(
+        [vars = _vars, val = _val, all_vars = move(all_vars)](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            // For each candidate value v of `val`: if two or more vars
+            // are fixed to v, infer val ≠ v. (RUP from the encoding's
+            // sum ≤ 1 plus the fixedness reasons.)
+            for (auto v : state.each_value_immutable(val)) {
+                int fixed_to_v = 0;
+                for (auto & var : vars) {
+                    if (state.optional_single_value(var) == make_optional(v)) {
+                        if (++fixed_to_v == 2)
+                            break;
+                    }
+                }
+                if (fixed_to_v >= 2)
+                    inference.infer(logger, val != v, JustifyUsingRUP{},
+                        generic_reason(state, all_vars));
+            }
+
+            // If val is now fixed to v and exactly one var is fixed to v,
+            // infer var_j ≠ v for every other var. (Same RUP argument.)
+            auto val_fixed = state.optional_single_value(val);
+            if (val_fixed) {
+                int fixed_count = 0;
+                size_t fixed_idx = 0;
+                for (size_t i = 0; cmp_less(i, vars.size()); ++i) {
+                    if (state.optional_single_value(vars[i]) == val_fixed) {
+                        ++fixed_count;
+                        fixed_idx = i;
+                        if (fixed_count > 1)
+                            break;
+                    }
+                }
+                if (fixed_count == 1) {
+                    for (size_t i = 0; cmp_less(i, vars.size()); ++i) {
+                        if (i != fixed_idx)
+                            inference.infer(logger, vars[i] != *val_fixed, JustifyUsingRUP{},
+                                generic_reason(state, all_vars));
+                    }
+                }
+            }
+
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto AtMostOne::s_exprify(const string & name, const ProofModel * const model) const -> string
+{
+    stringstream s;
+    print(s, "{} at_most_one (", name);
+    for (const auto & var : _vars)
+        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
+    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));
+    return s.str();
+}
+
+// ----- AtMostOneSmartTable (kept for benchmarking) --------------------------
 
 AtMostOneSmartTable::AtMostOneSmartTable(vector<IntegerVariableID> vars, IntegerVariableID val) :
     _vars(move(vars)),
@@ -50,12 +177,7 @@ auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_sta
     if (_vars.size() < 2)
         return;
 
-    // Build the constraint as smart table
-    // Question: Do we trust this encoding as a smart table?
-    // Should we morally have a simpler PB encoding and reformulate?
-    // Like an auto-smart-table proof?
     SmartTuples tuples;
-
     for (int i = 0; cmp_less(i, _vars.size()); ++i) {
         vector<SmartEntry> tuple;
         for (int j = 0; cmp_less(j, _vars.size()); ++j) {
@@ -73,15 +195,12 @@ auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_sta
     move(smt_table).install(propagators, initial_state, optional_model);
 }
 
-// The "semantics of cp document" says "at_most_one (smart table wrapper, don’t bother and just use count)"
-auto AtMostOneSmartTable::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto AtMostOneSmartTable::s_exprify(const string & name, const ProofModel * const model) const -> string
 {
     stringstream s;
-
-    print(s, "{} at_most_one (", name);
+    print(s, "{} at_most_one_smart_table (", name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));
-
     return s.str();
 }

--- a/gcs/constraints/at_most_one.hh
+++ b/gcs/constraints/at_most_one.hh
@@ -3,14 +3,57 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_AT_MOST_ONE_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/variable_id.hh>
 
+#include <tuple>
 #include <vector>
 
 namespace gcs
 {
     /**
-     * \brief At most one constraint, at most 1 var can equal val.
+     * \brief At most one of `vars` is allowed to equal `val`.
+     *
+     * Native propagator with a Count-style proof model: per-var flags
+     * defining `flag_i ⇔ var_i = val`, and the OPB constraint
+     * `sum_i flag_i ≤ 1`.
+     *
+     * Propagation rules:
+     *   - For each value `v` in the current domain of `val`, count how many
+     *     `vars` are fixed to `v`. If at least two are, infer `val ≠ v`.
+     *   - If `val` is fixed to `v` and exactly one var is fixed to `v`, infer
+     *     `var_j ≠ v` for every other var `var_j`.
+     *
+     * Both inferences are RUP from the encoding plus the relevant
+     * fixed-variable reasons.
+     *
+     * \ingroup Constraints
+     */
+    class AtMostOne : public Constraint
+    {
+    private:
+        std::vector<IntegerVariableID> _vars;
+        IntegerVariableID _val;
+        std::vector<std::tuple<innards::ProofFlag, innards::ProofFlag, innards::ProofFlag>> _flags;
+
+        virtual auto define_proof_model(innards::ProofModel &) -> void;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit AtMostOne(std::vector<IntegerVariableID> vars, IntegerVariableID val);
+
+        virtual auto install(innards::Propagators &, innards::State &,
+            innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+    };
+
+    /**
+     * \brief At most one of `vars` is allowed to equal `val`, encoded as a
+     * SmartTable.
+     *
+     * Kept as a baseline / benchmarking alternative to the native
+     * AtMostOne propagator. Prefer AtMostOne for production use.
      *
      * \ingroup Constraints
      */
@@ -28,8 +71,6 @@ namespace gcs
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
     };
-
-    using AtMostOne = AtMostOneSmartTable;
 }
 
 #endif

--- a/gcs/constraints/at_most_one_test.cc
+++ b/gcs/constraints/at_most_one_test.cc
@@ -43,21 +43,25 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
-auto run_at_most_one_test(bool proofs,
+enum class Variant
+{
+    Native,
+    SmartTable
+};
+
+auto run_at_most_one_test(Variant variant, bool proofs,
     const vector<pair<int, int>> & ranges, pair<int, int> val_range) -> void
 {
-    print(cerr, "at_most_one {} val={}{}", ranges, val_range, proofs ? " with proofs:" : ":");
+    auto label = (variant == Variant::Native) ? "at_most_one" : "at_most_one_smart_table";
+    print(cerr, "{} {} val={}{}", label, ranges, val_range, proofs ? " with proofs:" : ":");
     cerr << flush;
 
     set<tuple<vector<int>, int>> expected, actual;
-    build_expected(expected,
-        [](const vector<int> & vs, int v) {
+    build_expected(expected, [](const vector<int> & vs, int v) {
             int matches = 0;
             for (auto x : vs)
                 matches += (x == v);
-            return matches <= 1;
-        },
-        ranges, val_range);
+            return matches <= 1; }, ranges, val_range);
     println(cerr, " expecting {} solutions", expected.size());
 
     Problem p;
@@ -65,45 +69,48 @@ auto run_at_most_one_test(bool proofs,
     for (const auto & [l, u] : ranges)
         vars.push_back(p.create_integer_variable(Integer(l), Integer(u)));
     auto val = p.create_integer_variable(Integer(val_range.first), Integer(val_range.second));
-    p.post(AtMostOne{vars, val});
+    if (variant == Variant::Native)
+        p.post(AtMostOne{vars, val});
+    else
+        p.post(AtMostOneSmartTable{vars, val});
 
     auto proof_name = proofs ? make_optional("at_most_one_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars, val});
     check_results(proof_name, expected, actual);
 }
 
-auto run_all_tests(bool proofs) -> void
+auto run_all_tests(Variant variant, bool proofs) -> void
 {
     // Boundary: empty / singleton — both vacuously true.
-    run_at_most_one_test(proofs, {}, {1, 3});
-    run_at_most_one_test(proofs, {{1, 3}}, {1, 3});
+    run_at_most_one_test(variant, proofs, {}, {1, 3});
+    run_at_most_one_test(variant, proofs, {{1, 3}}, {1, 3});
 
     // Two vars: smallest meaningful case.
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}}, {2, 2});
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}}, {1, 3});
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}}, {1, 3});
 
     // 3-variable tests, fixed val (single-point range)
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {2, 2});          // basic, val=2
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {5, 5});          // val outside all domains
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {1, 1});          // val at domain boundary
-    run_at_most_one_test(proofs, {{-2, 2}, {-2, 2}, {-2, 2}}, {0, 0});       // negative domain, val=0
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}, {1, 3}}, {2, 2});    // basic, val=2
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}, {1, 3}}, {5, 5});    // val outside all domains
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}, {1, 3}}, {1, 1});    // val at domain boundary
+    run_at_most_one_test(variant, proofs, {{-2, 2}, {-2, 2}, {-2, 2}}, {0, 0}); // negative domain, val=0
 
     // 3-variable tests, variable val
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {1, 3});
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}}, {2, 4});
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}, {1, 3}}, {1, 3});
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}, {1, 3}}, {2, 4});
 
     // Propagation: one var forced to equal val, others must differ
-    run_at_most_one_test(proofs, {{2, 2}, {1, 3}, {1, 3}}, {2, 2});
-    run_at_most_one_test(proofs, {{2, 2}, {2, 2}, {1, 3}}, {1, 3});
+    run_at_most_one_test(variant, proofs, {{2, 2}, {1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(variant, proofs, {{2, 2}, {2, 2}, {1, 3}}, {1, 3});
 
     // Unsatisfiable: two vars forced to equal a fixed val
-    run_at_most_one_test(proofs, {{2, 2}, {2, 2}, {1, 3}}, {2, 2});
+    run_at_most_one_test(variant, proofs, {{2, 2}, {2, 2}, {1, 3}}, {2, 2});
 
     // 4-variable tests
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});
-    run_at_most_one_test(proofs, {{2, 2}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});
-    run_at_most_one_test(proofs, {{1, 3}, {1, 3}, {1, 3}, {1, 3}}, {1, 3});
-    run_at_most_one_test(proofs, {{2, 2}, {2, 2}, {1, 3}, {1, 3}}, {1, 3});
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(variant, proofs, {{2, 2}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});
+    run_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}, {1, 3}, {1, 3}}, {1, 3});
+    run_at_most_one_test(variant, proofs, {{2, 2}, {2, 2}, {1, 3}, {1, 3}}, {1, 3});
 }
 
 auto main(int, char *[]) -> int
@@ -111,27 +118,29 @@ auto main(int, char *[]) -> int
     random_device rand_dev;
     mt19937 rand(rand_dev());
 
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
-            continue;
-        run_all_tests(proofs);
+    for (auto variant : {Variant::Native, Variant::SmartTable}) {
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            run_all_tests(variant, proofs);
 
-        // Small random sweep: 2..5 vars, modest domains so the solution
-        // space stays small. Solution count is O(|val| * prod(|vars|))
-        // worst case, which on these bounds is at most ~5^5 = 3125 even
-        // before the at-most-one filter, so VeriPB stays fast.
-        uniform_int_distribution n_vars_dist{2, 5};
-        uniform_int_distribution lo_dist{-2, 4};
-        uniform_int_distribution width_dist{0, 4};
-        for (int x = 0; x < 10; ++x) {
-            int n_vars = n_vars_dist(rand);
-            vector<pair<int, int>> ranges;
-            for (int i = 0; i < n_vars; ++i) {
-                int lo = lo_dist(rand);
-                ranges.emplace_back(lo, lo + width_dist(rand));
+            // Small random sweep: 2..5 vars, modest domains so the solution
+            // space stays small. Solution count is O(|val| * prod(|vars|))
+            // worst case, which on these bounds is at most ~5^5 = 3125 even
+            // before the at-most-one filter, so VeriPB stays fast.
+            uniform_int_distribution n_vars_dist{2, 5};
+            uniform_int_distribution lo_dist{-2, 4};
+            uniform_int_distribution width_dist{0, 4};
+            for (int x = 0; x < 10; ++x) {
+                int n_vars = n_vars_dist(rand);
+                vector<pair<int, int>> ranges;
+                for (int i = 0; i < n_vars; ++i) {
+                    int lo = lo_dist(rand);
+                    ranges.emplace_back(lo, lo + width_dist(rand));
+                }
+                int v_lo = lo_dist(rand);
+                run_at_most_one_test(variant, proofs, ranges, {v_lo, v_lo + width_dist(rand)});
             }
-            int v_lo = lo_dist(rand);
-            run_at_most_one_test(proofs, ranges, {v_lo, v_lo + width_dist(rand)});
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #174.

Replaces the SmartTable delegation with a dedicated propagator and a direct OPB encoding. The previous \`AtMostOneSmartTable\` class is kept around for benchmarking; \`AtMostOne\` is now a separate class with its own implementation. Existing callers of \`AtMostOne{vars, val}\` pick up the new propagator transparently.

## Encoding

For each \`var_i\`, define a per-var equality flag using the same gt/lt/eq triple that \`Count\` uses:

- \`am1g_i ⇔ (var_i - val ≥ 1)\`
- \`am1l_i ⇔ (var_i - val ≤ -1)\`
- \`am1eq_i ⇔ (¬am1g_i ∧ ¬am1l_i)\`, i.e. \`var_i = val\`

Then post the OPB constraint:

\`\`\`
sum_i am1eq_i ≤ 1
\`\`\`

## Propagation

Two rules, both **RUP** from the encoding plus the relevant fixed-variable reasons:

1. For each value \`v\` in \`val\`'s current domain, count how many vars are fixed to \`v\`. If two or more are, infer \`val ≠ v\`.
2. If \`val\` is fixed to \`v\` and exactly one var is fixed to \`v\`, infer \`var_j ≠ v\` for every other var.

The first rule subsumes the contradiction case (when val is fixed to v and ≥ 2 vars are fixed to v, infer-val-≠-v on a singleton domain produces an empty domain → contradiction).

## Tests

\`gcs/constraints/at_most_one_test.cc\` is parametrised over both variants. Each variant runs through the existing fixed cases (boundary, two-var, three-var with both fixed and variable val, propagation cases, unsat cases, four-var) plus the same 10-instance random sweep. **54 VeriPB-verified runs (27 per variant), no failures.**

\`ctest --preset release\` is green: 194/194 passing.

## Test plan

- [x] \`build/at_most_one_test\` runs cleanly with proofs
- [x] Full \`ctest --preset release\` is 194/194
- [x] \`clang-format --dry-run --Werror\` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)