### PR TITLE
Bucket A duplicate-variable throws: NotEquals / LessThan / GreaterThan / Circuit / Inverse

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -331,6 +331,10 @@ if(GCS_BUILD_TESTS)
     add_test(NAME circuit_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_test>)
     add_view_tests(circuit_constraint circuit_test 5)
 
+    add_executable(circuit_dup_test constraints/circuit/circuit_dup_test.cc)
+    target_link_libraries(circuit_dup_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME circuit_dup COMMAND $<TARGET_FILE:circuit_dup_test>)
+
     add_executable(reification_test innards/proofs/reification_test.cc)
     target_link_libraries(reification_test PRIVATE glasgow_constraint_solver)
     add_test(NAME reification_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:reification_test>)

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/circuit/circuit_base.hh>
+#include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
@@ -51,6 +52,15 @@ CircuitBase::CircuitBase(vector<IntegerVariableID> v, const bool g) :
     _gac_all_different(g),
     _succ(std::move(v))
 {
+    // Two slots pinned to the same constant are a valid (if trivially
+    // infeasible) model; only reject true variable aliasing.
+    for (size_t i = 0; i < _succ.size(); ++i) {
+        if (is_constant_variable(_succ[i]))
+            continue;
+        for (size_t j = i + 1; j < _succ.size(); ++j)
+            if (_succ[i] == _succ[j])
+                throw InvalidProblemDefinitionException{"Circuit: successor array contains the same variable handle twice"};
+    }
 }
 
 auto gcs::innards::circuit::output_cycle_to_proof(const vector<IntegerVariableID> & succ,

--- a/gcs/constraints/circuit/circuit_dup_test.cc
+++ b/gcs/constraints/circuit/circuit_dup_test.cc
@@ -1,0 +1,39 @@
+#include <gcs/constraints/circuit.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+
+#include <cstdlib>
+#include <iostream>
+
+using namespace gcs;
+
+using std::cerr;
+
+namespace
+{
+    template <typename Constraint_>
+    auto expect_throw_on_dup(const char * which) -> bool
+    {
+        // Circuit's successor array must be all-different; aliasing two
+        // slots to the same variable handle is trivially infeasible. We
+        // reject at construction so users don't wait for search to UNSAT.
+        Problem p;
+        auto x = p.create_integer_variable_vector(4, 0_i, 3_i);
+        try {
+            p.post(Constraint_{{x[0], x[1], x[2], x[1]}});
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        cerr << which << ": expected InvalidProblemDefinitionException on duplicate successor var\n";
+        return false;
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    bool ok = true;
+    ok &= expect_throw_on_dup<CircuitSCC>("CircuitSCC");
+    ok &= expect_throw_on_dup<CircuitPrevent>("CircuitPrevent");
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -50,6 +50,22 @@ ReifiedCompareLessThanOrMaybeEqual::ReifiedCompareLessThanOrMaybeEqual(const Int
 {
 }
 
+LessThan::LessThan(const IntegerVariableID v1, const IntegerVariableID v2) :
+    ReifiedCompareLessThanOrMaybeEqual(v1, v2, reif::MustHold{}, false)
+{
+    // Two constants that happen to be equal is a valid (if trivially
+    // infeasible) model; only reject true variable aliasing.
+    if (v1 == v2 && ! is_constant_variable(v1))
+        throw InvalidProblemDefinitionException{"LessThan: both operands are the same variable handle"};
+}
+
+GreaterThan::GreaterThan(const IntegerVariableID v1, const IntegerVariableID v2) :
+    ReifiedCompareLessThanOrMaybeEqual(v2, v1, reif::MustHold{}, false, true)
+{
+    if (v1 == v2 && ! is_constant_variable(v1))
+        throw InvalidProblemDefinitionException{"GreaterThan: both operands are the same variable handle"};
+}
+
 auto ReifiedCompareLessThanOrMaybeEqual::clone() const -> unique_ptr<Constraint>
 {
     return make_unique<ReifiedCompareLessThanOrMaybeEqual>(_v1, _v2, _reif_cond, _or_equal, _vars_swapped);

--- a/gcs/constraints/comparison.hh
+++ b/gcs/constraints/comparison.hh
@@ -59,8 +59,7 @@ namespace gcs
     class LessThan : public ReifiedCompareLessThanOrMaybeEqual
     {
     public:
-        inline explicit LessThan(const IntegerVariableID v1, const IntegerVariableID v2) :
-            ReifiedCompareLessThanOrMaybeEqual(v1, v2, reif::MustHold{}, false) {};
+        explicit LessThan(const IntegerVariableID v1, const IntegerVariableID v2);
     };
 
     /**
@@ -95,8 +94,7 @@ namespace gcs
     class GreaterThan : public ReifiedCompareLessThanOrMaybeEqual
     {
     public:
-        inline explicit GreaterThan(const IntegerVariableID v1, const IntegerVariableID v2) :
-            ReifiedCompareLessThanOrMaybeEqual(v2, v1, reif::MustHold{}, false, true) {};
+        explicit GreaterThan(const IntegerVariableID v1, const IntegerVariableID v2);
     };
 
     /**

--- a/gcs/constraints/comparison_test.cc
+++ b/gcs/constraints/comparison_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/exception.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -338,7 +339,24 @@ auto main(int argc, char * argv[]) -> int
                 else if (mode == "ge_iff")
                     run_dup_reif_binary_comparison_test<GreaterThanEqualIff>(proofs, mode, xr,
                         [](int, int c) { return c == 1; });
-                // else: lt, gt, lt_if, gt_if — Bucket A/B, no dup test
+                // else: lt_if, gt_if — Bucket B (propagator fix), no dup test
+            }
+
+            // lt, gt on aliased operands are trivially unsat: reject at
+            // construction. Only check once per binary, not per view-cfg.
+            if (mode == "lt" || mode == "gt") {
+                Problem ep;
+                auto x = ep.create_integer_variable(Integer{0}, Integer{3});
+                try {
+                    if (mode == "lt")
+                        ep.post(LessThan{x, x});
+                    else
+                        ep.post(GreaterThan{x, x});
+                    cerr << "expected " << mode << "(x,x) to throw InvalidProblemDefinitionException" << '\n';
+                    return EXIT_FAILURE;
+                }
+                catch (const InvalidProblemDefinitionException &) {
+                }
             }
         }
     }

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -277,6 +277,10 @@ EqualsIff::EqualsIff(const IntegerVariableID v1, const IntegerVariableID v2, Int
 NotEquals::NotEquals(const IntegerVariableID v1, const IntegerVariableID v2) :
     ReifiedEquals(v1, v2, reif::MustNotHold{}, true)
 {
+    // Two constants that happen to be equal is a valid (if trivially
+    // infeasible) model; only reject true variable aliasing.
+    if (v1 == v2 && ! is_constant_variable(v1))
+        throw InvalidProblemDefinitionException{"NotEquals: both operands are the same variable handle"};
 }
 
 NotEqualsIf::NotEqualsIf(const IntegerVariableID v1, const IntegerVariableID v2, IntegerVariableCondition cond) :

--- a/gcs/constraints/equals_test.cc
+++ b/gcs/constraints/equals_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/exception.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -238,6 +239,20 @@ auto main(int argc, char * argv[]) -> int
                 run_dup_equals_test<NotEqualsIff>("notequals_iff", proofs, x_range,
                     [](int, int c) { return c == 0; });
             }
+    }
+
+    {
+        // NotEquals on aliased operands is trivially unsat; reject at
+        // construction rather than discovering after search.
+        Problem p;
+        auto x = p.create_integer_variable(Integer{0}, Integer{3});
+        try {
+            p.post(NotEquals{x, x});
+            cerr << "expected NotEquals(x,x) to throw InvalidProblemDefinitionException" << '\n';
+            return EXIT_FAILURE;
+        }
+        catch (const InvalidProblemDefinitionException &) {
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -49,6 +49,25 @@ Inverse::Inverse(vector<IntegerVariableID> x, vector<IntegerVariableID> y, Integ
     _y_start(y_start)
 
 {
+    // Intra-array aliasing is always infeasible: if x[i] and x[j] share a
+    // handle then any value v they take demands y[v] = i and y[v] = j at
+    // once. Cross-array aliasing (e.g. inverse(x, x) for involutions) is
+    // legitimate, so only check within each array. Repeated constants are
+    // permitted: they aren't a single variable, they're two slots pinned
+    // to the same value, which is a meaningful (and possibly infeasible)
+    // model — see the #171 regression case in inverse_test.
+    auto throw_if_dup = [](const vector<IntegerVariableID> & arr, const char * which) {
+        for (size_t i = 0; i < arr.size(); ++i) {
+            if (is_constant_variable(arr[i]))
+                continue;
+            for (size_t j = i + 1; j < arr.size(); ++j)
+                if (arr[i] == arr[j])
+                    throw InvalidProblemDefinitionException{string{"Inverse: "} + which +
+                        " array contains the same variable handle twice"};
+        }
+    };
+    throw_if_dup(_x, "first");
+    throw_if_dup(_y, "second");
 }
 
 auto Inverse::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/inverse_test.cc
+++ b/gcs/constraints/inverse_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/constraints/inverse.hh>
+#include <gcs/exception.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -165,6 +166,34 @@ auto main(int argc, char * argv[]) -> int
             continue;
         for (auto & [x, y] : var_data)
             run_inverse_test(proofs, view_cfg, x, y);
+    }
+
+    {
+        // Intra-array duplicates make Inverse trivially infeasible: reject
+        // at construction. Cross-array aliasing (e.g. Inverse(x, x) for
+        // involutions) is legitimate and stays accepted.
+        auto expect_throw = [](auto build) {
+            try {
+                build();
+            }
+            catch (const InvalidProblemDefinitionException &) {
+                return true;
+            }
+            return false;
+        };
+
+        Problem p;
+        auto x = p.create_integer_variable_vector(3, 0_i, 2_i);
+        auto y = p.create_integer_variable_vector(3, 0_i, 2_i);
+
+        if (! expect_throw([&] { p.post(Inverse{{x[0], x[1], x[0]}, y}); })) {
+            cerr << "expected Inverse with duplicate in first array to throw\n";
+            return EXIT_FAILURE;
+        }
+        if (! expect_throw([&] { p.post(Inverse{x, {y[0], y[2], y[2]}}); })) {
+            cerr << "expected Inverse with duplicate in second array to throw\n";
+            return EXIT_FAILURE;
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- Four Bucket A constraints from the dup-variable audit (#223–#228) now reject aliased operands at construction with `InvalidProblemDefinitionException`, rather than waiting for UNSAT-after-search (or, in Circuit's non-GAC path, silently dropping `define_clique_not_equals_encoding`'s `duplicate_witness`).
- Covered: `NotEquals(x,x)`; `LessThan(x,x)` / `GreaterThan(x,x)`; any `Circuit*` with a repeated successor handle (`CircuitBase` ctor — covers both `CircuitSCC` and `CircuitPrevent`); `Inverse` with an intra-array dup in either `_x` or `_y`. Cross-array aliasing like `Inverse(x, x)` for involutions stays allowed.
- Each check is gated on `! is_constant_variable(...)` so two slots pinned to the same constant remain a well-formed (if infeasible) model — preserves e.g. `inverse_test`'s #171 regression case `{3, 2, 3, ...}` and analogous patterns.

## Notes
- `LessThan` / `GreaterThan` constructors moved from inline-in-header into `comparison.cc` to keep the throw and exception include out of the public header. Their semantics are unchanged for non-aliased operands.
- Tests added inline in `equals_test.cc`, `comparison_test.cc`, `inverse_test.cc`. New `circuit_dup_test.cc` exercises both `CircuitSCC` and `CircuitPrevent`.

## Test plan
- [x] `cmake --build build --parallel 32` clean
- [x] Targeted: `equals_test`, `comparison_test` (all 10 modes), `inverse_test`, `circuit_dup_test`, existing `circuit_*_test` regression
- [x] Full `ctest -j 32`: 206/206 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)