### PR TITLE
View-wrap proof verification sweep: harness + 20 wired constraints

### DIFF
--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -44,7 +44,7 @@ template <typename Literal_>
         // infeasible. Issue #171.
         unsigned n_false = 0;
         for (const auto & atom : atoms) {
-            if (holds_alternative<FalseLiteral>(simplify_literal(atom))) {
+            if (holds_alternative<FalseLiteral>(simplify_literal(logger.names_and_ids_tracker(), atom))) {
                 if (++n_false >= 2)
                     return logger.emit(RUPProofRule{}, WPBSum{} >= 1_i, level);
             }

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -32,7 +32,7 @@ auto gcs::innards::emit_inequality_to(
                     [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
                         stream << -w << " " << names_and_ids_tracker.pb_file_string_for(cond) << " ";
                     }}
-                    .visit(simplify_literal(lit));
+                    .visit(simplify_literal(names_and_ids_tracker, lit));
             },
             [&, w = w](const ProofFlag & flag) {
                 stream << -w << " " << names_and_ids_tracker.pb_file_string_for(flag) << " ";
@@ -44,16 +44,13 @@ auto gcs::innards::emit_inequality_to(
                             stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
                     },
                     [&](const ViewOfIntegerVariableID & view) {
-                        if (! view.negate_first) {
-                            for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(view.actual_variable))
-                                stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
-                            rhs += w * view.then_add;
-                        }
-                        else {
-                            for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(view.actual_variable))
-                                stream << w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
-                            rhs += w * view.then_add;
-                        }
+                        // Route through the view's extension: emit the
+                        // extension's bits directly. The +/- and then_add
+                        // adjustments are absorbed by the extension's
+                        // encoding (it represents the view's visible value).
+                        auto ext = names_and_ids_tracker.extension_for(view);
+                        for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(ext))
+                            stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
                     },
                     [&](const ConstantIntegerVariableID & cvar) {
                         rhs += w * cvar.const_value;

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -44,13 +44,16 @@ auto gcs::innards::emit_inequality_to(
                             stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
                     },
                     [&](const ViewOfIntegerVariableID & view) {
-                        // Route through the view's extension: emit the
-                        // extension's bits directly. The +/- and then_add
-                        // adjustments are absorbed by the extension's
-                        // encoding (it represents the view's visible value).
-                        auto ext = names_and_ids_tracker.extension_for(view);
-                        for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(ext))
-                            stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                        if (! view.negate_first) {
+                            for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(view.actual_variable))
+                                stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                            rhs += w * view.then_add;
+                        }
+                        else {
+                            for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(view.actual_variable))
+                                stream << w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                            rhs += w * view.then_add;
+                        }
                     },
                     [&](const ConstantIntegerVariableID & cvar) {
                         rhs += w * cvar.const_value;

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -44,6 +44,14 @@ auto gcs::innards::emit_inequality_to(
                             stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
                     },
                     [&](const ViewOfIntegerVariableID & view) {
+                        // Emit underlying-form bits with sign flip (for
+                        // negate_first views) and RHS adjustment for the
+                        // constant offset. The view's extension exists in
+                        // the model (see preallocate_extensions_for_views_in)
+                        // and the bridges in need_gevar / need_direct_encoding_for
+                        // tie its atomic literals to the underlying's, but
+                        // host-level constraints stay in underlying-form for
+                        // verifier-side simplicity.
                         if (! view.negate_first) {
                             for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(view.actual_variable))
                                 stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -73,6 +73,18 @@ struct NamesAndIDsTracker::Imp
     map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> gevars_that_exist;
     map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> eqvars_that_exist;
 
+    // Cache of extension variables introduced for views. The optional<ProofLine>s
+    // are the OPB line numbers of the two halves of the definitional
+    // `e == (negate_first ? -actual : actual) + then_add`; pol-bridge
+    // emission needs them to cite the definitional.
+    struct ExtensionInfo
+    {
+        ProofOnlySimpleIntegerVariableID id;
+        optional<ProofLine> def_le_line;
+        optional<ProofLine> def_ge_line;
+    };
+    map<ViewOfIntegerVariableID, ExtensionInfo> view_extensions;
+
     map<ProofFlag, XLiteral> flags;
 
     map<SimpleOrProofOnlyIntegerVariableID, string> id_names;
@@ -276,7 +288,7 @@ auto NamesAndIDsTracker::need_all_proof_names_in(const SumOf<Weighted<PseudoBool
                     [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
                         need_proof_name(cond);
                     }}
-                    .visit(simplify_literal(lit));
+                    .visit(simplify_literal(*this, lit));
             },
             [&](const ProofFlag &) {},
             [&](const IntegerVariableID &) {},
@@ -294,7 +306,7 @@ auto NamesAndIDsTracker::need_all_proof_names_in(const Literals & lits) -> void
             [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
                 need_proof_name(cond);
             }}
-            .visit(simplify_literal(lit));
+            .visit(simplify_literal(*this, lit));
 }
 
 auto NamesAndIDsTracker::need_all_proof_names_in(const HalfReifyOnConjunctionOf & h) -> void
@@ -308,7 +320,7 @@ auto NamesAndIDsTracker::need_all_proof_names_in(const HalfReifyOnConjunctionOf 
                     [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
                         need_proof_name(cond);
                     }}
-                    .visit(simplify_literal(lit));
+                    .visit(simplify_literal(*this, lit));
             },
             [&](const ProofFlag &) {},
             [&](const ProofBitVariable &) {}}
@@ -546,6 +558,14 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             }}
             .visit(id);
     }
+}
+
+auto NamesAndIDsTracker::bounds_for(const SimpleOrProofOnlyIntegerVariableID & id) const -> pair<Integer, Integer>
+{
+    auto it = _imp->integer_variable_definition_bounds.find(id);
+    if (it == _imp->integer_variable_definition_bounds.end())
+        throw ProofError{"bounds_for called for a variable that hasn't been tracked"};
+    return it->second;
 }
 
 auto NamesAndIDsTracker::track_bounds(const SimpleOrProofOnlyIntegerVariableID & id, Integer lower, Integer upper) -> void
@@ -840,7 +860,7 @@ auto NamesAndIDsTracker::s_expr_name_of(Literal lit) const -> string
         [](const VariableConditionFrom<ProofOnlySimpleIntegerVariableID> &) -> string {
             throw UnimplementedException{};
         }}
-        .visit(simplify_literal(lit));
+        .visit(simplify_literal(const_cast<NamesAndIDsTracker &>(*this), lit));
 }
 
 auto NamesAndIDsTracker::s_expr_name_of(ReificationCondition cond) const -> string
@@ -867,6 +887,35 @@ auto NamesAndIDsTracker::s_expr_name_of(VariableConditionOperator op) const -> s
     }
 
     throw NonExhaustiveSwitch{};
