### PR TITLE
propagators: replace trim_*_bound + model_contradiction with define_bound (closes #181)

### DIFF
--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -90,8 +90,8 @@ auto SymmetricAllDifferent::prepare(Propagators & propagators, State & initial_s
     }
 
     for (const auto & v : _vars) {
-        propagators.trim_lower_bound(initial_state, optional_model, v, _start, "SymmetricAllDifferent");
-        propagators.trim_upper_bound(initial_state, optional_model, v, _start + Integer(n) - 1_i, "SymmetricAllDifferent");
+        propagators.define_bound(initial_state, optional_model, v, Bound::Lower, _start, "SymmetricAllDifferent", "value range");
+        propagators.define_bound(initial_state, optional_model, v, Bound::Upper, _start + Integer(n) - 1_i, "SymmetricAllDifferent", "value range");
     }
 
     return true;

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -156,11 +156,11 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 {
     // Can't have negative values
     for (const auto & s : _succ)
-        propagators.trim_lower_bound(initial_state, model, s, 0_i, "Circuit");
+        propagators.define_bound(initial_state, model, s, Bound::Lower, 0_i, "Circuit", "successor index range");
 
     // Can't have too-large values
     for (const auto & s : _succ)
-        propagators.trim_upper_bound(initial_state, model, s, Integer(static_cast<long long>(_succ.size() - 1)), "Circuit");
+        propagators.define_bound(initial_state, model, s, Bound::Upper, Integer(static_cast<long long>(_succ.size() - 1)), "Circuit", "successor index range");
 
     // Define all different, either gac or non-gac
     if (_gac_all_different) {

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -155,20 +155,23 @@ auto NDimensionalElement<EntryType_, dimensions_>::install(Propagators & propaga
 template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
-    // First pass: any zero-sized dimension means the constraint is unsatisfiable; signal
-    // model contradiction without trimming bounds (which could reference variables we're
-    // about to flag inconsistent).
+    // A zero-sized dimension means there is no valid assignment. Record the
+    // flag so define_proof_model emits a trivially-false `0 ≥ 1` constraint,
+    // and install_propagators installs a contradiction initialiser. Skip
+    // the index-range bound definitions for that dimension — they would
+    // produce a `[start, start - 1]` empty interval whose labels would
+    // misleadingly suggest a normal trim.
     for (const auto & [i, _] : enumerate(_index_vars)) {
         if (0_i == Integer(get_dimension_size<dimensions_>(i, *_array))) {
-            propagators.model_contradiction(initial_state, optional_model, "NDimensionalElement constraint with no values");
-            return false;
+            _has_empty_dim = true;
+            return true;
         }
     }
 
     for (const auto & [i, var] : enumerate(_index_vars)) {
         auto s = Integer(get_dimension_size<dimensions_>(i, *_array));
-        propagators.trim_lower_bound(initial_state, optional_model, var, _index_starts.at(i), "NDimensionalElement");
-        propagators.trim_upper_bound(initial_state, optional_model, var, _index_starts.at(i) + s - 1_i, "NDimensionalElement");
+        propagators.define_bound(initial_state, optional_model, var, Bound::Lower, _index_starts.at(i), "NDimensionalElement", "index range");
+        propagators.define_bound(initial_state, optional_model, var, Bound::Upper, _index_starts.at(i) + s - 1_i, "NDimensionalElement", "index range");
     }
 
     _array_has_nonconstants = any_array_variable_is_nonconstant(initial_state, *_array);
@@ -178,6 +181,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::prepare(Propagators & propaga
 template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel & model) -> void
 {
+    if (_has_empty_dim) {
+        // No valid assignment: emit a trivially-false constraint so the OPB
+        // file remains self-describing. The encoding's recursion over the
+        // empty dimension would have produced no constraints at all, which
+        // wouldn't capture the unsatisfiability.
+        model.add_constraint("NDimensionalElement", "zero-sized dimension", WPBSum{} >= 1_i);
+        return;
+    }
+
     HalfReifyOnConjunctionOf reif;
     vector<size_t> elem;
 
@@ -205,6 +217,12 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
 template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagators & propagators) -> void
 {
+    if (_has_empty_dim) {
+        propagators.install_initial_contradiction("NDimensionalElement constraint with no values",
+            JustifyUsingRUP{});
+        return;
+    }
+
     auto array_has_nonconstants = _array_has_nonconstants;
 
     vector<IntegerVariableID> all_array_vars;

--- a/gcs/constraints/element.hh
+++ b/gcs/constraints/element.hh
@@ -41,6 +41,7 @@ namespace gcs
         Array * _array;
         bool _bounds_only;
         bool _array_has_nonconstants = false;
+        bool _has_empty_dim = false;
 
     private:
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -85,7 +85,7 @@ auto In::install(Propagators & propagators, State & initial_state, ProofModel * 
     install_propagators(propagators);
 }
 
-auto In::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+auto In::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     erase_if(_var_vals, [&](const IntegerVariableID & v) -> bool {
         auto const_val = initial_state.optional_single_value(v);
@@ -98,9 +98,11 @@ auto In::prepare(Propagators & propagators, State & initial_state, ProofModel * 
     _val_vals.erase(unique(_val_vals).begin(), _val_vals.end());
 
     if (_var_vals.empty() && _val_vals.empty()) {
-        propagators.model_contradiction(initial_state, optional_model,
-            "No values or variables present for an 'In' constraint");
-        return false;
+        // No sources means the constraint is UNSAT. The encoding naturally
+        // collapses to `WPBSum{} >= 1_i` (i.e. `0 ≥ 1`), so we let
+        // define_proof_model run unchanged and install a contradiction
+        // initialiser instead of the regular propagator.
+        _has_no_values = true;
     }
 
     return true;
@@ -137,6 +139,13 @@ auto In::define_proof_model(ProofModel & model) -> void
 
 auto In::install_propagators(Propagators & propagators) -> void
 {
+    if (_has_no_values) {
+        propagators.install_initial_contradiction(
+            "No values or variables present for an 'In' constraint",
+            JustifyUsingRUP{});
+        return;
+    }
+
     Triggers triggers;
     triggers.on_change.emplace_back(_var);
     for (const auto & V : _var_vals)

--- a/gcs/constraints/in.hh
+++ b/gcs/constraints/in.hh
@@ -26,6 +26,7 @@ namespace gcs
         std::vector<IntegerVariableID> _var_vals;
         std::vector<Integer> _val_vals;
         std::vector<innards::ProofFlag> _selectors;
+        bool _has_no_values = false;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -69,19 +69,17 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
 
 auto Inverse::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
-    if (_x.size() != _y.size()) {
-        propagators.model_contradiction(initial_state, optional_model, "Inverse constraint on different sized arrays");
-        return false;
-    }
+    if (_x.size() != _y.size())
+        throw UnexpectedException{"Inverse constraint on different sized arrays"};
 
     for (const auto & [idx, v] : enumerate(_x)) {
-        propagators.trim_lower_bound(initial_state, optional_model, v, 0_i + _y_start, "Inverse");
-        propagators.trim_upper_bound(initial_state, optional_model, v, Integer(_y.size()) + _y_start - 1_i, "Inverse");
+        propagators.define_bound(initial_state, optional_model, v, Bound::Lower, 0_i + _y_start, "Inverse", "x index range");
+        propagators.define_bound(initial_state, optional_model, v, Bound::Upper, Integer(_y.size()) + _y_start - 1_i, "Inverse", "x index range");
     }
 
     for (const auto & [idx, v] : enumerate(_y)) {
-        propagators.trim_lower_bound(initial_state, optional_model, v, 0_i + _x_start, "Inverse");
-        propagators.trim_upper_bound(initial_state, optional_model, v, Integer(_x.size()) + _x_start - 1_i, "Inverse");
+        propagators.define_bound(initial_state, optional_model, v, Bound::Lower, 0_i + _x_start, "Inverse", "y index range");
+        propagators.define_bound(initial_state, optional_model, v, Bound::Upper, Integer(_x.size()) + _x_start - 1_i, "Inverse", "y index range");
     }
 
     return true;

--- a/gcs/constraints/seq_precede_chain.cc
+++ b/gcs/constraints/seq_precede_chain.cc
@@ -1,11 +1,8 @@
 #include <gcs/constraints/seq_precede_chain.hh>
 #include <gcs/constraints/value_precede.hh>
-#include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
-#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
-#include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -71,26 +68,9 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
     // bound is justified by the meta-argument that any value v requires
     // v distinct earlier positions to host 1..v-1, so v ≤ n.
     if (max_upper > effective_max) {
-        if (optional_model) {
-            for (const auto & v : _vars) {
-                if (initial_state.upper_bound(v) > effective_max) {
-                    optional_model->add_constraint(
-                        "SeqPrecedeChain", "value bound",
-                        WPBSum{} + 1_i * v <= effective_max);
-                }
-            }
-        }
-
-        propagators.install_initialiser(
-            [vars = _vars, effective_max](
-                const State & state, auto & inference, ProofLogger * const logger) -> void {
-                for (const auto & v : vars) {
-                    if (state.upper_bound(v) > effective_max) {
-                        inference.infer(logger, v < effective_max + 1_i,
-                            JustifyUsingRUP{}, generic_reason(state, vector<IntegerVariableID>{v}));
-                    }
-                }
-            });
+        for (const auto & v : _vars)
+            propagators.define_bound(initial_state, optional_model, v, Bound::Upper, effective_max,
+                "SeqPrecedeChain", "value bound");
     }
 
     if (effective_max < 2_i)

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -22,7 +22,6 @@ using std::optional;
 using std::pair;
 using std::string;
 using std::swap;
-using std::to_string;
 using std::to_underlying;
 using std::vector;
 using std::visit;
@@ -63,44 +62,30 @@ Propagators::Propagators(Propagators &&) = default;
 
 auto Propagators::operator=(Propagators &&) -> Propagators & = default;
 
-auto Propagators::model_contradiction(const State &, ProofModel * const optional_model, const string & explain_yourself) -> void
+auto Propagators::define_bound(const State & state, ProofModel * const optional_model,
+    IntegerVariableID var, Bound which, Integer val,
+    const StringLiteral & constraint_name, const StringLiteral & sub_rule) -> void
 {
-    if (optional_model)
-        optional_model->add_constraint({});
-
-    install([explain_yourself = explain_yourself](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }});
-    },
-        Triggers{});
-}
-
-auto Propagators::trim_lower_bound(const State & state, ProofModel * const optional_model, IntegerVariableID var, Integer val, const string & x) -> void
-{
-    if (state.lower_bound(var) < val) {
-        if (state.upper_bound(var) >= val) {
-            if (optional_model)
-                optional_model->add_constraint({var >= val});
-            install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-                inference.infer(logger, var >= val, JustifyUsingRUP{}, ReasonFunction{});
-            });
-        }
-        else
-            model_contradiction(state, optional_model, "Trimmed lower bound of " + debug_string(var) + " due to " + x + " is outside its domain");
-    }
-}
-
-auto Propagators::trim_upper_bound(const State & state, ProofModel * const optional_model, IntegerVariableID var, Integer val, const string & x) -> void
-{
-    if (state.upper_bound(var) > val) {
-        if (state.lower_bound(var) <= val) {
-            if (optional_model)
-                optional_model->add_constraint({var < val + 1_i});
-            install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-                inference.infer(logger, var < val + 1_i, JustifyUsingRUP{}, ReasonFunction{});
-            });
-        }
-        else
-            model_contradiction(state, optional_model, "Trimmed upper bound of " + debug_string(var) + " due to " + x + " is outside its domain");
+    switch (which) {
+        using enum Bound;
+    case Lower:
+        if (state.lower_bound(var) >= val)
+            return;
+        if (optional_model)
+            optional_model->add_constraint(constraint_name, sub_rule, WPBSum{} + 1_i * var >= val);
+        install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
+            inference.infer(logger, var >= val, JustifyUsingRUP{}, ReasonFunction{});
+        });
+        return;
+    case Upper:
+        if (state.upper_bound(var) <= val)
+            return;
+        if (optional_model)
+            optional_model->add_constraint(constraint_name, sub_rule, WPBSum{} + 1_i * var <= val);
+        install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
+            inference.infer(logger, var < val + 1_i, JustifyUsingRUP{}, ReasonFunction{});
+        });
+        return;
     }
 }
 
