### PR TITLE
among: emit pol-step scaffolding for proof-logged inferences

### DIFF
--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -26,6 +26,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::holds_alternative;
 using std::make_shared;
 using std::map;
 using std::optional;
@@ -150,7 +151,29 @@ auto Among::install_propagators(Propagators & propagators) -> void
             // many can't match, so we can derive bounds on the how many
             // variable.
             auto vars_reason = generic_reason(state, vars);
-            inference.infer(logger, how_many >= must_match_count, JustifyUsingRUP{}, vars_reason);
+            inference.infer(logger, how_many >= must_match_count, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) -> void {
+                // Combine the (sum <= how_many) half of the Among encoding with the
+                // at-least-one constraint for each must_match variable. After UP zeroes
+                // the (var == v) literals for v outside the variable's current domain
+                // (which, for must_match vars, includes everything outside voi), the
+                // resulting line collapses to (how_many >= must_match_count) — directly
+                // RUP-implying the inference. Without this scaffolding, RUP needs to
+                // re-derive at-least-one over voi from the bit encoding for each
+                // must_match var, which is not reliable when domains have width > 1.
+                if (sum_line.first && must_match_count > 0_i) {
+                    PolBuilder b;
+                    b.add(*sum_line.first);
+                    for (const auto & m : must_match_vars) {
+                        // Constants in must_match are folded into sum_line.first's RHS at OPB
+                        // emission, so they don't need (and don't have) an at-least-one line.
+                        if (holds_alternative<ConstantIntegerVariableID>(m))
+                            continue;
+                        b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                    }
+                    b.emit(*logger, ProofLevel::Temporary);
+                }
+            }},
+                vars_reason);
             auto less_than_this_many = Integer(vars.size()) - must_not_match_count + 1_i;
             inference.infer(logger, how_many < less_than_this_many, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) -> void {
                 // for any variable that isn't ruled out, show that it can contribute at
@@ -198,13 +221,20 @@ auto Among::install_propagators(Propagators & propagators) -> void
                             inferences.push_back(var != val);
 
                         inference.infer_all(logger, inferences, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) -> void {
-                            // for any variable that is forced, show that it can contribute at
-                            // most one to the count
-                            if (sum_line.second && ! empty(must_match_vars) && values_of_interest.size() > 1) {
+                            // We need to bound the sum from BELOW: must_match vars each
+                            // contribute at least one to the Among sum, so combining the
+                            // (sum <= how_many) half with at-least-one constraints for
+                            // every must_match var derives that any extra contribution
+                            // from a non-must-match variable conflicts with the fixed
+                            // how_many = must_match_count value.
+                            if (sum_line.first && ! empty(must_match_vars)) {
                                 PolBuilder b;
-                                b.add(*sum_line.second);
-                                for (const auto & var : must_match_vars)
-                                    b.add(am1_lines->at(var));
+                                b.add(*sum_line.first);
+                                for (const auto & m : must_match_vars) {
+                                    if (holds_alternative<ConstantIntegerVariableID>(m))
+                                        continue;
+                                    b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                                }
                                 b.emit(*logger, ProofLevel::Temporary);
                             }
                         }},
@@ -245,10 +275,15 @@ auto Among::install_propagators(Propagators & propagators) -> void
                                         for (const auto & voi : values_of_interest)
                                             logger->emit(RUPProofRule{}, WPBSum{} + 1_i * (var != val) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
 
-                                        // now each other variable that may or may not match is contributing at most one to the sum
+                                        // now every other variable that contributes to the sum is
+                                        // capped at one — must_match vars (whose AM1 lines bound their
+                                        // contribution to the at-most-must_match_count tally) AND every
+                                        // other can_be_either var.
                                         if (sum_line.second && values_of_interest.size() > 1) {
                                             PolBuilder b;
                                             b.add(*sum_line.second);
+                                            for (const auto & m : must_match_vars)
+                                                b.add(am1_lines->at(m));
                                             for (const auto & other_var : can_be_either_vars)
                                                 if (var != other_var)
                                                     b.add(am1_lines->at(other_var));


### PR DESCRIPTION
## Summary

Three Among inferences had pol-step bugs that VeriPB's RUP couldn't always close:

1. **`how_many >= must_match_count`** — emitted as `JustifyUsingRUP` with no pol scaffolding. RUP was expected to re-derive at-least-one over voi from the bit encoding for each must_match var, which only works reliably when each must_match var has domain size 1.
2. **`var != voi`** when `must_match_count == at_most_how_many` — pol used `sum_line.second` (GE half), which is the wrong direction for an upper-bound argument. Adding AM1s on top of the GE half cancels the eq terms and only weakens the RHS, leaving a constraint that's trivially satisfied after substitution.
3. **`var != non_voi`** when `must_match + can_be_either == at_least_how_many` — pol only summed AM1s on *other* can_be_either vars, missing the AM1s on must_match. When `can_be_either = {var}`, the pol step contributed nothing beyond what was already in the database.

The bug was masked on `main` because the unseeded `random` branching heuristic's RNG state didn't persist correctly across closure copies (it does in the seeded-variants branch), and the resulting deterministic-ish search shape happened to avoid the affected propagator paths.

## Fix

For (1) and (2): switch to `JustifyExplicitlyThenRUP` with a pol step that adds the LE half plus `need_constraint_saying_variable_takes_at_least_one_value` for each must_match var. Constants in must_match are skipped because the OPB encoding folds their contribution into the constraint RHS at emission time.

For (3): keep the existing GE-half + can_be_either-except-var pattern, but also fold in AM1s for must_match vars, so every variable that contributes to the sum is capped at one regardless of which variable the inference targets.

## Test plan

- [x] `among_test` 200 runs, 0 failures (was ~33% flaky on view-wrap-harness)
- [x] Full `ctest -j 32`, 205/205, three consecutive runs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)