+}
+
+auto NamesAndIDsTracker::schedule_pol_line_at_proof_start(const string & raw_line) -> void
+{
+    emit_proof_line_now_or_at_start([raw_line](ProofLogger * const logger) {
+        logger->emit_proof_line(raw_line, ProofLevel::Top);
+    });
+}
+
+auto NamesAndIDsTracker::extension_def_lines_for(const ViewOfIntegerVariableID & view) const
+    -> optional<pair<optional<ProofLine>, optional<ProofLine>>>
+{
+    auto it = _imp->view_extensions.find(view);
+    if (it == _imp->view_extensions.end())
+        return std::nullopt;
+    return std::make_pair(it->second.def_le_line, it->second.def_ge_line);
+}
+
+auto NamesAndIDsTracker::extension_for(const ViewOfIntegerVariableID & view) -> ProofOnlySimpleIntegerVariableID
+{
+    if (auto cached = _imp->view_extensions.find(view); cached != _imp->view_extensions.end())
+        return cached->second.id;
+
+    if (! _imp->model)
+        throw ProofError{"extension_for called for a view that hasn't been seen before, but no ProofModel is active"};
+
+    auto [ext_id, def_le_line, def_ge_line] = _imp->model->allocate_extension_for_view(view);
+    _imp->view_extensions.emplace(view, Imp::ExtensionInfo{ext_id, def_le_line, def_ge_line});
+    return ext_id;
 }
 
 auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif) -> WPBSumLE

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -73,17 +73,24 @@ struct NamesAndIDsTracker::Imp
     map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> gevars_that_exist;
     map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> eqvars_that_exist;
 
-    // Cache of extension variables introduced for views. The optional<ProofLine>s
-    // are the OPB line numbers of the two halves of the definitional
-    // `e == (negate_first ? -actual : actual) + then_add`; pol-bridge
-    // emission needs them to cite the definitional.
+    // Cache of extension variables introduced for views. The extension's
+    // value is defined to equal the view's value via a pair of PB
+    // constraints emitted at allocation time; we remember the OPB line
+    // numbers of those two halves so that the bridge pol derivations
+    // (emitted lazily by need_gevar/need_direct_encoding_for) can cite
+    // them.
     struct ExtensionInfo
     {
         ProofOnlySimpleIntegerVariableID id;
-        optional<ProofLine> def_le_line;
-        optional<ProofLine> def_ge_line;
+        ProofLine def_le_line;
+        ProofLine def_ge_line;
     };
     map<ViewOfIntegerVariableID, ExtensionInfo> view_extensions;
+    // Reverse lookup: which view does a proof-only variable represent?
+    // Populated alongside view_extensions. Used in need_gevar to recognise
+    // that a gevar is being introduced for an extension and emit the
+    // bridge to the underlying variable's corresponding atomic literal.
+    map<ProofOnlySimpleIntegerVariableID, ViewOfIntegerVariableID> view_extension_origins;
 
     map<ProofFlag, XLiteral> flags;
 
@@ -472,6 +479,36 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
 
     _imp->eqvars_that_exist[id].emplace(v, pair{forwards_line, reverse_line});
+
+    // If `id` is a view-extension, emit the Inv1'-style eq-bridges to
+    // the underlying variable's corresponding eq literal. The ge-bridges
+    // alone aren't enough: from a propagator that emits a RUP citing
+    // `i[X][eq_k]` directly, the underlying-side eq literal won't
+    // unit-propagate to the extension-side eq literal without an
+    // explicit clause.
+    visit(overloaded{
+        [&](const SimpleIntegerVariableID &) {},
+        [&](const ProofOnlySimpleIntegerVariableID & ext_id) {
+            auto view_it = _imp->view_extension_origins.find(ext_id);
+            if (view_it == _imp->view_extension_origins.end())
+                return;
+            const auto & view = view_it->second;
+            // e = view = X + then_add (not negate_first):  e=v iff X = v - then_add.
+            // e = view = -X + then_add (negate_first):     e=v iff X = then_add - v.
+            Integer translated_v = view.negate_first ? (view.then_add - v) : (v - view.then_add);
+            need_direct_encoding_for(view.actual_variable, translated_v);
+            IntegerVariableCondition underlying_cond{IntegerVariableID{view.actual_variable},
+                VariableConditionOperator::Equal, translated_v};
+            auto forward = WPBSum{} + 1_i * ! (ext_id == v) + 1_i * underlying_cond;
+            auto reverse = WPBSum{} + 1_i * (ext_id == v) + 1_i * ! underlying_cond;
+            emit_proof_line_now_or_at_start([f = forward >= 1_i](ProofLogger * const logger) {
+                logger->emit_rup_proof_line(f, ProofLevel::Top);
+            });
+            emit_proof_line_now_or_at_start([r = reverse >= 1_i](ProofLogger * const logger) {
+                logger->emit_rup_proof_line(r, ProofLevel::Top);
+            });
+        }},
+        id);
 }
 
 auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
@@ -558,6 +595,81 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             }}
             .visit(id);
     }
+
+    // If `id` is a view-extension, emit the Inv1' ge-bridges between
+    // this gevar and the corresponding gevar on the underlying variable,
+    // so unit propagation can chain between extension-side atomic
+    // literals (used by propagator-emitted RUPs) and underlying-side
+    // atomic literals (used by search-time backtracking RUPs). Bridges
+    // are derived via pol from the bit-level definitional pair and the
+    // two reified-literal halves on each side. (RUP would suffice for
+    // some encoding regimes but not others; pol is uniform and faster
+    // to check.)
+    visit(overloaded{
+        [&](const SimpleIntegerVariableID &) {},
+        [&](const ProofOnlySimpleIntegerVariableID & ext_id) {
+            auto view_it = _imp->view_extension_origins.find(ext_id);
+            if (view_it == _imp->view_extension_origins.end())
+                return;
+            const auto & view = view_it->second;
+            const auto & ext_info = _imp->view_extensions.at(view);
+            // For e = X + then_add (not negate_first): e>=v iff X>=v-then_add.
+            // For e = -X + then_add (negate_first): e>=v iff !(X >= then_add - v + 1).
+            Integer translated_v = view.negate_first ? (view.then_add - v + 1_i) : (v - view.then_add);
+            need_gevar(view.actual_variable, translated_v);
+            auto underlying = view.actual_variable;
+            // See exp_bridge_tc derivations: pol bit-half + e-half + X-half + saturate.
+            //   !negate_first:
+            //     forward (~e_ge_v + X_ge_m >= 1) = bit_def_GE + e_ge_v_fwd + X_ge_m_rev + s
+            //     reverse (e_ge_v + ~X_ge_m >= 1) = bit_def_LE + e_ge_v_rev + X_ge_m_fwd + s
+            //   negate_first:
+            //     forward (~e_ge_v + ~X_ge_m >= 1) = bit_def_GE + e_ge_v_fwd + X_ge_m_fwd + s
+            //     reverse (e_ge_v + X_ge_m >= 1) = bit_def_LE + e_ge_v_rev + X_ge_m_rev + s
+            // The extension side isn't an IntegerVariableID, so we can't
+            // use PolBuilder::add_for_literal for it. Hand-pull the
+            // corresponding gevar/eqvar entry instead.
+            auto add_pol_for_ext = [&](PolBuilder & b, EqualsOrGreaterEqual op, Integer val, bool reverse) {
+                auto & entry = (op == EqualsOrGreaterEqual::Equals)
+                    ? _imp->eqvars_that_exist.at(ext_id).at(val)
+                    : _imp->gevars_that_exist.at(ext_id).at(val);
+                auto & item = reverse ? entry.second : entry.first;
+                visit(overloaded{
+                          [&](const ProofLine & l) { b.add(l); },
+                          [&](const XLiteral & x) { b.add(x, *this); }},
+                    item);
+            };
+
+            // Forward bridge: e_ge_v -> (negate_first ? !X_ge_m : X_ge_m).
+            // pol parts: bit_def_GE + e_ge_v_fwd (line for e_ge_v's forward half) + X_ge_m_(rev if !nf, fwd if nf).
+            {
+                PolBuilder b;
+                b.add(ext_info.def_ge_line);
+                add_pol_for_ext(b, EqualsOrGreaterEqual::GreaterEqual, v, /*reverse*/ false);
+                IntegerVariableCondition x_cond{IntegerVariableID{underlying},
+                    view.negate_first ? VariableConditionOperator::GreaterEqual : VariableConditionOperator::Less,
+                    translated_v};
+                b.add_for_literal(*this, x_cond);
+                b.saturate();
+                emit_proof_line_now_or_at_start([s = b.str()](ProofLogger * const logger) {
+                    logger->emit_proof_line(s, ProofLevel::Top);
+                });
+            }
+            // Reverse bridge: (negate_first ? !X_ge_m : X_ge_m) -> e_ge_v.
+            {
+                PolBuilder b;
+                b.add(ext_info.def_le_line);
+                add_pol_for_ext(b, EqualsOrGreaterEqual::GreaterEqual, v, /*reverse*/ true);
+                IntegerVariableCondition x_cond{IntegerVariableID{underlying},
+                    view.negate_first ? VariableConditionOperator::Less : VariableConditionOperator::GreaterEqual,
+                    translated_v};
+                b.add_for_literal(*this, x_cond);
+                b.saturate();
+                emit_proof_line_now_or_at_start([s = b.str()](ProofLogger * const logger) {
+                    logger->emit_proof_line(s, ProofLevel::Top);
+                });
+            }
+        }},
+        id);
 }
 
 auto NamesAndIDsTracker::bounds_for(const SimpleOrProofOnlyIntegerVariableID & id) const -> pair<Integer, Integer>
