### PR TITLE
all_different_except_test: AllDifferentExceptZero dup case (tier 3)

### DIFF
--- a/gcs/constraints/all_different/all_different_except_test.cc
+++ b/gcs/constraints/all_different/all_different_except_test.cc
@@ -164,6 +164,36 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
 
         // Two duplicate runs in the same constraint.
         run_alldiffexcept_dup_test(proofs, {{0, 3}, {0, 3}}, {0, 0, 1, 1}, {0, 1});
+
+        // AllDifferentExceptZero is a thin wrapper over AllDifferentExcept
+        // with excluded={0}. Exercise it by name once on a dup posting to
+        // catch any regression in the wrapper forwarding.
+        {
+            print(cerr, "all_different_except_zero dup{}", proofs ? " with proofs:" : ":");
+            cerr << flush;
+            Problem p;
+            auto x = p.create_integer_variable(0_i, 3_i);
+            auto y = p.create_integer_variable(0_i, 3_i);
+            p.post(AllDifferentExceptZero{vector<IntegerVariableID>{x, x, y}});
+            set<tuple<int, int>> expected, actual;
+            // Posted array is {x, x, y}; check every pair.
+            for (int xv = 0; xv <= 3; ++xv) {
+                for (int yv = 0; yv <= 3; ++yv) {
+                    vector<int> v{xv, xv, yv};
+                    bool ok = true;
+                    for (size_t i = 0; i < v.size() && ok; ++i)
+                        for (size_t j = i + 1; j < v.size() && ok; ++j)
+                            if (v[i] == v[j] && v[i] != 0)
+                                ok = false;
+                    if (ok)
+                        expected.emplace(xv, yv);
+                }
+            }
+            println(cerr, " expecting {} solutions", expected.size());
+            auto proof_name = proofs ? make_optional<std::string>("all_different_except_zero_test_dup") : nullopt;
+            solve_for_tests(p, proof_name, actual, tuple{x, y});
+            check_results(proof_name, expected, actual);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Tier 3 of the dup-variable test rollout — turned out to be **almost a no-op**: the AllDifferent family already had comprehensive dup coverage.
- Stacked on `duplicate-var-tests-tier2` (#225), which is stacked on #224 and #223.

## What already existed (no work needed)

| Constraint | Existing dup test |
|---|---|
| `GACAllDifferent` | `all_different_test.cc:90-117, 168-176` |
| `VCAllDifferent` | same file |
| `AllDifferentExcept` | `all_different_except_test.cc:79-167` (very thorough) |
| `SymmetricAllDifferent` | `symmetric_all_different_test.cc:109-187` |

All pass with proofs on release + sanitize builds; verified before this PR.

## What this PR adds

One small test for `AllDifferentExceptZero` (~30 LOC). It's a thin wrapper over `AllDifferentExcept{vars, {0_i}}`. The existing dup tests cover the underlying behaviour via the parent class with `excluded={0}`, but the wrapper class itself was never exercised by name. This PR posts `AllDifferentExceptZero{x, x, y}` once on a dup posting to lock in the forwarding.

## Findings update

No new audit downgrades in tier 3. The AllDifferent family's "explicit defence" pattern (sort + adjacent_find in `prepare()`, route to `install_clique_duplicate_contradiction_initialiser`) holds up empirically — VeriPB verifies every duplicate-witness contradiction.

## Test plan

- [x] Release + sanitize builds green
- [x] `./run_test_and_verify.bash ./build/all_different_except_test` — new case verifies (4 solutions, expected = `{(0, y) : y ∈ [0,3]}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)