### PR TITLE
exception: add InvalidProblemDefinitionException

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -246,6 +246,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(integer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME integer_test COMMAND $<TARGET_FILE:integer_test>)
 
+    add_executable(exception_test exception_test.cc)
+    target_link_libraries(exception_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME exception_test COMMAND $<TARGET_FILE:exception_test>)
+
     add_executable(state_test innards/state_test.cc)
     target_link_libraries(state_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME state_test COMMAND $<TARGET_FILE:state_test>)

--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -44,15 +44,15 @@ Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<Integer> lengths
     _capacity(capacity)
 {
     if (_starts.size() != _lengths.size() || _starts.size() != _heights.size())
-        throw UnexpectedException{"Cumulative: starts, lengths, heights must have the same size"};
+        throw InvalidProblemDefinitionException{"Cumulative: starts, lengths, heights must have the same size"};
     if (_capacity < 0_i)
-        throw UnexpectedException{"Cumulative: capacity must be non-negative"};
+        throw InvalidProblemDefinitionException{"Cumulative: capacity must be non-negative"};
     for (auto & l : _lengths)
         if (l < 0_i)
-            throw UnexpectedException{"Cumulative: lengths must be non-negative"};
+            throw InvalidProblemDefinitionException{"Cumulative: lengths must be non-negative"};
     for (auto & h : _heights)
         if (h < 0_i)
-            throw UnexpectedException{"Cumulative: heights must be non-negative"};
+            throw InvalidProblemDefinitionException{"Cumulative: heights must be non-negative"};
 }
 
 auto Cumulative::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -55,10 +55,10 @@ Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengt
     _strict(strict)
 {
     if (_starts.size() != _lengths.size())
-        throw UnexpectedException{"Disjunctive: starts and lengths must have the same size"};
+        throw InvalidProblemDefinitionException{"Disjunctive: starts and lengths must have the same size"};
     for (auto & l : _lengths)
         if (l < 0_i)
-            throw UnexpectedException{"Disjunctive: lengths must be non-negative"};
+            throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
 }
 
 auto Disjunctive::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -56,14 +56,14 @@ namespace
     auto check_array_dimensions(const vector<T_> & v, size_t expected) -> void
     {
         if (v.size() != expected)
-            throw UnexpectedException{"didn't get a regularly sized array for element constraint"};
+            throw InvalidProblemDefinitionException{"didn't get a regularly sized array for element constraint"};
     }
 
     template <typename T_>
     auto check_array_dimensions(const vector<vector<T_>> & v, size_t expected) -> void
     {
         if (v.size() != expected)
-            throw UnexpectedException{"didn't get a regularly sized array for element constraint"};
+            throw InvalidProblemDefinitionException{"didn't get a regularly sized array for element constraint"};
 
         for (const auto & vv : v) {
             check_array_dimensions(vv, v.at(0).size());

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -70,7 +70,7 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
 auto Inverse::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     if (_x.size() != _y.size())
-        throw UnexpectedException{"Inverse constraint on different sized arrays"};
+        throw InvalidProblemDefinitionException{"Inverse constraint on different sized arrays"};
 
     for (const auto & [idx, v] : enumerate(_x)) {
         propagators.define_bound(initial_state, optional_model, v, Bound::Lower, 0_i + _y_start, "Inverse", "x index range");

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -608,28 +608,28 @@ auto Knapsack::install(Propagators & propagators, State & initial_state, ProofMo
 auto Knapsack::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     if (_coeffs.size() != _totals.size())
-        throw UnexpectedException{"mismatch between coefficients and totals sizes for knapsack"};
+        throw InvalidProblemDefinitionException{"mismatch between coefficients and totals sizes for knapsack"};
 
     if (_coeffs.empty())
-        throw UnexpectedException{"empty knapsack coefficients"};
+        throw InvalidProblemDefinitionException{"empty knapsack coefficients"};
     unsigned n_vars = _coeffs.begin()->size();
 
     for (auto & c : _coeffs)
         if (c.size() != n_vars)
-            throw UnexpectedException{"not sure what to do about different coefficient array sizes for knapsack"};
+            throw InvalidProblemDefinitionException{"not sure what to do about different coefficient array sizes for knapsack"};
 
     for (auto & cc : _coeffs)
         for (auto & c : cc)
             if (c < 0_i)
-                throw UnexpectedException{"not sure what to do about negative coefficients for knapsack"};
+                throw InvalidProblemDefinitionException{"not sure what to do about negative coefficients for knapsack"};
 
     for (auto & v : _vars)
         if (initial_state.lower_bound(v) < 0_i)
-            throw UnexpectedException{"can only support non-negative variables for knapsack"};
+            throw InvalidProblemDefinitionException{"can only support non-negative variables for knapsack"};
 
     for (auto & t : _totals)
         if (initial_state.lower_bound(t) < 0_i)
-            throw UnexpectedException{"not sure what to do about negative permitted totals for knapsack"};
+            throw InvalidProblemDefinitionException{"not sure what to do about negative permitted totals for knapsack"};
 
     return true;
 }

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -70,7 +70,7 @@ auto ArrayMinMax::install(Propagators & propagators, State & initial_state, Proo
 auto ArrayMinMax::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     if (_vars.empty())
-        throw UnexpectedException{"not sure how min and max are defined over an empty array"};
+        throw InvalidProblemDefinitionException{"not sure how min and max are defined over an empty array"};
     return true;
 }
 

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -146,7 +146,7 @@ auto NegativeTable::prepare(Propagators &, State &, ProofModel * const) -> bool
     visit([&](auto & tuples) {
         for (auto & tuple : depointinate(tuples))
             if (tuple.size() != _vars.size())
-                throw UnexpectedException{"table size mismatch"};
+                throw InvalidProblemDefinitionException{"table size mismatch"};
     },
         _tuples);
     return true;

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -140,7 +140,7 @@ auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) ->
         }
         for (auto & tuple : depointinate(tuples))
             if (tuple.size() != _vars.size())
-                throw UnexpectedException{"table size mismatch"};
+                throw InvalidProblemDefinitionException{"table size mismatch"};
         _selector = initial_state.allocate_integer_variable_with_state(0_i, Integer(depointinate(tuples).size() - 1));
     },
         _tuples);

