### PR TITLE
state: callback-style domain iteration; convert element.cc

### DIFF
--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -276,11 +276,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             auto looking_for = state.copy_of_values(result_var);
             auto looking_for_bounds = state.bounds(result_var);
 
-            for (const auto & test_val : state.each_value_mutable(index_vars.at(fixed_dim))) {
+            state.for_each_value_mutable(index_vars.at(fixed_dim), [&](Integer test_val) {
                 vector<size_t> elem;
                 vector<IntegerVariableID> explored_vars;
                 explored_vars.push_back(result_var);
-                function<auto(unsigned)->bool> look_for_support = [&](unsigned d) -> bool {
+                auto look_for_support = [&](this auto && self, unsigned d) -> bool {
                     // we're iterating over every dimension recursively, except for the one where
                     // we're checking support for the fixed test_val.
                     auto do_it_with = [&](Integer x) {
@@ -300,7 +300,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             }
                         }
                         else {
-                            if (look_for_support(d + 1))
+                            if (self(d + 1))
                                 return true;
                         }
                         elem.pop_back();
@@ -311,11 +311,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         return do_it_with(test_val);
                     else {
                         explored_vars.push_back(index_vars.at(d));
-                        for (const auto & x : state.each_value_immutable(index_vars.at(d)))
-                            if (do_it_with(x))
-                                return true;
-
-                        return false;
+                        bool support_found = false;
+                        state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
+                            if (do_it_with(x)) {
+                                support_found = true;
+                                return false;
+                            }
+                            return true;
+                        });
+                        return support_found;
                     }
                 };
 
@@ -325,7 +329,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         // index vars are assigned
                         vector<size_t> elem;
                         WPBSum sum_so_far;
-                        function<auto(unsigned)->void> show_no_support = [&](unsigned d) -> void {
+                        auto show_no_support = [&](this auto && self, unsigned d) -> void {
                             // again, we're iterating over every dimension recursively, except for the one where
                             // we're checking support for the fixed test_val.
                             auto do_it_with = [&](Integer x) {
@@ -337,13 +341,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                         throw UnimplementedException{};
                                     }
                                     else {
-                                        for (const auto & v : state.each_value_immutable(array_var))
+                                        state.for_each_value_immutable(array_var, [&](Integer v) {
                                             logger->emit_rup_proof_line_under_reason(reason,
                                                 sum_so_far + 1_i * (index_vars.at(fixed_dim) != test_val) + 1_i * (array_var != v) >= 1_i, ProofLevel::Temporary);
+                                        });
                                     }
                                 }
                                 else
-                                    show_no_support(d + 1);
+                                    self(d + 1);
 
                                 elem.pop_back();
                             };
@@ -351,7 +356,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             if (d == fixed_dim)
                                 return do_it_with(test_val);
                             else {
-                                for (const auto & x : state.each_value_immutable(index_vars.at(d))) {
+                                state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                                     auto save_sum_so_far = sum_so_far;
                                     sum_so_far += 1_i * (index_vars.at(d) != x);
                                     do_it_with(x);
@@ -359,7 +364,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                         sum_so_far + 1_i * (index_vars.at(fixed_dim) != test_val) >= 1_i,
                                         ProofLevel::Temporary);
                                     sum_so_far = save_sum_so_far;
-                                }
+                                });
                             }
                         };
 
@@ -367,7 +372,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                     }},
                         generic_reason(state, explored_vars));
                 }
-            }
+            });
 
             return PropagatorState::Enable;
         },
@@ -389,10 +394,10 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             optional<Integer> lowest_found, highest_found;
             auto current_bounds = state.bounds(result_var);
             vector<IntegerVariableID> considered_vars;
-            function<auto(unsigned)->void> collect_supported_bounds = [&](unsigned d) {
-                for (const auto & x : state.each_value_immutable(index_vars.at(d))) {
+            auto collect_supported_bounds = [&](this auto && self, unsigned d) -> void {
+                state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                     if (lowest_found && *lowest_found <= current_bounds.first && highest_found && *highest_found >= current_bounds.second)
-                        return;
+                        return false;
 
                     elem.push_back((x - index_starts.at(d)).as_index());
                     if (elem.size() == dimensions_) {
@@ -406,10 +411,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         }
                     }
                     else {
-                        collect_supported_bounds(d + 1);
+                        self(d + 1);
                     }
                     elem.pop_back();
-                }
+                    return true;
+                });
             };
             collect_supported_bounds(0);
 