@@ -897,7 +1009,7 @@ auto NamesAndIDsTracker::schedule_pol_line_at_proof_start(const string & raw_lin
 }
 
 auto NamesAndIDsTracker::extension_def_lines_for(const ViewOfIntegerVariableID & view) const
-    -> optional<pair<optional<ProofLine>, optional<ProofLine>>>
+    -> optional<pair<ProofLine, ProofLine>>
 {
     auto it = _imp->view_extensions.find(view);
     if (it == _imp->view_extensions.end())
@@ -915,6 +1027,7 @@ auto NamesAndIDsTracker::extension_for(const ViewOfIntegerVariableID & view) -> 
 
     auto [ext_id, def_le_line, def_ge_line] = _imp->model->allocate_extension_for_view(view);
     _imp->view_extensions.emplace(view, Imp::ExtensionInfo{ext_id, def_le_line, def_ge_line});
+    _imp->view_extension_origins.emplace(ext_id, view);
     return ext_id;
 }
 

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -257,6 +257,12 @@ namespace gcs::innards
         auto track_bounds(const SimpleOrProofOnlyIntegerVariableID & id, Integer, Integer) -> void;
 
         /**
+         * Look up the definition-time bounds for a variable, as recorded by
+         * track_bounds. Throws if the variable hasn't been tracked.
+         */
+        [[nodiscard]] auto bounds_for(const SimpleOrProofOnlyIntegerVariableID & id) const -> std::pair<Integer, Integer>;
+
+        /**
          * Create a proof flag with a new identifier.
          */
         [[nodiscard]] auto create_proof_flag(const std::string &) -> ProofFlag;
@@ -265,6 +271,40 @@ namespace gcs::innards
          * Reify a PB constraint on a conjunction of ProofFlags or ProofLiterals
          */
         [[nodiscard]] auto reify(const WPBSumLE &, const HalfReifyOnConjunctionOf &) -> WPBSumLE;
+
+        /**
+         * \brief Look up the OPB line numbers of the definitional pair for a
+         * view's extension. Returns nullopt if the view has no extension yet.
+         */
+        [[nodiscard]] auto extension_def_lines_for(const ViewOfIntegerVariableID & view) const
+            -> std::optional<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>>;
+
+        /**
+         * \brief Schedule a raw pol/proof line to be emitted at the start of
+         * the proof file (after OPB but before propagator-driven proof steps).
+         * Used by view-extension bridge emission to make the underlying-form
+         * of a constraint available for propagators that reference underlying
+         * flags.
+         */
+        auto schedule_pol_line_at_proof_start(const std::string & raw_line) -> void;
+
+        /**
+         * \brief Return the proof-only "extension" variable that represents
+         * the *visible* value of a view, allocating it on first call.
+         *
+         * Extensions are how the proof refers to a view's value as a
+         * first-class bit-encoded variable. On first request for a given
+         * view, the extension is allocated, its domain bounds are written
+         * to the OPB, and its definitional constraint linking it to the
+         * underlying (`e == (negate_first ? -actual : actual) + then_add`)
+         * is emitted as two halves. Subsequent calls return the cached
+         * extension.
+         *
+         * Must be called while a `ProofModel` is active (during OPB
+         * writing). The cached extension remains visible during proof
+         * logging.
+         */
+        [[nodiscard]] auto extension_for(const ViewOfIntegerVariableID & view) -> ProofOnlySimpleIntegerVariableID;
 
         /*
          * Allocate an XLiteral with the given semantic meaning.

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -273,18 +273,20 @@ namespace gcs::innards
         [[nodiscard]] auto reify(const WPBSumLE &, const HalfReifyOnConjunctionOf &) -> WPBSumLE;
 
         /**
-         * \brief Look up the OPB line numbers of the definitional pair for a
-         * view's extension. Returns nullopt if the view has no extension yet.
+         * \brief Look up the OPB line numbers of the bit-level definitional
+         * pair (LE/GE halves) for a view's extension. Returns nullopt if
+         * the view has no extension yet. Used by host-constraint bridge
+         * emission in ProofModel to materialise the extension-form of a
+         * host constraint via pol.
          */
         [[nodiscard]] auto extension_def_lines_for(const ViewOfIntegerVariableID & view) const
-            -> std::optional<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>>;
+            -> std::optional<std::pair<ProofLine, ProofLine>>;
 
         /**
          * \brief Schedule a raw pol/proof line to be emitted at the start of
          * the proof file (after OPB but before propagator-driven proof steps).
-         * Used by view-extension bridge emission to make the underlying-form
-         * of a constraint available for propagators that reference underlying
-         * flags.
+         * Used by view-extension host-bridge emission to materialise the
+         * extension-form copies of host constraints.
          */
         auto schedule_pol_line_at_proof_start(const std::string & raw_line) -> void;
 
@@ -299,6 +301,11 @@ namespace gcs::innards
          * underlying (`e == (negate_first ? -actual : actual) + then_add`)
          * is emitted as two halves. Subsequent calls return the cached
          * extension.
+         *
+         * Bridges between the extension's atomic literals and the
+         * underlying variable's corresponding atomic literals are emitted
+         * lazily by `need_gevar` when an extension-side gevar is first
+         * requested.
          *
          * Must be called while a `ProofModel` is active (during OPB
          * writing). The cached extension remains visible during proof

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -72,7 +72,7 @@ namespace
                     [&]<typename T_>(const VariableConditionFrom<T_> & var) -> string {
                         return names_and_ids_tracker.pb_file_string_for(var);
                     }}