--- a/gcs/exception.cc
+++ b/gcs/exception.cc
@@ -27,6 +27,16 @@ auto UnexpectedException::what() const noexcept -> const char *
     return _wat.c_str();
 }
 
+InvalidProblemDefinitionException::InvalidProblemDefinitionException(const string & w) :
+    _wat("invalid problem definition: " + w)
+{
+}
+
+auto InvalidProblemDefinitionException::what() const noexcept -> const char *
+{
+    return _wat.c_str();
+}
+
 #if __has_include(<source_location>) && __cpp_lib_source_location
 
 namespace

--- a/gcs/exception.hh
+++ b/gcs/exception.hh
@@ -29,6 +29,25 @@ namespace gcs
     };
 
     /**
+     * \brief Thrown when a problem definition is semantically invalid: a
+     * constraint constructor given mismatched array sizes or negative
+     * durations, a variable created with lower bound greater than upper bound,
+     * etc. This indicates a bug in the caller, not the solver.
+     *
+     * \ingroup Core
+     */
+    class InvalidProblemDefinitionException : public std::exception
+    {
+    private:
+        std::string _wat;
+
+    public:
+        explicit InvalidProblemDefinitionException(const std::string &);
+
+        virtual auto what() const noexcept -> const char * override;
+    };
+
+    /**
      * \brief Thrown if a switch statement is missing a case entry. This usually
      * indicates a bug in the solver.
      *

--- a/gcs/exception_test.cc
+++ b/gcs/exception_test.cc
@@ -1,0 +1,73 @@
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/disjunctive.hh>
+#include <gcs/constraints/inverse.hh>
+#include <gcs/current_state.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+using namespace gcs;
+
+using std::vector;
+
+TEST_CASE("Problem::create_integer_variable rejects lower > upper")
+{
+    Problem p;
+    REQUIRE_THROWS_AS(p.create_integer_variable(5_i, 3_i), InvalidProblemDefinitionException);
+}
+
+TEST_CASE("Problem::create_integer_variable rejects empty domain")
+{
+    Problem p;
+    REQUIRE_THROWS_AS((p.create_integer_variable(vector<Integer>{})), InvalidProblemDefinitionException);
+}
+
+TEST_CASE("Cumulative rejects negative capacity")
+{
+    Problem p;
+    auto s = p.create_integer_variable(0_i, 10_i);
+    REQUIRE_THROWS_AS((Cumulative{{s}, {1_i}, {1_i}, -1_i}), InvalidProblemDefinitionException);
+}
+
+TEST_CASE("Cumulative rejects size mismatch")
+{
+    Problem p;
+    auto s = p.create_integer_variable(0_i, 10_i);
+    REQUIRE_THROWS_AS((Cumulative{{s}, {1_i, 2_i}, {1_i}, 5_i}), InvalidProblemDefinitionException);
+}
+
+TEST_CASE("Cumulative rejects negative length")
+{
+    Problem p;
+    auto s = p.create_integer_variable(0_i, 10_i);
+    REQUIRE_THROWS_AS((Cumulative{{s}, {-1_i}, {1_i}, 5_i}), InvalidProblemDefinitionException);
+}
+
+TEST_CASE("Disjunctive rejects size mismatch")
+{
+    Problem p;
+    auto s = p.create_integer_variable(0_i, 10_i);
+    REQUIRE_THROWS_AS((Disjunctive{{s}, {1_i, 2_i}}), InvalidProblemDefinitionException);
+}
+
+TEST_CASE("Disjunctive rejects negative length")
+{
+    Problem p;
+    auto s = p.create_integer_variable(0_i, 10_i);
+    REQUIRE_THROWS_AS((Disjunctive{{s}, {-1_i}}), InvalidProblemDefinitionException);
+}
+
+TEST_CASE("Inverse rejects mismatched array sizes")
+{
+    Problem p;
+    auto x1 = p.create_integer_variable(0_i, 1_i);
+    auto y1 = p.create_integer_variable(0_i, 1_i);
+    auto y2 = p.create_integer_variable(0_i, 1_i);
+    p.post(Inverse{{x1}, {y1, y2}});
+    REQUIRE_THROWS_AS((solve(p, [](const CurrentState &) -> bool { return true; })),
+        InvalidProblemDefinitionException);
+}

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -130,7 +130,7 @@ auto State::clone() const -> State
 auto State::allocate_integer_variable_with_state(Integer lower, Integer upper) -> SimpleIntegerVariableID
 {
     if (lower > upper)
-        throw UnexpectedException{"variable created with lower bound greater than upper bound"};
+        throw InvalidProblemDefinitionException{"variable created with lower bound greater than upper bound"};
     _imp->integer_variable_states.back().emplace_back(lower, upper);
     return SimpleIntegerVariableID{_imp->integer_variable_states.back().size() - 1};
 }

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -107,7 +107,7 @@ auto Problem::create_integer_variable(Integer lower, Integer upper,
     const optional<string> & name) -> SimpleIntegerVariableID
 {
     if (lower > upper)
-        throw UnexpectedException{"variable has lower bound > upper bound"};
+        throw InvalidProblemDefinitionException{"variable has lower bound > upper bound"};
 
     auto result = _imp->initial_state.allocate_integer_variable_with_state(lower, upper);
     _imp->integer_variables.emplace_back(result, lower, upper, name ? check_name(*name) : "_" + to_string(++_imp->next_anon_variable));
@@ -118,7 +118,7 @@ auto Problem::create_integer_variable(Integer lower, Integer upper,
 auto Problem::create_integer_variable(const vector<Integer> & domain, const optional<string> & name) -> SimpleIntegerVariableID
 {
     if (domain.empty())
-        throw UnexpectedException{"variable has empty domain"};
+        throw InvalidProblemDefinitionException{"variable has empty domain"};
 
     auto [min, max] = minmax_element(domain);
 


### PR DESCRIPTION
## Summary

- Adds `InvalidProblemDefinitionException` as a sibling of `UnexpectedException` in `gcs/exception.hh`, with prefix `"invalid problem definition: "`.
- Migrates the genuine caller-input sites in constraint constructors (`Cumulative`, `Disjunctive`, `Inverse`, `Element`, `ArrayMinMax`, `Knapsack`, `Table`, `NegativeTable`) and variable creation (`Problem::create_integer_variable`, `State::allocate_integer_variable_with_state`).
- Leaves runtime propagator/proof invariants and visitor defaults on `UnexpectedException` — those are genuine solver-internal cases.
- Adds `gcs/exception_test.cc` (Catch2, modelled on `integer_test.cc`) with 8 cases covering both kinds of site.

Closes #194.

Follow-ups spotted while surveying remaining callers:
- #201 — Circuit's "negative successor value" check is caller-input validation hiding inside proof emission as `UnimplementedException`; should hoist to `prepare` and become `InvalidProblemDefinitionException`.
- #202 — `power2()` throws `UnimplementedException` for an overflow; should be `IntegerOverflow`.

## Test plan

- [x] Release build clean (clang 21 + libc++)
- [x] Debug build clean
- [x] `exception_test` passes (8/8)
- [x] All migrated-site constraint tests pass: cumulative, disjunctive×2, inverse, knapsack, min_max, element×4, table, negative_table
- [x] `integer_test`, `state_test` still pass
- [ ] CI green on GCC 13 / Ubuntu 24.04 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)