### PR TITLE
opb-encoding: pilot in-code doc blocks for Equals, Abs, AllDifferent, Element

### DIFF
--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -88,6 +88,22 @@ auto Abs::install(Propagators & propagators, State &, ProofModel * const optiona
     install_propagators(propagators);
 }
 
+// OPB-ENCODING-BEGIN: abs
+//   s-expr:  abs v1 v2
+//   Clauses:
+//     ("Abs", "non-negative")
+//         1*v2 + -1*v1 == 0            half-reified on { v1 >= 0 }
+//     ("Abs", "negative")
+//         1*v2 + 1*v1 == 0             half-reified on { v1 < 0 }
+//   Bounds:                 (none)
+//   CP literals referenced: v1 >= 0  (v1 < 0 is its negation, handled
+//                                     syntactically by the encoder)
+//   Auxiliary PB flags:     (none)
+//   Notes:
+//     Textbook abs definition: v2 = |v1| means (v1 >= 0 => v2 = v1) and
+//     (v1 < 0 => v2 = -v1). v2's non-negativity is a consequence, not
+//     part of the encoding -- it's derived inside the proof.
+// OPB-ENCODING-END
 auto Abs::define_proof_model(ProofModel & model) -> void
 {
     _abs_nonneg_lines = model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -15,6 +15,26 @@ using std::vector;
 using namespace gcs;
 using namespace gcs::innards;
 
+// OPB-ENCODING-BEGIN: all_different
+//   s-expr:  all_different (x_0, x_1, ..., x_{n-1})
+//   Clauses (for each pair (i, j) with 0 <= i < j < n):
+//     ("AllDifferent", "not equals because lower")
+//         1*x_i + -1*x_j <= -1         half-reified on { notequals_{i,j} }
+//     ("AllDifferent", "not equals because higher")
+//         -1*x_i + 1*x_j <= -1         half-reified on { !notequals_{i,j} }
+//   Bounds:                 (none)
+//   CP literals referenced: (none)
+//   Auxiliary PB flags introduced (one per pair):
+//     notequals_{i,j} -- fresh PB variable; case-split guard for
+//                        x_i != x_j. Source allocates each as
+//                        create_proof_flag("notequals"); a per-pair
+//                        distinguishing protocol is TBD.
+//   Notes:
+//     Standard pairwise disequality clique. Each pair gets its own fresh
+//     "notequals" flag and the same two-clause case-split used by the
+//     scalar `not_equals` encoding: notequals_{i,j} forces x_i < x_j,
+//     its negation forces x_i > x_j, together excluding x_i = x_j.
+// OPB-ENCODING-END
 auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const vector<gcs::IntegerVariableID> & vars) -> optional<pair<IntegerVariableID, ProofFlag>>
 {
     optional<pair<IntegerVariableID, ProofFlag>> duplicate_witness;

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -178,6 +178,40 @@ auto NDimensionalElement<EntryType_, dimensions_>::prepare(Propagators & propaga
     return true;
 }
 
+// OPB-ENCODING-BEGIN: element_Dd (D-dimensional family; D in {1, 2, 3})
+//   s-expr (D=1):  element_1d (a_0 a_1 ... a_{n_0-1}) (idx_0, start_0) result
+//   s-expr (D=2):  element_2d ((a_{00} ... a_{0,n_1-1}) ...)
+//                              (idx_0, start_0) (idx_1, start_1) result
+//   s-expr (D=3):  element_3d (nested arrays) (idx_d, start_d) x 3 result
+//
+//   For dimension D and array of shape (n_0, ..., n_{D-1}):
+//
+//   Bounds (for each d in 0..D-1):
+//     ("NDimensionalElement", "index range")
+//         idx_d in [start_d, start_d + n_d - 1]
+//
+//   Clauses (for every combination (i_0, ..., i_{D-1}) with 0 <= i_d < n_d):
+//     ("NDimensionalElement", "equality")
+//         1*result + -1*a[i_0]..[i_{D-1}] == 0
+//         half-reified on
+//             { idx_0 == start_0 + i_0, ..., idx_{D-1} == start_{D-1} + i_{D-1} }
+//
+//   Special case (any n_d == 0):
+//     ("NDimensionalElement", "zero-sized dimension")
+//         0 >= 1            (trivially false; signals UNSAT)
+//
+//   CP literals referenced (for each d, each i in 0..n_d-1):
+//     idx_d == start_d + i
+//
+//   Auxiliary PB flags:     (none)
+//
+//   Notes:
+//     The encoding enumerates the full cartesian product of index values,
+//     emitting one half-reified equality per array cell. Array entries
+//     may be either integer variables or fixed constants; in the constant
+//     case `a[...]` is just an integer literal and the equality reduces
+//     to `result == <constant>`.
+// OPB-ENCODING-END
 template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel & model) -> void
 {
@@ -604,7 +638,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const ProofModel * 
         }
     };
 
