### PR TITLE
Constraint names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ python/venv
 compile_commands.json
 out/
 .claude
+Testing/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Doxyfile
 *.pbp
 *.varmap
 *.scp
+*~
 XCSP3-CPP-Parser
 generator
 .idea

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -97,7 +97,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name,
+        [[nodiscard]] virtual auto s_exprify(
             const innards::ProofModel * const) const -> std::string override;
     };
 }

--- a/examples/money/money.cc
+++ b/examples/money/money.cc
@@ -77,13 +77,14 @@ auto main(int argc, char * argv[]) -> int
     auto y = p.create_integer_variable(0_i, 9_i, "y");
 
     vector<IntegerVariableID> vars{s, e, n, d, m, o, r, y};
-    p.post(AllDifferent{vars});
+    p.post(AllDifferent{vars}, "_money_a_d");
 
     // clang-format off
     p.post(WeightedSum{}
             +                 1000_i * s +  100_i * e +  10_i * n +  1_i * d
             +                 1000_i * m +  100_i * o +  10_i * r +  1_i * e
-            + -10000_i * m + -1000_i * o + -100_i * n + -10_i * e + -1_i * y == 0_i);
+            + -10000_i * m + -1000_i * o + -100_i * n + -10_i * e + -1_i * y
+            == 0_i , "_money_sum");
     // clang-format on
 
     auto stats = solve(

--- a/examples/money/money.cc
+++ b/examples/money/money.cc
@@ -77,14 +77,14 @@ auto main(int argc, char * argv[]) -> int
     auto y = p.create_integer_variable(0_i, 9_i, "y");
 
     vector<IntegerVariableID> vars{s, e, n, d, m, o, r, y};
-    p.post(AllDifferent{vars}, "_money_a_d");
+    p.post_named(AllDifferent{vars}, "money_a_d");
 
     // clang-format off
-    p.post(WeightedSum{}
+    p.post_named(WeightedSum{}
             +                 1000_i * s +  100_i * e +  10_i * n +  1_i * d
             +                 1000_i * m +  100_i * o +  10_i * r +  1_i * e
             + -10000_i * m + -1000_i * o + -100_i * n + -10_i * e + -1_i * y
-            == 0_i , "_money_sum");
+            == 0_i , "money_sum");
     // clang-format on
 
     auto stats = solve(

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -2,6 +2,7 @@
 #include <gcs/exception.hh>
 
 using std::string;
+using std::variant;
 
 using namespace gcs;
 
@@ -9,6 +10,6 @@ Constraint::~Constraint() = default;
 
 namespace gcs {
     auto as_string(const ConstraintName & name) -> std::string {
-        return std::visit([](const auto & n) { return n.as_string(); }, name);
+        return visit([](const auto & n) { return n.as_string(); }, name);
     }
 }

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -6,3 +6,9 @@ using std::string;
 using namespace gcs;
 
 Constraint::~Constraint() = default;
+
+namespace gcs {
+    auto as_string(const ConstraintName & name) -> std::string {
+        return std::visit([](const auto & n) { return n.as_string(); }, name);
+    }
+}

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -17,6 +17,7 @@ namespace gcs
 
     struct CurrentlyUnnamedConstraint final
     {
+        auto as_string() const -> std::string { return "unnamed"; }
     };
 
     struct NumberedConstraint final
@@ -26,15 +27,19 @@ namespace gcs
         // Claude (web) says this is a good idea for comparisons.
         // Do we need comparisons? (C++20 spaceship operator)
         auto operator<=>(const NumberedConstraint &) const = default;
+        auto as_string() const -> std::string { return "C" + std::to_string(number); }  // TODO: change "C" to "_" at some point before merge
     };
 
     struct NamedConstraint final
     {
         std::string name;
         auto operator<=>(const NamedConstraint &) const = default;
+        auto as_string() const -> std::string { return name; }
     };
 
     using ConstraintName = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
+
+    auto as_string(const ConstraintName &) -> std::string;
 
     /**
      * \brief Subclasses of Constraint give a high level way of defining
@@ -83,7 +88,7 @@ namespace gcs
         /**
          * Return an s-expr representation of the constraint. To be used internally.
          */
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string = 0;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string = 0;
     };
 }
 

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -9,6 +9,12 @@
 #include <string>
 #include <variant>
 