-                    .visit(simplify_literal(lit));
+                    .visit(simplify_literal(names_and_ids_tracker, lit));
             },
             [&](const ProofFlag & flag) {
                 return names_and_ids_tracker.pb_file_string_for(flag);
@@ -253,7 +253,7 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
             [&](const TrueLiteral &) {},
             [&](const FalseLiteral &) {},
             [&]<typename T_>(const VariableConditionFrom<T_> & cond) { names_and_ids_tracker().need_proof_name(cond); }}
-            .visit(simplify_literal(lit));
+            .visit(simplify_literal(names_and_ids_tracker(), lit));
     };
 
     overloaded{

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -116,23 +116,18 @@ namespace
         }
     }
 
-    // Build a pol line that, starting from the underlying-form constraint
-    // at `underlying_line`, adds e-def lines so the `_actual` terms cancel
-    // and the corresponding extension `e` terms appear, materialising the
-    // extension-form of the same constraint half.
+    // Emit a pol line at proof-start that, starting from the underlying-form
+    // OPB constraint at `underlying_line`, adds the extension's definitional
+    // pair to materialise the same constraint in extension-form. This is a
+    // host-level analogue of the atomic-literal Inv1' bridges: it makes the
+    // extension-form copy of the host constraint available in the proof
+    // database, which lets downstream pol/RUP steps mix and match
+    // underlying- and extension-form references.
     //
-    // For an operand v = (negate_first ? -actual : actual) + then_add with
-    // weight w in the original WPBSum and the LE half (coef on actual in
-    // OPB-GE form is -w for !negate_first, +w for negate_first):
-    //  - Add e-def-LE (`-e ± actual >= -then_add`) to cancel _actual and
-    //    introduce -e. For the GE half, add e-def-GE.
-    //
-    // Same-named halves (LE with LE, GE with GE) pair up regardless of
-    // negate_first, since the coefficient on `actual` in the e-def matches
-    // the coefficient on `actual` in the underlying-form constraint.
-    //
-    // Only ±1 weights are handled here; chains across multiple views in one
-    // constraint are emitted as a single pol with successive additions.
+    // Same-named half pairing (LE with LE, GE with GE) is correct regardless
+    // of `negate_first`, since the coefficient on `actual` in the bit-level
+    // definitional matches the coefficient on `actual` in the underlying-form
+    // host constraint.
     enum class ConstraintHalf
     {
         LE,
@@ -155,16 +150,15 @@ namespace
                 continue;
             const auto & view = std::get<ViewOfIntegerVariableID>(var_id);
             auto def_lines = tracker.extension_def_lines_for(view);
-            if (! def_lines || ! def_lines->first || ! def_lines->second)
+            if (! def_lines)
                 continue;
             if (w != 1_i && w != -1_i)
                 continue; // multi-coef bridges not handled yet
             any_view = true;
 
-            // Same-named half (LE with LE, GE with GE) — see comment above.
             ProofLine line_to_add = (which_half == ConstraintHalf::LE)
-                ? *def_lines->first
-                : *def_lines->second;
+                ? def_lines->first
+                : def_lines->second;
             defs_to_add.push_back(line_to_add);
         }
 
@@ -291,7 +285,7 @@ auto ProofModel::names_and_ids_tracker() const -> const NamesAndIDsTracker &
 }
 
 auto ProofModel::allocate_extension_for_view(const ViewOfIntegerVariableID & view)
-    -> std::tuple<ProofOnlySimpleIntegerVariableID, optional<ProofLine>, optional<ProofLine>>
+    -> std::tuple<ProofOnlySimpleIntegerVariableID, ProofLine, ProofLine>
 {
     // Visible domain of the view, derived from the underlying's definition
     // bounds. Negation swaps the endpoint roles.
@@ -310,10 +304,10 @@ auto ProofModel::allocate_extension_for_view(const ViewOfIntegerVariableID & vie
     // wrapped in IntegerVariableID); neither is a view, so the recursive call
     // to add_constraint won't trigger another extension lookup.
     auto actual_coeff = view.negate_first ? 1_i : -1_i;
-    auto [le_line, ge_line] = add_constraint("ViewExtension", "definitional",
+    auto [def_le_line, def_ge_line] = add_constraint("ViewExtension", "definitional",
         WPBSum{} + 1_i * ext_id + actual_coeff * IntegerVariableID{view.actual_variable} == view.then_add);
 
-    return {ext_id, le_line, ge_line};
+    return {ext_id, *def_le_line, *def_ge_line};
 }
 
 auto ProofModel::create_proof_only_integer_variable(Integer lower, Integer upper, const string & name,

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -98,15 +98,38 @@ auto ProofModel::advance_constraint_counter() -> ProofLineNumber
 
 namespace
 {
-    // Build a pol line that, starting from the extension-form constraint at
-    // `ext_line`, adds e-def lines to cancel each view operand's `e` term
-    // and recover the underlying-form constraint.
+    // Walk a WPBSum's terms and pre-allocate the extension variable for
+    // every ViewOfIntegerVariableID operand. Necessary because the
+    // allocation path writes the extension's domain bounds and definitional
+    // constraint to the OPB stream — if that happens *during*
+    // emit_inequality_to for the host constraint, the host constraint's
+    // OPB line gets sliced in half by the extension's emission.
+    auto preallocate_extensions_for_views_in(NamesAndIDsTracker & tracker, const WPBSum & sum) -> void
+    {
+        for (const auto & [w, term] : sum.terms) {
+            if (! std::holds_alternative<IntegerVariableID>(term))
+                continue;
+            const auto & var_id = std::get<IntegerVariableID>(term);
+            if (! std::holds_alternative<ViewOfIntegerVariableID>(var_id))
+                continue;
+            (void) tracker.extension_for(std::get<ViewOfIntegerVariableID>(var_id));
+        }
+    }
+
+    // Build a pol line that, starting from the underlying-form constraint
+    // at `underlying_line`, adds e-def lines so the `_actual` terms cancel
+    // and the corresponding extension `e` terms appear, materialising the
+    // extension-form of the same constraint half.
     //
-    // `which_half` is which half (LE or GE) of the just-emitted equality the
-    // ext_line corresponds to. For each view operand with weight w:
-    //  - LE half OPB coef on e is -w; cancel by adding e-def with +w on e
-    //    (e-def-GE for w > 0, e-def-LE for w < 0).
-    //  - GE half OPB coef on e is +w; cancel using the opposite e-def.
+    // For an operand v = (negate_first ? -actual : actual) + then_add with
+    // weight w in the original WPBSum and the LE half (coef on actual in
+    // OPB-GE form is -w for !negate_first, +w for negate_first):
+    //  - Add e-def-LE (`-e ± actual >= -then_add`) to cancel _actual and
+    //    introduce -e. For the GE half, add e-def-GE.
+    //
+    // Same-named halves (LE with LE, GE with GE) pair up regardless of
+    // negate_first, since the coefficient on `actual` in the e-def matches
+    // the coefficient on `actual` in the underlying-form constraint.
     //
     // Only ±1 weights are handled here; chains across multiple views in one
     // constraint are emitted as a single pol with successive additions.
@@ -117,9 +140,9 @@ namespace
     };
 
     auto emit_view_bridge_pol_lines(NamesAndIDsTracker & tracker,
-        const WPBSum & original_lhs, optional<ProofLine> ext_line, ConstraintHalf which_half) -> void
+        const WPBSum & original_lhs, optional<ProofLine> underlying_line, ConstraintHalf which_half) -> void
     {
-        if (! ext_line)
+        if (! underlying_line)
             return;
 
         std::vector<ProofLine> defs_to_add;
@@ -138,11 +161,10 @@ namespace
                 continue; // multi-coef bridges not handled yet
             any_view = true;
 
-            ProofLine line_to_add;
-            if (which_half == ConstraintHalf::LE)
-                line_to_add = (w > 0_i) ? *def_lines->second : *def_lines->first;
-            else
-                line_to_add = (w > 0_i) ? *def_lines->first : *def_lines->second;
+            // Same-named half (LE with LE, GE with GE) — see comment above.
+            ProofLine line_to_add = (which_half == ConstraintHalf::LE)
+                ? *def_lines->first
+                : *def_lines->second;
             defs_to_add.push_back(line_to_add);
         }
 
@@ -150,61 +172,11 @@ namespace
             return;
 
         std::stringstream pol_str;
-        pol_str << "pol " << *ext_line;
+        pol_str << "pol " << *underlying_line;
         for (const auto & d : defs_to_add)
             pol_str << " " << d << " +";
         pol_str << " s ;";
         tracker.schedule_pol_line_at_proof_start(pol_str.str());
-    }
-
-    // Substitute every ViewOfIntegerVariableID inside a PseudoBooleanTerm with
-    // its extension. Other variants are passed through unchanged.
-    auto substitute_views_in_term(const PseudoBooleanTerm & term, NamesAndIDsTracker & tracker) -> PseudoBooleanTerm
-    {
-        return overloaded{
-            [&](const IntegerVariableID & var) -> PseudoBooleanTerm {
-                return overloaded{
-                    [&](const SimpleIntegerVariableID &) -> PseudoBooleanTerm { return var; },
-                    [&](const ConstantIntegerVariableID &) -> PseudoBooleanTerm { return var; },
-                    [&](const ViewOfIntegerVariableID & view) -> PseudoBooleanTerm {
-                        return tracker.extension_for(view);
-                    }}
-                    .visit(var);
-            },
-            [&](const ProofLiteral & lit) -> PseudoBooleanTerm {
-                return overloaded{
-                    [&](const Literal & l) -> PseudoBooleanTerm {
-                        return overloaded{
-                            [&](const TrueLiteral &) -> PseudoBooleanTerm { return lit; },
-                            [&](const FalseLiteral &) -> PseudoBooleanTerm { return lit; },
-                            [&](const IntegerVariableCondition & cond) -> PseudoBooleanTerm {
-                                return overloaded{
-                                    [&](const SimpleIntegerVariableID &) -> PseudoBooleanTerm { return lit; },
-                                    [&](const ConstantIntegerVariableID &) -> PseudoBooleanTerm { return lit; },
-                                    [&](const ViewOfIntegerVariableID & view) -> PseudoBooleanTerm {
-                                        auto ext = tracker.extension_for(view);
-                                        return ProofLiteral{ProofVariableCondition{ext, cond.op, cond.value}};
-                                    }}
-                                    .visit(cond.var);
-                            }}
-                            .visit(l);
-                    },
-                    [&](const ProofVariableCondition &) -> PseudoBooleanTerm { return lit; }}
-                    .visit(lit);
-            },
-            [&](const ProofFlag &) -> PseudoBooleanTerm { return term; },
-            [&](const ProofOnlySimpleIntegerVariableID &) -> PseudoBooleanTerm { return term; },
-            [&](const ProofBitVariable &) -> PseudoBooleanTerm { return term; }}
-            .visit(term);
-    }
-
-    template <typename Sum_>
-    auto substitute_views(const Sum_ & sum, NamesAndIDsTracker & tracker) -> Sum_
-    {
-        Sum_ result = sum;
-        for (auto & [w, term] : result.lhs.terms)
-            term = substitute_views_in_term(term, tracker);
-        return result;
     }
 }
 