-    print(s, "{} element (", _name);
+    print(s, "{} element_{}d (", _name, dimensions_);
 
     print_array(s, *_array, print_array);
 

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -145,10 +145,35 @@ auto ReifiedEquals::prepare(Propagators &, State & initial_state, ProofModel * c
 auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
 {
     overloaded{
+        // OPB-ENCODING-BEGIN: equals
+        //   s-expr:  equals v1 v2
+        //   Clauses:
+        //     ("ReifiedEquals", "equals option")
+        //         1*v1 + -1*v2 == 0
+        //   Bounds:                 (none)
+        //   CP literals referenced: (none)
+        //   Auxiliary PB flags:     (none)
+        // OPB-ENCODING-END
         [&](const reif::MustHold &) {
             model.add_constraint("ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i);
         },
+        // OPB-ENCODING-BEGIN: not_equals
+        //   s-expr:  not_equals v1 v2
+        //   Clauses:
+        //     ("ReifiedEquals", "greater option")
+        //         1*v1 + -1*v2 >= 1            half-reified on { gt }
+        //     ("ReifiedEquals", "less option")
+        //         1*v1 + -1*v2 <= -1           half-reified on { !gt }
+        //   Bounds:                 (none)
+        //   CP literals referenced: (none)
+        //   Auxiliary PB flags introduced:
+        //     gt -- fresh PB variable; case-split guard.
+        //   Notes:
+        //     PB cannot express disequality directly. The two clauses
+        //     case-split on gt: gt forces v1 > v2, !gt forces v1 < v2.
+        //     Together they exclude v1 = v2.
+        // OPB-ENCODING-END
         [&](const reif::MustNotHold &) {
             auto gtflag = model.create_proof_flag("gt");
             model.add_constraint("ReifiedEquals", "greater option",
@@ -156,10 +181,35 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
             model.add_constraint("ReifiedEquals", "less option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! gtflag}});
         },
+        // OPB-ENCODING-BEGIN: equals_if
+        //   s-expr:  equals_if cond v1 v2
+        //   Clauses:
+        //     ("ReifiedEquals", "equals option")
+        //         1*v1 + -1*v2 == 0            half-reified on { cond }
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags:     (none)
+        // OPB-ENCODING-END
         [&](const reif::If & reif) {
             model.add_constraint("ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
         },
+        // OPB-ENCODING-BEGIN: not_equals_if
+        //   s-expr:  not_equals_if cond v1 v2
+        //   Clauses:
+        //     ("ReifiedEquals", "greater option")
+        //         1*v1 + -1*v2 >= 1            half-reified on { cond, gt }
+        //     ("ReifiedEquals", "less option")
+        //         1*v1 + -1*v2 <= -1           half-reified on { cond, !gt }
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags introduced:
+        //     gt -- fresh PB variable; case-split guard.
+        //   Notes:
+        //     As `not_equals`, but each clause is additionally guarded by
+        //     cond. When cond is false neither clause fires, so v1 = v2
+        //     is permitted.
+        // OPB-ENCODING-END
         [&](const reif::NotIf & reif) {
             auto gtflag = model.create_proof_flag("gt");
             model.add_constraint("ReifiedEquals", "greater option",
@@ -167,6 +217,48 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
             model.add_constraint("ReifiedEquals", "less option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{reif.cond, ! gtflag}});
         },
+        // OPB-ENCODING-BEGIN: equals_iff
+        //   s-expr:  equals_iff cond v1 v2
+        //   Clauses:
+        //     ("ReifiedEquals", "equals option")
+        //         1*v1 + -1*v2 == 0            half-reified on { cond }
+        //     ("ReifiedEquals", "greater option")
+        //         1*v1 + -1*v2 >= 1            half-reified on { gt }
+        //     ("ReifiedEquals", "less option")
+        //         1*v1 + -1*v2 <= -1           half-reified on { lt }
+        //     ("ReifiedEquals", "one of less than, equals, greater than")
+        //         1*lt + 1*gt + 1*cond >= 1
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags introduced:
+        //     gt -- fresh PB variable; "v1 > v2" guard.
+        //     lt -- fresh PB variable; "v1 < v2" guard.
+        //   Notes:
+        //     Trichotomy: at least one of lt, gt, cond must hold. When
+        //     cond holds, the equals clause forces v1 = v2; when cond is
+        //     false, gt or lt must hold, each excluding v1 = v2.
+        // OPB-ENCODING-END
+        // OPB-ENCODING-BEGIN: not_equals_iff
+        //   s-expr:  not_equals_iff cond v1 v2
+        //   Clauses:
+        //     ("ReifiedEquals", "equals option")
+        //         1*v1 + -1*v2 == 0            half-reified on { !cond }
+        //     ("ReifiedEquals", "greater option")
+        //         1*v1 + -1*v2 >= 1            half-reified on { gt }
+        //     ("ReifiedEquals", "less option")
+        //         1*v1 + -1*v2 <= -1           half-reified on { lt }
+        //     ("ReifiedEquals", "one of less than, equals, greater than")
+        //         1*lt + 1*gt + 1*!cond >= 1
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (negated; encoder handles negation)
+        //   Auxiliary PB flags introduced:
+        //     gt -- fresh PB variable; "v1 > v2" guard.
+        //     lt -- fresh PB variable; "v1 < v2" guard.
+        //   Notes:
+        //     Same shape as `equals_iff` with cond replaced by !cond
+        //     throughout. Implemented in C++ by passing reif::Iff{!cond}
+        //     into the same arm.
+        // OPB-ENCODING-END
         [&](const reif::Iff & reif) {
             // condition unknown, the condition implies it is neither greater nor less
             model.add_constraint("ReifiedEquals", "equals option",

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -172,25 +172,119 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
         terms += c * v;
 
     overloaded{
+        // OPB-ENCODING-BEGIN: lin_equals
+        //   s-expr:  lin_equals ( c_1 v_1 c_2 v_2 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearEquality", "unconditional sum")
+        //         c_1*v_1 + c_2*v_2 + ... + c_n*v_n == value
+        //   Bounds:                 (none)
+        //   CP literals referenced: (none)
+        //   Auxiliary PB flags:     (none)
+        // OPB-ENCODING-END
         [&](const reif::MustHold &) {
             // condition is definitely true, it's just an inequality
             _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
         },
+        // OPB-ENCODING-BEGIN: lin_not_equals
+        //   s-expr:  lin_not_equals ( c_1 v_1 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearEquality", "greater option")
+        //         c_1*v_1 + ... + c_n*v_n >= value + 1     half-reified on { linne }
+        //     ("ReifiedLinearEquality", "less than option")
+        //         c_1*v_1 + ... + c_n*v_n <= value - 1     half-reified on { !linne }
+        //   Bounds:                 (none)
+        //   CP literals referenced: (none)
+        //   Auxiliary PB flags introduced:
+        //     linne -- fresh PB variable; case-split guard for the disequality.
+        //   Notes:
+        //     PB cannot express disequality directly. The two clauses
+        //     case-split on linne: linne forces the sum strictly greater
+        //     than value, !linne forces it strictly less. Together they
+        //     exclude equality with value.
+        // OPB-ENCODING-END
         [&](const reif::MustNotHold &) {
             // condition is definitely false, the flag implies either greater or less
             auto neflag = model.create_proof_flag("linne");
             model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
             model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
         },
+        // OPB-ENCODING-BEGIN: lin_equals_if
+        //   s-expr:  lin_equals_if cond ( c_1 v_1 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearEquality", "unconditional sum")
+        //         c_1*v_1 + ... + c_n*v_n == value         half-reified on { cond }
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags:     (none)
+        // OPB-ENCODING-END
         [&](const reif::If & cond) {
             _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
         },
+        // OPB-ENCODING-BEGIN: lin_not_equals_if
+        //   s-expr:  lin_not_equals_if cond ( c_1 v_1 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearEquality", "greater option")
+        //         c_1*v_1 + ... + c_n*v_n >= value + 1     half-reified on { cond, linne }
+        //     ("ReifiedLinearEquality", "less than option")
+        //         c_1*v_1 + ... + c_n*v_n <= value - 1     half-reified on { cond, !linne }
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags introduced:
+        //     linne -- fresh PB variable; case-split guard.
+        //   Notes:
+        //     As `lin_not_equals`, but each clause is additionally guarded
+        //     by cond. When cond is false neither clause fires, so the sum
+        //     is permitted to equal value.
+        // OPB-ENCODING-END
         [&](const reif::NotIf & cond) {
             // condition is definitely false, the flag implies either greater or less
             auto neflag = model.create_proof_flag("linne");
             model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
             model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
         },
+        // OPB-ENCODING-BEGIN: lin_equals_iff
+        //   s-expr:  lin_equals_iff cond ( c_1 v_1 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearEquality", "equals option")
+        //         c_1*v_1 + ... + c_n*v_n == value         half-reified on { cond }
+        //     ("ReifiedLinearEquality", "greater option")
+        //         c_1*v_1 + ... + c_n*v_n >= value + 1     half-reified on { lineqgt }
+        //     ("ReifiedLinearEquality", "less than option")
+        //         c_1*v_1 + ... + c_n*v_n <= value - 1     half-reified on { lineqlt }
+        //     ("ReifiedLinearEquality", "one of less than, equals, greater than")
+        //         1*lineqlt + 1*lineqgt + 1*cond >= 1
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags introduced:
+        //     lineqgt -- fresh PB variable; "sum > value" guard.
+        //     lineqlt -- fresh PB variable; "sum < value" guard.
+        //   Notes:
+        //     Trichotomy: at least one of lineqlt, lineqgt, cond must hold.
+        //     When cond holds, the equals clause forces sum == value;
+        //     when cond is false, lineqgt or lineqlt must hold, each
+        //     excluding equality with value.
+        // OPB-ENCODING-END
+        // OPB-ENCODING-BEGIN: lin_not_equals_iff
+        //   s-expr:  lin_not_equals_iff cond ( c_1 v_1 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearEquality", "equals option")
+        //         c_1*v_1 + ... + c_n*v_n == value         half-reified on { !cond }
+        //     ("ReifiedLinearEquality", "greater option")
+        //         c_1*v_1 + ... + c_n*v_n >= value + 1     half-reified on { lineqgt }
+        //     ("ReifiedLinearEquality", "less than option")
+        //         c_1*v_1 + ... + c_n*v_n <= value - 1     half-reified on { lineqlt }
+        //     ("ReifiedLinearEquality", "one of less than, equals, greater than")
+        //         1*lineqlt + 1*lineqgt + 1*!cond >= 1
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (negated; encoder handles negation)
+        //   Auxiliary PB flags introduced:
+        //     lineqgt -- fresh PB variable; "sum > value" guard.
+        //     lineqlt -- fresh PB variable; "sum < value" guard.
+        //   Notes:
+        //     Same shape as `lin_equals_iff` with cond replaced by !cond
+        //     throughout. Implemented in C++ by passing reif::Iff{!cond}
+        //     into the same arm.
+        // OPB-ENCODING-END
         [&](const reif::Iff & cond) {
             // condition unknown, the condition implies it is neither greater nor less
             _proof_line = model.add_constraint("ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -121,18 +121,51 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
         terms += c * v;
 
     overloaded{
+        // OPB-ENCODING-BEGIN: lin_less_than_equal
+        //   s-expr:  lin_less_than_equal ( c_1 v_1 c_2 v_2 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearInequality", "unconditional less than")
+        //         c_1*v_1 + c_2*v_2 + ... + c_n*v_n <= value
+        //   Bounds:                 (none)
+        //   CP literals referenced: (none)
+        //   Auxiliary PB flags:     (none)
+        // OPB-ENCODING-END
         [&](const reif::MustHold &) {
             _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional less than", terms <= _value, nullopt), nullopt};
         },
         [&](const reif::MustNotHold &) {
             _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional greater than", terms >= _value + 1_i, nullopt), nullopt};
         },
+        // OPB-ENCODING-BEGIN: lin_less_than_equal_if
+        //   s-expr:  lin_less_than_equal_if cond ( c_1 v_1 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearInequality", "less than option")
+        //         c_1*v_1 + ... + c_n*v_n <= value         half-reified on { cond }
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags:     (none)
+        // OPB-ENCODING-END
         [&](const reif::If & cond) {
             _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         },
         [&](const reif::NotIf & cond) {
             _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "greater than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         },
+        // OPB-ENCODING-BEGIN: lin_less_than_equal_iff
+        //   s-expr:  lin_less_than_equal_iff cond ( c_1 v_1 ... c_n v_n ) value
+        //   Clauses:
+        //     ("ReifiedLinearInequality", "less than option")
+        //         c_1*v_1 + ... + c_n*v_n <= value         half-reified on { cond }
+        //     ("ReifiedLinearInequality", "greater than option")
+        //         c_1*v_1 + ... + c_n*v_n >= value + 1     half-reified on { !cond }
+        //   Bounds:                 (none)
+        //   CP literals referenced: cond  (passed through, in canonical form)
+        //   Auxiliary PB flags:     (none)
+        //   Notes:
+        //     Total order: when cond holds, the sum is <= value; when cond
+        //     is false, the sum is >= value + 1. The two halves together
+        //     pin cond to the truth value of (sum <= value).
+        // OPB-ENCODING-END
         [&](const reif::Iff & cond) {
             _proof_lines = pair{
                 *model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),


### PR DESCRIPTION
## Summary

First pilot for the OPB-encoding documentation effort (#198): a structured
in-code `OPB-ENCODING-BEGIN` / `OPB-ENCODING-END` block above each
`define_proof_model` (or shared encoding helper), one block per s-expr
name. The block captures clauses (with `(name, sub_name)` labels and
half-reification guards), `define_bound` calls, CP literals referenced,
auxiliary PB flags introduced, and notes for anything non-obvious.

This is enough material to look at the format end-to-end and share with
the rest of the project for feedback before fanning out to every
constraint.

Constraints covered:

- **Equals** family: six blocks inline in the visitor for `equals`,
  `not_equals`, `equals_if`, `not_equals_if`, `equals_iff`,
  `not_equals_iff`. The `Iff` arm covers two s-expr names; each is given
  its own self-contained block rather than a "see X with substitution"
  pointer.
- **Abs**: one block; the textbook two-half-reified definition.
- **AllDifferent**: one block on the shared
  `define_clique_not_equals_encoding` helper (used by GAC, VC, and
  `SymmetricAllDifferent`). Records honestly that all per-pair
  `notequals` flags share a string name; per-pair distinguishing
  protocol is flagged TBD.
- **Element**: one parametric block describing `element_1d` /
  `element_2d` / `element_3d` as a D-dimensional family, plus a matching
  `s_exprify` rename so the s-expr name carries the dimension suffix.

Pilot-level design choices made along the way (open to revision once the
team reviews):

- In-code structured comment blocks, one per s-expr name; extractor
  script can come later once the format has settled.
- Inline placement above the relevant visitor arm / function. When two
  s-expr names share one C++ arm (Iff covers `equals_iff` and
  `not_equals_iff`), they get two consecutive blocks.
- Parametric pseudocode for constraints that loop over arity or
  dimension (AllDifferent, Element). Concrete per-name spelling-out
  would also work; can switch if reviewers prefer it.
- Clause syntax mirrors `WPBSum` source form rather than raw OPB
  syntax; the encoder team converts.
- Constraint labels in OPB (`"NDimensionalElement"` etc.) are kept as
  the source already has them; they aren't required to match s-expr
  names.

## Test plan

- [x] `abs_test`, `equals_test`, `all_different_test`, `element_test`
      all build and pass (Release).
- [x] No tests check s-expr file output, so the `element_1d` /
      `element_2d` / `element_3d` rename has no in-tree fixtures to
      regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)