### PR TITLE
constraints: stop special-casing degenerate inputs in prepare() (issue #181)

### DIFF
--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -69,7 +69,7 @@ auto AllDifferentExcept::install(Propagators & propagators, State & initial_stat
     install_propagators(propagators);
 }
 
-auto AllDifferentExcept::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+auto AllDifferentExcept::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _sanitised_vars = move(_vars);
     sort(_sanitised_vars);
@@ -91,13 +91,11 @@ auto AllDifferentExcept::prepare(Propagators & propagators, State & initial_stat
 
     // A variable that appears more than once must equal itself, so the
     // constraint forces it into the excluded set. With no usable excluded
-    // values left, that's a hard contradiction (matches plain AllDifferent
-    // semantics on duplicates).
+    // values left, the encoding emitted by define_clique_not_equals_except
+    // collapses to a self-contradicting half-reified pair (no excluded
+    // relaxation), and install_propagators installs a clique-duplicate
+    // contradiction initialiser to fail at search start.
     _has_duplicates = adjacent_find(_sanitised_vars.begin(), _sanitised_vars.end()) != _sanitised_vars.end();
-    if (_has_duplicates && _sanitised_excluded.empty()) {
-        propagators.model_contradiction(initial_state, optional_model, "AllDifferentExcept with duplicate variables and no usable excluded values");
-        return false;
-    }
 
     if (_has_duplicates) {
         for (auto it = _sanitised_vars.begin(); it != _sanitised_vars.end();) {
@@ -129,6 +127,17 @@ auto AllDifferentExcept::define_proof_model(ProofModel & model) -> void
 
 auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
 {
+    if (_has_duplicates && _sanitised_excluded.empty()) {
+        // Same shape as plain AllDifferent on duplicates: with empty excluded,
+        // the encoding's half-reified relaxation terms disappear and the
+        // duplicate pair's two constraints jointly force selector and
+        // !selector simultaneously. Install the shared clique-contradiction
+        // initialiser instead of the per-value path below; the propagator
+        // also can't run, so we early-return.
+        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        return;
+    }
+
     // For each duplicated variable, install an initialiser that forces it
     // into the excluded set: for every value v in its current domain that is
     // not in `excluded`, infer var != v. The justification rests on the two

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <iterator>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -134,7 +135,10 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
         // !selector simultaneously. Install the shared clique-contradiction
         // initialiser instead of the per-value path below; the propagator
         // also can't run, so we early-return.
-        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        auto witness = _duplicate_selectors.empty()
+            ? std::nullopt
+            : std::optional{*_duplicate_selectors.begin()};
+        install_clique_duplicate_contradiction_initialiser(propagators, move(witness));
         return;
     }
 

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -8,14 +8,16 @@
 
 using std::map;
 using std::move;
+using std::optional;
+using std::pair;
 using std::vector;
 
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const vector<gcs::IntegerVariableID> & vars) -> map<IntegerVariableID, ProofFlag>
+auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const vector<gcs::IntegerVariableID> & vars) -> optional<pair<IntegerVariableID, ProofFlag>>
 {
-    map<IntegerVariableID, ProofFlag> duplicate_selectors;
+    optional<pair<IntegerVariableID, ProofFlag>> duplicate_witness;
 
     for (unsigned i = 0; i < vars.size(); ++i)
         for (unsigned j = i + 1; j < vars.size(); ++j) {
@@ -23,22 +25,22 @@ auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const v
             model.add_constraint("AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
             model.add_constraint("AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
 
-            if (vars[i] == vars[j])
-                duplicate_selectors.insert_or_assign(vars[i], selector);
+            if (vars[i] == vars[j] && ! duplicate_witness)
+                duplicate_witness = pair{vars[i], selector};
         }
 
-    return duplicate_selectors;
+    return duplicate_witness;
 }
 
 auto gcs::innards::install_clique_duplicate_contradiction_initialiser(
     Propagators & propagators,
-    map<IntegerVariableID, ProofFlag> duplicate_selectors) -> void
+    optional<pair<IntegerVariableID, ProofFlag>> duplicate_witness) -> void
 {
     propagators.install_initialiser(
-        [duplicate_selectors = move(duplicate_selectors)](
+        [duplicate_witness = move(duplicate_witness)](
             State &, auto & inference, ProofLogger * const logger) -> void {
-            if (logger && ! duplicate_selectors.empty()) {
-                auto & [_, selector] = *duplicate_selectors.begin();
+            if (logger && duplicate_witness) {
+                const auto & selector = duplicate_witness->second;
                 inference.contradiction(logger,
                     JustifyExplicitlyThenRUP{
                         [logger, selector](const ReasonFunction &) -> void {

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -1,21 +1,64 @@
 #include <gcs/constraints/all_different/encoding.hh>
+#include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+
+#include <utility>
 
 using std::map;
+using std::move;
 using std::vector;
 
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const vector<gcs::IntegerVariableID> & vars) -> void
+auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const vector<gcs::IntegerVariableID> & vars) -> map<IntegerVariableID, ProofFlag>
 {
+    map<IntegerVariableID, ProofFlag> duplicate_selectors;
+
     for (unsigned i = 0; i < vars.size(); ++i)
         for (unsigned j = i + 1; j < vars.size(); ++j) {
             auto selector = model.create_proof_flag("notequals");
             model.add_constraint("AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
             model.add_constraint("AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
+
+            if (vars[i] == vars[j])
+                duplicate_selectors.insert_or_assign(vars[i], selector);
         }
+
+    return duplicate_selectors;
+}
+
+auto gcs::innards::install_clique_duplicate_contradiction_initialiser(
+    Propagators & propagators,
+    map<IntegerVariableID, ProofFlag> duplicate_selectors) -> void
+{
+    propagators.install_initialiser(
+        [duplicate_selectors = move(duplicate_selectors)](
+            State &, auto & inference, ProofLogger * const logger) -> void {
+            if (logger && ! duplicate_selectors.empty()) {
+                auto & [_, selector] = *duplicate_selectors.begin();
+                inference.contradiction(logger,
+                    JustifyExplicitlyThenRUP{
+                        [logger, selector](const ReasonFunction &) -> void {
+                            // For the duplicated pair (i, j) with vars[i] = vars[j], the encoding
+                            // emitted:
+                            //   selector  -> (vars[i] - vars[j] <= -1)  i.e.  selector  -> false
+                            //   !selector -> (vars[j] - vars[i] <= -1)  i.e.  !selector -> false
+                            // RUP each polarity from its own half-reification, then RUP false.
+                            logger->emit(RUPProofRule{},
+                                WPBSum{} + 1_i * selector >= 1_i, ProofLevel::Temporary);
+                            logger->emit(RUPProofRule{},
+                                WPBSum{} + 1_i * (! selector) >= 1_i, ProofLevel::Temporary);
+                        }},
+                    ReasonFunction{});
+            }
+            else {
+                inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{});
+            }
+        },
+        InitialiserPriority::SimpleDefinition);
 }
 
 auto gcs::innards::define_clique_not_equals_except_encoding(ProofModel & model,

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -5,19 +5,29 @@
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
 #include <map>
+#include <string>
 #include <vector>
 
 namespace gcs
 {
     namespace innards
     {
+        // Emits the clique-of-not-equals encoding. Where the same variable
+        // appears more than once in `vars`, the resulting pair-of-half-reified
+        // constraints is jointly inconsistent — both polarities of the
+        // selector are forced false. The returned map gives one of the
+        // per-pair selector flags for each such duplicated variable, so
+        // callers can cite it from a justification that derives
+        // contradiction explicitly (RUP alone cannot pick a polarity, since
+        // both half-reifications are non-unit).
         auto define_clique_not_equals_encoding(ProofModel & model,
-            const std::vector<IntegerVariableID> & vars) -> void;
+            const std::vector<IntegerVariableID> & vars) -> std::map<IntegerVariableID, ProofFlag>;
 
         // Emits the AllDifferentExcept clique encoding. Where the same variable
         // appears more than once in `vars`, the resulting pair-of-half-reified
@@ -28,6 +38,18 @@ namespace gcs
         auto define_clique_not_equals_except_encoding(ProofModel & model,
             const std::vector<IntegerVariableID> & vars,
             const std::vector<Integer> & excluded) -> std::map<IntegerVariableID, ProofFlag>;
+
+        // Install a SimpleDefinition-priority contradiction initialiser that
+        // proves the input was unsatisfiable because of a duplicate variable
+        // in a clique-of-not-equals encoding. If proof logging is enabled and
+        // selectors is non-empty, the initialiser cites one duplicate pair's
+        // selector flag explicitly: it RUPs `selector` and `!selector` from
+        // the two half-reifications the encoding emitted, then RUPs false.
+        // Otherwise it just contradicts via plain RUP, which is enough when
+        // not logging proofs.
+        auto install_clique_duplicate_contradiction_initialiser(
+            Propagators & propagators,
+            std::map<IntegerVariableID, ProofFlag> duplicate_selectors) -> void;
     }
 }
 

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -11,7 +11,9 @@
 #include <gcs/variable_id.hh>
 
 #include <map>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -21,13 +23,13 @@ namespace gcs
         // Emits the clique-of-not-equals encoding. Where the same variable
         // appears more than once in `vars`, the resulting pair-of-half-reified
         // constraints is jointly inconsistent — both polarities of the
-        // selector are forced false. The returned map gives one of the
-        // per-pair selector flags for each such duplicated variable, so
-        // callers can cite it from a justification that derives
-        // contradiction explicitly (RUP alone cannot pick a polarity, since
-        // both half-reifications are non-unit).
+        // selector are forced false. If any duplicate pair is found, the
+        // return value carries one of the offending variables and its
+        // selector flag, which the caller can cite from a justification that
+        // derives contradiction explicitly (RUP alone cannot pick a polarity,
+        // since both half-reifications are non-unit).
         auto define_clique_not_equals_encoding(ProofModel & model,
-            const std::vector<IntegerVariableID> & vars) -> std::map<IntegerVariableID, ProofFlag>;
+            const std::vector<IntegerVariableID> & vars) -> std::optional<std::pair<IntegerVariableID, ProofFlag>>;
 
         // Emits the AllDifferentExcept clique encoding. Where the same variable
         // appears more than once in `vars`, the resulting pair-of-half-reified
@@ -42,14 +44,14 @@ namespace gcs
         // Install a SimpleDefinition-priority contradiction initialiser that
         // proves the input was unsatisfiable because of a duplicate variable
         // in a clique-of-not-equals encoding. If proof logging is enabled and
-        // selectors is non-empty, the initialiser cites one duplicate pair's
-        // selector flag explicitly: it RUPs `selector` and `!selector` from
-        // the two half-reifications the encoding emitted, then RUPs false.
-        // Otherwise it just contradicts via plain RUP, which is enough when
-        // not logging proofs.
+        // a witness selector is supplied, the initialiser cites it
+        // explicitly: it RUPs `selector` and `!selector` from the two
+        // half-reifications the encoding emitted, then RUPs false. Otherwise
+        // it just contradicts via plain RUP, which is enough when not
+        // logging proofs.
         auto install_clique_duplicate_contradiction_initialiser(
             Propagators & propagators,
-            std::map<IntegerVariableID, ProofFlag> duplicate_selectors) -> void;
+            std::optional<std::pair<IntegerVariableID, ProofFlag>> duplicate_witness) -> void;
     }
 }
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -599,13 +599,18 @@ auto GACAllDifferent::install(Propagators & propagators, State & initial_state, 
     install_propagators(propagators);
 }
 
-auto GACAllDifferent::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+auto GACAllDifferent::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _sanitised_vars = move(_vars);
     sort(_sanitised_vars);
-    if (adjacent_find(_sanitised_vars) != _sanitised_vars.end()) {
-        propagators.model_contradiction(initial_state, optional_model, "AllDifferent with duplicate variables");
-        return false;
+    _has_duplicate_vars = adjacent_find(_sanitised_vars) != _sanitised_vars.end();
+    if (_has_duplicate_vars) {
+        // The matching propagator can't model duplicate left-vertices, so
+        // install_propagators only installs a contradiction initialiser. We
+        // still let define_proof_model run unchanged: the encoding emits a
+        // self-contradicting half-reified pair for the duplicated variable
+        // for the initialiser to cite.
+        return true;
     }
 
     for (auto & var : _sanitised_vars)
@@ -618,11 +623,16 @@ auto GACAllDifferent::prepare(Propagators & propagators, State & initial_state, 
 
 auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    define_clique_not_equals_encoding(model, _sanitised_vars);
+    _duplicate_selectors = define_clique_not_equals_encoding(model, _sanitised_vars);
 }
 
 auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
 {
+    if (_has_duplicate_vars) {
+        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        return;
+    }
+
     Triggers triggers;
     triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -623,13 +623,13 @@ auto GACAllDifferent::prepare(Propagators &, State & initial_state, ProofModel *
 
 auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    _duplicate_selectors = define_clique_not_equals_encoding(model, _sanitised_vars);
+    _duplicate_witness = define_clique_not_equals_encoding(model, _sanitised_vars);
 }
 
 auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_witness));
         return;
     }
 

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -1,9 +1,10 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GAC_ALL_DIFFERENT_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GAC_ALL_DIFFERENT_HH
 
-#include <gcs/constraint.hh>
+#include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/variable_id.hh>
 
 #include <map>
@@ -35,6 +36,8 @@ namespace gcs
         const std::vector<IntegerVariableID> _vars;
         std::vector<IntegerVariableID> _sanitised_vars;
         std::vector<Integer> _compressed_vals;
+        bool _has_duplicate_vars = false;
+        std::map<IntegerVariableID, innards::ProofFlag> _duplicate_selectors;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -8,6 +8,8 @@
 #include <gcs/variable_id.hh>
 
 #include <map>
+#include <optional>
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -37,7 +39,7 @@ namespace gcs
         std::vector<IntegerVariableID> _sanitised_vars;
         std::vector<Integer> _compressed_vals;
         bool _has_duplicate_vars = false;
-        std::map<IntegerVariableID, innards::ProofFlag> _duplicate_selectors;
+        std::optional<std::pair<IntegerVariableID, innards::ProofFlag>> _duplicate_witness;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -71,17 +71,22 @@ auto SymmetricAllDifferent::prepare(Propagators & propagators, State & initial_s
 {
     auto n = _vars.size();
 
-    // A variable appearing more than once would have to equal itself
-    // *and* be pairwise different from itself; that's never satisfiable,
-    // and propagate_gac_all_different's bipartite matching does not
-    // model duplicate left-vertices, so we reject upfront.
     {
         auto sorted_vars = _vars;
         sort(sorted_vars);
-        if (adjacent_find(sorted_vars) != sorted_vars.end()) {
-            propagators.model_contradiction(initial_state, optional_model, "SymmetricAllDifferent with duplicate variables");
-            return false;
-        }
+        _has_duplicate_vars = adjacent_find(sorted_vars) != sorted_vars.end();
+    }
+
+    if (_has_duplicate_vars) {
+        // A variable appearing more than once would have to equal itself
+        // *and* be pairwise different from itself, so the constraint is UNSAT.
+        // The bipartite matching used by propagate_gac_all_different doesn't
+        // model duplicate left-vertices either, so install_propagators only
+        // installs a contradiction initialiser. We let define_proof_model run
+        // unchanged: the clique-of-not-equals encoding emits a self-
+        // contradicting half-reified pair for the duplicated variable, which
+        // the initialiser cites in its proof.
+        return true;
     }
 
     for (const auto & v : _vars) {
@@ -110,7 +115,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
                     + 1_i * (_vars[i] == Integer(j) + _start) >= 1_i);
         }
 
-    define_clique_not_equals_encoding(model, _vars);
+    _duplicate_selectors = define_clique_not_equals_encoding(model, _vars);
 
     // Per-value am1s for the alldiff hall-set / SCC justifications,
     // built once at the root.
@@ -119,6 +124,11 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
 
 auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> void
 {
+    if (_has_duplicate_vars) {
+        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        return;
+    }
+
     auto vars = move(_vars);
     auto start = _start;
     auto n = vars.size();

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -115,7 +115,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
                     + 1_i * (_vars[i] == Integer(j) + _start) >= 1_i);
         }
 
-    _duplicate_selectors = define_clique_not_equals_encoding(model, _vars);
+    _duplicate_witness = define_clique_not_equals_encoding(model, _vars);
 
     // Per-value am1s for the alldiff hall-set / SCC justifications,
     // built once at the root.
@@ -125,7 +125,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
 auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_witness));
         return;
     }
 

--- a/gcs/constraints/all_different/symmetric_all_different.hh
+++ b/gcs/constraints/all_different/symmetric_all_different.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
@@ -33,6 +34,8 @@ namespace gcs
         std::vector<IntegerVariableID> _vars;
         Integer _start;
         std::shared_ptr<std::map<Integer, innards::ProofLine>> _value_am1s;
+        bool _has_duplicate_vars = false;
+        std::map<IntegerVariableID, innards::ProofFlag> _duplicate_selectors;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different/symmetric_all_different.hh
+++ b/gcs/constraints/all_different/symmetric_all_different.hh
@@ -9,6 +9,8 @@
 
 #include <map>
 #include <memory>
+#include <optional>
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -35,7 +37,7 @@ namespace gcs
         Integer _start;
         std::shared_ptr<std::map<Integer, innards::ProofLine>> _value_am1s;
         bool _has_duplicate_vars = false;
-        std::map<IntegerVariableID, innards::ProofFlag> _duplicate_selectors;
+        std::optional<std::pair<IntegerVariableID, innards::ProofFlag>> _duplicate_witness;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different/symmetric_all_different_test.cc
+++ b/gcs/constraints/all_different/symmetric_all_different_test.cc
@@ -115,9 +115,9 @@ namespace
 
         // Posting the same variable twice in a SymmetricAllDifferent is
         // always infeasible (the constraint requires X != X). We confirm
-        // the propagator rejects it with model_contradiction by checking
-        // that the proof still verifies as UNSATISFIABLE; expected is
-        // necessarily empty.
+        // an initialiser rejects it with a clique-duplicate contradiction
+        // proof by checking that the proof still verifies as UNSATISFIABLE;
+        // expected is necessarily empty.
         set<tuple<vector<int>>> expected, actual;
         println(cerr, " expecting 0 solutions");
 

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -114,13 +114,18 @@ auto VCAllDifferent::install(Propagators & propagators, State & initial_state, P
     install_propagators(propagators);
 }
 
-auto VCAllDifferent::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+auto VCAllDifferent::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _sanitised_vars = move(_vars);
     sort(_sanitised_vars);
-    if (adjacent_find(_sanitised_vars) != _sanitised_vars.end()) {
-        propagators.model_contradiction(initial_state, optional_model, "AllDifferent with duplicate variables");
-        return false;
+    _has_duplicate_vars = adjacent_find(_sanitised_vars) != _sanitised_vars.end();
+    if (_has_duplicate_vars) {
+        // The bipartite-matching propagator can't model duplicate left-vertices,
+        // so install_propagators will only install a contradiction initialiser.
+        // We still let define_proof_model run unchanged: the encoding emits a
+        // self-contradicting half-reified pair for the duplicated variable,
+        // which the initialiser cites in its proof.
+        return true;
     }
 
     // Keep track of unassigned vars
@@ -136,11 +141,16 @@ auto VCAllDifferent::prepare(Propagators & propagators, State & initial_state, P
 
 auto VCAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    define_clique_not_equals_encoding(model, _sanitised_vars);
+    _duplicate_selectors = define_clique_not_equals_encoding(model, _sanitised_vars);
 }
 
 auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
 {
+    if (_has_duplicate_vars) {
+        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        return;
+    }
+
     Triggers triggers;
     triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -141,13 +141,13 @@ auto VCAllDifferent::prepare(Propagators &, State & initial_state, ProofModel * 
 
 auto VCAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    _duplicate_selectors = define_clique_not_equals_encoding(model, _sanitised_vars);
+    _duplicate_witness = define_clique_not_equals_encoding(model, _sanitised_vars);
 }
 
 auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_selectors));
+        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_witness));
         return;
     }
 

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -1,11 +1,13 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_VC_ALL_DIFFERENT_HH
 #define GLASGOW_CONSTRAINT_SOLVER_VC_ALL_DIFFERENT_HH
 
