### PR TITLE
Regular: upfront-DAG reimpl with Top-level proof scaffolding (#200)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -49,6 +49,12 @@ library. For an introduction to *using* the solver, start with the top-level
   in `constraints.md`; this doc spells them out for one concrete propagator
   and flags the bits that should carry across to `Disjunctive` and
   `BinPacking`.
+- [`Regular`: design and proof scaffolding](regular.md) — working-design
+  note for the upfront-DAG `Regular` propagator: layered-DAG view, OPB
+  encoding, Top-level scaffolding (per-val backward chains + statically-
+  dead-state lines), slim per-call propagator, and bench numbers vs
+  `RegularLegacy`. Cross-references the broader unification path of
+  issue #200.
 - [Proof logging for `Disjunctive`](disjunctive-proof-logging.md) — companion
   to the cumulative writeup, focused on the new bridge pattern:
   keeping the OPB encoding declarative (pairwise non-overlap clauses

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -57,6 +57,12 @@ library. For an introduction to *using* the solver, start with the top-level
   in `constraints.md`; this doc spells them out for one concrete propagator
   and flags the bits that should carry across to `Disjunctive` and
   `BinPacking`.
+- [`Regular`: design and proof scaffolding](regular.md) — working-design
+  note for the upfront-DAG `Regular` propagator: layered-DAG view, OPB
+  encoding, Top-level scaffolding (per-val backward chains + statically-
+  dead-state lines), slim per-call propagator, and bench numbers vs
+  `RegularLegacy`. Cross-references the broader unification path of
+  issue #200.
 - [Proof logging for `Disjunctive`](disjunctive-proof-logging.md) — companion
   to the cumulative writeup, focused on the new bridge pattern:
   keeping the OPB encoding declarative (pairwise non-overlap clauses

--- a/dev_docs/regular.md
+++ b/dev_docs/regular.md
@@ -1,0 +1,171 @@
+# `Regular`: design and proof scaffolding
+
+Working-design note for the `Regular` propagator. The legacy
+`RegularLegacy` is preserved alongside for side-by-side benchmarking
+and as a correctness reference; new code should post `Regular`. The
+high-level approach mirrors [`mdd.md`](mdd.md) (when written) and
+[`knapsack.md`](knapsack.md) (when written) — build the layered graph
+once in `prepare()`, emit the proof scaffolding (per-val backward
+chains, statically-dead-state lines) once at `ProofLevel::Top` via
+`install_initialiser`, and run a slim per-call sweep that emits at
+most one cache-gated `~state[i][q]` line at `ProofLevel::Current`
+per state-death.
+
+For the broader unification goal across `MDD`, `Regular`, `Knapsack`
+and `BinPacking`, see issue #200.
+
+## Constraint definition
+
+A `Regular` constraint over a sequence `vars[0..n-1]` is parameterised
+by a deterministic finite automaton:
+
+- `num_states`, the number of DFA states (state `0` is the start)
+- `transitions[q][val]`, a partial map from `(state, symbol) -> next
+  state` shared across all positions
+- `final_states`, the set of accepting states
+
+The sequence `vars[0..n-1]` is accepted iff feeding the symbols from
+left to right starting at state `0` ends in a state in `final_states`.
+
+Two constructors are supported, mirroring `RegularLegacy`:
+
+- `Regular(vars, num_states, vector<unordered_map<Integer,long>>
+  transitions, final_states)` — sparse map form.
+- `Regular(vars, num_states, vector<vector<long>> transitions,
+  final_states)` — dense table form (`-1` for no transition).
+
+The `short_reasons` constructor parameter is kept on the new `Regular`
+for API parity with `RegularLegacy` and for benchmarking
+(`regular_random --legacy --short-reasons` covers the
+short-reasons-on-legacy variant). It is forwarded to the propagator
+but the new design emits at most one proof line per state-death, so
+its effect is small or zero on this path.
+
+## Layered DAG view
+
+`Regular` is structurally a layer-uniform MDD: each input position
+yields a copy of the same state set `0..num_states-1`, and the same
+transition function applies at every position. Layer `i` holds the
+DFA state after consuming the first `i` symbols, so there are
+`n + 1` layers in total.
+
+This makes `Regular` a degenerate case of `MDD` where every layer
+shares its node set and transition function. The new implementation
+exploits that fact only at the level of OPB encoding (one shared
+alphabet rather than per-layer) and the scaffolding emission loop
+(no per-layer state-count or transition lookup); the proof
+derivations are the same as in `MDD`.
+
+## OPB encoding (unchanged from `RegularLegacy`)
+
+`define_proof_model` emits:
+
+```
+state_i_is_q          (proof flag for each (i, q), i ∈ 0..n, q ∈ 0..num_states-1)
+∑_q state_i_is_q == 1  for every layer i              (exactly-one per layer)
+state_0_is_0 >= 1                                     (start state pinned)
+∑_{f ∈ final_states} state_n_is_f >= 1                (accept at the end)
+```
+
+and, for every layer `i ∈ 0..n-1`, every state `q`, and every value
+`val` in the OPB alphabet (the union of all transition keys and every
+variable's initial domain):
+
+- If `transitions[q]` has no entry for `val`:
+  `(vars[i] != val) + ~state_i_is_q >= 1`
+- Otherwise, where `q' = transitions[q][val]`:
+  `~state_i_is_q + (vars[i] != val) + state_{i+1}_is_q' >= 1`
+
+A human reading the OPB sees DFA semantics, not propagator internals.
+
+## Top-level scaffolding (new in `Regular`)
+
+`install_initialiser` emits, **once** at search root and only if proof
+logging is enabled:
+
+1. **Per-val backward chains.** For each `(i, q', val)` with
+   `val ∈ initial dom(vars[i])`:
+   ```
+   ~state_{i+1}_is_q' + (vars[i] != val) + ∑_{q : T(q,val)=q'} state_i_is_q >= 1
+   ```
+   These are RUP-derivable from the OPB forward chains plus the
+   per-layer exactly-one: assume `state_{i+1}_is_q' = 1` and
+   `vars[i] = val`; AMO at layer `i+1` forces every other
+   `state_{i+1}_*` to zero; layer-`i` ALO forces some non-parent
+   `state_i_is_q* = 1`; the OPB forward chain for `(q*, val)`
+   UP-contradicts.
+
+2. **Statically-dead-state lines.** A state is statically dead iff
+   it has no path from the root forward, or no path forward to any
+   accepting state, under initial domains. For each dead `(i, q)`
+   `Regular` emits `~state_i_is_q >= 1` at Top:
+   - Forward-unreachable nodes in ascending layer order — their RUP
+     uses the new per-val backward chains plus already-emitted
+     earlier-layer `~state_{i-1}_*` lines.
+   - The rest (forward-reachable but no path forward to a final
+     state) in descending layer order — their RUP uses the OPB
+     forward chains plus already-emitted later-layer `~state_{i+1}_*`
+     lines, plus the `final_states` ALO at layer `n`.
+
+The per-subtree `DeadCache` is pre-populated with the static-dead set
+so the per-call propagator's first emission for those states is a
+no-op.
+
+## Per-call propagator
+
+For each propagation call:
+
+1. On the first call, build the support graph (forward-reachability,
+   then accepting-state filter, then backward-reachability) under the
+   current domain. Each newly-dead `(i, q)` triggers one cache-gated
+   `~state_i_is_q >= 1` line at Current.
+2. On every call, for each value `val` that the propagator's record
+   of `states_supporting[i][val]` knows still has support but is now
+   absent from `vars[i]`'s current domain, drop the corresponding
+   edges; the resulting `out_deg`/`in_deg` reductions cascade through
+   `decrement_outdeg` / `decrement_indeg`, each step optionally
+   emitting one cache-gated `~state_i_is_q >= 1` line at Current when
+   a state's last edge disappears.
+3. Final inferences: for every `(i, val)` where
+   `states_supporting[i][val]` is empty, infer `vars[i] != val` with
+   `JustifyUsingRUP{}` against the generic reason. The OPB forward
+   chains plus the Top-level backward chains plus the cached
+   `~state_*_*` lines let UP close it without any per-call
+   intermediate emissions.
+
+The contrast with `RegularLegacy` is exactly the same as the
+MDD/Knapsack contrast: the legacy implementation emitted per-(parent
+state, val) intermediate aggregations on every propagation call;
+`Regular` does that work once at root.
+
+## Benchmark (regular_random)
+
+`regular_random --legacy [--short-reasons]` exposes all three
+variants from one binary. Sampled at the seed already hard-coded into
+`add_test(regular_random-seeded ...)`:
+
+| n  | variant            | solve | proof    | verify |
+|---:|--------------------|------:|---------:|-------:|
+| 10 | new                | 0.00s | 86 KB    | 0.00s  |
+| 10 | legacy             | 0.01s | 1.76 MB  | 0.03s  |
+| 10 | legacy + short-rsn | 0.00s | 454 KB   | 0.04s  |
+| 14 | new                | 0.00s | 230 KB   | 0.02s  |
+| 14 | legacy             | 0.06s | 8.76 MB  | 0.13s  |
+| 14 | legacy + short-rsn | 0.01s | 1.75 MB  | 0.24s  |
+| 18 | new                | 0.01s | 490 KB   | 0.06s  |
+| 18 | legacy             | 0.25s | 33.3 MB  | 0.51s  |
+| 18 | legacy + short-rsn | 0.04s | 4.95 MB  | 0.98s  |
+
+The new `Regular` produces proofs that are 4–68× smaller than the
+legacy default and 1.5–10× smaller than the legacy with
+`short_reasons` enabled, and VeriPB verifies them faster on every
+sampled size. This matches the MDD-reimpl shape (proof shrink + slim
+per-call); it doesn't follow the `BinPacking` regression because
+`RegularLegacy`'s per-call work is far from already-lean.
+
+## #200 follow-up
+
+`Regular` and `MDD` now share the same Top-scaffolding shape modulo
+layer-uniform vs per-layer transitions. Folding both into a single
+layered-DAG scaffolder is the natural next step; that's the scope of
+issue #200.

--- a/dev_docs/regular.md
+++ b/dev_docs/regular.md
@@ -1,15 +1,50 @@
 # `Regular`: design and proof scaffolding
 
-Working-design note for the `Regular` propagator. The legacy
-`RegularLegacy` is preserved alongside for side-by-side benchmarking
-and as a correctness reference; new code should post `Regular`. The
-high-level approach mirrors [`mdd.md`](mdd.md) (when written) and
+Working-design note for the `Regular` propagator. The high-level
+approach mirrors [`mdd.md`](mdd.md) (when written) and
 [`knapsack.md`](knapsack.md) (when written) — build the layered graph
 once in `prepare()`, emit the proof scaffolding (per-val backward
 chains, statically-dead-state lines) once at `ProofLevel::Top` via
 `install_initialiser`, and run a slim per-call sweep that emits at
 most one cache-gated `~state[i][q]` line at `ProofLevel::Current`
 per state-death.
+
+## Default: the upfront `Regular`
+
+**`Regular` (this upfront-scaffolding propagator) is the default.**
+Everything posts it — both frontends
+(`xcsp_glasgow_constraint_solver`, `fzn_glasgow`), the constraint
+tests, and the `regular_random` example. `RegularLegacy` — the older
+per-call propagator that re-emits per-`(parent state, val)`
+intermediate aggregations on every propagation call — is preserved
+only as the `--legacy` opt-in twin, for side-by-side benchmarking and
+as a correctness reference.
+
+The reason for defaulting to upfront is that it **wins on both axes
+that matter for proof logging**, measured within-branch (same search
+tree to the digit — only the propagator is toggled):
+
+- **Proof size: 13–55× smaller.** At the largest sampled instance the
+  upfront `Regular` produced a 9 MB proof against `RegularLegacy`'s
+  496 MB (7660 solutions).
+- **VeriPB verification time: 2.3–7× faster** (1.66 s vs 11.69 s on
+  that instance).
+
+Both effects grow with search size: the fixed root scaffold amortises,
+and the displaced per-call volume compounds. (At trivially small search
+— tens of solutions — the fixed root scaffold is not yet amortised, so
+upfront can be marginally bigger/slower; the crossover is well below
+any real instance.)
+
+This is the *narrow-diagram* case of the general decision-diagram
+proof-strategy analysis: because a `Regular` automaton is narrow, the
+permanent Top-level scaffold is tiny, so it adds almost no per-line
+"DB-tax" to the rest of the proof, while the per-call `RegularLegacy`
+baseline is very verbose (large displacement). Displacement far
+exceeds the tax, so upfront wins size *and* time. See
+[`decision-diagram-proof-strategies.md`](decision-diagram-proof-strategies.md)
+for the cost model, the predictive rule, and how the same analysis
+lands MDD, Knapsack and BinPacking on different defaults.
 
 For the broader unification goal across `MDD`, `Regular`, `Knapsack`
 and `BinPacking`, see issue #200.

--- a/examples/regular_random/regular_random.cc
+++ b/examples/regular_random/regular_random.cc
@@ -35,7 +35,7 @@ auto index_of(const IntegerVariableID & val, const vector<IntegerVariableID> & v
     return (int)pos;
 }
 
-auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_reasons)
+auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_reasons, bool legacy)
 {
     stringstream string_rep;
 
@@ -78,7 +78,10 @@ auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_r
         }
     }
 
-    p.post(Regular{x, num_states, transitions, final_states, short_reasons});
+    if (legacy)
+        p.post(RegularLegacy{x, num_states, transitions, final_states, short_reasons});
+    else
+        p.post(Regular{x, num_states, transitions, final_states, short_reasons});
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -94,7 +97,8 @@ auto main(int argc, char * argv[]) -> int
             ("n", "Number of variables in the sequence", cxxopts::value<int>()->default_value("6"))                                //
             ("stats", "Print stats, including solve time")                                                                         //
             ("proof-files-basename", "Alternative path and name for the proof", cxxopts::value<string>()->default_value("regular_random")) //
-            ("short-reasons", "Use short reasons method");
+            ("short-reasons", "Use short reasons method (RegularLegacy only)")                                                      //
+            ("legacy", "Post RegularLegacy instead of the new Regular");
 
         options_vars = options.parse(argc, argv);
     }
@@ -116,6 +120,7 @@ auto main(int argc, char * argv[]) -> int
     auto prove = options_vars.contains("prove");
     auto print_stats = options_vars.contains("stats");
     auto short_reasons = options_vars.contains("short-reasons");
+    auto legacy = options_vars.contains("legacy");
     auto proof_prefix = options_vars["proof-files-basename"].as<string>();
 
     if (seed == -1) {
@@ -127,7 +132,7 @@ auto main(int argc, char * argv[]) -> int
     // cout << "Seed for random DFAs for Regular: " << seed << endl;
     //    mt19937 rng(0); // Switch to this to have it the same every time.
     auto p = Problem{};
-    post_random_regular(p, n, rng, short_reasons);
+    post_random_regular(p, n, rng, short_reasons, legacy);
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/regular_random/regular_random.cc
+++ b/examples/regular_random/regular_random.cc
@@ -36,7 +36,7 @@ auto index_of(const IntegerVariableID & val, const vector<IntegerVariableID> & v
     return (int)pos;
 }
 
-auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_reasons)
+auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_reasons, bool legacy)
 {
     stringstream string_rep;
 
@@ -79,8 +79,12 @@ auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_r
         }
     }
 
-    p.post(Regular{x, num_states, transitions, final_states} //
-            .with_short_reasons(short_reasons));
+    if (legacy)
+        p.post(RegularLegacy{x, num_states, transitions, final_states} //
+                .with_short_reasons(short_reasons));
+    else
+        p.post(Regular{x, num_states, transitions, final_states} //
+                .with_short_reasons(short_reasons));
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -96,7 +100,8 @@ auto main(int argc, char * argv[]) -> int
             ("n", "Number of variables in the sequence", cxxopts::value<int>()->default_value("6"))                                        //
             ("stats", "Print stats, including solve time")                                                                                 //
             ("proof-files-basename", "Alternative path and name for the proof", cxxopts::value<string>()->default_value("regular_random")) //
-            ("short-reasons", "Use short reasons method");
+            ("short-reasons", "Use short reasons method (RegularLegacy only)")                                                             //
+            ("legacy", "Post RegularLegacy instead of the new Regular");
 
         options_vars = options.parse(argc, argv);
     }
@@ -118,6 +123,7 @@ auto main(int argc, char * argv[]) -> int
     auto prove = options_vars.contains("prove");
     auto print_stats = options_vars.contains("stats");
     auto short_reasons = options_vars.contains("short-reasons");