+#if defined(__cpp_lib_format)
+#include <format>
+#else
+#include <fmt/core.h>
+#endif
+
 namespace gcs
 {
     /**
@@ -91,7 +97,6 @@ namespace gcs
 
 // The following is needed to allow ConstraintName to be used in format strings.
 #if defined(__cpp_lib_format)
-#include <format>
 template <>
 struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
 {
@@ -101,7 +106,6 @@ struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
     }
 };
 #else
-#include <fmt/format.h>
 template <>
 struct fmt::formatter<gcs::ConstraintName> : fmt::formatter<std::string>
 {

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
 
+#include <format>
 #include <memory>
 #include <string>
 #include <variant>
@@ -91,5 +92,29 @@ namespace gcs
         [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string = 0;
     };
 }
+
+// The following is needed to allow ConstraintName to be used in format strings.
+// We do this quite a lot in s_exprify().  If we didn't do this, we'd have to write
+// `format("{}", as_string(_name))` everywhere instead of just `format("{}", _name)`.
+// It's comfort over clarity.  What's the best option?
+#if defined(__cpp_lib_format)
+template <>
+struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
+{
+    auto format(const gcs::ConstraintName & name, std::format_context & ctx) const
+    {
+        return std::formatter<std::string>::format(gcs::as_string(name), ctx);
+    }
+};
+#else
+template <>
+struct fmt::formatter<gcs::ConstraintName> : fmt::formatter<std::string>
+{
+    auto format(const gcs::ConstraintName & name, fmt::format_context & ctx) const
+    {
+        return fmt::formatter<std::string>::format(gcs::as_string(name), ctx);
+    }
+};
+#endif
 
 #endif

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -31,9 +31,6 @@ namespace gcs
     struct NamedConstraint final
     {
         std::string name;
-
-        // Claude (web) says this is a good idea for comparisons.
-        // Do we need comparisons? (C++20 spaceship operator)
         auto operator<=>(const NamedConstraint &) const = default;
     };
 
@@ -54,6 +51,9 @@ namespace gcs
     class [[nodiscard]] Constraint
     {
     protected:
+        ConstraintName _name;
+        Constraint() : _name(CurrentlyUnnamedConstraint{}) {};
+        explicit Constraint(ConstraintName name) : _name(std::move(name)) {};
         virtual auto define_proof_model(innards::ProofModel &) -> void {};
         virtual auto install_propagators(innards::Propagators &) -> void {};
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool
@@ -63,7 +63,8 @@ namespace gcs
 
     public:
         virtual ~Constraint() = 0;
-
+        auto name() const -> const ConstraintName & { return _name; }
+        auto set_name(ConstraintName name) -> void { _name = std::move(name); }
         /**
          * Called internally to install the constraint. A Constraint is expected
          * to define zero or more propagators, and to provide a description of

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -5,7 +5,6 @@
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
 
-#include <format>
 #include <memory>
 #include <string>
 #include <variant>
@@ -92,6 +91,7 @@ namespace gcs
 
 // The following is needed to allow ConstraintName to be used in format strings.
 #if defined(__cpp_lib_format)
+#include <format>
 template <>
 struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
 {
@@ -101,6 +101,7 @@ struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
     }
 };
 #else
+#include <fmt/format.h>
 template <>
 struct fmt::formatter<gcs::ConstraintName> : fmt::formatter<std::string>
 {

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -7,12 +7,37 @@
 
 #include <memory>
 #include <string>
+#include <variant>
 
 namespace gcs
 {
     /**
      * \defgroup Constraints Constraints
      */
+
+    struct CurrentlyUnnamedConstraint final
+    {
+    };
+
+    struct NumberedConstraint final
+    {
+        unsigned long long number;
+
+        // Claude (web) says this is a good idea for comparisons.
+        // Do we need comparisons? (C++20 spaceship operator)
+        auto operator<=>(const NumberedConstraint &) const = default;
+    };
+
+    struct NamedConstraint final
+    {
+        std::string name;
+
+        // Claude (web) says this is a good idea for comparisons.
+        // Do we need comparisons? (C++20 spaceship operator)
+        auto operator<=>(const NamedConstraint &) const = default;
+    };
+
+    using ConstraintName = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
 
     /**
      * \brief Subclasses of Constraint give a high level way of defining

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -18,29 +18,26 @@ namespace gcs
 
     struct CurrentlyUnnamedConstraint final
     {
-        auto as_string() const -> std::string { return "unnamed"; }
+        [[nodiscard]] auto as_string() const -> std::string { return "unnamed"; }
     };
 
     struct NumberedConstraint final
     {
         unsigned long long number;
-
-        // Claude (web) says this is a good idea for comparisons.
-        // Do we need comparisons? (C++20 spaceship operator)
-        auto operator<=>(const NumberedConstraint &) const = default;
-        auto as_string() const -> std::string { return "C" + std::to_string(number); }  // TODO: change "C" to "_" at some point before merge
+        [[nodiscard]] auto operator<=>(const NumberedConstraint &) const = default;
+        [[nodiscard]] auto as_string() const -> std::string { return "_" + std::to_string(number); }
     };
 
     struct NamedConstraint final
     {
         std::string name;
-        auto operator<=>(const NamedConstraint &) const = default;
-        auto as_string() const -> std::string { return name; }
+        [[nodiscard]] auto operator<=>(const NamedConstraint &) const = default;
+        [[nodiscard]] auto as_string() const -> std::string { return name; }
     };
 
     using ConstraintName = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
 
-    auto as_string(const ConstraintName &) -> std::string;
+    [[nodiscard]] auto as_string(const ConstraintName &) -> std::string;
 
     /**
      * \brief Subclasses of Constraint give a high level way of defining
@@ -69,7 +66,7 @@ namespace gcs
 
     public:
         virtual ~Constraint() = 0;
-        auto name() const -> const ConstraintName & { return _name; }
+        [[nodiscard]] auto name() const -> const ConstraintName & { return _name; }
         auto set_name(ConstraintName name) -> void { _name = std::move(name); }
         /**
          * Called internally to install the constraint. A Constraint is expected
@@ -94,9 +91,6 @@ namespace gcs
 }
 
 // The following is needed to allow ConstraintName to be used in format strings.
-// We do this quite a lot in s_exprify().  If we didn't do this, we'd have to write
-// `format("{}", as_string(_name))` everywhere instead of just `format("{}", _name)`.
-// It's comfort over clarity.  What's the best option?
 #if defined(__cpp_lib_format)
 template <>
 struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -10,7 +10,7 @@
 #include <variant>
 #include <version>
 
-#if defined(__cpp_lib_format)
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 #include <format>
 #else
 #include <fmt/core.h>
@@ -97,7 +97,7 @@ namespace gcs
 }
 
 // The following is needed to allow ConstraintName to be used in format strings.
-#if defined(__cpp_lib_format)
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 template <>
 struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
 {

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <variant>
+#include <version>
 
 #if defined(__cpp_lib_format)
 #include <format>

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -239,18 +239,11 @@ auto Abs::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Abs::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto Abs::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    string local_name;
-    overloaded {
-        [&](const CurrentlyUnnamedConstraint &) { local_name = "unnamed"; },
-        [&](const NumberedConstraint & nc) { local_name = format("C{}", nc.number); },
-        [&](const NamedConstraint & nc) { local_name = nc.name; }
-    }.visit(_name);
-
-    print(s, "{} abs", local_name);
+    print(s, "{} abs", as_string(_name));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
 

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -243,7 +243,7 @@ auto Abs::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} abs", as_string(_name));
+    print(s, "{} abs", _name);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
 

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -28,6 +28,7 @@ using std::max;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
+using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -31,9 +31,11 @@ using std::unique_ptr;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 using std::println;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -241,7 +243,14 @@ auto Abs::s_exprify(const string & name, const innards::ProofModel * const model
 {
     stringstream s;
 
-    print(s, "{} abs", name);
+    string local_name;
+    overloaded {
+        [&](const CurrentlyUnnamedConstraint &) { local_name = "unnamed"; },
+        [&](const NumberedConstraint & nc) { local_name = format("C{}", nc.number); },
+        [&](const NamedConstraint & nc) { local_name = nc.name; }
+    }.visit(_name);
+
+    print(s, "{} abs", local_name);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
 

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -33,7 +33,6 @@ using std::vector;
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::format;
 using std::print;
-using std::println;
 #else
 using fmt::format;
 using fmt::print;

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/abs/justify.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/interval_set.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -10,6 +11,8 @@
 #include <algorithm>
 #include <optional>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 #include <version>
 
@@ -25,6 +28,9 @@ using namespace gcs::innards;
 
 using std::holds_alternative;
 using std::max;
+using std::min;
+using std::pair;
+using std::ranges::sort;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -39,21 +45,27 @@ using fmt::print;
 
 namespace
 {
-    // PB resolution: sum the operand proof lines and saturate, eliminating
-    // any literals whose coefficients cancel. Emitted via VeriPB's polish-
-    // notation rule, hence "pol ... + s" in the wire format.
-    auto emit_resolution(ProofLogger * const logger, ProofLine a, ProofLine b) -> void
+    // Collect a set of (lower, upper) pieces (possibly unordered and
+    // overlapping) into an IntervalSet via insert_at_end. Linear sort +
+    // merge; small for the dominant single-interval cases.
+    auto pieces_to_set(vector<pair<Integer, Integer>> & pieces) -> IntervalSet<Integer>
     {
-        stringstream pol;
-        pol << "pol " << a << " " << b << " + s ;";
-        logger->emit_proof_line(pol.str(), ProofLevel::Temporary);
-    }
+        IntervalSet<Integer> result;
+        if (pieces.empty())
+            return result;
 
-    auto emit_resolution(ProofLogger * const logger, ProofLine a, ProofLine b, ProofLine c) -> void
-    {
-        stringstream pol;
-        pol << "pol " << a << " " << b << " + " << c << " + s ;";
-        logger->emit_proof_line(pol.str(), ProofLevel::Temporary);
+        sort(pieces);
+        auto cur = pieces.front();
+        for (auto it = pieces.begin() + 1; it != pieces.end(); ++it) {
+            if (it->first <= cur.second + 1_i)
+                cur.second = max(cur.second, it->second);
+            else {
+                result.insert_at_end(cur.first, cur.second);
+                cur = *it;
+            }
+        }
+        result.insert_at_end(cur.first, cur.second);
+        return result;
     }
 }
 
@@ -86,19 +98,17 @@ auto Abs::install_propagators(Propagators & propagators) -> void
 {
     // All four consequence bounds live in a single SimpleDefinition-priority
     // initialiser. The OPB encoding stays free of "Abs" labels for inferences
-    // that aren't definitional; each bound's proof is assembled at search-init
-    // time as PB resolution steps over the encoding's two half-reified halves
-    // and the relevant `v_ge_X` flag definitions.
+    // that aren't definitional; each bound's proof is assembled via the
+    // shared helpers in abs/justify.hh as PB resolution steps over the
+    // encoding's two half-reified halves.
     //
     // VeriPB's RUP alone cannot derive any of these bounds for non-constant
-    // v1, because it can't case-split on `v1 >= 0 \/ v1 < 0`. Each proof
-    // callback supplies the case split explicitly: resolve a constraint that
-    // holds under `v1 >= 0` with one that holds under `v1 < 0`, leaving the
-    // flag literal the bound is about. The final RUP then closes the
+    // v1, because it can't case-split on `v1 >= 0 \/ v1 < 0`. The helpers
+    // supply the case split explicitly; the final RUP then closes the
     // inference. When v1 IS constant the encoding's relevant half is
-    // unreified, so the proof callback emits nothing and plain RUP suffices.
-    // When v2 is constant we bail out entirely — the propagator will discover
-    // any UNSAT via per-value pruning.
+    // unreified, the helpers short-circuit, and plain RUP suffices. When v2
+    // is constant we bail out -- the propagator's per-value loop will
+    // discover any UNSAT.
     propagators.install_initialiser(
         [v1 = _v1, v2 = _v2,
             abs_nonneg_le = _abs_nonneg_lines.first,
@@ -109,131 +119,177 @@ auto Abs::install_propagators(Propagators & propagators) -> void
             if (holds_alternative<ConstantIntegerVariableID>(v2))
                 return;
 
-            auto v1_is_constant = holds_alternative<ConstantIntegerVariableID>(v1);
-
-            // Bound 1: v2 >= 0. One resolution suffices — the v1 < 0 branch
-            // (v2 = -v1 > 0) is short enough for VeriPB to chase through the
-            // encoding once the v1 >= 0 branch is in the database.
-            //   resolve(v1_ge0 part 1, Abs non-negative ≥ half, v2 < 0 part 2)
-            //   → v2_ge0 ∨ ~v1_ge0.
             inference.infer(logger, v2 >= 0_i,
                 JustifyExplicitlyThenRUP{
-                    [logger, v1, v2, v1_is_constant, abs_nonneg_ge](const ReasonFunction &) -> void {
-                        if (v1_is_constant)
-                            return;
-                        auto & ids = logger->names_and_ids_tracker();
-                        auto v1_ge0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v1 >= 0_i));
-                        auto v2_lt0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v2 < 0_i));
-                        emit_resolution(logger, v1_ge0, *abs_nonneg_ge, v2_lt0);
+                    [logger, v1, v2, abs_nonneg_ge](const ReasonFunction &) -> void {
+                        justify_abs_v2_ge_zero(*logger, v1, v2, *abs_nonneg_ge);
                     }},
                 ReasonFunction{});
 
             auto v2_ub = state.upper_bound(v2);
 
-            // Bound 2: v1 <= ub(v2). Both case-split halves explicit (wider /
-            // asymmetric domains stretch VeriPB's bit-level RUP). Skip if
-            // ub(v2) < 0 — the v1_ge_(ub(v2)+1) flag would collide with
-            // v1_ge0 / become vacuous; the propagator detects UNSAT directly.
-            //   v1 >= 0: resolve(Abs nonneg ≥, v2 ≤ ub(v2), v1_ge_(ub(v2)+1) part 1)
-            //            → ~v1_ge_(ub(v2)+1) ∨ ~v1_ge0.
-            //   v1 < 0 : resolve(v1_ge_(ub(v2)+1) part 1, v1_ge0 part 2)
-            //            → ~v1_ge_(ub(v2)+1) ∨ v1_ge0. (Trivial.)
+            // Skip when ub(v2) < 0 -- the v1_ge_(ub(v2)+1) flag would
+            // collide with v1_ge0 / become vacuous; the propagator detects
+            // UNSAT directly.
             if (v2_ub >= 0_i) {
                 inference.infer(logger, v1 < v2_ub + 1_i,
                     JustifyExplicitlyThenRUP{
-                        [logger, v1, v2, v2_ub, v1_is_constant, abs_nonneg_ge](const ReasonFunction &) -> void {
-                            if (v1_is_constant)
-                                return;
-                            auto & ids = logger->names_and_ids_tracker();
-                            auto v1_ge_bound_plus_1 = std::get<ProofLine>(
-                                ids.need_pol_item_defining_literal(v1 >= v2_ub + 1_i));
-                            auto v2_upper = logger->emit_rup_proof_line(
-                                WPBSum{} + 1_i * v2 <= v2_ub, ProofLevel::Temporary);
-                            emit_resolution(logger, *abs_nonneg_ge, v2_upper, v1_ge_bound_plus_1);
-
-                            auto v1_lt0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v1 < 0_i));
-                            emit_resolution(logger, v1_ge_bound_plus_1, v1_lt0);
+                        [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
+                            justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
                         }},
                     ReasonFunction{});
             }
 
-            // Bound 3: v1 >= -ub(v2). Mirror of bound 2 on the "Abs negative"
-            // side. Skip if ub(v2) <= 0 (same flag-collision concern).
-            //   v1 < 0 : resolve(Abs neg ≥, v2 ≤ ub(v2), v1_ge_(-ub(v2)) part 2)
-            //            → v1_ge_(-ub(v2)) ∨ v1_ge0.
-            //   v1 >= 0: resolve(v1_ge0 part 1, v1_ge_(-ub(v2)) part 2)
-            //            → v1_ge_(-ub(v2)) ∨ ~v1_ge0. (Trivial.)
+            // Symmetric flag-collision concern: skip when ub(v2) <= 0.
             if (v2_ub > 0_i) {
                 inference.infer(logger, v1 >= -v2_ub,
                     JustifyExplicitlyThenRUP{
-                        [logger, v1, v2, v2_ub, v1_is_constant, abs_neg_ge](const ReasonFunction &) -> void {
-                            if (v1_is_constant)
-                                return;
-                            auto & ids = logger->names_and_ids_tracker();
-                            auto v1_lt_neg_bound = std::get<ProofLine>(
-                                ids.need_pol_item_defining_literal(v1 < -v2_ub));
-                            auto v2_upper = logger->emit_rup_proof_line(
-                                WPBSum{} + 1_i * v2 <= v2_ub, ProofLevel::Temporary);
-                            emit_resolution(logger, *abs_neg_ge, v2_upper, v1_lt_neg_bound);
-
-                            auto v1_ge0 = std::get<ProofLine>(ids.need_pol_item_defining_literal(v1 >= 0_i));
-                            emit_resolution(logger, v1_ge0, v1_lt_neg_bound);
+                        [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
+                            justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
                         }},
                     ReasonFunction{});
             }
 
-            // Bound 4: v2 <= max(ub(v1), -lb(v1)) = M. Mirror of bound 1 on
-            // the "<=" side, needing both case-split halves explicit.
-            //   v1 >= 0: resolve(Abs nonneg ≤, v1 ≤ ub(v1), v2_ge_(M+1) part 1)
-            //            → ~v2_ge_(M+1) ∨ ~v1_ge0.
-            //   v1 < 0 : resolve(Abs neg ≤, -v1 ≤ -lb(v1), v2_ge_(M+1) part 1)
-            //            → ~v2_ge_(M+1) ∨ v1_ge0.
             auto [v1_lb, v1_ub] = state.bounds(v1);
-            auto bound4 = max(v1_ub, -v1_lb);
-            inference.infer(logger, v2 < bound4 + 1_i,
+            auto big_m = max(v1_ub, -v1_lb);
+            inference.infer(logger, v2 < big_m + 1_i,
                 JustifyExplicitlyThenRUP{
-                    [logger, v1, v2, v1_lb, v1_ub, bound4, v1_is_constant, abs_nonneg_le, abs_neg_le](
-                        const ReasonFunction &) -> void {
-                        if (v1_is_constant)
-                            return;
-                        auto & ids = logger->names_and_ids_tracker();
-                        auto v2_ge_M_plus_1 = std::get<ProofLine>(
-                            ids.need_pol_item_defining_literal(v2 >= bound4 + 1_i));
-
-                        auto v1_upper = logger->emit_rup_proof_line(
-                            WPBSum{} + 1_i * v1 <= v1_ub, ProofLevel::Temporary);
-                        emit_resolution(logger, *abs_nonneg_le, v1_upper, v2_ge_M_plus_1);
-
-                        auto v1_lower = logger->emit_rup_proof_line(
-                            WPBSum{} + -1_i * v1 <= -v1_lb, ProofLevel::Temporary);
-                        emit_resolution(logger, *abs_neg_le, v1_lower, v2_ge_M_plus_1);
+                    [logger, v1, v2, v1_lb, v1_ub, big_m, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
+                        justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, big_m, *abs_nonneg_le, *abs_neg_le, r);
                     }},
                 ReasonFunction{});
         },
         InitialiserPriority::SimpleDefinition);
 
-    // _v2 = abs(_v1)
+    // Propagator: v2 = abs(v1). Reasons over v1's image (under abs) and
+    // v2's preimage. Contiguous-domain cases collapse to a handful of bound
+    // updates with O(1) proof lines; interior holes still need per-value
+    // pruning, but the iteration is over gaps, not values.
     Triggers triggers{.on_change = {_v1, _v2}};
-    propagators.install([v1 = _v1, v2 = _v2](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        // remove from v1 any value whose absolute value isn't in v2's domain.
-        for (const auto & val : state.each_value_mutable(v1))
-            if (! state.in_domain(v2, abs(val))) {
-                inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{v2 != abs(val)}; }});
+    propagators.install(
+        [v1 = _v1, v2 = _v2,
+            abs_nonneg_le = _abs_nonneg_lines.first,
+            abs_nonneg_ge = _abs_nonneg_lines.second,
+            abs_neg_le = _abs_neg_lines.first,
+            abs_neg_ge = _abs_neg_lines.second](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            auto v1_set = state.copy_of_values(v1);
+            auto v2_set = state.copy_of_values(v2);
+            auto [v1_lb, v1_ub] = state.bounds(v1);
+            auto [v2_lb, v2_ub] = state.bounds(v2);
+            auto v2_is_constant = holds_alternative<ConstantIntegerVariableID>(v2);
+
+            // Direction v1 -> v2: tighten v2 from the image of v1. Skipped
+            // when v2 is constant -- the proof helpers need v2's order-encoding
+            // flags, which don't exist for constants; per-value pruning below
+            // detects any UNSAT directly.
+            //
+            // image_ub = max(|v1_lb|, v1_ub). image_lb = lb(v1) when v1 is
+            // entirely positive, -ub(v1) when entirely negative, and 0
+            // otherwise (already established by the initialiser).
+            if (! v2_is_constant) {
+                auto image_ub = max(-v1_lb, v1_ub);
+                if (image_ub < v2_ub) {
+                    inference.infer_less_than(logger, v2, image_ub + 1_i,
+                        JustifyExplicitlyThenRUP{
+                            [logger, v1, v2, v1_lb, v1_ub, image_ub, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
+                                justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, image_ub, *abs_nonneg_le, *abs_neg_le, r);
+                            }},
+                        ReasonFunction{[v1, v1_lb, v1_ub]() { return Reason{{v1 >= v1_lb, v1 < v1_ub + 1_i}}; }});
+                }
+
+                if (v1_lb >= 1_i && v1_lb > v2_lb) {
+                    inference.infer_greater_than_or_equal(logger, v2, v1_lb,
+                        JustifyExplicitlyThenRUP{
+                            [logger, v1, v2, v1_lb, abs_nonneg_ge](const ReasonFunction & r) -> void {
+                                justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonneg, v1_lb, *abs_nonneg_ge, r);
+                            }},
+                        ReasonFunction{[v1, v1_lb]() { return Reason{v1 >= v1_lb}; }});
+                }
+                else if (v1_ub <= -1_i && -v1_ub > v2_lb) {
+                    inference.infer_greater_than_or_equal(logger, v2, -v1_ub,
+                        JustifyExplicitlyThenRUP{
+                            [logger, v1, v2, v1_ub, abs_neg_ge](const ReasonFunction & r) -> void {
+                                justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonpos, -v1_ub, *abs_neg_ge, r);
+                            }},
+                        ReasonFunction{[v1, v1_ub]() { return Reason{v1 < v1_ub + 1_i}; }});
+                }
             }
 
-        // now remove from v2 any value whose +/-value isn't in v1's domain.
-        for (const auto & val : state.each_value_mutable(v2)) {
-            if (! state.in_domain(v1, val) && ! state.in_domain(v1, -val) && state.in_domain(v2, val)) {
-                auto just = [v1, v2, val, logger](const ReasonFunction & reason) {
-                    justify_abs_hole(*logger, reason, v1, v2, val);
-                };
-                inference.infer_not_equal(logger, v2, val, JustifyExplicitlyThenRUP{just}, ReasonFunction{[=]() { return Reason{{v1 != val, v1 != -val}}; }});
+            // Direction v2 -> v1: tighten v1 from the preimage of v2.
+            if (v2_ub < v1_ub) {
+                inference.infer_less_than(logger, v1, v2_ub + 1_i,
+                    JustifyExplicitlyThenRUP{
+                        [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
+                            justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
+                        }},
+                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 < v2_ub + 1_i}; }});
             }
-        }
+            if (-v2_ub > v1_lb) {
+                inference.infer_greater_than_or_equal(logger, v1, -v2_ub,
+                    JustifyExplicitlyThenRUP{
+                        [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
+                            justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
+                        }},
+                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 < v2_ub + 1_i}; }});
+            }
 
-        return PropagatorState::Enable;
-    },
+            // Interior pruning: remove values in v2 with no preimage in v1,
+            // and values in v1 whose abs is not in v2. Walk gaps via
+            // each_interval_minus, then per-value within the now-tightened
+            // bounds.
+
+            vector<pair<Integer, Integer>> image_pieces;
+            for (auto [a, b] : v1_set.each_interval()) {
+                if (a >= 0_i)
+                    image_pieces.emplace_back(a, b);
+                else if (b < 0_i)
+                    image_pieces.emplace_back(-b, -a);
+                else
+                    image_pieces.emplace_back(0_i, max(-a, b));
+            }
+            auto image_set = pieces_to_set(image_pieces);
+
+            auto [post_v2_lb, post_v2_ub] = state.bounds(v2);
+            for (auto [lo, hi] : v2_set.each_interval_minus(image_set)) {
+                auto clipped_lo = max(lo, post_v2_lb);
+                auto clipped_hi = min(hi, post_v2_ub);
+                for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
+                    if (! state.in_domain(v2, val))
+                        continue;
+                    inference.infer_not_equal(logger, v2, val,
+                        JustifyExplicitlyThenRUP{[logger, v1, v2, val](const ReasonFunction & r) {
+                            justify_abs_hole(*logger, r, v1, v2, val);
+                        }},
+                        ReasonFunction{[v1, val]() { return Reason{{v1 != val, v1 != -val}}; }});
+                }
+            }
+
+            vector<pair<Integer, Integer>> preimage_pieces;
+            for (auto [a, b] : v2_set.each_interval()) {
+                if (a == 0_i)
+                    preimage_pieces.emplace_back(-b, b);
+                else {
+                    preimage_pieces.emplace_back(-b, -a);
+                    preimage_pieces.emplace_back(a, b);
+                }
+            }
+            auto preimage_set = pieces_to_set(preimage_pieces);
+
+            auto [post_v1_lb, post_v1_ub] = state.bounds(v1);
+            for (auto [lo, hi] : v1_set.each_interval_minus(preimage_set)) {
+                auto clipped_lo = max(lo, post_v1_lb);
+                auto clipped_hi = min(hi, post_v1_ub);
+                for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
+                    if (! state.in_domain(v1, val))
+                        continue;
+                    inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{},
+                        ReasonFunction{[v2, val]() { return Reason{v2 != abs(val)}; }});
+                }
+            }
+
+            return PropagatorState::Enable;
+        },
         triggers);
 }
 

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -14,7 +14,6 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-#include <format>
 #include <print>
 #else
 #include <fmt/core.h>

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -14,6 +14,7 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
 #include <fmt/core.h>
@@ -28,10 +29,8 @@ using std::max;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
-using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-using std::format;
 using std::print;
 #else
 using fmt::format;

--- a/gcs/constraints/abs.hh
+++ b/gcs/constraints/abs.hh
@@ -35,7 +35,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
 
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/abs/justify.cc
+++ b/gcs/constraints/abs/justify.cc
@@ -1,7 +1,34 @@
 #include <gcs/constraints/abs/justify.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+
+#include <sstream>
 
 using namespace gcs;
 using namespace gcs::innards;
+
+using std::get;
+using std::holds_alternative;
+using std::stringstream;
+
+namespace
+{
+    // PB resolution: sum the operand proof lines and saturate, eliminating
+    // any literals whose coefficients cancel. Emitted via VeriPB's polish-
+    // notation rule, hence "pol ... + s" in the wire format.
+    auto emit_resolution(ProofLogger & logger, ProofLine a, ProofLine b) -> void
+    {
+        stringstream pol;
+        pol << "pol " << a << " " << b << " + s ;";
+        logger.emit_proof_line(pol.str(), ProofLevel::Temporary);
+    }
+
+    auto emit_resolution(ProofLogger & logger, ProofLine a, ProofLine b, ProofLine c) -> void
+    {
+        stringstream pol;
+        pol << "pol " << a << " " << b << " + " << c << " + s ;";
+        logger.emit_proof_line(pol.str(), ProofLevel::Temporary);
+    }
+}
 
 auto gcs::innards::justify_abs_hole(
     ProofLogger & logger,
@@ -19,4 +46,119 @@ auto gcs::innards::justify_abs_hole(
         WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v1 != -val) + 1_i * (v2 != val) >= 1_i, ProofLevel::Temporary);
 
     // rest follows by RUP
+}
+
+auto gcs::innards::justify_abs_v2_ge_zero(
+    ProofLogger & logger,
+    IntegerVariableID v1,
+    IntegerVariableID v2,
+    ProofLine abs_nonneg_ge) -> void
+{
+    if (holds_alternative<ConstantIntegerVariableID>(v1))
+        return;
+
+    auto & ids = logger.names_and_ids_tracker();
+    auto v1_ge0 = get<ProofLine>(ids.need_pol_item_defining_literal(v1 >= 0_i));
+    auto v2_lt0 = get<ProofLine>(ids.need_pol_item_defining_literal(v2 < 0_i));
+    emit_resolution(logger, v1_ge0, abs_nonneg_ge, v2_lt0);
+}
+
+auto gcs::innards::justify_abs_v2_lb(
+    ProofLogger & logger,
+    IntegerVariableID v1,
+    IntegerVariableID v2,
+    AbsLbSide side,
+    Integer v2_lb,
+    ProofLine abs_ge,
+    const ReasonFunction & reason) -> void
+{
+    if (holds_alternative<ConstantIntegerVariableID>(v1))
+        return;
+
+    auto & ids = logger.names_and_ids_tracker();
+    auto v2_lt_lb = get<ProofLine>(ids.need_pol_item_defining_literal(v2 < v2_lb));
+
+    // Materialise the relevant v1 bound under the reason, then resolve
+    // with the matching half-reified piece. abs_ge under v1 >= 0 gives
+    // v2 - v1 >= 0; under v1 < 0 gives v2 + v1 >= 0. Resolving with the
+    // v1 bound and v2 < v2_lb leaves a single side; the v1 sign branch
+    // not taken is closed by RUP from the reason.
+    auto v1_bound_line = (side == AbsLbSide::Nonneg)
+        ? logger.emit_rup_proof_line_under_reason(reason,
+              WPBSum{} + -1_i * v1 <= -v2_lb, ProofLevel::Temporary)
+        : logger.emit_rup_proof_line_under_reason(reason,
+              WPBSum{} + 1_i * v1 <= -v2_lb, ProofLevel::Temporary);
+
+    emit_resolution(logger, abs_ge, v1_bound_line, v2_lt_lb);
+}
+
+auto gcs::innards::justify_abs_v1_le_v2_ub(
+    ProofLogger & logger,
+    IntegerVariableID v1,
+    IntegerVariableID v2,
+    Integer v2_ub,
+    ProofLine abs_nonneg_ge,
+    const ReasonFunction & reason) -> void
+{
+    if (holds_alternative<ConstantIntegerVariableID>(v1))
+        return;
+
+    auto & ids = logger.names_and_ids_tracker();
+    auto v1_ge_bound_plus_1 = get<ProofLine>(
+        ids.need_pol_item_defining_literal(v1 >= v2_ub + 1_i));
+    auto v2_upper = logger.emit_rup_proof_line_under_reason(reason,
+        WPBSum{} + 1_i * v2 <= v2_ub, ProofLevel::Temporary);
+    emit_resolution(logger, abs_nonneg_ge, v2_upper, v1_ge_bound_plus_1);
+
+    auto v1_lt0 = get<ProofLine>(ids.need_pol_item_defining_literal(v1 < 0_i));
+    emit_resolution(logger, v1_ge_bound_plus_1, v1_lt0);
+}
+
+auto gcs::innards::justify_abs_v1_ge_neg_v2_ub(
+    ProofLogger & logger,
+    IntegerVariableID v1,
+    IntegerVariableID v2,
+    Integer v2_ub,
+    ProofLine abs_neg_ge,
+    const ReasonFunction & reason) -> void
+{
+    if (holds_alternative<ConstantIntegerVariableID>(v1))
+        return;
+
+    auto & ids = logger.names_and_ids_tracker();
+    auto v1_lt_neg_bound = get<ProofLine>(
+        ids.need_pol_item_defining_literal(v1 < -v2_ub));
+    auto v2_upper = logger.emit_rup_proof_line_under_reason(reason,
+        WPBSum{} + 1_i * v2 <= v2_ub, ProofLevel::Temporary);
+    emit_resolution(logger, abs_neg_ge, v2_upper, v1_lt_neg_bound);
+
+    auto v1_ge0 = get<ProofLine>(ids.need_pol_item_defining_literal(v1 >= 0_i));
+    emit_resolution(logger, v1_ge0, v1_lt_neg_bound);
+}
+
+auto gcs::innards::justify_abs_v2_le_big_m(
+    ProofLogger & logger,
+    IntegerVariableID v1,
+    IntegerVariableID v2,
+    Integer v1_lb,
+    Integer v1_ub,
+    Integer big_m,
+    ProofLine abs_nonneg_le,
+    ProofLine abs_neg_le,
+    const ReasonFunction & reason) -> void
+{
+    if (holds_alternative<ConstantIntegerVariableID>(v1))
+        return;
+
+    auto & ids = logger.names_and_ids_tracker();
+    auto v2_ge_M_plus_1 = get<ProofLine>(
+        ids.need_pol_item_defining_literal(v2 >= big_m + 1_i));
+
+    auto v1_upper = logger.emit_rup_proof_line_under_reason(reason,
+        WPBSum{} + 1_i * v1 <= v1_ub, ProofLevel::Temporary);
+    emit_resolution(logger, abs_nonneg_le, v1_upper, v2_ge_M_plus_1);
+
+    auto v1_lower = logger.emit_rup_proof_line_under_reason(reason,
+        WPBSum{} + -1_i * v1 <= -v1_lb, ProofLevel::Temporary);
+    emit_resolution(logger, abs_neg_le, v1_lower, v2_ge_M_plus_1);
 }

--- a/gcs/constraints/abs/justify.hh
+++ b/gcs/constraints/abs/justify.hh
@@ -5,12 +5,86 @@
 
 namespace gcs::innards
 {
+    // Hole removal: justifies v2 != val by case-splitting on v1's sign.
+    // Used in the v1 -> v2 direction when both val and -val are absent
+    // from dom(v1).
     auto justify_abs_hole(
         ProofLogger & logger,
         const ReasonFunction & reason,
         IntegerVariableID v1,
         IntegerVariableID v2,
         Integer val) -> void;
+
+    // The bound proofs below share their resolution shape between the
+    // prepare-time initialiser and the run-time propagator. The initialiser
+    // calls them with an empty ReasonFunction (the operand bound RUPs from
+    // the encoding's initial domain); the propagator passes its reason in
+    // so the operand bound RUPs under that literal instead. In both cases
+    // the helper short-circuits when v1 is constant -- the encoding's
+    // relevant half is then unreified and plain RUP closes the inference
+    // without an explicit pol step.
+
+    // v2 >= 0. Initialiser-only: at run time v1 spanning zero already keeps
+    // v2's lower bound at 0, and the entirely-positive/negative cases use
+    // justify_abs_v2_lb below.
+    auto justify_abs_v2_ge_zero(
+        ProofLogger & logger,
+        IntegerVariableID v1,
+        IntegerVariableID v2,
+        ProofLine abs_nonneg_ge) -> void;
+
+    // Side picks which half-reified piece drives the proof:
+    //   Nonneg: dom(v1) sits at or above v1_bound >= 1; abs_ge is the
+    //           encoding's "Abs non-negative" >= half.
+    //   Nonpos: dom(v1) sits at or below v1_bound <= -1; abs_ge is the
+    //           encoding's "Abs negative" >= half.
+    enum struct AbsLbSide
+    {
+        Nonneg,
+        Nonpos
+    };
+
+    // v2 >= v2_lb. Propagator-only -- the initialiser cannot move this
+    // bound above 0 since at search start v1 spans zero whenever v2's
+    // image-min is positive.
+    auto justify_abs_v2_lb(
+        ProofLogger & logger,
+        IntegerVariableID v1,
+        IntegerVariableID v2,
+        AbsLbSide side,
+        Integer v2_lb,
+        ProofLine abs_ge,
+        const ReasonFunction & reason) -> void;
+
+    // v1 <= v2_ub.
+    auto justify_abs_v1_le_v2_ub(
+        ProofLogger & logger,
+        IntegerVariableID v1,
+        IntegerVariableID v2,
+        Integer v2_ub,
+        ProofLine abs_nonneg_ge,
+        const ReasonFunction & reason) -> void;
+
+    // v1 >= -v2_ub.
+    auto justify_abs_v1_ge_neg_v2_ub(
+        ProofLogger & logger,
+        IntegerVariableID v1,
+        IntegerVariableID v2,
+        Integer v2_ub,
+        ProofLine abs_neg_ge,
+        const ReasonFunction & reason) -> void;
+
+    // v2 <= big_m, where big_m = max(-v1_lb, v1_ub).
+    auto justify_abs_v2_le_big_m(
+        ProofLogger & logger,
+        IntegerVariableID v1,
+        IntegerVariableID v2,
+        Integer v1_lb,
+        Integer v1_ub,
+        Integer big_m,
+        ProofLine abs_nonneg_le,
+        ProofLine abs_neg_le,
+        const ReasonFunction & reason) -> void;
 }
 
 #endif

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -202,11 +202,11 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto AllDifferentExcept::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto AllDifferentExcept::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} all_different_except (", name);
+    print(s, "{} all_different_except (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/all_different/all_different_except.hh
+++ b/gcs/constraints/all_different/all_different_except.hh
@@ -48,7 +48,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     /**

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -670,7 +670,7 @@ auto GACAllDifferent::s_exprify(const string & name, const innards::ProofModel *
 {
     stringstream s;
 
-    print(s, "{} all_different (", name);
+    print(s, "{} all_different (", as_string(_name));
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -666,11 +666,11 @@ template auto gcs::innards::propagate_gac_all_different(
     EagerProofLoggingInferenceTracker & inference_tracker,
     ProofLogger * const logger) -> void;
 
-auto GACAllDifferent::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto GACAllDifferent::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} all_different (", as_string(_name));
+    print(s, "{} all_different (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -50,7 +50,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
 }

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -181,11 +181,11 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
         triggers);
 }
 
-auto SymmetricAllDifferent::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto SymmetricAllDifferent::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} symmetric_all_different (", name);
+    print(s, "{} symmetric_all_different (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", _start);

--- a/gcs/constraints/all_different/symmetric_all_different.hh
+++ b/gcs/constraints/all_different/symmetric_all_different.hh
@@ -49,8 +49,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name,
-            const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -168,11 +168,11 @@ template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintState
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
     EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
 
-auto VCAllDifferent::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto VCAllDifferent::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} all_different (", name);
+    print(s, "{} all_different (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -45,7 +45,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 #endif // GLASGOW_CONSTRAINT_SOLVER_VC_ALL_DIFFERENT_HH

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -13,7 +13,6 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-#include <format>
 #include <print>
 #else
 #include <fmt/ostream.h>

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -150,10 +150,10 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto AllEqual::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto AllEqual::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} all_equal", name);
+    print(s, "{} all_equal", _name);
     for (const auto & v : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     return s.str();

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -13,6 +13,7 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
 #include <fmt/ostream.h>

--- a/gcs/constraints/all_equal.hh
+++ b/gcs/constraints/all_equal.hh
@@ -35,7 +35,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -273,11 +273,11 @@ auto Among::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Among::s_exprify(const std::string & name, const ProofModel * const model) const -> std::string
+auto Among::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} among (", name);
+    print(s, "{} among (", _name);
     for (const auto & var : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     }

--- a/gcs/constraints/among.hh
+++ b/gcs/constraints/among.hh
@@ -34,7 +34,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -28,6 +28,12 @@ using std::stringstream;
 using std::unique_ptr;
 using std::vector;
 
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+#else
+using fmt::print;
+#endif
+
 template <ArithmeticOperator op_>
 GACArithmetic<op_>::GACArithmetic(const IntegerVariableID v1, const IntegerVariableID v2, const IntegerVariableID result) :
     _v1(v1),
@@ -116,9 +122,10 @@ auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) cons
     case ArithmeticOperator::Mod: op_str = "mod"; break;
     case ArithmeticOperator::Power: op_str = "power"; break;
     }
-
-    return format("({} {} {} {} {})", as_string(_name), op_str,
+    stringstream s;
+    print(s, "({} {} {} {} {})", _name, op_str,
         model->names_and_ids_tracker().s_expr_name_of(_v1),
         model->names_and_ids_tracker().s_expr_name_of(_v2),
         model->names_and_ids_tracker().s_expr_name_of(_result));
+    return s.str();
 }

--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -104,7 +104,7 @@ namespace gcs::innards
 }
 
 template <ArithmeticOperator op_>
-auto GACArithmetic<op_>::s_exprify(const std::string & name, const innards::ProofModel * const model) const -> std::string
+auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) const -> std::string
 {
     // (name op v1 v2 result)
     string op_str;
@@ -117,7 +117,7 @@ auto GACArithmetic<op_>::s_exprify(const std::string & name, const innards::Proo
     case ArithmeticOperator::Power: op_str = "power"; break;
     }
 
-    return format("({} {} {} {} {})", name, op_str,
+    return format("({} {} {} {} {})", _name, op_str,
         model->names_and_ids_tracker().s_expr_name_of(_v1),
         model->names_and_ids_tracker().s_expr_name_of(_v2),
         model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -117,7 +117,7 @@ auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) cons
     case ArithmeticOperator::Power: op_str = "power"; break;
     }
 
-    return format("({} {} {} {} {})", _name, op_str,
+    return format("({} {} {} {} {})", as_string(_name), op_str,
         model->names_and_ids_tracker().s_expr_name_of(_v1),
         model->names_and_ids_tracker().s_expr_name_of(_v2),
         model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/arithmetic.hh
+++ b/gcs/constraints/arithmetic.hh
@@ -53,7 +53,7 @@ namespace gcs
 
             virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
             virtual auto clone() const -> std::unique_ptr<Constraint> override;
-            [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+            [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
         };
     }
 

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -145,10 +145,10 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto AtMostOne::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto AtMostOne::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} at_most_one (", name);
+    print(s, "{} at_most_one (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -15,6 +15,7 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
 #include <fmt/ostream.h>

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -15,7 +15,6 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-#include <format>
 #include <print>
 #else
 #include <fmt/ostream.h>

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -195,10 +195,10 @@ auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_sta
     move(smt_table).install(propagators, initial_state, optional_model);
 }
 
-auto AtMostOneSmartTable::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto AtMostOneSmartTable::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} at_most_one_smart_table (", name);
+    print(s, "{} at_most_one_smart_table (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));

--- a/gcs/constraints/at_most_one.hh
+++ b/gcs/constraints/at_most_one.hh
@@ -36,7 +36,7 @@ namespace gcs
         IntegerVariableID _val;
         std::vector<std::tuple<innards::ProofFlag, innards::ProofFlag, innards::ProofFlag>> _flags;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
@@ -45,7 +45,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     /**

--- a/gcs/constraints/at_most_one.hh
+++ b/gcs/constraints/at_most_one.hh
@@ -69,7 +69,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -236,11 +236,11 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
     return pos_var_data;
 }
 
-auto CircuitBase::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto CircuitBase::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} circuit (", name);
+    print(s, "{} circuit (", _name);
     for (const auto & var : _succ)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/circuit/circuit_base.hh
+++ b/gcs/constraints/circuit/circuit_base.hh
@@ -81,7 +81,7 @@ namespace gcs::innards::circuit
     public:
         explicit CircuitBase(std::vector<IntegerVariableID> var, bool gac_all_different = false);
         [[nodiscard]] auto clone() const -> std::unique_ptr<Constraint> override = 0;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -191,7 +191,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
     }
 }
 
-auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const std::string & name, const ProofModel * const model) const -> std::string
+auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
@@ -208,12 +208,12 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const std::string & name, con
         reif);
 
     if (reif.empty()) {
-        print(s, "{} {} {} {}", name, cmp,
+        print(s, "{} {} {} {}", _name, cmp,
             model->names_and_ids_tracker().s_expr_name_of(_v1),
             model->names_and_ids_tracker().s_expr_name_of(_v2));
     }
     else {
-        print(s, "{} {} {} {} {}", name, cmp,
+        print(s, "{} {} {} {} {}", _name, cmp,
             model->names_and_ids_tracker().s_expr_name_of(_reif_cond),
             model->names_and_ids_tracker().s_expr_name_of(_v1),
             model->names_and_ids_tracker().s_expr_name_of(_v2));

--- a/gcs/constraints/comparison.hh
+++ b/gcs/constraints/comparison.hh
@@ -48,7 +48,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     /**

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -233,11 +233,11 @@ auto Count::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Count::s_exprify(const std::string & name, const ProofModel * const model) const -> std::string
+auto Count::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} count (", name);
+    print(s, "{} count (", _name);
     for (const auto & v : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/count.hh
+++ b/gcs/constraints/count.hh
@@ -32,7 +32,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -567,7 +567,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::clone() const -> unique_ptr<C
 }
 
 template <typename EntryType_, unsigned dimensions_>
-auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const std::string & name, const ProofModel * const model) const -> std::string
+auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
@@ -604,7 +604,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const std::string &
         }
     };
 
-    print(s, "{} element (", name);
+    print(s, "{} element (", _name);
 
     print_array(s, *_array, print_array);
 

--- a/gcs/constraints/element.hh
+++ b/gcs/constraints/element.hh
@@ -54,7 +54,7 @@ namespace gcs
     public:
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     class Element : public NDimensionalElement<IntegerVariableID, 1>

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -289,7 +289,7 @@ NotEqualsIff::NotEqualsIff(const IntegerVariableID v1, const IntegerVariableID v
 {
 }
 
-auto ReifiedEquals::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto ReifiedEquals::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
@@ -302,7 +302,7 @@ auto ReifiedEquals::s_exprify(const string & name, const innards::ProofModel * c
             return _neq ? "not_equals_iff" : "equals_iff";
         }}.visit(_cond);
 
-    print(s, "{} {}", name, constraint_type);
+    print(s, "{} {}", _name, constraint_type);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_cond));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));

--- a/gcs/constraints/equals.hh
+++ b/gcs/constraints/equals.hh
@@ -41,7 +41,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     /**

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -261,11 +261,11 @@ auto In::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto In::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto In::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} in {} (", name, model->names_and_ids_tracker().s_expr_name_of(_var));
+    print(s, "{} in {} (", _name, model->names_and_ids_tracker().s_expr_name_of(_var));
     for (const auto & v : _var_vals)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     for (const auto & v : _val_vals)

--- a/gcs/constraints/in.hh
+++ b/gcs/constraints/in.hh
@@ -40,7 +40,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/increasing.cc
+++ b/gcs/constraints/increasing.cc
@@ -135,7 +135,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto IncreasingChain::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto IncreasingChain::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
@@ -143,7 +143,7 @@ auto IncreasingChain::s_exprify(const string & name, const ProofModel * const mo
         ? (_descending ? "strictly_decreasing" : "strictly_increasing")
         : (_descending ? "decreasing" : "increasing");
 
-    print(s, "{} {}", name, keyword);
+    print(s, "{} {}", _name, keyword);
     for (const auto & v : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
 

--- a/gcs/constraints/increasing.hh
+++ b/gcs/constraints/increasing.hh
@@ -42,7 +42,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     /**

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -167,11 +167,11 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Inverse::s_exprify(const std::string & name, const innards::ProofModel * const model) const -> std::string
+auto Inverse::s_exprify(const innards::ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} inverse\n          (", name);
+    print(s, "{} inverse\n          (", _name);
     for (const auto & x : _x) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(x));
     }

--- a/gcs/constraints/inverse.hh
+++ b/gcs/constraints/inverse.hh
@@ -36,7 +36,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -656,11 +656,11 @@ auto Knapsack::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Knapsack::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto Knapsack::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} knapsack\n            (", name);
+    print(s, "{} knapsack\n            (", _name);
     for (const auto & cs : _coeffs) {
         print(s, "\n                (");
         for (const auto & c : cs)

--- a/gcs/constraints/knapsack.hh
+++ b/gcs/constraints/knapsack.hh
@@ -38,7 +38,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/lex.cc
+++ b/gcs/constraints/lex.cc
@@ -621,7 +621,7 @@ auto LexCompareGreaterThanOrMaybeEqual::install_propagators(Propagators & propag
         std::move(infer_cond_when_undecided));
 }
 
-auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const std::string & name, const innards::ProofModel * const model) const -> std::string
+auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const innards::ProofModel * const model) const -> std::string
 {
     stringstream s;
 
@@ -638,7 +638,7 @@ auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const std::string & name, cons
         _or_equal ? "_equal" : "",
         reif_suffix);
 
-    print(s, "{} {}", name, cmp);
+    print(s, "{} {}", _name, cmp);
 
     auto cond_lit = overloaded{
         [](const reif::MustHold &) -> optional<IntegerVariableCondition> { return nullopt; },

--- a/gcs/constraints/lex.hh
+++ b/gcs/constraints/lex.hh
@@ -100,7 +100,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     /**

--- a/gcs/constraints/lex_smart_table.cc
+++ b/gcs/constraints/lex_smart_table.cc
@@ -65,11 +65,11 @@ auto LexSmartTable::install(Propagators & propagators, State & initial_state, Pr
     move(smt_table).install(propagators, initial_state, optional_model);
 }
 
-auto LexSmartTable::s_exprify(const std::string & name, const innards::ProofModel * const model) const -> std::string
+auto LexSmartTable::s_exprify(const innards::ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} lex (", name);
+    print(s, "{} lex (", _name);
     for (const auto & var : _vars_1)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/lex_smart_table.hh
+++ b/gcs/constraints/lex_smart_table.hh
@@ -31,7 +31,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -401,7 +401,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
     }
 }
 
-auto ReifiedLinearEquality::s_exprify(const std::string & name, const ProofModel * const model) const -> std::string
+auto ReifiedLinearEquality::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
@@ -413,7 +413,7 @@ auto ReifiedLinearEquality::s_exprify(const std::string & name, const ProofModel
         [&](const reif::NotIf &) { return make_pair(true, "lin_not_equals_if"); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", name, cons);
+    print(s, "{} {}", _name, cons);
     if (rei) {
         print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
     }

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -48,7 +48,7 @@ namespace gcs
             innards::ProofModel * const) && -> void override;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     class LinearEquality : public ReifiedLinearEquality

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -222,7 +222,7 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
         sanitised_cv, sanitised_neg_cv);
 }
 
-auto ReifiedLinearInequality::s_exprify(const std::string & name, const ProofModel * const model) const -> std::string
+auto ReifiedLinearInequality::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
@@ -233,10 +233,11 @@ auto ReifiedLinearInequality::s_exprify(const std::string & name, const ProofMod
         [&](const auto &) { throw UnexpectedException{"Unexpected reification type in s_exprify"}; return make_pair(false, ""); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", name, cons);
+    print(s, "{} {}", _name, cons);
     if (rei) {
         print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
     }
+    print(s, "(");
     for (const auto & [c, v] : _coeff_vars.terms) {
         print(s, " {} {}", c, model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -43,7 +43,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -255,11 +255,11 @@ auto And::install_propagators(Propagators & propagators) -> void
     install_propagators_logical(propagators, _lits, _full_reif, _reif_state);
 }
 
-auto And::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto And::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} and (", name);
+    print(s, "{} and (", _name);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }
@@ -322,11 +322,11 @@ auto Or::install_propagators(Propagators & propagators) -> void
     install_propagators_logical(propagators, move(lits), ! _full_reif, _reif_state);
 }
 
-auto Or::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto Or::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} or (", name);
+    print(s, "{} or (", _name);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }

--- a/gcs/constraints/logical.hh
+++ b/gcs/constraints/logical.hh
@@ -39,7 +39,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     /**
@@ -70,7 +70,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -201,11 +201,11 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto ArrayMinMax::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto ArrayMinMax::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} {} (", name, _min ? "min" : "max");
+    print(s, "{} {} (", _name, _min ? "min" : "max");
     for (const auto & v : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/min_max.hh
+++ b/gcs/constraints/min_max.hh
@@ -39,7 +39,7 @@ namespace gcs
 
             virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
             virtual auto clone() const -> std::unique_ptr<Constraint> override;
-            [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+            [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
         };
     }
 

--- a/gcs/constraints/minus.cc
+++ b/gcs/constraints/minus.cc
@@ -73,11 +73,11 @@ auto Minus::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Minus::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto Minus::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} minus (", name);
+    print(s, "{} minus (", _name);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/minus.hh
+++ b/gcs/constraints/minus.hh
@@ -30,7 +30,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -1361,11 +1361,11 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
         triggers);
 }
 
-auto MultBC::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto MultBC::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} multiply (", name);
+    print(s, "{} multiply (", _name);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v3));

--- a/gcs/constraints/mult_bc.hh
+++ b/gcs/constraints/mult_bc.hh
@@ -25,7 +25,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators & propagators, innards::State &, innards::ProofModel *) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -136,11 +136,11 @@ auto NValue::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto NValue::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto NValue::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} nvalue (", name);
+    print(s, "{} nvalue (", _name);
     for (const auto & var : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     }

--- a/gcs/constraints/n_value.hh
+++ b/gcs/constraints/n_value.hh
@@ -33,7 +33,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -141,11 +141,11 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
     },
         triggers);
 }
-auto ParityOdd::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto ParityOdd::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} xor (", name);
+    print(s, "{} xor (", _name);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }

--- a/gcs/constraints/parity.hh
+++ b/gcs/constraints/parity.hh
@@ -31,7 +31,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/plus.cc
+++ b/gcs/constraints/plus.cc
@@ -74,11 +74,11 @@ auto Plus::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Plus::s_exprify(const string & name, const innards::ProofModel * const model) const -> string
+auto Plus::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} plus (", name);
+    print(s, "{} plus (", _name);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/plus.hh
+++ b/gcs/constraints/plus.hh
@@ -31,7 +31,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 
     namespace innards

--- a/gcs/constraints/regular.cc
+++ b/gcs/constraints/regular.cc
@@ -454,11 +454,11 @@ auto Regular::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Regular::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto Regular::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} regular (", name);
+    print(s, "{} regular (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}\n       (", _num_states);

--- a/gcs/constraints/regular.hh
+++ b/gcs/constraints/regular.hh
@@ -52,7 +52,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/seq_precede_chain.cc
+++ b/gcs/constraints/seq_precede_chain.cc
@@ -83,10 +83,10 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
     ValuePrecede{move(chain), move(_vars)}.install(propagators, initial_state, optional_model);
 }
 
-auto SeqPrecedeChain::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto SeqPrecedeChain::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} seq_precede_chain (", name);
+    print(s, "{} seq_precede_chain (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/seq_precede_chain.hh
+++ b/gcs/constraints/seq_precede_chain.hh
@@ -45,7 +45,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -915,7 +915,7 @@ auto SmartTable::install(Propagators & propagators, State & initial_state, Proof
         triggers);
 }
 
-auto SmartTable::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto SmartTable::s_exprify(const ProofModel * const model) const -> string
 {
     auto to_op = [](SmartEntryConstraint c) {
         switch (c) {
@@ -933,10 +933,9 @@ auto SmartTable::s_exprify(const string & name, const ProofModel * const model) 
 
     stringstream s;
 
-    print(s, "{} smart_table (\n        (", name);
+    print(s, "{} smart_table (\n        (", _name);
 
     for (const auto & tuple : _tuples) {
-        print(s, "(");
         for (const auto & entry : tuple) {
             overloaded{
                 [&](const BinaryEntry & binary_entry) {
@@ -967,6 +966,7 @@ auto SmartTable::s_exprify(const string & name, const ProofModel * const model) 
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")\n        )");
+
 
     return s.str();
 }

--- a/gcs/constraints/smart_table.hh
+++ b/gcs/constraints/smart_table.hh
@@ -141,7 +141,7 @@ namespace gcs
         {
             return innards::UnarySetEntry{a, move(b), innards::SmartEntryConstraint::NotIn};
         }
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -303,11 +303,11 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
         _tuples);
 }
 
-auto NegativeTable::s_exprify(const string & name, const innards::ProofModel * const model) const -> std::string
+auto NegativeTable::s_exprify(const innards::ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} negative_table", name);
+    print(s, "{} negative_table", _name);
     println(s, "(");
 
     println(s, "    (");

--- a/gcs/constraints/table/negative_table.hh
+++ b/gcs/constraints/table/negative_table.hh
@@ -31,7 +31,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -205,11 +205,11 @@ auto Table::install_propagators(Propagators & propagators) -> void
         move(_tuples));
 }
 
-auto Table::s_exprify(const string & name, const innards::ProofModel * const model) const -> std::string
+auto Table::s_exprify(const innards::ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} table", name);
+    print(s, "{} table", _name);
     println(s, "(");
 
     println(s, "    (");

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -33,7 +33,7 @@ namespace gcs
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
 
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/constraints/value_precede.cc
+++ b/gcs/constraints/value_precede.cc
@@ -205,11 +205,11 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
     }
 }
 
-auto ValuePrecede::s_exprify(const string & name, const ProofModel * const model) const -> string
+auto ValuePrecede::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} value_precede (", name);
+    print(s, "{} value_precede (", _name);
     for (const auto & val : _chain)
         print(s, " {}", val);
     print(s, ") (");

--- a/gcs/constraints/value_precede.hh
+++ b/gcs/constraints/value_precede.hh
@@ -69,7 +69,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const std::string & name, const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
     };
 }
 

--- a/gcs/integer.hh
+++ b/gcs/integer.hh
@@ -11,8 +11,10 @@
 #include <string>
 #include <version>
 
-#if defined(__cpp_lib_format)
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 #include <format>
+#else
+#include <fmt/core.h>
 #endif
 
 namespace gcs
@@ -225,7 +227,7 @@ namespace gcs
     }
 }
 
-#if defined(__cpp_lib_format)
+#if defined(__cpp_lib_format) && defined(__cpp_lib_print)
 template <>
 struct std::formatter<gcs::Integer> : std::formatter<long long> {
     template <typename FormatContext_>

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -164,6 +164,14 @@ auto Problem::post(const Constraint & c) -> void
     _imp->constraints.push_back(std::move(cloned));
 }
 
+auto Problem::post(const Constraint & c, const string & name) -> void
+{
+    auto cloned = c.clone();
+    if (std::holds_alternative<CurrentlyUnnamedConstraint>(cloned->name()))
+        cloned->set_name(NamedConstraint{name});
+    _imp->constraints.push_back(std::move(cloned));
+}
+
 auto Problem::post(SumLessThanEqual<Weighted<IntegerVariableID>> expr) -> void
 {
     post(LinearLessThanEqual(move(expr.lhs), expr.rhs));

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -1,4 +1,4 @@
-#include "gcs/constraint.hh"
+#include <gcs/constraint.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -17,7 +17,6 @@
 #include <regex>
 #include <tuple>
 #include <unordered_set>
-#include <variant>
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -163,7 +162,7 @@ auto Problem::post(const Constraint & c) -> void
     _imp->constraints.push_back(std::move(cloned));
 }
 
-auto Problem::post(const Constraint & c, const string & name) -> void
+auto Problem::post_named(const Constraint & c, const string & name) -> void
 {
     auto cloned = c.clone();
     cloned->set_name(NamedConstraint{check_name(name)}); 
@@ -175,9 +174,9 @@ auto Problem::post(SumLessThanEqual<Weighted<IntegerVariableID>> expr) -> void
     post(LinearLessThanEqual(move(expr.lhs), expr.rhs));
 }
 
-auto Problem::post(SumLessThanEqual<Weighted<IntegerVariableID>> expr, const string & name) -> void
+auto Problem::post_named(SumLessThanEqual<Weighted<IntegerVariableID>> expr, const string & name) -> void
 {
-    post(LinearLessThanEqual(move(expr.lhs), expr.rhs), name);
+    post_named(LinearLessThanEqual(move(expr.lhs), expr.rhs), name);
 }
 
 auto Problem::post(SumEquals<Weighted<IntegerVariableID>> expr) -> void
@@ -185,9 +184,9 @@ auto Problem::post(SumEquals<Weighted<IntegerVariableID>> expr) -> void
     post(LinearEquality(move(expr.lhs), expr.rhs));
 }
 
-auto Problem::post(SumEquals<Weighted<IntegerVariableID>> expr, const string & name) -> void
+auto Problem::post_named(SumEquals<Weighted<IntegerVariableID>> expr, const string & name) -> void
 {
-    post(LinearEquality(move(expr.lhs), expr.rhs), name);
+    post_named(LinearEquality(move(expr.lhs), expr.rhs), name);
 }
 
 auto Problem::add_presolver(const Presolver & p) -> void

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -1,3 +1,4 @@
+#include "gcs/constraint.hh"
 #include <gcs/constraints/in.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -16,6 +17,7 @@
 #include <regex>
 #include <tuple>
 #include <unordered_set>
+#include <variant>
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -58,6 +60,7 @@ struct Problem::Imp
     optional<IntegerVariableID> optional_minimise_variable{};
     unordered_set<string> names;
     unsigned long long next_anon_variable = 0;
+    unsigned long long next_constraint_number = 0;
 };
 
 Problem::Problem() :
@@ -155,7 +158,10 @@ auto Problem::create_state_for_new_search(
 
 auto Problem::post(const Constraint & c) -> void
 {
-    _imp->constraints.push_back(c.clone());
+    auto cloned = c.clone();
+    if (std::holds_alternative<CurrentlyUnnamedConstraint>(cloned->name()))
+        cloned->set_name(NumberedConstraint{++_imp->next_constraint_number});
+    _imp->constraints.push_back(std::move(cloned));
 }
 
 auto Problem::post(SumLessThanEqual<Weighted<IntegerVariableID>> expr) -> void

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -159,16 +159,14 @@ auto Problem::create_state_for_new_search(
 auto Problem::post(const Constraint & c) -> void
 {
     auto cloned = c.clone();
-    if (std::holds_alternative<CurrentlyUnnamedConstraint>(cloned->name()))
-        cloned->set_name(NumberedConstraint{++_imp->next_constraint_number});
+    cloned->set_name(NumberedConstraint{++_imp->next_constraint_number});
     _imp->constraints.push_back(std::move(cloned));
 }
 
 auto Problem::post(const Constraint & c, const string & name) -> void
 {
     auto cloned = c.clone();
-    if (std::holds_alternative<CurrentlyUnnamedConstraint>(cloned->name()))
-        cloned->set_name(NamedConstraint{name});
+    cloned->set_name(NamedConstraint{check_name(name)}); 
     _imp->constraints.push_back(std::move(cloned));
 }
 
@@ -177,9 +175,19 @@ auto Problem::post(SumLessThanEqual<Weighted<IntegerVariableID>> expr) -> void
     post(LinearLessThanEqual(move(expr.lhs), expr.rhs));
 }
 
+auto Problem::post(SumLessThanEqual<Weighted<IntegerVariableID>> expr, const string & name) -> void
+{
+    post(LinearLessThanEqual(move(expr.lhs), expr.rhs), name);
+}
+
 auto Problem::post(SumEquals<Weighted<IntegerVariableID>> expr) -> void
 {
     post(LinearEquality(move(expr.lhs), expr.rhs));
+}
+
+auto Problem::post(SumEquals<Weighted<IntegerVariableID>> expr, const string & name) -> void
+{
+    post(LinearEquality(move(expr.lhs), expr.rhs), name);
 }
 
 auto Problem::add_presolver(const Presolver & p) -> void

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -88,6 +88,11 @@ namespace gcs
         auto post(const Constraint &) -> void;
 
         /**
+         * \brief Add a named clone of this Constraint to the model.
+         */
+        auto post(const Constraint &, const std::string &) -> void;
+
+        /**
          * \brief Post this expression as a LinearLessThanEqual constraint.
          */
         auto post(SumLessThanEqual<Weighted<IntegerVariableID>>) -> void;

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -90,7 +90,7 @@ namespace gcs
         /**
          * \brief Add a named clone of this Constraint to the model.
          */
-        auto post(const Constraint &, const std::string &) -> void;
+        auto post_named(const Constraint &, const std::string &) -> void;
 
         /**
          * \brief Post this expression as a LinearLessThanEqual constraint.
@@ -100,7 +100,7 @@ namespace gcs
         /**
          * \brief Post this expression as a named LinearLessThanEqual constraint.
          */
-        auto post(SumLessThanEqual<Weighted<IntegerVariableID>>, const std::string &) -> void;
+        auto post_named(SumLessThanEqual<Weighted<IntegerVariableID>>, const std::string &) -> void;
 
         /**
          * \brief Post this expression as a LinearEquality constraint.
@@ -110,7 +110,7 @@ namespace gcs
         /**
          * \brief Post this expression as a named LinearEquality constraint.
          */
-        auto post(SumEquals<Weighted<IntegerVariableID>>, const std::string &) -> void;
+        auto post_named(SumEquals<Weighted<IntegerVariableID>>, const std::string &) -> void;
 
         /**
          * \brief Add a clone of this Presolver to the model.

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -98,9 +98,19 @@ namespace gcs
         auto post(SumLessThanEqual<Weighted<IntegerVariableID>>) -> void;
 
         /**
+         * \brief Post this expression as a named LinearLessThanEqual constraint.
+         */
+        auto post(SumLessThanEqual<Weighted<IntegerVariableID>>, const std::string &) -> void;
+
+        /**
          * \brief Post this expression as a LinearEquality constraint.
          */
         auto post(SumEquals<Weighted<IntegerVariableID>>) -> void;
+
+        /**
+         * \brief Post this expression as a named LinearEquality constraint.
+         */
+        auto post(SumEquals<Weighted<IntegerVariableID>>, const std::string &) -> void;
 
         /**
          * \brief Add a clone of this Presolver to the model.

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -184,7 +184,6 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
                 }
                 println(s_expr, "    )");
                 println(s_expr, "    (");
-                unsigned n = 1;
                 for (const auto & c : problem.each_constraint()) {
                     println(s_expr, "        ({})", c.s_exprify(optional_proof->model()));
                 }

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -186,7 +186,7 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
                 println(s_expr, "    (");
                 unsigned n = 1;
                 for (const auto & c : problem.each_constraint()) {
-                    println(s_expr, "        ({})", c.s_exprify(format("c{}", n++), optional_proof->model()));
+                    println(s_expr, "        ({})", c.s_exprify(optional_proof->model()));
                 }
                 println(s_expr, "    )");
                 println(s_expr, ")");

--- a/test/capture_encodings.py
+++ b/test/capture_encodings.py
@@ -245,10 +245,13 @@ def assign_snapshots_to_cases(
 def run_one_test(
     test_bin: Path,
     out_root: Path,
+    args: Optional[List[str]] = None,
     timeout_sec: int = 0
 ) -> Tuple[List[CaseEvent], List[Snapshot], int]:
     test_name = test_bin.name
-    test_out = out_root / test_name
+    run_label="_".join(args) if args else None
+    subdir = f"{test_name}_{run_label}" if run_label else test_name
+    test_out = out_root / subdir
     run_dir = test_out / "run"
     snapshots_dir = test_out / "snapshots"
 
@@ -262,7 +265,7 @@ def run_one_test(
     stdout_log = test_out / "stdout.log"
     stderr_log = test_out / "stderr.log"
 
-    cmd = [str(test_bin)]
+    cmd = [str(test_bin)] + (args if args is not None else [])
     proc = subprocess.Popen(
         cmd,
         cwd=run_dir,
@@ -270,7 +273,6 @@ def run_one_test(
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
-        universal_newlines=True,
     )
 
     stdout_lines: List[str] = []
@@ -351,6 +353,7 @@ def write_reports(
         "s-expression encoding",
         "expected solutions",
         "proof result",
+        "valid encoding",
     ]
 
     with tsv_min.open("w", newline="", encoding="utf-8") as f:
@@ -374,6 +377,7 @@ def write_reports(
                 "s-expression encoding",
                 "expected solutions",
                 "proof result",
+                "valid encoding",
                 "test_binary",
                 "source_scp_name",
                 "case_index",
@@ -382,6 +386,19 @@ def write_reports(
         )
         for r in rows_debug:
             w.writerow(r)
+
+            
+def is_valid_encoding(enc) -> bool:
+    # Use a stack to check for balanced brackets
+    stack = []
+    for char in enc:
+        if char == '(':
+            stack.append(char)
+        elif char == ')':
+            if not stack:
+                return False
+            stack.pop()
+    return not stack
 
 
 def main() -> int:
@@ -405,35 +422,60 @@ def main() -> int:
 
     for test_bin in test_bins:
         print(f"Running {test_bin.name} ...")
-        case_events, snaps, rc = run_one_test(test_bin, out_dir, timeout_sec=0)
 
-        if rc != 0:
-            failures.append(f"{test_bin.name} exited with {rc}")
+        if "linear_test" in test_bin.name:
+            arg_sets = [["le"], ["eq"], ["ne"], ["ge"]]
+        elif "comparison_test" in test_bin.name:
+            arg_sets = [["lt"], ["lt_if"], ["lt_iff"],
+                        ["le"], ["le_if"], ["le_iff"],
+                        ["ge"], ["ge_if"], ["ge_iff"],
+                        ["gt"], ["gt_if"], ["gt_iff"]]
+        elif "element_test" in test_bin.name:
+            arg_sets = [["var"], ["var2d"], ["const"], ["const2d"]]
+        elif "smart_table_test" in test_bin.name:
+            arg_sets = [["lex_gt"], ["lex_ge"], ["lex_lt"], ["lex_le"], 
+                        ["lex_gt_fixed"], ["lex_ge_fixed"], ["lex_lt_fixed"], ["lex_le_fixed"], 
+                        ["am1_eq"], ["am1_in_set"], ["al1_eq"],["al1_in_set"]]
+        else:
+            arg_sets = [[]]
 
-        pairs, pair_warnings = assign_snapshots_to_cases(case_events, snaps)
-        warnings.extend(f"{test_bin.name}: {w}" for w in pair_warnings)
+        for args in arg_sets:
+            label = f"{test_bin.name}" + (f" [{' '.join(args)}]" if args else "")
+            if args:
+                print(f"  Adding args for {test_bin.name}: {args}")
 
-        for case_event, snap in pairs:
-            c = case_event.row
-            enc = extract_s_expression_encoding(snap.path)
-            rows_minimal.append((
-                c.constraint_type,
-                c.configuration,
-                enc,
-                c.expected_solutions,
-                c.proof_result,
-            ))
-            rows_debug.append((
-                c.constraint_type,
-                c.configuration,
-                enc,
-                c.expected_solutions,
-                c.proof_result,
-                test_bin.name,
-                snap.source_name,
-                case_event.seq,
-                str(snap.path),
-            ))
+            case_events, snaps, rc = run_one_test(test_bin, out_dir, args, timeout_sec=0)
+
+            if rc != 0:
+                failures.append(f"{label} exited with {rc}")
+
+            pairs, pair_warnings = assign_snapshots_to_cases(case_events, snaps)
+            warnings.extend(f"{label}: {w}" for w in pair_warnings)
+
+            for case_event, snap in pairs:
+                c = case_event.row
+                enc = extract_s_expression_encoding(snap.path)
+                valid = is_valid_encoding(enc)
+                rows_minimal.append((
+                    c.constraint_type,
+                    c.configuration,
+                    enc,
+                    c.expected_solutions,
+                    c.proof_result,
+                    valid,
+                ))
+                rows_debug.append((
+                    c.constraint_type,
+                    c.configuration,
+                    enc,
+                    c.expected_solutions,
+                    c.proof_result,
+                    valid,
+                    label,
+                    snap.source_name,
+                    case_event.seq,
+                    str(snap.path),
+                ))
 
     write_reports(out_dir, rows_minimal, rows_debug)
 


### PR DESCRIPTION
Looks like a rebase is in order.

This PR is implementing the named constraints functionality.  It looks like this:

`using ConstraintName = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;`

CurrentlyUnamedConstraint is the default, and is what constraints get when the constructor is called.  Cloning a constraint loses any set names back to CurrentlyUnamedConstraint.

I added plumbing to Problem::post() to support users adding named constraints.  I also added supporting code to enable "automatic" formatting of names in format strings.