@@ -175,9 +160,8 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
     };
 
     if (! lit) {
-        // filthy hack: to make trim_lower_bound etc work, on the first pass, we need to
-        // guarantee that we're running propagators in numerical order, except our queue
-        // runs backwards so we need to put them in backwards.
+        // On the first pass, walk propagators in registration order. Our queue runs
+        // backwards, so push them in reverse.
         _imp->queue.resize(_imp->propagation_functions.size());
         _imp->lookup.resize(_imp->propagation_functions.size());
         unsigned p = 0;

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -7,6 +7,7 @@
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/problem.hh>
@@ -101,6 +102,18 @@ namespace gcs::innards
     constexpr std::size_t number_of_initialiser_priorities = 3;
 
     /**
+     * \brief Which side of a variable's domain a definitional bound restricts.
+     *
+     * \ingroup Innards
+     * \sa Propagators::define_bound
+     */
+    enum class Bound
+    {
+        Lower,
+        Upper
+    };
+
+    /**
      * \brief Tell Propagators when a Constraint's propagators should be triggered.
      *
      * Every propagator will be called at least once, when search starts.
@@ -160,19 +173,22 @@ namespace gcs::innards
         ///@{
 
         /**
-         * Can be called by a Constraint if it is contradictory by definition.
+         * \brief Define a variable's lower or upper bound as part of a Constraint's
+         * proof model.
+         *
+         * Emits a labelled OPB constraint (\c constraint_name + \c sub_rule),
+         * and installs a SimpleDefinition-priority initialiser that RUPs the
+         * bound into the State at search start. If the bound is already
+         * implied by the variable's existing domain, no OPB constraint is
+         * emitted and no initialiser is installed. If the bound would make
+         * the variable's domain empty, the initialiser raises a
+         * contradiction at search start — the labelled OPB constraint
+         * remains, so the proof reader sees a self-describing reason.
          */
-        auto model_contradiction(const State &, innards::ProofModel * const, const std::string & explain_yourself) -> void;
-
-        /**
-         * Called by a Constraint if a variable's lower bound must, by definition, be at least a value.
-         */
-        auto trim_lower_bound(const State &, innards::ProofModel * const, IntegerVariableID var, Integer val, const std::string & explain_yourself) -> void;
-
-        /**
-         * Called by a Constraint if a variable's upper bound must, by definition, be at least a value.
-         */
-        auto trim_upper_bound(const State &, innards::ProofModel * const, IntegerVariableID var, Integer val, const std::string & explain_yourself) -> void;
+        auto define_bound(const State &, innards::ProofModel * const, IntegerVariableID var,
+            Bound which, Integer val,
+            const innards::StringLiteral & constraint_name,
+            const innards::StringLiteral & sub_rule) -> void;
 
         ///@}
 


### PR DESCRIPTION
## Summary

Fourth and final PR implementing the plan in #181, stacked on top of #187. Replaces today's `trim_lower_bound` / `trim_upper_bound` / `model_contradiction` triple with a single labelled entry point `Propagators::define_bound(state, model, var, Lower|Upper, val, constraint_name, sub_rule)`, then retires the old three. Every bound now lands in the OPB with a self-describing `(constraint_name, sub_rule)` label — no more unlabelled axioms, no more cross-constraint contamination from the audit.

`define_bound` emits a labelled OPB constraint via the labelled `add_constraint` overload and installs a `SimpleDefinition`-priority RUP initialiser. If the requested bound would empty the domain, the initialiser raises a contradiction at search start citing the labelled line.

Migrated call sites:

- **Inverse** (`x` and `y` index range bounds): `define_bound`. Mismatched-size arrays now `throw UnexpectedException` — malformed input, not a meaningful constraint (per the audit decision in #181).
- **NDimensionalElement** (index range bounds): `define_bound`. Zero-sized dimensions follow the PR #186 pattern — `prepare` records `_has_empty_dim`, `define_proof_model` emits `0 ≥ 1` labelled "zero-sized dimension", `install_propagators` installs a RUP contradiction initialiser.
- **SymmetricAllDifferent** (value range bounds): `define_bound`.
- **Circuit** (successor index range bounds): `define_bound`.
- **SeqPrecedeChain**: the hand-rolled labelled-`add_constraint` + parallel `install_initialiser` bypass collapses into a single `define_bound` call per variable.
- **In** (empty value/variable lists): follows the PR #186 pattern — the encoding already naturally collapses to `0 ≥ 1`, so `prepare` records `_has_no_values` and `install_propagators` installs a RUP contradiction initialiser.

With every site converted, `Propagators::model_contradiction`, `trim_lower_bound`, and `trim_upper_bound` are deleted. The "filthy hack" comment about first-pass propagator ordering is retitled — initialisers now own that responsibility, but registration-order traversal stays in case downstream propagators rely on it.

## Test plan

- [x] `cmake --build build --parallel 8` clean
- [x] `ctest -j 8` — 194/194 pass (with veripb proof verification)
- [x] Targeted re-run of `inverse_constraint`, `element_constraint_*`, `symmetric_all_different_constraint`, `circuit_*`, `seq_precede_chain_constraint`, `in_constraint`, `minizinc-inverses` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)