@@ -241,22 +213,18 @@ auto ProofModel::add_constraint(const Literals & lits) -> std::optional<ProofLin
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule,
     const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
 {
-    // Substitute views with their extension variables before the rest of the
-    // pipeline sees the constraint. This keeps emit_inequality_to / reify
-    // working on bit-clean (view-free) sums.
-    auto substituted = substitute_views(ineq, names_and_ids_tracker());
-
-    names_and_ids_tracker().need_all_proof_names_in(substituted.lhs);
+    preallocate_extensions_for_views_in(names_and_ids_tracker(), ineq.lhs);
+    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     if (half_reif)
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
     _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(substituted, *half_reif) : substituted, _imp->opb);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
     _imp->opb << ";\n";
-    auto ext_line = advance_constraint_counter();
+    auto underlying_line = advance_constraint_counter();
     if (! half_reif)
-        emit_view_bridge_pol_lines(names_and_ids_tracker(), ineq.lhs, ext_line, ConstraintHalf::LE);
-    return ext_line;
+        emit_view_bridge_pol_lines(names_and_ids_tracker(), ineq.lhs, underlying_line, ConstraintHalf::LE);
+    return underlying_line;
 }
 
 auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
@@ -268,18 +236,17 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<optional<ProofLine>, optional<ProofLine>>
 {
-    auto substituted = substitute_views(eq, names_and_ids_tracker());
-
-    names_and_ids_tracker().need_all_proof_names_in(substituted.lhs);
+    preallocate_extensions_for_views_in(names_and_ids_tracker(), eq.lhs);
+    names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
     if (half_reif)
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
     _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(substituted.lhs <= substituted.rhs, *half_reif) : substituted.lhs <= substituted.rhs, _imp->opb);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
     _imp->opb << ";\n";
     auto first = advance_constraint_counter();
 
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(substituted.lhs >= substituted.rhs, *half_reif) : substituted.lhs >= substituted.rhs, _imp->opb);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
     _imp->opb << ";\n";
     auto second = advance_constraint_counter();
 

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -96,6 +96,118 @@ auto ProofModel::advance_constraint_counter() -> ProofLineNumber
     return ProofLineNumber{++_imp->number_of_constraints.number};
 }
 
