### PR TITLE
element / min_max / knapsack / regular: dup-variable tests (tier 4)

### DIFF
--- a/gcs/constraints/element_test.cc
+++ b/gcs/constraints/element_test.cc
@@ -171,6 +171,57 @@ auto run_element2d_constant_test(bool proofs, const string & mode, pair<int, int
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Element with the same handle in several array
+// positions, or the result var aliasing an array entry. Consistency
+// isn't checked on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_element_test(bool proofs, const string & label,
+    const vector<pair<int, int>> & unique_array_domains,
+    const vector<int> & array_positions,
+    pair<int, int> idx_range,
+    int result_position_in_unique) -> void
+{
+    // result_position_in_unique == -1 means: create result as a fresh
+    // variable. Otherwise the result variable IS unique_vars[result_position_in_unique].
+    print(cerr, "element dup {} unique_doms={} positions={} idx={} result_pos={}{}",
+        label, unique_array_domains, array_positions, idx_range, result_position_in_unique,
+        proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Expected: pick values for each unique var, then evaluate the array
+    // by indexing through array_positions and check Element semantics.
+    set<tuple<vector<int>, int, int>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & unique_vals, int idx_val, int result_val) -> bool {
+            if (idx_val < 0 || cmp_less(static_cast<int>(array_positions.size()), idx_val + 1))
+                return false;
+            int chosen = unique_vals.at(array_positions.at(idx_val));
+            if (result_val != chosen)
+                return false;
+            if (result_position_in_unique >= 0)
+                return unique_vals.at(result_position_in_unique) == result_val;
+            return true;
+        },
+        unique_array_domains, idx_range, pair{-10, 10});
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_array_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : array_positions)
+        array.push_back(unique_vars.at(pos));
+    auto idx = p.create_integer_variable(Integer(idx_range.first), Integer(idx_range.second), "idx");
+    IntegerVariableID var = (result_position_in_unique >= 0)
+        ? unique_vars.at(result_position_in_unique)
+        : p.create_integer_variable(Integer{-10}, Integer{10}, "var");
+    p.post(Element{var, idx, &array});
+
+    auto proof_name = proofs ? make_optional("element_test_dup_" + label) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars, idx, var});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     if (argc != 2)
@@ -245,6 +296,17 @@ auto main(int argc, char * argv[]) -> int
         if (mode == "var") {
             for (auto & [r1, r2, r3] : var_data)
                 run_element_test(proofs, mode, r1, r2, r3);
+
+            // Dup-variable cases.
+            // [x, y, x] — same handle at non-adjacent positions.
+            run_dup_element_test(proofs, "xyx", {{1, 3}, {1, 3}}, {0, 1, 0}, {0, 2}, -1);
+            // [x, x] — same handle at adjacent positions.
+            run_dup_element_test(proofs, "xx", {{1, 3}}, {0, 0}, {0, 1}, -1);
+            // [x, y, x] but result is x — forces idx-selected value = x.
+            run_dup_element_test(proofs, "xyx_resx", {{1, 3}, {1, 3}}, {0, 1, 0}, {0, 2}, 0);
+            // [x, y] with result = x — forces array[idx] = x, i.e. either
+            // idx=0 (trivial) or idx=1 and y = x.
+            run_dup_element_test(proofs, "xy_resx", {{1, 3}, {1, 3}}, {0, 1}, {0, 1}, 0);
         }
         else if (mode == "const") {
             for (auto & [r1, r2, r3] : const_data)

--- a/gcs/constraints/knapsack_test.cc
+++ b/gcs/constraints/knapsack_test.cc
@@ -89,6 +89,65 @@ auto run_knapsack_test(bool proofs, pair<int, int> valrange, const vector<vector
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Knapsack with a duplicated handle in `vars` (or in
+// `totals`). Two vars positions sharing a handle should be equivalent
+// to one position with summed coefficients; the PB encoding sums by
+// coefficient in normal form. Consistency isn't checked on dup runs;
+// see tmp/duplicate_var_audit.md.
+auto run_dup_knapsack_test(bool proofs, const string & label,
+    pair<int, int> valrange,
+    const vector<pair<int, int>> & unique_var_domains,
+    const vector<int> & positions,
+    const vector<vector<int>> & coeffs,
+    const vector<pair<int, int>> & totals_bounds) -> void
+{
+    print(cerr, "knapsack dup {} val={} unique_doms={} positions={} coeffs={} totals={}{}",
+        label, valrange, unique_var_domains, positions, coeffs, totals_bounds,
+        proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>, vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & unique_vals, const vector<int> & profits) -> bool {
+            vector<int> taken;
+            for (auto pos : positions)
+                taken.push_back(unique_vals.at(pos));
+            vector<int> sums(coeffs.size(), 0);
+            for (unsigned i = 0; i < coeffs.size(); ++i) {
+                for (unsigned k = 0; k < taken.size(); ++k)
+                    sums[i] += coeffs[i].at(k) * taken[k];
+                if (sums[i] < totals_bounds[i].first || sums[i] > totals_bounds[i].second)
+                    return false;
+            }
+            return sums == profits;
+        },
+        unique_var_domains, totals_bounds);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_var_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> vs;
+    for (auto pos : positions)
+        vs.push_back(unique_vars.at(pos));
+    vector<IntegerVariableID> bs;
+    for (const auto & b : totals_bounds)
+        bs.push_back(p.create_integer_variable(Integer(b.first), Integer(b.second)));
+    vector<vector<Integer>> coeffs_i;
+    for (const auto & row : coeffs) {
+        coeffs_i.emplace_back();
+        for (auto c : row)
+            coeffs_i.back().push_back(Integer(c));
+    }
+    p.post(Knapsack{coeffs_i, vs, bs});
+
+    auto proof_name = proofs ? make_optional("knapsack_test_dup_" + label) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars, bs});
+    check_results(proof_name, expected, actual);
+    (void) valrange;
+}
+
 auto main(int, char *[]) -> int
 {
     vector<tuple<pair<int, int>, vector<vector<int>>, vector<pair<int, int>>>> data = {
@@ -128,6 +187,15 @@ auto main(int, char *[]) -> int
             continue;
         for (auto & [valrange, coeffs, bounds] : data)
             run_knapsack_test(proofs, valrange, coeffs, bounds);
+
+        // {x, x} — single var doubled; coefficients sum (1+2)*x = 3x and
+        // (2+3)*x = 5x; totals must equal those.
+        run_dup_knapsack_test(proofs, "xx", {0, 3}, {{0, 3}}, {0, 0},
+            {{1, 2}, {2, 3}}, {{0, 9}, {0, 15}});
+
+        // {x, y, x} — x's coefficient is summed at positions 0 and 2.
+        run_dup_knapsack_test(proofs, "xyx", {0, 2}, {{0, 2}, {0, 2}}, {0, 1, 0},
+            {{1, 2, 1}, {3, 1, 2}}, {{0, 8}, {0, 12}});
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/min_max_test.cc
+++ b/gcs/constraints/min_max_test.cc
@@ -81,6 +81,57 @@ auto run_min_max_test(bool proofs, const ViewWrapConfig & view_cfg, bool min,
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Min/Max with the same handle in several array
+// positions, or the result var aliasing an array entry. Consistency
+// isn't checked on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_min_max_test(bool proofs, bool min, const string & label,
+    const vector<pair<int, int>> & unique_domains,
+    const vector<int> & array_positions,
+    int result_position_in_unique,
+    pair<int, int> result_range) -> void
+{
+    print(cerr, "{} dup {} unique_doms={} positions={} result_pos={}{}",
+        min ? "min" : "max", label, unique_domains, array_positions, result_position_in_unique,
+        proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>, int>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & unique_vals, int r) -> bool {
+            vector<int> array_vals;
+            for (auto pos : array_positions)
+                array_vals.push_back(unique_vals.at(pos));
+            if (array_vals.empty()) return false;
+            int expected_r = min ? *min_element(array_vals.begin(), array_vals.end())
+                                 : *max_element(array_vals.begin(), array_vals.end());
+            if (r != expected_r) return false;
+            if (result_position_in_unique >= 0)
+                return unique_vals.at(result_position_in_unique) == r;
+            return true;
+        },
+        unique_domains, result_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> array;
+    for (auto pos : array_positions)
+        array.push_back(unique_vars.at(pos));
+    IntegerVariableID result = (result_position_in_unique >= 0)
+        ? unique_vars.at(result_position_in_unique)
+        : p.create_integer_variable(Integer(result_range.first), Integer(result_range.second));
+    if (min)
+        p.post(ArrayMin{array, result});
+    else
+        p.post(ArrayMax{array, result});
+
+    auto proof_name = proofs ? make_optional((min ? string{"min_max_test_min_dup_"} : string{"min_max_test_max_dup_"}) + label) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars, result});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -127,12 +178,26 @@ auto main(int argc, char * argv[]) -> int
         generate_random_data(rand, data, random_constant(-5, 5), vector(n_values, random_bounds_or_constant(-5, 5, 3, 8)));
     }
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         for (auto & [r1, r2] : data) {
             run_min_max_test(proofs, view_cfg, false, r1, r2);
             run_min_max_test(proofs, view_cfg, true, r1, r2);
+        }
+        if (run_dup) {
+            for (bool m : {true, false}) {
+                // {x, x, y} — duplicates in array.
+                run_dup_min_max_test(proofs, m, "xxy", {{1, 5}, {1, 5}}, {0, 0, 1}, -1, {0, 6});
+                // {x, y, x} — non-adjacent dup.
+                run_dup_min_max_test(proofs, m, "xyx", {{1, 5}, {1, 5}}, {0, 1, 0}, -1, {0, 6});
+                // {x, y} with result = x — Min: x <= y; Max: x >= y.
+                run_dup_min_max_test(proofs, m, "xy_resx", {{1, 5}, {1, 5}}, {0, 1}, 0, {0, 6});
+                // {x, y, z} with result = y — forces y == min/max(x,y,z).
+                run_dup_min_max_test(proofs, m, "xyz_resy", {{1, 4}, {1, 4}, {1, 4}}, {0, 1, 2}, 1, {0, 5});
+            }
         }
     }
 

