### PR TITLE
Reified *If on aliased operands: pin cond at root via infer_cond_when_undecided

### DIFF
--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -182,6 +182,20 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
         auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, or_equal = _or_equal](
                                              const State & state, auto &, ProofLogger * const,
                                              const IntegerVariableCondition &) -> ReificationVerdict {
+            // Aliased non-constant operands: v1<v2 never (when strict),
+            // v1≤v2 always. Returning the resolved verdict here lets the
+            // dispatcher pin cond at root instead of relying on bounds
+            // shrinking to expose the contradiction.
+            if (v1 == v2 && ! is_constant_variable(v1)) {
+                if (or_equal)
+                    return reification_verdict::MustHold{
+                        .justification = JustifyUsingRUP{},
+                        .reason = ReasonFunction{}};
+                else
+                    return reification_verdict::MustNotHold{
+                        .justification = JustifyUsingRUP{},
+                        .reason = ReasonFunction{}};
+            }
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
             if (or_equal ? (v1_bounds.second <= v2_bounds.first) : (v1_bounds.second < v2_bounds.first)) {
                 // v1 has to be less than (or equal): constraint must hold.

--- a/gcs/constraints/comparison_test.cc
+++ b/gcs/constraints/comparison_test.cc
@@ -310,8 +310,10 @@ auto main(int argc, char * argv[]) -> int
                 throw UnimplementedException{};
         }
 
-        // Dup-variable cases. Only the audit's OK variants are exercised here;
-        // lt, gt, lt_if, gt_if are skipped (Bucket A throw / Bucket B fix).
+        // Dup-variable cases. lt/gt themselves throw (Bucket A — covered
+        // separately); lt_if/gt_if were Bucket B (propagator weak on alias)
+        // and are now fixed via the alias check in
+        // ReifiedCompareLessThanOrMaybeEqual's infer_cond_when_undecided.
         if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
             vector<pair<int, int>> dup_data = {{0, 0}, {0, 5}, {-3, 3}, {2, 5}};
             for (auto & xr : dup_data) {
@@ -327,6 +329,14 @@ auto main(int argc, char * argv[]) -> int
                 else if (mode == "ge_if")
                     run_dup_reif_binary_comparison_test<GreaterThanEqualIf>(proofs, mode, xr,
                         [](int, int) { return true; });
+                else if (mode == "lt_if")
+                    // LessThanIf(x, x, c) ≡ c → x<x ≡ ¬c.
+                    run_dup_reif_binary_comparison_test<LessThanIf>(proofs, mode, xr,
+                        [](int, int c) { return c == 0; });
+                else if (mode == "gt_if")
+                    // GreaterThanIf(x, x, c) ≡ c → x>x ≡ ¬c.
+                    run_dup_reif_binary_comparison_test<GreaterThanIf>(proofs, mode, xr,
+                        [](int, int c) { return c == 0; });
                 else if (mode == "lt_iff")
                     run_dup_reif_binary_comparison_test<LessThanIff>(proofs, mode, xr,
                         [](int, int c) { return c == 0; });
@@ -339,7 +349,7 @@ auto main(int argc, char * argv[]) -> int
                 else if (mode == "ge_iff")
                     run_dup_reif_binary_comparison_test<GreaterThanEqualIff>(proofs, mode, xr,
                         [](int, int c) { return c == 1; });
-                // else: lt_if, gt_if — Bucket B (propagator fix), no dup test
+                // else: lt, gt — Bucket A throw, no dup test
             }
 
             // lt, gt on aliased operands are trivially unsat: reject at

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -218,6 +218,14 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
     auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2](
                                          const State & state, auto &, ProofLogger * const logger,
                                          const IntegerVariableCondition & cond) -> ReificationVerdict {
+        // Aliased non-constant operands: equality definitely holds regardless of
+        // domain. Returning MustHold here lets the dispatcher pin the cond
+        // immediately at root, instead of waiting until search fixes v1 to a
+        // value and the singleton check below fires.
+        if (v1 == v2 && ! is_constant_variable(v1))
+            return reification_verdict::MustHold{
+                .justification = JustifyUsingRUP{},
+                .reason = ReasonFunction{}};
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {

--- a/gcs/constraints/equals_test.cc
+++ b/gcs/constraints/equals_test.cc
@@ -238,6 +238,11 @@ auto main(int argc, char * argv[]) -> int
                     [](int, int c) { return c == 1; });
                 run_dup_equals_test<NotEqualsIff>("notequals_iff", proofs, x_range,
                     [](int, int c) { return c == 0; });
+                // NotEqualsIf(x, x, c) ≡ c → x ≠ x ≡ ¬c. Was Bucket B
+                // (propagator silent on alias) — fixed by alias check in
+                // ReifiedEquals' infer_cond_when_undecided.
+                run_dup_equals_test<NotEqualsIf>("notequals_if", proofs, x_range,
+                    [](int, int c) { return c == 0; });
             }
     }
 


### PR DESCRIPTION
## Summary
- Bucket B propagator-strength fix from the duplicate-variable audit (#229's cover note).
- `NotEqualsIf(x, x, c)`, `LessThanIf(x, x, c)`, `GreaterThanIf(x, x, c)` all reduce to `¬c`. Before this change the propagator was silent on alias — search had to fix `x` to a singleton before the underlying inequality propagator fired the back-implication to `c`. Solutions and proofs were correct, but search burned ~2.5× more recursions than necessary on tight problems.
- The fix: detect `v1 == v2 && ! is_constant_variable(v1)` inside `infer_cond_when_undecided` in both `ReifiedEquals` and `ReifiedCompareLessThanOrMaybeEqual`, and return the resolved `MustHold` / `MustNotHold` verdict immediately. The existing reification dispatcher already maps that to the right `cond` inference via `cond_to_infer_if_constraint_*`. No OPB or `define_proof_model` changes needed; the encoding already RUPs the inference at proof time.
- Repeated constants are excluded per the same precedent as the Bucket A throws (#229): two slots pinned to the same constant remain a well-formed model.
- As a side benefit, `EqualsIff(x, x, c)` and `NotEqualsIff(x, x, c)` also now pin `c` at root rather than after search (these weren't explicitly flagged in the audit but share the same code path).

## Tests
- `NotEqualsIf` added to the `equals_test` dup-data sweep (previously dropped with a "Bucket B fix" comment).
- `lt_if` and `gt_if` added to the `comparison_test` dup sweep (same skip comment).
- All 12 comparison modes (`lt`, `gt`, `le`, `ge`, plus `_if` and `_iff` variants) verify with VeriPB on the dup data; full `ctest -j 32` 205/205.

## Out of scope
- MultBC alias proof failure — the only remaining real Bucket B bug. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)