+namespace
+{
+    // Build a pol line that, starting from the extension-form constraint at
+    // `ext_line`, adds e-def lines to cancel each view operand's `e` term
+    // and recover the underlying-form constraint.
+    //
+    // `which_half` is which half (LE or GE) of the just-emitted equality the
+    // ext_line corresponds to. For each view operand with weight w:
+    //  - LE half OPB coef on e is -w; cancel by adding e-def with +w on e
+    //    (e-def-GE for w > 0, e-def-LE for w < 0).
+    //  - GE half OPB coef on e is +w; cancel using the opposite e-def.
+    //
+    // Only ±1 weights are handled here; chains across multiple views in one
+    // constraint are emitted as a single pol with successive additions.
+    enum class ConstraintHalf
+    {
+        LE,
+        GE
+    };
+
+    auto emit_view_bridge_pol_lines(NamesAndIDsTracker & tracker,
+        const WPBSum & original_lhs, optional<ProofLine> ext_line, ConstraintHalf which_half) -> void
+    {
+        if (! ext_line)
+            return;
+
+        std::vector<ProofLine> defs_to_add;
+        bool any_view = false;
+        for (const auto & [w, term] : original_lhs.terms) {
+            if (! std::holds_alternative<IntegerVariableID>(term))
+                continue;
+            const auto & var_id = std::get<IntegerVariableID>(term);
+            if (! std::holds_alternative<ViewOfIntegerVariableID>(var_id))
+                continue;
+            const auto & view = std::get<ViewOfIntegerVariableID>(var_id);
+            auto def_lines = tracker.extension_def_lines_for(view);
+            if (! def_lines || ! def_lines->first || ! def_lines->second)
+                continue;
+            if (w != 1_i && w != -1_i)
+                continue; // multi-coef bridges not handled yet
+            any_view = true;
+
+            ProofLine line_to_add;
+            if (which_half == ConstraintHalf::LE)
+                line_to_add = (w > 0_i) ? *def_lines->second : *def_lines->first;
+            else
+                line_to_add = (w > 0_i) ? *def_lines->first : *def_lines->second;
+            defs_to_add.push_back(line_to_add);
+        }
+
+        if (! any_view)
+            return;
+
+        std::stringstream pol_str;
+        pol_str << "pol " << *ext_line;
+        for (const auto & d : defs_to_add)
+            pol_str << " " << d << " +";
+        pol_str << " s ;";
+        tracker.schedule_pol_line_at_proof_start(pol_str.str());
+    }
+
+    // Substitute every ViewOfIntegerVariableID inside a PseudoBooleanTerm with
+    // its extension. Other variants are passed through unchanged.
+    auto substitute_views_in_term(const PseudoBooleanTerm & term, NamesAndIDsTracker & tracker) -> PseudoBooleanTerm
+    {
+        return overloaded{
+            [&](const IntegerVariableID & var) -> PseudoBooleanTerm {
+                return overloaded{
+                    [&](const SimpleIntegerVariableID &) -> PseudoBooleanTerm { return var; },
+                    [&](const ConstantIntegerVariableID &) -> PseudoBooleanTerm { return var; },
+                    [&](const ViewOfIntegerVariableID & view) -> PseudoBooleanTerm {
+                        return tracker.extension_for(view);
+                    }}
+                    .visit(var);
+            },
+            [&](const ProofLiteral & lit) -> PseudoBooleanTerm {
+                return overloaded{
+                    [&](const Literal & l) -> PseudoBooleanTerm {
+                        return overloaded{
+                            [&](const TrueLiteral &) -> PseudoBooleanTerm { return lit; },
+                            [&](const FalseLiteral &) -> PseudoBooleanTerm { return lit; },
+                            [&](const IntegerVariableCondition & cond) -> PseudoBooleanTerm {
+                                return overloaded{
+                                    [&](const SimpleIntegerVariableID &) -> PseudoBooleanTerm { return lit; },
+                                    [&](const ConstantIntegerVariableID &) -> PseudoBooleanTerm { return lit; },
+                                    [&](const ViewOfIntegerVariableID & view) -> PseudoBooleanTerm {
+                                        auto ext = tracker.extension_for(view);
+                                        return ProofLiteral{ProofVariableCondition{ext, cond.op, cond.value}};
+                                    }}
+                                    .visit(cond.var);
+                            }}
+                            .visit(l);
+                    },
+                    [&](const ProofVariableCondition &) -> PseudoBooleanTerm { return lit; }}
+                    .visit(lit);
+            },
+            [&](const ProofFlag &) -> PseudoBooleanTerm { return term; },
+            [&](const ProofOnlySimpleIntegerVariableID &) -> PseudoBooleanTerm { return term; },
+            [&](const ProofBitVariable &) -> PseudoBooleanTerm { return term; }}
+            .visit(term);
+    }
+
+    template <typename Sum_>
+    auto substitute_views(const Sum_ & sum, NamesAndIDsTracker & tracker) -> Sum_
+    {
+        Sum_ result = sum;
+        for (auto & [w, term] : result.lhs.terms)
+            term = substitute_views_in_term(term, tracker);
+        return result;
+    }
+}
+
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> std::optional<ProofLine>
 {
     WPBSum sum;
@@ -108,7 +220,7 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
                     sum += 1_i * cond;
                     return false;
                 }}
-                .visit(simplify_literal(lit)))
+                .visit(simplify_literal(names_and_ids_tracker(), lit)))
             return nullopt;
     }
 
@@ -129,14 +241,22 @@ auto ProofModel::add_constraint(const Literals & lits) -> std::optional<ProofLin
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule,
     const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
 {
-    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
+    // Substitute views with their extension variables before the rest of the
+    // pipeline sees the constraint. This keeps emit_inequality_to / reify
+    // working on bit-clean (view-free) sums.
+    auto substituted = substitute_views(ineq, names_and_ids_tracker());
+
+    names_and_ids_tracker().need_all_proof_names_in(substituted.lhs);
     if (half_reif)
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
     _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(substituted, *half_reif) : substituted, _imp->opb);
     _imp->opb << ";\n";
-    return advance_constraint_counter();
+    auto ext_line = advance_constraint_counter();
+    if (! half_reif)
+        emit_view_bridge_pol_lines(names_and_ids_tracker(), ineq.lhs, ext_line, ConstraintHalf::LE);
+    return ext_line;
 }
 
 auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
@@ -148,18 +268,25 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<optional<ProofLine>, optional<ProofLine>>
 {
-    names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
+    auto substituted = substitute_views(eq, names_and_ids_tracker());
+
+    names_and_ids_tracker().need_all_proof_names_in(substituted.lhs);
     if (half_reif)
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
     _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(substituted.lhs <= substituted.rhs, *half_reif) : substituted.lhs <= substituted.rhs, _imp->opb);
     _imp->opb << ";\n";
     auto first = advance_constraint_counter();
 
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(substituted.lhs >= substituted.rhs, *half_reif) : substituted.lhs >= substituted.rhs, _imp->opb);
     _imp->opb << ";\n";
     auto second = advance_constraint_counter();
+
+    if (! half_reif) {
+        emit_view_bridge_pol_lines(names_and_ids_tracker(), eq.lhs, first, ConstraintHalf::LE);
+        emit_view_bridge_pol_lines(names_and_ids_tracker(), eq.lhs, second, ConstraintHalf::GE);
+    }
 
     return pair{first, second};
 }
