### PR TITLE
linear / table / cumulative / disjunctive / logical: dup tests (tier 5)

### DIFF
--- a/gcs/constraints/cumulative_test.cc
+++ b/gcs/constraints/cumulative_test.cc
@@ -101,6 +101,72 @@ namespace
     }
 }
 
+namespace
+{
+    // Dup-variable test: Cumulative with the same start handle for two
+    // tasks. The two tasks share a start time, so their heights add at
+    // every time point inside their (possibly different) durations.
+    // Consistency isn't checked on dup runs; see tmp/duplicate_var_audit.md.
+    auto run_dup_cumulative_test(bool proofs,
+        const vector<pair<int, int>> & unique_start_ranges,
+        const vector<int> & positions,
+        const vector<int> & lengths, const vector<int> & heights, int capacity) -> void
+    {
+        print(cerr, "cumulative dup unique_starts={} positions={} lens={} hts={} c={}{}",
+            unique_start_ranges, positions, lengths, heights, capacity,
+            proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        auto n = positions.size();
+
+        auto is_satisfying = [&](const vector<int> & unique_starts) {
+            int t_lo = INT_MAX, t_hi = INT_MIN;
+            for (size_t i = 0; i < n; ++i) {
+                if (lengths[i] == 0 || heights[i] == 0)
+                    continue;
+                int s = unique_starts.at(positions.at(i));
+                t_lo = min(t_lo, s);
+                t_hi = max(t_hi, s + lengths[i] - 1);
+            }
+            for (int t = t_lo; t <= t_hi; ++t) {
+                int load = 0;
+                for (size_t i = 0; i < n; ++i) {
+                    int s = unique_starts.at(positions.at(i));
+                    if (s <= t && t < s + lengths[i])
+                        load += heights[i];
+                }
+                if (load > capacity)
+                    return false;
+            }
+            return true;
+        };
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, is_satisfying, unique_start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        vector<IntegerVariableID> unique_starts;
+        for (auto & [lo, hi] : unique_start_ranges)
+            unique_starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        vector<IntegerVariableID> starts;
+        for (auto pos : positions)
+            starts.push_back(unique_starts.at(pos));
+
+        vector<Integer> lengths_i, heights_i;
+        for (auto l : lengths)
+            lengths_i.push_back(Integer{l});
+        for (auto h : heights)
+            heights_i.push_back(Integer{h});
+
+        p.post(Cumulative{starts, lengths_i, heights_i, Integer{capacity}});
+
+        auto proof_name = proofs ? make_optional("cumulative_test_dup") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{unique_starts});
+        check_results(proof_name, expected, actual);
+    }
+}
+
 auto main(int, char *[]) -> int
 {
     // Each test: { start_ranges, lengths, heights, capacity }
@@ -172,6 +238,17 @@ auto main(int, char *[]) -> int
             continue;
         for (auto & [sr, lens, hts, cap] : data)
             run_cumulative_test(proofs, sr, lens, hts, cap);
+
+        // Two tasks sharing a start variable: their heights add at every
+        // time point in their (intersecting) durations.
+        // Capacity 2, two unit-height tasks: must fit (sum = 2). OK.
+        run_dup_cumulative_test(proofs, {{0, 3}}, {0, 0}, {2, 2}, {1, 1}, 2);
+        // Capacity 1, two unit-height tasks sharing a start: load=2 > cap=1
+        // → UNSAT.
+        run_dup_cumulative_test(proofs, {{0, 3}}, {0, 0}, {2, 2}, {1, 1}, 1);
+        // Three tasks, two of which share a start. Third has its own start.
+        run_dup_cumulative_test(proofs, {{0, 3}, {0, 3}}, {0, 0, 1},
+            {2, 2, 1}, {1, 1, 1}, 2);
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive_test.cc
@@ -50,6 +50,59 @@ using namespace gcs::test_innards;
 
 namespace
 {
+    // Dup-variable test: Disjunctive with the same start handle for two
+    // tasks. Two positive-length tasks sharing a start ⇒ UNSAT (they
+    // overlap by construction). Consistency isn't checked on dup runs;
+    // see tmp/duplicate_var_audit.md.
+    auto run_dup_disjunctive_test(bool proofs, const string & mode, bool strict,
+        const vector<pair<int, int>> & unique_start_ranges,
+        const vector<int> & positions, const vector<int> & lengths) -> void
+    {
+        print(cerr, "disjunctive{} dup unique_starts={} positions={} lens={}{}",
+            strict ? "_strict" : "", unique_start_ranges, positions, lengths,
+            proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        auto n = positions.size();
+
+        auto is_satisfying = [&](const vector<int> & unique_starts) {
+            for (size_t i = 0; i < n; ++i)
+                for (size_t j = i + 1; j < n; ++j) {
+                    if (! strict && (lengths[i] == 0 || lengths[j] == 0))
+                        continue;
+                    int si = unique_starts.at(positions.at(i));
+                    int sj = unique_starts.at(positions.at(j));
+                    bool i_before_j = si + lengths[i] <= sj;
+                    bool j_before_i = sj + lengths[j] <= si;
+                    if (! i_before_j && ! j_before_i)
+                        return false;
+                }
+            return true;
+        };
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, is_satisfying, unique_start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        vector<IntegerVariableID> unique_starts;
+        for (auto & [lo, hi] : unique_start_ranges)
+            unique_starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+        vector<IntegerVariableID> starts;
+        for (auto pos : positions)
+            starts.push_back(unique_starts.at(pos));
+
+        vector<Integer> lengths_i;
+        for (auto l : lengths)
+            lengths_i.push_back(Integer{l});
+
+        p.post(Disjunctive{starts, lengths_i, strict});
+
+        auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_dup") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{unique_starts});
+        check_results(proof_name, expected, actual);
+    }
+
     auto run_disjunctive_test(bool proofs, const string & mode, bool strict,
         const vector<pair<int, int>> & start_ranges, const vector<int> & lengths) -> void
     {
@@ -166,6 +219,15 @@ auto main(int argc, char * argv[]) -> int
             continue;
         for (auto & [sr, lens] : data)
             run_disjunctive_test(proofs, mode, strict, sr, lens);
+
+        // Two tasks sharing a start var: positive lengths ⇒ UNSAT,
+        // zero lengths ⇒ depends on strict.
+        run_dup_disjunctive_test(proofs, mode, strict, {{0, 3}}, {0, 0}, {2, 2});
+        // {x, x, y} — first two share, third independent.
+        run_dup_disjunctive_test(proofs, mode, strict, {{0, 3}, {0, 3}}, {0, 0, 1},
+            {1, 1, 2});
+        // Zero-length dup pair — non-strict OK, strict edge case.
+        run_dup_disjunctive_test(proofs, mode, strict, {{0, 2}}, {0, 0}, {0, 0});
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -182,6 +182,45 @@ auto run_linear_reif_test(bool full_reif, bool proofs, const string & mode, cons
     }
 }
 
+// Dup-variable test: Linear with the same handle in two terms. The
+// audit predicts the propagator coalesces via tidy_up_linear and the
+// PB encoding sums coefficients in normal form. Consistency isn't
+// checked on dup runs; see tmp/duplicate_var_audit.md.
+template <typename Constraint_>
+auto run_dup_linear_test(bool proofs, const string & mode,
+    pair<int, int> a_range, pair<int, int> b_range,
+    const vector<int> & coeffs_a_then_b, int rhs,
+    const std::function<auto(int, int)->bool> & compare) -> void
+{
+    // coeffs_a_then_b has 3 entries; positions 0 and 1 use variable a,
+    // position 2 uses variable b. Effective sum: (c0+c1)*a + c2*b.
+    print(cerr, "linear dup {} a={} b={} coeffs={} rhs={}{}",
+        mode, a_range, b_range, coeffs_a_then_b, rhs, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto is_satisfying = [&](int av, int bv) {
+        int sum = coeffs_a_then_b.at(0) * av + coeffs_a_then_b.at(1) * av + coeffs_a_then_b.at(2) * bv;
+        return compare(sum, rhs);
+    };
+
+    set<tuple<int, int>> expected, actual;
+    build_expected(expected, is_satisfying, a_range, b_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    auto a = p.create_integer_variable(Integer(a_range.first), Integer(a_range.second));
+    auto b = p.create_integer_variable(Integer(b_range.first), Integer(b_range.second));
+    WeightedSum c;
+    c += Integer{coeffs_a_then_b.at(0)} * a;
+    c += Integer{coeffs_a_then_b.at(1)} * a;
+    c += Integer{coeffs_a_then_b.at(2)} * b;
+    p.post(Constraint_{c, Integer{rhs}});
+
+    auto proof_name = proofs ? make_optional("linear_equality_test_" + mode + "_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{a, b});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     string mode;
@@ -330,6 +369,29 @@ auto main(int argc, char * argv[]) -> int
             }
             else
                 throw UnimplementedException{};
+        }
+
+        // Dup-variable cases. Cover the non-reified Linear variants;
+        // reified forms share the same coalescing infrastructure.
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            // 2*a + 3*a + 1*b coalesces to 5*a + 1*b.
+            if (mode == "eq")
+                run_dup_linear_test<LinearEquality>(proofs, mode, {0, 5}, {-5, 5},
+                    {2, 3, 1}, 10, [](int a, int b) { return a == b; });
+            else if (mode == "ne")
+                run_dup_linear_test<LinearNotEquals>(proofs, mode, {0, 5}, {-5, 5},
+                    {2, 3, 1}, 10, [](int a, int b) { return a != b; });
+            else if (mode == "le")
+                run_dup_linear_test<LinearLessThanEqual>(proofs, mode, {0, 5}, {-5, 5},
+                    {2, 3, 1}, 10, [](int a, int b) { return a <= b; });
+            else if (mode == "ge")
+                run_dup_linear_test<LinearGreaterThanEqual>(proofs, mode, {0, 5}, {-5, 5},
+                    {2, 3, 1}, 10, [](int a, int b) { return a >= b; });
+            // 1*a + (-1)*a + 2*b coalesces to 0*a + 2*b = 2*b — exercises
+            // the zero-coefficient-after-coalescing path.
+            if (mode == "eq")
+                run_dup_linear_test<LinearEquality>(proofs, mode, {0, 5}, {0, 5},
+                    {1, -1, 2}, 4, [](int a, int b) { return a == b; });
         }
     }
 

--- a/gcs/constraints/logical_test.cc
+++ b/gcs/constraints/logical_test.cc
@@ -66,6 +66,50 @@ auto run_logical_test(const string & which, bool proofs, const vector<pair<int, 
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: And/Or with the same handle in several lit
+// positions, but full_reif is a distinct variable (skipping the
+// full_reif-aliases-a-lit Bucket B case which is currently broken
+// — see tmp/duplicate_var_audit.md). Duplicate lits are redundant.
+template <typename Logical_>
+auto run_dup_logical_test(const string & which, bool proofs,
+    const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions, pair<int, int> full_reif,
+    const function<auto(const vector<int> &, int)->bool> & is_satisfying) -> void
+{
+    print(cerr, "logical dup {} unique_doms={} positions={} reif={}{}",
+        which, unique_domains, positions, full_reif, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<pair<vector<int>, int>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & unique_vals, int r) -> bool {
+            vector<int> lits;
+            for (auto pos : positions)
+                lits.push_back(unique_vals.at(pos));
+            return is_satisfying(lits, r);
+        },
+        unique_domains, full_reif);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & [l, u] : unique_domains)
+        unique_vars.emplace_back(p.create_integer_variable(Integer(l), Integer(u)));
+    vector<IntegerVariableID> vs;
+    for (auto pos : positions)
+        vs.push_back(unique_vars.at(pos));
+    auto r = p.create_integer_variable(Integer(full_reif.first), Integer(full_reif.second));
+
+    if (-1 == full_reif.first && -1 == full_reif.second)
+        p.post(Logical_{vs});
+    else
+        p.post(Logical_{vs, r});
+
+    auto proof_name = proofs ? make_optional("logical_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars, r});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int, char *[]) -> int
 {
     vector<tuple<vector<pair<int, int>>, pair<int, int>>> data = {
@@ -111,6 +155,30 @@ auto main(int, char *[]) -> int
                     return result == (r != 0);
             });
         }
+
+        // Dup-variable cases: full_reif is a separate variable (the
+        // full_reif-aliases-a-lit case is Bucket B "fix" — skip).
+        auto and_sat = [](const vector<int> & v, int r) {
+            bool result = true;
+            for (auto & i : v)
+                result = result && (i != 0);
+            return result == (r != 0);
+        };
+        auto or_sat = [](const vector<int> & v, int r) {
+            bool result = false;
+            for (auto & i : v)
+                result = result || (i != 0);
+            return result == (r != 0);
+        };
+        // {x, x, y} with full_reif distinct.
+        run_dup_logical_test<And>("and", proofs, {{0, 1}, {0, 1}}, {0, 0, 1}, {0, 1}, and_sat);
+        run_dup_logical_test<Or>("or", proofs, {{0, 1}, {0, 1}}, {0, 0, 1}, {0, 1}, or_sat);
+        // {x, y, x} — non-adjacent dup.
+        run_dup_logical_test<And>("and", proofs, {{0, 1}, {0, 1}}, {0, 1, 0}, {0, 1}, and_sat);
+        run_dup_logical_test<Or>("or", proofs, {{0, 1}, {0, 1}}, {0, 1, 0}, {0, 1}, or_sat);
+        // {x, x} alone — And/Or both reduce to x.
+        run_dup_logical_test<And>("and", proofs, {{0, 1}}, {0, 0}, {0, 1}, and_sat);
+        run_dup_logical_test<Or>("or", proofs, {{0, 1}}, {0, 0}, {0, 1}, or_sat);
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/table/negative_table_test.cc
+++ b/gcs/constraints/table/negative_table_test.cc
@@ -125,6 +125,48 @@ auto run_negative_wildcard_table_test(bool proofs, const ViewWrapConfig & view_c
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: NegativeTable with the same handle in several
+// positions. Forbidden tuples whose dup positions disagree are
+// vacuously satisfied (the underlying assignment is impossible).
+// Consistency isn't checked on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_negative_table_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions, SimpleTuples forbidden) -> void
+{
+    print(cerr, "negative table dup unique_doms={} positions={} {} tuples{}",
+        unique_domains, positions, forbidden.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & unique_vals) -> bool {
+            for (const auto & t : forbidden) {
+                bool match = true;
+                for (size_t i = 0; i < positions.size(); ++i)
+                    if (t.at(i).raw_value != unique_vals.at(positions.at(i))) {
+                        match = false;
+                        break;
+                    }
+                if (match) return false;
+            }
+            return true;
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> vars;
+    for (auto pos : positions)
+        vars.push_back(unique_vars.at(pos));
+    p.post(NegativeTable{vars, forbidden});
+
+    auto proof_name = proofs ? make_optional("negative_table_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
 {
     // Two-variable cases.
@@ -180,10 +222,21 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         run_all_tests(proofs, view_cfg);
+        if (run_dup) {
+            // {x, y, x} — a forbidden tuple (1, 2, 1) forbids x=1,y=2; tuple
+            // (1, 2, 3) is vacuously satisfied (x can't be both 1 and 3).
+            run_dup_negative_table_test(proofs, {{1, 3}, {1, 3}}, {0, 1, 0},
+                {{1_i, 2_i, 1_i}, {1_i, 2_i, 3_i}, {2_i, 3_i, 2_i}});
+            // {x, x} — only diagonal tuples actually forbid anything.
+            run_dup_negative_table_test(proofs, {{1, 3}}, {0, 0},
+                {{1_i, 1_i}, {2_i, 3_i}});
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/table_test.cc
+++ b/gcs/constraints/table_test.cc
@@ -128,6 +128,47 @@ auto run_wildcard_table_test(bool proofs, const ViewWrapConfig & view_cfg, pair<
     check_results(proof_name, expected, actual);
 }
 
+// Dup-variable test: Table with the same handle in several positions.
+// Tuples where the duplicated positions disagree are infeasible.
+// Consistency isn't checked on dup runs; see tmp/duplicate_var_audit.md.
+auto run_dup_table_test(bool proofs, const vector<pair<int, int>> & unique_domains,
+    const vector<int> & positions, SimpleTuples allowed) -> void
+{
+    print(cerr, "table dup unique_doms={} positions={} {} tuples{}",
+        unique_domains, positions, allowed.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(
+        expected, [&](const vector<int> & unique_vals) -> bool {
+            for (const auto & t : allowed) {
+                bool match = true;
+                for (size_t i = 0; i < positions.size(); ++i)
+                    if (t.at(i).raw_value != unique_vals.at(positions.at(i))) {
+                        match = false;
+                        break;
+                    }
+                if (match) return true;
+            }
+            return false;
+        },
+        unique_domains);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> unique_vars;
+    for (const auto & d : unique_domains)
+        unique_vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
+    vector<IntegerVariableID> vars;
+    for (auto pos : positions)
+        vars.push_back(unique_vars.at(pos));
+    p.post(Table{vars, allowed});
+
+    auto proof_name = proofs ? make_optional("table_test_dup") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{unique_vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
 {
     // Table, 2 variables
@@ -170,10 +211,21 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
+    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         run_all_tests(proofs, view_cfg);
+        if (run_dup) {
+            // {x, y, x} with mixed-match tuples: (1, 2, 1) matches (cols 0
+            // and 2 share x=1), (1, 2, 2) does not (cols 0 and 2 disagree).
+            run_dup_table_test(proofs, {{1, 3}, {1, 3}}, {0, 1, 0},
+                {{1_i, 2_i, 1_i}, {1_i, 2_i, 2_i}, {2_i, 3_i, 2_i}, {3_i, 3_i, 3_i}});
+            // {x, x} — only diagonal tuples can match.
+            run_dup_table_test(proofs, {{1, 3}}, {0, 0},
+                {{1_i, 1_i}, {2_i, 3_i}, {3_i, 3_i}});
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary

- Tier 5 of the dup-variable test rollout — final tier covering linear, extensional, scheduling, and logical constraints.
- Stacked on `duplicate-var-tests-tier4` (#227) → #226 → #225 → #224 → #223.
- **No new audit downgrades.** All six constraints behave as the audit predicted.

## What's in

| File | Cases |
|---|---|
| `linear/linear_test.cc` | `Linear` with two terms on the same variable: `2*x + 3*x + 1*y == 10` coalesces to `5*x + y = 10`; eq/ne/le/ge modes; eq also tests `1*x + (-1)*x + 2*y == 4` (zero-coefficient-after-coalescing) |
| `table_test.cc` | `Table({x,y,x}, ...)`, `Table({x,x}, ...)` with diagonal-only tuples |
| `table/negative_table_test.cc` | `NegativeTable({x,y,x}, ...)` — disagree-tuples vacuously satisfied |
| `cumulative_test.cc` | Two tasks sharing a start variable; heights add |
| `disjunctive_test.cc` | Two tasks sharing a start — positive-length ⇒ UNSAT; covered for both strict and nonstrict modes |
| `logical_test.cc` | `And/Or` with duplicated lits, full_reif **distinct** (skips Bucket B full_reif-aliases-a-lit) |

## What's deliberately out

- **`And/Or` with `full_reif` aliasing a lit** — Bucket B "fix" per audit. Reverse direction of the OPB encoding becomes a tautology and the proof loses one half. Tests land with the fix.
- Reified Linear variants (`*If`, `*Iff`) — share the same `tidy_up_linear` coalescing as the non-reified forms; if the non-reified versions verify, the reified ones inherit. Could be added as a follow-up if higher coverage is wanted.

## Test plan

- [x] Release + sanitize builds green for all 6 modified test binaries
- [x] All 4 linear modes (eq, ne, le, ge) verify dup cases
- [x] Both disjunctive modes (strict, nonstrict) verify dup cases
- [x] `cumulative_test`, `table_test`, `negative_table_test`, `logical_test` all green with proofs

## Tier-rollout summary (across PRs #223–#228)

The findings doc (`tmp/duplicate_var_tier1_findings.md` — local, not in the tree) now lists:

1. **MultBC** — propagator sound on dup, all 4 alias patterns; bit-product channelling encoding fails VeriPB on every pattern. Audit Bucket C → Bucket B.
2. **AtMostOneSmartTable** — wrong solutions returned for `{x, y, x}` (non-adjacent dup). Same shape as the audit's already-flagged SmartTable BinaryEntry self-loop. Audit Bucket C → Bucket B.
3. **LexSmartTable** — no test file exists at all; verdict unverifiable; deferred to a follow-up that creates the test file (and likely finds a SmartTable bug).

Everything else in the audit's OK column verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)