+    auto legacy = options_vars.contains("legacy");
     auto proof_prefix = options_vars["proof-files-basename"].as<string>();
 
     if (seed == -1) {
@@ -127,7 +133,7 @@ auto main(int argc, char * argv[]) -> int
 
     std::mt19937 rng(seed);
     auto p = Problem{};
-    post_random_regular(p, n, rng, short_reasons);
+    post_random_regular(p, n, rng, short_reasons, legacy);
 
     auto stats = solve_with(p,                                                           //
         SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return false; }}, //

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(glasgow_constraint_solver
         constraints/power/power.cc
         constraints/power/power_table.cc
         constraints/regular/regular.cc
+        constraints/regular/regular_legacy.cc
         constraints/regular/regex.cc
         constraints/seq_precede_chain/seq_precede_chain.cc
         constraints/smart_table/smart_table.cc
@@ -213,6 +214,7 @@ if(GCS_BUILD_TESTS)
     add_executable(product_bounds_test constraints/innards/product_bounds_test.cc)
     add_executable(product_justify_test constraints/innards/product_justify_test.cc)
     add_executable(regular_test constraints/regular/regular_test.cc)
+    add_executable(regular_legacy_test constraints/regular/regular_legacy_test.cc)
     add_executable(seq_precede_chain_test constraints/seq_precede_chain/seq_precede_chain_test.cc)
     add_executable(smart_table_test constraints/smart_table/smart_table_test.cc)
     add_executable(smart_table_dup_test constraints/smart_table/smart_table_dup_test.cc)
@@ -230,7 +232,7 @@ if(GCS_BUILD_TESTS)
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test comparison_test
             count_test cumulative_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test lex_test linear_test linear_constant_test
             logical_test min_max_test multiply_test n_value_test parity_test
-            plus_minus_test power_test product_bounds_test product_justify_test regular_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
+            plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
     endforeach()
@@ -376,6 +378,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME parity_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_test>)
     add_test(NAME plus_minus_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:plus_minus_test>)
     add_test(NAME regular_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:regular_test>)
+    add_test(NAME regular_legacy_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:regular_legacy_test>)
     add_test(NAME seq_precede_chain_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:seq_precede_chain_test>)
     foreach(mode lex_gt lex_ge lex_lt lex_le
                  lex_gt_fixed lex_ge_fixed lex_lt_fixed lex_le_fixed

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -54,7 +54,8 @@ add_library(glasgow_constraint_solver
         constraints/n_value.cc
         constraints/parity.cc
         constraints/plus.cc
-        constraints/regular.cc
+        constraints/regular/regular.cc
+        constraints/regular/regular_legacy.cc
         constraints/seq_precede_chain.cc
         constraints/smart_table.cc
         constraints/table/negative_table.cc
@@ -148,6 +149,7 @@ if(GCS_BUILD_TESTS)
     add_executable(parity_test constraints/parity_test.cc)
     add_executable(plus_minus_test constraints/plus_minus_test.cc)
     add_executable(regular_test constraints/regular_test.cc)
+    add_executable(regular_legacy_test constraints/regular_legacy_test.cc)
     add_executable(seq_precede_chain_test constraints/seq_precede_chain_test.cc)
     add_executable(smart_table_test constraints/smart_table_test.cc)
     add_executable(negative_table_test constraints/table/negative_table_test.cc)
@@ -159,7 +161,7 @@ if(GCS_BUILD_TESTS)
             abs_test all_different_test all_different_except_test all_equal_test among_test arithmetic_test at_most_one_test comparison_test
             count_test cumulative_test disjunctive_test element_test equals_test in_test increasing_test inverse_test knapsack_test lex_test linear_test
             logical_test min_max_test mult_bc_test n_value_test parity_test
-            plus_minus_test regular_test seq_precede_chain_test smart_table_test symmetric_all_different_test
+            plus_minus_test regular_test regular_legacy_test seq_precede_chain_test smart_table_test symmetric_all_different_test
             negative_table_test table_test value_precede_test)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
     endforeach()
@@ -202,6 +204,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME parity_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_test>)
     add_test(NAME plus_minus_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:plus_minus_test>)
     add_test(NAME regular_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:regular_test>)
+    add_test(NAME regular_legacy_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:regular_legacy_test>)
     add_test(NAME seq_precede_chain_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:seq_precede_chain_test>)
     foreach(mode lex_gt lex_ge lex_lt lex_le
                  lex_gt_fixed lex_ge_fixed lex_lt_fixed lex_le_fixed

--- a/gcs/constraints/regular.hh
+++ b/gcs/constraints/regular.hh
@@ -1,59 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_HH
 
-#include <gcs/constraint.hh>
-#include <gcs/extensional.hh>
-#include <gcs/innards/proofs/proof_only_variables.hh>
-#include <gcs/innards/state.hh>
-#include <gcs/variable_id.hh>
-#include <set>
-#include <unordered_map>
-#include <vector>
-namespace gcs
-{
-    /**
-     * \brief Constrain that the sequence of variables is a member of the
-     * language recognised by the given Deterministic Finite Automaton,
-     * equivalent to a regex expression. "short_reasons" uses aliases for
-     * reasons when proof logging is enabled, which can result in shorter
-     * proofs.
-     *
-     * \ingroup Constraints
-     */
-    class Regular : public Constraint
-    {
-    private:
-        const std::vector<IntegerVariableID> _vars;
-        const long _num_states;
-        std::vector<std::unordered_map<Integer, long>> _transitions;
-        const std::vector<long> _final_states;
-        const bool _short_reasons;
-        std::vector<Integer> _symbols;
-        std::vector<std::vector<innards::ProofFlag>> _state_at_pos_flags;
-        innards::ConstraintStateHandle _graph_idx;
-        std::set<Integer> _opb_alphabet;
-
-        [[nodiscard]] auto symbols() const -> const std::vector<Integer> &;
-
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
-
-    public:
-        explicit Regular(std::vector<IntegerVariableID> vars,
-            long num_states,
-            std::vector<std::unordered_map<Integer, long>> transitions,
-            std::vector<long> final_states, bool short_reasons = true);
-
-        explicit Regular(std::vector<IntegerVariableID> vars,
-            long num_states,
-            std::vector<std::vector<long>> transitions,
-            std::vector<long> final_states, bool sr = true);
-
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-        virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
-    };
-}
+#include <gcs/constraints/regular/regular.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
 
 #endif

--- a/gcs/constraints/regular.hh
+++ b/gcs/constraints/regular.hh
@@ -2,5 +2,6 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_HH
 
 #include <gcs/constraints/regular/regular.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
 
 #endif

--- a/gcs/constraints/regular/hints.hh
+++ b/gcs/constraints/regular/hints.hh
@@ -17,6 +17,17 @@ namespace gcs::innards::hints
         ConstraintID originator;
         static constexpr std::string_view hint_name = "regular";
     };