--- a/gcs/constraints/regular_test.cc
+++ b/gcs/constraints/regular_test.cc
@@ -78,6 +78,57 @@ auto run_regular_test(bool proofs, const string & desc,
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Regular with the same handle at several positions.
+// Each position is processed independently by the DFA; aliasing forces
+// those positions to take the same letter. Consistency isn't checked
+// on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_regular_test(bool proofs, const string & label,
+    const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions,
+    long num_states,
+    vector<unordered_map<Integer, long>> transitions,
+    vector<long> final_states) -> void
+{
+    print(cerr, "regular dup {} unique_doms={} positions={}{}",
+        label, unique_domains, positions, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto dfa_accepts = [&](const vector<int> & seq) -> bool {
+        long state = 0;
+        for (int val : seq) {
+            auto it = transitions[state].find(Integer(val));
+            if (it == transitions[state].end() || it->second == -1L)
+                return false;
+            state = it->second;
+        }
+        return find(final_states, state) != final_states.end();
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & unique_vals) -> bool {
+            vector<int> seq;
+            for (auto pos : positions)
+                seq.push_back(unique_vals.at(pos));
+            return dfa_accepts(seq);
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & [lo, hi] : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
+    vector<IntegerVariableID> vars;
+    for (auto pos : positions)
+        vars.push_back(unique_vars.at(pos));
+    p.post(Regular{vars, num_states, transitions, final_states});
+
+    auto proof_name = proofs ? make_optional("regular_test_dup_" + label) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto run_all_tests(bool proofs) -> void
 {
     // DFA: even number of 0s, binary alphabet {0,1}
@@ -140,6 +191,35 @@ auto run_all_tests(bool proofs) -> void
         2,
         {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},
         {1});
+
+    // Dup-variable cases: "even zeros" DFA with positions[0] reused.
+    // {x, x, y} — two equal letters then y; "even zeros" wants total zeros
+    // to be even, so two-of-the-same plus y leaves parity determined by y
+    // when x=1, or determined by !y when x=0.
+    run_dup_regular_test(proofs, "xxy_even_zeros",
+        {{0, 1}, {0, 1}}, {0, 0, 1},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0});
+    // {x, y, x} — non-adjacent dup.
+    run_dup_regular_test(proofs, "xyx_even_zeros",
+        {{0, 1}, {0, 1}}, {0, 1, 0},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0});
+    // {x, x} with "all same" DFA: same handle at two positions ⇒ trivially
+    // all-same; this just checks the DFA accepts.
+    run_dup_regular_test(proofs, "xx_all_same",
+        {{0, 1}}, {0, 0},
+        4,
+        {{{0_i, 1}, {1_i, 2}}, {{0_i, 1}}, {{1_i, 2}}, {}},
+        {1, 2});
+    // {x, x, y, y} with "all same": requires x == y so the sequence is constant.
+    run_dup_regular_test(proofs, "xxyy_all_same",
+        {{0, 1}, {0, 1}}, {0, 0, 1, 1},
+        4,
+        {{{0_i, 1}, {1_i, 2}}, {{0_i, 1}}, {{1_i, 2}}, {}},
+        {1, 2});
 }
 
 auto main(int, char *[]) -> int


