### PR TITLE
abs: rework consequence trims as single initialiser with PB-resolution proof (issue #181)

### DIFF
--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -23,6 +23,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::holds_alternative;
 using std::max;
 using std::string;
 using std::stringstream;
@@ -36,6 +37,26 @@ using std::println;
 using fmt::print;
 #endif
 
+namespace
+{
+    // PB resolution: sum the operand proof lines and saturate, eliminating
+    // any literals whose coefficients cancel. Emitted via VeriPB's polish-
+    // notation rule, hence "pol ... + s" in the wire format.
+    auto emit_resolution(ProofLogger * const logger, ProofLine a, ProofLine b) -> void
+    {
+        stringstream pol;
+        pol << "pol " << a << " " << b << " + s ;";
+        logger->emit_proof_line(pol.str(), ProofLevel::Temporary);
+    }
+
+    auto emit_resolution(ProofLogger * const logger, ProofLine a, ProofLine b, ProofLine c) -> void
+    {
+        stringstream pol;
+        pol << "pol " << a << " " << b << " + " << c << " + s ;";
+        logger->emit_proof_line(pol.str(), ProofLevel::Temporary);
+    }
+}
+
 Abs::Abs(const IntegerVariableID v1, const IntegerVariableID v2) :
     _v1(v1),
     _v2(v2)
@@ -47,43 +68,150 @@ auto Abs::clone() const -> unique_ptr<Constraint>
     return make_unique<Abs>(_v1, _v2);
 }
 
-auto Abs::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+auto Abs::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
 {
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
     if (optional_model)
         define_proof_model(*optional_model);
 
     install_propagators(propagators);
 }
 
