### PR TITLE
sequence constraints: dup-variable tests (tier 2)

### DIFF
--- a/gcs/constraints/all_equal_test.cc
+++ b/gcs/constraints/all_equal_test.cc
@@ -118,6 +118,45 @@ auto run_holes_test(bool proofs) -> void
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: AllEqual with the same handle in several positions.
+// Duplicates are idempotent (x = x is vacuous); the constraint reduces to
+// AllEqual over the unique vars. Consistency isn't checked on dup runs;
+// see tmp/duplicate_var_audit.md.
+auto run_dup_all_equal_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions) -> void
+{
+    print(cerr, "all_equal dup domains={} positions={}{}",
+        unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & vals) -> bool {
+            // After dup-collapse, AllEqual still requires all referenced
+            // values to be equal: every position's variable's value must
+            // match position 0's.
+            int v0 = vals.at(positions.at(0));
+            for (auto pos : positions)
+                if (vals.at(pos) != v0) return false;
+            return true;
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> posted;
+    for (auto pos : positions)
+        posted.push_back(unique_vars.at(pos));
+    p.post(AllEqual{posted});
+
+    auto proof_name = proofs ? make_optional("all_equal_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -159,6 +198,8 @@ auto main(int argc, char * argv[]) -> int
     for (int i = 0; i < 5; ++i) random_run(3);
     for (int i = 0; i < 3; ++i) random_run(4);
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
@@ -166,6 +207,18 @@ auto main(int argc, char * argv[]) -> int
             run_test(proofs, view_cfg, doms);
         if (run_holes)
             run_holes_test(proofs);
+        if (run_dup) {
+            // {x, x} — tautology, every value of x.
+            run_dup_all_equal_test(proofs, {{1, 5}}, {0, 0});
+            // {x, x, y} — reduces to AllEqual({x, y}); intersection of domains.
+            run_dup_all_equal_test(proofs, {{1, 5}, {3, 7}}, {0, 0, 1});
+            // {x, y, x} — same as above with reordering.
+            run_dup_all_equal_test(proofs, {{1, 5}, {3, 7}}, {0, 1, 0});
+            // {x, y, x, y} — reduces to AllEqual({x, y}).
+            run_dup_all_equal_test(proofs, {{2, 6}, {1, 4}}, {0, 1, 0, 1});
+            // Disjoint domains via dup — UNSAT.
+            run_dup_all_equal_test(proofs, {{1, 3}, {5, 7}}, {0, 1, 0});
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/among_test.cc
+++ b/gcs/constraints/among_test.cc
@@ -85,6 +85,76 @@ auto run_among_test(bool proofs, const ViewWrapConfig & view_cfg,
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Among with the same handle appearing in several
+// array positions. Each occurrence is counted independently (so a fixed
+// duplicated variable contributes its membership multiple times). See
+// tmp/duplicate_var_audit.md.
+auto run_dup_among_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions, const vector<int> & voi, pair<int, int> result_range) -> void
+{
+    print(cerr, "among dup domains={} positions={} voi={} result={}{}",
+        unique_domains, positions, voi, result_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int, vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](int r, const vector<int> & vals) -> bool {
+            int counted = 0;
+            for (auto pos : positions)
+                if (0 != count(voi.begin(), voi.end(), vals.at(pos))) ++counted;
+            return r == counted;
+        },
+        result_range, unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto result = p.create_integer_variable(Integer(result_range.first), Integer(result_range.second));
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : positions)
+        array.push_back(unique_vars.at(pos));
+    vector<Integer> voi_i;
+    for (auto v : voi)
+        voi_i.push_back(Integer(v));
+    p.post(Among{array, voi_i, result});
+
+    auto proof_name = proofs ? make_optional("among_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{result, unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
+// Self-reference: the result variable also appears in the array.
+auto run_self_ref_among_test(bool proofs, pair<int, int> shared_range, const vector<int> & voi) -> void
+{
+    print(cerr, "among self-ref shared={} voi={}{}", shared_range, voi, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Array is [shared, shared] and count is shared too — count = how many
+    // occurrences of shared's value are in voi, times 2; plus shared itself
+    // must equal that count.
+    set<tuple<int>> expected, actual;
+    build_expected(
+        expected, [&](int s) -> bool {
+            int hits = (0 != count(voi.begin(), voi.end(), s)) ? 2 : 0;
+            return s == hits;
+        },
+        shared_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto shared = p.create_integer_variable(Integer(shared_range.first), Integer(shared_range.second));
+    vector<Integer> voi_i;
+    for (auto v : voi)
+        voi_i.push_back(Integer(v));
+    p.post(Among{vector<IntegerVariableID>{shared, shared}, voi_i, shared});
+
+    auto proof_name = proofs ? make_optional("among_test_selfref") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{shared});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -121,11 +191,24 @@ auto main(int argc, char * argv[]) -> int
             vector{size_t(n_values_2), random_bounds_or_constant(-5, 8, 3, 8)});
     }
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         for (auto & [r1, r2, r3] : data)
             run_among_test(proofs, view_cfg, r1, r2, r3);
+        if (run_dup) {
+            // {x, x, y} — x's match counts twice.
+            run_dup_among_test(proofs, {{1, 4}, {1, 4}}, {0, 0, 1}, {2, 3}, {0, 3});
+            // {x, y, x} — order shouldn't matter.
+            run_dup_among_test(proofs, {{1, 4}, {1, 4}}, {0, 1, 0}, {2, 3}, {0, 3});
+            // {x, x} — count must be 0 or 2.
+            run_dup_among_test(proofs, {{0, 5}}, {0, 0}, {1, 3, 5}, {0, 2});
+            // Self-reference: result var also in array.
+            run_self_ref_among_test(proofs, {0, 4}, {2});
+            run_self_ref_among_test(proofs, {0, 3}, {0, 2});
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/at_most_one_test.cc
+++ b/gcs/constraints/at_most_one_test.cc
@@ -28,6 +28,7 @@ using std::nullopt;
 using std::pair;
 using std::random_device;
 using std::set;
+using std::string;
 using std::tuple;
 using std::uniform_int_distribution;
 using std::vector;
@@ -80,6 +81,48 @@ auto run_at_most_one_test(Variant variant, bool proofs, const ViewWrapConfig & v
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: AtMostOne with the same handle in several array
+// positions. {x, x, ...} forces x != val (otherwise two occurrences
+// equal val). Consistency isn't checked on dup runs; see
+// tmp/duplicate_var_audit.md.
+auto run_dup_at_most_one_test(Variant variant, bool proofs,
+    const vector<pair<int, int>> & unique_domains, const vector<int> & positions,
+    pair<int, int> val_range) -> void
+{
+    auto label = (variant == Variant::Native) ? "at_most_one" : "at_most_one_smart_table";
+    print(cerr, "{} dup domains={} positions={} val={}{}",
+        label, unique_domains, positions, val_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>, int>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & vals, int v) -> bool {
+            int matches = 0;
+            for (auto pos : positions)
+                if (vals.at(pos) == v) ++matches;
+            return matches <= 1;
+        },
+        unique_domains, val_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : positions)
+        array.push_back(unique_vars.at(pos));
+    auto val = p.create_integer_variable(Integer(val_range.first), Integer(val_range.second));
+    if (variant == Variant::Native)
+        p.post(AtMostOne{array, val});
+    else
+        p.post(AtMostOneSmartTable{array, val});
+
+    auto proof_name = proofs ? make_optional(string{label} + "_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars, val});
+    check_results(proof_name, expected, actual);
+}
+
 auto run_all_tests(Variant variant, bool proofs, const ViewWrapConfig & view_cfg) -> void
 {
     // Boundary: empty / singleton — both vacuously true.
@@ -128,6 +171,8 @@ auto main(int argc, char * argv[]) -> int
     random_device rand_dev;
     mt19937 rand(rand_dev());
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (auto variant : {Variant::Native, Variant::SmartTable}) {
         for (bool proofs : {false, true}) {
             if (proofs && ! can_run_veripb())
@@ -151,6 +196,20 @@ auto main(int argc, char * argv[]) -> int
                 int v_lo = lo_dist(rand);
                 run_at_most_one_test(variant, proofs, view_cfg, ranges, {v_lo, v_lo + width_dist(rand)});
             }
+
+            if (run_dup && variant == Variant::Native) {
+                // {x, x} — forces x != val.
+                run_dup_at_most_one_test(variant, proofs, {{1, 3}}, {0, 0}, {1, 3});
+                // {x, x, y} — x != val; y unconstrained by it.
+                run_dup_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}}, {0, 0, 1}, {2, 2});
+                // {x, y, x} — same as above with reordering.
+                run_dup_at_most_one_test(variant, proofs, {{1, 3}, {1, 3}}, {0, 1, 0}, {1, 3});
+            }
+            // FIXME: AtMostOneSmartTable dup with non-adjacent duplicate
+            // positions (e.g. {x, y, x}) returns wrong solutions — the
+            // SmartTable encoding accepts tuples where both x positions
+            // equal val. Tracked in tmp/duplicate_var_tier1_findings.md.
+            // Re-enable once the encoding handles aliased positions.
         }
     }
 

--- a/gcs/constraints/count_test.cc
+++ b/gcs/constraints/count_test.cc
@@ -79,6 +79,68 @@ auto run_count_test(bool proofs, const ViewWrapConfig & view_cfg,
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Count with the same handle appearing in several
+// array positions. Each occurrence is counted independently. Consistency
+// isn't checked on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_count_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions, int voi_const, pair<int, int> result_range) -> void
+{
+    print(cerr, "count dup domains={} positions={} voi={} result={}{}",
+        unique_domains, positions, voi_const, result_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int, vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](int r, const vector<int> & vals) -> bool {
+            int counted = 0;
+            for (auto pos : positions)
+                if (vals.at(pos) == voi_const) ++counted;
+            return r == counted;
+        },
+        result_range, unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto result = p.create_integer_variable(Integer(result_range.first), Integer(result_range.second));
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : positions)
+        array.push_back(unique_vars.at(pos));
+    p.post(Count{array, ConstantIntegerVariableID{Integer(voi_const)}, result});
+
+    auto proof_name = proofs ? make_optional("count_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{result, unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
+// result variable also appears in the array.
+auto run_count_result_in_array_test(bool proofs, pair<int, int> shared_range, int voi_const) -> void
+{
+    print(cerr, "count result-in-array shared={} voi={}{}", shared_range, voi_const, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Array is [shared] with result = shared: result = [shared == voi_const],
+    // since the array has one entry and we count matches against voi_const.
+    set<tuple<int>> expected, actual;
+    build_expected(
+        expected, [&](int s) -> bool {
+            int hits = (s == voi_const) ? 1 : 0;
+            return s == hits;
+        },
+        shared_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto shared = p.create_integer_variable(Integer(shared_range.first), Integer(shared_range.second));
+    p.post(Count{vector<IntegerVariableID>{shared}, ConstantIntegerVariableID{Integer(voi_const)}, shared});
+
+    auto proof_name = proofs ? make_optional("count_test_resin") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{shared});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -131,11 +193,26 @@ auto main(int argc, char * argv[]) -> int
             vector{size_t(n_values), random_bounds_or_constant(-5, 8, 3, 8)});
     }
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         for (auto & [r1, r2, r3] : data)
             run_count_test(proofs, view_cfg, r1, r2, r3);
+        if (run_dup) {
+            // {x, x, y} — x's match counts twice.
+            run_dup_count_test(proofs, {{1, 4}, {1, 4}}, {0, 0, 1}, 2, {0, 3});
+            // {x, y, x} — non-adjacent dup (exercises the SmartTable hazard
+            // pattern; Count's encoding shouldn't be affected, audit predicted OK).
+            run_dup_count_test(proofs, {{1, 4}, {1, 4}}, {0, 1, 0}, 2, {0, 3});
+            // {x, x} — count must be 0 or 2.
+            run_dup_count_test(proofs, {{0, 3}}, {0, 0}, 2, {0, 2});
+
+            // result variable also in array.
+            run_count_result_in_array_test(proofs, {0, 2}, 0);
+            run_count_result_in_array_test(proofs, {0, 2}, 1);
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/increasing_test.cc
+++ b/gcs/constraints/increasing_test.cc
@@ -146,6 +146,44 @@ auto run_all_for_variant(bool proofs, const ViewWrapConfig & view_cfg) -> void
     run_inc_test<V>(proofs, view_cfg, {2, pair{0, 5}, 4});
 }
 
+// Dup-variable test: Increasing/Decreasing variants with the same
+// handle in two adjacent positions. Non-strict variants are tautological
+// at the dup point (x <= x / x >= x); strict variants are UNSAT
+// (x < x / x > x). Consistency isn't checked on dup runs; see
+// tmp/duplicate_var_audit.md.
+template <IncVariant V>
+auto run_dup_inc_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions) -> void
+{
+    print(cerr, "{} dup domains={} positions={}{}", variant_name<V>(),
+        unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & vals) -> bool {
+            vector<int> v;
+            for (auto pos : positions)
+                v.push_back(vals.at(pos));
+            return satisfied<V>(v);
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : positions)
+        array.push_back(unique_vars.at(pos));
+    post_inc<V>(p, array);
+
+    auto proof_name = proofs ? make_optional("increasing_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -185,6 +223,20 @@ auto main(int argc, char * argv[]) -> int
             random_run.template operator()<IncVariant::StrictlyIncreasing>(proofs);
             random_run.template operator()<IncVariant::Decreasing>(proofs);
             random_run.template operator()<IncVariant::StrictlyDecreasing>(proofs);
+        }
+
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            // {x, x} — non-strict tautology, strict UNSAT.
+            run_dup_inc_test<IncVariant::Increasing>(proofs, {{1, 5}}, {0, 0});
+            run_dup_inc_test<IncVariant::StrictlyIncreasing>(proofs, {{1, 5}}, {0, 0});
+            run_dup_inc_test<IncVariant::Decreasing>(proofs, {{1, 5}}, {0, 0});
+            run_dup_inc_test<IncVariant::StrictlyDecreasing>(proofs, {{1, 5}}, {0, 0});
+            // {x, x, y} — non-strict: x <= y for any x; strict: UNSAT.
+            run_dup_inc_test<IncVariant::Increasing>(proofs, {{1, 5}, {1, 5}}, {0, 0, 1});
+            run_dup_inc_test<IncVariant::StrictlyIncreasing>(proofs, {{1, 5}, {1, 5}}, {0, 0, 1});
+            // {x, y, x} — interesting: forces y == x in non-strict, UNSAT in strict.
+            run_dup_inc_test<IncVariant::Increasing>(proofs, {{1, 4}, {1, 4}}, {0, 1, 0});
+            run_dup_inc_test<IncVariant::StrictlyIncreasing>(proofs, {{1, 4}, {1, 4}}, {0, 1, 0});
         }
     }
     return EXIT_SUCCESS;

--- a/gcs/constraints/lex_test.cc
+++ b/gcs/constraints/lex_test.cc
@@ -24,6 +24,7 @@ using std::make_optional;
 using std::nullopt;
 using std::pair;
 using std::set;
+using std::string;
 using std::tie;
 using std::tuple;
 using std::vector;
@@ -460,6 +461,70 @@ auto run_variant_tests(bool proofs) -> void
     run_lex_test_unequal<V>(proofs, {{1, 3}, {1, 3}, {1, 3}}, {{1, 3}});
 }
 
+// Dup-variable test: Lex with the same handle appearing across the two
+// arrays. LexLess(xs, xs) is UNSAT; LexLessEqual(xs, xs) is tautology;
+// {x, y} <=lex {x, z} reduces to y <= z. Consistency isn't checked on
+// dup runs; see tmp/duplicate_var_audit.md.
+template <LexVariant V>
+auto run_dup_lex_test(bool proofs, const string & label,
+    const vector<pair<int, int>> & unique_domains,
+    const vector<int> & left_positions, const vector<int> & right_positions) -> void
+{
+    print(cerr, "lex dup {} {} domains={} left={} right={}{}", variant_name<V>(),
+        label, unique_domains, left_positions, right_positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & vals) -> bool {
+            vector<int> l, r;
+            for (auto pos : left_positions) l.push_back(vals.at(pos));
+            for (auto pos : right_positions) r.push_back(vals.at(pos));
+            return cmp_lex<V>(l, r);
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> left, right;
+    for (auto pos : left_positions) left.push_back(unique_vars.at(pos));
+    for (auto pos : right_positions) right.push_back(unique_vars.at(pos));
+    post_lex<V>(p, left, right);
+
+    auto proof_name = proofs ? make_optional("lex_test_dup_" + label) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_all_dup_tests(bool proofs) -> void
+{
+    // LexCompare(xs, xs) — strict UNSAT, non-strict tautology.
+    // Use distinct unique vars for the two-element xs.
+    run_dup_lex_test<LexVariant::LessThan>(proofs, "lt_same", {{0, 2}, {0, 2}}, {0, 1}, {0, 1});
+    run_dup_lex_test<LexVariant::LessThanEqual>(proofs, "le_same", {{0, 2}, {0, 2}}, {0, 1}, {0, 1});
+    run_dup_lex_test<LexVariant::GreaterThan>(proofs, "gt_same", {{0, 2}, {0, 2}}, {0, 1}, {0, 1});
+    run_dup_lex_test<LexVariant::GreaterEqual>(proofs, "ge_same", {{0, 2}, {0, 2}}, {0, 1}, {0, 1});
+
+    // {x, y} <=lex {x, z} — first positions equal → y <=lex z.
+    run_dup_lex_test<LexVariant::LessThanEqual>(proofs, "le_share0",
+        {{0, 2}, {0, 2}, {0, 2}}, {0, 1}, {0, 2});
+
+    // {x, y} <lex {x, z} — first positions equal → y < z.
+    run_dup_lex_test<LexVariant::LessThan>(proofs, "lt_share0",
+        {{0, 2}, {0, 2}, {0, 2}}, {0, 1}, {0, 2});
+
+    // Within-left dup: {x, x} <=lex {a, b}.
+    run_dup_lex_test<LexVariant::LessThanEqual>(proofs, "le_dupleft",
+        {{1, 3}, {1, 3}, {1, 3}}, {0, 0}, {1, 2});
+
+    // Within-right dup: {a, b} <lex {x, x}.
+    run_dup_lex_test<LexVariant::LessThan>(proofs, "lt_dupright",
+        {{1, 3}, {1, 3}, {1, 3}}, {0, 1}, {2, 2});
+}
+
 auto run_all_tests(bool proofs) -> void
 {
     run_variant_tests<LexVariant::GreaterThan>(proofs);
@@ -483,6 +548,7 @@ auto main(int, char *[]) -> int
         if (proofs && ! can_run_veripb())
             continue;
         run_all_tests(proofs);
+        run_all_dup_tests(proofs);
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/n_value_test.cc
+++ b/gcs/constraints/n_value_test.cc
@@ -68,6 +68,43 @@ auto run_n_value_test(bool proofs, const ViewWrapConfig & view_cfg,
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: NValue with the same handle in several array
+// positions. Distinct-value count is unaffected by duplicates (set
+// semantics). Consistency isn't checked on dup runs; see
+// tmp/duplicate_var_audit.md.
+auto run_dup_n_value_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions, pair<int, int> result_range) -> void
+{
+    print(cerr, "nvalue dup domains={} positions={} result={}{}",
+        unique_domains, positions, result_range, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<int, vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](int r, const vector<int> & vals) -> bool {
+            set<int> distinct;
+            for (auto pos : positions)
+                distinct.insert(vals.at(pos));
+            return cmp_equal(r, distinct.size());
+        },
+        result_range, unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto result = p.create_integer_variable(Integer(result_range.first), Integer(result_range.second));
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : positions)
+        array.push_back(unique_vars.at(pos));
+    p.post(NValue{result, array});
+
+    auto proof_name = proofs ? make_optional("n_value_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{result, unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -112,11 +149,23 @@ auto main(int argc, char * argv[]) -> int
         generate_random_data(rand, data, random_constant(-5, 5), vector(n_values, random_bounds_or_constant(-5, 5, 2, 7)));
     }
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         for (auto & [r1, r2] : data)
             run_n_value_test(proofs, view_cfg, r1, r2);
+        if (run_dup) {
+            // {x, x} — distinct count is always 1.
+            run_dup_n_value_test(proofs, {{1, 4}}, {0, 0}, {0, 3});
+            // {x, x, y} — distinct count is 1 (when x==y) or 2.
+            run_dup_n_value_test(proofs, {{1, 3}, {1, 3}}, {0, 0, 1}, {0, 3});
+            // {x, y, x} — same as above with reordering.
+            run_dup_n_value_test(proofs, {{1, 3}, {1, 3}}, {0, 1, 0}, {0, 3});
+            // {x, x, y, y} — distinct count is 1 or 2.
+            run_dup_n_value_test(proofs, {{1, 3}, {1, 3}}, {0, 0, 1, 1}, {0, 3});
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/seq_precede_chain_test.cc
+++ b/gcs/constraints/seq_precede_chain_test.cc
@@ -160,6 +160,42 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
     run_test(proofs, view_cfg, {0, pair{1, 3}, -1, pair{1, 3}});
 }
 
+// Dup-variable test: SeqPrecedeChain with the same handle in several
+// array positions. A duplicated occurrence still must satisfy the chain;
+// taking the same value at two positions just means "earliest v" lands
+// at the first. See tmp/duplicate_var_audit.md.
+auto run_dup_seq_precede_chain_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions) -> void
+{
+    print(cerr, "seq_precede_chain dup domains={} positions={}{}",
+        unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & vals) -> bool {
+            vector<int> v;
+            for (auto pos : positions)
+                v.push_back(vals.at(pos));
+            return satisfies_seq_precede_chain(v);
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : positions)
+        array.push_back(unique_vars.at(pos));
+    p.post(SeqPrecedeChain{array});
+
+    auto proof_name = proofs ? make_optional("seq_precede_chain_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -198,6 +234,15 @@ auto main(int argc, char * argv[]) -> int
             for (int i = 0; i < n; ++i)
                 doms.emplace_back(generate_random_data_item(rand, random_bounds_or_constant(0, 3, 1, 3)));
             run_test(proofs, view_cfg, doms);
+        }
+
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            // {x, x} — single distinct value; both positions take it.
+            run_dup_seq_precede_chain_test(proofs, {{1, 3}}, {0, 0});
+            // {x, x, y} — duplicate then a new value.
+            run_dup_seq_precede_chain_test(proofs, {{1, 3}, {1, 3}}, {0, 0, 1});
+            // {x, y, x} — y between duplicates.
+            run_dup_seq_precede_chain_test(proofs, {{1, 3}, {1, 3}}, {0, 1, 0});
         }
     }
 

--- a/gcs/constraints/value_precede_test.cc
+++ b/gcs/constraints/value_precede_test.cc
@@ -148,6 +148,44 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
     run_value_precede_test(proofs, view_cfg, {1, 2, 3}, {1, pair{1, 3}, 2, pair{1, 3}});
 }
 
+// Dup-variable test: ValuePrecede with the same handle in several array
+// positions. Duplicate occurrences are independent positions; the chain
+// just gates which values can appear where. See tmp/duplicate_var_audit.md.
+auto run_dup_value_precede_test(bool proofs, const vector<int> & chain,
+    const vector<pair<int, int>> & unique_domains, const vector<int> & positions) -> void
+{
+    print(cerr, "value_precede dup chain={} domains={} positions={}{}",
+        chain, unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & vals) -> bool {
+            vector<int> v;
+            for (auto pos : positions)
+                v.push_back(vals.at(pos));
+            return satisfies_value_precede(chain, v);
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : positions)
+        array.push_back(unique_vars.at(pos));
+    vector<Integer> chain_i;
+    for (const auto & v : chain)
+        chain_i.push_back(Integer(v));
+    p.post(ValuePrecede{chain_i, array});
+
+    auto proof_name = proofs ? make_optional("value_precede_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -183,6 +221,15 @@ auto main(int argc, char * argv[]) -> int
             for (int i = 0; i < n_vars; ++i)
                 doms.emplace_back(generate_random_data_item(rand, random_bounds_or_constant(1, 2, 1, 2)));
             run_value_precede_test(proofs, view_cfg, chain, doms);
+        }
+
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            // {x, x, y} — x takes one value twice; y separate.
+            run_dup_value_precede_test(proofs, {1, 2}, {{1, 3}, {1, 3}}, {0, 0, 1});
+            // {x, y, x} — y between dups.
+            run_dup_value_precede_test(proofs, {1, 2}, {{1, 3}, {1, 3}}, {0, 1, 0});
+            // {x, x} — only one distinct value can appear.
+            run_dup_value_precede_test(proofs, {1, 2}, {{1, 3}}, {0, 0});
         }
     }
 


### PR DESCRIPTION
## Summary

- Tier 2 follow-up to #224 — adds dup-variable tests for the audit's OK sequence/array constraints.
- Stacked on `duplicate-var-tests-tier1` (#224) which is stacked on the pilot (#223). Merge order matters.
- Two findings surfaced (tracked in `tmp/duplicate_var_tier1_findings.md`):
  1. **AtMostOneSmartTable returns wrong solutions on dup** — `{x, y, x}` over `x, y ∈ [1,3]`, `val ∈ [1,3]` produces 20 solutions instead of 18; the extras put `x = val` at both positions 0 and 2. Same shape as the audit's SmartTable `BinaryEntry` self-loop concern. Dup tests for the SmartTable variant dropped from this PR; native `AtMostOne` dup tests landed.
  2. **LexSmartTable has no test file at all** — deferred. A follow-up should create both the non-dup tests and the dup tests, expecting to find a SmartTable-shaped bug too.

## What's in

| File | Constraint(s) | Notes |
|---|---|---|
| `all_equal_test.cc` | AllEqual | 5 dup shapes incl. disjoint-domain UNSAT |
| `among_test.cc` | Among | Array dup + self-ref (result also in array) |
| `at_most_one_test.cc` | AtMostOne (native only) | SmartTable variant dropped (see finding 1) |
| `count_test.cc` | Count | Array dup + result-in-array |
| `n_value_test.cc` | NValue | Distinct-value count under array dup |
| `increasing_test.cc` | Increasing, StrictlyIncreasing, Decreasing, StrictlyDecreasing | Non-strict OK, strict UNSAT |
| `lex_test.cc` | LexLessThan / LessEqual / GreaterThan / GreaterEqual | Cross-array sharing, same-xs, within-array dup |
| `seq_precede_chain_test.cc` | SeqPrecedeChain | Dup positions |
| `value_precede_test.cc` | ValuePrecede | Dup positions |

## Pattern

Every helper takes `unique_domains[]` + `positions[]` indexing into a smaller set of distinct variables. Reference predicate evaluates by mapping positions back through the unique vars. `solve_for_tests` (no consistency check) per the tier 1 stance.

## Test plan

- [x] Release build green for all 9 modified test binaries
- [x] Sanitize build green
- [x] `./run_test_and_verify.bash` green on each: VeriPB verifies every dup-with-proofs case
- [x] AtMostOne (native) dup verifies; SmartTable variant deliberately skipped

## Out of scope

- AtMostOneSmartTable fix (separate PR; tracked in findings)
- LexSmartTable test creation + dup tests (separate PR)
- Tier 3+ constraints (AllDifferent siblings, Element, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)