### PR DESCRIPTION
## Summary

- Tier 4 of the dup-variable test rollout. Element-style and graph constraints.
- Stacked on `duplicate-var-tests-tier3` (#226) → #225 → #224 → #223.
- **No new audit downgrades.** The audit was right about all four constraints in this tier.

## What's in

| File | Cases |
|---|---|
| `element_test.cc` | `Element(idx, [x,y,x], r)`, `Element(idx, [x,x], r)`, `Element` with result aliasing an array entry (`Element(idx, [x,y,x], x)`, `Element(idx, [x,y], x)`) |
| `min_max_test.cc` | `Min/Max({x,x,y}, m)`, `Min/Max({x,y,x}, m)`, result aliasing input (`Min({x,y}, x)` forces `x <= y`), `Min({x,y,z}, y)` (forces `y == min(x,y,z)`) |
| `knapsack_test.cc` | `Knapsack` with `{x, x}` — coefficients sum in PB normal form; `{x, y, x}` — x's coefficient summed at two positions |
| `regular_test.cc` | `Regular({x,x,y}, ...)`, `Regular({x,y,x}, ...)` over the "even zeros" and "all same" DFAs |

Pattern: same `unique_domains[] + positions[]` shape used in tiers 2/3.

## What's out

- **Circuit, Inverse** — Bucket A "throw" verdicts in the audit. Current behaviour is silent acceptance of duplicate slots; the throw fix is a separate change, and the tests for it land alongside that fix.
- Per the existing comment in the audit's risk section: Min/Max has a documented completeness gap on alias (`min_max.cc:151-160` — `support_1`/`support_2` doesn't dedup on variable identity). Soundness preserved, just weaker pruning. Tests pass because solution-set correctness is unaffected.

## Test plan

- [x] Release + sanitize builds green for all 4 modified test binaries
- [x] `./build/element_test var` — 4 dup invocations × 2 proof modes, all VeriPB-verified
- [x] `./build/min_max_test` — 8 dup invocations (4 patterns × min/max) × 2 proof modes
- [x] `./run_test_and_verify.bash ./build/knapsack_test` — 2 dup invocations × 2 proof modes
- [x] `./run_test_and_verify.bash ./build/regular_test` — 4 dup invocations × 2 proof modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)