-#include <gcs/constraint.hh>
+#include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
+#include <map>
 #include <vector>
 
 namespace gcs
@@ -15,9 +17,6 @@ namespace gcs
         auto propagate_non_gac_alldifferent(
             const ConstraintStateHandle & unassigned_handle, const State & state,
             auto & inference_tracker, ProofLogger * const logger) -> void;
-
-        auto define_clique_not_equals_encoding(ProofModel & model,
-            const std::vector<IntegerVariableID> & vars) -> void;
     }
 
     /**
@@ -33,6 +32,8 @@ namespace gcs
         const std::vector<IntegerVariableID> _vars;
         std::vector<IntegerVariableID> _sanitised_vars;
         innards::ConstraintStateHandle _unassigned_handle;
+        bool _has_duplicate_vars = false;
+        std::map<IntegerVariableID, innards::ProofFlag> _duplicate_selectors;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -7,7 +7,8 @@
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
-#include <map>
+#include <optional>
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -33,7 +34,7 @@ namespace gcs
         std::vector<IntegerVariableID> _sanitised_vars;
         innards::ConstraintStateHandle _unassigned_handle;
         bool _has_duplicate_vars = false;
-        std::map<IntegerVariableID, innards::ProofFlag> _duplicate_selectors;
+        std::optional<std::pair<IntegerVariableID, innards::ProofFlag>> _duplicate_witness;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different_test.cc
+++ b/gcs/constraints/all_different_test.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
@@ -78,6 +79,41 @@ auto run_all_different_test(bool proofs, variant<int, pair<int, int>> v1_range, 
     check_results(proof_name, expected, actual);
 }
 
+// AllDifferent with the same variable in two positions is unsatisfiable
+// (the constraint requires `x != x`). Exercise both the GAC and VC
+// flavours: the consequence-contradiction path runs the standard
+// clique-of-not-equals encoding (which emits a self-contradicting
+// half-reified pair for the duplicated variable) and a contradiction
+// initialiser that cites one duplicated pair's selector flag.
+template <typename AllDifferentVariant_>
+auto run_alldiff_dup_test(bool proofs, const vector<vector<int>> & unique_domains,
+    const vector<int> & positions, const string & flavour) -> void
+{
+    print(cerr, "all_different_dup [{}] domains {} positions {}{}",
+        flavour, unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    println(cerr, " expecting 0 solutions");
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains) {
+        vector<Integer> vals;
+        for (int v : d)
+            vals.push_back(Integer(v));
+        unique_vars.push_back(p.create_integer_variable(vals));
+    }
+    vector<IntegerVariableID> posted_vars;
+    for (auto pos : positions)
+        posted_vars.push_back(unique_vars[pos]);
+    p.post(AllDifferentVariant_{posted_vars});
+
+    auto proof_name = proofs ? make_optional("all_different_test") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int, char *[]) -> int
 {
     vector<tuple<variant<int, pair<int, int>>, variant<int, pair<int, int>>, variant<int, pair<int, int>>,
@@ -113,6 +149,16 @@ auto main(int, char *[]) -> int
             continue;
         for (auto & [r1, r2, r3, r4, r5, r6] : data)
             run_all_different_test(proofs, r1, r2, r3, r4, r5, r6);
+
+        // Duplicate-variable cases for both flavours: smallest non-trivial
+        // pair, a duplicate among more variables, and two duplicate runs.
+        for (auto & [unique_domains, positions] : vector<pair<vector<vector<int>>, vector<int>>>{
+                 {{{0, 1}}, {0, 0}},
+                 {{{0, 3}, {0, 3}}, {0, 0, 1}},
+                 {{{0, 3}, {0, 3}}, {0, 0, 1, 1}}}) {
+            run_alldiff_dup_test<GACAllDifferent>(proofs, unique_domains, positions, "gac");
+            run_alldiff_dup_test<VCAllDifferent>(proofs, unique_domains, positions, "vc");
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -125,15 +125,17 @@ auto Table::install(Propagators & propagators, State & initial_state, ProofModel
     install_propagators(propagators);
 }
 
-auto Table::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
-    bool continue_installation = true;
     visit([&](auto & tuples) {
         if (depointinate(tuples).empty()) {
-            propagators.model_contradiction(initial_state, optional_model, "Empty table constraint from table");
-            // throw UnexpectedException{"Empty table constraint from table"};
-            continue_installation = false;
-
+            // No allowed tuples means the constraint is UNSAT. We let
+            // define_proof_model emit a trivially-false `0 >= 1` constraint
+            // (which is morally what an empty selector domain encodes), and
+            // install_propagators installs a contradiction initialiser. Skip
+            // the selector allocation: an empty range [0, -1] would be
+            // invalid, and the propagator won't run anyway.
+            _has_no_tuples = true;
             return;
         }
         for (auto & tuple : depointinate(tuples))
@@ -143,11 +145,17 @@ auto Table::prepare(Propagators & propagators, State & initial_state, ProofModel
     },
         _tuples);
 
-    return continue_installation;
+    return true;
 }
 
 auto Table::define_proof_model(ProofModel & model) -> void
 {
+    if (_has_no_tuples) {
+        // Morally equivalent to a selector with empty domain (`0 ≥ 1`).
+        model.add_constraint("Table", "no allowed tuples", WPBSum{} >= 1_i);
+        return;
+    }
+
     visit([&](auto && tuples) {
         model.set_up_integer_variable(_selector, 0_i, Integer(depointinate(tuples).size() - 1),
             "aux_table" + to_string(_selector.index),
@@ -176,6 +184,12 @@ auto Table::define_proof_model(ProofModel & model) -> void
 
 auto Table::install_propagators(Propagators & propagators) -> void
 {
+    if (_has_no_tuples) {
+        propagators.install_initial_contradiction("Empty table constraint from table",
+            JustifyUsingRUP{});
+        return;
+    }
+
     visit([&](auto && tuples) {
         Triggers triggers;
         for (auto & v : _vars)

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -22,6 +22,7 @@ namespace gcs
         const std::vector<IntegerVariableID> _vars;
         ExtensionalTuples _tuples;
         SimpleIntegerVariableID _selector{0};
+        bool _has_no_tuples = false;
 
     public:
         explicit Table(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);


### PR DESCRIPTION
## Summary

Second of four PRs implementing the plan in #181, stacked on top of #185. Replaces every `Propagators::model_contradiction` call with `install_initial_contradiction` (or its clique-duplicate variant), and lets each constraint's `define_proof_model` handle the degenerate input itself. The OPB file becomes fully self-describing — no more unlabelled empty-clause axioms emitted out-of-band.

- **AllDifferent (VC, GAC, Symmetric, and AllDifferentExcept's dup+empty-excluded leg).** On duplicate variables, `prepare()` records a flag and returns `true`; `define_proof_model` runs the existing clique-of-not-equals encoding unchanged (it already emits a self-contradicting half-reified pair for the duplicated pair); `install_propagators` installs a `SimpleDefinition`-priority initialiser instead of the matching propagator. The proof RUPs `selector` and `!selector` citing one duplicated pair's flag (drawn from the encoding's return value), then RUPs false. The two-step shape is necessary because RUP for false directly cannot pick a selector polarity from two non-unit half-reifications.
- **Table with no allowed tuples.** `prepare()` records the flag and skips the selector allocation (an empty range `[0, -1]` would be invalid). `define_proof_model` emits `WPBSum{} >= 1_i` directly — morally what an empty-domain selector would produce. `install_propagators` uses `install_initial_contradiction` with plain RUP, since a literal `0 >= 1` is unit-derivable.

`define_clique_not_equals_encoding` now returns the duplicate-pair selectors, mirroring the existing `_except` variant. The shared contradiction-initialiser body lives in `encoding.cc` as `install_clique_duplicate_contradiction_initialiser`; VC, GAC, Symmetric, and AllDifferentExcept (dup+empty-excluded leg) all use it.

A small follow-up commit adds explicit `run_alldiff_dup_test` cases for VC and GAC AllDifferent — the contradiction path was previously only exercised indirectly via Symmetric and AllDifferentExcept. Six new VeriPB-verified scenarios.

## Test plan

- [x] `cmake --build --preset release --parallel 8` clean
- [x] `ctest --preset release -j 8` — 194/194 pass
- [x] New `run_alldiff_dup_test` cases for both `GACAllDifferent` and `VCAllDifferent` verify UNSATISFIABLE under VeriPB
- [x] Existing duplicate-vars / empty-table tests in `symmetric_all_different_test`, `all_different_except_test`, `table_test` continue to pass with proof logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)