+
+    /**
+     * \brief RegularLegacy's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct RegularLegacy
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "regular_legacy";
+    };
 }
 
 #endif

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -192,6 +192,14 @@ namespace
     {
         graph.out_deg[i][k]--;
         if (graph.out_deg[i][k] == 0 && i > 0) {
+            // Emit before recursing to parents at i-1: ~state[i-1][l]'s RUP
+            // (when l's out_deg also hits 0 in the recursion) consumes the
+            // forward chain `state[i-1][l] ∧ x[i-1]=val → state[i][T(l,val)]`
+            // together with ~state[i][T(l,val)], so all dead children at
+            // layer i must be in the proof DB before any layer-(i-1) parent
+            // is derived. emit_dead_state is cache-gated, so the recursion
+            // can still reach this node without re-emission.
+            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
             for (const auto & edge : graph.in_edges[i][k]) {
                 auto l = edge.first;
                 graph.out_edges[i - 1][l].erase(k);
@@ -201,7 +209,6 @@ namespace
                 }
             }
             graph.in_edges[i][k] = {};
-            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
         }
     }
 

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -230,6 +230,14 @@ namespace
     {
         graph.out_deg[i][k]--;
         if (graph.out_deg[i][k] == 0 && i > 0) {
+            // Emit before recursing to parents at i-1: ~state[i-1][l]'s RUP
+            // (when l's out_deg also hits 0 in the recursion) consumes the
+            // forward chain `state[i-1][l] ∧ x[i-1]=val → state[i][T(l,val)]`
+            // together with ~state[i][T(l,val)], so all dead children at
+            // layer i must be in the proof DB before any layer-(i-1) parent
+            // is derived. emit_dead_state is cache-gated, so the recursion
+            // can still reach this node without re-emission.
+            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
             for (const auto & edge : graph.in_edges[i][k]) {
                 auto l = edge.first;
                 graph.out_edges[i - 1][l].erase(k);
@@ -242,7 +250,6 @@ namespace
                 }
             }
             graph.in_edges[i][k] = {};
-            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
         }
     }
 

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -1,4 +1,3 @@
-#include <cmath>
 #include <gcs/constraints/regular/hints.hh>
 #include <gcs/constraints/regular/regex.hh>
 #include <gcs/constraints/regular/regular.hh>
@@ -9,8 +8,8 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
-
 #include <gcs/proof.hh>
+
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -22,8 +21,7 @@
 
 #include <algorithm>
 #include <any>
-#include <cstdio>
-#include <functional>
+#include <memory>
 #include <optional>
 #include <set>
 #include <sstream>
@@ -38,7 +36,7 @@ using namespace gcs::innards;
 
 using std::any_cast;
 using std::cmp_less;
-using std::ios;
+using std::make_shared;
 using std::max;
 using std::min;
 using std::move;
@@ -46,6 +44,7 @@ using std::nullopt;
 using std::optional;
 using std::pair;
 using std::set;
+using std::shared_ptr;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -76,13 +75,28 @@ namespace
         return it->second;
     }
 
+    // Records the alphabet (sorted transition keys) for proof logging and s_expr.
+    auto symbols_of(const vector<unordered_map<Integer, set<long>>> & transitions) -> vector<Integer>
+    {
+        set<Integer> sym_set;
+        for (const auto & state_map : transitions)
+            for (const auto & [val, _] : state_map)
+                sym_set.insert(val);
+        return {sym_set.begin(), sym_set.end()};
+    }
+
     struct RegularGraph
     {
+        // states_supporting[i][val] = states in layer i with an outgoing transition
+        // on val that currently sit on a root-to-accepting path.
         vector<unordered_map<Integer, set<long>>> states_supporting;
+        // out_edges[i][q] maps target state q' (in layer i+1) to the set of values
+        // labelling edges q -> q'.
         vector<vector<unordered_map<long, unordered_set<Integer>>>> out_edges;
         vector<vector<long>> out_deg;
         vector<vector<unordered_map<long, unordered_set<Integer>>>> in_edges;
         vector<vector<long>> in_deg;
+        // nodes[i] = active states in layer i.
         vector<set<long>> nodes;
         bool initialised = false;
 
@@ -98,35 +112,47 @@ namespace
         }
     };
 
-    auto log_additional_inference(ProofLogger * const logger, const vector<Literal> & literals, const vector<ProofFlag> & proof_flags, const State &,
-        const ReasonLiterals & reason, string comment = "") -> void
+    // Per-subtree dead-state cache: tracks which `~state[i][q]` proof lines have
+    // already been emitted at or above the current search depth, so the per-call
+    // propagator skips re-emission. Pre-populated with the statically-dead set
+    // (those emitted at Top by the initialiser) so the first per-call sweep
+    // doesn't redundantly re-derive them.
+    struct DeadCache
     {
-        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
-            // Trying to cut down on repeated code
-            if (! comment.empty())
-                logger->emit_proof_comment(comment);
+        vector<set<long>> dead;
+    };
 
-            WPBSum terms;
-            for (const auto & lit : literals)
-                terms += 1_i * lit;
-            for (const auto & flag : proof_flags)
-                terms += 1_i * flag;
-            logger->emit_rup_proof_line_under_reason(reason, terms >= 1_i, ProofLevel::Current);
-        }
+    auto emit_dead_state(ProofLogger * const logger, DeadCache & cache, const vector<vector<ProofFlag>> & state_at_pos_flags, long i, long q,
+        const ReasonLiterals & reason) -> void
+    {
+        if (! logger || logger->get_assertion_level() != AssertionLevel::Off)
+            return;
+        if (cache.dead[i].contains(q))
+            return;
+        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * ! state_at_pos_flags[i][q] >= 1_i, ProofLevel::Current);
+        cache.dead[i].insert(q);
     }
 
-    auto initialise_graph(RegularGraph & graph, const vector<IntegerVariableID> & vars, const long num_states,
+    // True if state l at position pos still has a live out-edge labelled val. For
+    // a DFA this is never the case once the single (l, val) edge is gone, but an
+    // NFA may have several edges on the same value.
+    auto still_supports(const RegularGraph & graph, const long pos, const long l, Integer val) -> bool
+    {
+        for (const auto & [next_q, vals] : graph.out_edges[pos][l])
+            if (vals.contains(val))
+                return true;
+        return false;
+    }
+
+    auto initialise_graph(RegularGraph & graph, DeadCache & cache, const vector<IntegerVariableID> & vars, const long num_states,
         const vector<unordered_map<Integer, set<long>>> & transitions, const vector<long> & final_states,
         const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonLiterals & reason, ProofLogger * const logger)
     {
         auto num_vars = vars.size();
 
-        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-            logger->emit_proof_comment("Initialising graph");
-
-        // Forward phase: accumulate
+        // Forward phase: states reachable from the root under current domains.
         graph.nodes[0].insert(0);
-        for (unsigned long i = 0; i < num_vars; ++i) {
+        for (size_t i = 0; i < num_vars; ++i) {
             for (auto val : state.each_value_immutable(vars[i])) {
                 for (const auto & q : graph.nodes[i]) {
                     const auto & next_states = find_transitions(transitions[q], val);
@@ -138,37 +164,33 @@ namespace
                 }
             }
 
-            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
-                for (long next_q = 0; next_q < num_states; ++next_q) {
-                    if (graph.nodes[i + 1].contains(next_q))
-                        continue;
-                    // Want to eliminate this node i.e. prove !state[i+1][next_q]
-                    for (const auto & q : graph.nodes[i]) {
-                        // So first eliminate each previous state/variable combo
-                        for (auto val : state.each_value_mutable(vars[i]))
-                            log_additional_inference(
-                                logger, {vars[i] != val}, {! state_at_pos_flags[i][q], ! state_at_pos_flags[i + 1][next_q]}, state, reason);
-
-                        // Then eliminate each previous state
-                        log_additional_inference(logger, {}, {! state_at_pos_flags[i][q], ! state_at_pos_flags[i + 1][next_q]}, state, reason);
-                    }
-
-                    // Finally, can eliminate what we want
-                    log_additional_inference(logger, {}, {! state_at_pos_flags[i + 1][next_q]}, state, reason);
-                }
+            // States at layer i+1 not forward-reachable under current dom get a
+            // single ~state[i+1][next_q] line at Current, gated on the cache. The
+            // initialiser's Top backward chains plus the cached ~state[i][q] lines
+            // for parents eliminated at earlier layers let UP close this RUP.
+            for (long next_q = 0; next_q < num_states; ++next_q) {
+                if (graph.nodes[i + 1].contains(next_q))
+                    continue;
+                emit_dead_state(logger, cache, state_at_pos_flags, static_cast<long>(i) + 1, next_q, reason);
             }
         }
-        set<long> possible_final_states;
-        for (const auto & f : final_states) {
+
+        // Restrict the final layer to final states that are also reachable.
+        set<long> reachable_final;
+        for (auto f : final_states)
             if (graph.nodes[num_vars].contains(f))
-                possible_final_states.insert(f);
-        }
+                reachable_final.insert(f);
 
-        graph.nodes[num_vars] = possible_final_states;
+        // Anything reachable under current dom but not in final_states is already
+        // in cache.dead from the static set, so emit_dead_state is a no-op here
+        // for well-formed automata.
+        for (const auto & q : graph.nodes[num_vars])
+            if (! reachable_final.contains(q))
+                emit_dead_state(logger, cache, state_at_pos_flags, static_cast<long>(num_vars), q, reason);
+        graph.nodes[num_vars] = reachable_final;
 
-        // Backward phase: validate
-        for (long i = num_vars - 1; i >= 0; --i) {
-
+        // Backward phase: drop states with no path forward to a final state.
+        for (long i = static_cast<long>(num_vars) - 1; i >= 0; --i) {
             vector<char> state_is_support(num_states, 0);
 
             for (auto val : state.each_value_mutable(vars[i])) {
@@ -186,11 +208,8 @@ namespace
                     }
                     if (any_live_target)
                         state_is_support[q] = 1;
-                    else {
+                    else
                         graph.states_supporting[i][val].erase(q);
-                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-                            log_additional_inference(logger, {vars[i] != val}, {! state_at_pos_flags[i][q]}, state, reason);
-                    }
                 }
             }
 
@@ -198,8 +217,7 @@ namespace
             for (const auto & q : gn) {
                 if (! state_is_support[q]) {
                     graph.nodes[i].erase(q);
-                    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-                        log_additional_inference(logger, {}, {! state_at_pos_flags[i][q]}, state, reason, "back pass");
+                    emit_dead_state(logger, cache, state_at_pos_flags, i, q, reason);
                 }
             }
         }
@@ -207,19 +225,8 @@ namespace
         graph.initialised = true;
     }
 
-    // True if state l at position pos still has a live out-edge labelled val. For
-    // a DFA this is never the case once the single (l, val) edge is gone, but an
-    // NFA may have several edges on the same value.
-    auto still_supports(const RegularGraph & graph, const long pos, const long l, Integer val) -> bool
-    {
-        for (const auto & [next_q, vals] : graph.out_edges[pos][l])
-            if (vals.contains(val))
-                return true;
-        return false;
-    }
-
-    auto decrement_outdeg(RegularGraph & graph, const long i, const long k, const vector<IntegerVariableID> & vars,
-        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonLiterals & reason, ProofLogger * const logger) -> void
+    auto decrement_outdeg(RegularGraph & graph, DeadCache & cache, const long i, const long k, const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const ReasonLiterals & reason, ProofLogger * const logger) -> void
     {
         graph.out_deg[i][k]--;
         if (graph.out_deg[i][k] == 0 && i > 0) {
@@ -228,72 +235,44 @@ namespace
                 graph.out_edges[i - 1][l].erase(k);
                 for (const auto & val : edge.second) {
                     // For an NFA, l may still reach a live state on val via
-                    // another edge; only drop support (and justify doing so)
-                    // once no such edge remains.
-                    if (! still_supports(graph, i - 1, l, val)) {
+                    // another edge; only drop support once no such edge remains.
+                    if (! still_supports(graph, i - 1, l, val))
                         graph.states_supporting[i - 1][val].erase(l);
-                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-                            log_additional_inference(
-                                logger, {vars[i - 1] != val}, {! state_at_pos_flags[i - 1][l]}, state, reason, "dec outdeg inner");
-                    }
-                    decrement_outdeg(graph, i - 1, l, vars, state_at_pos_flags, state, reason, logger);
+                    decrement_outdeg(graph, cache, i - 1, l, state_at_pos_flags, reason, logger);
                 }
             }
             graph.in_edges[i][k] = {};
-            if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-                log_additional_inference(logger, {}, {! state_at_pos_flags[i][k]}, state, reason, "dec outdeg");
+            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
         }
     }
 
-    auto decrement_indeg(RegularGraph & graph, const long i, const long k, const vector<IntegerVariableID> & vars,
-        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonLiterals & reason, ProofLogger * const logger) -> void
+    auto decrement_indeg(RegularGraph & graph, DeadCache & cache, const long i, const long k, const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const ReasonLiterals & reason, ProofLogger * const logger) -> void
     {
         graph.in_deg[i][k]--;
         if (graph.in_deg[i][k] == 0 && cmp_less(i, graph.in_deg.size() - 1)) {
-            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
-                // Again, want to eliminate this node i.e. prove !state[i][k]
-                for (const auto & q : graph.nodes[i - 1]) {
-                    // So first eliminate each previous state/variable combo
-                    for (auto val : state.each_value_mutable(vars[i])) {
-                        log_additional_inference(
-                            logger, {vars[i] != val}, {! state_at_pos_flags[i - 1][q], ! state_at_pos_flags[i][k]}, state, reason);
-                    }
-
-                    // Then eliminate each previous state
-                    log_additional_inference(logger, {}, {! state_at_pos_flags[i - 1][q], ! state_at_pos_flags[i][k]}, state, reason);
-                }
-
-                // Finally, can eliminate what we want
-                log_additional_inference(logger, {}, {! state_at_pos_flags[i][k]}, state, reason);
-            }
+            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
             for (const auto & edge : graph.out_edges[i][k]) {
                 auto l = edge.first;
                 graph.in_edges[i + 1][l].erase(k);
-
                 for (const auto & val : edge.second) {
                     graph.states_supporting[i][val].erase(k);
-                    decrement_indeg(graph, i + 1, l, vars, state_at_pos_flags, state, reason, logger);
+                    decrement_indeg(graph, cache, i + 1, l, state_at_pos_flags, reason, logger);
                 }
             }
-
             graph.out_edges[i][k] = {};
         }
     }
 
     auto propagate_regular(const vector<IntegerVariableID> & vars, const long num_states,
         const vector<unordered_map<Integer, set<long>>> & transitions, const vector<long> & final_states,
-        const vector<vector<ProofFlag>> & state_at_pos_flags, const ConstraintStateHandle & graph_handle, const State & state, auto & inference,
-        ProofLogger * const logger, const bool short_reasons, const ConstraintID & owner) -> void
+        const vector<vector<ProofFlag>> & state_at_pos_flags, const ConstraintStateHandle & graph_handle, const ConstraintStateHandle & cache_handle,
+        const State & state, auto & inference, ProofLogger * const logger, const ConstraintID & owner) -> void
     {
-        auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
-        auto gen_reason = eager_reason(generic_reason(vars), state);
-
         // Degenerate empty sequence (issue #254): with no variables there is
         // nothing to propagate over, but the empty word is accepted only if the
-        // initial state (0) is itself a final state. The per-position loops
-        // below are all empty when vars.empty(), so detect the infeasible case
-        // explicitly. The proof model pins state_at_pos[0] to state 0 and
-        // requires it to be final (with an exactly-one over the states), so the
+        // initial state (0) is itself a final state. The proof model pins
+        // state_at_pos[0] to state 0 and requires it to be final, so the
         // contradiction is reverse-unit-propagatable.
         if (vars.empty()) {
             bool initial_is_final = false;
@@ -303,39 +282,25 @@ namespace
                     break;
                 }
             if (! initial_is_final)
-                inference.contradiction(logger, JustifyUsingRUP{hints::Regular{owner}}, gen_reason);
+                inference.contradiction(logger, JustifyUsingRUP{hints::Regular{owner}}, generic_reason(vars));
             return;
         }
 
-        ReasonLiterals reason;
-        ProofLine reason_definition_1, reason_definition_2;
-
-        if (logger && short_reasons) {
-            auto reason_sum = WPBSum{};
-            for (const auto & lit : gen_reason) {
-                reason_sum += 1_i * get<ProofLiteral>(lit);
-            }
-            // We will manually delete this later.
-            auto [_reason_short, _line1, _line2] =
-                logger->create_proof_flag_reifying(reason_sum >= Integer(reason_sum.terms.size()), "", ProofLevel::Top);
-            ProofFlag reason_short = _reason_short;
-            reason_definition_1 = _line1;
-            reason_definition_2 = _line2;
-            reason = eager_reason(singleton_reason(reason_short), state);
-        }
-        else {
-            reason = gen_reason;
-        }
+        auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
+        auto & cache = any_cast<DeadCache &>(state.get_constraint_state(cache_handle));
+        auto reason = generic_reason(vars);
+        // All manual proof emission happens before any domain change below, so a
+        // single materialised snapshot is sound (see MDD, PORTING-NOTES §13).
+        auto eager = eager_reason(reason, state);
 
         if (! graph.initialised)
-            initialise_graph(graph, vars, num_states, transitions, final_states, state_at_pos_flags, state, reason, logger);
+            initialise_graph(graph, cache, vars, num_states, transitions, final_states, state_at_pos_flags, state, eager, logger);
 
-        for (size_t i = 0; i < graph.states_supporting.size(); i++) {
+        for (size_t i = 0; i < graph.states_supporting.size(); ++i) {
             for (const auto & val_and_states : graph.states_supporting[i]) {
                 auto val = val_and_states.first;
 
                 if (! graph.states_supporting[i][val].empty() && ! state.in_domain(vars[i], val)) {
-
                     for (const auto & q : graph.states_supporting[i][val]) {
                         // Remove every edge out of q that carries this value; an
                         // NFA may have several. Collect them first to avoid
@@ -356,8 +321,8 @@ namespace
                                     graph.in_edges[i + 1][next_q].erase(q);
                             }
 
-                            decrement_outdeg(graph, i, q, vars, state_at_pos_flags, state, reason, logger);
-                            decrement_indeg(graph, i + 1, next_q, vars, state_at_pos_flags, state, reason, logger);
+                            decrement_outdeg(graph, cache, static_cast<long>(i), q, state_at_pos_flags, eager, logger);
+                            decrement_indeg(graph, cache, static_cast<long>(i) + 1, next_q, state_at_pos_flags, eager, logger);
                         }
                     }
                     graph.states_supporting[i][val] = {};
@@ -365,35 +330,128 @@ namespace
             }
         }
 
-        for (size_t i = 0; i < graph.states_supporting.size(); i++) {
+        for (size_t i = 0; i < graph.states_supporting.size(); ++i) {
             for (auto val : state.each_value_mutable(vars[i])) {
-                // Clean up domains
                 if (graph.states_supporting[i][val].empty())
                     inference.infer_not_equal(logger, vars[i], val, JustifyUsingRUP{hints::Regular{owner}}, reason);
             }
         }
-
-        // Need to check later whether this is safe to do now we have enumeration proofs
-        // if (logger && short_reasons) {
-        //     if (short_reasons) {
-        //         logger->delete_range(reason_definition_1, reason_definition_2 + 1);
-        //     }
-        // }
     }
-}
 
-namespace
-{
-    // Records the alphabet (sorted transition keys) for proof logging and s_expr.
-    auto symbols_of(const vector<unordered_map<Integer, set<long>>> & transitions) -> vector<Integer>
+    // Static forward + backward reachability under initial domains. Returns the
+    // per-layer set of dead states; the initialiser emits a Top-level
+    // ~state[i][q] for each, and pre-populates the per-subtree DeadCache so the
+    // per-call propagator never re-emits them.
+    auto compute_static_dead(const vector<IntegerVariableID> & vars, const long num_states,
+        const vector<unordered_map<Integer, set<long>>> & transitions, const vector<long> & final_states, const State & initial_state)
+        -> vector<set<long>>
     {
-        set<Integer> sym_set;
-        for (const auto & state_map : transitions)
-            for (const auto & [val, _] : state_map)
-                sym_set.insert(val);
-        return {sym_set.begin(), sym_set.end()};
+        auto num_vars = vars.size();
+
+        vector<set<long>> fwd_reachable(num_vars + 1);
+        fwd_reachable[0].insert(0);
+        for (size_t i = 0; i < num_vars; ++i)
+            for (auto val : initial_state.each_value_immutable(vars[i]))
+                for (auto q : fwd_reachable[i])
+                    for (auto next_q : find_transitions(transitions[q], val))
+                        fwd_reachable[i + 1].insert(next_q);
+
+        vector<set<long>> bwd_reachable(num_vars + 1);
+        for (auto f : final_states)
+            if (fwd_reachable[num_vars].contains(f))
+                bwd_reachable[num_vars].insert(f);
+        for (long i = static_cast<long>(num_vars) - 1; i >= 0; --i)
+            for (auto q : fwd_reachable[i]) {
+                bool found = false;
+                for (auto val : initial_state.each_value_immutable(vars[i])) {
+                    for (auto next_q : find_transitions(transitions[q], val))
+                        if (bwd_reachable[i + 1].contains(next_q)) {
+                            bwd_reachable[i].insert(q);
+                            found = true;
+                            break;
+                        }
+                    if (found)
+                        break;
+                }
+            }
+
+        vector<set<long>> dead(num_vars + 1);
+        for (size_t i = 0; i <= num_vars; ++i)
+            for (long q = 0; q < num_states; ++q)
+                if (! bwd_reachable[i].contains(q))
+                    dead[i].insert(q);
+        return dead;
+    }
+
+    // Emit the Top-level proof scaffolding once at search root:
+    //
+    //  1. For every (i, q', val) with val in initial dom, a per-val backward
+    //     chain
+    //        ~state[i+1][q'] + (vars[i] != val) + sum_{q : q' in T(q,val)} state[i][q] >= 1
+    //     RUP-derivable from the OPB forward chains plus the per-layer
+    //     exactly-one (assume the negation, at-most-one at layer i+1 forces all
+    //     other state[i+1] to 0, layer-i at-least-one forces some non-parent
+    //     state[i][q*]=1, the forward chain for (q*, val) UP-contradicts because
+    //     none of q*'s targets on val is q').
+    //
+    //  2. ~state[i][q] for every statically dead (forward-unreachable or
+    //     backward-unreachable-to-accepting) state, in an order that lets RUP
+    //     close: forward-unreachable in layer-ascending order (uses the backward
+    //     chains plus earlier-layer dead flags), then everything left in
+    //     descending layer order (uses OPB forward chains plus later-layer dead
+    //     flags).
+    auto emit_top_scaffolding(ProofLogger * const logger, const vector<IntegerVariableID> & vars, const long num_states,
+        const vector<unordered_map<Integer, set<long>>> & transitions, const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const State & initial_state, const vector<set<long>> & static_dead) -> void
+    {
+        auto num_vars = vars.size();
+
+        logger->emit_proof_comment("Regular: per-val backward chains");
+        for (size_t i = 0; i < num_vars; ++i) {
+            for (long next_q = 0; next_q < num_states; ++next_q) {
+                for (auto val : initial_state.each_value_immutable(vars[i])) {
+                    WPBSum chain;
+                    chain += 1_i * ! state_at_pos_flags[i + 1][next_q];
+                    chain += 1_i * (vars[i] != val);
+                    for (long q = 0; q < num_states; ++q)
+                        if (find_transitions(transitions[q], val).contains(next_q))
+                            chain += 1_i * state_at_pos_flags[i][q];
+                    logger->emit_rup_proof_line(move(chain) >= 1_i, ProofLevel::Top);
+                }
+            }
+        }
+
+        // Forward-unreachable static dead states, in ascending layer order.
+        logger->emit_proof_comment("Regular: forward-unreachable static dead states");
+        vector<set<long>> fwd_reachable(num_vars + 1);
+        fwd_reachable[0].insert(0);
+        for (size_t i = 0; i < num_vars; ++i)
+            for (auto val : initial_state.each_value_immutable(vars[i]))
+                for (auto q : fwd_reachable[i])
+                    for (auto next_q : find_transitions(transitions[q], val))
+                        fwd_reachable[i + 1].insert(next_q);
+        for (size_t i = 1; i <= num_vars; ++i)
+            for (long q = 0; q < num_states; ++q)
+                if (! fwd_reachable[i].contains(q))
+                    logger->emit_rup_proof_line(WPBSum{} + 1_i * ! state_at_pos_flags[i][q] >= 1_i, ProofLevel::Top);
+
+        // Backward-unreachable (forward-reachable but no path forward to a final
+        // state), in descending layer order.
+        logger->emit_proof_comment("Regular: backward-unreachable static dead states");
+        for (long i = static_cast<long>(num_vars); i >= 0; --i)
+            for (auto q : static_dead[i]) {
+                if (i > 0 && ! fwd_reachable[i].contains(q))
+                    continue; // already emitted by the forward-unreachable pass
+                logger->emit_rup_proof_line(WPBSum{} + 1_i * ! state_at_pos_flags[i][q] >= 1_i, ProofLevel::Top);
+            }
     }
 }
+
+struct Regular::Bridge
+{
+    vector<vector<ProofFlag>> state_at_pos_flags;
+    vector<set<long>> static_dead;
+};
 
 Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f) :
     _vars(move(v)), _num_states(n), _transitions(t.size()), _final_states(move(f)), _regex(nullopt)
@@ -408,8 +466,8 @@ Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integ
 Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f) :
     _vars(move(v)), _num_states(n), _transitions(n), _final_states(move(f)), _regex(nullopt)
 {
-    for (size_t i = 0; i < transitions.size(); i++)
-        for (size_t j = 0; j < transitions[i].size(); j++)
+    for (size_t i = 0; i < transitions.size(); ++i)
+        for (size_t j = 0; j < transitions[i].size(); ++j)
             if (transitions[i][j] != -1L)
                 _transitions[i][Integer(j)].insert(transitions[i][j]);
     _symbols = symbols_of(_transitions);
@@ -473,7 +531,9 @@ auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) 
         _symbols = symbols_of(_transitions);
     }
 
-    _graph_idx = initial_state.add_constraint_state(RegularGraph(_vars.size(), _num_states));
+    _bridge = make_shared<Bridge>();
+    _graph_idx = initial_state.add_constraint_state(RegularGraph(static_cast<long>(_vars.size()), _num_states));
+    _dead_cache_idx = initial_state.add_constraint_state(DeadCache{vector<set<long>>(_vars.size() + 1)});
 
     // Build the OPB alphabet: the union of transition keys and each var's initial
     // domain. Domain values absent from every transition get a "no transition"
@@ -489,30 +549,30 @@ auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) 
 
 auto Regular::define_proof_model(ProofModel & model) -> void
 {
-    // Make 2D array of flags: state_at_pos_flags[i][q] means the DFA is in state q when it receives the
-    // input value from vars[i], with an extra row of flags for the state after the last transition.
-    // NB: Might be easier to have a 1D array of ProofOnlyIntegerVariables, but making literals of these is
-    // awkward currently. (TODO ?)
+    // state_at_pos_flags[i][q] means "after reading the first i symbols, the
+    // automaton's chosen accepting run is in state q". Layer i takes input
+    // vars[i] and produces layer i+1, with an extra row for the final state.
+    auto & flags = _bridge->state_at_pos_flags;
     for (size_t idx = 0; idx <= _vars.size(); ++idx) {
         WPBSum exactly_1_true{};
-        _state_at_pos_flags.emplace_back();
+        flags.emplace_back();
         for (long q = 0; q < _num_states; ++q) {
             // cake_pb_cp names the "in state q at position idx" flag x[id][idx_q][st];
             // match it so the proof's state literals line up with cake's OPB.
-            _state_at_pos_flags[idx].emplace_back(
+            flags[idx].emplace_back(
                 model.create_proof_flag(_constraint_id, vector<long long>{static_cast<long long>(idx), static_cast<long long>(q)}, "st"));
-            exactly_1_true += 1_i * _state_at_pos_flags[idx][q];
+            exactly_1_true += 1_i * flags[idx][q];
         }
         model.add_constraint(move(exactly_1_true) == 1_i);
     }
 
-    // State at pos 0 is 0
-    model.add_constraint(WPBSum{} + 1_i * _state_at_pos_flags[0][0] >= 1_i);
-    // State at pos n is one of the final states
+    // State at pos 0 is 0.
+    model.add_constraint(WPBSum{} + 1_i * flags[0][0] >= 1_i);
+
+    // State at pos n is one of the final states.
     WPBSum pos_n_states;
-    for (const auto & f : _final_states) {
-        pos_n_states += 1_i * _state_at_pos_flags[_vars.size()][f];
-    }
+    for (const auto & f : _final_states)
+        pos_n_states += 1_i * flags[_vars.size()][f];
     model.add_constraint(move(pos_n_states) >= 1_i);
 
     for (size_t idx = 0; idx < _vars.size(); ++idx) {
@@ -520,15 +580,15 @@ auto Regular::define_proof_model(ProofModel & model) -> void
             for (const auto & val : _opb_alphabet) {
                 const auto & targets = find_transitions(_transitions[q], val);
                 if (targets.empty()) {
-                    // No transition for (q, val), so constrain ~(state_i = q /\ X_i = val)
-                    model.add_constraint(WPBSum{} + 1_i * (_vars[idx] != val) + (1_i * ! _state_at_pos_flags[idx][q]) >= 1_i);
+                    // No transition for (q, val), so constrain ~(state_i = q /\ X_i = val).
+                    model.add_constraint(WPBSum{} + 1_i * (_vars[idx] != val) + 1_i * ! flags[idx][q] >= 1_i);
                 }
                 else {
                     // state_i = q /\ X_i = val implies state_{i+1} is one of the
                     // targets (a single target for a DFA, several for an NFA).
-                    auto clause = WPBSum{} + 1_i * ! _state_at_pos_flags[idx][q] + 1_i * (_vars[idx] != val);
+                    auto clause = WPBSum{} + 1_i * ! flags[idx][q] + 1_i * (_vars[idx] != val);
                     for (const auto & new_q : targets)
-                        clause += 1_i * _state_at_pos_flags[idx + 1][new_q];
+                        clause += 1_i * flags[idx + 1][new_q];
                     model.add_constraint(move(clause) >= 1_i);
                 }
             }
@@ -541,11 +601,27 @@ auto Regular::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
 
+    // Top-level scaffolding: per-val backward chains and static dead-state lines,
+    // derived once from the OPB encoding at search root. Pre-populates the
+    // per-subtree DeadCache so the propagator skips re-emission for
+    // statically-dead states. In assertion mode the per-call inferences are
+    // asserted under the typed hint, so the scaffolding is wasted output.
+    propagators.install_initialiser([vars = _vars, ns = _num_states, t = _transitions, fs = _final_states, bridge = _bridge,
+                                        dead_cache_handle = _dead_cache_idx](State & state, auto &, ProofLogger * const logger) -> void {
+        if (! logger || logger->get_assertion_level() != AssertionLevel::Off)
+            return;
+        bridge->static_dead = compute_static_dead(vars, ns, t, fs, state);
+        emit_top_scaffolding(logger, vars, ns, t, bridge->state_at_pos_flags, state, bridge->static_dead);
+        auto & cache = any_cast<DeadCache &>(state.get_constraint_state(dead_cache_handle));
+        for (size_t i = 0; i < bridge->static_dead.size(); ++i)
+            cache.dead[i].insert(bridge->static_dead[i].begin(), bridge->static_dead[i].end());
+    });
+
     propagators.install(
         constraint_id(),
-        [v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = _graph_idx, flags = move(_state_at_pos_flags),
-            sr = _short_reasons, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_regular(v, n, t, f, flags, g, state, inference, logger, sr, owner);
+        [v = _vars, ns = _num_states, t = _transitions, fs = _final_states, g = _graph_idx, dc = _dead_cache_idx, bridge = _bridge,
+            owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_regular(v, ns, t, fs, bridge->state_at_pos_flags, g, dc, state, inference, logger, owner);
             return PropagatorState::Enable;
         },
         triggers);
@@ -564,13 +640,13 @@ auto Regular::s_expr(const ProofModel * const model) const -> SExpr
     for (const auto & var : _vars)
         vars.push_back(tracker.s_expr_term_of(var));
 
-    // A regex-built Regular only compiles its automaton in prepare(), and
-    // prepare runs on the installed clone, never on the stored constraint this
-    // is called on -- so without compiling here too, the written .scp would
-    // describe an empty automaton rather than the constraint actually solved
-    // (issue #481). Rebuild the same alphabet prepare() uses: the contiguous
-    // min..max range over the variables' initial domains, whose extremes are
-    // exactly the bounds the tracker recorded at variable set-up.
+    // A regex-built Regular only compiles its automaton in prepare(), and prepare
+    // runs on the installed clone, never on the stored constraint this is called
+    // on -- so without compiling here too, the written .scp would describe an
+    // empty automaton rather than the constraint actually solved (issue #481).
+    // Rebuild the same alphabet prepare() uses: the contiguous min..max range
+    // over the variables' initial domains, whose extremes are exactly the bounds
+    // the tracker recorded at variable set-up.
     long num_states = _num_states;
     const auto * transitions = &_transitions;
     const auto * final_states = &_final_states;
@@ -603,13 +679,10 @@ auto Regular::s_expr(const ProofModel * const model) const -> SExpr
     // One edge list per state, in state order: position i holds the edges out of
     // state i, and each edge is (symbol target) -- reading `symbol` moves from
     // state i to state `target`. This is the shape cake_pb_cp's regular parser
-    // expects: `(vars...) nstates ((edges-of-0) (edges-of-1) ...) (finals...)`,
-    // with no separate alphabet list (cake recovers the symbols from the edges).
-    // A non-deterministic automaton emits several edges with the same symbol.
-    // The transitions are unordered_maps, so collect the (symbol, target) pairs
-    // and sort them: the written .scp must be byte-stable across standard
-    // libraries (hash iteration order is not portable, which breaks the
-    // write -> read -> write round-trip), and a canonical order does that.
+    // expects. A non-deterministic automaton emits several edges with the same
+    // symbol. The transitions are unordered_maps, so collect the (symbol, target)
+    // pairs and sort them: the written .scp must be byte-stable across standard
+    // libraries.
     vector<SExpr> states;
     for (long i = 0; i < num_states; ++i) {
         vector<SExpr> edges;

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -1,0 +1,583 @@
+#include <gcs/constraints/regular/regular.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#include <print>
+#else
+#include <fmt/ostream.h>
+#endif
+
+#include <any>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::any_cast;
+using std::cmp_less;
+using std::make_shared;
+using std::make_unique;
+using std::move;
+using std::set;
+using std::shared_ptr;
+using std::string;
+using std::stringstream;
+using std::unique_ptr;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
+using std::print;
+#else
+using fmt::format;
+using fmt::print;
+#endif
+
+namespace
+{
+    auto find_transition(const unordered_map<Integer, long> & state_transitions, Integer val) -> long
+    {
+        auto it = state_transitions.find(val);
+        if (it == state_transitions.end())
+            return -1L;
+        return it->second;
+    }
+
+    struct RegularGraph
+    {
+        // states_supporting[i][val] = states in layer i with an outgoing transition
+        // on val that currently sit on a root-to-accepting path.
+        vector<unordered_map<Integer, set<long>>> states_supporting;
+        // out_edges[i][q] maps target state q' (in layer i+1) to the set of values
+        // labelling edges q -> q'.
+        vector<vector<unordered_map<long, unordered_set<Integer>>>> out_edges;
+        vector<vector<long>> out_deg;
+        vector<vector<unordered_map<long, unordered_set<Integer>>>> in_edges;
+        vector<vector<long>> in_deg;
+        // nodes[i] = active states in layer i.
+        vector<set<long>> nodes;
+        bool initialised = false;
+
+        explicit RegularGraph(long num_vars, long num_states) :
+            states_supporting(num_vars),
+            out_edges(num_vars, vector<unordered_map<long, unordered_set<Integer>>>(num_states)),
+            out_deg(num_vars, vector<long>(num_states, 0)),
+            in_edges(num_vars + 1, vector<unordered_map<long, unordered_set<Integer>>>(num_states)),
+            in_deg(num_vars + 1, vector<long>(num_states, 0)),
+            nodes(num_vars + 1)
+        {
+        }
+    };
+
+    // Per-subtree dead-state cache: tracks which `~state[i][q]` proof lines
+    // have already been emitted at or above the current search depth, so the
+    // per-call propagator skips re-emission. Pre-populated with the
+    // statically-dead set (those emitted at Top by the initialiser) so the
+    // first per-call sweep doesn't redundantly re-derive them.
+    struct DeadCache
+    {
+        vector<set<long>> dead;
+    };
+
+    auto emit_dead_state(ProofLogger * const logger, DeadCache & cache,
+        const vector<vector<ProofFlag>> & state_at_pos_flags,
+        long i, long q, const ReasonFunction & reason) -> void
+    {
+        if (! logger)
+            return;
+        if (cache.dead[i].contains(q))
+            return;
+        logger->emit_rup_proof_line_under_reason(reason,
+            WPBSum{} + 1_i * ! state_at_pos_flags[i][q] >= 1_i, ProofLevel::Current);
+        cache.dead[i].insert(q);
+    }
+
+    auto initialise_graph(RegularGraph & graph, DeadCache & cache, const vector<IntegerVariableID> & vars,
+        const long num_states, const vector<unordered_map<Integer, long>> & transitions,
+        const vector<long> & final_states,
+        const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const State & state, const ReasonFunction & reason, ProofLogger * const logger)
+    {
+        auto num_vars = vars.size();
+
+        // Forward phase: states reachable from the root under current domains.
+        graph.nodes[0].insert(0);
+        for (size_t i = 0; i < num_vars; ++i) {
+            for (auto val : state.each_value_immutable(vars[i])) {
+                for (const auto & q : graph.nodes[i]) {
+                    auto next_q = find_transition(transitions[q], val);
+                    if (next_q != -1) {
+                        graph.states_supporting[i][val].insert(q);
+                        graph.nodes[i + 1].insert(next_q);
+                    }
+                }
+            }
+
+            // States at layer i+1 that aren't forward-reachable under current
+            // dom get a single ~state[i+1][next_q] line at Current, gated on
+            // the cache. The initialiser's backward chains (Top) plus the
+            // cached ~state[i][q] lines for parents we already eliminated at
+            // earlier layers let UP close this RUP.
+            for (long next_q = 0; next_q < num_states; ++next_q) {
+                if (graph.nodes[i + 1].contains(next_q)) continue;
+                emit_dead_state(logger, cache, state_at_pos_flags, static_cast<long>(i) + 1, next_q, reason);
+            }
+        }
+
+        // Restrict the final layer to final states that are also reachable.
+        set<long> reachable_final;
+        for (auto f : final_states)
+            if (graph.nodes[num_vars].contains(f))
+                reachable_final.insert(f);
+
+        // Anything reachable under current dom but not in final_states was
+        // already in cache.dead from the static set, so emit_dead_state is a
+        // no-op here for well-formed DFAs.
+        for (const auto & q : graph.nodes[num_vars])
+            if (! reachable_final.contains(q))
+                emit_dead_state(logger, cache, state_at_pos_flags, static_cast<long>(num_vars), q, reason);
+        graph.nodes[num_vars] = reachable_final;
+
+        // Backward phase: drop states with no path forward to a final state.
+        for (long i = static_cast<long>(num_vars) - 1; i >= 0; --i) {
+            vector<char> state_is_support(num_states, 0);
+
+            for (auto val : state.each_value_mutable(vars[i])) {
+                set<long> states = graph.states_supporting[i][val];
+                for (const auto & q : states) {
+                    auto next_q = find_transition(transitions[q], val);
+                    if (next_q != -1 && graph.nodes[i + 1].contains(next_q)) {
+                        graph.out_edges[i][q][next_q].emplace(val);
+                        graph.out_deg[i][q]++;
+                        graph.in_edges[i + 1][next_q][q].emplace(val);
+                        graph.in_deg[i + 1][next_q]++;
+                        state_is_support[q] = 1;
+                    }
+                    else {
+                        graph.states_supporting[i][val].erase(q);
+                    }
+                }
+            }
+
+            set<long> gn = graph.nodes[i];
+            for (const auto & q : gn) {
+                if (! state_is_support[q]) {
+                    graph.nodes[i].erase(q);
+                    emit_dead_state(logger, cache, state_at_pos_flags, i, q, reason);
+                }
+            }
+        }
+
+        graph.initialised = true;
+    }
+
+    auto decrement_outdeg(RegularGraph & graph, DeadCache & cache, const long i, const long k,
+        const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const ReasonFunction & reason, ProofLogger * const logger) -> void
+    {
+        graph.out_deg[i][k]--;
+        if (graph.out_deg[i][k] == 0 && i > 0) {
+            for (const auto & edge : graph.in_edges[i][k]) {
+                auto l = edge.first;
+                graph.out_edges[i - 1][l].erase(k);
+                for (const auto & val : edge.second) {
+                    graph.states_supporting[i - 1][val].erase(l);
+                    decrement_outdeg(graph, cache, i - 1, l, state_at_pos_flags, reason, logger);
+                }
+            }
+            graph.in_edges[i][k] = {};
+            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
+        }
+    }
+
+    auto decrement_indeg(RegularGraph & graph, DeadCache & cache, const long i, const long k,
+        const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const ReasonFunction & reason, ProofLogger * const logger) -> void
+    {
+        graph.in_deg[i][k]--;
+        if (graph.in_deg[i][k] == 0 && cmp_less(i, graph.in_deg.size() - 1)) {
+            emit_dead_state(logger, cache, state_at_pos_flags, i, k, reason);
+            for (const auto & edge : graph.out_edges[i][k]) {
+                auto l = edge.first;
+                graph.in_edges[i + 1][l].erase(k);
+                for (const auto & val : edge.second) {
+                    graph.states_supporting[i][val].erase(k);
+                    decrement_indeg(graph, cache, i + 1, l, state_at_pos_flags, reason, logger);
+                }
+            }
+            graph.out_edges[i][k] = {};
+        }
+    }
+
+    auto propagate_regular(const vector<IntegerVariableID> & vars,
+        const long num_states,
+        const vector<unordered_map<Integer, long>> & transitions,
+        const vector<long> & final_states,
+        const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const ConstraintStateHandle & graph_handle,
+        const ConstraintStateHandle & cache_handle,
+        const State & state, auto & inference, ProofLogger * const logger) -> void
+    {
+        auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
+        auto & cache = any_cast<DeadCache &>(state.get_constraint_state(cache_handle));
+        auto reason = generic_reason(state, vars);
+
+        if (! graph.initialised)
+            initialise_graph(graph, cache, vars, num_states, transitions, final_states,
+                state_at_pos_flags, state, reason, logger);
+
+        for (size_t i = 0; i < graph.states_supporting.size(); ++i) {
+            for (const auto & val_and_states : graph.states_supporting[i]) {
+                auto val = val_and_states.first;
+
+                if (! graph.states_supporting[i][val].empty() && ! state.in_domain(vars[i], val)) {
+                    for (const auto & q : graph.states_supporting[i][val]) {
+                        auto next_q = find_transition(transitions[q], val);
+
+                        if (graph.out_edges[i][q].contains(next_q)) {
+                            graph.out_edges[i][q][next_q].erase(val);
+                            if (graph.out_edges[i][q][next_q].empty())
+                                graph.out_edges[i][q].erase(next_q);
+                        }
+                        if (graph.in_edges[i + 1][next_q].contains(q)) {
+                            graph.in_edges[i + 1][next_q][q].erase(val);
+                            if (graph.in_edges[i + 1][next_q][q].empty())
+                                graph.in_edges[i + 1][next_q].erase(q);
+                        }
+
+                        decrement_outdeg(graph, cache, static_cast<long>(i), q, state_at_pos_flags, reason, logger);
+                        decrement_indeg(graph, cache, static_cast<long>(i) + 1, next_q, state_at_pos_flags, reason, logger);
+                    }
+                    graph.states_supporting[i][val] = {};
+                }
+            }
+        }
+
+        for (size_t i = 0; i < graph.states_supporting.size(); ++i) {
+            for (auto val : state.each_value_mutable(vars[i])) {
+                if (graph.states_supporting[i][val].empty())
+                    inference.infer_not_equal(logger, vars[i], val, JustifyUsingRUP{}, reason);
+            }
+        }
+    }
+
+    // Static forward + backward reachability under initial domains. Returns
+    // the per-layer set of dead states; the initialiser emits a Top-level
+    // ~state[i][q] for each, and pre-populates the per-subtree DeadCache so
+    // the per-call propagator never re-emits them.
+    auto compute_static_dead(const vector<IntegerVariableID> & vars,
+        const long num_states,
+        const vector<unordered_map<Integer, long>> & transitions,
+        const vector<long> & final_states,
+        const State & initial_state) -> vector<set<long>>
+    {
+        auto num_vars = vars.size();
+
+        vector<set<long>> fwd_reachable(num_vars + 1);
+        fwd_reachable[0].insert(0);
+        for (size_t i = 0; i < num_vars; ++i) {
+            for (auto val : initial_state.each_value_immutable(vars[i])) {
+                for (auto q : fwd_reachable[i]) {
+                    auto next_q = find_transition(transitions[q], val);
+                    if (next_q != -1)
+                        fwd_reachable[i + 1].insert(next_q);
+                }
+            }
+        }
+
+        vector<set<long>> bwd_reachable(num_vars + 1);
+        for (auto f : final_states)
+            if (fwd_reachable[num_vars].contains(f))
+                bwd_reachable[num_vars].insert(f);
+        for (long i = static_cast<long>(num_vars) - 1; i >= 0; --i) {
+            for (auto q : fwd_reachable[i]) {
+                for (auto val : initial_state.each_value_immutable(vars[i])) {
+                    auto next_q = find_transition(transitions[q], val);
+                    if (next_q != -1 && bwd_reachable[i + 1].contains(next_q)) {
+                        bwd_reachable[i].insert(q);
+                        break;
+                    }
+                }
+            }
+        }
+
+        vector<set<long>> dead(num_vars + 1);
+        for (size_t i = 0; i <= num_vars; ++i)
+            for (long q = 0; q < num_states; ++q)
+                if (! bwd_reachable[i].contains(q))
+                    dead[i].insert(q);
+        return dead;
+    }
+
+    // Emit the Top-level proof scaffolding once at search root:
+    //
+    //  1. For every (i, q', val) with val in initial dom, a per-val backward
+    //     chain
+    //        ~state[i+1][q'] + (vars[i] != val) + sum_{q : T(q,val) = q'} state[i][q] >= 1
+    //     RUP-derivable from the OPB forward chains plus the per-layer
+    //     exactly-one (assume the negation, AMO at layer i+1 forces all other
+    //     state[i+1] to 0, layer-i ALO forces some non-parent state[i][q*]=1,
+    //     the forward chain for (q*, val) UP-contradicts).
+    //
+    //  2. ~state[i][q] for every statically dead (forward-unreachable or
+    //     backward-unreachable-to-accepting) state, in an order that lets RUP
+    //     close: forward-unreachable in layer-ascending order (uses the
+    //     backward chains plus earlier-layer dead flags), then everything
+    //     left (forward-reachable but no path forward to a final state) in
+    //     descending layer order (uses OPB forward chains plus later-layer
+    //     dead flags).
+    auto emit_top_scaffolding(ProofLogger * const logger,
+        const vector<IntegerVariableID> & vars,
+        const long num_states,
+        const vector<unordered_map<Integer, long>> & transitions,
+        const vector<vector<ProofFlag>> & state_at_pos_flags,
+        const State & initial_state,
+        const vector<set<long>> & static_dead) -> void
+    {
+        auto num_vars = vars.size();
+
+        logger->emit_proof_comment("Regular: per-val backward chains");
+        for (size_t i = 0; i < num_vars; ++i) {
+            for (long next_q = 0; next_q < num_states; ++next_q) {
+                for (auto val : initial_state.each_value_immutable(vars[i])) {
+                    WPBSum chain;
+                    chain += 1_i * ! state_at_pos_flags[i + 1][next_q];
+                    chain += 1_i * (vars[i] != val);
+                    for (long q = 0; q < num_states; ++q) {
+                        auto succ = find_transition(transitions[q], val);
+                        if (succ == next_q)
+                            chain += 1_i * state_at_pos_flags[i][q];
+                    }
+                    logger->emit_rup_proof_line(move(chain) >= 1_i, ProofLevel::Top);
+                }
+            }
+        }
+
+        // Forward-unreachable static dead states, in ascending layer order.
+        logger->emit_proof_comment("Regular: forward-unreachable static dead states");
+        vector<set<long>> fwd_reachable(num_vars + 1);
+        fwd_reachable[0].insert(0);
+        for (size_t i = 0; i < num_vars; ++i) {
+            for (auto val : initial_state.each_value_immutable(vars[i])) {
+                for (auto q : fwd_reachable[i]) {
+                    auto next_q = find_transition(transitions[q], val);
+                    if (next_q != -1)
+                        fwd_reachable[i + 1].insert(next_q);
+                }
+            }
+        }
+        for (size_t i = 1; i <= num_vars; ++i) {
+            for (long q = 0; q < num_states; ++q) {
+                if (! fwd_reachable[i].contains(q))
+                    logger->emit_rup_proof_line(
+                        WPBSum{} + 1_i * ! state_at_pos_flags[i][q] >= 1_i, ProofLevel::Top);
+            }
+        }
+
+        // Backward-unreachable (forward-reachable but no path forward to a
+        // final state), in descending layer order.
+        logger->emit_proof_comment("Regular: backward-unreachable static dead states");
+        for (long i = static_cast<long>(num_vars); i >= 0; --i) {
+            for (auto q : static_dead[i]) {
+                if (i > 0 && ! fwd_reachable[i].contains(q))
+                    continue; // already emitted by the forward-unreachable pass
+                logger->emit_rup_proof_line(
+                    WPBSum{} + 1_i * ! state_at_pos_flags[i][q] >= 1_i, ProofLevel::Top);
+            }
+        }
+    }
+}
+
+struct Regular::Bridge
+{
+    vector<vector<ProofFlag>> state_at_pos_flags;
+    vector<set<long>> static_dead;
+};
+
+Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f, bool sr) :
+    _vars(move(v)),
+    _num_states(n),
+    _transitions(move(t)),
+    _final_states(move(f)),
+    _short_reasons(sr)
+{
+    set<Integer> sym_set;
+    for (const auto & state_map : _transitions)
+        for (const auto & [val, _] : state_map)
+            sym_set.insert(val);
+    _symbols.assign(sym_set.begin(), sym_set.end());
+}
+
+Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f, bool sr) :
+    _vars(move(v)),
+    _num_states(n),
+    _transitions(vector<unordered_map<Integer, long>>(n, unordered_map<Integer, long>{})),
+    _final_states(move(f)),
+    _short_reasons(sr)
+{
+    for (size_t i = 0; i < transitions.size(); ++i)
+        for (size_t j = 0; j < transitions[i].size(); ++j)
+            if (transitions[i][j] != -1)
+                _transitions[i][Integer(j)] = transitions[i][j];
+    set<Integer> sym_set;
+    for (const auto & state_map : _transitions)
+        for (const auto & [val, _] : state_map)
+            sym_set.insert(val);
+    _symbols.assign(sym_set.begin(), sym_set.end());
+}
+
+auto Regular::symbols() const -> const vector<Integer> &
+{
+    return _symbols;
+}
+
+auto Regular::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<Regular>(_vars, _num_states, _transitions, _final_states, _short_reasons);
+}
+
+auto Regular::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    _bridge = make_shared<Bridge>();
+    _graph_idx = initial_state.add_constraint_state(RegularGraph(static_cast<long>(_vars.size()), _num_states));
+    _dead_cache_idx = initial_state.add_constraint_state(
+        DeadCache{vector<set<long>>(_vars.size() + 1)});
+
+    // OPB alphabet: union of transition keys and every variable's initial
+    // domain. Domain values absent from every transition get a
+    // "no-transition" constraint emitted in define_proof_model, which is
+    // what veripb needs to verify the propagator's RUP-justified pruning of
+    // those values.
+    _opb_alphabet.insert(_symbols.begin(), _symbols.end());
+    for (const auto & var : _vars)
+        for (const auto & val : initial_state.each_value_immutable(var))
+            _opb_alphabet.insert(val);
+
+    return true;
+}
+
+auto Regular::define_proof_model(ProofModel & model) -> void
+{
+    // state_at_pos_flags[i][q] means "after reading the first i symbols, the
+    // DFA is in state q". Layer i takes input vars[i] and produces layer
+    // i+1.
+    auto & flags = _bridge->state_at_pos_flags;
+    for (size_t idx = 0; idx <= _vars.size(); ++idx) {
+        WPBSum exactly_1_true{};
+        flags.emplace_back();
+        for (long q = 0; q < _num_states; ++q) {
+            flags[idx].emplace_back(model.create_proof_flag(format("state{}is{}", idx, q)));
+            exactly_1_true += 1_i * flags[idx][q];
+        }
+        model.add_constraint(move(exactly_1_true) == 1_i);
+    }
+
+    // Root: state at layer 0 is the start state 0.
+    model.add_constraint(WPBSum{} + 1_i * flags[0][0] >= 1_i);
+
+    // Final layer: at least one final state is reached.
+    WPBSum pos_n_states;
+    for (const auto & f : _final_states)
+        pos_n_states += 1_i * flags[_vars.size()][f];
+    model.add_constraint(move(pos_n_states) >= 1_i);
+
+    for (size_t idx = 0; idx < _vars.size(); ++idx) {
+        for (long q = 0; q < _num_states; ++q) {
+            for (const auto & val : _opb_alphabet) {
+                auto new_q = find_transition(_transitions[q], val);
+                if (new_q == -1) {
+                    model.add_constraint(
+                        WPBSum{} + 1_i * (_vars[idx] != val) + 1_i * ! flags[idx][q] >= 1_i);
+                }
+                else {
+                    model.add_constraint(
+                        WPBSum{} + 1_i * ! flags[idx][q] + 1_i * (_vars[idx] != val) + 1_i * flags[idx + 1][new_q] >= 1_i);
+                }
+            }
+        }
+    }
+}
+
+auto Regular::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    triggers.on_change = {_vars.begin(), _vars.end()};
+
+    // Top-level scaffolding: per-val backward chains and static dead-state
+    // lines, derived once from the OPB encoding at search root. Pre-populates
+    // the per-subtree DeadCache so the propagator skips re-emission for
+    // statically-dead states. Without a logger there's nothing to scaffold.
+    propagators.install_initialiser(
+        [vars = _vars, ns = _num_states, t = _transitions, fs = _final_states,
+            bridge = _bridge, dead_cache_handle = _dead_cache_idx](
+            State & state, auto &, ProofLogger * const logger) -> void {
+            if (! logger)
+                return;
+            bridge->static_dead = compute_static_dead(vars, ns, t, fs, state);
+            emit_top_scaffolding(logger, vars, ns, t, bridge->state_at_pos_flags, state, bridge->static_dead);
+            auto & cache = any_cast<DeadCache &>(state.get_constraint_state(dead_cache_handle));
+            for (size_t i = 0; i < bridge->static_dead.size(); ++i)
+                cache.dead[i].insert(bridge->static_dead[i].begin(), bridge->static_dead[i].end());
+        });
+
+    propagators.install(
+        [v = _vars, ns = _num_states, t = _transitions, fs = _final_states,
+            g = _graph_idx, dc = _dead_cache_idx, bridge = _bridge](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_regular(v, ns, t, fs, bridge->state_at_pos_flags, g, dc, state, inference, logger);
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto Regular::s_exprify(const ProofModel * const model) const -> string
+{
+    stringstream s;
+
+    print(s, "{} regular (", _name);
+    for (const auto & var : _vars)
+        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
+    print(s, ") {}\n       (", _num_states);
+    for (const auto & sym : symbols())
+        print(s, " {}", sym);
+    print(s, ")\n       ((");
+    for (size_t i = 0; i < _transitions.size(); ++i) {
+        print(s, "(");
+        for (const auto & tran : _transitions[i]) {
+            print(s, " ({} {})", tran.first, tran.second);
+        }
+        print(s, ")\n        ");
+    }
+    print(s, "))\n       (");
+    for (const auto & f : _final_states)
+        print(s, " {}", f);
+    print(s, ")");
+
+    return s.str();
+}

--- a/gcs/constraints/regular/regular.hh
+++ b/gcs/constraints/regular/regular.hh
@@ -1,0 +1,77 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/variable_id.hh>
+
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief Constrain that the sequence of variables is a member of the
+     * language recognised by the given Deterministic Finite Automaton,
+     * equivalent to a regex expression.
+     *
+     * Proof scaffolding mirrors the upfront pattern used by MDD,
+     * Knapsack, and BinPacking Stage 3: the OPB encoding is the natural
+     * per-(state, val) forward chains plus per-layer exactly-one, and a
+     * one-shot Top-level initialiser derives per-val backward chains
+     * plus statically-dead-node lines. The per-call propagator's
+     * `~state[i][q]` derivations RUP-close through that scaffolding
+     * instead of re-emitting per-(parent, val) intermediates on every
+     * propagation call.
+     *
+     * The `short_reasons` flag is retained for API parity with
+     * RegularLegacy and benchmarking. The new propagator emits at most
+     * one proof line per state-death, so the effect of the flag is
+     * small or zero here — it is forwarded as a hint to the per-call
+     * reason emission, no more.
+     *
+     * \ingroup Constraints
+     */
+    class Regular : public Constraint
+    {
+    private:
+        struct Bridge;
+
+        const std::vector<IntegerVariableID> _vars;
+        const long _num_states;
+        std::vector<std::unordered_map<Integer, long>> _transitions;
+        const std::vector<long> _final_states;
+        const bool _short_reasons;
+        std::vector<Integer> _symbols;
+        std::shared_ptr<Bridge> _bridge;
+        innards::ConstraintStateHandle _graph_idx;
+        innards::ConstraintStateHandle _dead_cache_idx;
+        std::set<Integer> _opb_alphabet;
+
+        [[nodiscard]] auto symbols() const -> const std::vector<Integer> &;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit Regular(std::vector<IntegerVariableID> vars,
+            long num_states,
+            std::vector<std::unordered_map<Integer, long>> transitions,
+            std::vector<long> final_states, bool short_reasons = true);
+
+        explicit Regular(std::vector<IntegerVariableID> vars,
+            long num_states,
+            std::vector<std::vector<long>> transitions,
+            std::vector<long> final_states, bool short_reasons = true);
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/regular/regular_legacy.cc
+++ b/gcs/constraints/regular/regular_legacy.cc
@@ -1,4 +1,4 @@
-#include <gcs/constraints/regular.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -329,7 +329,7 @@ namespace
     }
 }
 
-Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f, bool sr) :
+RegularLegacy::RegularLegacy(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f, bool sr) :
     _vars(move(v)),
     _num_states(n),
     _transitions(move(t)),
@@ -343,7 +343,7 @@ Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integ
     _symbols.assign(sym_set.begin(), sym_set.end());
 }
 
-Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f, bool sr) :
+RegularLegacy::RegularLegacy(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f, bool sr) :
     _vars(move(v)),
     _num_states(n),
     _transitions(vector<unordered_map<Integer, long>>(n, unordered_map<Integer, long>{})),
@@ -361,17 +361,17 @@ Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> trans
     _symbols.assign(sym_set.begin(), sym_set.end());
 }
 
-auto Regular::symbols() const -> const vector<Integer> &
+auto RegularLegacy::symbols() const -> const vector<Integer> &
 {
     return _symbols;
 }
 
-auto Regular::clone() const -> unique_ptr<Constraint>
+auto RegularLegacy::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Regular>(_vars, _num_states, _transitions, _final_states, _short_reasons);
+    return make_unique<RegularLegacy>(_vars, _num_states, _transitions, _final_states, _short_reasons);
 }
 
-auto Regular::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+auto RegularLegacy::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
     if (! prepare(propagators, initial_state, optional_model))
         return;
@@ -382,7 +382,7 @@ auto Regular::install(Propagators & propagators, State & initial_state, ProofMod
     install_propagators(propagators);
 }
 
-auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+auto RegularLegacy::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _graph_idx = initial_state.add_constraint_state(RegularGraph(_vars.size(), _num_states));
 
@@ -398,7 +398,7 @@ auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) 
     return true;
 }
 
-auto Regular::define_proof_model(ProofModel & model) -> void
+auto RegularLegacy::define_proof_model(ProofModel & model) -> void
 {
     // Make 2D array of flags: state_at_pos_flags[i][q] means the DFA is in state q when it receives the
     // input value from vars[i], with an extra row of flags for the state after the last transition.
@@ -441,7 +441,7 @@ auto Regular::define_proof_model(ProofModel & model) -> void
     }
 }
 
-auto Regular::install_propagators(Propagators & propagators) -> void
+auto RegularLegacy::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
@@ -454,11 +454,11 @@ auto Regular::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Regular::s_exprify(const ProofModel * const model) const -> string
+auto RegularLegacy::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} regular (", _name);
+    print(s, "{} regular_legacy (", _name);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}\n       (", _num_states);

--- a/gcs/constraints/regular/regular_legacy.cc
+++ b/gcs/constraints/regular/regular_legacy.cc
@@ -1,0 +1,634 @@
+#include <cmath>
+#include <gcs/constraints/regular/hints.hh>
+#include <gcs/constraints/regular/regex.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
+
+#include <gcs/proof.hh>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#include <print>
+#else
+#include <fmt/ostream.h>
+#endif
+
+#include <algorithm>
+#include <any>
+#include <cstdio>
+#include <functional>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::any_cast;
+using std::cmp_less;
+using std::ios;
+using std::max;
+using std::min;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::unique_ptr;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
+using std::ranges::sort;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
+using std::print;
+#else
+using fmt::format;
+using fmt::print;
+#endif
+
+namespace
+{
+    // Returns the set of next states for (state, val), or an empty set if no
+    // transition exists. A deterministic automaton is the special case where
+    // every non-empty set is a singleton.
+    auto find_transitions(const unordered_map<Integer, set<long>> & state_transitions, Integer val) -> const set<long> &
+    {
+        static const set<long> none;
+        auto it = state_transitions.find(val);
+        if (it == state_transitions.end())
+            return none;
+        return it->second;
+    }
+
+    struct RegularGraph
+    {
+        vector<unordered_map<Integer, set<long>>> states_supporting;
+        vector<vector<unordered_map<long, unordered_set<Integer>>>> out_edges;
+        vector<vector<long>> out_deg;
+        vector<vector<unordered_map<long, unordered_set<Integer>>>> in_edges;
+        vector<vector<long>> in_deg;
+        vector<set<long>> nodes;
+        bool initialised = false;
+
+        explicit RegularGraph(long num_vars, long num_states) :
+            states_supporting(vector<unordered_map<Integer, set<long>>>(num_vars)),
+            out_edges(vector<vector<unordered_map<long, unordered_set<Integer>>>>(
+                num_vars, vector<unordered_map<long, unordered_set<Integer>>>(num_states))),
+            out_deg(vector<vector<long>>(num_vars, vector<long>(num_states, 0))),
+            in_edges(vector<vector<unordered_map<long, unordered_set<Integer>>>>(
+                num_vars + 1, vector<unordered_map<long, unordered_set<Integer>>>(num_states))),
+            in_deg(vector<vector<long>>(num_vars + 1, vector<long>(num_states, 0))), nodes(vector<set<long>>(num_vars + 1))
+        {
+        }
+    };
+
+    auto log_additional_inference(ProofLogger * const logger, const vector<Literal> & literals, const vector<ProofFlag> & proof_flags, const State &,
+        const ReasonLiterals & reason, string comment = "") -> void
+    {
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
+            // Trying to cut down on repeated code
+            if (! comment.empty())
+                logger->emit_proof_comment(comment);
+
+            WPBSum terms;
+            for (const auto & lit : literals)
+                terms += 1_i * lit;
+            for (const auto & flag : proof_flags)
+                terms += 1_i * flag;
+            logger->emit_rup_proof_line_under_reason(reason, terms >= 1_i, ProofLevel::Current);
+        }
+    }
+
+    auto initialise_graph(RegularGraph & graph, const vector<IntegerVariableID> & vars, const long num_states,
+        const vector<unordered_map<Integer, set<long>>> & transitions, const vector<long> & final_states,
+        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonLiterals & reason, ProofLogger * const logger)
+    {
+        auto num_vars = vars.size();
+
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
+            logger->emit_proof_comment("Initialising graph");
+
+        // Forward phase: accumulate
+        graph.nodes[0].insert(0);
+        for (unsigned long i = 0; i < num_vars; ++i) {
+            for (auto val : state.each_value_immutable(vars[i])) {
+                for (const auto & q : graph.nodes[i]) {
+                    const auto & next_states = find_transitions(transitions[q], val);
+                    if (! next_states.empty()) {
+                        graph.states_supporting[i][val].insert(q);
+                        for (const auto & next_q : next_states)
+                            graph.nodes[i + 1].insert(next_q);
+                    }
+                }
+            }
+
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
+                for (long next_q = 0; next_q < num_states; ++next_q) {
+                    if (graph.nodes[i + 1].contains(next_q))
+                        continue;
+                    // Want to eliminate this node i.e. prove !state[i+1][next_q]
+                    for (const auto & q : graph.nodes[i]) {
+                        // So first eliminate each previous state/variable combo
+                        for (auto val : state.each_value_mutable(vars[i]))
+                            log_additional_inference(
+                                logger, {vars[i] != val}, {! state_at_pos_flags[i][q], ! state_at_pos_flags[i + 1][next_q]}, state, reason);
+
+                        // Then eliminate each previous state
+                        log_additional_inference(logger, {}, {! state_at_pos_flags[i][q], ! state_at_pos_flags[i + 1][next_q]}, state, reason);
+                    }
+
+                    // Finally, can eliminate what we want
+                    log_additional_inference(logger, {}, {! state_at_pos_flags[i + 1][next_q]}, state, reason);
+                }
+            }
+        }
+        set<long> possible_final_states;
+        for (const auto & f : final_states) {
+            if (graph.nodes[num_vars].contains(f))
+                possible_final_states.insert(f);
+        }
+
+        graph.nodes[num_vars] = possible_final_states;
+
+        // Backward phase: validate
+        for (long i = num_vars - 1; i >= 0; --i) {
+
+            vector<char> state_is_support(num_states, 0);
+
+            for (auto val : state.each_value_mutable(vars[i])) {
+                set<long> states = graph.states_supporting[i][val];
+                for (const auto & q : states) {
+                    bool any_live_target = false;
+                    for (const auto & next_q : find_transitions(transitions[q], val)) {
+                        if (graph.nodes[i + 1].contains(next_q)) {
+                            graph.out_edges[i][q][next_q].emplace(val);
+                            graph.out_deg[i][q]++;
+                            graph.in_edges[i + 1][next_q][q].emplace(val);
+                            graph.in_deg[i + 1][next_q]++;
+                            any_live_target = true;
+                        }
+                    }
+                    if (any_live_target)
+                        state_is_support[q] = 1;
+                    else {
+                        graph.states_supporting[i][val].erase(q);
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
+                            log_additional_inference(logger, {vars[i] != val}, {! state_at_pos_flags[i][q]}, state, reason);
+                    }
+                }
+            }
+
+            set<long> gn = graph.nodes[i];
+            for (const auto & q : gn) {
+                if (! state_is_support[q]) {
+                    graph.nodes[i].erase(q);
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
+                        log_additional_inference(logger, {}, {! state_at_pos_flags[i][q]}, state, reason, "back pass");
+                }
+            }
+        }
+
+        graph.initialised = true;
+    }
+
+    // True if state l at position pos still has a live out-edge labelled val. For
+    // a DFA this is never the case once the single (l, val) edge is gone, but an
+    // NFA may have several edges on the same value.
+    auto still_supports(const RegularGraph & graph, const long pos, const long l, Integer val) -> bool
+    {
+        for (const auto & [next_q, vals] : graph.out_edges[pos][l])
+            if (vals.contains(val))
+                return true;
+        return false;
+    }
+
+    auto decrement_outdeg(RegularGraph & graph, const long i, const long k, const vector<IntegerVariableID> & vars,
+        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonLiterals & reason, ProofLogger * const logger) -> void
+    {
+        graph.out_deg[i][k]--;
+        if (graph.out_deg[i][k] == 0 && i > 0) {
+            for (const auto & edge : graph.in_edges[i][k]) {
+                auto l = edge.first;
+                graph.out_edges[i - 1][l].erase(k);
+                for (const auto & val : edge.second) {
+                    // For an NFA, l may still reach a live state on val via
+                    // another edge; only drop support (and justify doing so)
+                    // once no such edge remains.
+                    if (! still_supports(graph, i - 1, l, val)) {
+                        graph.states_supporting[i - 1][val].erase(l);
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
+                            log_additional_inference(
+                                logger, {vars[i - 1] != val}, {! state_at_pos_flags[i - 1][l]}, state, reason, "dec outdeg inner");
+                    }
+                    decrement_outdeg(graph, i - 1, l, vars, state_at_pos_flags, state, reason, logger);
+                }
+            }
+            graph.in_edges[i][k] = {};
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off)
+                log_additional_inference(logger, {}, {! state_at_pos_flags[i][k]}, state, reason, "dec outdeg");
+        }
+    }
+
+    auto decrement_indeg(RegularGraph & graph, const long i, const long k, const vector<IntegerVariableID> & vars,
+        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonLiterals & reason, ProofLogger * const logger) -> void
+    {
+        graph.in_deg[i][k]--;
+        if (graph.in_deg[i][k] == 0 && cmp_less(i, graph.in_deg.size() - 1)) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
+                // Again, want to eliminate this node i.e. prove !state[i][k]
+                for (const auto & q : graph.nodes[i - 1]) {
+                    // So first eliminate each previous state/variable combo
+                    for (auto val : state.each_value_mutable(vars[i])) {
+                        log_additional_inference(
+                            logger, {vars[i] != val}, {! state_at_pos_flags[i - 1][q], ! state_at_pos_flags[i][k]}, state, reason);
+                    }
+
+                    // Then eliminate each previous state
+                    log_additional_inference(logger, {}, {! state_at_pos_flags[i - 1][q], ! state_at_pos_flags[i][k]}, state, reason);
+                }
+
+                // Finally, can eliminate what we want
+                log_additional_inference(logger, {}, {! state_at_pos_flags[i][k]}, state, reason);
+            }
+            for (const auto & edge : graph.out_edges[i][k]) {
+                auto l = edge.first;
+                graph.in_edges[i + 1][l].erase(k);
+
+                for (const auto & val : edge.second) {
+                    graph.states_supporting[i][val].erase(k);
+                    decrement_indeg(graph, i + 1, l, vars, state_at_pos_flags, state, reason, logger);
+                }
+            }
+
+            graph.out_edges[i][k] = {};
+        }
+    }
+
+    auto propagate_regular(const vector<IntegerVariableID> & vars, const long num_states,
+        const vector<unordered_map<Integer, set<long>>> & transitions, const vector<long> & final_states,
+        const vector<vector<ProofFlag>> & state_at_pos_flags, const ConstraintStateHandle & graph_handle, const State & state, auto & inference,
+        ProofLogger * const logger, const bool short_reasons, const ConstraintID & owner) -> void
+    {
+        auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
+        auto gen_reason = eager_reason(generic_reason(vars), state);
+
+        // Degenerate empty sequence (issue #254): with no variables there is
+        // nothing to propagate over, but the empty word is accepted only if the
+        // initial state (0) is itself a final state. The per-position loops
+        // below are all empty when vars.empty(), so detect the infeasible case
+        // explicitly. The proof model pins state_at_pos[0] to state 0 and
+        // requires it to be final (with an exactly-one over the states), so the
+        // contradiction is reverse-unit-propagatable.
+        if (vars.empty()) {
+            bool initial_is_final = false;
+            for (auto f : final_states)
+                if (f == 0L) {
+                    initial_is_final = true;
+                    break;
+                }
+            if (! initial_is_final)
+                inference.contradiction(logger, JustifyUsingRUP{hints::RegularLegacy{owner}}, gen_reason);
+            return;
+        }
+
+        ReasonLiterals reason;
+        ProofLine reason_definition_1, reason_definition_2;
+
+        if (logger && short_reasons) {
+            auto reason_sum = WPBSum{};
+            for (const auto & lit : gen_reason) {
+                reason_sum += 1_i * get<ProofLiteral>(lit);
+            }
+            // We will manually delete this later.
+            auto [_reason_short, _line1, _line2] =
+                logger->create_proof_flag_reifying(reason_sum >= Integer(reason_sum.terms.size()), "", ProofLevel::Top);
+            ProofFlag reason_short = _reason_short;
+            reason_definition_1 = _line1;
+            reason_definition_2 = _line2;
+            reason = eager_reason(singleton_reason(reason_short), state);
+        }
+        else {
+            reason = gen_reason;
+        }
+
+        if (! graph.initialised)
+            initialise_graph(graph, vars, num_states, transitions, final_states, state_at_pos_flags, state, reason, logger);
+
+        for (size_t i = 0; i < graph.states_supporting.size(); i++) {
+            for (const auto & val_and_states : graph.states_supporting[i]) {
+                auto val = val_and_states.first;
+
+                if (! graph.states_supporting[i][val].empty() && ! state.in_domain(vars[i], val)) {
+
+                    for (const auto & q : graph.states_supporting[i][val]) {
+                        // Remove every edge out of q that carries this value; an
+                        // NFA may have several. Collect them first to avoid
+                        // mutating out_edges[i][q] while iterating it.
+                        vector<long> next_qs;
+                        for (const auto & [next_q, vals] : graph.out_edges[i][q])
+                            if (vals.contains(val))
+                                next_qs.push_back(next_q);
+
+                        for (const auto & next_q : next_qs) {
+                            graph.out_edges[i][q][next_q].erase(val);
+                            if (graph.out_edges[i][q][next_q].empty())
+                                graph.out_edges[i][q].erase(next_q);
+
+                            if (graph.in_edges[i + 1][next_q].contains(q)) {
+                                graph.in_edges[i + 1][next_q][q].erase(val);
+                                if (graph.in_edges[i + 1][next_q][q].empty())
+                                    graph.in_edges[i + 1][next_q].erase(q);
+                            }
+
+                            decrement_outdeg(graph, i, q, vars, state_at_pos_flags, state, reason, logger);
+                            decrement_indeg(graph, i + 1, next_q, vars, state_at_pos_flags, state, reason, logger);
+                        }
+                    }
+                    graph.states_supporting[i][val] = {};
+                }
+            }
+        }
+
+        for (size_t i = 0; i < graph.states_supporting.size(); i++) {
+            for (auto val : state.each_value_mutable(vars[i])) {
+                // Clean up domains
+                if (graph.states_supporting[i][val].empty())
+                    inference.infer_not_equal(logger, vars[i], val, JustifyUsingRUP{hints::RegularLegacy{owner}}, reason);
+            }
+        }
+
+        // Need to check later whether this is safe to do now we have enumeration proofs
+        // if (logger && short_reasons) {
+        //     if (short_reasons) {
+        //         logger->delete_range(reason_definition_1, reason_definition_2 + 1);
+        //     }
+        // }
+    }
+}
+
+namespace
+{
+    // Records the alphabet (sorted transition keys) for proof logging and s_expr.
+    auto symbols_of(const vector<unordered_map<Integer, set<long>>> & transitions) -> vector<Integer>
+    {
+        set<Integer> sym_set;
+        for (const auto & state_map : transitions)
+            for (const auto & [val, _] : state_map)
+                sym_set.insert(val);
+        return {sym_set.begin(), sym_set.end()};
+    }
+}
+
+RegularLegacy::RegularLegacy(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f) :
+    _vars(move(v)), _num_states(n), _transitions(t.size()), _final_states(move(f)), _regex(nullopt)
+{
+    for (size_t q = 0; q < t.size(); ++q)
+        for (const auto & [val, target] : t[q])
+            if (target != -1L)
+                _transitions[q][val].insert(target);
+    _symbols = symbols_of(_transitions);
+}
+
+RegularLegacy::RegularLegacy(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f) :
+    _vars(move(v)), _num_states(n), _transitions(n), _final_states(move(f)), _regex(nullopt)
+{
+    for (size_t i = 0; i < transitions.size(); i++)
+        for (size_t j = 0; j < transitions[i].size(); j++)
+            if (transitions[i][j] != -1L)
+                _transitions[i][Integer(j)].insert(transitions[i][j]);
+    _symbols = symbols_of(_transitions);
+}
+
+RegularLegacy::RegularLegacy(vector<IntegerVariableID> v, string regex) : _vars(move(v)), _num_states(0), _regex(move(regex))
+{
+    // The automaton is compiled from the regex in prepare(), once the
+    // variables' domains (and hence the alphabet for "." and "[^...]") are known.
+}
+
+RegularLegacy::RegularLegacy(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, set<long>>> t, vector<long> f, vector<Integer> syms,
+    bool sr, optional<string> regex) :
+    _vars(move(v)), _num_states(n), _transitions(move(t)), _final_states(move(f)), _short_reasons(sr), _regex(move(regex)), _symbols(move(syms))
+{
+}
+
+auto RegularLegacy::with_short_reasons(std::optional<bool> short_reasons) -> RegularLegacy &
+{
+    _short_reasons = short_reasons.value_or(true);
+    return *this;
+}
+
+auto RegularLegacy::clone() const -> unique_ptr<Constraint>
+{
+    return unique_ptr<Constraint>(new RegularLegacy(_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex));
+}
+
+auto RegularLegacy::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto RegularLegacy::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    if (_regex) {
+        // Alphabet for "." and "[^...]": the contiguous min..max range over the
+        // union of the variables' domains, mirroring MiniZinc's semantics.
+        auto lo = Integer::max_value(), hi = Integer::min_value();
+        for (const auto & var : _vars)
+            for (const auto & val : initial_state.each_value_immutable(var)) {
+                if (val < lo)
+                    lo = val;
+                if (val > hi)
+                    hi = val;
+            }
+        vector<Integer> alphabet;
+        for (auto val = lo; val <= hi; ++val)
+            alphabet.push_back(val);
+
+        auto nfa = regex_to_nfa(*_regex, alphabet);
+        _num_states = nfa.num_states;
+        _transitions = move(nfa.transitions);
+        _final_states = move(nfa.final_states);
+        _symbols = symbols_of(_transitions);
+    }
+
+    _graph_idx = initial_state.add_constraint_state(RegularGraph(_vars.size(), _num_states));
+
+    // Build the OPB alphabet: the union of transition keys and each var's initial
+    // domain. Domain values absent from every transition get a "no transition"
+    // constraint emitted below, which is what veripb needs to verify the
+    // propagator's RUP-justified pruning of those values.
+    _opb_alphabet.insert(_symbols.begin(), _symbols.end());
+    for (const auto & var : _vars)
+        for (const auto & val : initial_state.each_value_immutable(var))
+            _opb_alphabet.insert(val);
+
+    return true;
+}
+
+auto RegularLegacy::define_proof_model(ProofModel & model) -> void
+{
+    // Make 2D array of flags: state_at_pos_flags[i][q] means the DFA is in state q when it receives the
+    // input value from vars[i], with an extra row of flags for the state after the last transition.
+    // NB: Might be easier to have a 1D array of ProofOnlyIntegerVariables, but making literals of these is
+    // awkward currently. (TODO ?)
+    for (size_t idx = 0; idx <= _vars.size(); ++idx) {
+        WPBSum exactly_1_true{};
+        _state_at_pos_flags.emplace_back();
+        for (long q = 0; q < _num_states; ++q) {
+            // cake_pb_cp names the "in state q at position idx" flag x[id][idx_q][st];
+            // match it so the proof's state literals line up with cake's OPB.
+            _state_at_pos_flags[idx].emplace_back(
+                model.create_proof_flag(_constraint_id, vector<long long>{static_cast<long long>(idx), static_cast<long long>(q)}, "st"));
+            exactly_1_true += 1_i * _state_at_pos_flags[idx][q];
+        }
+        model.add_constraint(move(exactly_1_true) == 1_i);
+    }
+
+    // State at pos 0 is 0
+    model.add_constraint(WPBSum{} + 1_i * _state_at_pos_flags[0][0] >= 1_i);
+    // State at pos n is one of the final states
+    WPBSum pos_n_states;
+    for (const auto & f : _final_states) {
+        pos_n_states += 1_i * _state_at_pos_flags[_vars.size()][f];
+    }
+    model.add_constraint(move(pos_n_states) >= 1_i);
+
+    for (size_t idx = 0; idx < _vars.size(); ++idx) {
+        for (long q = 0; q < _num_states; ++q) {
+            for (const auto & val : _opb_alphabet) {
+                const auto & targets = find_transitions(_transitions[q], val);
+                if (targets.empty()) {
+                    // No transition for (q, val), so constrain ~(state_i = q /\ X_i = val)
+                    model.add_constraint(WPBSum{} + 1_i * (_vars[idx] != val) + (1_i * ! _state_at_pos_flags[idx][q]) >= 1_i);
+                }
+                else {
+                    // state_i = q /\ X_i = val implies state_{i+1} is one of the
+                    // targets (a single target for a DFA, several for an NFA).
+                    auto clause = WPBSum{} + 1_i * ! _state_at_pos_flags[idx][q] + 1_i * (_vars[idx] != val);
+                    for (const auto & new_q : targets)
+                        clause += 1_i * _state_at_pos_flags[idx + 1][new_q];
+                    model.add_constraint(move(clause) >= 1_i);
+                }
+            }
+        }
+    }
+}
+
+auto RegularLegacy::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    triggers.on_change = {_vars.begin(), _vars.end()};
+
+    propagators.install(
+        constraint_id(),
+        [v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = _graph_idx, flags = move(_state_at_pos_flags),
+            sr = _short_reasons, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_regular(v, n, t, f, flags, g, state, inference, logger, sr, owner);
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto RegularLegacy::constraint_type() const -> std::string
+{
+    return "regular_legacy";
+}
+
+auto RegularLegacy::s_expr(const ProofModel * const model) const -> SExpr
+{
+    auto & tracker = model->names_and_ids_tracker();
+
+    vector<SExpr> vars;
+    for (const auto & var : _vars)
+        vars.push_back(tracker.s_expr_term_of(var));
+
+    // A regex-built RegularLegacy only compiles its automaton in prepare(), and
+    // prepare runs on the installed clone, never on the stored constraint this
+    // is called on -- so without compiling here too, the written .scp would
+    // describe an empty automaton rather than the constraint actually solved
+    // (issue #481). Rebuild the same alphabet prepare() uses: the contiguous
+    // min..max range over the variables' initial domains, whose extremes are
+    // exactly the bounds the tracker recorded at variable set-up.
+    long num_states = _num_states;
+    const auto * transitions = &_transitions;
+    const auto * final_states = &_final_states;
+    RegexNfa compiled{};
+    if (_regex && 0 == num_states) {
+        auto lo = Integer::max_value(), hi = Integer::min_value();
+        for (const auto & var : _vars) {
+            auto [l, u] = overloaded{[&](const SimpleIntegerVariableID & v) -> pair<Integer, Integer> { return tracker.tracked_bounds(v); },
+                [&](const ViewOfIntegerVariableID & v) -> pair<Integer, Integer> {
+                    auto [al, au] = tracker.tracked_bounds(v.actual_variable);
+                    if (v.negate_first)
+                        return {-au + v.then_add, -al + v.then_add};
+                    return {al + v.then_add, au + v.then_add};
+                },
+                [&](const ConstantIntegerVariableID & v) -> pair<Integer, Integer> {
+                    return {v.const_value, v.const_value};
+                }}.visit(var);
+            lo = min(lo, l);
+            hi = max(hi, u);
+        }
+        vector<Integer> alphabet;
+        for (auto val = lo; val <= hi; ++val)
+            alphabet.push_back(val);
+        compiled = regex_to_nfa(*_regex, alphabet);
+        num_states = compiled.num_states;
+        transitions = &compiled.transitions;
+        final_states = &compiled.final_states;
+    }
+
+    // One edge list per state, in state order: position i holds the edges out of
+    // state i, and each edge is (symbol target) -- reading `symbol` moves from
+    // state i to state `target`. This is the shape cake_pb_cp's regular parser
+    // expects: `(vars...) nstates ((edges-of-0) (edges-of-1) ...) (finals...)`,
+    // with no separate alphabet list (cake recovers the symbols from the edges).
+    // A non-deterministic automaton emits several edges with the same symbol.
+    // The transitions are unordered_maps, so collect the (symbol, target) pairs
+    // and sort them: the written .scp must be byte-stable across standard
+    // libraries (hash iteration order is not portable, which breaks the
+    // write -> read -> write round-trip), and a canonical order does that.
+    vector<SExpr> states;
+    for (long i = 0; i < num_states; ++i) {
+        vector<SExpr> edges;
+        if (static_cast<size_t>(i) < transitions->size()) {
+            vector<pair<Integer, long>> sorted_edges;
+            for (const auto & tran : (*transitions)[i])
+                for (const auto & target : tran.second)
+                    sorted_edges.emplace_back(tran.first, target);
+            sort(sorted_edges);
+            for (const auto & [sym, target] : sorted_edges)
+                edges.push_back(SExpr::list({SExpr::atom(sym.to_string()), SExpr::atom(std::to_string(target))}));
+        }
+        states.push_back(SExpr::list(move(edges)));
+    }
+
+    vector<SExpr> finals;
+    for (const auto & f : *final_states)
+        finals.push_back(SExpr::atom(std::to_string(f)));
+
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(move(vars)),
+        SExpr::atom(std::to_string(num_states)), SExpr::list(move(states)), SExpr::list(move(finals))});
+}

