### PR TITLE
propagators: add InitialiserPriority + initial_contradiction (issue #181)

### DIFF
--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -237,7 +237,8 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 *data = build_table(coeff_vars, value, cond, state, logger);
                 if (! data->has_value())
                     inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }});
-            });
+            },
+                InitialiserPriority::Expensive);
 
             propagators.install([data = data](
                                     const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -10,6 +10,7 @@
 #include <util/overloaded.hh>
 
 #include <algorithm>
+#include <array>
 #include <utility>
 
 using namespace gcs;
@@ -37,7 +38,7 @@ namespace
 struct Propagators::Imp
 {
     vector<PropagationFunction> propagation_functions;
-    vector<InitialisationFunction> initialisation_functions;
+    std::array<vector<InitialisationFunction>, number_of_initialiser_priorities> initialisation_functions_by_priority;
 
     // Every propagation function's index appears exactly once in queue, and lookup[id] always tells
     // us where that position is. The items from index 0 to enqueued_end - 1 are ready to be
@@ -124,20 +125,31 @@ auto Propagators::install(PropagationFunction && f, const Triggers & triggers) -
     }
 }
 
-auto Propagators::install_initialiser(InitialisationFunction && f) -> void
+auto Propagators::install_initialiser(InitialisationFunction && f, InitialiserPriority priority) -> void
 {
-    _imp->initialisation_functions.emplace_back(move(f));
+    _imp->initialisation_functions_by_priority[to_underlying(priority)].emplace_back(move(f));
+}
+
+auto Propagators::install_initial_contradiction(const string &, Justification why, ReasonFunction reason, InitialiserPriority priority) -> void
+{
+    install_initialiser(
+        [why = move(why), reason = move(reason)](const State &, auto & inference, ProofLogger * const logger) -> void {
+            inference.contradiction(logger, why, reason);
+        },
+        priority);
 }
 
 auto Propagators::initialise(State & state, ProofLogger * const logger) const -> bool
 {
-    for (auto & f : _imp->initialisation_functions) {
-        EagerProofLoggingInferenceTracker inf(state);
-        try {
-            f(state, inf, logger);
-        }
-        catch (const TrackedPropagationFailed &) {
-            return false;
+    for (auto & bucket : _imp->initialisation_functions_by_priority) {
+        for (auto & f : bucket) {
+            EagerProofLoggingInferenceTracker inf(state);
+            try {
+                f(state, inf, logger);
+            }
+            catch (const TrackedPropagationFailed &) {
+                return false;
+            }
         }
     }
 

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -4,8 +4,10 @@
 #include <gcs/expression.hh>
 #include <gcs/extensional.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/problem.hh>
 
@@ -79,6 +81,24 @@ namespace gcs::innards
     };
 
     using InitialisationFunction = std::function<auto(State &, EagerProofLoggingInferenceTracker &, ProofLogger * const)->void>;
+
+    /**
+     * \brief Priority for initialisers, controlling the order in which they run.
+     *
+     * Initialisers run in the order SimpleDefinition, Cheap, Expensive. Within
+     * the same priority they run in registration order.
+     *
+     * \ingroup Innards
+     * \sa Propagators::install_initialiser
+     */
+    enum class InitialiserPriority
+    {
+        SimpleDefinition,
+        Cheap,
+        Expensive
+    };
+
+    constexpr std::size_t number_of_initialiser_priorities = 3;
 
     /**
      * \brief Tell Propagators when a Constraint's propagators should be triggered.
@@ -172,9 +192,25 @@ namespace gcs::innards
 
         /**
          * Install an initialiser, which will be called once just before search
-         * starts.
+         * starts. Initialisers run in priority order
+         * (\c SimpleDefinition before \c Cheap before \c Expensive); within
+         * the same priority they run in registration order.
          */
-        auto install_initialiser(InitialisationFunction &&) -> void;
+        auto install_initialiser(InitialisationFunction &&,
+            InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void;
+
+        /**
+         * Install an initialiser whose only job is to immediately raise a
+         * contradiction with the given Justification (RUP, explicit, or
+         * none) and ReasonFunction. Convenience wrapper around
+         * install_initialiser; intended for cases where the OPB encoding
+         * emitted by define_proof_model collapses to a trivially-false
+         * constraint and we want propagation to detect that up front.
+         */
+        auto install_initial_contradiction(const std::string & explain_yourself,
+            Justification why,
+            ReasonFunction reason = ReasonFunction{},
+            InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void;
 
         ///@}
 


### PR DESCRIPTION
## Summary

First of four PRs implementing the plan from #181. Mechanical groundwork only — no behaviour change beyond initialiser ordering.

- `InitialiserPriority { SimpleDefinition, Cheap, Expensive }` with an adjacent `number_of_initialiser_priorities` constant so adding levels later only needs the enum + the constant updated together.
- `install_initialiser` gains a defaulted priority arg; storage moves from a single vector to an `array<vector<...>, N>` keyed by priority, and `initialise()` walks them in enum order.
- `install_initial_contradiction(label, Justification, ReasonFunction = {}, priority = SimpleDefinition)`: convenience wrapper for "install an initialiser whose only job is to contradict immediately". Takes `Justification` rather than hard-coding RUP, so callers that need explicit proof steps can use it too.
- `linear_equality.cc:235` `build_table` initialiser (gac mode) classified as `Expensive` — it enumerates the cartesian product of variable domains, so it benefits from running after `SimpleDefinition` initialisers tighten those domains.

The remaining three PRs (per #181) will land on top of this:

2. Migrate consequence contradictions (AllDifferent duplicates, empty Table, AllDifferentExcept dup+empty-excluded) onto `install_initial_contradiction`, removing the duplicate-variable special-cases in `prepare()`.
3. Rework Abs's consequence trims into `SimpleDefinition` initialisers that RUP from the encoding instead of writing OPB axioms.
4. Introduce `define_bound(...)` with the `(constraint_name, sub_rule)` labelled args, migrate the definitional bound sites, retire `trim_*_bound` and `model_contradiction`, convert `inverse.cc:73` to `throw`.

## Test plan

- [x] `cmake --build --preset release --parallel 8` clean
- [x] `ctest --preset release -j 8` — 194/194 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)