@@ -194,6 +321,32 @@ auto ProofModel::names_and_ids_tracker() -> NamesAndIDsTracker &
 auto ProofModel::names_and_ids_tracker() const -> const NamesAndIDsTracker &
 {
     return _imp->tracker;
+}
+
+auto ProofModel::allocate_extension_for_view(const ViewOfIntegerVariableID & view)
+    -> std::tuple<ProofOnlySimpleIntegerVariableID, optional<ProofLine>, optional<ProofLine>>
+{
+    // Visible domain of the view, derived from the underlying's definition
+    // bounds. Negation swaps the endpoint roles.
+    auto [actual_lo, actual_hi] = names_and_ids_tracker().bounds_for(view.actual_variable);
+    Integer visible_lo = view.negate_first ? (-actual_hi + view.then_add) : (actual_lo + view.then_add);
+    Integer visible_hi = view.negate_first ? (-actual_lo + view.then_add) : (actual_hi + view.then_add);
+
+    auto name = "extension_v" + std::to_string(_imp->proof_only_integer_variable_nr) + (view.negate_first ? "_neg" : "")
+        + (view.then_add == 0_i ? "" : ("_p" + std::to_string(view.then_add.raw_value)));
+
+    auto ext_id = create_proof_only_integer_variable(visible_lo, visible_hi, name, IntegerVariableProofRepresentation::Bits);
+
+    // Definitional: e == (negate_first ? -actual : actual) + then_add, emitted
+    // as two halves. The constraint's LHS terms reference the extension
+    // (ProofOnlySimpleIntegerVariableID) and the underlying (SimpleIntegerVariableID
+    // wrapped in IntegerVariableID); neither is a view, so the recursive call
+    // to add_constraint won't trigger another extension lookup.
+    auto actual_coeff = view.negate_first ? 1_i : -1_i;
+    auto [le_line, ge_line] = add_constraint("ViewExtension", "definitional",
+        WPBSum{} + 1_i * ext_id + actual_coeff * IntegerVariableID{view.actual_variable} == view.then_add);
+
+    return {ext_id, le_line, ge_line};
 }
 
 auto ProofModel::create_proof_only_integer_variable(Integer lower, Integer upper, const string & name,

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -153,6 +153,19 @@ namespace gcs::innards
         [[nodiscard]] auto create_proof_only_integer_variable(Integer, Integer, const std::string &,
             const IntegerVariableProofRepresentation enc) -> ProofOnlySimpleIntegerVariableID;
 
+        /**
+         * \brief Allocate the proof-only "extension" variable for a view.
+         *
+         * Allocates a fresh `ProofOnlySimpleIntegerVariableID` whose bits
+         * represent the view's *visible* value range, emits its domain
+         * bounds, and emits the definitional pair
+         * `e == (negate_first ? -actual : actual) + then_add`. Intended to
+         * be called from `NamesAndIDsTracker::extension_for`, which caches
+         * the result; user code should reach for `extension_for` instead.
+         */
+        [[nodiscard]] auto allocate_extension_for_view(const ViewOfIntegerVariableID & view)
+            -> std::tuple<ProofOnlySimpleIntegerVariableID, std::optional<ProofLine>, std::optional<ProofLine>>;
+
         [[nodiscard]] auto create_proof_flag(const std::string &) -> ProofFlag;
 
         /**

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -159,12 +159,15 @@ namespace gcs::innards
          * Allocates a fresh `ProofOnlySimpleIntegerVariableID` whose bits
          * represent the view's *visible* value range, emits its domain
          * bounds, and emits the definitional pair
-         * `e == (negate_first ? -actual : actual) + then_add`. Intended to
-         * be called from `NamesAndIDsTracker::extension_for`, which caches
-         * the result; user code should reach for `extension_for` instead.
+         * `e == (negate_first ? -actual : actual) + then_add`. Returns the
+         * fresh extension id plus the OPB line numbers of the two halves
+         * of the definitional, which the bridge-pol derivations need.
+         * Intended to be called from `NamesAndIDsTracker::extension_for`,
+         * which caches the result; user code should reach for
+         * `extension_for` instead.
          */
         [[nodiscard]] auto allocate_extension_for_view(const ViewOfIntegerVariableID & view)
-            -> std::tuple<ProofOnlySimpleIntegerVariableID, std::optional<ProofLine>, std::optional<ProofLine>>;
+            -> std::tuple<ProofOnlySimpleIntegerVariableID, ProofLine, ProofLine>;
 
         [[nodiscard]] auto create_proof_flag(const std::string &) -> ProofFlag;
 

--- a/gcs/innards/proofs/simplify_literal.cc
+++ b/gcs/innards/proofs/simplify_literal.cc
@@ -1,3 +1,4 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 
 #include <util/overloaded.hh>
@@ -24,7 +25,7 @@ namespace
     }
 }
 