@@ -425,8 +431,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 inference.infer(logger, lit_to_infer, JustifyExplicitlyThenRUP{[&](const ReasonFunction & reason) {
                     // show that it doesn't work for any feasible choice of indices
                     WPBSum sum_so_far;
-                    function<auto(unsigned)->void> rule_out = [&](unsigned d) {
-                        for (const auto & v : state.each_value_immutable(index_vars.at(d))) {
+                    auto rule_out = [&](this auto && self, unsigned d) -> void {
+                        state.for_each_value_immutable(index_vars.at(d), [&](Integer v) {
                             if (d + 1 == dimensions_)
                                 logger->emit_rup_proof_line_under_reason(reason,
                                     sum_so_far + 1_i * lit_to_infer + 1_i * (index_vars.at(d) != v) >= 1_i,
@@ -434,10 +440,10 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             else {
                                 auto save_sum_so_far = sum_so_far;
                                 sum_so_far += 1_i * (index_vars.at(d) != v);
-                                rule_out(d + 1);
+                                self(d + 1);
                                 sum_so_far = save_sum_so_far;
                             }
-                        }
+                        });
                         if (! sum_so_far.terms.empty()) {
                             logger->emit_rup_proof_line_under_reason(reason,
                                 sum_so_far + 1_i * lit_to_infer >= 1_i,
@@ -471,24 +477,26 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             vector<size_t> elem;
             IntervalSet<Integer> still_to_find_support_for = state.copy_of_values(result_var);
             vector<IntegerVariableID> considered_vars;
-            function<auto(unsigned)->void> collect_supported_values = [&](unsigned d) {
-                for (const auto & x : state.each_value_immutable(index_vars.at(d))) {
+            auto collect_supported_values = [&](this auto && self, unsigned d) -> void {
+                state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                     if (still_to_find_support_for.empty())
-                        return;
+                        return false;
 
                     elem.push_back((x - index_starts.at(d)).as_index());
                     if (elem.size() == dimensions_) {
                         auto array_var = get_array_var<dimensions_>(elem, *array);
                         if (array_has_nonconstants)
                             considered_vars.push_back(array_var);
-                        for (const auto & v : state.each_value_immutable(array_var))
+                        state.for_each_value_immutable(array_var, [&](Integer v) {
                             still_to_find_support_for.erase(v);
+                        });
                     }
                     else {
-                        collect_supported_values(d + 1);
+                        self(d + 1);
                     }
                     elem.pop_back();
-                }
+                    return true;
+                });
             };
             collect_supported_values(0);
 
@@ -499,8 +507,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 inference.infer_not_equal(logger, result_var, value, JustifyExplicitlyThenRUP{[&](const ReasonFunction & reason) {
                     // show that it doesn't work for any feasible choice of indices
                     WPBSum sum_so_far;
-                    function<auto(unsigned)->void> rule_out = [&](unsigned d) {
-                        for (const auto & v : state.each_value_immutable(index_vars.at(d))) {
+                    auto rule_out = [&](this auto && self, unsigned d) -> void {
+                        state.for_each_value_immutable(index_vars.at(d), [&](Integer v) {
                             if (d + 1 == dimensions_)
                                 logger->emit_rup_proof_line_under_reason(reason,
                                     sum_so_far + 1_i * (result_var != value) + 1_i * (index_vars.at(d) != v) >= 1_i,
@@ -508,10 +516,10 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             else {
                                 auto save_sum_so_far = sum_so_far;
                                 sum_so_far += 1_i * (index_vars.at(d) != v);
-                                rule_out(d + 1);
+                                self(d + 1);
                                 sum_so_far = save_sum_so_far;
                             }
-                        }
+                        });
                         if (! sum_so_far.terms.empty()) {
                             logger->emit_rup_proof_line_under_reason(reason,
                                 sum_so_far + 1_i * (result_var != value) >= 1_i,

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -287,11 +287,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 auto looking_for = state.copy_of_values(result_var);
                 auto looking_for_bounds = state.bounds(result_var);
 
-                for (const auto & test_val : state.each_value_mutable(index_vars.at(fixed_dim))) {
+                state.for_each_value_mutable(index_vars.at(fixed_dim), [&](Integer test_val) {
                     vector<size_t> elem;
                     vector<IntegerVariableID> explored_vars;
                     explored_vars.push_back(result_var);
-                    function<auto(unsigned)->bool> look_for_support = [&](unsigned d) -> bool {
+                    auto look_for_support = [&](auto && self, unsigned d) -> bool {
                         // we're iterating over every dimension recursively, except for the one where
                         // we're checking support for the fixed test_val.
                         auto do_it_with = [&](Integer x) {
@@ -312,7 +312,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                 }
                             }
                             else {
-                                if (look_for_support(d + 1))
+                                if (self(self, d + 1))
                                     return true;
                             }
                             elem.pop_back();
@@ -323,15 +323,19 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             return do_it_with(test_val);
                         else {
                             explored_vars.push_back(index_vars.at(d));
-                            for (const auto & x : state.each_value_immutable(index_vars.at(d)))
-                                if (do_it_with(x))
-                                    return true;
-
-                            return false;
+                            bool support_found = false;
+                            state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
+                                if (do_it_with(x)) {
+                                    support_found = true;
+                                    return false;
+                                }
+                                return true;
+                            });
+                            return support_found;
                         }
                     };
 
-                    if (! look_for_support(0)) {
+                    if (! look_for_support(look_for_support, 0)) {
                         inference.infer_not_equal(logger, index_vars.at(fixed_dim), test_val,
                             JustifyExplicitly{//
                                 [&](const ReasonLiterals & reason) {
@@ -339,7 +343,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                     // index vars are assigned
                                     vector<size_t> elem;
                                     WPBSum sum_so_far;
-                                    function<auto(unsigned)->void> show_no_support = [&](unsigned d) -> void {
+                                    auto show_no_support = [&](auto && self, unsigned d) -> void {
                                         // again, we're iterating over every dimension recursively, except for the one where
                                         // we're checking support for the fixed test_val.
                                         auto do_it_with = [&](Integer x) {
@@ -351,14 +355,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                                     throw UnimplementedException{};
                                                 }
                                                 else {
-                                                    for (const auto & v : state.each_value_immutable(array_var))
+                                                    state.for_each_value_immutable(array_var, [&](Integer v) {
                                                         logger->emit_rup_proof_line_under_reason(reason,
                                                             sum_so_far + 1_i * (index_vars.at(fixed_dim) != test_val) + 1_i * (array_var != v) >= 1_i,
                                                             ProofLevel::Temporary);
+                                                    });
                                                 }
                                             }
                                             else
-                                                show_no_support(d + 1);
+                                                self(self, d + 1);
 
                                             elem.pop_back();
                                         };
@@ -366,23 +371,23 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                         if (d == fixed_dim)
                                             return do_it_with(test_val);
                                         else {
-                                            for (const auto & x : state.each_value_immutable(index_vars.at(d))) {
+                                            state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                                                 auto save_sum_so_far = sum_so_far;
                                                 sum_so_far += 1_i * (index_vars.at(d) != x);
                                                 do_it_with(x);
                                                 logger->emit_rup_proof_line_under_reason(
                                                     reason, sum_so_far + 1_i * (index_vars.at(fixed_dim) != test_val) >= 1_i, ProofLevel::Temporary);
                                                 sum_so_far = save_sum_so_far;
-                                            }
+                                            });
                                         }
                                     };
 
-                                    show_no_support(0);
+                                    show_no_support(show_no_support, 0);
                                 },
                                 ThenRUP::Yes, hints::Element{owner}},
                             generic_reason(explored_vars));
                     }
-                }
+                });
 
                 return PropagatorState::Enable;
             },
@@ -407,10 +412,10 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 optional<Integer> lowest_found, highest_found;
                 auto current_bounds = state.bounds(result_var);
                 vector<IntegerVariableID> considered_vars;
-                function<auto(unsigned)->void> collect_supported_bounds = [&](unsigned d) {
-                    for (const auto & x : state.each_value_immutable(index_vars.at(d))) {
+                auto collect_supported_bounds = [&](auto && self, unsigned d) -> void {
+                    state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                         if (lowest_found && *lowest_found <= current_bounds.first && highest_found && *highest_found >= current_bounds.second)
-                            return;
+                            return false;
 
                         elem.push_back((x - index_starts.at(d)).as_index());
                         if (elem.size() == dimensions_) {
@@ -424,12 +429,13 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             }
                         }
                         else {
-                            collect_supported_bounds(d + 1);
+                            self(self, d + 1);
                         }
                         elem.pop_back();
-                    }
+                        return true;
+                    });
                 };
-                collect_supported_bounds(0);
+                collect_supported_bounds(collect_supported_bounds, 0);
 
                 auto infer_bound = [&](Integer relevant_bound, bool ge) {
                     auto lit_to_infer = ge ? (result_var >= relevant_bound) : (result_var <= relevant_bound);
@@ -445,24 +451,24 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             [&](const ReasonLiterals & reason) {
                                 // show that it doesn't work for any feasible choice of indices
                                 WPBSum sum_so_far;
-                                function<auto(unsigned)->void> rule_out = [&](unsigned d) {
-                                    for (const auto & v : state.each_value_immutable(index_vars.at(d))) {
+                                auto rule_out = [&](auto && self, unsigned d) -> void {
+                                    state.for_each_value_immutable(index_vars.at(d), [&](Integer v) {
                                         if (d + 1 == dimensions_)
                                             logger->emit_rup_proof_line_under_reason(reason,
                                                 sum_so_far + 1_i * lit_to_infer + 1_i * (index_vars.at(d) != v) >= 1_i, ProofLevel::Temporary);
                                         else {
                                             auto save_sum_so_far = sum_so_far;
                                             sum_so_far += 1_i * (index_vars.at(d) != v);
-                                            rule_out(d + 1);
+                                            self(self, d + 1);
                                             sum_so_far = save_sum_so_far;
                                         }
-                                    }
+                                    });
                                     if (! sum_so_far.terms.empty()) {
                                         logger->emit_rup_proof_line_under_reason(
                                             reason, sum_so_far + 1_i * lit_to_infer >= 1_i, ProofLevel::Temporary);
                                     }
                                 };
-                                rule_out(0);
+                                rule_out(rule_out, 0);
                             },
                             ThenRUP::Yes, hints::Element{owner}},
                         ExplicitReason{reason});
@@ -493,26 +499,26 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 vector<size_t> elem;
                 IntervalSet<Integer> still_to_find_support_for = state.copy_of_values(result_var);
                 vector<IntegerVariableID> considered_vars;
-                function<auto(unsigned)->void> collect_supported_values = [&](unsigned d) {
-                    for (const auto & x : state.each_value_immutable(index_vars.at(d))) {
+                auto collect_supported_values = [&](auto && self, unsigned d) -> void {
+                    state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                         if (still_to_find_support_for.empty())
-                            return;
+                            return false;
 
                         elem.push_back((x - index_starts.at(d)).as_index());
                         if (elem.size() == dimensions_) {
                             auto array_var = get_array_var<dimensions_>(elem, *array);
                             if (array_has_nonconstants)
                                 considered_vars.push_back(array_var);
-                            for (const auto & v : state.each_value_immutable(array_var))
-                                still_to_find_support_for.erase(v);
+                            state.for_each_value_immutable(array_var, [&](Integer v) { still_to_find_support_for.erase(v); });
                         }
                         else {
-                            collect_supported_values(d + 1);
+                            self(self, d + 1);
                         }
                         elem.pop_back();
-                    }
+                        return true;
+                    });
                 };
-                collect_supported_values(0);
+                collect_supported_values(collect_supported_values, 0);
 
                 for (auto value : still_to_find_support_for.each()) {
                     ReasonLiterals reason = materialise(generic_reason(index_vars), state);
@@ -523,8 +529,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             [&](const ReasonLiterals & reason) {
                                 // show that it doesn't work for any feasible choice of indices
                                 WPBSum sum_so_far;
-                                function<auto(unsigned)->void> rule_out = [&](unsigned d) {
-                                    for (const auto & v : state.each_value_immutable(index_vars.at(d))) {
+                                auto rule_out = [&](auto && self, unsigned d) -> void {
+                                    state.for_each_value_immutable(index_vars.at(d), [&](Integer v) {
                                         if (d + 1 == dimensions_)
                                             logger->emit_rup_proof_line_under_reason(reason,
                                                 sum_so_far + 1_i * (result_var != value) + 1_i * (index_vars.at(d) != v) >= 1_i,
@@ -532,16 +538,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                         else {
                                             auto save_sum_so_far = sum_so_far;
                                             sum_so_far += 1_i * (index_vars.at(d) != v);
-                                            rule_out(d + 1);
+                                            self(self, d + 1);
                                             sum_so_far = save_sum_so_far;
                                         }
-                                    }
+                                    });
                                     if (! sum_so_far.terms.empty()) {
                                         logger->emit_rup_proof_line_under_reason(
                                             reason, sum_so_far + 1_i * (result_var != value) >= 1_i, ProofLevel::Temporary);
                                     }
                                 };
-                                rule_out(0);
+                                rule_out(rule_out, 0);
                             },
                             ThenRUP::Yes, hints::Element{owner}},
                         ExplicitReason{reason});

--- a/gcs/innards/interval_set.hh
+++ b/gcs/innards/interval_set.hh
@@ -6,6 +6,7 @@
 #include <gch/small_vector.hpp>
 
 #include <cstdlib>
+#include <type_traits>
 #include <utility>
 #include <version>
 
@@ -361,7 +362,7 @@ namespace gcs::innards
         /**
          * \brief Returns a generator that yields each value in the set in ascending order.
          *
-         * \sa each_reversed(), each_interval()
+         * \sa each_reversed(), each_interval(), for_each()
          */
         [[nodiscard]] auto each() const -> std::generator<Int_>
         {
@@ -370,6 +371,35 @@ namespace gcs::innards
                     for (Int_ i = l; i <= u; ++i)
                         co_yield i;
             }(intervals);
+        }
+
+        /**
+         * \brief Calls \p f(value) for each value in the set in ascending order.
+         *
+         * Non-coroutine alternative to each(): no heap-allocated generator
+         * frame, the iteration inlines into the caller. Prefer this over
+         * each() in hot loops where the caller doesn't need the iterator
+         * protocol.
+         *
+         * If \p f returns \c bool, returning \c false stops iteration early.
+         * If \p f returns \c void, iteration always runs to completion.
+         *
+         * \sa each(), each_interval()
+         */
+        template <typename F_>
+        auto for_each(F_ && f) const -> void
+        {
+            if constexpr (std::is_void_v<std::invoke_result_t<F_ &, Int_>>) {
+                for (const auto & [l, u] : intervals)
+                    for (Int_ i = l; i <= u; ++i)
+                        f(i);
+            }
+            else {
+                for (const auto & [l, u] : intervals)
+                    for (Int_ i = l; i <= u; ++i)
+                        if (! f(i))
+                            return;
+            }
         }
 
         /**

--- a/gcs/innards/interval_set.hh
+++ b/gcs/innards/interval_set.hh
@@ -6,6 +6,7 @@
 #include <gch/small_vector.hpp>
 
 #include <cstdlib>
+#include <type_traits>
 #include <utility>
 #include <version>
 
@@ -423,7 +424,7 @@ namespace gcs::innards
          * The generator borrows this set, which must outlive it and must not be
          * modified while iterating; see the class documentation.
          *
-         * \sa each_reversed(), each_interval()
+         * \sa each_reversed(), each_interval(), for_each()
          */
         [[nodiscard]] auto each() const -> std::generator<Int_>
         {
@@ -432,6 +433,35 @@ namespace gcs::innards
                     for (Int_ i = l; i <= u; ++i)
                         co_yield i;
             }(intervals);
+        }
+
+        /**
+         * \brief Calls \p f(value) for each value in the set in ascending order.
+         *
+         * Non-coroutine alternative to each(): no heap-allocated generator
+         * frame, the iteration inlines into the caller. Prefer this over
+         * each() in hot loops where the caller doesn't need the iterator
+         * protocol.
+         *
+         * If \p f returns \c bool, returning \c false stops iteration early.
+         * If \p f returns \c void, iteration always runs to completion.
+         *
+         * \sa each(), each_interval()
+         */
+        template <typename F_>
+        auto for_each(F_ && f) const -> void
+        {
+            if constexpr (std::is_void_v<std::invoke_result_t<F_ &, Int_>>) {
+                for (const auto & [l, u] : intervals)
+                    for (Int_ i = l; i <= u; ++i)
+                        f(i);
+            }
+            else {
+                for (const auto & [l, u] : intervals)
+                    for (Int_ i = l; i <= u; ++i)
+                        if (! f(i))
+                            return;
+            }
         }
 
         /**

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -149,6 +149,11 @@ auto State::state_of(const SimpleIntegerVariableID & v) const -> const IntervalS
     return _imp->integer_variable_states.back().at(v.index);
 }
 
+auto State::state_of_for_iteration(const SimpleIntegerVariableID & v) const -> const IntervalSet<Integer> &
+{
+    return _imp->integer_variable_states.back().at(v.index);
+}
+
 auto State::change_state_for_equal(const SimpleIntegerVariableID & var, Integer value) -> Inference
 {
     auto & set = state_of(var);

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -150,6 +150,11 @@ auto State::state_of(const SimpleIntegerVariableID & v) const -> const IntervalS
     return _imp->integer_variable_states.back().at(v.index);
 }
 
+auto State::state_of_for_iteration(const SimpleIntegerVariableID & v) const -> const IntervalSet<Integer> &
+{
+    return _imp->integer_variable_states.back().at(v.index);
+}
+
 auto State::change_state_for_equal(const SimpleIntegerVariableID & var, Integer value) -> Inference
 {
     auto & set = state_of(var);

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -7,11 +7,13 @@
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/innards/variable_id_utils.hh>
 #include <gcs/integer.hh>
+#include <util/overloaded.hh>
 
 #include <any>
 #include <functional>
 #include <memory>
 #include <optional>
+#include <tuple>
 #include <version>
 
 #ifdef __cpp_lib_generator
@@ -67,6 +69,68 @@ namespace gcs::innards
         unsigned long index;
     };
 
+    namespace state_detail
+    {
+        // Helpers for decomposing variable IDs into a (direct-or-simple,
+        // view-flags) representation. Kept in the header so member function
+        // templates of State can use them without paying for std::generator,
+        // std::function or copies in the common iteration paths.
+
+        inline auto deview(const SimpleIntegerVariableID & var) -> std::tuple<SimpleIntegerVariableID, bool, Integer>
+        {
+            return std::tuple{var, false, 0_i};
+        }
+
+        inline auto deview(const ViewOfIntegerVariableID & var) -> std::tuple<SimpleIntegerVariableID, bool, Integer>
+        {
+            return std::tuple{var.actual_variable, var.negate_first, var.then_add};
+        }
+
+        inline auto deview(const ConstantIntegerVariableID & var) -> std::tuple<ConstantIntegerVariableID, bool, Integer>
+        {
+            return std::tuple{var, false, 0_i};
+        }
+
+        inline auto deview(const IntegerVariableID & var) -> std::tuple<DirectIntegerVariableID, bool, Integer>
+        {
+            return overloaded{
+                [&](const SimpleIntegerVariableID & v) {
+                    return std::tuple{DirectIntegerVariableID{v}, false, 0_i};
+                },
+                [&](const ConstantIntegerVariableID & v) {
+                    return std::tuple{DirectIntegerVariableID{v}, false, 0_i};
+                },
+                [&](const ViewOfIntegerVariableID & v) {
+                    return std::tuple{DirectIntegerVariableID{v.actual_variable}, v.negate_first, v.then_add};
+                },
+            }
+                .visit(var);
+        }
+
+        inline auto apply_view(Integer v, bool negate_first, Integer then_add) -> Integer
+        {
+            return (negate_first ? -v : v) + then_add;
+        }
+
+        template <typename SimpleFn_, typename ConstantFn_>
+        auto visit_actual(const SimpleIntegerVariableID & v, SimpleFn_ && sf, ConstantFn_ &&) -> decltype(sf(v))
+        {
+            return sf(v);
+        }
+
+        template <typename SimpleFn_, typename ConstantFn_>
+        auto visit_actual(const ConstantIntegerVariableID & v, SimpleFn_ &&, ConstantFn_ && cf) -> decltype(cf(v))
+        {
+            return cf(v);
+        }
+
+        template <typename SimpleFn_, typename ConstantFn_>
+        auto visit_actual(const DirectIntegerVariableID & v, SimpleFn_ && sf, ConstantFn_ && cf)
+        {
+            return overloaded{sf, cf}.visit(v);
+        }
+    }
+
     /**
      * \brief Keeps track of the current state, at a point inside search.
      *
@@ -101,6 +165,15 @@ namespace gcs::innards
 
         [[nodiscard]] inline auto state_of(const SimpleIntegerVariableID &) -> IntervalSet<Integer> &;
         [[nodiscard]] inline auto state_of(const SimpleIntegerVariableID &) const -> const IntervalSet<Integer> &;
+
+        // Non-inline sibling of state_of() for use from member function templates
+        // defined in this header. The for_each_value_* templates need the IntervalSet
+        // by const reference from a header-visible context; state_of() is `inline` only
+        // in the C++ sense (its body lives in state.cc), so calling it from a header
+        // template fails to link. This helper is defined out-of-line in state.cc.
+        // Internal state.cc paths keep using state_of() unchanged so the compiler
+        // retains its previous freedom to inline that call.
+        [[nodiscard]] auto state_of_for_iteration(const SimpleIntegerVariableID &) const -> const IntervalSet<Integer> &;
 
     public:
         /**
@@ -318,7 +391,7 @@ namespace gcs::innards
          * variable's domain must not be modified whilst the generator is alive. Call using
          * either IntegerVariableID or one of its more specific types.
          *
-         * \sa State::each_value_mutable()
+         * \sa State::each_value_mutable(), State::for_each_value_immutable()
          */
         template <IntegerVariableIDLike VarType_>
         auto each_value_immutable(const VarType_ &) const -> std::generator<Integer>;
@@ -329,10 +402,62 @@ namespace gcs::innards
          * will run over the values pre-modification. Call using either IntegerVariableID or
          * one of its more specific types.
          *
-         * \sa State::each_value_immutable()
+         * \sa State::each_value_immutable(), State::for_each_value_mutable()
          */
         template <IntegerVariableIDLike VarType_>
         auto each_value_mutable(const VarType_ &) const -> std::generator<Integer>;
+
+        /**
+         * Non-coroutine alternative to each_value_immutable(). Calls \p cb(value)
+         * for each value in the variable's domain, in ascending order. Avoids the
+         * std::generator frame allocation, the std::function the view-application
+         * needs in the generator version, and copying the underlying IntervalSet.
+         *
+         * The variable's domain must not be modified during the callback. If \p cb
+         * returns \c bool, returning \c false stops iteration early.
+         *
+         * \sa State::each_value_immutable(), State::for_each_value_mutable()
+         */
+        template <IntegerVariableIDLike VarType_, typename Callback_>
+        auto for_each_value_immutable(const VarType_ & var, Callback_ && cb) const -> void
+        {
+            auto [actual_var, negate_first, then_add] = state_detail::deview(var);
+            state_detail::visit_actual(
+                actual_var,
+                [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
+                    state_of_for_iteration(v).for_each([&](Integer i) {
+                        return cb(state_detail::apply_view(i, negate_first, then_add));
+                    });
+                },
+                [&, negate_first = negate_first, then_add = then_add](const ConstantIntegerVariableID & v) {
+                    cb(state_detail::apply_view(v.const_value, negate_first, then_add));
+                });
+        }
+
+        /**
+         * Non-coroutine alternative to each_value_mutable(). The variable's
+         * domain may be modified by \p cb; iteration walks a snapshot of the
+         * pre-modification domain. If \p cb returns \c bool, returning \c false
+         * stops iteration early.
+         *
+         * \sa State::each_value_mutable(), State::for_each_value_immutable()
+         */
+        template <IntegerVariableIDLike VarType_, typename Callback_>
+        auto for_each_value_mutable(const VarType_ & var, Callback_ && cb) const -> void
+        {
+            auto [actual_var, negate_first, then_add] = state_detail::deview(var);
+            state_detail::visit_actual(
+                actual_var,
+                [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
+                    auto snapshot = state_of_for_iteration(v);
+                    snapshot.for_each([&](Integer i) {
+                        return cb(state_detail::apply_view(i, negate_first, then_add));
+                    });
+                },
+                [&, negate_first = negate_first, then_add = then_add](const ConstantIntegerVariableID & v) {
+                    cb(state_detail::apply_view(v.const_value, negate_first, then_add));
+                });
+        }
 
         /**
          * Return the contents of the domain.

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -7,11 +7,13 @@
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/innards/variable_id_utils.hh>
 #include <gcs/integer.hh>
+#include <util/overloaded.hh>
 
 #include <any>
 #include <functional>
 #include <memory>
 #include <optional>
+#include <tuple>
 #include <version>
 
 #ifdef __cpp_lib_generator
@@ -65,6 +67,62 @@ namespace gcs::innards
         unsigned long index;
     };
 
+    namespace state_detail
+    {
+        // Helpers for decomposing variable IDs into a (direct-or-simple,
+        // view-flags) representation. Kept in the header so member function
+        // templates of State can use them without paying for std::generator,
+        // std::function or copies in the common iteration paths.
+
+        inline auto deview(const SimpleIntegerVariableID & var) -> std::tuple<SimpleIntegerVariableID, bool, Integer>
+        {
+            return std::tuple{var, false, 0_i};
+        }
+
+        inline auto deview(const ViewOfIntegerVariableID & var) -> std::tuple<SimpleIntegerVariableID, bool, Integer>
+        {
+            return std::tuple{var.actual_variable, var.negate_first, var.then_add};
+        }
+
+        inline auto deview(const ConstantIntegerVariableID & var) -> std::tuple<ConstantIntegerVariableID, bool, Integer>
+        {
+            return std::tuple{var, false, 0_i};
+        }
+
+        inline auto deview(const IntegerVariableID & var) -> std::tuple<DirectIntegerVariableID, bool, Integer>
+        {
+            return overloaded{
+                [&](const SimpleIntegerVariableID & v) { return std::tuple{DirectIntegerVariableID{v}, false, 0_i}; },
+                [&](const ConstantIntegerVariableID & v) { return std::tuple{DirectIntegerVariableID{v}, false, 0_i}; },
+                [&](const ViewOfIntegerVariableID & v) { return std::tuple{DirectIntegerVariableID{v.actual_variable}, v.negate_first, v.then_add}; },
+            }
+                .visit(var);
+        }
+
+        inline auto apply_view(Integer v, bool negate_first, Integer then_add) -> Integer
+        {
+            return (negate_first ? -v : v) + then_add;
+        }
+
+        template <typename SimpleFn_, typename ConstantFn_>
+        auto visit_actual(const SimpleIntegerVariableID & v, SimpleFn_ && sf, ConstantFn_ &&) -> decltype(sf(v))
+        {
+            return sf(v);
+        }
+
+        template <typename SimpleFn_, typename ConstantFn_>
+        auto visit_actual(const ConstantIntegerVariableID & v, SimpleFn_ &&, ConstantFn_ && cf) -> decltype(cf(v))
+        {
+            return cf(v);
+        }
+
+        template <typename SimpleFn_, typename ConstantFn_>
+        auto visit_actual(const DirectIntegerVariableID & v, SimpleFn_ && sf, ConstantFn_ && cf)
+        {
+            return overloaded{sf, cf}.visit(v);
+        }
+    }
+
     /**
      * \brief Keeps track of the current state, at a point inside search.
      *
@@ -95,6 +153,15 @@ namespace gcs::innards
 
         [[nodiscard]] inline auto state_of(const SimpleIntegerVariableID &) -> IntervalSet<Integer> &;
         [[nodiscard]] inline auto state_of(const SimpleIntegerVariableID &) const -> const IntervalSet<Integer> &;
+
+        // Non-inline sibling of state_of() for use from member function templates
+        // defined in this header. The for_each_value_* templates need the IntervalSet
+        // by const reference from a header-visible context; state_of() is `inline` only
+        // in the C++ sense (its body lives in state.cc), so calling it from a header
+        // template fails to link. This helper is defined out-of-line in state.cc.
+        // Internal state.cc paths keep using state_of() unchanged so the compiler
+        // retains its previous freedom to inline that call.
+        [[nodiscard]] auto state_of_for_iteration(const SimpleIntegerVariableID &) const -> const IntervalSet<Integer> &;
 
     public:
         /**
@@ -332,7 +399,7 @@ namespace gcs::innards
          * variable's domain must not be modified whilst the generator is alive. Call using
          * either IntegerVariableID or one of its more specific types.
          *
-         * \sa State::each_value_mutable()
+         * \sa State::each_value_mutable(), State::for_each_value_immutable()
          */
         template <IntegerVariableIDLike VarType_>
         auto each_value_immutable(const VarType_ &) const -> std::generator<Integer>;
@@ -343,10 +410,56 @@ namespace gcs::innards
          * will run over the values pre-modification. Call using either IntegerVariableID or
          * one of its more specific types.
          *
-         * \sa State::each_value_immutable()
+         * \sa State::each_value_immutable(), State::for_each_value_mutable()
          */
         template <IntegerVariableIDLike VarType_>
         auto each_value_mutable(const VarType_ &) const -> std::generator<Integer>;
+
+        /**
+         * Non-coroutine alternative to each_value_immutable(). Calls \p cb(value)
+         * for each value in the variable's domain, in ascending order. Avoids the
+         * std::generator frame allocation, the std::function the view-application
+         * needs in the generator version, and copying the underlying IntervalSet.
+         *
+         * The variable's domain must not be modified during the callback. If \p cb
+         * returns \c bool, returning \c false stops iteration early.
+         *
+         * \sa State::each_value_immutable(), State::for_each_value_mutable()
+         */
+        template <IntegerVariableIDLike VarType_, typename Callback_>
+        auto for_each_value_immutable(const VarType_ & var, Callback_ && cb) const -> void
+        {
+            auto [actual_var, negate_first, then_add] = state_detail::deview(var);
+            state_detail::visit_actual(
+                actual_var,
+                [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
+                    state_of_for_iteration(v).for_each([&](Integer i) { return cb(state_detail::apply_view(i, negate_first, then_add)); });
+                },
+                [&, negate_first = negate_first, then_add = then_add](
+                    const ConstantIntegerVariableID & v) { cb(state_detail::apply_view(v.const_value, negate_first, then_add)); });
+        }
+
+        /**
+         * Non-coroutine alternative to each_value_mutable(). The variable's
+         * domain may be modified by \p cb; iteration walks a snapshot of the
+         * pre-modification domain. If \p cb returns \c bool, returning \c false
+         * stops iteration early.
+         *
+         * \sa State::each_value_mutable(), State::for_each_value_immutable()
+         */
+        template <IntegerVariableIDLike VarType_, typename Callback_>
+        auto for_each_value_mutable(const VarType_ & var, Callback_ && cb) const -> void
+        {
+            auto [actual_var, negate_first, then_add] = state_detail::deview(var);
+            state_detail::visit_actual(
+                actual_var,
+                [&, negate_first = negate_first, then_add = then_add](const SimpleIntegerVariableID & v) {
+                    auto snapshot = state_of_for_iteration(v);
+                    snapshot.for_each([&](Integer i) { return cb(state_detail::apply_view(i, negate_first, then_add)); });
+                },
+                [&, negate_first = negate_first, then_add = then_add](
+                    const ConstantIntegerVariableID & v) { cb(state_detail::apply_view(v.const_value, negate_first, then_add)); });
+        }
 
         /**
          * Return the contents of the domain.


### PR DESCRIPTION
## Summary

Adds a non-coroutine sibling to `each_value_immutable` / `each_value_mutable` — `State::for_each_value_immutable/_mutable(var, cb)` — backed by a new `IntervalSet::for_each(F&&)`, and converts `element/element.cc` to use it. The six hot recursive `std::function<auto(unsigned)->X>` lambdas in element become gcc-13-compatible Y-combinator lambdas (`auto && self`). The two run-once `std::function` recursions (in `define_proof_model` / top of `install_propagators`) are left alone.

The existing `std::generator`-returning API is untouched; other constraints still use it.

> **Re-ported onto current `main` (2026-06-26).** The original branch was cut on 2026-05-23; since then #393 relocated `element.cc` to `gcs/constraints/element/element.cc` and #394 reworked reasons/hints, so the old patch no longer applied. This branch re-derives the element conversion against today's file. The State API commit cherry-picked cleanly bar a one-line doc-context conflict in `interval_set.hh`.

## Motivation

`std::generator` machinery and `std::function` type erasure both showed up clearly in `perf record`: ~28 % of `qap_12`'s cycles in coroutine generator actors, ~13 % in libc `malloc`/`free`. Element is hit hard by both.

## Benchmark deltas (re-measured on current `main`, median of trials)

| benchmark | main | branch | Δ |
|---|---:|---:|---:|
| qap 12 | 6.36s | **3.84s** | **−39.7 %** |
| langford 11 | 9.11s | **7.92s** | **−13.1 %** |
| tsp (gr17) | 38.32s | **33.49s** | **−12.6 %** |

Search behaviour is **bit-identical** to `main`: recursions, propagations, failures and the full objective trajectory match exactly on every benchmark above (verified by diffing `--stats` / cost output).

## Test plan

- [x] Full `cmake --build` of all targets green
- [x] `element_test` all four modes (`const`/`const2d`/`var`/`var2d`) pass under internal VeriPB verification (76 `s VERIFIED` lines, 0 failures)
- [x] `scp_chain_element_{sat,unsat}` pass
- [x] `element` ctest suite (10 targets) green
- [x] clang-format (21) clean
- [x] Search behaviour bit-identical (recursions, propagations, failures, objective trajectory)

## Notes

- Follow-ups from the original PR still stand (same pattern on `optional_single_value` / `bounds` / `domain_size`; `TrackedPropagationFailed` exception removal). Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)