--- a/gcs/constraints/regular/regular_legacy.hh
+++ b/gcs/constraints/regular/regular_legacy.hh
@@ -1,0 +1,66 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_LEGACY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_LEGACY_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/extensional.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/variable_id.hh>
+#include <set>
+#include <unordered_map>
+#include <vector>
+namespace gcs
+{
+    /**
+     * \brief Legacy Regular propagator: rebuilds its support graph and
+     * proof scaffolding on every propagation call.
+     *
+     * This is the original implementation, retained for benchmarking
+     * against the new upfront-scaffolding Regular. New code should
+     * post Regular instead.
+     *
+     * Constrain that the sequence of variables is a member of the
+     * language recognised by the given Deterministic Finite Automaton,
+     * equivalent to a regex expression. "short_reasons" uses aliases for
+     * reasons when proof logging is enabled, which can result in shorter
+     * proofs.
+     *
+     * \ingroup Constraints
+     */
+    class RegularLegacy : public Constraint
+    {
+    private:
+        const std::vector<IntegerVariableID> _vars;
+        const long _num_states;
+        std::vector<std::unordered_map<Integer, long>> _transitions;
+        const std::vector<long> _final_states;
+        const bool _short_reasons;
+        std::vector<Integer> _symbols;
+        std::vector<std::vector<innards::ProofFlag>> _state_at_pos_flags;
+        innards::ConstraintStateHandle _graph_idx;
+        std::set<Integer> _opb_alphabet;
+
+        [[nodiscard]] auto symbols() const -> const std::vector<Integer> &;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit RegularLegacy(std::vector<IntegerVariableID> vars,
+            long num_states,
+            std::vector<std::unordered_map<Integer, long>> transitions,
+            std::vector<long> final_states, bool short_reasons = true);
+
+        explicit RegularLegacy(std::vector<IntegerVariableID> vars,
+            long num_states,
+            std::vector<std::vector<long>> transitions,
+            std::vector<long> final_states, bool sr = true);
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/regular/regular_legacy.hh
+++ b/gcs/constraints/regular/regular_legacy.hh
@@ -1,50 +1,35 @@
-#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_HH
-#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_HH
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_LEGACY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGULAR_LEGACY_HH
 
 #include <gcs/constraint.hh>
 #include <gcs/extensional.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
-
-#include <memory>
 #include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
 namespace gcs
 {
     /**
      * \brief Constrain that the sequence of variables is a member of the
      * language recognised by the given finite automaton, equivalent to a regex
      * expression. The automaton may be non-deterministic: each (state, value)
-     * pair maps to a set of next states.
+     * pair maps to a set of next states. "short_reasons" uses aliases for
+     * reasons when proof logging is enabled, which can result in shorter
+     * proofs.
      *
      * The automaton may instead be given as a regular expression string, which
      * is compiled to an NFA over the constrained variables' domains. The syntax
      * matches MiniZinc/Gecode (see regular/regex.hh).
      *
-     * Proof scaffolding mirrors the upfront pattern used by MDD, Knapsack, and
-     * BinPacking Stage 3: the OPB encoding is the natural per-(state, val)
-     * forward chains plus per-layer exactly-one, and a one-shot Top-level
-     * initialiser derives per-val backward chains plus statically-dead-node
-     * lines. The per-call propagator's `~state[i][q]` derivations RUP-close
-     * through that scaffolding instead of re-emitting per-(parent, val)
-     * intermediates on every propagation call.
-     *
-     * The `short_reasons` flag is retained for API parity with RegularLegacy
-     * and benchmarking. The new propagator emits at most one proof line per
-     * state-death, so the effect of the flag is small or zero here.
-     *
      * \ingroup Constraints
      */
-    class Regular : public Constraint
+    class RegularLegacy : public Constraint
     {
     private:
-        struct Bridge;
-
         const std::vector<IntegerVariableID> _vars;
         long _num_states;
         std::vector<std::unordered_map<Integer, std::set<long>>> _transitions;
@@ -52,14 +37,13 @@ namespace gcs
         bool _short_reasons = true;
         const std::optional<std::string> _regex;
         std::vector<Integer> _symbols;
-        std::shared_ptr<Bridge> _bridge;
+        std::vector<std::vector<innards::ProofFlag>> _state_at_pos_flags;
         innards::ConstraintStateHandle _graph_idx;
-        innards::ConstraintStateHandle _dead_cache_idx;
         std::set<Integer> _opb_alphabet;
 
         // Copy-style constructor used by clone(): takes the internal multi-target
         // representation (and the regex, if any) directly.
-        Regular(std::vector<IntegerVariableID> vars, long num_states, std::vector<std::unordered_map<Integer, std::set<long>>> transitions,
+        RegularLegacy(std::vector<IntegerVariableID> vars, long num_states, std::vector<std::unordered_map<Integer, std::set<long>>> transitions,
             std::vector<long> final_states, std::vector<Integer> symbols, bool short_reasons, std::optional<std::string> regex);
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
@@ -67,10 +51,10 @@ namespace gcs
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
-        explicit Regular(std::vector<IntegerVariableID> vars, long num_states, std::vector<std::unordered_map<Integer, long>> transitions,
+        explicit RegularLegacy(std::vector<IntegerVariableID> vars, long num_states, std::vector<std::unordered_map<Integer, long>> transitions,
             std::vector<long> final_states);
 
-        explicit Regular(
+        explicit RegularLegacy(
             std::vector<IntegerVariableID> vars, long num_states, std::vector<std::vector<long>> transitions, std::vector<long> final_states);
 
         /**
@@ -78,12 +62,12 @@ namespace gcs
          * regular expression. The expression is compiled to an NFA over the
          * contiguous min..max range of the variables' domains.
          */
-        explicit Regular(std::vector<IntegerVariableID> vars, std::string regex);
+        explicit RegularLegacy(std::vector<IntegerVariableID> vars, std::string regex);
 
         /// Whether to use short reasons in the proof log (default true). Takes a
         /// std::optional<bool> so a runtime flag can be passed directly; nullopt
         /// or no argument leaves it at true.
-        auto with_short_reasons(std::optional<bool> short_reasons = true) -> Regular &;
+        auto with_short_reasons(std::optional<bool> short_reasons = true) -> RegularLegacy &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/regular/regular_legacy_test.cc
+++ b/gcs/constraints/regular/regular_legacy_test.cc
@@ -1,0 +1,314 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/regular/regex.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::nullopt;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::unordered_map;
+using std::vector;
+using std::ranges::find;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+auto run_regular_test(bool proofs, const ViewWrapConfig & view_cfg, const string & desc, vector<pair<int, int>> var_ranges, long num_states,
+    vector<unordered_map<Integer, long>> transitions, vector<long> final_states) -> void
+{
+    auto wraps = wraps_for_positions(view_cfg, static_cast<int>(var_ranges.size()));
+    print(cerr, "regular [{}] {} {} vars{}", view_wrap_config_label(view_cfg), desc, var_ranges.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto dfa_accepts = [&](const vector<int> & seq) -> bool {
+        long state = 0;
+        for (int val : seq) {
+            auto it = transitions[state].find(Integer(val));
+            if (it == transitions[state].end() || it->second == -1L)
+                return false;
+            state = it->second;
+        }
+        return find(final_states, state) != final_states.end();
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> seq) { return dfa_accepts(seq); }, var_ranges);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> vars;
+    for (std::size_t i = 0; i < var_ranges.size(); ++i)
+        vars.push_back(create_integer_variable_or_constant_with_view(p, var_ranges.at(i), wraps.at(i)));
+    p.post(RegularLegacy{vars, num_states, transitions, final_states});
+
+    auto proof_name = proofs ? make_optional("regular_legacy_test_" + view_wrap_config_label(view_cfg)) : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
+    check_results(proof_name, expected, actual);
+}
+
+// Dup-variable test: RegularLegacy with the same handle at several positions.
+// Each position is processed independently by the DFA; aliasing forces
+// those positions to take the same letter. Consistency isn't checked
+// on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_regular_test(bool proofs, const string & label, const vector<pair<int, int>> & unique_domains, const vector<int> & positions,
+    long num_states, vector<unordered_map<Integer, long>> transitions, vector<long> final_states) -> void
+{
+    print(cerr, "regular dup {} unique_doms={} positions={}{}", label, unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto dfa_accepts = [&](const vector<int> & seq) -> bool {
+        long state = 0;
+        for (int val : seq) {
+            auto it = transitions[state].find(Integer(val));
+            if (it == transitions[state].end() || it->second == -1L)
+                return false;
+            state = it->second;
+        }
+        return find(final_states, state) != final_states.end();
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected,
+        [&](const vector<int> & unique_vals) -> bool {
+            vector<int> seq;
+            for (auto pos : positions)
+                seq.push_back(unique_vals.at(pos));
+            return dfa_accepts(seq);
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & [lo, hi] : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
+    vector<IntegerVariableID> vars;
+    for (auto pos : positions)
+        vars.push_back(unique_vars.at(pos));
+    p.post(RegularLegacy{vars, num_states, transitions, final_states});
+
+    auto proof_name = proofs ? make_optional("regular_legacy_test_dup_" + label) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
+// Regex-string form of the constraint. The oracle is the independent reference
+// matcher from regular/regex.hh, given the same contiguous min..max alphabet
+// that RegularLegacy::prepare derives from the variable domains.
+auto run_regular_regex_test(bool proofs, const string & label, const string & regex, const vector<pair<int, int>> & var_ranges) -> void
+{
+    print(cerr, "regular regex {} \"{}\" {} vars{}", label, regex, var_ranges.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    int lo = var_ranges.front().first, hi = var_ranges.front().second;
+    for (const auto & [a, b] : var_ranges) {
+        lo = a < lo ? a : lo;
+        hi = b > hi ? b : hi;
+    }
+    vector<Integer> alphabet;
+    for (int v = lo; v <= hi; ++v)
+        alphabet.push_back(Integer(v));
+
+    auto accepts = [&](const vector<int> & seq) -> bool {
+        vector<Integer> as_integers;
+        for (int v : seq)
+            as_integers.push_back(Integer(v));
+        return gcs::innards::regex_reference_accepts(regex, alphabet, as_integers);
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> seq) { return accepts(seq); }, var_ranges);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> vars;
+    for (const auto & [a, b] : var_ranges)
+        vars.push_back(p.create_integer_variable(Integer(a), Integer(b)));
+    p.post(RegularLegacy{vars, regex});
+
+    auto proof_name = proofs ? make_optional("regular_legacy_regex_test_" + label) : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_all_regex_tests(bool proofs) -> void
+{
+    // Deterministic: a fixed sequence.
+    run_regular_regex_test(proofs, "concat", "0 1 0", {{0, 1}, {0, 1}, {0, 1}});
+    // The 0*11*0* language from the Pesant example.
+    run_regular_regex_test(proofs, "star", "0* 1 1* 0*", {{0, 1}, {0, 1}, {0, 1}, {0, 1}});
+    // Genuine non-determinism: after reading a 1 the NFA can be in two states,
+    // exercising the disjunctive transition clause in the proof model.
+    run_regular_regex_test(proofs, "nfa_fanout", "1 2|1 3", {{1, 3}, {1, 3}});
+    // Wildcard expands to the domain's min..max.
+    run_regular_regex_test(proofs, "wildcard", "0 . 0", {{0, 1}, {0, 1}, {0, 1}});
+    // Counted quantifier with a trailing star.
+    run_regular_regex_test(proofs, "counted", "0{1,2} 1*", {{0, 1}, {0, 1}, {0, 1}});
+    // Negated class over an alphabet with a hole at the top of the range.
+    run_regular_regex_test(proofs, "negclass", "[^0] [^0]", {{0, 2}, {0, 2}});
+}
+
+auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -> void
+{
+    // DFA: even number of 0s, binary alphabet {0,1}
+    // State 0 (initial, final): 0->1, 1->0
+    // State 1: 0->0, 1->1
+    run_regular_test(proofs, view_cfg, "even zeros", {{0, 1}, {0, 1}, {0, 1}}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                       //
+        {0});
+
+    // DFA: no two consecutive 0s, binary alphabet {0,1}
+    // State 0 (initial, final): 0->1, 1->0
+    // State 1 (final, last was 0): 0->dead (absent), 1->0
+    run_regular_test(proofs, view_cfg, "no consecutive 0s", {{0, 1}, {0, 1}, {0, 1}, {0, 1}}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{1_i, 0}}},                                                //
+        {0, 1});
+
+    // DFA: sequence contains at least one 2, ternary alphabet {0,1,2}
+    // State 0: 0->0, 1->0, 2->1
+    // State 1 (final): all symbols -> 1
+    run_regular_test(proofs, view_cfg, "contains 2", {{0, 2}, {0, 2}, {0, 2}}, //
+        2, {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},   //
+        {1});
+
+    // Same DFA: first two variables restricted to {0,1}, last to {0,1,2}.
+    // GAC must prune the last variable's domain to {2} at the root, since
+    // no accepting path exists unless some variable carries the value 2.
+    run_regular_test(proofs, view_cfg, "contains 2, last forced to 2", {{0, 1}, {0, 1}, {0, 2}}, //
+        2, {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},                     //
+        {1});
+
+    // DFA: all symbols in the sequence must be identical, binary alphabet {0,1}
+    // State 0 (initial): 0->1, 1->2
+    // State 1 (all 0s so far, final): 0->1, 1->dead (absent)
+    // State 2 (all 1s so far, final): 0->dead (absent), 1->2
+    run_regular_test(proofs, view_cfg, "all same", {{0, 1}, {0, 1}, {0, 1}, {0, 1}}, //
+        4, {{{0_i, 1}, {1_i, 2}}, {{0_i, 1}}, {{1_i, 2}}, {}},                       //
+        {1, 2});
+
+    // Unsatisfiable: no final states
+    run_regular_test(proofs, view_cfg, "no final states", {{0, 1}, {0, 1}, {0, 1}}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                            //
+        {});
+
+    // Unsatisfiable: variable domains exclude all accepting paths.
+    // "Contains 2" DFA with all variables restricted to {0,1} — 2 is never reachable.
+    run_regular_test(proofs, view_cfg, "domain excludes accepting paths", {{0, 1}, {0, 1}, {0, 1}}, //
+        2, {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},                        //
+        {1});
+
+    // Degenerate cases (issue #254). The even-zeros DFA: state 0 (initial) is
+    // the "even count of 0s" state; 0 toggles state, 1 keeps it.
+    // Empty sequence with the initial state accepting -> the empty word is
+    // accepted (zero 0s is even).
+    run_regular_test(proofs, view_cfg, "empty seq accepted", {}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},         //
+        {0});
+    // Empty sequence with only the non-initial state accepting -> the empty
+    // word is rejected.
+    run_regular_test(proofs, view_cfg, "empty seq rejected", {}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},         //
+        {1});
+    // Single fixed symbol, both directions.
+    run_regular_test(proofs, view_cfg, "single fixed accepted", {{1, 1}}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                  //
+        {0});                                                             // [1] has zero 0s: accepted
+    run_regular_test(proofs, view_cfg, "single fixed rejected", {{0, 0}}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                  //
+        {0});                                                             // [0] has one 0 (odd): rejected
+    // Fully fixed multi-symbol accepted word.
+    run_regular_test(proofs, view_cfg, "all fixed accepted", {{1, 1}, {0, 0}, {0, 0}}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                               //
+        {0});                                                                          // two 0s (even): accepted
+    // Mixed fixed + variable: only the middle symbol can make the count even.
+    run_regular_test(proofs, view_cfg, "mixed fixed and variable", {{0, 0}, {0, 1}, {0, 0}}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                                     //
+        {0});                                                                                // accepted only when the middle symbol is 1
+
+    // Regex-string and dup tests use bare variables; only run them when no
+    // wrapping is in effect, to avoid duplicating the bare coverage under
+    // every wrap.
+    if (! run_dup)
+        return;
+
+    run_all_regex_tests(proofs);
+
+    // Dup-variable cases: "even zeros" DFA with positions[0] reused.
+    // {x, x, y} — two equal letters then y; "even zeros" wants total zeros
+    // to be even, so two-of-the-same plus y leaves parity determined by y
+    // when x=1, or determined by !y when x=0.
+    run_dup_regular_test(proofs, "xxy_even_zeros", {{0, 1}, {0, 1}}, {0, 0, 1}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                        //
+        {0});
+    // {x, y, x} — non-adjacent dup.
+    run_dup_regular_test(proofs, "xyx_even_zeros", {{0, 1}, {0, 1}}, {0, 1, 0}, //
+        2, {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},                        //
+        {0});
+    // {x, x} with "all same" DFA: same handle at two positions ⇒ trivially
+    // all-same; this just checks the DFA accepts.
+    run_dup_regular_test(proofs, "xx_all_same", {{0, 1}}, {0, 0}, //
+        4, {{{0_i, 1}, {1_i, 2}}, {{0_i, 1}}, {{1_i, 2}}, {}},    //
+        {1, 2});
+    // {x, x, y, y} with "all same": requires x == y so the sequence is constant.
+    run_dup_regular_test(proofs, "xxyy_all_same", {{0, 1}, {0, 1}}, {0, 0, 1, 1}, //
+        4, {{{0_i, 1}, {1_i, 2}}, {{0_i, 1}}, {{1_i, 2}}, {}},                    //
+        {1, 2});
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+
+    // Sequence positions wrapped by the single-position sweep. The fixed
+    // data tops out at 4 vars, so a single-position index beyond this would
+    // wrap nothing on any test; detect and skip rather than emit a duplicate
+    // bare run. mixed/uniform wrap every position.
+    constexpr int n_positions = 4;
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        println(cerr, "regular view sweep: position {} out of range for n_positions = {}; skipping", *view_cfg.single_position, n_positions);
+        return EXIT_SUCCESS;
+    }
+
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        run_all_tests(proofs, view_cfg, run_dup);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/regular_legacy_test.cc
+++ b/gcs/constraints/regular_legacy_test.cc
@@ -1,0 +1,154 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::nullopt;
+using std::pair;
+using std::ranges::find;
+using std::set;
+using std::string;
+using std::tuple;
+using std::unordered_map;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+auto run_regular_legacy_test(bool proofs, const string & desc,
+    vector<pair<int, int>> var_ranges,
+    long num_states,
+    vector<unordered_map<Integer, long>> transitions,
+    vector<long> final_states) -> void
+{
+    print(cerr, "regular_legacy {} {} vars{}", desc, var_ranges.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto dfa_accepts = [&](const vector<int> & seq) -> bool {
+        long state = 0;
+        for (int val : seq) {
+            auto it = transitions[state].find(Integer(val));
+            if (it == transitions[state].end() || it->second == -1L)
+                return false;
+            state = it->second;
+        }
+        return find(final_states, state) != final_states.end();
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> seq) { return dfa_accepts(seq); }, var_ranges);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> vars;
+    for (const auto & [lo, hi] : var_ranges)
+        vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
+    p.post(RegularLegacy{vars, num_states, transitions, final_states});
+
+    auto proof_name = proofs ? make_optional("regular_legacy_test") : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_all_tests(bool proofs) -> void
+{
+    // DFA: even number of 0s, binary alphabet {0,1}
+    // State 0 (initial, final): 0->1, 1->0
+    // State 1: 0->0, 1->1
+    run_regular_legacy_test(proofs, "even zeros",
+        {{0, 1}, {0, 1}, {0, 1}},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0});
+
+    // DFA: no two consecutive 0s, binary alphabet {0,1}
+    // State 0 (initial, final): 0->1, 1->0
+    // State 1 (final, last was 0): 0->dead (absent), 1->0
+    run_regular_legacy_test(proofs, "no consecutive 0s",
+        {{0, 1}, {0, 1}, {0, 1}, {0, 1}},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{1_i, 0}}},
+        {0, 1});
+
+    // DFA: sequence contains at least one 2, ternary alphabet {0,1,2}
+    // State 0: 0->0, 1->0, 2->1
+    // State 1 (final): all symbols -> 1
+    run_regular_legacy_test(proofs, "contains 2",
+        {{0, 2}, {0, 2}, {0, 2}},
+        2,
+        {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},
+        {1});
+
+    // Same DFA: first two variables restricted to {0,1}, last to {0,1,2}.
+    // GAC must prune the last variable's domain to {2} at the root, since
+    // no accepting path exists unless some variable carries the value 2.
+    run_regular_legacy_test(proofs, "contains 2, last forced to 2",
+        {{0, 1}, {0, 1}, {0, 2}},
+        2,
+        {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},
+        {1});
+
+    // DFA: all symbols in the sequence must be identical, binary alphabet {0,1}
+    // State 0 (initial): 0->1, 1->2
+    // State 1 (all 0s so far, final): 0->1, 1->dead (absent)
+    // State 2 (all 1s so far, final): 0->dead (absent), 1->2
+    run_regular_legacy_test(proofs, "all same",
+        {{0, 1}, {0, 1}, {0, 1}, {0, 1}},
+        4,
+        {{{0_i, 1}, {1_i, 2}}, {{0_i, 1}}, {{1_i, 2}}, {}},
+        {1, 2});
+
+    // Unsatisfiable: no final states
+    run_regular_legacy_test(proofs, "no final states",
+        {{0, 1}, {0, 1}, {0, 1}},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {});
+
+    // Unsatisfiable: variable domains exclude all accepting paths.
+    // "Contains 2" DFA with all variables restricted to {0,1} — 2 is never reachable.
+    run_regular_legacy_test(proofs, "domain excludes accepting paths",
+        {{0, 1}, {0, 1}, {0, 1}},
+        2,
+        {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},
+        {1});
+}
+
+auto main(int, char *[]) -> int
+{
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        run_all_tests(proofs);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Reimplements `Regular` along the upfront-scaffolding pattern from MDD (#211) and Knapsack (#210): build the DFA support graph once in `prepare()`, emit per-val backward chains and statically-dead-state lines once at `ProofLevel::Top` via `install_initialiser`, and slim the per-call propagator to a single cache-gated `~state[i][q]` line at `ProofLevel::Current` per state-death. The OPB encoding is unchanged from `RegularLegacy`.

The legacy implementation is preserved verbatim as `RegularLegacy` in `gcs/constraints/regular/regular_legacy.{hh,cc}` and exercised by `regular_legacy_test` for as long as we want side-by-side benchmarking.

`Regular` is structurally a layer-uniform MDD, so it's essentially the MDD-reimpl pattern specialised to a shared transition function across layers. Same Top-scaffolding shape, same `DeadCache` plumbing, same per-call sweep.

## Default: the upfront `Regular` is now the default

Everything posts the upfront `Regular` — both frontends (`xcsp_glasgow_constraint_solver`, `fzn_glasgow`), the constraint tests, and the `regular_random` example. `RegularLegacy` (the older per-call propagator) is kept only as the `--legacy` opt-in twin, for side-by-side benchmarking and as a correctness reference.

Upfront is the right default because it **wins on both proof-logging axes**, measured this session *within-branch* (same search tree to the digit — only the propagator is toggled):

- **Proof size: 13–55× smaller** — 9 MB vs `RegularLegacy`'s 496 MB at the largest instance (7660 solutions).
- **VeriPB verify time: 2.3–7× faster** — 1.66 s vs 11.69 s on that instance.

Both effects grow with search size (the fixed root scaffold amortises; the displaced per-call volume compounds). Mechanistically a `Regular` automaton is *narrow*, so the permanent Top-level scaffold is tiny and adds almost no per-line "DB-tax", while the per-call `RegularLegacy` baseline is very verbose — large displacement, small tax, so upfront wins size *and* time. This is the narrow-diagram case of the cross-cutting analysis in `dev_docs/decision-diagram-proof-strategies.md`, which lands MDD (#211), Knapsack (#210) and BinPacking (#212) on their respective defaults.

## What's where

- **`gcs/constraints/regular/regular.{hh,cc}`** — new implementation.
- **`gcs/constraints/regular/regular_legacy.{hh,cc}`** — old implementation, class renamed to `RegularLegacy`; `s_exprify` label is now `regular_legacy`.
- **`gcs/constraints/regular.hh`** — thin shim including both, so existing callers (`gcs/gcs.hh`, xcsp, minizinc, examples) compile unchanged.
- **`gcs/constraints/regular_test.cc`** — tests the new `Regular` (same seven cases as before).
- **`gcs/constraints/regular_legacy_test.cc`** — same seven cases retargeted at `RegularLegacy`, separate proof basename so both run side by side under VeriPB.
- **`examples/regular_random/regular_random.cc`** — adds `--legacy`; combined with the existing `--short-reasons` (which only affects the legacy), one binary now covers all three variants.
- **`dev_docs/regular.md`** — design note: layered-DAG view, OPB encoding, Top scaffolding derivation, per-call propagator shape, bench numbers, #200 pointer.

The `short_reasons` constructor arg is retained on the new `Regular` as a dummy for API parity with `RegularLegacy` and to let `regular_random` cover all three variants from a single command line. The new propagator emits at most one proof line per state-death, so the flag's effect on the new path is small or zero.

## Bench (regular_random, seed `-1115540197`)

One binary, three variants:

| n  | variant            | solve | proof    | verify |
|---:|--------------------|------:|---------:|-------:|
| 10 | new                | 0.00s | 86 KB    | 0.00s  |
| 10 | legacy             | 0.01s | 1.76 MB  | 0.03s  |
| 10 | legacy + short-rsn | 0.00s | 454 KB   | 0.04s  |
| 14 | new                | 0.00s | 230 KB   | 0.02s  |
| 14 | legacy             | 0.06s | 8.76 MB  | 0.13s  |
| 14 | legacy + short-rsn | 0.01s | 1.75 MB  | 0.24s  |
| 18 | new                | 0.01s | 490 KB   | 0.06s  |
| 18 | legacy             | 0.25s | 33.3 MB  | 0.51s  |
| 18 | legacy + short-rsn | 0.04s | 4.95 MB  | 0.98s  |

The new `Regular` produces proofs 4–68× smaller than the legacy default and 1.5–10× smaller than the legacy with `short_reasons`, and VeriPB verifies them faster on every sampled size. This is the MDD-reimpl shape (proof shrink + slim per-call); it doesn't follow the BinPacking-#212 regression because `RegularLegacy` was emitting per-(parent, val) intermediates on every propagation call, so it's far from the already-lean category.

## Risks / trade-offs

- Same Top-vs-Current bet as MDD/Knapsack: if a search uses very few of the dead-state flags the scaffolding bought, we still emit the chains at root. With Regular's relatively small DFAs (vs Knapsack's wide DP) and the layer-uniform sharing, root cost is small in practice — visible in the verify-time table above being lower than the legacy at every sampled size.
- `RegularLegacy::s_exprify` now emits `regular_legacy` instead of `regular`. No callers consume `s_exprify` output as a parser of constraint identity, but worth flagging.

## Test plan

- [x] `cmake --build --preset release --target regular_test regular_legacy_test` clean.
- [x] `./build/regular_test` and `./build/regular_legacy_test` — all 7 subtests verify under VeriPB for each.
- [x] `cmake --build --preset sanitize` clean.
- [x] `./build-sanitize/regular_test` and `./build-sanitize/regular_legacy_test` — clean under ASan + UBSan.
- [x] `ctest --preset release -j 32` — 205/205 pass.
- [x] `ctest --preset sanitize -j 32 -R regular` — 4/4 pass (incl. `regular_random` and `regular_random-seeded`).
- [x] `regular_random --prove --seed -1115540197` — verifies for all three variants (`new`, `--legacy`, `--legacy --short-reasons`).
- [x] `xcsp_regular` passes through the new `Regular` (no constructor change at the frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
