### PR TITLE
MultBC: throw on aliased operands; defer proof-encoding fix to a follow-up issue

### DIFF
--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/mult_bc.hh>
+#include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -1118,6 +1119,15 @@ namespace
 MultBC::MultBC(const SimpleIntegerVariableID v1, const SimpleIntegerVariableID v2, const SimpleIntegerVariableID v3) :
     _v1(v1), _v2(v2), _v3(v3)
 {
+    // Aliased slots are well-defined semantically (squaring, fixed
+    // points) but the bit-product proof encoding doesn't tolerate
+    // them: make_magnitude_representation, prove_product_bounds, and
+    // the sign_lines accounting all assume distinct underlying
+    // variables. See GitHub issue for the deeper fix; until then
+    // surface as an InvalidProblemDefinitionException so users get
+    // an actionable error instead of a proof-verification failure.
+    if (v1 == v2 || v1 == v3 || v2 == v3)
+        throw InvalidProblemDefinitionException{"MultBC: operands must be three distinct variable handles"};
 }
 
 auto MultBC::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/mult_bc_test.cc
+++ b/gcs/constraints/mult_bc_test.cc
@@ -1,5 +1,7 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/constraints/mult_bc.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
 
 #include <cstdlib>
 #include <version>
@@ -64,6 +66,25 @@ auto run_mult_test(bool proofs, pair<int, int> v1_range, pair<int, int> v2_range
     check_results(proof_name, expected, actual);
 }
 
+// MultBC's bit-product proof encoding doesn't tolerate aliased
+// operands. Construction throws InvalidProblemDefinitionException
+// rather than failing later under VeriPB.
+auto expect_mult_alias_throws(const char * tag, int v1_pos, int v2_pos, int v3_pos) -> bool
+{
+    Problem p;
+    auto a = p.create_integer_variable(-3_i, 3_i, "a");
+    auto b = p.create_integer_variable(-3_i, 3_i, "b");
+    auto pick = [&](int pos) { return pos == 0 ? a : b; };
+    try {
+        p.post(MultBC{pick(v1_pos), pick(v2_pos), pick(v3_pos)});
+    }
+    catch (const InvalidProblemDefinitionException &) {
+        return true;
+    }
+    println(cerr, "MultBC dup {} expected InvalidProblemDefinitionException", tag);
+    return false;
+}
+
 auto main(int, char *[]) -> int
 {
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> data = {
@@ -94,7 +115,27 @@ auto main(int, char *[]) -> int
         for (auto & [r1, r2, r3] : data) {
             run_mult_test(proofs, r1, r2, r3, [](int a, int b, int c) { return a * b == c; });
         }
+
     }
 
-    return EXIT_SUCCESS;
+    // Aliased operands throw at construction. Don't tie these to the
+    // proofs axis — the throw happens before any proof artifact is
+    // emitted.
+    bool ok = true;
+    ok &= expect_mult_alias_throws("v1==v2", 0, 0, 1);
+    ok &= expect_mult_alias_throws("v1==v3", 0, 1, 0);
+    ok &= expect_mult_alias_throws("v2==v3", 1, 0, 0);
+    {
+        Problem p;
+        auto x = p.create_integer_variable(-3_i, 3_i, "x");
+        try {
+            p.post(MultBC{x, x, x});
+            println(cerr, "MultBC(x, x, x) expected InvalidProblemDefinitionException");
+            ok = false;
+        }
+        catch (const InvalidProblemDefinitionException &) {
+        }
+    }
+
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
## Summary
- Third (and final) Bucket B item from the duplicate-variable audit. Aliased slots (`v1==v2`, `v1==v3`, `v2==v3`, all three) have well-defined math — squaring, fixed points — but the bit-product proof encoding doesn't tolerate them today.
- The audit suggested `make_magnitude_representation` should reuse an already-emitted magnitude variable when one exists for the underlying var. On attempt, that turns out to be necessary but not sufficient: `prove_product_bounds` has four `for (var : {x, y})` loops that build doubled-up `conditional_bounds` on alias and emit mismatched proof line counts, plus the sign_lines emission in `define_proof_model` needs to handle aliased vars too.
- Until that deeper fix lands, surface an `InvalidProblemDefinitionException` at construction so users get an actionable error instead of a VeriPB verification failure on what looks like a valid model. Matches the Bucket A pattern (`NotEquals(x,x)` etc.; #229).

## Tests
- Replace the previously-removed dup verification cases (reverted in tier 1 as an "audit downgrade") with construction-throws assertions for the four alias patterns: `v1==v2`, `v1==v3`, `v2==v3`, and all-three.
- All 205 ctest cases pass.

## Follow-up
- Issue #232 captures the deeper fix needed in `prove_product_bounds`, the sign_lines accounting, and the `{x,y}` loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)