### PR TITLE
abs / arithmetic / comparison / parity: dup-variable tests (tier 1)

### DIFF
--- a/gcs/constraints/abs_test.cc
+++ b/gcs/constraints/abs_test.cc
@@ -69,6 +69,27 @@ auto run_abs_test(bool proofs, const ViewWrapConfig & view_cfg,
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Abs(x, x) forces x = abs(x), i.e. x >= 0.
+// Consistency isn't checked on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_abs_test(bool proofs, pair<int, int> x_range) -> void
+{
+    print(cerr, "abs dup {} {}", x_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int>> expected, actual;
+    build_expected(expected, [](int a) { return a == abs(a); }, x_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto x = p.create_integer_variable(Integer{x_range.first}, Integer{x_range.second});
+    p.post(Abs{x, x});
+
+    auto proof_name = proofs ? make_optional("abs_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{x});
+
+    check_results(proof_name, expected, actual);
+}
+
 // Targeted tests for the proofs Abs::prepare emits for its four consequence
 // bounds. Domains are picked so that one specific bound is non-trivial, so a
 // proof failure points unambiguously at that bound. Uses
@@ -156,11 +177,18 @@ auto main(int argc, char * argv[]) -> int
         run_abs_initialiser_test("wide_asym_ub_dominant", {-5, 50}, {0, 80});
     }
 
+    // Bare-handle dup ranges. Skipped under the view-wrap sweep.
+    vector<pair<int, int>> dup_data = {
+        {-3, 3}, {-5, 0}, {0, 5}, {-1, 1}, {2, 5}};
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         for (auto & [r1, r2] : data)
             run_abs_test(proofs, view_cfg, r1, r2);
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions))
+            for (auto & x_range : dup_data)
+                run_dup_abs_test(proofs, x_range);
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/arithmetic_test.cc
+++ b/gcs/constraints/arithmetic_test.cc
@@ -25,6 +25,7 @@
 using std::cerr;
 using std::flush;
 using std::function;
+using std::is_same_v;
 using std::make_optional;
 using std::mt19937;
 using std::nullopt;
@@ -170,6 +171,64 @@ auto run_power_pinned_test(bool proofs, Integer base, Integer exp, pair<long lon
             throw UnexpectedException{"veripb verification failed"};
 }
 
+// Dup-variable tests: post a GACArithmetic constraint with the same handle
+// in two (or all three) slots. The GAC algorithm operates over a tuple
+// table that doesn't know two slots alias, so consistency on alias drops
+// to "weak"; we don't check it. See tmp/duplicate_var_audit.md.
+namespace
+{
+    struct AliasV1V2 { };
+    struct AliasV1V3 { };
+    struct AliasV2V3 { };
+    struct AliasAll { };
+}
+
+template <typename Arithmetic_, typename AliasPattern_>
+auto run_dup_arithmetic_test(bool proofs, AliasPattern_, const string & tag,
+    pair<int, int> a_range, pair<int, int> b_range,
+    const function<auto(int, int, int)->bool> & is_satisfying) -> void
+{
+    print(cerr, "arithmetic {} dup {} {} {} {}", NameOf<Arithmetic_>::name, tag, a_range, b_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    Problem p;
+    auto proof_name = proofs ? make_optional(string{"arithmetic_test_"} + NameOf<Arithmetic_>::name + "_dup_" + tag) : nullopt;
+
+    if constexpr (is_same_v<AliasPattern_, AliasAll>) {
+        set<tuple<int>> expected, actual;
+        build_expected(expected, [&](int a) { return is_satisfying(a, a, a); }, a_range);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        auto a = p.create_integer_variable(Integer(a_range.first), Integer(a_range.second));
+        p.post(Arithmetic_{a, a, a});
+
+        solve_for_tests(p, proof_name, actual, tuple{a});
+        check_results(proof_name, expected, actual);
+    }
+    else {
+        set<tuple<int, int>> expected, actual;
+        if constexpr (is_same_v<AliasPattern_, AliasV1V2>)
+            build_expected(expected, [&](int a, int b) { return is_satisfying(a, a, b); }, a_range, b_range);
+        else if constexpr (is_same_v<AliasPattern_, AliasV1V3>)
+            build_expected(expected, [&](int a, int b) { return is_satisfying(a, b, a); }, a_range, b_range);
+        else
+            build_expected(expected, [&](int a, int b) { return is_satisfying(a, b, b); }, a_range, b_range);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        auto a = p.create_integer_variable(Integer(a_range.first), Integer(a_range.second));
+        auto b = p.create_integer_variable(Integer(b_range.first), Integer(b_range.second));
+        if constexpr (is_same_v<AliasPattern_, AliasV1V2>)
+            p.post(Arithmetic_{a, a, b});
+        else if constexpr (is_same_v<AliasPattern_, AliasV1V3>)
+            p.post(Arithmetic_{a, b, a});
+        else
+            p.post(Arithmetic_{a, b, b});
+
+        solve_for_tests(p, proof_name, actual, tuple{a, b});
+        check_results(proof_name, expected, actual);
+    }
+}
+
 auto main(int, char *[]) -> int
 {
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> data = {
@@ -226,6 +285,51 @@ auto main(int, char *[]) -> int
 
         // 0^0 = 1 by convention.
         run_power_pinned_test(proofs, 0_i, 0_i, {-2, 2}, make_optional(1_i));
+
+        // Dup-variable cases for the GAC-via-Table specialisations. Domains
+        // are kept small because the underlying tuple table is materialised.
+        // Div/Mod need divisors to avoid zero; the lambdas already guard.
+        vector<pair<pair<int, int>, pair<int, int>>> dup_data = {
+            {{-3, 3}, {-9, 9}},
+            {{1, 4}, {-5, 5}}};
+        auto plus_sat = [](int a, int b, int c) { return a + b == c; };
+        auto minus_sat = [](int a, int b, int c) { return a - b == c; };
+        auto times_sat = [](int a, int b, int c) { return a * b == c; };
+        auto div_sat = [](int a, int b, int c) { return 0 != b && a / b == c; };
+        auto mod_sat = [](int a, int b, int c) { return 0 != b && a % b == c; };
+        for (auto & [ar, br] : dup_data) {
+            run_dup_arithmetic_test<PlusGAC>(proofs, AliasV1V2{}, "v1v2", ar, br, plus_sat);
+            run_dup_arithmetic_test<PlusGAC>(proofs, AliasV1V3{}, "v1v3", ar, br, plus_sat);
+            run_dup_arithmetic_test<PlusGAC>(proofs, AliasV2V3{}, "v2v3", ar, br, plus_sat);
+            run_dup_arithmetic_test<PlusGAC>(proofs, AliasAll{}, "all", ar, br, plus_sat);
+            run_dup_arithmetic_test<MinusGAC>(proofs, AliasV1V2{}, "v1v2", ar, br, minus_sat);
+            run_dup_arithmetic_test<MinusGAC>(proofs, AliasV1V3{}, "v1v3", ar, br, minus_sat);
+            run_dup_arithmetic_test<MinusGAC>(proofs, AliasV2V3{}, "v2v3", ar, br, minus_sat);
+            run_dup_arithmetic_test<MinusGAC>(proofs, AliasAll{}, "all", ar, br, minus_sat);
+            run_dup_arithmetic_test<Times>(proofs, AliasV1V2{}, "v1v2", ar, br, times_sat);
+            run_dup_arithmetic_test<Times>(proofs, AliasV1V3{}, "v1v3", ar, br, times_sat);
+            run_dup_arithmetic_test<Times>(proofs, AliasV2V3{}, "v2v3", ar, br, times_sat);
+            run_dup_arithmetic_test<Times>(proofs, AliasAll{}, "all", ar, br, times_sat);
+            run_dup_arithmetic_test<Div>(proofs, AliasV1V2{}, "v1v2", ar, br, div_sat);
+            run_dup_arithmetic_test<Div>(proofs, AliasV1V3{}, "v1v3", ar, br, div_sat);
+            run_dup_arithmetic_test<Div>(proofs, AliasV2V3{}, "v2v3", ar, br, div_sat);
+            run_dup_arithmetic_test<Div>(proofs, AliasAll{}, "all", ar, br, div_sat);
+            run_dup_arithmetic_test<Mod>(proofs, AliasV1V2{}, "v1v2", ar, br, mod_sat);
+            run_dup_arithmetic_test<Mod>(proofs, AliasV1V3{}, "v1v3", ar, br, mod_sat);
+            run_dup_arithmetic_test<Mod>(proofs, AliasV2V3{}, "v2v3", ar, br, mod_sat);
+            run_dup_arithmetic_test<Mod>(proofs, AliasAll{}, "all", ar, br, mod_sat);
+        }
+
+        // Power dup: kept very small since result range can blow up quickly.
+        vector<pair<pair<int, int>, pair<int, int>>> power_dup_data = {
+            {{0, 3}, {0, 10}},
+            {{-2, 2}, {-5, 5}}};
+        for (auto & [ar, br] : power_dup_data) {
+            run_dup_arithmetic_test<Power>(proofs, AliasV1V2{}, "v1v2", ar, br, power_is_satisfying);
+            run_dup_arithmetic_test<Power>(proofs, AliasV1V3{}, "v1v3", ar, br, power_is_satisfying);
+            run_dup_arithmetic_test<Power>(proofs, AliasV2V3{}, "v2v3", ar, br, power_is_satisfying);
+            run_dup_arithmetic_test<Power>(proofs, AliasAll{}, "all", ar, br, power_is_satisfying);
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/comparison_test.cc
+++ b/gcs/constraints/comparison_test.cc
@@ -172,6 +172,52 @@ auto run_reif_binary_comparison_test(bool proofs, const string & mode, const Vie
     }
 }
 
+// Dup-variable test: post a binary comparison with the same handle in
+// both slots. Consistency isn't checked on dup runs; see
+// tmp/duplicate_var_audit.md.
+template <typename Constraint_>
+auto run_dup_binary_comparison_test(bool proofs, const string & mode, pair<int, int> x_range,
+    const function<auto(int) -> bool> & is_satisfying) -> void
+{
+    print(cerr, "comparison dup {} {} {}", NameOf<Constraint_>::name, x_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int>> expected, actual;
+    build_expected(expected, is_satisfying, x_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto x = p.create_integer_variable(Integer(x_range.first), Integer(x_range.second));
+    p.post(Constraint_{x, x});
+
+    auto proof_name = proofs ? make_optional("comparison_test_" + mode + "_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{x});
+
+    check_results(proof_name, expected, actual);
+}
+
+template <typename Constraint_>
+auto run_dup_reif_binary_comparison_test(bool proofs, const string & mode, pair<int, int> x_range,
+    const function<auto(int, int) -> bool> & is_satisfying) -> void
+{
+    print(cerr, "comparison dup reif {} {} {}", NameOf<Constraint_>::name, x_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int, int>> expected, actual;
+    build_expected(expected, is_satisfying, x_range, pair{0, 1});
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto x = p.create_integer_variable(Integer(x_range.first), Integer(x_range.second));
+    auto c = p.create_integer_variable(0_i, 1_i, "c");
+    p.post(Constraint_{x, x, c == 1_i});
+
+    auto proof_name = proofs ? make_optional("comparison_test_" + mode + "_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{x, c});
+
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     // Mode is the first non-flag positional; --view-* flags may follow.
@@ -261,6 +307,39 @@ auto main(int argc, char * argv[]) -> int
             }
             else
                 throw UnimplementedException{};
+        }
+
+        // Dup-variable cases. Only the audit's OK variants are exercised here;
+        // lt, gt, lt_if, gt_if are skipped (Bucket A throw / Bucket B fix).
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            vector<pair<int, int>> dup_data = {{0, 0}, {0, 5}, {-3, 3}, {2, 5}};
+            for (auto & xr : dup_data) {
+                if (mode == "le")
+                    run_dup_binary_comparison_test<LessThanEqual>(proofs, mode, xr,
+                        [](int) { return true; });
+                else if (mode == "ge")
+                    run_dup_binary_comparison_test<GreaterThanEqual>(proofs, mode, xr,
+                        [](int) { return true; });
+                else if (mode == "le_if")
+                    run_dup_reif_binary_comparison_test<LessThanEqualIf>(proofs, mode, xr,
+                        [](int, int) { return true; });
+                else if (mode == "ge_if")
+                    run_dup_reif_binary_comparison_test<GreaterThanEqualIf>(proofs, mode, xr,
+                        [](int, int) { return true; });
+                else if (mode == "lt_iff")
+                    run_dup_reif_binary_comparison_test<LessThanIff>(proofs, mode, xr,
+                        [](int, int c) { return c == 0; });
+                else if (mode == "le_iff")
+                    run_dup_reif_binary_comparison_test<LessThanEqualIff>(proofs, mode, xr,
+                        [](int, int c) { return c == 1; });
+                else if (mode == "gt_iff")
+                    run_dup_reif_binary_comparison_test<GreaterThanIff>(proofs, mode, xr,
+                        [](int, int c) { return c == 0; });
+                else if (mode == "ge_iff")
+                    run_dup_reif_binary_comparison_test<GreaterThanEqualIff>(proofs, mode, xr,
+                        [](int, int c) { return c == 1; });
+                // else: lt, gt, lt_if, gt_if — Bucket A/B, no dup test
+            }
         }
     }
 

--- a/gcs/constraints/parity_test.cc
+++ b/gcs/constraints/parity_test.cc
@@ -74,6 +74,44 @@ auto run_parity_test(bool proofs, const ViewWrapConfig & view_cfg, const vector<
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: post ParityOdd with the same handle in several
+// positions. Duplicate literals XOR-cancel: ParityOdd({x, x, y}) ≡
+// ParityOdd({y}). Consistency isn't checked on dup runs; see
+// tmp/duplicate_var_audit.md.
+auto run_dup_parity_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions) -> void
+{
+    print(cerr, "parity odd dup domains {} positions {}{}",
+        unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Reference predicate: post-cancellation, the parity is the parity
+    // of the count of unique-var occurrences with odd multiplicity.
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & vals) -> bool {
+            int trues = 0;
+            for (auto pos : positions)
+                if (vals.at(pos) != 0) ++trues;
+            return trues % 2 == 1;
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> posted;
+    for (auto pos : positions)
+        posted.push_back(unique_vars.at(pos));
+    p.post(ParityOdd{posted});
+
+    auto proof_name = proofs ? make_optional("parity_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -123,11 +161,27 @@ auto main(int argc, char * argv[]) -> int
         generate_random_data(rand, data, vector{size_t(n_values), random_bounds_or_constant(-1, 2, 1, 4)});
     }
 
+    // Dup-variable cases. Skipped under the view-wrap sweep.
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         for (auto & v : data)
             run_parity_test(proofs, view_cfg, v);
+
+        if (run_dup) {
+            // {x, x} — dups cancel; over {0,1} the empty parity is even ⇒ UNSAT.
+            run_dup_parity_test(proofs, {{0, 1}}, {0, 0});
+            // {x, x, y} — dups cancel; reduces to ParityOdd({y}).
+            run_dup_parity_test(proofs, {{0, 1}, {0, 1}}, {0, 0, 1});
+            // {x, y, x} — order shouldn't matter.
+            run_dup_parity_test(proofs, {{0, 1}, {0, 1}}, {0, 1, 0});
+            // {x, x, x, y} — three xs is odd-multiplicity ⇒ same as ParityOdd({x,y}).
+            run_dup_parity_test(proofs, {{0, 1}, {0, 1}}, {0, 0, 0, 1});
+            // Wider domains: non-zero values still count as "true" for parity.
+            run_dup_parity_test(proofs, {{-2, 2}, {0, 3}}, {0, 0, 1});
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary

- Tier 1 follow-up to #223 — adds dup-variable tests for the small-arity OK constraints in the audit (`tmp/duplicate_var_audit.md`).
- Stacked on `duplicate-var-tests` (the pilot PR) so the helpers introduced there are reused; please merge #223 first.
- One audit downgrade surfaced: **MultBC** dup tests had to be dropped — propagator is sound on every alias pattern, but the bit-product channelling encoding (`mult_bc.cc:1168`) double-creates magnitude variables and the proof fails VeriPB. Tracked in `tmp/duplicate_var_tier1_findings.md`; will need a separate fix before the MultBC dup tests can land.

## What's in

| File | Cases |
|---|---|
| `abs_test.cc` | `Abs(x, x)` over 5 ranges |
| `arithmetic_test.cc` | PlusGAC / MinusGAC / Times / Div / Mod / Power × 4 alias patterns × 2 ranges (Power kept small) |
| `comparison_test.cc` | OK variants only — `LessThanEqual`, `GreaterThanEqual`, both `*EqualIf`, all four `*Iff` |
| `parity_test.cc` | `ParityOdd` with duplicated positions (XOR-cancellation test) |

`In` already covers its dup case via the pre-existing `run_in_self_reference_test`; no change there.

## What's deliberately not in

- `LessThan(x,x)`, `GreaterThan(x,x)` — Bucket A "throw" (audit). Current behaviour is search-time UNSAT; tests land with the throw fix.
- `LessThanIf(x,x,c)`, `GreaterThanIf(x,x,c)` — Bucket B "fix". Propagator silent on dup, OPB correct; tests land with the propagator fix.
- `MultBC` — see findings doc.

## Test plan

- [x] `cmake --build build --target abs_test arithmetic_test comparison_test parity_test` (release)
- [x] `cmake --build build-sanitize --target abs_test arithmetic_test comparison_test parity_test in_test` (sanitize)
- [x] `./run_test_and_verify.bash ./build/abs_test` — 5 dup invocations × 2 proof modes, all green
- [x] `./run_test_and_verify.bash ./build/arithmetic_test` — 48 dup invocations across 6 constraints × 4 patterns, all green
- [x] All 12 comparison modes verified individually; only the 8 OK modes execute dup runs
- [x] `./run_test_and_verify.bash ./build/parity_test` — 5 dup invocations × 2 proof modes
- [x] `./build-sanitize/*_test` smoke-runs cleanly for every modified test

🤖 Generated with [Claude Code](https://claude.com/claude-code)