-auto gcs::innards::simplify_literal(const ProofLiteral & lit) -> SimpleLiteral
+auto gcs::innards::simplify_literal(NamesAndIDsTracker & tracker, const ProofLiteral & lit) -> SimpleLiteral
 {
     return overloaded{
         [&](const TrueLiteral & t) -> SimpleLiteral { return t; },
@@ -35,33 +36,11 @@ auto gcs::innards::simplify_literal(const ProofLiteral & lit) -> SimpleLiteral
                     return VariableConditionFrom<SimpleIntegerVariableID>{var, lit.op, lit.value};
                 },
                 [&](const ViewOfIntegerVariableID & view) -> SimpleLiteral {
-                    switch (lit.op) {
-                    case VariableConditionOperator::NotEqual:
-                        return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::NotEqual,
-                            (view.negate_first ? -lit.value + view.then_add : lit.value - view.then_add)};
-                        break;
-                    case VariableConditionOperator::Equal:
-                        return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::Equal,
-                            view.negate_first ? -lit.value + view.then_add : lit.value - view.then_add};
-                        break;
-                    case VariableConditionOperator::Less:
-                        if (view.negate_first)
-                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::GreaterEqual,
-                                -lit.value + view.then_add + 1_i};
-                        else
-                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::Less,
-                                (lit.value - view.then_add)};
-                        break;
-                    case VariableConditionOperator::GreaterEqual:
-                        if (view.negate_first)
-                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::Less,
-                                -lit.value + view.then_add + 1_i};
-                        else
-                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::GreaterEqual,
-                                lit.value - view.then_add};
-                        break;
-                    }
-                    throw NonExhaustiveSwitch{};
+                    // Route through the extension: the literal `view op value`
+                    // becomes `extension(view) op value` with no value adjustment,
+                    // because the extension's value IS the view's value.
+                    auto ext = tracker.extension_for(view);
+                    return ProofVariableCondition{ext, lit.op, lit.value};
                 },
                 [&](const ConstantIntegerVariableID & cvar) -> SimpleLiteral {
                     switch (lit.op) {

--- a/gcs/innards/proofs/simplify_literal.cc
+++ b/gcs/innards/proofs/simplify_literal.cc
@@ -36,15 +36,16 @@ auto gcs::innards::simplify_literal(NamesAndIDsTracker & tracker, const ProofLit
                     return VariableConditionFrom<SimpleIntegerVariableID>{var, lit.op, lit.value};
                 },
                 [&](const ViewOfIntegerVariableID & view) -> SimpleLiteral {
-                    // De-view to the underlying SimpleIntegerVariableID: this
-                    // is the historical behaviour, which keeps propagator-
-                    // emitted RUPs consistent with the rest of the proof
-                    // (solution writeback, chain-pol-driven eq flag defs)
-                    // which all reference underlying flags. The view's
-                    // extension exists (allocated by ProofModel when the
-                    // view appears in a constraint) but is reached only
-                    // through the eagerly-emitted pol bridges, not through
-                    // literal simplification.
+                    // De-view to the underlying SimpleIntegerVariableID.
+                    // The host constraint OPB is also in underlying-form
+                    // (see emit_inequality_to), so this keeps propagator-
+                    // emitted RUPs and search-time RUPs in the same
+                    // namespace as the host constraint. The view's
+                    // extension is allocated and tied to the underlying
+                    // via bit-level definitional + per-literal Inv1'
+                    // bridges (see need_gevar / need_direct_encoding_for),
+                    // so propagators that emit extension-side RUPs still
+                    // chain through to the underlying-side host.
                     (void) tracker;
                     switch (lit.op) {
                     case VariableConditionOperator::NotEqual:

--- a/gcs/innards/proofs/simplify_literal.cc
+++ b/gcs/innards/proofs/simplify_literal.cc
@@ -36,11 +36,39 @@ auto gcs::innards::simplify_literal(NamesAndIDsTracker & tracker, const ProofLit
                     return VariableConditionFrom<SimpleIntegerVariableID>{var, lit.op, lit.value};
                 },
                 [&](const ViewOfIntegerVariableID & view) -> SimpleLiteral {
-                    // Route through the extension: the literal `view op value`
-                    // becomes `extension(view) op value` with no value adjustment,
-                    // because the extension's value IS the view's value.
-                    auto ext = tracker.extension_for(view);
-                    return ProofVariableCondition{ext, lit.op, lit.value};
+                    // De-view to the underlying SimpleIntegerVariableID: this
+                    // is the historical behaviour, which keeps propagator-
+                    // emitted RUPs consistent with the rest of the proof
+                    // (solution writeback, chain-pol-driven eq flag defs)
+                    // which all reference underlying flags. The view's
+                    // extension exists (allocated by ProofModel when the
+                    // view appears in a constraint) but is reached only
+                    // through the eagerly-emitted pol bridges, not through
+                    // literal simplification.
+                    (void) tracker;
+                    switch (lit.op) {
+                    case VariableConditionOperator::NotEqual:
+                        return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::NotEqual,
+                            (view.negate_first ? -lit.value + view.then_add : lit.value - view.then_add)};
+                    case VariableConditionOperator::Equal:
+                        return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::Equal,
+                            view.negate_first ? -lit.value + view.then_add : lit.value - view.then_add};
+                    case VariableConditionOperator::Less:
+                        if (view.negate_first)
+                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::GreaterEqual,
+                                -lit.value + view.then_add + 1_i};
+                        else
+                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::Less,
+                                (lit.value - view.then_add)};
+                    case VariableConditionOperator::GreaterEqual:
+                        if (view.negate_first)
+                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::Less,
+                                -lit.value + view.then_add + 1_i};
+                        else
+                            return VariableConditionFrom<SimpleIntegerVariableID>{view.actual_variable, VariableConditionOperator::GreaterEqual,
+                                lit.value - view.then_add};
+                    }
+                    throw NonExhaustiveSwitch{};
                 },
                 [&](const ConstantIntegerVariableID & cvar) -> SimpleLiteral {
                     switch (lit.op) {

--- a/gcs/innards/proofs/simplify_literal.hh
+++ b/gcs/innards/proofs/simplify_literal.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_SIMPLIFY_LITERAL_HH
 
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/variable_condition.hh>
 
@@ -13,12 +14,24 @@ namespace gcs::innards
         ProofVariableCondition, TrueLiteral, FalseLiteral>;
 
     /**
-     * Simplify a ProofLiteral down by removing some of the more awkward possible
-     * variants.
+     * \brief Simplify a ProofLiteral down to a form that names the variable
+     * by its proof identity.
+     *
+     * For SimpleIntegerVariableID and ConstantIntegerVariableID, this is a
+     * direct translation. For ViewOfIntegerVariableID, the literal is routed
+     * through the view's *extension* variable (`NamesAndIDsTracker::extension_for`):
+     * `v >= k` becomes `extension(v) >= k` without any value adjustment,
+     * because the extension's value equals the view's value. This keeps the
+     * resulting proof literal bit-clean against the constraint's
+     * extension-form encoding.
+     *
+     * The extension must already exist by the time this function is called,
+     * either because the OPB-writing phase saw the view in a constraint or
+     * because the caller explicitly pre-allocated it.
      *
      * \ingroup Innards
      */
-    [[nodiscard]] auto simplify_literal(const ProofLiteral & lit) -> SimpleLiteral;
+    [[nodiscard]] auto simplify_literal(NamesAndIDsTracker & tracker, const ProofLiteral & lit) -> SimpleLiteral;
 }
 
 #endif

--- a/gcs/innards/proofs/simplify_literal.hh
+++ b/gcs/innards/proofs/simplify_literal.hh
@@ -23,11 +23,12 @@ namespace gcs::innards
      * `v >= k` becomes `extension(v) >= k` without any value adjustment,
      * because the extension's value equals the view's value. This keeps the
      * resulting proof literal bit-clean against the constraint's
-     * extension-form encoding.
+     * extension-form encoding. Bridges that tie the extension's atomic
+     * literals to the underlying variable's atomic literals are emitted
+     * lazily at gevar-introduction time (see `NamesAndIDsTracker::need_gevar`).
      *
-     * The extension must already exist by the time this function is called,
-     * either because the OPB-writing phase saw the view in a constraint or
-     * because the caller explicitly pre-allocated it.
+     * Calling this function on a view will allocate the extension if it
+     * doesn't already exist, which requires a `ProofModel` to be active.
      *
      * \ingroup Innards
      */


### PR DESCRIPTION
## Summary

- Adds a per-test view-wrap sweep harness in `constraints/innards/constraints_test_utils.hh`: `ViewWrap`, `view_offset`/`view_neg`/`view_neg_offset` factories, `create_integer_variable_or_constant_with_view` overloads, and argv plumbing (`--view-wrap=N --view-position=<all|K>`) that leaves existing per-test mode argv alone.
- Wires 20 constraints to the harness across 11 commits — each commit notes its smoke-test findings.
- CMake gains an `add_view_wrap_sweep` function that generates ~3186 ctest entries (`ctest -R '_view_'`) without changing the existing baseline tests.

## What this is for

Views (`x + k`, `-x`, `-x + k`) are broken in proof logging in several distinct ways, and we currently have ~zero per-constraint coverage testing it. This sweep surfaces the failures so we can decide which fixes are worth investing in (see #217 for the catalogue and next-step thinking).

## Constraints wired

equals, abs, comparison (×12 modes), plus_minus, linear (×12 modes), all_different, all_equal, increasing, min_max, at_most_one, parity, n_value, seq_precede_chain, count, among, all_different_except, value_precede, table, negative_table, in.

## Constraints deliberately *not* wired

arithmetic, mult_bc, knapsack, cumulative, disjunctive, element, inverse, regular, smart_table, logical, lex, symmetric_all_different. Each has a structural reason wrapping breaks semantics (bit representation, values-as-indices, must-be-positive durations, etc.) — see the "haven't tried yet" section in #217.

## Wiring conventions used

- Wrap targets are the *primary* constraint arguments. Auxiliary scalars like at_most_one's `val`, in_test's value-set, count's voi (in some constraints) or reification flags stay bare for the pilot.
- For variable-length vector constraints, n_positions in CMake is set to a reasonable max from the test data; out-of-range single-position configs print a "skipping" line and return success so ctest sees a benign skip rather than a duplicated bare run.
- Subtests with fixed bounds (initialiser proofs, duplicate-variable proofs, scale tests with hardcoded expected counts) run only on the baseline config — the wrap sweep is for the random/parameterised body of each test.

## Note on commits

The first commit (`3cd7e1c`) is missing the `Co-Authored-By` trailer — accidental on my part, every subsequent commit has it. Happy to amend if you'd prefer; otherwise it'll squash cleanly on merge.

## Test plan

- [x] `cmake --build build --parallel 32` — clean across all wired targets
- [x] baseline `ctest` (i.e. without `_view_`-suffixed cases) — unchanged
- [x] spot-check baseline + a handful of wrap configs per wired test (commit messages have details)
- [ ] `ctest -R '_view_'` — full sweep, ~4-5 hours. Catalogue will be populated in #217 as the data comes in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