-auto Abs::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
-{
-    // _v2 >= 0
-    propagators.trim_lower_bound(initial_state, optional_model, _v2, 0_i, "Abs");
-
-    // _v1 <= upper_bound(_v2)
-    propagators.trim_upper_bound(initial_state, optional_model, _v1, initial_state.upper_bound(_v2), "Abs");
-
-    // _v1 >= -upper_bound(_v2)
-    propagators.trim_lower_bound(initial_state, optional_model, _v1, -initial_state.upper_bound(_v2), "Abs");
-
-    // _v2 <= max(upper_bound(_v1), -lower_bound(_v1))
-    auto v2u = max(initial_state.upper_bound(_v1), -initial_state.lower_bound(_v1));
-    propagators.trim_upper_bound(initial_state, optional_model, _v2, v2u, "Abs");
-
-    return true;
-}
-
 auto Abs::define_proof_model(ProofModel & model) -> void
 {
-    model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-    model.add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
+    _abs_nonneg_lines = model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
+    _abs_neg_lines = model.add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
 }
 
 auto Abs::install_propagators(Propagators & propagators) -> void
 {
+    // All four consequence bounds live in a single SimpleDefinition-priority
+    // initialiser. The OPB encoding stays free of "Abs" labels for inferences
+    // that aren't definitional; each bound's proof is assembled at search-init
+    // time as PB resolution steps over the encoding's two half-reified halves
+    // and the relevant `v_ge_X` flag definitions.
+    //
+    // VeriPB's RUP alone cannot derive any of these bounds for non-constant
+    // v1, because it can't case-split on `v1 >= 0 \/ v1 < 0`. Each proof
+    // callback supplies the case split explicitly: resolve a constraint that
+    // holds under `v1 >= 0` with one that holds under `v1 < 0`, leaving the
+    // flag literal the bound is about. The final RUP then closes the
+    // inference. When v1 IS constant the encoding's relevant half is
+    // unreified, so the proof callback emits nothing and plain RUP suffices.
+    // When v2 is constant we bail out entirely — the propagator will discover
+    // any UNSAT via per-value pruning.
+    propagators.install_initialiser(
+        [v1 = _v1, v2 = _v2,
+            abs_nonneg_le = _abs_nonneg_lines.first,
+            abs_nonneg_ge = _abs_nonneg_lines.second,
+            abs_neg_le = _abs_neg_lines.first,
+            abs_neg_ge = _abs_neg_lines.second](
+            State & state, auto & inference, ProofLogger * const logger) -> void {
+            if (holds_alternative<ConstantIntegerVariableID>(v2))
+                return;
+
+            auto v1_is_constant = holds_alternative<ConstantIntegerVariableID>(v1);
+
+            // Bound 1: v2 >= 0. One resolution suffices — the v1 < 0 branch
+            // (v2 = -v1 > 0) is short enough for VeriPB to chase through the
+            // encoding once the v1 >= 0 branch is in the database.
+            //   resolve(v1_ge0 part 1, Abs non-negative ≥ half, v2 < 0 part 2)
+            //   → v2_ge0 ∨ ~v1_ge0.
+            inference.infer(logger, v2 >= 0_i,
+                JustifyExplicitlyThenRUP{
+                    [logger, v1, v2, v1_is_constant, abs_nonneg_ge](const ReasonFunction &) -> void {
+                        if (v1_is_constant)
+                            return;
+                        auto & ids = logger->names_and_ids_tracker();
+                        auto v1_ge0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v1 >= 0_i));
+                        auto v2_lt0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v2 < 0_i));
+                        emit_resolution(logger, v1_ge0, *abs_nonneg_ge, v2_lt0);
+                    }},
+                ReasonFunction{});
+
+            auto v2_ub = state.upper_bound(v2);
+
+            // Bound 2: v1 <= ub(v2). Both case-split halves explicit (wider /
+            // asymmetric domains stretch VeriPB's bit-level RUP). Skip if
+            // ub(v2) < 0 — the v1_ge_(ub(v2)+1) flag would collide with
+            // v1_ge0 / become vacuous; the propagator detects UNSAT directly.
+            //   v1 >= 0: resolve(Abs nonneg ≥, v2 ≤ ub(v2), v1_ge_(ub(v2)+1) part 1)
+            //            → ~v1_ge_(ub(v2)+1) ∨ ~v1_ge0.
+            //   v1 < 0 : resolve(v1_ge_(ub(v2)+1) part 1, v1_ge0 part 2)
+            //            → ~v1_ge_(ub(v2)+1) ∨ v1_ge0. (Trivial.)
+            if (v2_ub >= 0_i) {
+                inference.infer(logger, v1 < v2_ub + 1_i,
+                    JustifyExplicitlyThenRUP{
+                        [logger, v1, v2, v2_ub, v1_is_constant, abs_nonneg_ge](const ReasonFunction &) -> void {
+                            if (v1_is_constant)
+                                return;
+                            auto & ids = logger->names_and_ids_tracker();
+                            auto v1_ge_bound_plus_1 = std::get<ProofLine>(
+                                ids.need_pol_item_defining_literal(v1 >= v2_ub + 1_i));
+                            auto v2_upper = logger->emit_rup_proof_line(
+                                WPBSum{} + 1_i * v2 <= v2_ub, ProofLevel::Temporary);
+                            emit_resolution(logger, *abs_nonneg_ge, v2_upper, v1_ge_bound_plus_1);
+
+                            auto v1_lt0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v1 < 0_i));
+                            emit_resolution(logger, v1_ge_bound_plus_1, v1_lt0);
+                        }},
+                    ReasonFunction{});
+            }
+
+            // Bound 3: v1 >= -ub(v2). Mirror of bound 2 on the "Abs negative"
+            // side. Skip if ub(v2) <= 0 (same flag-collision concern).
+            //   v1 < 0 : resolve(Abs neg ≥, v2 ≤ ub(v2), v1_ge_(-ub(v2)) part 2)
+            //            → v1_ge_(-ub(v2)) ∨ v1_ge0.
+            //   v1 >= 0: resolve(v1_ge0 part 1, v1_ge_(-ub(v2)) part 2)
+            //            → v1_ge_(-ub(v2)) ∨ ~v1_ge0. (Trivial.)
+            if (v2_ub > 0_i) {
+                inference.infer(logger, v1 >= -v2_ub,
+                    JustifyExplicitlyThenRUP{
+                        [logger, v1, v2, v2_ub, v1_is_constant, abs_neg_ge](const ReasonFunction &) -> void {
+                            if (v1_is_constant)
+                                return;
+                            auto & ids = logger->names_and_ids_tracker();
+                            auto v1_lt_neg_bound = std::get<ProofLine>(
+                                ids.need_pol_item_defining_literal(v1 < -v2_ub));
+                            auto v2_upper = logger->emit_rup_proof_line(
+                                WPBSum{} + 1_i * v2 <= v2_ub, ProofLevel::Temporary);
+                            emit_resolution(logger, *abs_neg_ge, v2_upper, v1_lt_neg_bound);
+
+                            auto v1_ge0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v1 >= 0_i));
+                            emit_resolution(logger, v1_ge0, v1_lt_neg_bound);
+                        }},
+                    ReasonFunction{});
+            }
+
+            // Bound 4: v2 <= max(ub(v1), -lb(v1)) = M. Mirror of bound 1 on
+            // the "<=" side, needing both case-split halves explicit.
+            //   v1 >= 0: resolve(Abs nonneg ≤, v1 ≤ ub(v1), v2_ge_(M+1) part 1)
+            //            → ~v2_ge_(M+1) ∨ ~v1_ge0.
+            //   v1 < 0 : resolve(Abs neg ≤, -v1 ≤ -lb(v1), v2_ge_(M+1) part 1)
+            //            → ~v2_ge_(M+1) ∨ v1_ge0.
+            auto [v1_lb, v1_ub] = state.bounds(v1);
+            auto bound4 = max(v1_ub, -v1_lb);
+            inference.infer(logger, v2 < bound4 + 1_i,
+                JustifyExplicitlyThenRUP{
+                    [logger, v1, v2, v1_lb, v1_ub, bound4, v1_is_constant, abs_nonneg_le, abs_neg_le](
+                        const ReasonFunction &) -> void {
+                        if (v1_is_constant)
+                            return;
+                        auto & ids = logger->names_and_ids_tracker();
+                        auto v2_ge_M_plus_1 = std::get<ProofLine>(
+                            ids.need_pol_item_defining_literal(v2 >= bound4 + 1_i));
+
+                        auto v1_upper = logger->emit_rup_proof_line(
+                            WPBSum{} + 1_i * v1 <= v1_ub, ProofLevel::Temporary);
+                        emit_resolution(logger, *abs_nonneg_le, v1_upper, v2_ge_M_plus_1);
+
+                        auto v1_lower = logger->emit_rup_proof_line(
+                            WPBSum{} + -1_i * v1 <= -v1_lb, ProofLevel::Temporary);
+                        emit_resolution(logger, *abs_neg_le, v1_lower, v2_ge_M_plus_1);
+                    }},
+                ReasonFunction{});
+        },
+        InitialiserPriority::SimpleDefinition);
+
     // _v2 = abs(_v1)
     Triggers triggers{.on_change = {_v1, _v2}};
     propagators.install([v1 = _v1, v2 = _v2](

--- a/gcs/constraints/abs.hh
+++ b/gcs/constraints/abs.hh
@@ -5,6 +5,9 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/variable_id.hh>
 
+#include <optional>
+#include <utility>
+
 namespace gcs
 {
     /**
@@ -17,7 +20,12 @@ namespace gcs
     private:
         IntegerVariableID _v1, _v2;
 
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        // Captured in define_proof_model() for use by the consequence-bound
+        // initialisers' PB-resolution proof steps. Each pair is (≤ half line,
+        // ≥ half line) of the half-reified equality.
+        std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _abs_nonneg_lines;
+        std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _abs_neg_lines;
+
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 

--- a/gcs/constraints/abs_test.cc
+++ b/gcs/constraints/abs_test.cc
@@ -67,6 +67,25 @@ auto run_abs_test(bool proofs, variant<int, pair<int, int>> v1_range, variant<in
     check_results(proof_name, expected, actual);
 }
 
+// Targeted tests for the proofs Abs::prepare emits for its four consequence
+// bounds. Domains are picked so that one specific bound is non-trivial, so a
+// proof failure points unambiguously at that bound. Uses
+// check_initialisation_only_for_tests to verify just the initialisation proof
+// (cheap: no full search, no solution enumeration).
+auto run_abs_initialiser_test(const string & label, pair<int, int> v1_range, pair<int, int> v2_range) -> void
+{
+    print(cerr, "abs initialiser [{}] v1=[{},{}] v2=[{},{}] with proofs\n",
+        label, v1_range.first, v1_range.second, v2_range.first, v2_range.second);
+    cerr << flush;
+
+    Problem p;
+    auto v1 = p.create_integer_variable(Integer{v1_range.first}, Integer{v1_range.second});
+    auto v2 = p.create_integer_variable(Integer{v2_range.first}, Integer{v2_range.second});
+    p.post(Abs{v1, v2});
+
+    check_initialisation_only_for_tests(p, "abs_initialiser_" + label);
+}
+
 auto main(int, char *[]) -> int
 {
     vector<pair<variant<int, pair<int, int>>, variant<int, pair<int, int>>>> data = {
@@ -89,6 +108,37 @@ auto main(int, char *[]) -> int
         generate_random_data(rand, data, random_constant(-10, 10), random_bounds(-10, 10, 5, 15));
     for (int x = 0; x < 10; ++x)
         generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_constant(-10, 10));
+
+    if (can_run_veripb()) {
+        // Each case isolates one of Abs::prepare's four consequence bounds.
+        // The first failure aborts; comment out earlier cases as each one's
+        // proof gets fixed. Run before the rest of the proof suite so the
+        // failure is unambiguous — the random tests below also exercise these
+        // bounds and will fail until the proofs are filled in.
+
+        // Bound 1: v2 >= 0 — non-trivial (v2.lb < 0); other bounds trivial.
+        run_abs_initialiser_test("bound1_v2_ge_0", {-3, 3}, {-2, 3});
+
+        // Bound 2: v1 <= ub(v2) — non-trivial (v1.ub > v2.ub); others trivial.
+        run_abs_initialiser_test("bound2_v1_le_ubv2", {-3, 5}, {0, 3});
+
+        // Bound 3: v1 >= -ub(v2) — non-trivial (v1.lb < -v2.ub); others trivial.
+        run_abs_initialiser_test("bound3_v1_ge_negubv2", {-5, 3}, {0, 3});
+
+        // Bound 4: v2 <= max(ub(v1), -lb(v1)) — non-trivial (v2.ub > that max).
+        run_abs_initialiser_test("bound4_v2_le_maxv1", {-3, 3}, {0, 5});
+
+        // Wider domains that cross bit-encoding boundaries — the pol-step
+        // shape mustn't rely on small bit widths happening to keep things
+        // simple. Domains chosen to bracket powers of two (where the bit
+        // encoding picks up an extra bit), and asymmetric ranges where M =
+        // -lb(v1) ≠ ub(v1). UNSAT cases keep enumeration cheap.
+        run_abs_initialiser_test("wide_8bit", {-32, 31}, {-16, 47});
+        run_abs_initialiser_test("wide_just_over_8bit", {-33, 32}, {-16, 47});
+        run_abs_initialiser_test("wide_unsat", {-50, 50}, {100, 200});
+        run_abs_initialiser_test("wide_asym_lb_dominant", {-50, 5}, {0, 80});
+        run_abs_initialiser_test("wide_asym_ub_dominant", {-5, 50}, {0, 80});
+    }
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -249,6 +249,25 @@ namespace gcs::test_innards
             proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}, true, false) : std::nullopt);
     }
 
+    /**
+     * Solve only as far as the first complete propagation, then bail out via
+     * a trace callback returning false. VeriPB checks any RUP / pol steps the
+     * initialisers emitted and accepts the resulting "conclusion NONE" proof,
+     * without making us pay for full enumeration. Useful for testing the
+     * proofs emitted by initialisers in isolation.
+     */
+    auto check_initialisation_only_for_tests(Problem & p, const std::string & proof_name) -> void
+    {
+        solve_with(p,
+            SolveCallbacks{
+                .trace = [](const CurrentState &) -> bool { return false; },
+                .branch = branch_with(variable_order::random(p), value_order::random_out())},
+            std::make_optional<ProofOptions>(ProofFileNames{proof_name}, true, false));
+
+        if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
+            throw UnexpectedException{"veripb verification failed"};
+    }
+
     auto extract_from_state(const CurrentState & s, IntegerVariableID v) -> int
     {
         return s(v).raw_value;


### PR DESCRIPTION
## Summary

Third of four PRs implementing the plan in #181, stacked on top of #186. Abs's four consequence trims used to go through `Propagators::trim_*_bound`, each writing an OPB axiom labelled "Abs". This PR replaces them with a single `SimpleDefinition`-priority initialiser whose proof derives the bounds from the existing half-reified encoding via PB resolution. After this, no "Abs" labels reach the OPB for non-definitional inferences — which closes the cross-constraint contamination case from the audit.

All four bounds share the same proof shape: VeriPB's RUP alone can't case-split on `v1 >= 0 ∨ v1 < 0`, so each proof callback emits explicit PB-resolution steps combining

- the relevant half of "Abs non-negative" or "Abs negative" (eliminates `v1`'s bits/neg under the right polarity),
- a RUP-trivial bound on `v1` or `v2` (eliminates the variable side),
- the target flag's definition (yields the bound's flag literal),

then saturates. With both `v1` polarities covered, the final RUP closes.

Constant-`v2`: skip entirely — the propagator discovers any UNSAT via per-value pruning. Constant-`v1`: the resolution step inside each proof callback skips itself, and plain RUP suffices because the encoding's relevant half is unreified.

Two related changes in this PR:

- `check_initialisation_only_for_tests(problem, proof_name)` in `constraints_test_utils.hh` — runs `solve_with` with a trace callback returning `false`, so search bails after the first complete propagation. VeriPB verifies the resulting "conclusion NONE" proof without making us pay for enumeration. Useful for testing the proofs emitted by initialisers in isolation.
- `abs_test` gains nine `run_abs_initialiser_test` cases that target each bound in isolation (small symmetric, just-past-8-bit, asymmetric `v1`, UNSAT) and use the new helper to skip enumeration. abs_test runtime ~2s.

## Test plan

- [x] `cmake --build --preset release --parallel 8` clean
- [x] `ctest --preset release -j 8` — 194/194 pass
- [x] `./build/abs_test` — 20+ consecutive runs pass (no flakiness on wide / asymmetric / boundary domains)
- [x] Sanity: deliberately broken proof exits 134 (SIGABRT from `UnexpectedException`), so ctest catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)