### PR TITLE
Adding constraint labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ out/
 Testing/
 verification_pipeline.sh
 crystal_maze_pipeline.sh
+verification/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,4 @@ compile_commands.json
 out/
 .claude
 Testing/
-verification_pipeline.sh
-crystal_maze_pipeline.sh
-verification/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ Doxyfile
 *.pbp
 *.varmap
 *.scp
+*.corepb
+*.verifiedopb
 *~
 XCSP3-CPP-Parser
 generator
@@ -24,3 +26,5 @@ compile_commands.json
 out/
 .claude
 Testing/
+verification_pipeline.sh
+crystal_maze_pipeline.sh

--- a/examples/auto_table/auto_table.cc
+++ b/examples/auto_table/auto_table.cc
@@ -72,9 +72,9 @@ auto main(int argc, char * argv[]) -> int
     Problem p;
 
     auto v = p.create_integer_variable_vector(5, 1_i, 5_i, "v");
-    p.post_named(AllDifferent{vector{v[0], v[1], v[2]}}, "at_ad012");
-    p.post_named(AllDifferent{vector{v[2], v[3], v[4]}}, "at_ad234");
-    p.post_named(WeightedSum{} + 1_i * v[0] + 1_i * v[1] + 1_i * v[2] + 1_i * v[3] + 1_i * v[4] == 10_i, "at_sum");
+    p.post_named(AllDifferent{vector{v[0], v[1], v[2]}}, "atad012");
+    p.post_named(AllDifferent{vector{v[2], v[3], v[4]}}, "atad234");
+    p.post_named(WeightedSum{} + 1_i * v[0] + 1_i * v[1] + 1_i * v[2] + 1_i * v[3] + 1_i * v[4] == 10_i, "atsum");
 
     p.add_presolver(AutoTable{vector{v[0], v[1], v[2]}});
 

--- a/examples/auto_table/auto_table.cc
+++ b/examples/auto_table/auto_table.cc
@@ -72,9 +72,9 @@ auto main(int argc, char * argv[]) -> int
     Problem p;
 
     auto v = p.create_integer_variable_vector(5, 1_i, 5_i, "v");
-    p.post(AllDifferent{vector{v[0], v[1], v[2]}});
-    p.post(AllDifferent{vector{v[2], v[3], v[4]}});
-    p.post(WeightedSum{} + 1_i * v[0] + 1_i * v[1] + 1_i * v[2] + 1_i * v[3] + 1_i * v[4] == 10_i);
+    p.post_named(AllDifferent{vector{v[0], v[1], v[2]}}, "at_ad012");
+    p.post_named(AllDifferent{vector{v[2], v[3], v[4]}}, "at_ad234");
+    p.post_named(WeightedSum{} + 1_i * v[0] + 1_i * v[1] + 1_i * v[2] + 1_i * v[3] + 1_i * v[4] == 10_i, "at_sum");
 
     p.add_presolver(AutoTable{vector{v[0], v[1], v[2]}});
 

--- a/examples/cake/cake.cc
+++ b/examples/cake/cake.cc
@@ -72,14 +72,14 @@ auto main(int argc, char * argv[]) -> int
     // https://www.minizinc.org/doc-2.5.5/en/modelling.html#an-arithmetic-optimisation-example
     auto banana = p.create_integer_variable(0_i, 100_i, "banana");
     auto chocolate = p.create_integer_variable(0_i, 100_i, "chocolate");
-    p.post(WeightedSum{} + 250_i * banana + 200_i * chocolate <= 4000_i);
-    p.post(WeightedSum{} + 2_i * banana <= 6_i);
-    p.post(WeightedSum{} + 75_i * banana + 150_i * chocolate <= 2000_i);
-    p.post(WeightedSum{} + 100_i * banana + 150_i * chocolate <= 500_i);
-    p.post(WeightedSum{} + 75_i * chocolate <= 500_i);
+    p.post_named(WeightedSum{} + 250_i * banana + 200_i * chocolate <= 4000_i, "flour");
+    p.post_named(WeightedSum{} + 2_i * banana <= 6_i, "bananas");
+    p.post_named(WeightedSum{} + 75_i * banana + 150_i * chocolate <= 2000_i, "sugar");
+    p.post_named(WeightedSum{} + 100_i * banana + 150_i * chocolate <= 500_i, "butter");
+    p.post_named(WeightedSum{} + 75_i * chocolate <= 500_i, "cocoa");
 
     auto profit = p.create_integer_variable(0_i, 107500_i, "profit");
-    p.post(WeightedSum{} + 400_i * banana + 450_i * chocolate == 1_i * profit);
+    p.post_named(WeightedSum{} + 400_i * banana + 450_i * chocolate == 1_i * profit, "cakes");
 
     p.maximise(profit);
     auto stats = solve_with(p,

--- a/examples/circuit_random/circuit_random.cc
+++ b/examples/circuit_random/circuit_random.cc
@@ -55,19 +55,19 @@ Stats run_circuit_problem(int n, const vector<vector<long>> & distances, SCCOpti
     for (int loc1 = 0; loc1 < n; loc1++) {
         for (int loc2 = 0; loc2 < n; loc2++) {
             if (distances[loc1][loc2] < 0) {
-                p.post(NotEquals{x[loc1], ConstantIntegerVariableID{Integer{loc2}}});
+                p.post_named(NotEquals{x[loc1], ConstantIntegerVariableID{Integer{loc2}}}, "cir_neq_" + std::to_string(loc1) + "_" + std::to_string(loc2));
             }
         }
     }
     auto use_gac_all_different = false;
-    p.post(Circuit{x, use_gac_all_different, options});
+    p.post_named(Circuit{x, use_gac_all_different, options}, "cir_ad");
 
     // Minimise the distance between any two stops
     auto max_leg = p.create_integer_variable(0_i, 100_i, "max_leg");
     for (int loc1 = 0; loc1 < n; loc1++) {
         for (int loc2 = 0; loc2 < n; loc2++) {
-            p.post(LessThanIf{ConstantIntegerVariableID{Integer{distances[loc1][loc2]}}, max_leg,
-                x[loc1] == Integer{loc2}});
+            p.post_named(LessThanIf{ConstantIntegerVariableID{Integer{distances[loc1][loc2]}}, max_leg,
+                x[loc1] == Integer{loc2}}, "cir_dist_" + std::to_string(loc1) + "_" + std::to_string(loc2));
         }
     }
 

--- a/examples/circuit_random/circuit_random.cc
+++ b/examples/circuit_random/circuit_random.cc
@@ -55,19 +55,19 @@ Stats run_circuit_problem(int n, const vector<vector<long>> & distances, SCCOpti
     for (int loc1 = 0; loc1 < n; loc1++) {
         for (int loc2 = 0; loc2 < n; loc2++) {
             if (distances[loc1][loc2] < 0) {
-                p.post_named(NotEquals{x[loc1], ConstantIntegerVariableID{Integer{loc2}}}, "cir_neq_" + std::to_string(loc1) + "_" + std::to_string(loc2));
+                p.post_named(NotEquals{x[loc1], ConstantIntegerVariableID{Integer{loc2}}}, "cirneq[" + std::to_string(loc1) + "][" + std::to_string(loc2) + "]");
             }
         }
     }
     auto use_gac_all_different = false;
-    p.post_named(Circuit{x, use_gac_all_different, options}, "cir_ad");
+    p.post_named(Circuit{x, use_gac_all_different, options}, "cirad");
 
     // Minimise the distance between any two stops
-    auto max_leg = p.create_integer_variable(0_i, 100_i, "max_leg");
+    auto max_leg = p.create_integer_variable(0_i, 100_i, "maxleg");
     for (int loc1 = 0; loc1 < n; loc1++) {
         for (int loc2 = 0; loc2 < n; loc2++) {
             p.post_named(LessThanIf{ConstantIntegerVariableID{Integer{distances[loc1][loc2]}}, max_leg,
-                x[loc1] == Integer{loc2}}, "cir_dist_" + std::to_string(loc1) + "_" + std::to_string(loc2));
+                x[loc1] == Integer{loc2}}, "cirdist[" + std::to_string(loc1) + "][" + std::to_string(loc2) + "]");
         }
     }
 

--- a/examples/circuit_small/circuit_small.cc
+++ b/examples/circuit_small/circuit_small.cc
@@ -25,13 +25,13 @@ auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes)
      * There is only one SCC, but multiple subtrees explored below the root in the DFS.
      **/
 
-    p.post(In{nodes[0], {1_i, 4_i, 5_i}});
-    p.post(In{nodes[1], {2_i, 3_i}});
-    p.post(In{nodes[2], {0_i}});
-    p.post(In{nodes[3], {2_i}});
-    p.post(In{nodes[4], {1_i, 3_i}});
-    p.post(In{nodes[5], {0_i, 6_i}});
-    p.post(In{nodes[6], {3_i, 4_i}});
+    p.post_named(In{nodes[0], {1_i, 4_i, 5_i}}, "node0");
+    p.post_named(In{nodes[1], {2_i, 3_i}}, "node1");
+    p.post_named(In{nodes[2], {0_i}}, "node2");
+    p.post_named(In{nodes[3], {2_i}}, "node3");
+    p.post_named(In{nodes[4], {1_i, 3_i}}, "node4");
+    p.post_named(In{nodes[5], {0_i, 6_i}}, "node5");
+    p.post_named(In{nodes[6], {3_i, 4_i}}, "node6");
 }
 auto main(int argc, char * argv[]) -> int
 {
@@ -80,13 +80,13 @@ auto main(int argc, char * argv[]) -> int
     post_constraints(p, nodes);
 
     if (options_vars["propagator"].as<string>() == "prevent") {
-        p.post(CircuitPrevent{nodes});
+        p.post_named(CircuitPrevent{nodes}, "circuit_prevent");
     }
     else if (options_vars["propagator"].as<string>() == "scc") {
-        p.post(CircuitSCC{nodes});
+        p.post_named(CircuitSCC{nodes}, "circuit_scc");
     }
     else {
-        p.post(Circuit{nodes});
+        p.post_named(Circuit{nodes}, "circuit");
     }
 
     auto stats = solve_with(

--- a/examples/colour/colour.cc
+++ b/examples/colour/colour.cc
@@ -121,10 +121,10 @@ auto main(int argc, char * argv[]) -> int
     auto vertices = p.create_integer_variable_vector(size, 0_i, Integer{size - 1}, "vertex");
 
     for (auto & [f, t] : edges)
-        p.post_named(NotEquals{vertices[f], vertices[t]}, "edge_" + std::to_string(f) + "_" + std::to_string(t));
+        p.post_named(NotEquals{vertices[f], vertices[t]}, "edge[" + std::to_string(f) + "][" + std::to_string(t) + "]");
 
     IntegerVariableID colours = p.create_integer_variable(0_i, Integer{size - 1}, "colours");
-    p.post_named(ArrayMax{vertices, colours}, "colours_def");
+    p.post_named(ArrayMax{vertices, colours}, "colours_definition");
 
     p.minimise(colours);
 

--- a/examples/colour/colour.cc
+++ b/examples/colour/colour.cc
@@ -121,10 +121,10 @@ auto main(int argc, char * argv[]) -> int
     auto vertices = p.create_integer_variable_vector(size, 0_i, Integer{size - 1}, "vertex");
 
     for (auto & [f, t] : edges)
-        p.post(NotEquals{vertices[f], vertices[t]});
+        p.post_named(NotEquals{vertices[f], vertices[t]}, "edge_" + std::to_string(f) + "_" + std::to_string(t));
 
     IntegerVariableID colours = p.create_integer_variable(0_i, Integer{size - 1}, "colours");
-    p.post(ArrayMax{vertices, colours});
+    p.post_named(ArrayMax{vertices, colours}, "colours_def");
 
     p.minimise(colours);
 

--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -90,15 +90,15 @@ auto main(int argc, char * argv[]) -> int
         diffs.emplace_back(p.create_integer_variable(-7_i, 7_i, "diff" + to_string(x1) + "_" + to_string(x2)));
         if (options_vars.contains("abs")) {
             abs_diffs.emplace_back(p.create_integer_variable(2_i, 7_i, "absdiff" + to_string(x1) + "_" + to_string(x2)));
-            p.post_named(Abs{diffs.back(), abs_diffs.back()}, "cmabs[" + to_string(x1) + "][" + to_string(x2) + "]");
+            p.post_named(Abs{diffs.back(), abs_diffs.back()}, "cmabs_" + to_string(x1) + "_" + to_string(x2));
         }
         else {
-            p.post_named(NotEquals{diffs.back(), 0_c}, "cmneq[0][" + to_string(x1) + "][" + to_string(x2) + "]");
-            p.post_named(NotEquals{diffs.back(), 1_c}, "cmneq[1][" + to_string(x1) + "][" + to_string(x2) + "]");
-            p.post_named(NotEquals{diffs.back(), -1_c}, "cmneq[-1][" + to_string(x1) + "][" + to_string(x2) + "]");
+            p.post_named(NotEquals{diffs.back(), 0_c}, "cmneq_p0_" + to_string(x1) + "_" + to_string(x2));
+            p.post_named(NotEquals{diffs.back(), 1_c}, "cmneq_p1_" + to_string(x1) + "_" + to_string(x2));
+            p.post_named(NotEquals{diffs.back(), -1_c}, "cmneq_m1_" + to_string(x1) + "_" + to_string(x2));
         }
 
-        p.post_named(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")}, "cmleq[" + to_string(x1) + "][" + to_string(x2) + "]");
+        p.post_named(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")}, "cmleq_" + to_string(x1) + "_" + to_string(x2));
     }
 
     auto stats = solve_with(p,

--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -34,9 +34,11 @@ using std::to_string;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 using std::println;
 #else
+using fmt::format;
 using fmt::print;
 using fmt::println;
 #endif
@@ -87,18 +89,18 @@ auto main(int argc, char * argv[]) -> int
 
     vector<IntegerVariableID> diffs, abs_diffs;
     for (auto & [x1, x2] : edges) {
-        diffs.emplace_back(p.create_integer_variable(-7_i, 7_i, "diff" + to_string(x1) + "_" + to_string(x2)));
+        diffs.emplace_back(p.create_integer_variable(-7_i, 7_i, format("diff[{}][{}]", x1, x2)));
         if (options_vars.contains("abs")) {
-            abs_diffs.emplace_back(p.create_integer_variable(2_i, 7_i, "absdiff" + to_string(x1) + "_" + to_string(x2)));
-            p.post_named(Abs{diffs.back(), abs_diffs.back()}, "cmabs_" + to_string(x1) + "_" + to_string(x2));
+            abs_diffs.emplace_back(p.create_integer_variable(2_i, 7_i, format("absdiff[{}][{}]", x1, x2)));
+            p.post_named(Abs{diffs.back(), abs_diffs.back()}, format("cmabs[{}][{}]", x1, x2));
         }
         else {
-            p.post_named(NotEquals{diffs.back(), 0_c}, "cmneq_p0_" + to_string(x1) + "_" + to_string(x2));
-            p.post_named(NotEquals{diffs.back(), 1_c}, "cmneq_p1_" + to_string(x1) + "_" + to_string(x2));
-            p.post_named(NotEquals{diffs.back(), -1_c}, "cmneq_m1_" + to_string(x1) + "_" + to_string(x2));
+            p.post_named(NotEquals{diffs.back(), 0_c}, format("cmneq_p0[{}][{}]", x1, x2));
+            p.post_named(NotEquals{diffs.back(), 1_c}, format("cmneq_p1[{}][{}]", x1, x2));
+            p.post_named(NotEquals{diffs.back(), -1_c}, format("cmneq_m1[{}][{}]", x1, x2));
         }
 
-        p.post_named(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")}, "cmleq_" + to_string(x1) + "_" + to_string(x2));
+        p.post_named(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")}, format("cmleq[{}][{}]", x1, x2));
     }
 
     auto stats = solve_with(p,

--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -79,7 +79,7 @@ auto main(int argc, char * argv[]) -> int
     Problem p;
 
     auto xs = p.create_integer_variable_vector(8, 1_i, 8_i, "box");
-    p.post(AllDifferent{xs});
+    p.post_named(AllDifferent{xs}, "cmad");
 
     vector<pair<int, int>> edges{{0, 1}, {0, 2}, {0, 3}, {0, 4},
         {1, 3}, {1, 4}, {1, 5}, {2, 3}, {2, 6}, {3, 4}, {3, 6},
@@ -90,15 +90,15 @@ auto main(int argc, char * argv[]) -> int
         diffs.emplace_back(p.create_integer_variable(-7_i, 7_i, "diff" + to_string(x1) + "_" + to_string(x2)));
         if (options_vars.contains("abs")) {
             abs_diffs.emplace_back(p.create_integer_variable(2_i, 7_i, "absdiff" + to_string(x1) + "_" + to_string(x2)));
-            p.post(Abs{diffs.back(), abs_diffs.back()});
+            p.post_named(Abs{diffs.back(), abs_diffs.back()}, "cmabs[" + to_string(x1) + "][" + to_string(x2) + "]");
         }
         else {
-            p.post(NotEquals{diffs.back(), 0_c});
-            p.post(NotEquals{diffs.back(), 1_c});
-            p.post(NotEquals{diffs.back(), -1_c});
+            p.post_named(NotEquals{diffs.back(), 0_c}, "cmneq[0][" + to_string(x1) + "][" + to_string(x2) + "]");
+            p.post_named(NotEquals{diffs.back(), 1_c}, "cmneq[1][" + to_string(x1) + "][" + to_string(x2) + "]");
+            p.post_named(NotEquals{diffs.back(), -1_c}, "cmneq[-1][" + to_string(x1) + "][" + to_string(x2) + "]");
         }
 
-        p.post(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")});
+        p.post_named(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")}, "cmleq[" + to_string(x1) + "][" + to_string(x2) + "]");
     }
 
     auto stats = solve_with(p,

--- a/examples/cumulative/cumulative.cc
+++ b/examples/cumulative/cumulative.cc
@@ -81,11 +81,11 @@ auto main(int argc, char * argv[]) -> int
     Problem p;
     auto starts = p.create_integer_variable_vector(lengths.size(), 0_i, horizon, "s");
 
-    p.post(Cumulative{starts, lengths, heights, capacity});
+    p.post_named(Cumulative{starts, lengths, heights, capacity}, "cumulative");
 
     auto makespan = p.create_integer_variable(0_i, horizon + Integer{static_cast<long long>(lengths.size())}, "makespan");
     for (auto i = 0u; i < lengths.size(); ++i)
-        p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * makespan + -1_i * starts[i], lengths[i]});
+        p.post_named(LinearGreaterThanEqual{WeightedSum{} + 1_i * makespan + -1_i * starts[i], lengths[i]}, "makespan_" + std::to_string(i));
 
     p.minimise(makespan);
 

--- a/examples/knapsack/knapsack.cc
+++ b/examples/knapsack/knapsack.cc
@@ -77,11 +77,11 @@ auto main(int argc, char * argv[]) -> int
     vector<Integer> profits = {2_i, 4_i, 2_i, 5_i, 4_i, 3_i};
 
     auto oddity = p.create_integer_variable(0_i, 20_i, "oddity");
-    p.post(LinearEquality{WeightedSum{} + 1_i * profit + -2_i * oddity, 1_i, true});
+    p.post_named(LinearEquality{WeightedSum{} + 1_i * profit + -2_i * oddity, 1_i, true}, "odditydef");
 
-    p.post(WeightedSum{} + 1_i * items[5] == 0_i);
+    p.post_named(WeightedSum{} + 1_i * items[5] == 0_i, "item5zero");
 
-    p.post(Knapsack{weights, profits, items, weight, profit});
+    p.post_named(Knapsack{weights, profits, items, weight, profit}, "knapsack");
 
     p.maximise(profit);
 

--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -81,15 +81,15 @@ auto main(int argc, char * argv[]) -> int
         solution.emplace_back(p.create_integer_variable(1_i, Integer{k}));
     }
 
-    p.post(AllDifferent{position});
+    p.post_named(AllDifferent{position}, "positions");
 
     for (int i = 0; i < k; ++i) {
         auto i_var = p.create_integer_variable(Integer{i + 1}, Integer{i + 1});
-        p.post(Element{i_var, position[i], &solution});
-        p.post(Element{i_var, position[i + k], &solution});
+        p.post_named(Element{i_var, position[i], &solution}, "element_i_" + std::to_string(i));
+        p.post_named(Element{i_var, position[i + k], &solution}, "element_k_" + std::to_string(i));
 
         // position[i + k] = position[i] + i + 2
-        p.post(PlusGAC{position[i + k], constant_variable(Integer{i + 2}), position[i]});
+        p.post_named(PlusGAC{position[i + k], constant_variable(Integer{i + 2}), position[i]}, "plus_" + std::to_string(i));
     }
 
     auto stats = solve(

--- a/examples/multiply_random/multiply_random.cc
+++ b/examples/multiply_random/multiply_random.cc
@@ -83,7 +83,7 @@ auto main(int argc, char * argv[]) -> int
     auto z_upper = z_lower + Integer{add_dist(rng)};
     auto z = p.create_integer_variable(z_lower, z_upper, "z");
 
-    p.post(MultBC{x, y, z});
+    p.post_named(MultBC{x, y, z}, "multbc");
 
     if (display_problem) {
         println(cout, "x in {}..{}", x_lower, x_upper);

--- a/examples/n_fractions/n_fractions.cc
+++ b/examples/n_fractions/n_fractions.cc
@@ -95,16 +95,20 @@ auto main(int argc, char * argv[]) -> int
     vector<IntegerVariableID> digits(numerators.begin(), numerators.end());
     digits.insert(digits.end(), denominators_first_digit.begin(), denominators_first_digit.end());
     digits.insert(digits.end(), denominators_second_digit.begin(), denominators_second_digit.end());
-    p.post(AllDifferent{digits});
+    p.post_named(AllDifferent{digits}, "ad_nfractions");
 
     vector<SimpleIntegerVariableID> denominators_partial_products{};
     SimpleIntegerVariableID prev_product_var = p.create_integer_variable(1_i, 1_i);
 
     auto max_product_val = 100_i;
     for (unsigned int i = 0; i < denominators.size(); i++) {
-        p.post(WeightedSum{} + 10_i * denominators_first_digit[i] + 1_i * denominators_second_digit[i] + -1_i * denominators[i] == 0_i);
+        p.post_named(
+            WeightedSum{} + 10_i * denominators_first_digit[i] + 1_i * denominators_second_digit[i] + -1_i * denominators[i] == 0_i,
+            "denominator_digits_to_value_" + std::to_string(i));
         denominators_partial_products.emplace_back(p.create_integer_variable(1_i, max_product_val));
-        p.post(MultBC{prev_product_var, denominators[i], denominators_partial_products[i]});
+        p.post_named(
+            MultBC{prev_product_var, denominators[i], denominators_partial_products[i]},
+            "multbc_denominator_" + std::to_string(i));
         prev_product_var = denominators_partial_products[i];
         max_product_val = max_product_val * 100_i;
     }
@@ -116,20 +120,24 @@ auto main(int argc, char * argv[]) -> int
     for (unsigned int i = 0; i < denominators.size(); i++) {
         numerator_multiplier.emplace_back(p.create_integer_variable(1_i, max_product_val / 100_i));
         summands.emplace_back(p.create_integer_variable(1_i, max_product_val / 10_i));
-        p.post(MultBC{numerator_multiplier[i], denominators[i], denominators_product});
-        p.post(MultBC{numerator_multiplier[i], numerators[i], summands[i]});
+        p.post_named(
+            MultBC{numerator_multiplier[i], denominators[i], denominators_product},
+            "multbc_numerator_denominator_" + std::to_string(i));
+        p.post_named(
+            MultBC{numerator_multiplier[i], numerators[i], summands[i]},
+            "multbc_numerator_numerator_" + std::to_string(i));
         frac_sum += 1_i * summands[i];
         // Break symmetries
         if (i > 0)
-            p.post(LessThan{numerators[i - 1], numerators[i]});
+            p.post_named(LessThan{numerators[i - 1], numerators[i]}, "less_than_numerators_" + std::to_string(i));
     }
     frac_sum += -1_i * denominators_product;
-    p.post(frac_sum == 0_i);
+    p.post_named(frac_sum == 0_i, "frac_sum_eq_0");
     if (options_vars.contains("unsat") && n == 2) {
-        p.post(NotEquals(numerators[0], 8_c));
-        p.post(NotEquals(numerators[1], 9_c));
-        p.post(NotEquals(denominators[0], 26_c));
-        p.post(NotEquals(denominators[1], 13_c));
+        p.post_named(NotEquals(numerators[0], 8_c), "unsat_numerator_0");
+        p.post_named(NotEquals(numerators[1], 9_c), "unsat_numerator_1");
+        p.post_named(NotEquals(denominators[0], 26_c), "unsat_denominator_0");
+        p.post_named(NotEquals(denominators[1], 13_c), "unsat_denominator_1");
     }
 
     auto solution_callback = [&](const CurrentState & s) -> bool {

--- a/examples/odd_even_sum/odd_even_sum.cc
+++ b/examples/odd_even_sum/odd_even_sum.cc
@@ -69,8 +69,8 @@ auto main(int argc, char * argv[]) -> int
     auto d = p.create_integer_variable(0_i, 10_i, "d");
     auto e = p.create_integer_variable(0_i, 2_i, "e");
 
-    p.post(LinearEquality{WeightedSum{} + 2_i * a + 2_i * b + 2_i * c + -2_i * d + 1_i * e, 1_i, true});
-    p.post(LinearEquality{WeightedSum{} + -2_i * a + 2_i * b + -2_i * c + 2_i * d + 1_i * e, 1_i, true});
+    p.post_named(LinearEquality{WeightedSum{} + 2_i * a + 2_i * b + 2_i * c + -2_i * d + 1_i * e, 1_i, true}, "odd_even_sum");
+    p.post_named(LinearEquality{WeightedSum{} + -2_i * a + 2_i * b + -2_i * c + 2_i * d + 1_i * e, 1_i, true}, "odd_even_diff");
 
     auto stats = solve(
         p, [&](const CurrentState & s) -> bool {

--- a/examples/ortho_latin/ortho_latin.cc
+++ b/examples/ortho_latin/ortho_latin.cc
@@ -89,8 +89,10 @@ auto main(int argc, char * argv[]) -> int
 
     for (int x = 0; x < size; ++x)
         for (int y = 0; y < size; ++y) {
-            p.post(Div{g12[x * size + y], constant_variable(Integer{size}), g1[x][y]});
-            p.post(Mod{g12[x * size + y], constant_variable(Integer{size}), g2[x][y]});
+            p.post_named(Div{g12[x * size + y], constant_variable(Integer{size}), g1[x][y]},
+                "div[" + std::to_string(x) + "][" + std::to_string(y) + "]");
+            p.post_named(Mod{g12[x * size + y], constant_variable(Integer{size}), g2[x][y]},
+                "mod[" + std::to_string(x) + "][" + std::to_string(y) + "]");
         }
 
     for (int x = 0; x < size; ++x) {
@@ -99,8 +101,8 @@ auto main(int argc, char * argv[]) -> int
             box1.emplace_back(g1[x][y]);
             box2.emplace_back(g2[x][y]);
         }
-        p.post(AllDifferent{box1});
-        p.post(AllDifferent{box2});
+        p.post_named(AllDifferent{box1}, "row[1][" + std::to_string(x) + "]");
+        p.post_named(AllDifferent{box2}, "row[2][" + std::to_string(x) + "]");
     }
 
     for (int y = 0; y < size; ++y) {
@@ -109,17 +111,17 @@ auto main(int argc, char * argv[]) -> int
             box1.emplace_back(g1[x][y]);
             box2.emplace_back(g2[x][y]);
         }
-        p.post(AllDifferent{box1});
-        p.post(AllDifferent{box2});
+        p.post_named(AllDifferent{box1}, "col[1][" + std::to_string(y) + "]");
+        p.post_named(AllDifferent{box2}, "col[2][" + std::to_string(y) + "]");
     }
 
-    p.post(AllDifferent{g12});
+    p.post_named(AllDifferent{g12}, "ad_ortho");
 
     // Normal form: first row of each square and first column of first square is 0 1 2 3 ...
     for (int x = 0; x < size; ++x) {
-        p.post(Equals{g1[0][x], constant_variable(Integer{x})});
-        p.post(Equals{g2[0][x], constant_variable(Integer{x})});
-        p.post(Equals{g1[x][0], constant_variable(Integer{x})});
+        p.post_named(Equals{g1[0][x], constant_variable(Integer{x})}, "nf_row[1][" + std::to_string(x) + "]");
+        p.post_named(Equals{g2[0][x], constant_variable(Integer{x})}, "nf_row[2][" + std::to_string(x) + "]");
+        p.post_named(Equals{g1[x][0], constant_variable(Integer{x})}, "nf_col[1][" + std::to_string(x) + "]");
     }
 
     auto stats = solve(

--- a/examples/random_polynomial/random_polynomial.cc
+++ b/examples/random_polynomial/random_polynomial.cc
@@ -115,14 +115,16 @@ auto main(int argc, char * argv[]) -> int
         for (auto j = 0; j < d; ++j) {
             prod_bounds *= n;
             auto new_prod = p.create_integer_variable(Integer{-prod_bounds}, Integer{prod_bounds});
-            p.post(MultBC{current_prod, indexed.at(j).first, new_prod});
+            p.post_named(
+                MultBC{current_prod, indexed.at(j).first, new_prod},
+                "rp_term[" + std::to_string(i+1) + "][" + std::to_string(j+1) + "]");
             current_prod = new_prod;
             display_str << " * x[" << indexed.at(j).second << "]";
         }
         sum += 1_i * current_prod;
     }
     auto sum_result = p.create_integer_variable(Integer{-n * n}, Integer{n * n}, "result");
-    p.post(sum == 1_i * sum_result);
+    p.post_named(sum == 1_i * sum_result, "rp_sum");
     p.maximise(sum_result);
     if (display_problem) {
         cout << "Max :" << display_str.str() << endl;

--- a/examples/regex/regex.cc
+++ b/examples/regex/regex.cc
@@ -67,7 +67,7 @@ auto main(int argc, char * argv[]) -> int
 
     auto regular = Regular{x, 5, transitions, {3, 4}};
 
-    p.post(regular);
+    p.post_named(regular, "regex");
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/regular_random/regular_random.cc
+++ b/examples/regular_random/regular_random.cc
@@ -78,7 +78,7 @@ auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_r
         }
     }
 
-    p.post(Regular{x, num_states, transitions, final_states, short_reasons});
+    p.post_named(Regular{x, num_states, transitions, final_states, short_reasons}, "rand_regular");
 }
 
 auto main(int argc, char * argv[]) -> int

--- a/examples/rostering/rostering.cc
+++ b/examples/rostering/rostering.cc
@@ -95,7 +95,7 @@ auto main(int argc, char * argv[]) -> int
 
     auto regular = Regular{day, 7, transitions, {0, 1, 2, 3, 4, 5, 6}};
 
-    p.post(regular);
+    p.post_named(regular, "rostering");
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/skeleton_puzzle/skeleton_puzzle.cc
+++ b/examples/skeleton_puzzle/skeleton_puzzle.cc
@@ -43,7 +43,7 @@ auto constrain_digit_sum(Problem & p, vector<SimpleIntegerVariableID> digits, Si
         wsum += Integer{(long)pow(10, i)} * digits[i];
     }
     wsum += -1_i * number;
-    p.post(wsum == 0_i);
+    p.post_named(wsum == 0_i, "digit_sum");
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -91,7 +91,7 @@ auto main(int argc, char * argv[]) -> int
     vector<SimpleIntegerVariableID> a_digits{};
     for (int i = 0; i < a; i++) {
         a_digits.emplace_back(p.create_integer_variable(0_i, 9_i));
-        p.post(NotEquals(a_digits[i], k_var));
+        p.post_named(NotEquals(a_digits[i], k_var), "a_digits[" + std::to_string(i) + "]");
     }
 
     SimpleIntegerVariableID a_var = p.create_integer_variable(0_i, Integer{static_cast<long>(pow(10, a))});
@@ -100,7 +100,7 @@ auto main(int argc, char * argv[]) -> int
     vector<SimpleIntegerVariableID> b_digits{};
     for (int i = 0; i < b; i++) {
         b_digits.emplace_back(p.create_integer_variable(0_i, 9_i));
-        p.post(NotEquals(b_digits[i], k_var));
+        p.post_named(NotEquals(b_digits[i], k_var), "b_digits[" + std::to_string(i) + "]");
     }
 
     vector<vector<SimpleIntegerVariableID>> partial_product_digits{};
@@ -110,23 +110,25 @@ auto main(int argc, char * argv[]) -> int
         partial_product.emplace_back(p.create_integer_variable(0_i, Integer{static_cast<long>(pow(10, a + 1))}));
         for (int j = 0; j < a + 1; j++) {
             partial_product_digits[i].emplace_back(p.create_integer_variable(0_i, 9_i));
+            auto role = "partial_product_digits[" + std::to_string(i) + "][" + std::to_string(j) + "]";
             if (k_vector[i][a - j])
-                p.post(Equals(partial_product_digits[i][j], k_var));
+                p.post_named(Equals(partial_product_digits[i][j], k_var), role);
             else
-                p.post(NotEquals(partial_product_digits[i][j], k_var));
+                p.post_named(NotEquals(partial_product_digits[i][j], k_var), role);
         }
         constrain_digit_sum(p, partial_product_digits[i], partial_product[i]);
-        p.post(MultBC{a_var, b_digits[i], partial_product[i]});
+        p.post_named(MultBC{a_var, b_digits[i], partial_product[i]}, "partial_product[" + std::to_string(i) + "]");
     }
 
     vector<SimpleIntegerVariableID> c_digits{};
     auto c_var = p.create_integer_variable(0_i, Integer{static_cast<long>(pow(10, a + b))});
     for (int i = 0; i < a + b; i++) {
         c_digits.emplace_back(p.create_integer_variable(0_i, 9_i));
+        auto role = "c_digits[" + std::to_string(i) + "]";
         if (k_vector[b][a + b - 1 - i])
-            p.post(Equals(c_digits[i], k_var));
+            p.post_named(Equals(c_digits[i], k_var), role);
         else
-            p.post(NotEquals(c_digits[i], k_var));
+            p.post_named(NotEquals(c_digits[i], k_var), role);
     }
     cout << endl;
 

--- a/examples/skyscrapers/skyscrapers.cc
+++ b/examples/skyscrapers/skyscrapers.cc
@@ -192,19 +192,20 @@ auto main(int argc, char * argv[]) -> int
     }
 
     for (int r = 0; r < size; ++r)
-        p.post(AllDifferent{grid[r]});
+        p.post_named(AllDifferent{grid[r]}, "ad_row[" + to_string(r) + "]");
 
     for (int c = 0; c < size; ++c) {
         vector<IntegerVariableID> column;
         for (int r = 0; r < size; ++r)
             column.push_back(grid[r][c]);
-        p.post(AllDifferent{column});
+        p.post_named(AllDifferent{column}, "ad_col[" + to_string(c) + "]");
     }
 
     for (int r = 0; r < size; ++r)
         for (int c = 0; c < size; ++c)
             if (predefs[r][c] != 0)
-                p.post(Equals{grid[r][c], constant_variable(Integer{predefs[r][c]})});
+                p.post_named(Equals{grid[r][c], constant_variable(Integer{predefs[r][c]})}, 
+                    "predef[" + to_string(r) + "][" + to_string(c) + "]");
 
     auto build_visible_constraints = [&](const string & name, auto & visible_vars, const auto & target, bool downwards, bool forwards) {
         visible_vars.resize(size);
@@ -218,29 +219,32 @@ auto main(int argc, char * argv[]) -> int
                 how_many_visible += 1_i * *visible_vars[downwards ? r : c][downwards ? c : r];
                 if (r == (forwards ? 0 : size - 1)) {
                     // We're the topmost thing, so we're visible
-                    p.post(Equals{*visible_vars[downwards ? r : c][downwards ? c : r], 1_c});
+                    p.post_named(Equals{*visible_vars[downwards ? r : c][downwards ? c : r], 1_c},
+                        format("{}_topmost_visible[{}][{}]", name, r, c));
                 }
                 else {
                     // How many things above us will hide us? We're visible iff it's zero
                     WeightedSum hiding;
                     for (int rr = (forwards ? 0 : size - 1); forwards ? rr < r : rr > r; forwards ? ++rr : --rr) {
                         hiding += 1_i * p.create_integer_variable(0_i, 1_i, format("{}_hiding_flag[{}][{}][{}]", name, r, c, rr));
-                        p.post(GreaterThanIff{
+                        p.post_named(GreaterThanIff{
                             grid[downwards ? r : c][downwards ? c : r],
                             grid[downwards ? rr : c][downwards ? c : rr],
-                            hiding.terms.back().variable == 0_i});
+                            hiding.terms.back().variable == 0_i},
+                            format("{}_hiding[{}][{}][{}]", name, r, c, rr));
                     }
                     auto how_many_hidden = p.create_integer_variable(0_i, Integer(hiding.terms.size()),
                         format("{}_how_many_hidden[{}][{}]", name, r, c));
                     hiding += -1_i * how_many_hidden;
-                    p.post(move(hiding) == 0_i);
-                    p.post(EqualsIff{
+                    p.post_named(move(hiding) == 0_i, format("{}_hiding_sum[{}][{}]", name, r, c));
+                    p.post_named(EqualsIff{
                         how_many_hidden,
                         constant_variable(0_i),
-                        *visible_vars[downwards ? r : c][downwards ? c : r] == 1_i});
+                        *visible_vars[downwards ? r : c][downwards ? c : r] == 1_i},
+                        format("{}_visible_iff_hidden[{}][{}]", name, r, c));
                 }
             }
-            p.post(LinearEquality{move(how_many_visible), Integer(target[c]), true});
+            p.post_named(LinearEquality{move(how_many_visible), Integer(target[c]), true}, format("{}_how_many_visible[{}]", name, c));
         }
     };
 

--- a/examples/smart_table_am1/smart_table_am1.cc
+++ b/examples/smart_table_am1/smart_table_am1.cc
@@ -61,7 +61,7 @@ auto main(int argc, char * argv[]) -> int
     auto vars = p.create_integer_variable_vector(n, 0_i, Integer{n}, "x");
     auto val = p.create_integer_variable(Integer{n}, Integer{n}, "y");
 
-    p.post(AtMostOneSmartTable{vars, val});
+    p.post_named(AtMostOneSmartTable{vars, val}, "am1st");
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/smart_table_lex/smart_table_lex.cc
+++ b/examples/smart_table_lex/smart_table_lex.cc
@@ -55,16 +55,16 @@ auto main(int argc, char * argv[]) -> int
     auto x = p.create_integer_variable_vector(n, 0_i, 10_i, "x");
     auto y = p.create_integer_variable_vector(n, 0_i, 10_i, "y");
 
-    p.post_named(Equals(y[0], 5_c), "y0");
-    p.post_named(Equals(y[1], 2_c), "y1");
-    p.post_named(Equals(y[2], 10_c), "y2");
-    p.post_named(Equals(y[3], 5_c), "y3");
+    p.post_named(Equals(y[0], 5_c), "y_0");
+    p.post_named(Equals(y[1], 2_c), "y_1");
+    p.post_named(Equals(y[2], 10_c), "y_2");
+    p.post_named(Equals(y[3], 5_c), "y_3");
 
-    p.post_named(Equals(x[0], 5_c), "x0");
-    p.post_named(Equals(x[1], 2_c), "x1");
+    p.post_named(Equals(x[0], 5_c), "x_0");
+    p.post_named(Equals(x[1], 2_c), "x_1");
     // Only option for x[2] is 10, since it comes lexicographically after
-    p.post_named(Equals(x[2], 10_c), "x2");
-    p.post_named(Equals(x[3], 6_c), "x3");
+    p.post_named(Equals(x[2], 10_c), "x_2");
+    p.post_named(Equals(x[3], 6_c), "x_3");
 
     p.post_named(LexSmartTable{x, y}, "lex_smart_table");
 

--- a/examples/smart_table_lex/smart_table_lex.cc
+++ b/examples/smart_table_lex/smart_table_lex.cc
@@ -55,17 +55,18 @@ auto main(int argc, char * argv[]) -> int
     auto x = p.create_integer_variable_vector(n, 0_i, 10_i, "x");
     auto y = p.create_integer_variable_vector(n, 0_i, 10_i, "y");
 
-    p.post(Equals(y[0], 5_c));
-    p.post(Equals(y[1], 2_c));
-    p.post(Equals(y[2], 10_c));
-    p.post(Equals(y[3], 5_c));
+    p.post_named(Equals(y[0], 5_c), "y0");
+    p.post_named(Equals(y[1], 2_c), "y1");
+    p.post_named(Equals(y[2], 10_c), "y2");
+    p.post_named(Equals(y[3], 5_c), "y3");
 
-    p.post(Equals(x[0], 5_c));
-    p.post(Equals(x[1], 2_c));
+    p.post_named(Equals(x[0], 5_c), "x0");
+    p.post_named(Equals(x[1], 2_c), "x1");
     // Only option for x[2] is 10, since it comes lexicographically after
-    p.post(Equals(x[3], 6_c));
+    p.post_named(Equals(x[2], 10_c), "x2");
+    p.post_named(Equals(x[3], 6_c), "x3");
 
-    p.post(LexSmartTable{x, y});
+    p.post_named(LexSmartTable{x, y}, "lex_smart_table");
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/smart_table_random/smart_table_random.cc
+++ b/examples/smart_table_random/smart_table_random.cc
@@ -287,7 +287,7 @@ auto main(int argc, char * argv[]) -> int
         auto tuple_length = uniform_int_distribution<>(n / 2, n)(rng);
         SmartTuples tuples = random_tuples(tuple_length, vars, rng, display_table, table_as_string);
 
-        p.post(SmartTable{vars, tuples, short_reasons});
+        p.post_named(SmartTable{vars, tuples, short_reasons}, "st_randon");
 
         auto stats = solve_with(p,
             SolveCallbacks{

--- a/examples/smart_table_small/smart_table_small.cc
+++ b/examples/smart_table_small/smart_table_small.cc
@@ -59,7 +59,7 @@ auto main(int argc, char * argv[]) -> int
     auto tuples = SmartTuples{
         {SmartTable::less_than(A, B), SmartTable::in_set(A, {1_i, 2_i}), SmartTable::equals(C, 3_i)},
         {SmartTable::equals(A, B), SmartTable::not_equals(A, 1_i), SmartTable::greater_than_equal(B, C)}};
-    p.post(SmartTable{{A, B, C}, tuples});
+    p.post_named(SmartTable{{A, B, C}, tuples}, "st_small");
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/sudoku/sudoku.cc
+++ b/examples/sudoku/sudoku.cc
@@ -143,7 +143,7 @@ auto main(int argc, char * argv[]) -> int
     vector<vector<IntegerVariableID>> grid;
 
     for (int r = 0; r < n; ++r)
-        grid.emplace_back(p.create_integer_variable_vector(n, 1_i, Integer{n}, format("grid[{}]", r)));
+        grid.emplace_back(p.create_integer_variable_vector(n, 1_i, Integer{n}, format("grid_{}_", r)));
 
     for (int r = 0; r < n; ++r)
         p.post(AllDifferent{grid[r]});

--- a/examples/sudoku/sudoku.cc
+++ b/examples/sudoku/sudoku.cc
@@ -143,16 +143,16 @@ auto main(int argc, char * argv[]) -> int
     vector<vector<IntegerVariableID>> grid;
 
     for (int r = 0; r < n; ++r)
-        grid.emplace_back(p.create_integer_variable_vector(n, 1_i, Integer{n}, format("grid_{}_", r)));
+        grid.emplace_back(p.create_integer_variable_vector(n, 1_i, Integer{n}, format("grid_{}_", r))); // I want grid[][], btw.
 
     for (int r = 0; r < n; ++r)
-        p.post(AllDifferent{grid[r]});
+        p.post_named(AllDifferent{grid[r]}, format("ad_row[{}]", r));
 
     for (int c = 0; c < n; ++c) {
         vector<IntegerVariableID> column;
         for (int r = 0; r < n; ++r)
             column.push_back(grid[r][c]);
-        p.post(AllDifferent{column});
+        p.post_named(AllDifferent{column}, format("ad_col[{}]", c));
     }
 
     for (int r = 0; r < size; ++r)
@@ -161,13 +161,15 @@ auto main(int argc, char * argv[]) -> int
             for (int rr = 0; rr < size; ++rr)
                 for (int cc = 0; cc < size; ++cc)
                     box.push_back(grid[r * size + rr][c * size + cc]);
-            p.post(AllDifferent{box});
+            p.post_named(AllDifferent{box}, format("ad_box[{}][{}]", r, c));
         }
 
     for (int r = 0; r < n; ++r)
         for (int c = 0; c < n; ++c)
             if (predef[r][c] != 0)
-                p.post(Equals{grid[r][c], constant_variable(Integer{predef[r][c]})});
+                p.post_named(Equals{grid[r][c], 
+                    constant_variable(Integer{predef[r][c]})}, 
+                    format("predef[{}][{}]", r, c));
 
     if (! vertical_xvs.empty()) {
         for (int c = 0; c < n; ++c)
@@ -176,16 +178,20 @@ auto main(int argc, char * argv[]) -> int
                 case N:
                     break;
                 case V:
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 5_i, true});
+                    p.post_named(
+                        LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 5_i, true},
+                        format("eq[V][{}][{}]", r, c));
                     break;
                 case X:
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 10_i, true});
+                    p.post_named(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 10_i, true},
+                        format("eq[X][{}][{}]", r, c));
                     break;
                 case O:
                     auto sum = p.create_integer_variable(0_i, Integer{n * 2});
-                    p.post(NotEquals{sum, 5_c});
-                    p.post(NotEquals{sum, 10_c});
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c] + -1_i * sum, 0_i, true});
+                    p.post_named(NotEquals{sum, 5_c}, format("neq[O][{}][{}]", r, c));
+                    p.post_named(NotEquals{sum, 10_c}, format("neq[O][{}][{}]", r, c));
+                    p.post_named(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c] + -1_i * sum, 0_i, true}, 
+                        format("eq[O][{}][{}]", r, c));
                     break;
                 }
 
@@ -195,16 +201,19 @@ auto main(int argc, char * argv[]) -> int
                 case N:
                     break;
                 case V:
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 5_i, true});
+                    p.post_named(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 5_i, true},
+                        format("eq[V][{}][{}]", r, c));
                     break;
                 case X:
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 10_i, true});
+                    p.post_named(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 10_i, true},
+                        format("eq[X][{}][{}]", r, c));
                     break;
                 case O:
                     auto sum = p.create_integer_variable(0_i, Integer{n * 2});
-                    p.post(NotEquals{sum, 5_c});
-                    p.post(NotEquals{sum, 10_c});
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1] + -1_i * sum, 0_i, true});
+                    p.post_named(NotEquals{sum, 5_c}, format("neq[O][{}][{}]", r, c));
+                    p.post_named(NotEquals{sum, 10_c}, format("neq[O][{}][{}]", r, c));
+                    p.post_named(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1] + -1_i * sum, 0_i, true}, 
+                        format("eq[O][{}][{}]", r, c));
                     break;
                 }
     }

--- a/examples/tables/tables.cc
+++ b/examples/tables/tables.cc
@@ -74,7 +74,7 @@ auto main(int argc, char * argv[]) -> int
     auto v3 = p.create_integer_variable(1_i, 4_i, "v3");
     auto v4 = p.create_integer_variable(1_i, 4_i, "v4");
 
-    p.post(Table{
+    p.post_named(Table{
         {v1, v2, v3},
         SimpleTuples{
             {1_i, 2_i, 3_i},
@@ -82,17 +82,17 @@ auto main(int argc, char * argv[]) -> int
             {2_i, 1_i, 3_i},
             {2_i, 3_i, 1_i},
             {3_i, 1_i, 2_i},
-            {3_i, 2_i, 1_i}}});
+            {3_i, 2_i, 1_i}}}, "table_test_1");
 
-    p.post(Table{
+    p.post_named(Table{
         {v1, v4},
         WildcardTuples{
             {1_i, Wildcard{}},
             {2_i, 2_i},
             {3_i, 3_i},
-            {4_i, 4_i}}});
+            {4_i, 4_i}}}, "table_test_2");
 
-    p.post(Table{
+    p.post_named(Table{
         {v1, v2, v3, v4},
         WildcardTuples{
             {1_i, 1_i, Wildcard{}, Wildcard{}},
@@ -107,7 +107,7 @@ auto main(int argc, char * argv[]) -> int
             {4_i, 4_i, Wildcard{}, Wildcard{}},
             {Wildcard{}, 4_i, 4_i, Wildcard{}},
             {Wildcard{}, Wildcard{}, 4_i, 4_i},
-        }});
+        }}, "table_test_3");
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/talent/talent.cc
+++ b/examples/talent/talent.cc
@@ -100,36 +100,36 @@ int main(int argc, char * argv[])
                 actorsScenes.back().emplace_back(s);
             }
         }
-        auto actorsSlots = p.create_integer_variable_vector(actorsScenes.size(), 0_i, Integer(numScenes - 1), format("actorsSlots[{}]", a));
+        auto actorsSlots = p.create_integer_variable_vector(actorsScenes.size(), 0_i, Integer(numScenes - 1), format("actorsSlots_{}_", a));
         for (unsigned int s = 0; s < actorsScenes.size(); s++) {
-            p.post(Equals{actorsSlots[s], slot[actorsScenes[a][s]]});
+            p.post_named(Equals{actorsSlots[s], slot[actorsScenes[a][s]]}, format("actor[{}]inScene[{}]", a, actorsScenes[a][s]));
         }
-        p.post(ArrayMin{actorsSlots, firstSlot[a]});
-        p.post(ArrayMax{actorsSlots, lastSlot[a]});
+        p.post_named(ArrayMin{actorsSlots, firstSlot[a]}, format("firstSlot_{}_", a));
+        p.post_named(ArrayMax{actorsSlots, lastSlot[a]}, format("lastSlot_{}_", a));
 
         auto wait_expr = WeightedSum{};
         for (int s = 0; s < numScenes; ++s) {
             auto afterFirst = p.create_integer_variable(0_i, 1_i);
-            p.post(LessThanEqualIff{firstSlot[a], slot[s], afterFirst == 1_i});
+            p.post_named(LessThanEqualIff{firstSlot[a], slot[s], afterFirst == 1_i}, format("afterFirst_{}_{}_", a, s));
             auto beforeLast = p.create_integer_variable(0_i, 1_i);
-            p.post(LessThanEqualIff{slot[s], lastSlot[a], beforeLast == 1_i});
+            p.post_named(LessThanEqualIff{slot[s], lastSlot[a], beforeLast == 1_i}, format("beforeLast_{}_{}_", a, s));
             auto onSet = p.create_integer_variable(0_i, 1_i);
-            p.post(And{{afterFirst, beforeLast}, onSet});
+            p.post_named(And{{afterFirst, beforeLast}, onSet}, format("onSet_{}_{}_", a, s));
 
             if (actorInScene[a][s] == 0) {
                 wait_expr += Integer(sceneDuration[s]) * onSet;
             }
         }
         wait_expr += -1_i * actorWait[a];
-        p.post(wait_expr == 0_i);
+        p.post_named(wait_expr == 0_i, format("wait_{}_", a));
         idle_expr += Integer(actorPay[a]) * actorWait[a];
     }
 
-    p.post(Inverse{scene, slot});
+    p.post_named(Inverse{scene, slot}, "inverse");
 
     IntegerVariableID idleCost = p.create_integer_variable(0_i, Integer(100), "idleCost");
     idle_expr += -1_i * idleCost;
-    p.post(idle_expr == 0_i);
+    p.post_named(idle_expr == 0_i, "idle");
     p.minimise(idleCost);
 
     auto stats = solve_with(p,

--- a/examples/tour/tour.cc
+++ b/examples/tour/tour.cc
@@ -8,6 +8,12 @@
 #include <iostream>
 #include <vector>
 
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#else
+#include <fmt/core.h>
+#endif
+
 using namespace gcs;
 
 using std::cerr;
@@ -17,6 +23,12 @@ using std::make_optional;
 using std::nullopt;
 using std::string;
 using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
+#else
+using fmt::format;
+#endif
 
 auto main(int argc, char * argv[]) -> int
 {
@@ -98,29 +110,29 @@ auto main(int argc, char * argv[]) -> int
     for (int loc1 = 0; loc1 < n; loc1++) {
         for (int loc2 = 0; loc2 < n; loc2++) {
             if (distance[loc1][loc2] < 0) {
-                p.post(NotEquals{succ[loc1], ConstantIntegerVariableID{Integer{loc2}}});
+                p.post_named(NotEquals{succ[loc1], ConstantIntegerVariableID{Integer{loc2}}}, format("no_edge[{}][{}]", loc1, loc2));
             }
         }
     }
 
     if (options_vars["propagator"].as<string>() == "prevent") {
-        p.post(CircuitPrevent{succ, false});
+        p.post_named(CircuitPrevent{succ, false}, "circuit_prevent");
     }
     else if (options_vars["propagator"].as<string>() == "scc") {
         SCCOptions options{};
         options.enable_comments = false;
-        p.post(CircuitSCC{succ, false, options});
+        p.post_named(CircuitSCC{succ, false, options}, "circuit_scc");
     }
     else {
-        p.post(Circuit{succ, false});
+        p.post_named(Circuit{succ, false}, "circuit");
     }
 
     // Minimise the distance between any two stops
     auto max_leg = p.create_integer_variable(0_i, 100_i, "max_leg");
     for (int loc1 = 0; loc1 < n; loc1++) {
         for (int loc2 = 0; loc2 < n; loc2++) {
-            p.post(LessThanIf{ConstantIntegerVariableID{Integer{distance[loc1][loc2]}}, max_leg,
-                succ[loc1] == Integer{loc2}});
+            p.post_named(LessThanIf{ConstantIntegerVariableID{Integer{distance[loc1][loc2]}}, max_leg,
+                succ[loc1] == Integer{loc2}}, format("max_leg[{}][{}]", loc1, loc2));
         }
     }
 

--- a/examples/tutorial_proof/tutorial_proof.cc
+++ b/examples/tutorial_proof/tutorial_proof.cc
@@ -70,11 +70,11 @@ auto main(int argc, char * argv[]) -> int
     auto vb = p.create_integer_variable(1_i, 2_i, "b");
     auto vc = p.create_integer_variable(2_i, 3_i, "c");
     auto vd = p.create_integer_variable(2_i, 3_i, "d");
-    p.post(AllDifferent({va, vb, vc, vd}));
-    p.post(WeightedSum{} + 1_i * va + 1_i * vb + 1_i * vc <= 9_i);
+    p.post_named(AllDifferent({va, vb, vc, vd}), "all_different");
+    p.post_named(WeightedSum{} + 1_i * va + 1_i * vb + 1_i * vc <= 9_i, "sum_constraint");
 
     auto obj = p.create_integer_variable(0_i, 10000_i, "obj");
-    p.post(WeightedSum{} + 2_i * va + 3_i * vd == 1_i * obj);
+    p.post_named(WeightedSum{} + 2_i * va + 3_i * vd == 1_i * obj, "obj_constraint");
 
     p.minimise(obj);
     auto stats = solve_with(p,

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -9,7 +9,7 @@ using namespace gcs;
 Constraint::~Constraint() = default;
 
 namespace gcs {
-    auto as_string(const ConstraintName & name) -> std::string {
-        return visit([](const auto & n) { return n.as_string(); }, name);
+    auto as_string(const ConstraintID & constraint_id) -> std::string {
+        return visit([](const auto & id) { return id.as_string(); }, constraint_id);
     }
 }

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -24,6 +24,7 @@ namespace gcs
 
     struct CurrentlyUnnamedConstraint final
     {
+        [[nodiscard]] auto operator<=>(const CurrentlyUnnamedConstraint &) const = default;
         [[nodiscard]] auto as_string() const -> std::string { return "unnamed"; }
     };
 
@@ -41,9 +42,14 @@ namespace gcs
         [[nodiscard]] auto as_string() const -> std::string { return name; }
     };
 
-    using ConstraintName = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
+    using ConstraintID = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
 
-    [[nodiscard]] auto as_string(const ConstraintName &) -> std::string;
+    [[nodiscard]] auto as_string(const ConstraintID &) -> std::string;
+
+    inline auto operator<<(std::ostream & os, const ConstraintID & constraint_id) -> std::ostream &
+    {
+        return os << as_string(constraint_id);
+    }
 
     /**
      * \brief Subclasses of Constraint give a high level way of defining
@@ -60,9 +66,9 @@ namespace gcs
     class [[nodiscard]] Constraint
     {
     protected:
-        ConstraintName _name;
-        Constraint() : _name(CurrentlyUnnamedConstraint{}) {};
-        explicit Constraint(ConstraintName name) : _name(std::move(name)) {};
+        ConstraintID _constraint_id;
+        Constraint() = default; // defaults to CurrentlyUnnamedConstraint{}
+        explicit Constraint(ConstraintID constraint_id) : _constraint_id(std::move(constraint_id)) {};
         virtual auto define_proof_model(innards::ProofModel &) -> void {};
         virtual auto install_propagators(innards::Propagators &) -> void {};
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool
@@ -72,8 +78,9 @@ namespace gcs
 
     public:
         virtual ~Constraint() = 0;
-        [[nodiscard]] auto name() const -> const ConstraintName & { return _name; }
-        auto set_name(ConstraintName name) -> void { _name = std::move(name); }
+        [[nodiscard]] auto name() const -> const ConstraintID & { return _constraint_id; }
+        auto set_constraint_id(ConstraintID constraint_id) -> void { _constraint_id = std::move(constraint_id); }
+        auto get_constraint_id() const -> const ConstraintID & { return _constraint_id; }
         /**
          * Called internally to install the constraint. A Constraint is expected
          * to define zero or more propagators, and to provide a description of
@@ -99,20 +106,20 @@ namespace gcs
 // The following is needed to allow ConstraintName to be used in format strings.
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 template <>
-struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
+struct std::formatter<gcs::ConstraintID> : std::formatter<std::string>
 {
-    auto format(const gcs::ConstraintName & name, std::format_context & ctx) const
+    auto format(const gcs::ConstraintID & constraint_id, std::format_context & ctx) const
     {
-        return std::formatter<std::string>::format(gcs::as_string(name), ctx);
+        return std::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
     }
 };
 #else
 template <>
-struct fmt::formatter<gcs::ConstraintName> : fmt::formatter<std::string>
+struct fmt::formatter<gcs::ConstraintID> : fmt::formatter<std::string>
 {
-    auto format(const gcs::ConstraintName & name, fmt::format_context & ctx) const
+    auto format(const gcs::ConstraintID & constraint_id, fmt::format_context & ctx) const
     {
-        return fmt::formatter<std::string>::format(gcs::as_string(name), ctx);
+        return fmt::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
     }
 };
 #endif

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -90,8 +90,10 @@ auto Abs::install(Propagators & propagators, State &, ProofModel * const optiona
 
 auto Abs::define_proof_model(ProofModel & model) -> void
 {
-    _abs_nonneg_lines = model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-    _abs_neg_lines = model.add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
+    // _abs_nonneg_lines = model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
+    // _abs_neg_lines = model.add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
+    _abs_nonneg_lines = model.add_labelled_constraint(_constraint_id, "posge", "posle", "Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
+    _abs_neg_lines = model.add_labelled_constraint(_constraint_id, "negle", "negge", "Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
 }
 
 auto Abs::install_propagators(Propagators & propagators) -> void
@@ -297,7 +299,7 @@ auto Abs::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} abs", _name);
+    print(s, "{} abs", _constraint_id);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
 

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -90,10 +90,12 @@ auto Abs::install(Propagators & propagators, State &, ProofModel * const optiona
 
 auto Abs::define_proof_model(ProofModel & model) -> void
 {
-    // _abs_nonneg_lines = model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-    // _abs_neg_lines = model.add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
-    _abs_nonneg_lines = model.add_labelled_constraint(_constraint_id, "posge", "posle", "Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-    _abs_neg_lines = model.add_labelled_constraint(_constraint_id, "negle", "negge", "Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
+    _abs_nonneg_lines = model.add_labelled_constraint(
+        _constraint_id, "posle", "posge", "Abs", "non-negative", 
+        WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
+    _abs_neg_lines = model.add_labelled_constraint(
+        _constraint_id, "negle", "negge", "Abs", "negative", 
+        WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
 }
 
 auto Abs::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/abs_test.cc
+++ b/gcs/constraints/abs_test.cc
@@ -59,9 +59,9 @@ auto run_abs_test(bool proofs, variant<int, pair<int, int>> v1_range, variant<in
     Problem p;
     auto v1 = visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, v1_range);
     auto v2 = visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, v2_range);
-    p.post(Abs{v1, v2});
+    p.post_named(Abs{v1, v2}, "abstest");
 
-    auto proof_name = proofs ? make_optional("abs_test") : nullopt;
+    auto proof_name = proofs ? make_optional("abstest") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2});
 
     check_results(proof_name, expected, actual);
@@ -81,7 +81,7 @@ auto run_abs_initialiser_test(const string & label, pair<int, int> v1_range, pai
     Problem p;
     auto v1 = p.create_integer_variable(Integer{v1_range.first}, Integer{v1_range.second});
     auto v2 = p.create_integer_variable(Integer{v2_range.first}, Integer{v2_range.second});
-    p.post(Abs{v1, v2});
+    p.post_named(Abs{v1, v2}, "absinit");
 
     check_initialisation_only_for_tests(p, "abs_initialiser_" + label);
 }

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -206,7 +206,7 @@ auto AllDifferentExcept::s_exprify(const ProofModel * const model) const -> stri
 {
     stringstream s;
 
-    print(s, "{} all_different_except (", _name);
+    print(s, "{} all_different_except (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -44,10 +44,10 @@ auto gcs::innards::define_labelled_clique_not_equals_encoding(
     for (unsigned i = 0; i < vars.size(); ++i)
         for (unsigned j = i + 1; j < vars.size(); ++j) {
             auto selector = model.create_proof_flag("notequals");
-            auto role_gt = "[" + to_string(i+1) + "]gt[" + to_string(j+1) + "]";
-            auto role_lt = "[" + to_string(i+1) + "]lt[" + to_string(j+1) + "]";
-            model.add_labelled_constraint(constraint_id, role_gt, "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
-            model.add_labelled_constraint(constraint_id, role_lt, "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
+            auto role_gt = to_string(i+1) + "gt" + to_string(j+1);
+            auto role_lt = to_string(i+1) + "lt" + to_string(j+1);
+            model.add_labelled_constraint(constraint_id, role_lt, "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
+            model.add_labelled_constraint(constraint_id, role_gt, "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
 
             if (vars[i] == vars[j] && ! duplicate_witness)
                 duplicate_witness = pair{vars[i], selector};

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -4,12 +4,15 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 
+#include <string>
 #include <utility>
 
 using std::map;
 using std::move;
 using std::optional;
 using std::pair;
+using std::string;
+using std::to_string;
 using std::vector;
 
 using namespace gcs;
@@ -24,6 +27,27 @@ auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const v
             auto selector = model.create_proof_flag("notequals");
             model.add_constraint("AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
             model.add_constraint("AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
+
+            if (vars[i] == vars[j] && ! duplicate_witness)
+                duplicate_witness = pair{vars[i], selector};
+        }
+
+    return duplicate_witness;
+}
+
+auto gcs::innards::define_labelled_clique_not_equals_encoding(
+    ConstraintID constraint_id,
+    ProofModel & model, const vector<gcs::IntegerVariableID> & vars) -> optional<pair<IntegerVariableID, ProofFlag>>
+{
+    optional<pair<IntegerVariableID, ProofFlag>> duplicate_witness;
+
+    for (unsigned i = 0; i < vars.size(); ++i)
+        for (unsigned j = i + 1; j < vars.size(); ++j) {
+            auto selector = model.create_proof_flag("notequals");
+            auto role_gt = "[" + to_string(i+1) + "]gt[" + to_string(j+1) + "]";
+            auto role_lt = "[" + to_string(i+1) + "]lt[" + to_string(j+1) + "]";
+            model.add_labelled_constraint(constraint_id, role_gt, "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
+            model.add_labelled_constraint(constraint_id, role_lt, "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
 
             if (vars[i] == vars[j] && ! duplicate_witness)
                 duplicate_witness = pair{vars[i], selector};

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -4,6 +4,12 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#else
+#include <fmt/core.h>
+#endif
+
 #include <string>
 #include <utility>
 
@@ -12,8 +18,13 @@ using std::move;
 using std::optional;
 using std::pair;
 using std::string;
-using std::to_string;
 using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
+#else
+using fmt::format;
+#endif
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -44,10 +55,16 @@ auto gcs::innards::define_labelled_clique_not_equals_encoding(
     for (unsigned i = 0; i < vars.size(); ++i)
         for (unsigned j = i + 1; j < vars.size(); ++j) {
             auto selector = model.create_proof_flag("notequals");
-            auto role_gt = to_string(i+1) + "gt" + to_string(j+1);
-            auto role_lt = to_string(i+1) + "lt" + to_string(j+1);
-            model.add_labelled_constraint(constraint_id, role_lt, "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
-            model.add_labelled_constraint(constraint_id, role_gt, "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
+            model.add_labelled_constraint(
+                constraint_id, format("lt[{}][{}]", i+1, j+1),
+                "AllDifferent", "not equals because lower",
+                WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i,
+                HalfReifyOnConjunctionOf{selector});
+            model.add_labelled_constraint(
+                constraint_id, format("gt[{}][{}]", i+1, j+1),
+                "AllDifferent", "not equals because higher",
+                WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i,
+                HalfReifyOnConjunctionOf{! selector});
 
             if (vars[i] == vars[j] && ! duplicate_witness)
                 duplicate_witness = pair{vars[i], selector};

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -31,6 +31,11 @@ namespace gcs
         auto define_clique_not_equals_encoding(ProofModel & model,
             const std::vector<IntegerVariableID> & vars) -> std::optional<std::pair<IntegerVariableID, ProofFlag>>;
 
+        auto define_labelled_clique_not_equals_encoding(
+            ConstraintID constraint_id,
+            ProofModel & model, const std::vector<IntegerVariableID> & vars) 
+            -> std::optional<std::pair<IntegerVariableID, ProofFlag>>;
+
         // Emits the AllDifferentExcept clique encoding. Where the same variable
         // appears more than once in `vars`, the resulting pair-of-half-reified
         // constraints implies that variable must take a value in `excluded`;

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -623,7 +623,7 @@ auto GACAllDifferent::prepare(Propagators &, State & initial_state, ProofModel *
 
 auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    _duplicate_witness = define_clique_not_equals_encoding(model, _sanitised_vars);
+    _duplicate_witness = define_labelled_clique_not_equals_encoding(_constraint_id, model, _sanitised_vars);
 }
 
 auto GACAllDifferent::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -670,7 +670,7 @@ auto GACAllDifferent::s_exprify(const innards::ProofModel * const model) const -
 {
     stringstream s;
 
-    print(s, "{} all_different (", _name);
+    print(s, "{} all_different (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -185,7 +185,7 @@ auto SymmetricAllDifferent::s_exprify(const ProofModel * const model) const -> s
 {
     stringstream s;
 
-    print(s, "{} symmetric_all_different (", _name);
+    print(s, "{} symmetric_all_different (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", _start);

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -172,7 +172,7 @@ auto VCAllDifferent::s_exprify(const innards::ProofModel * const model) const ->
 {
     stringstream s;
 
-    print(s, "{} all_different (", _name);
+    print(s, "{} all_different (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/all_different_test.cc
+++ b/gcs/constraints/all_different_test.cc
@@ -71,7 +71,7 @@ auto run_all_different_test(bool proofs, variant<int, pair<int, int>> v1_range, 
     auto v4 = visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, v4_range);
     auto v5 = visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, v5_range);
     auto v6 = visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, v6_range);
-    p.post(AllDifferent{vector<IntegerVariableID>{v1, v2, v3, v4, v5, v6}});
+    p.post_named(AllDifferent{vector<IntegerVariableID>{v1, v2, v3, v4, v5, v6}}, "ad_test");
 
     auto proof_name = proofs ? make_optional("all_different_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3, v4, v5, v6});

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -66,7 +66,7 @@ auto AllEqual::define_proof_model(ProofModel & model) -> void
 {
     for (size_t i = 0; i + 1 < _vars.size(); ++i)
         model.add_labelled_constraint(_constraint_id,
-            "fwd_" + to_string(i), "back_" + to_string(i), "AllEqual", "chain step",
+            "fwd[" + to_string(i+1) + "]", "back[" + to_string(i+1) + "]", "AllEqual", "chain step",
             WPBSum{} + 1_i * _vars[i] + -1_i * _vars[i + 1] == 0_i);
 }
 

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 
+#include <iostream>
 #include <memory>
 #include <sstream>
 #include <utility>
@@ -25,6 +26,7 @@ using std::make_unique;
 using std::move;
 using std::string;
 using std::stringstream;
+using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
@@ -63,7 +65,8 @@ auto AllEqual::prepare(Propagators &, State &, ProofModel * const) -> bool
 auto AllEqual::define_proof_model(ProofModel & model) -> void
 {
     for (size_t i = 0; i + 1 < _vars.size(); ++i)
-        model.add_constraint("AllEqual", "chain step",
+        model.add_labelled_constraint(_constraint_id,
+            "fwd_" + to_string(i), "back_" + to_string(i), "AllEqual", "chain step",
             WPBSum{} + 1_i * _vars[i] + -1_i * _vars[i + 1] == 0_i);
 }
 

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -153,7 +153,7 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
 auto AllEqual::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} all_equal", _name);
+    print(s, "{} all_equal", _constraint_id);
     for (const auto & v : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     return s.str();

--- a/gcs/constraints/all_equal_test.cc
+++ b/gcs/constraints/all_equal_test.cc
@@ -64,7 +64,7 @@ auto run_test(bool proofs, const vector<pair<int, int>> & domains) -> void
     vector<IntegerVariableID> vars;
     for (const auto & d : domains)
         vars.push_back(p.create_integer_variable(Integer(d.first), Integer(d.second)));
-    p.post(AllEqual{vars});
+    p.post_named(AllEqual{vars}, "all_eq_test");
 
     auto proof_name = proofs ? make_optional("all_equal_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
@@ -110,7 +110,7 @@ auto run_holes_test(bool proofs) -> void
     p.post(In{x, to_integers(dx)});
     p.post(In{y, to_integers(dy)});
     p.post(In{z, to_integers(dz)});
-    p.post(AllEqual{vector<IntegerVariableID>{x, y, z}});
+    p.post_named(AllEqual{vector<IntegerVariableID>{x, y, z}}, "all_equal_test_holes");
 
     auto proof_name = proofs ? make_optional("all_equal_test_holes") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{x, y, z});

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -92,7 +92,7 @@ auto Among::define_proof_model(ProofModel & model) -> void
     for (auto & var : _vars)
         for (auto & val : _values_of_interest)
             sum += 1_i * (var == val);
-    _sum_line = model.add_constraint("Among", "how many", sum == 1_i * _how_many);
+    _sum_line = model.add_labelled_constraint(_constraint_id, "ge", "le", "Among", "how many", sum == 1_i * _how_many);
 }
 
 auto Among::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -275,7 +275,7 @@ auto Among::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} among (", _name);
+    print(s, "{} among (", _constraint_id);
     for (const auto & var : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     }

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -92,7 +92,7 @@ auto Among::define_proof_model(ProofModel & model) -> void
     for (auto & var : _vars)
         for (auto & val : _values_of_interest)
             sum += 1_i * (var == val);
-    _sum_line = model.add_labelled_constraint(_constraint_id, "ge", "le", "Among", "how many", sum == 1_i * _how_many);
+    _sum_line = model.add_labelled_constraint(_constraint_id, "le", "ge", "Among", "how many", sum == 1_i * _how_many);
 }
 
 auto Among::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/among_test.cc
+++ b/gcs/constraints/among_test.cc
@@ -72,7 +72,7 @@ auto run_among_test(bool proofs, variant<int, pair<int, int>> result_range, cons
     vector<Integer> voi_i;
     for (const auto & v : voi)
         voi_i.push_back(Integer(v));
-    p.post(Among{array, voi_i, result});
+    p.post_named(Among{array, voi_i, result}, "among_test");
 
     auto proof_name = proofs ? make_optional("among_test") : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual, tuple{pair{result, CheckConsistency::GAC}, pair{array, CheckConsistency::GAC}});

--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -123,7 +123,7 @@ auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) cons
     case ArithmeticOperator::Power: op_str = "power"; break;
     }
     stringstream s;
-    print(s, "({} {} {} {} {})", _name, op_str,
+    print(s, "({} {} {} {} {})", _constraint_id, op_str,
         model->names_and_ids_tracker().s_expr_name_of(_v1),
         model->names_and_ids_tracker().s_expr_name_of(_v2),
         model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -123,7 +123,7 @@ auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) cons
     case ArithmeticOperator::Power: op_str = "power"; break;
     }
     stringstream s;
-    print(s, "({} {} {} {} {})", _constraint_id, op_str,
+    print(s, "{} {} {} {} {}", _constraint_id, op_str,
         model->names_and_ids_tracker().s_expr_name_of(_v1),
         model->names_and_ids_tracker().s_expr_name_of(_v2),
         model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -26,6 +26,7 @@ using std::make_optional;
 using std::move;
 using std::string;
 using std::stringstream;
+using std::to_string;
 using std::tuple;
 using std::unique_ptr;
 using std::vector;
@@ -68,16 +69,23 @@ auto AtMostOne::install(Propagators & propagators, State & initial_state, ProofM
 
 auto AtMostOne::define_proof_model(ProofModel & model) -> void
 {
+    // I'm using a counter to ensure labels are unique.  I don't see any
+    // mention of this in the semantics paper, so almost certainly wrong.
+    auto counter = 0;
+    
     // For each var_i: define flag_i ⇔ (var_i = _val) via a Count-style
     // gt/lt/eq triple, then post sum_i flag_i ≤ 1.
     for (auto & var : _vars) {
-        auto var_minus_val_gt_0 = model.create_proof_flag_fully_reifying("am1g",
+        auto var_minus_val_gt_0 = model.create_labelled_proof_flag_fully_reifying(
+            _constraint_id, to_string(++counter) + "][gt", "am1g",
             "AtMostOne", "var greater", WPBSum{} + 1_i * var + -1_i * _val >= 1_i);
 
-        auto var_minus_val_lt_0 = model.create_proof_flag_fully_reifying("am1l",
+        auto var_minus_val_lt_0 = model.create_labelled_proof_flag_fully_reifying(
+            _constraint_id, to_string(counter) + "][lt", "am1l",
             "AtMostOne", "var less", WPBSum{} + 1_i * var + -1_i * _val <= -1_i);
 
-        auto eq = model.create_proof_flag_fully_reifying("am1eq",
+        auto eq = model.create_labelled_proof_flag_fully_reifying(
+            _constraint_id, to_string(counter) + "][eq", "am1eq",
             "AtMostOne", "var equal val", WPBSum{} + 1_i * ! var_minus_val_gt_0 + 1_i * ! var_minus_val_lt_0 >= 2_i);
 
         _flags.emplace_back(eq, var_minus_val_gt_0, var_minus_val_lt_0);
@@ -86,7 +94,7 @@ auto AtMostOne::define_proof_model(ProofModel & model) -> void
     WPBSum sum;
     for (auto & [flag, _gt, _lt] : _flags)
         sum += 1_i * flag;
-    model.add_constraint("AtMostOne", "at most one match", sum <= 1_i);
+    model.add_labelled_constraint(_constraint_id, "sum", "AtMostOne", "at most one match", sum <= 1_i);
 }
 
 auto AtMostOne::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -148,7 +148,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
 auto AtMostOne::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} at_most_one (", _name);
+    print(s, "{} at_most_one (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));
@@ -198,7 +198,7 @@ auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_sta
 auto AtMostOneSmartTable::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} at_most_one_smart_table (", _name);
+    print(s, "{} at_most_one_smart_table (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));

--- a/gcs/constraints/at_most_one_test.cc
+++ b/gcs/constraints/at_most_one_test.cc
@@ -70,9 +70,9 @@ auto run_at_most_one_test(Variant variant, bool proofs,
         vars.push_back(p.create_integer_variable(Integer(l), Integer(u)));
     auto val = p.create_integer_variable(Integer(val_range.first), Integer(val_range.second));
     if (variant == Variant::Native)
-        p.post(AtMostOne{vars, val});
+        p.post_named(AtMostOne{vars, val}, "at_most_one_test");
     else
-        p.post(AtMostOneSmartTable{vars, val});
+        p.post_named(AtMostOneSmartTable{vars, val}, "at_most_one_test_smart_table");
 
     auto proof_name = proofs ? make_optional("at_most_one_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars, val});
@@ -118,7 +118,7 @@ auto main(int, char *[]) -> int
     random_device rand_dev;
     mt19937 rand(rand_dev());
 
-    for (auto variant : {Variant::Native, Variant::SmartTable}) {
+    for (auto variant : {Variant::SmartTable, Variant::Native}) {
         for (bool proofs : {false, true}) {
             if (proofs && ! can_run_veripb())
                 continue;

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -177,12 +177,13 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
         // Define encoding to eliminate sub-cycles
         // Need extra proof variable: pos[i] = j means "the ith node visited in the circuit is the jth var"
         // WLOG start at node 0, so pos[0] = 0
-        pos_var_data.emplace(0,
-            PosVarData{"p[0]", model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits), map<long, PosVarLineData>{}});
+        pos_var_data.emplace(0, PosVarData{"p[0]", 
+            model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos[0]", IntegerVariableProofRepresentation::Bits),
+            map<long, PosVarLineData>{}});
         model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
         // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
         auto [leq_line, geq_line] = model->add_labelled_constraint(
-            _constraint_id, "le_0_0", "ge_0_0",
+            _constraint_id, "le[0][0]", "ge[0][0]",
             "Circuit", "sub-cycle prevention",
             WPBSum{} == Integer{n - 1},
             HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
@@ -190,17 +191,15 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
         pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line.value(), geq_line.value()});
 
         for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
-            pos_var_data.emplace(idx,
-                PosVarData{format("p[{}]", idx),
-                    model->create_proof_only_integer_variable(0_i, Integer{n - 1}, format("pos{}", idx),
-                        IntegerVariableProofRepresentation::Bits),
-                    map<long, PosVarLineData>{}});
+            pos_var_data.emplace(idx, PosVarData{format("p[{}]", idx),
+                model->create_proof_only_integer_variable(0_i, Integer{n - 1}, format("pos[{}]", idx), IntegerVariableProofRepresentation::Bits),
+                map<long, PosVarLineData>{}});
         }
 
         for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
             // (succ[0] = i) -> pos[i] - pos[0] = 1
             tie(leq_line, geq_line) = model->add_labelled_constraint(
-                _constraint_id, format("le_0_{}", idx), format("ge_0_{}", idx),
+                _constraint_id, format("le[0][{}]", idx), format("ge[0][{}]", idx),
                 "Circuit", "sub-cycle prevention",
                 WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i,
                 HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
@@ -208,7 +207,7 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 
             // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
             tie(leq_line, geq_line) = model->add_labelled_constraint(
-                _constraint_id, format("le_{}_0", idx), format("ge_{}_0", idx),
+                _constraint_id, format("le[{}][0]", idx), format("ge[{}][0]", idx),
                 "Circuit", "sub-cycle prevention",
                 WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
                 HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
@@ -217,7 +216,7 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
             // (succ[i] = j) -> pos[j] = pos[i] + 1
             for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
                 tie(leq_line, geq_line) = model->add_labelled_constraint(
-                    _constraint_id, format("le_{}_{}", idx, jdx), format("ge_{}_{}", idx, jdx),
+                    _constraint_id, format("le[{}][{}]", idx, jdx), format("ge[{}][{}]", idx, jdx),
                     "Circuit", "sub-cycle prevention",
                     WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
                     HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -236,7 +236,7 @@ auto CircuitBase::s_exprify(const innards::ProofModel * const model) const -> st
 {
     stringstream s;
 
-    print(s, "{} circuit (", _name);
+    print(s, "{} circuit (", _constraint_id);
     for (const auto & var : _succ)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -166,7 +166,7 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
     else {
         // Still need to define the all different encoding.
         if (model)
-            define_clique_not_equals_encoding(*model, _succ);
+            define_labelled_clique_not_equals_encoding(_constraint_id, *model, _succ);
     }
 
     // Define encoding to eliminate sub-cycles
@@ -181,7 +181,9 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
             PosVarData{"p[0]", model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits), map<long, PosVarLineData>{}});
         model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
         // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
-        auto [leq_line, geq_line] = model->add_constraint(
+        auto [leq_line, geq_line] = model->add_labelled_constraint(
+            _constraint_id, "le_0_0", "ge_0_0",
+            "Circuit", "sub-cycle prevention",
             WPBSum{} == Integer{n - 1},
             HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
 
@@ -190,27 +192,33 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
         for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
             pos_var_data.emplace(idx,
                 PosVarData{format("p[{}]", idx),
-                    model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0",
+                    model->create_proof_only_integer_variable(0_i, Integer{n - 1}, format("pos{}", idx),
                         IntegerVariableProofRepresentation::Bits),
                     map<long, PosVarLineData>{}});
         }
 
         for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
             // (succ[0] = i) -> pos[i] - pos[0] = 1
-            tie(leq_line, geq_line) = model->add_constraint(
+            tie(leq_line, geq_line) = model->add_labelled_constraint(
+                _constraint_id, format("le_0_{}", idx), format("ge_0_{}", idx),
+                "Circuit", "sub-cycle prevention",
                 WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i,
                 HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
             pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line.value(), geq_line.value()});
 
             // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
-            tie(leq_line, geq_line) = model->add_constraint(
+            tie(leq_line, geq_line) = model->add_labelled_constraint(
+                _constraint_id, format("le_{}_0", idx), format("ge_{}_0", idx),
+                "Circuit", "sub-cycle prevention",
                 WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
                 HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
             pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line.value(), geq_line.value()});
 
             // (succ[i] = j) -> pos[j] = pos[i] + 1
             for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
-                tie(leq_line, geq_line) = model->add_constraint(
+                tie(leq_line, geq_line) = model->add_labelled_constraint(
+                    _constraint_id, format("le_{}_{}", idx, jdx), format("ge_{}_{}", idx, jdx),
+                    "Circuit", "sub-cycle prevention",
                     WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
                     HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
                 pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line.value(), geq_line.value()});

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -76,26 +76,26 @@ auto ReifiedCompareLessThanOrMaybeEqual::prepare(Propagators &, State & initial_
 
 auto ReifiedCompareLessThanOrMaybeEqual::define_proof_model(ProofModel & model) -> void
 {
-    auto do_less = [&](IntegerVariableID v1, IntegerVariableID v2, optional<HalfReifyOnConjunctionOf> cond, bool or_equal, const StringLiteral & rule) {
-        model.add_constraint("ReifiedCompareLessThanOrMaybeEqual", rule, WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i), cond);
+    auto do_less = [&](IntegerVariableID v1, IntegerVariableID v2, optional<HalfReifyOnConjunctionOf> cond, bool or_equal, const StringLiteral & rule, const string & role) {
+        model.add_labelled_constraint(_constraint_id, role, "ReifiedCompareLessThanOrMaybeEqual", rule, WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i), cond);
     };
 
     overloaded{
         [&](const reif::MustHold &) {
-            do_less(_v1, _v2, nullopt, _or_equal, "condition true");
+            do_less(_v1, _v2, nullopt, _or_equal, "condition true", "");
         },
         [&](const reif::MustNotHold &) {
-            do_less(_v2, _v1, nullopt, ! _or_equal, "condition false");
+            do_less(_v2, _v1, nullopt, ! _or_equal, "condition false", "");
         },
         [&](const reif::If & cond) {
-            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
+            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition", "");
         },
         [&](const reif::NotIf & cond) {
-            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{cond.cond}}, ! _or_equal, "if condition");
+            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{cond.cond}}, ! _or_equal, "if condition", "");
         },
         [&](const reif::Iff & cond) {
-            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
-            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{! cond.cond}}, ! _or_equal, "if not condition");
+            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition", "if");
+            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{! cond.cond}}, ! _or_equal, "if not condition", "not_if");
         }}
         .visit(_reif_cond);
 }

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -208,12 +208,12 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const mode
         reif);
 
     if (reif.empty()) {
-        print(s, "{} {} {} {}", _name, cmp,
+        print(s, "{} {} {} {}", _constraint_id, cmp,
             model->names_and_ids_tracker().s_expr_name_of(_v1),
             model->names_and_ids_tracker().s_expr_name_of(_v2));
     }
     else {
-        print(s, "{} {} {} {} {}", _name, cmp,
+        print(s, "{} {} {} {} {}", _constraint_id, cmp,
             model->names_and_ids_tracker().s_expr_name_of(_reif_cond),
             model->names_and_ids_tracker().s_expr_name_of(_v1),
             model->names_and_ids_tracker().s_expr_name_of(_v2));

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -203,7 +203,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const mode
                     .visit(_reif_cond);
 
     string cmp = format("{}{}{}",
-        _vars_swapped ? "greater_than" : "less_than",
+        _vars_swapped ? "greater" : "less",
         _or_equal ? "_equal" : "",
         reif);
 

--- a/gcs/constraints/comparison_test.cc
+++ b/gcs/constraints/comparison_test.cc
@@ -159,7 +159,7 @@ auto run_reif_binary_comparison_test(bool proofs, const string & mode, variant<i
         auto v1 = visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, v1_range);
         auto v2 = visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, v2_range);
         auto v3 = p.create_integer_variable(Integer(v3_range.first), Integer(v3_range.second), "c");
-        p.post(Constraint_{v1, v2, v3 == 1_i});
+        p.post_named(Constraint_{v1, v2, v3 == 1_i}, "comparison_test");
 
         auto proof_name = proofs ? make_optional("comparison_test_" + mode) : nullopt;
         solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3});

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -86,7 +86,7 @@ auto Count::define_proof_model(ProofModel & model) -> void
         how_many_sum += 1_i * flag;
     how_many_sum += -1_i * _how_many;
 
-    model.add_labelled_constraint(_constraint_id, "ge", "le", "Count", "sum of flags", how_many_sum == 0_i);
+    model.add_labelled_constraint(_constraint_id, "le", "ge", "Count", "sum of flags", how_many_sum == 0_i);
 }
 
 auto Count::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -27,6 +27,7 @@ using namespace gcs::innards;
 using std::optional;
 using std::string;
 using std::stringstream;
+using std::to_string;
 using std::tuple;
 using std::unique_ptr;
 using std::vector;
@@ -62,17 +63,18 @@ auto Count::install(Propagators & propagators, State & initial_state, ProofModel
 
 auto Count::define_proof_model(ProofModel & model) -> void
 {
+    auto count = 0;
     for (auto & var : _vars) {
         // var_minus_val_gt_0 ⇔ var > val
-        auto var_minus_val_gt_0 = model.create_proof_flag_fully_reifying("countg",
+        auto var_minus_val_gt_0 = model.create_labelled_proof_flag_fully_reifying(_constraint_id, to_string(++count) + "][ge", "countg",
             "Count", "var greater", WPBSum{} + 1_i * var + -1_i * _value_of_interest >= 1_i);
 
         // var_minus_val_lt_0 ⇔ var < val
-        auto var_minus_val_lt_0 = model.create_proof_flag_fully_reifying("countl",
+        auto var_minus_val_lt_0 = model.create_labelled_proof_flag_fully_reifying(_constraint_id, to_string(count) + "][le", "countl",
             "Count", "var less", WPBSum{} + 1_i * var + -1_i * _value_of_interest <= -1_i);
 
         // flag ⇔ var = val (encoded as ¬gt ∧ ¬lt)
-        auto flag = model.create_proof_flag_fully_reifying("count",
+        auto flag = model.create_labelled_proof_flag_fully_reifying(_constraint_id, to_string(count) + "][eq", "counteq",
             "Count", "var equal", WPBSum{} + 1_i * ! var_minus_val_gt_0 + 1_i * ! var_minus_val_lt_0 >= 2_i);
 
         _flags.emplace_back(flag, var_minus_val_gt_0, var_minus_val_lt_0);
@@ -84,7 +86,7 @@ auto Count::define_proof_model(ProofModel & model) -> void
         how_many_sum += 1_i * flag;
     how_many_sum += -1_i * _how_many;
 
-    model.add_constraint("Count", "sum of flags", how_many_sum == 0_i);
+    model.add_labelled_constraint(_constraint_id, "ge", "le", "Count", "sum of flags", how_many_sum == 0_i);
 }
 
 auto Count::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -237,7 +237,7 @@ auto Count::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} count (", _name);
+    print(s, "{} count (", _constraint_id);
     for (const auto & v : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/count_test.cc
+++ b/gcs/constraints/count_test.cc
@@ -66,7 +66,7 @@ auto run_count_test(bool proofs, variant<int, pair<int, int>> result_range, vari
     vector<IntegerVariableID> array;
     for (const auto & entry : array_range)
         array.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
-    p.post(Count{array, voi, result});
+    p.post_named(Count{array, voi, result}, "count_test");
 
     auto proof_name = proofs ? make_optional("count_test") : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual, tuple{pair{voi, CheckConsistency::GAC}, pair{result, CheckConsistency::GAC}, pair{array, CheckConsistency::None}});

--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -32,8 +32,10 @@ using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
+using std::format;
 #else
 using fmt::print;
+using fmt::format;
 #endif
 
 Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<Integer> lengths,
@@ -114,13 +116,16 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
         if (first || t_hi > global_hi) global_hi = t_hi;
         first = false;
         for (Integer t = t_lo; t <= t_hi; ++t) {
-            auto before = model.create_proof_flag_fully_reifying(
+            auto before = model.create_labelled_proof_flag_fully_reifying(
+                _constraint_id, format("before_{{{}_{}}}", i+1, t),
                 "cumbefore", "Cumulative", "starts at or before time",
                 WPBSum{} + 1_i * _starts[i] <= t);
-            auto after = model.create_proof_flag_fully_reifying(
+            auto after = model.create_labelled_proof_flag_fully_reifying(
+                _constraint_id, format("after_{{{}_{}}}", i+1, t),
                 "cumafter", "Cumulative", "not yet finished at time",
                 WPBSum{} + 1_i * _starts[i] >= t - _lengths[i] + 1_i);
-            auto active = model.create_proof_flag_fully_reifying(
+            auto active = model.create_labelled_proof_flag_fully_reifying(
+                _constraint_id, format("active_{{{}_{}}}", i+1, t),
                 "cumactive", "Cumulative", "task active at time",
                 WPBSum{} + 1_i * before + 1_i * after >= 2_i);
             _before_flags[i].push_back(before);
@@ -140,7 +145,9 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
             any = true;
         }
         if (any) {
-            auto line = model.add_constraint("Cumulative", "load at time",
+            auto line = model.add_labelled_constraint(
+                _constraint_id, format("cap_{}", t), 
+                "Cumulative", "load at time",
                 load <= _capacity);
             if (line)
                 _capacity_lines.emplace(t, *line);

--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -117,15 +117,15 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
         first = false;
         for (Integer t = t_lo; t <= t_hi; ++t) {
             auto before = model.create_labelled_proof_flag_fully_reifying(
-                _constraint_id, format("before_{{{}_{}}}", i+1, t),
+                _constraint_id, format("before[{}][{}]", i+1, t),
                 "cumbefore", "Cumulative", "starts at or before time",
                 WPBSum{} + 1_i * _starts[i] <= t);
             auto after = model.create_labelled_proof_flag_fully_reifying(
-                _constraint_id, format("after_{{{}_{}}}", i+1, t),
+                _constraint_id, format("after[{}][{}]", i+1, t),
                 "cumafter", "Cumulative", "not yet finished at time",
                 WPBSum{} + 1_i * _starts[i] >= t - _lengths[i] + 1_i);
             auto active = model.create_labelled_proof_flag_fully_reifying(
-                _constraint_id, format("active_{{{}_{}}}", i+1, t),
+                _constraint_id, format("active[{}][{}]", i+1, t),
                 "cumactive", "Cumulative", "task active at time",
                 WPBSum{} + 1_i * before + 1_i * after >= 2_i);
             _before_flags[i].push_back(before);
@@ -146,7 +146,7 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
         }
         if (any) {
             auto line = model.add_labelled_constraint(
-                _constraint_id, format("cap_{}", t), 
+                _constraint_id, format("cap[{}]", t), 
                 "Cumulative", "load at time",
                 load <= _capacity);
             if (line)

--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -428,7 +428,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
 auto Cumulative::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} cumulative (", _name);
+    print(s, "{} cumulative (", _constraint_id);
     for (const auto & v : _starts)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     print(s, " ) ( ");

--- a/gcs/constraints/cumulative_test.cc
+++ b/gcs/constraints/cumulative_test.cc
@@ -92,7 +92,7 @@ namespace
         for (auto h : heights)
             heights_i.push_back(Integer{h});
 
-        p.post(Cumulative{starts, lengths_i, heights_i, Integer{capacity}});
+        p.post_named(Cumulative{starts, lengths_i, heights_i, Integer{capacity}}, "ct");
 
         auto proof_name = proofs ? make_optional("cumulative_test") : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{starts});

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -19,8 +19,10 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #endif
 
@@ -44,8 +46,10 @@ using std::unique_ptr;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -129,7 +133,8 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
     // bridge-derived at-most-one lemmas during justifications.
     auto emit_before = [&](size_t i, size_t j) -> BeforeFlagData {
         auto flag = model.create_proof_flag("disjbefore");
-        auto [fwd, rev] = model.add_two_way_reified_constraint(
+        auto [fwd, rev] = model.add_labelled_two_way_reified_constraint(
+            _constraint_id, format("before_{{{}_{}}}", i+1, j+1), 
             "Disjunctive", "first task finishes before second starts",
             WPBSum{} + 1_i * _starts[i] + -1_i * _starts[j] <= -_lengths[i],
             flag);
@@ -143,7 +148,9 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
             auto j = _active_tasks[b];
             auto data_ij = emit_before(i, j);
             auto data_ji = emit_before(j, i);
-            auto clause = model.add_constraint("Disjunctive", "one task must finish first",
+            auto clause = model.add_labelled_constraint(
+                _constraint_id, format("pair_{{{}_{}}}", i+1, j+1),
+                "Disjunctive", "one task must finish first",
                 WPBSum{} + 1_i * data_ij.flag + 1_i * data_ji.flag >= 1_i);
             if (! clause)
                 throw UnexpectedException{"Disjunctive: pairwise clause missing"};

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -687,7 +687,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 auto Disjunctive::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} disjunctive{} (", _name, _strict ? "_strict" : "");
+    print(s, "{} disjunctive{} (", _constraint_id, _strict ? "_strict" : "");
     for (const auto & v : _starts)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     print(s, " ) ( ");

--- a/gcs/constraints/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive_test.cc
@@ -86,7 +86,7 @@ namespace
         for (auto l : lengths)
             lengths_i.push_back(Integer{l});
 
-        p.post(Disjunctive{starts, lengths_i, strict});
+        p.post_named(Disjunctive{starts, lengths_i, strict}, "dis");
 
         auto proof_name = proofs ? make_optional("disjunctive_test_" + mode) : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{starts});

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -217,7 +217,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
                     return s;
                 }();
                 model.add_labelled_constraint(
-                    _constraint_id, format("ge_{{{}}}", idx), format("le_{{{}}}", idx),
+                    _constraint_id, format("le_{}", idx), format("ge_{}", idx),
                     "NDimensionalElement", "equality",
                     WPBSum{} + (1_i * _result_var) + (-1_i * array_var) == 0_i, reif);
             }

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -604,7 +604,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const ProofModel * 
         }
     };
 
-    print(s, "{} element (", _name);
+    print(s, "{} element (", _constraint_id);
 
     print_array(s, *_array, print_array);
 

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -217,7 +217,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
                     return s;
                 }();
                 model.add_labelled_constraint(
-                    _constraint_id, format("le_{}", idx), format("ge_{}", idx),
+                    _constraint_id, format("{}le", idx), format("{}ge", idx),
                     "NDimensionalElement", "equality",
                     WPBSum{} + (1_i * _result_var) + (-1_i * array_var) == 0_i, reif);
             }
@@ -590,10 +590,10 @@ auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const ProofModel * 
 
     auto print_elem = [&](auto & s, const auto & elem, const auto & index) {
         if constexpr (std::is_same_v<EntryType_, IntegerVariableID>) {
-            print(s, " {},{}", model->names_and_ids_tracker().s_expr_name_of(elem), index);
+            print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(elem));
         }
         else {
-            print(s, " {},{}", elem, index);
+            print(s, " {}", elem);
         }
     };
 
@@ -628,7 +628,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const ProofModel * 
     print(s, ")");
 
     for (size_t i = 0; i < _index_vars.size(); ++i) {
-        print(s, " ({},{})",
+        print(s, " ({} {})",
             model->names_and_ids_tracker().s_expr_name_of(_index_vars[i]),
             _index_starts[i]);
     }

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -15,8 +15,10 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #endif
 
@@ -38,12 +40,15 @@ using std::min;
 using std::optional;
 using std::string;
 using std::stringstream;
+using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -186,7 +191,9 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
         // file remains self-describing. The encoding's recursion over the
         // empty dimension would have produced no constraints at all, which
         // wouldn't capture the unsatisfiability.
-        model.add_constraint("NDimensionalElement", "zero-sized dimension", WPBSum{} >= 1_i);
+        model.add_labelled_constraint(
+            _constraint_id, "empty",
+            "NDimensionalElement", "zero-sized dimension", WPBSum{} >= 1_i);
         return;
     }
 
@@ -201,7 +208,17 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
             if (elem.size() == dimensions_) {
                 // this still works out fine if the variable is actually a constant
                 auto array_var = get_array_var<dimensions_>(elem, *_array);
-                model.add_constraint("NDimensionalElement", "equality",
+                auto idx = [&]() {
+                    string s;
+                    for (auto e : elem) {
+                        if (! s.empty()) s += "_";
+                        s += to_string(e);  // Zero-indexed
+                    }
+                    return s;
+                }();
+                model.add_labelled_constraint(
+                    _constraint_id, format("ge_{{{}}}", idx), format("le_{{{}}}", idx),
+                    "NDimensionalElement", "equality",
                     WPBSum{} + (1_i * _result_var) + (-1_i * array_var) == 0_i, reif);
             }
             else {

--- a/gcs/constraints/element_test.cc
+++ b/gcs/constraints/element_test.cc
@@ -69,7 +69,7 @@ auto run_element_test(bool proofs, const string & mode, pair<int, int> var_range
     vector<IntegerVariableID> array;
     for (const auto & [l, u] : array_range)
         array.push_back(p.create_integer_variable(Integer(l), Integer(u)));
-    p.post(Element{var, idx, &array});
+    p.post_named(Element{var, idx, &array}, "el");
 
     auto proof_name = proofs ? make_optional("element_test_" + mode) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{var, idx, array});
@@ -97,7 +97,7 @@ auto run_element_constant_test(bool proofs, const string & mode, pair<int, int> 
     vector<Integer> a;
     for (const auto & v : array)
         a.push_back(Integer(v));
-    p.post(ElementConstantArray{var, idx, &a});
+    p.post_named(ElementConstantArray{var, idx, &a}, "eca");
 
     auto proof_name = proofs ? make_optional("element_test_" + mode) : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual,
@@ -130,7 +130,7 @@ auto run_element2d_test(bool proofs, const string & mode, pair<int, int> var_ran
         for (const auto & [l, u] : v)
             a.back().push_back(p.create_integer_variable(Integer(l), Integer(u)));
     }
-    p.post(Element2D{var, idx1, idx2, &a});
+    p.post_named(Element2D{var, idx1, idx2, &a}, "el2d");
 
     auto proof_name = proofs ? make_optional("element_test_" + mode) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{var, idx1, idx2, a});
@@ -162,7 +162,7 @@ auto run_element2d_constant_test(bool proofs, const string & mode, pair<int, int
         for (const auto & vv : v)
             a.back().push_back(Integer(vv));
     }
-    p.post(Element2DConstantArray{var, idx1, idx2, &a});
+    p.post_named(Element2DConstantArray{var, idx1, idx2, &a}, "el2dc");
 
     auto proof_name = proofs ? make_optional("element_test_" + mode) : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual,

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -146,41 +146,41 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
 {
     overloaded{
         [&](const reif::MustHold &) {
-            model.add_constraint("ReifiedEquals", "equals option",
+            model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i);
         },
         [&](const reif::MustNotHold &) {
             auto gtflag = model.create_proof_flag("gt");
-            model.add_constraint("ReifiedEquals", "greater option",
+            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedEquals", "greater option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
-            model.add_constraint("ReifiedEquals", "less option",
+            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedEquals", "less option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! gtflag}});
         },
         [&](const reif::If & reif) {
-            model.add_constraint("ReifiedEquals", "equals option",
+            model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
         },
         [&](const reif::NotIf & reif) {
             auto gtflag = model.create_proof_flag("gt");
-            model.add_constraint("ReifiedEquals", "greater option",
+            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedEquals", "greater option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{reif.cond, gtflag}});
-            model.add_constraint("ReifiedEquals", "less option",
+            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedEquals", "less option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{reif.cond, ! gtflag}});
         },
         [&](const reif::Iff & reif) {
             // condition unknown, the condition implies it is neither greater nor less
-            model.add_constraint("ReifiedEquals", "equals option",
+            model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
 
             auto gtflag = model.create_proof_flag("gt");
-            model.add_constraint("ReifiedEquals", "greater option",
+            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedEquals", "greater option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
             auto ltflag = model.create_proof_flag("lt");
-            model.add_constraint("ReifiedEquals", "less option",
+            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedEquals", "less option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{ltflag}});
 
             // lt + eq + gt >= 1
-            model.add_constraint("ReifiedEquals", "one of less than, equals, greater than",
+            model.add_labelled_constraint(_constraint_id, "al1", "ReifiedEquals", "one of less than, equals, greater than",
                 WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * reif.cond >= 1_i);
         }}
         .visit(_cond);

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -150,11 +150,11 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i);
         },
         [&](const reif::MustNotHold &) {
-            auto gtflag = model.create_proof_flag("gt");
+            auto neflag = model.create_proof_flag("ne");
             model.add_labelled_constraint(_constraint_id, "gt", "ReifiedEquals", "greater option",
-                WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{neflag}});
             model.add_labelled_constraint(_constraint_id, "lt", "ReifiedEquals", "less option",
-                WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! gtflag}});
+                WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! neflag}});
         },
         [&](const reif::If & reif) {
             model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedEquals", "equals option",

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -146,7 +146,7 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
 {
     overloaded{
         [&](const reif::MustHold &) {
-            model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedEquals", "equals option",
+            model.add_labelled_constraint(_constraint_id, "lt", "gt", "ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i);
         },
         [&](const reif::MustNotHold &) {
@@ -157,7 +157,7 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! neflag}});
         },
         [&](const reif::If & reif) {
-            model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedEquals", "equals option",
+            model.add_labelled_constraint(_constraint_id, "lt", "gt", "ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
         },
         [&](const reif::NotIf & reif) {
@@ -169,7 +169,7 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
         },
         [&](const reif::Iff & reif) {
             // condition unknown, the condition implies it is neither greater nor less
-            model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedEquals", "equals option",
+            model.add_labelled_constraint(_constraint_id, "lt", "gt", "ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i, HalfReifyOnConjunctionOf{{reif.cond}});
 
             auto gtflag = model.create_proof_flag("gt");

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -302,7 +302,7 @@ auto ReifiedEquals::s_exprify(const innards::ProofModel * const model) const -> 
             return _neq ? "not_equals_iff" : "equals_iff";
         }}.visit(_cond);
 
-    print(s, "{} {}", _name, constraint_type);
+    print(s, "{} {}", _constraint_id, constraint_type);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_cond));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -123,18 +123,21 @@ auto In::define_proof_model(ProofModel & model) -> void
     // Mirrors the encoding used by Count. Full reification of every
     // proof flag is the project rule for new OPB encodings.
     for (const auto & [idx, V] : enumerate(_var_vals)) {
-        auto lt = model.create_proof_flag_fully_reifying(format("inlt{}", idx),
+        auto lt = model.create_labelled_proof_flag_fully_reifying(
+            _constraint_id, format("lt_{}", idx), format("inlt{}", idx),
             "In", "var less than", WPBSum{} + 1_i * _var + -1_i * V <= -1_i);
-        auto gt = model.create_proof_flag_fully_reifying(format("ingt{}", idx),
+        auto gt = model.create_labelled_proof_flag_fully_reifying(
+            _constraint_id, format("gt_{}", idx), format("ingt{}", idx),
             "In", "var greater than", WPBSum{} + 1_i * _var + -1_i * V >= 1_i);
-        auto sel = model.create_proof_flag_fully_reifying(format("in{}", idx),
+        auto sel = model.create_labelled_proof_flag_fully_reifying(
+            _constraint_id, format("sel_{}", idx), format("in{}", idx),
             "In", "var equal", WPBSum{} + 1_i * ! lt + 1_i * ! gt >= 2_i);
         _selectors.push_back(sel);
 
         sum += 1_i * sel;
     }
 
-    model.add_constraint("In", "var is one of these", sum >= 1_i);
+    model.add_labelled_constraint(_constraint_id, "al1", "In", "var is one of these", sum >= 1_i);
 }
 
 auto In::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -265,7 +265,7 @@ auto In::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} in {} (", _name, model->names_and_ids_tracker().s_expr_name_of(_var));
+    print(s, "{} in {} (", _constraint_id, model->names_and_ids_tracker().s_expr_name_of(_var));
     for (const auto & v : _var_vals)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     for (const auto & v : _val_vals)

--- a/gcs/constraints/in_test.cc
+++ b/gcs/constraints/in_test.cc
@@ -59,7 +59,7 @@ auto run_in_integer_vals_test(bool proofs, pair<int, int> var_range, vector<int>
     vector<Integer> vals;
     for (int v : allowed)
         vals.push_back(Integer(v));
-    p.post(In{var, vals});
+    p.post_named(In{var, vals}, "in_test");
 
     auto proof_name = proofs ? make_optional("in_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{var});
@@ -80,7 +80,7 @@ auto run_in_const_vars_test(bool proofs, pair<int, int> var_range, vector<int> a
     vector<IntegerVariableID> const_vars;
     for (int v : allowed)
         const_vars.push_back(ConstantIntegerVariableID{Integer(v)});
-    p.post(In{var, const_vars});
+    p.post_named(In{var, const_vars}, "in_test");
 
     auto proof_name = proofs ? make_optional("in_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{var});
@@ -107,7 +107,7 @@ auto run_in_mixed_test(bool proofs, pair<int, int> var_range, vector<int> const_
     vector<Integer> vals;
     for (int v : int_vals)
         vals.push_back(Integer(v));
-    p.post(In{var, const_vars, vals});
+    p.post_named(In{var, const_vars, vals}, "in_test");
 
     auto proof_name = proofs ? make_optional("in_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{var});
@@ -132,7 +132,7 @@ auto run_in_var_list_test(bool proofs, pair<int, int> var_range, const vector<pa
     vector<IntegerVariableID> vars;
     for (const auto & [l, u] : vars_ranges)
         vars.push_back(p.create_integer_variable(Integer(l), Integer(u)));
-    p.post(In{var, vars});
+    p.post_named(In{var, vars}, "in_test");
 
     auto proof_name = proofs ? make_optional("in_test") : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual,
@@ -164,7 +164,7 @@ auto run_in_var_list_mixed_test(bool proofs, pair<int, int> var_range, const vec
     vector<Integer> vals;
     for (int v : int_vals)
         vals.push_back(Integer(v));
-    p.post(In{var, vars, vals});
+    p.post_named(In{var, vars, vals}, "in_test");
 
     auto proof_name = proofs ? make_optional("in_test") : nullopt;
     solve_for_tests_checking_consistency(p, proof_name, expected, actual,
@@ -183,7 +183,7 @@ auto run_in_self_reference_test(bool proofs, pair<int, int> var_range) -> void
 
     Problem p;
     auto var = p.create_integer_variable(Integer(var_range.first), Integer(var_range.second));
-    p.post(In{var, vector<IntegerVariableID>{var}});
+    p.post_named(In{var, vector<IntegerVariableID>{var}}, "in_test");
 
     auto proof_name = proofs ? make_optional("in_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{var});

--- a/gcs/constraints/increasing.cc
+++ b/gcs/constraints/increasing.cc
@@ -143,7 +143,7 @@ auto IncreasingChain::s_exprify(const ProofModel * const model) const -> string
         ? (_descending ? "strictly_decreasing" : "strictly_increasing")
         : (_descending ? "decreasing" : "increasing");
 
-    print(s, "{} {}", _name, keyword);
+    print(s, "{} {}", _constraint_id, keyword);
     for (const auto & v : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
 

--- a/gcs/constraints/increasing.cc
+++ b/gcs/constraints/increasing.cc
@@ -9,8 +9,10 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #endif
 
@@ -30,8 +32,10 @@ using std::vector;
 using std::ranges::reverse;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -72,7 +76,9 @@ auto IncreasingChain::define_proof_model(ProofModel & model) -> void
 {
     auto offset = _strict ? -1_i : 0_i;
     for (size_t i = 0; i + 1 < _ordered_vars.size(); ++i)
-        model.add_constraint("IncreasingChain", "chain step",
+        model.add_labelled_constraint(
+            _constraint_id, format("step_{}", i),
+            "IncreasingChain", "chain step",
             WPBSum{} + 1_i * _ordered_vars[i] + -1_i * _ordered_vars[i + 1] <= offset);
 }
 

--- a/gcs/constraints/increasing_test.cc
+++ b/gcs/constraints/increasing_test.cc
@@ -77,13 +77,13 @@ template <IncVariant V>
 auto post_inc(Problem & p, vector<IntegerVariableID> vars) -> void
 {
     if constexpr (V == IncVariant::Increasing)
-        p.post(Increasing{std::move(vars)});
+        p.post_named(Increasing{std::move(vars)}, "inc");
     else if constexpr (V == IncVariant::StrictlyIncreasing)
-        p.post(StrictlyIncreasing{std::move(vars)});
+        p.post_named(StrictlyIncreasing{std::move(vars)}, "str_inc");
     else if constexpr (V == IncVariant::Decreasing)
-        p.post(Decreasing{std::move(vars)});
+        p.post_named(Decreasing{std::move(vars)}, "dec");
     else
-        p.post(StrictlyDecreasing{std::move(vars)});
+        p.post_named(StrictlyDecreasing{std::move(vars)}, "str_dec");
 }
 
 template <IncVariant V>

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -95,12 +95,12 @@ auto Inverse::define_proof_model(ProofModel & model) -> void
         for (const auto & [j, y_j] : enumerate(_y)) {
             // x[i] = j -> y[j] = i
             model.add_labelled_constraint(
-                _constraint_id, format("ge_{}_{}", i, j),
+                _constraint_id, format("ge[{}][{}]", i, j),
                 "Inverse", "x_i = j -> y[j] = i", 
                 WPBSum{} + 1_i * (x_i != Integer(j) + _y_start) + 1_i * (y_j == Integer(i) + _x_start) >= 1_i);
             // y[j] = i -> x[i] = j
             model.add_labelled_constraint(
-                _constraint_id, format("le_{}_{}", i, j),
+                _constraint_id, format("le[{}][{}]", i, j),
                 "Inverse", "y_j = i -> x[i] = j", 
                 WPBSum{} + 1_i * (y_j != Integer(i) + _x_start) + 1_i * (x_i == Integer(j) + _y_start) >= 1_i);
         }
@@ -181,15 +181,15 @@ auto Inverse::s_exprify(const innards::ProofModel * const model) const -> std::s
 {
     stringstream s;
 
-    print(s, "{} inverse\n          (", _constraint_id);
+    print(s, "{} inverse\n           ((", _constraint_id);
     for (const auto & x : _x) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(x));
     }
-    print(s, ")\n          (");
+    print(s, ") {})\n           ((", _x_start);
     for (const auto & y : _y) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(y));
     }
-    print(s, ")\n          {} {})", _x_start, _y_start);
+    print(s, ") {})\n        ", _y_start);
 
     return s.str();
 }

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -171,7 +171,7 @@ auto Inverse::s_exprify(const innards::ProofModel * const model) const -> std::s
 {
     stringstream s;
 
-    print(s, "{} inverse\n          (", _name);
+    print(s, "{} inverse\n          (", _constraint_id);
     for (const auto & x : _x) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(x));
     }

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -15,8 +15,10 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #endif
 
@@ -37,8 +39,10 @@ using std::unique_ptr;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -90,9 +94,15 @@ auto Inverse::define_proof_model(ProofModel & model) -> void
     for (const auto & [i, x_i] : enumerate(_x))
         for (const auto & [j, y_j] : enumerate(_y)) {
             // x[i] = j -> y[j] = i
-            model.add_constraint("Inverse", "x_i = j -> y[j] = i", WPBSum{} + 1_i * (x_i != Integer(j) + _y_start) + 1_i * (y_j == Integer(i) + _x_start) >= 1_i);
+            model.add_labelled_constraint(
+                _constraint_id, format("ge_{}_{}", i, j),
+                "Inverse", "x_i = j -> y[j] = i", 
+                WPBSum{} + 1_i * (x_i != Integer(j) + _y_start) + 1_i * (y_j == Integer(i) + _x_start) >= 1_i);
             // y[j] = i -> x[i] = j
-            model.add_constraint("Inverse", "y_j = i -> x[i] = j", WPBSum{} + 1_i * (y_j != Integer(i) + _x_start) + 1_i * (x_i == Integer(j) + _y_start) >= 1_i);
+            model.add_labelled_constraint(
+                _constraint_id, format("le_{}_{}", i, j),
+                "Inverse", "y_j = i -> x[i] = j", 
+                WPBSum{} + 1_i * (y_j != Integer(i) + _x_start) + 1_i * (x_i == Integer(j) + _y_start) >= 1_i);
         }
 
     // Set up the AM1 map only when proof logging is on; the propagator captures it

--- a/gcs/constraints/inverse_test.cc
+++ b/gcs/constraints/inverse_test.cc
@@ -87,7 +87,7 @@ auto run_inverse_test(bool proofs, const vector<variant<int, pair<int, int>>> & 
         x.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
     for (const auto & entry : y_range)
         y.push_back(visit([&](auto e) { return create_integer_variable_or_constant(p, e); }, entry));
-    p.post(Inverse{x, y});
+    p.post_named(Inverse{x, y}, "inverse_test");
 
     auto proof_name = proofs ? make_optional("inverse_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{x, y});

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -663,7 +663,7 @@ auto Knapsack::s_exprify(const innards::ProofModel * const model) const -> strin
 {
     stringstream s;
 
-    print(s, "{} knapsack\n            (", _name);
+    print(s, "{} knapsack\n            (", _constraint_id);
     for (const auto & cs : _coeffs) {
         print(s, "\n                (");
         for (const auto & c : cs)

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -12,7 +12,9 @@
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 #include <print>
+#include <format>
 #else
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #endif
 
@@ -47,8 +49,10 @@ using std::ranges::minmax_element;
 using std::ranges::none_of;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -640,7 +644,10 @@ auto Knapsack::define_proof_model(ProofModel & model) -> void
         WPBSum sum_eq;
         for (const auto & [idx, v] : enumerate(_vars))
             sum_eq += cc.at(idx) * v;
-        auto [eq1, eq2] = model.add_constraint(sum_eq == 1_i * _totals.at(cc_idx));
+        auto [eq1, eq2] = model.add_labelled_constraint(
+                _constraint_id, format("le[{}]", cc_idx), format("ge[{}]", cc_idx),
+                "Knapsack", "resource constraint",
+                sum_eq == 1_i * _totals.at(cc_idx));
         _eqns_lines.emplace_back(eq1.value(), eq2.value());
     }
 }

--- a/gcs/constraints/lex.cc
+++ b/gcs/constraints/lex.cc
@@ -638,7 +638,7 @@ auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const innards::ProofModel * co
         _or_equal ? "_equal" : "",
         reif_suffix);
 
-    print(s, "{} {}", _name, cmp);
+    print(s, "{} {}", _constraint_id, cmp);
 
     auto cond_lit = overloaded{
         [](const reif::MustHold &) -> optional<IntegerVariableCondition> { return nullopt; },

--- a/gcs/constraints/lex_smart_table.cc
+++ b/gcs/constraints/lex_smart_table.cc
@@ -69,7 +69,7 @@ auto LexSmartTable::s_exprify(const innards::ProofModel * const model) const -> 
 {
     stringstream s;
 
-    print(s, "{} lex (", _name);
+    print(s, "{} lex (", _constraint_id);
     for (const auto & var : _vars_1)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -200,10 +200,12 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
         [&](const reif::NotIf & cond) {
             // condition is definitely false, the flag implies either greater or less
             auto neflag = model.create_proof_flag("linne");
-            model.add_labelled_constraint(_constraint_id, "gt",
+            model.add_labelled_constraint(
+                _constraint_id, "gt",
                 "ReifiedLinearEquality", "greater option",
                 terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
-            model.add_labelled_constraint(_constraint_id, "lt",
+            model.add_labelled_constraint(
+                _constraint_id, "lt",
                 "ReifiedLinearEquality", "less than option",
                 terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
         },

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -413,7 +413,7 @@ auto ReifiedLinearEquality::s_exprify(const ProofModel * const model) const -> s
         [&](const reif::NotIf &) { return make_pair(true, "lin_not_equals_if"); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", _name, cons);
+    print(s, "{} {}", _constraint_id, cons);
     if (rei) {
         print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
     }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -174,34 +174,34 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
     overloaded{
         [&](const reif::MustHold &) {
             // condition is definitely true, it's just an inequality
-            _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
+            _proof_line = model.add_labelled_constraint(_constraint_id, "neq_fwd", "neq_back", "ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
         },
         [&](const reif::MustNotHold &) {
             // condition is definitely false, the flag implies either greater or less
             auto neflag = model.create_proof_flag("linne");
-            model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
-            model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
+            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
+            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
         },
         [&](const reif::If & cond) {
-            _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_labelled_constraint(_constraint_id, "neq_fwd", "neq_back", "ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
         },
         [&](const reif::NotIf & cond) {
             // condition is definitely false, the flag implies either greater or less
             auto neflag = model.create_proof_flag("linne");
-            model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
-            model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
+            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
+            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
         },
         [&](const reif::Iff & cond) {
             // condition unknown, the condition implies it is neither greater nor less
-            _proof_line = model.add_constraint("ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
 
             auto gtflag = model.create_proof_flag("lineqgt");
-            model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});
+            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});
             auto ltflag = model.create_proof_flag("lineqlt");
-            model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{ltflag}});
+            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{ltflag}});
 
             // lt + eq + gt >= 1
-            model.add_constraint("ReifiedLinearEquality", "one of less than, equals, greater than", WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * cond.cond >= 1_i);
+            model.add_labelled_constraint(_constraint_id, "al1", "ReifiedLinearEquality", "one of less than, equals, greater than", WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * cond.cond >= 1_i);
         }}
         .visit(_reif_cond);
 }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -174,34 +174,62 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
     overloaded{
         [&](const reif::MustHold &) {
             // condition is definitely true, it's just an inequality
-            _proof_line = model.add_labelled_constraint(_constraint_id, "le", "ge", "ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
+            _proof_line = model.add_labelled_constraint(
+                _constraint_id, "le", "ge",
+                "ReifiedLinearEquality", "unconditional sum",
+                terms == _value, nullopt);
         },
         [&](const reif::MustNotHold &) {
             // condition is definitely false, the flag implies either greater or less
             auto neflag = model.create_proof_flag("linne");
-            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
-            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
+            model.add_labelled_constraint(
+                _constraint_id, "gt",
+                "ReifiedLinearEquality", "greater option",
+                terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
+            model.add_labelled_constraint(
+                _constraint_id, "lt",
+                "ReifiedLinearEquality", "less than option",
+                terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
         },
         [&](const reif::If & cond) {
-            _proof_line = model.add_labelled_constraint(_constraint_id, "le", "ge", "ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_labelled_constraint(
+                _constraint_id, "le", "ge",
+                "ReifiedLinearEquality", "unconditional sum",
+                terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
         },
         [&](const reif::NotIf & cond) {
             // condition is definitely false, the flag implies either greater or less
             auto neflag = model.create_proof_flag("linne");
-            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
-            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
+            model.add_labelled_constraint(_constraint_id, "gt",
+                "ReifiedLinearEquality", "greater option",
+                terms >= _value + 1_i, HalfReifyOnConjunctionOf{{cond.cond, neflag}});
+            model.add_labelled_constraint(_constraint_id, "lt",
+                "ReifiedLinearEquality", "less than option",
+                terms <= _value - 1_i, HalfReifyOnConjunctionOf{{cond.cond, ! neflag}});
         },
         [&](const reif::Iff & cond) {
             // condition unknown, the condition implies it is neither greater nor less
-            _proof_line = model.add_labelled_constraint(_constraint_id, "le", "ge", "ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_labelled_constraint(
+                _constraint_id, "le", "ge",
+                "ReifiedLinearEquality", "equals option",
+                terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
 
             auto gtflag = model.create_proof_flag("lineqgt");
-            model.add_labelled_constraint(_constraint_id, "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});
+            model.add_labelled_constraint(
+                _constraint_id, "gt",
+                "ReifiedLinearEquality", "greater option",
+                terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});
             auto ltflag = model.create_proof_flag("lineqlt");
-            model.add_labelled_constraint(_constraint_id, "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{ltflag}});
+            model.add_labelled_constraint(
+                _constraint_id, "lt",
+                "ReifiedLinearEquality", "less than option", 
+                terms <= _value - 1_i, HalfReifyOnConjunctionOf{{ltflag}});
 
             // lt + eq + gt >= 1
-            model.add_labelled_constraint(_constraint_id, "al1", "ReifiedLinearEquality", "one of less than, equals, greater than", WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * cond.cond >= 1_i);
+            model.add_labelled_constraint(
+                _constraint_id, "al1",
+                "ReifiedLinearEquality", "one of less than, equals, greater than",
+                WPBSum{} + 1_i * ltflag + 1_i * gtflag + 1_i * cond.cond >= 1_i);
         }}
         .visit(_reif_cond);
 }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -174,7 +174,7 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
     overloaded{
         [&](const reif::MustHold &) {
             // condition is definitely true, it's just an inequality
-            _proof_line = model.add_labelled_constraint(_constraint_id, "neq_fwd", "neq_back", "ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
+            _proof_line = model.add_labelled_constraint(_constraint_id, "le", "ge", "ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
         },
         [&](const reif::MustNotHold &) {
             // condition is definitely false, the flag implies either greater or less
@@ -183,7 +183,7 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
             model.add_labelled_constraint(_constraint_id, "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
         },
         [&](const reif::If & cond) {
-            _proof_line = model.add_labelled_constraint(_constraint_id, "neq_fwd", "neq_back", "ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_labelled_constraint(_constraint_id, "le", "ge", "ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
         },
         [&](const reif::NotIf & cond) {
             // condition is definitely false, the flag implies either greater or less
@@ -193,7 +193,7 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
         },
         [&](const reif::Iff & cond) {
             // condition unknown, the condition implies it is neither greater nor less
-            _proof_line = model.add_labelled_constraint(_constraint_id, "eq_fwd", "eq_back", "ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_labelled_constraint(_constraint_id, "le", "ge", "ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
 
             auto gtflag = model.create_proof_flag("lineqgt");
             model.add_labelled_constraint(_constraint_id, "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -116,18 +116,18 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
         },
         [&](const reif::NotIf & cond) {
             _proof_lines = pair{*model.add_labelled_constraint(
-                _constraint_id, "gt",
+                _constraint_id, "le",
                 "ReifiedLinearInequality", "greater than option",
                 terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         },
         [&](const reif::Iff & cond) {
             _proof_lines = pair{
                 *model.add_labelled_constraint(
-                    _constraint_id, "lt",
+                    _constraint_id, "le",
                     "ReifiedLinearInequality", "less than option",
                     terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
                 *model.add_labelled_constraint(
-                    _constraint_id, "gt",
+                    _constraint_id, "ge",
                     "ReifiedLinearInequality", "greater than option", 
                     terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
         }}

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -208,7 +208,7 @@ auto ReifiedLinearInequality::s_exprify(const ProofModel * const model) const ->
         [&](const auto &) { throw UnexpectedException{"Unexpected reification type in s_exprify"}; return make_pair(false, ""); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", _name, cons);
+    print(s, "{} {}", _constraint_id, cons);
     if (rei) {
         print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
     }

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -97,21 +97,39 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
 
     overloaded{
         [&](const reif::MustHold &) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional less than", terms <= _value, nullopt), nullopt};
+            _proof_lines = pair{*model.add_labelled_constraint(
+                _constraint_id, "",
+                "ReifiedLinearInequality", "unconditional less than",
+                terms <= _value, nullopt), nullopt};
         },
         [&](const reif::MustNotHold &) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional greater than", terms >= _value + 1_i, nullopt), nullopt};
+            _proof_lines = pair{*model.add_labelled_constraint(
+                _constraint_id, "",
+                "ReifiedLinearInequality", "unconditional greater than",
+                terms >= _value + 1_i, nullopt), nullopt};
         },
         [&](const reif::If & cond) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines = pair{*model.add_labelled_constraint(
+                _constraint_id, "lt",
+                "ReifiedLinearInequality", "less than option",
+                terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         },
         [&](const reif::NotIf & cond) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "greater than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines = pair{*model.add_labelled_constraint(
+                _constraint_id, "gt",
+                "ReifiedLinearInequality", "greater than option",
+                terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         },
         [&](const reif::Iff & cond) {
             _proof_lines = pair{
-                *model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
-                model.add_constraint("ReifiedLinearInequality", "greater than option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
+                *model.add_labelled_constraint(
+                    _constraint_id, "lt",
+                    "ReifiedLinearInequality", "less than option",
+                    terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
+                *model.add_labelled_constraint(
+                    _constraint_id, "gt",
+                    "ReifiedLinearInequality", "greater than option", 
+                    terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
         }}
         .visit(_reif_cond);
 }
@@ -202,17 +220,18 @@ auto ReifiedLinearInequality::s_exprify(const ProofModel * const model) const ->
     stringstream s;
 
     auto [rei, cons] = overloaded{
-        [&](const reif::MustHold &) { return make_pair(false, "lin_less_than_equal"); },
-        [&](const reif::If &) { return make_pair(true, "lin_less_than_equal_if"); },
-        [&](const reif::Iff &) { return make_pair(true, "lin_less_than_equal_iff"); },
-        [&](const auto &) { throw UnexpectedException{"Unexpected reification type in s_exprify"}; return make_pair(false, ""); }}
-                           .visit(_reif_cond);
+        [&](const reif::MustHold &)    { return make_pair(false, "lin_less_equal"); },
+        [&](const reif::MustNotHold &) { return make_pair(false, "lin_greater_than"); },
+        [&](const reif::If &)          { return make_pair(true,  "lin_less_equal_if"); },
+        [&](const reif::NotIf &)       { return make_pair(true,  "lin_greater_than_if"); },
+        [&](const reif::Iff &)         { return make_pair(true,  "lin_less_equal_iff"); },
+    }.visit(_reif_cond);
 
     print(s, "{} {}", _constraint_id, cons);
     if (rei) {
         print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
     }
-    print(s, "(");
+    print(s, " (");
     for (const auto & [c, v] : _coeff_vars.terms) {
         print(s, " {} {}", c, model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -259,7 +259,7 @@ auto And::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} and (", _name);
+    print(s, "{} and (", _constraint_id);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }
@@ -326,7 +326,7 @@ auto Or::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} or (", _name);
+    print(s, "{} or (", _constraint_id);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -169,14 +169,16 @@ namespace
             triggers);
     }
 
-    auto define_proof_model_logical(ProofModel & model, const Literals & lits,
+    auto define_proof_model_logical(ConstraintID & constraint_id, ProofModel & model, const Literals & lits,
         const Literal & full_reif, LiteralIs reif_state) -> void
     {
         using enum LiteralIs;
 
         if (reif_state == DefinitelyTrue) {
             for (auto & l : lits)
-                model.add_constraint("Logical", "cnf", Literals{l});
+                model.add_labelled_constraint(
+                    constraint_id, "Logical",
+                    "Logical", "cnf", Literals{l});
             return;
         }
 
@@ -188,7 +190,7 @@ namespace
                 .visit(l);
 
         if (saw_false) {
-            model.add_constraint("Logical", "saw reif false", Literals{! full_reif});
+            model.add_labelled_constraint(constraint_id, "logical_false", "Logical", "saw reif false", Literals{! full_reif});
             return;
         }
 
@@ -196,14 +198,14 @@ namespace
             WPBSum forward;
             for (auto & l : lits)
                 forward += 1_i * PseudoBooleanTerm{l};
-            model.add_constraint("Logical", "if condition", forward >= Integer(lits.size()), HalfReifyOnConjunctionOf{full_reif});
+            model.add_labelled_constraint(constraint_id, "logical_if_condition", "Logical", "if condition", forward >= Integer(lits.size()), HalfReifyOnConjunctionOf{full_reif});
         }
 
         Literals reverse;
         for (auto & l : lits)
             reverse.push_back(! l);
         reverse.push_back(full_reif);
-        model.add_constraint("Logical", "if not condition", move(reverse));
+        model.add_labelled_constraint(constraint_id, "logical_if_not_condition", "Logical", "if not condition", move(reverse));
     }
 }
 
@@ -247,7 +249,7 @@ auto And::prepare(Propagators &, State & initial_state, ProofModel * const) -> b
 
 auto And::define_proof_model(ProofModel & model) -> void
 {
-    define_proof_model_logical(model, _lits, _full_reif, _reif_state);
+    define_proof_model_logical(_constraint_id, model, _lits, _full_reif, _reif_state);
 }
 
 auto And::install_propagators(Propagators & propagators) -> void
@@ -311,7 +313,7 @@ auto Or::define_proof_model(ProofModel & model) -> void
     Literals lits = _lits;
     for (auto & l : lits)
         l = ! l;
-    define_proof_model_logical(model, move(lits), ! _full_reif, _reif_state);
+    define_proof_model_logical(_constraint_id, model, move(lits), ! _full_reif, _reif_state);
 }
 
 auto Or::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -205,7 +205,7 @@ auto ArrayMinMax::s_exprify(const innards::ProofModel * const model) const -> st
 {
     stringstream s;
 
-    print(s, "{} {} (", _name, _min ? "min" : "max");
+    print(s, "{} {} (", _constraint_id, _min ? "min" : "max");
     for (const auto & v : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -77,8 +77,11 @@ auto ArrayMinMax::prepare(Propagators &, State &, ProofModel * const) -> bool
 auto ArrayMinMax::define_proof_model(ProofModel & model) -> void
 {
     // (for min) each var >= result, i.e. var - result >= 0
-    for (const auto & v : _vars) {
-        model.add_constraint("ArrayMinMax", "result compared to value", WPBSum{} + (_min ? 1_i : -1_i) * v + (_min ? -1_i : 1_i) * _result >= 0_i, nullopt);
+    for (const auto & [id, v] : enumerate(_vars)) {
+        model.add_labelled_constraint(
+            _constraint_id, format("{}", id),
+            "ArrayMinMax", "result compared to value",
+            WPBSum{} + (_min ? 1_i : -1_i) * v + (_min ? -1_i : 1_i) * _result >= 0_i, nullopt);
     }
 
     WPBSum al1_selector;
@@ -87,13 +90,22 @@ auto ArrayMinMax::define_proof_model(ProofModel & model) -> void
     for (const auto & [id, var] : enumerate(_vars)) {
         auto selector = model.create_proof_flag(format("arrayminmax{}", id));
         _selectors.push_back(selector);
-        model.add_constraint("ArrayMinMax", "result is this value", WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result <= 0_i, {{selector}});
-        model.add_constraint("ArrayMinMax", "result is this value", WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result >= 1_i, {{! selector}});
+        model.add_labelled_constraint(
+            _constraint_id, format("{}le", id),
+            "ArrayMinMax", "result is this value",
+            WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result <= 0_i, {{selector}});
+        model.add_labelled_constraint(
+            _constraint_id, format("{}ge", id),
+            "ArrayMinMax", "result is this value",
+            WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result >= 1_i, {{! selector}});
         al1_selector += 1_i * selector;
     }
 
     // sum f_i >= 1
-    model.add_constraint("ArrayMinMax", "result is one of the values", al1_selector >= 1_i);
+    model.add_labelled_constraint(
+        _constraint_id, "al1",
+        "ArrayMinMax", "result is one of the values",
+        al1_selector >= 1_i);
 }
 
 auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
@@ -205,7 +217,7 @@ auto ArrayMinMax::s_exprify(const innards::ProofModel * const model) const -> st
 {
     stringstream s;
 
-    print(s, "{} {} (", _constraint_id, _min ? "min" : "max");
+    print(s, "{} {} (", _constraint_id, _min ? "array_min" : "array_max");
     for (const auto & v : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -91,11 +91,11 @@ auto ArrayMinMax::define_proof_model(ProofModel & model) -> void
         auto selector = model.create_proof_flag(format("arrayminmax{}", id));
         _selectors.push_back(selector);
         model.add_labelled_constraint(
-            _constraint_id, format("{}le", id),
+            _constraint_id, format("le[{}]", id),
             "ArrayMinMax", "result is this value",
             WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result <= 0_i, {{selector}});
         model.add_labelled_constraint(
-            _constraint_id, format("{}ge", id),
+            _constraint_id, format("ge[{}]", id),
             "ArrayMinMax", "result is this value",
             WPBSum{} + (_min ? 1_i : -1_i) * var + (_min ? -1_i : 1_i) * _result >= 1_i, {{! selector}});
         al1_selector += 1_i * selector;

--- a/gcs/constraints/minus.cc
+++ b/gcs/constraints/minus.cc
@@ -77,7 +77,7 @@ auto Minus::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} minus (", _name);
+    print(s, "{} minus (", _constraint_id);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -1156,13 +1156,21 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
                 for (Integer pos = 0_i; pos < num_bits - 1_i; pos++)
                     bit_sum_without_neg += power2(pos) * ProofBitVariable{v, pos + 1_i, true};
 
-                auto pos_ge = optional_model->add_constraint(
+                auto pos_ge = optional_model->add_labelled_constraint(
+                    _constraint_id, format("{}[pos][ge]", name),
+                    "MultBC", "pos_ge",
                     bit_sum_without_neg + (-1_i * v_magnitude) >= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto pos_le = optional_model->add_constraint(
+                auto pos_le = optional_model->add_labelled_constraint(
+                    _constraint_id, format("{}[pos][le]", name),
+                    "MultBC", "pos_le",
                     bit_sum_without_neg + (-1_i * v_magnitude) <= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto neg_ge = optional_model->add_constraint(
+                auto neg_ge = optional_model->add_labelled_constraint(
+                    _constraint_id, format("{}[neg][ge]", name),
+                    "MultBC", "neg_ge",
                     bit_sum_without_neg + (1_i * v_magnitude) >= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
-                auto neg_le = optional_model->add_constraint(
+                auto neg_le = optional_model->add_labelled_constraint(
+                    _constraint_id, format("{}[neg][le]", name),
+                    "MultBC", "neg_le",
                     bit_sum_without_neg + (1_i * v_magnitude) <= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
 
                 channelling_constraints.insert({v, ChannellingData{*pos_ge, *pos_le, *neg_ge, *neg_le}});

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -1277,7 +1277,7 @@ auto MultBC::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} multiply (", _name);
+    print(s, "{} multiply (", _constraint_id);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v3));

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -140,7 +140,7 @@ auto NValue::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} nvalue (", _name);
+    print(s, "{} nvalue (", _constraint_id);
     for (const auto & var : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     }

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -145,7 +145,7 @@ auto ParityOdd::s_exprify(const innards::ProofModel * const model) const -> stri
 {
     stringstream s;
 
-    print(s, "{} xor (", _name);
+    print(s, "{} xor (", _constraint_id);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }

--- a/gcs/constraints/plus.cc
+++ b/gcs/constraints/plus.cc
@@ -79,7 +79,7 @@ auto Plus::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} plus (", _name);
+    print(s, "{} plus (", _constraint_id);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/regular.cc
+++ b/gcs/constraints/regular.cc
@@ -411,17 +411,26 @@ auto Regular::define_proof_model(ProofModel & model) -> void
             _state_at_pos_flags[idx].emplace_back(model.create_proof_flag(format("state{}is{}", idx, q)));
             exactly_1_true += 1_i * _state_at_pos_flags[idx][q];
         }
-        model.add_constraint(move(exactly_1_true) == 1_i);
+        model.add_labelled_constraint(
+            _constraint_id, format("le[{}]", idx), format("ge[{}]", idx),
+            "Regular", "exactly one state at each position",
+            move(exactly_1_true) == 1_i);
     }
 
     // State at pos 0 is 0
-    model.add_constraint(WPBSum{} + 1_i * _state_at_pos_flags[0][0] >= 1_i);
+    model.add_labelled_constraint(
+        _constraint_id, "init",
+        "Regular", "state at pos 0 is 0",
+        WPBSum{} + 1_i * _state_at_pos_flags[0][0] >= 1_i);
     // State at pos n is one of the final states
     WPBSum pos_n_states;
     for (const auto & f : _final_states) {
         pos_n_states += 1_i * _state_at_pos_flags[_vars.size()][f];
     }
-    model.add_constraint(move(pos_n_states) >= 1_i);
+    model.add_labelled_constraint(
+        _constraint_id, "final",
+        "Regular", "state at pos n is one of the final states",
+        move(pos_n_states) >= 1_i);
 
     for (size_t idx = 0; idx < _vars.size(); ++idx) {
         for (long q = 0; q < _num_states; ++q) {
@@ -429,11 +438,15 @@ auto Regular::define_proof_model(ProofModel & model) -> void
                 auto new_q = find_transition(_transitions[q], val);
                 if (new_q == -1) {
                     // No transition for q, v, so constrain ~(state_i = q /\ X_i = val)
-                    model.add_constraint(
+                    model.add_labelled_constraint(
+                        _constraint_id, format("nt[{}][{}][{}]", idx, q, val),
+                        "Regular", "no transition for state and value",
                         WPBSum{} + 1_i * (_vars[idx] != val) + (1_i * ! _state_at_pos_flags[idx][q]) >= 1_i);
                 }
                 else {
-                    model.add_constraint(
+                    model.add_labelled_constraint(
+                        _constraint_id, format("t[{}][{}][{}]", idx, q, val),
+                        "Regular", "transition for state and value",
                         WPBSum{} + 1_i * ! _state_at_pos_flags[idx][q] + 1_i * (_vars[idx] != val) + 1_i * _state_at_pos_flags[idx + 1][new_q] >= 1_i);
                 }
             }

--- a/gcs/constraints/regular.cc
+++ b/gcs/constraints/regular.cc
@@ -458,7 +458,7 @@ auto Regular::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} regular (", _name);
+    print(s, "{} regular (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}\n       (", _num_states);

--- a/gcs/constraints/seq_precede_chain.cc
+++ b/gcs/constraints/seq_precede_chain.cc
@@ -86,7 +86,7 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
 auto SeqPrecedeChain::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} seq_precede_chain (", _name);
+    print(s, "{} seq_precede_chain (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -933,7 +933,7 @@ auto SmartTable::s_exprify(const ProofModel * const model) const -> string
 
     stringstream s;
 
-    print(s, "{} smart_table (\n        (", _name);
+    print(s, "{} smart_table (\n        (", _constraint_id);
 
     for (const auto & tuple : _tuples) {
         for (const auto & entry : tuple) {

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -307,7 +307,7 @@ auto NegativeTable::s_exprify(const innards::ProofModel * const model) const -> 
 {
     stringstream s;
 
-    print(s, "{} negative_table", _name);
+    print(s, "{} negative_table", _constraint_id);
     println(s, "(");
 
     println(s, "    (");

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -36,9 +36,11 @@ using std::vector;
 using std::visit;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 using std::println;
 #else
+using fmt::format;
 using fmt::print;
 using fmt::println;
 #endif
@@ -174,9 +176,15 @@ auto Table::define_proof_model(ProofModel & model) -> void
                     add_lit_unless_immediately_true(lits, var, tuple[var_idx]);
             }
             if (infeasible)
-                model.add_constraint({_selector != Integer(tuple_idx)});
+                model.add_labelled_constraint(
+                    _constraint_id, format("tuple[{}]", tuple_idx),
+                    "Table", "tuple infeasible",
+                    {_selector != Integer(tuple_idx)});
             else
-                model.add_constraint(lits >= Integer(lits.terms.size() - 1));
+                model.add_labelled_constraint(
+                    _constraint_id, format("tuple[{}]", tuple_idx),
+                    "Table", "tuple feasible",
+                    lits >= Integer(lits.terms.size() - 1));
         }
     },
         move(_tuples));
@@ -208,10 +216,7 @@ auto Table::install_propagators(Propagators & propagators) -> void
 auto Table::s_exprify(const innards::ProofModel * const model) const -> std::string
 {
     stringstream s;
-
     print(s, "{} table", _constraint_id);
-    println(s, " (");
-
     println(s, "    (");
     visit([&](const auto & tuples) {
         for (const auto & t : depointinate(tuples)) {
@@ -224,13 +229,9 @@ auto Table::s_exprify(const innards::ProofModel * const model) const -> std::str
     },
         _tuples);
     println(s, "    )");
-
     println(s, "    (");
     for (const auto & var : _vars)
         println(s, "        {}", model->names_and_ids_tracker().s_expr_name_of(var));
     println(s, "    )");
-
-    println(s, ")");
-
     return s.str();
 }

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -210,7 +210,7 @@ auto Table::s_exprify(const innards::ProofModel * const model) const -> std::str
     stringstream s;
 
     print(s, "{} table", _constraint_id);
-    println(s, "(");
+    println(s, " (");
 
     println(s, "    (");
     visit([&](const auto & tuples) {

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -209,7 +209,7 @@ auto Table::s_exprify(const innards::ProofModel * const model) const -> std::str
 {
     stringstream s;
 
-    print(s, "{} table", _name);
+    print(s, "{} table", _constraint_id);
     println(s, "(");
 
     println(s, "    (");

--- a/gcs/constraints/table_test.cc
+++ b/gcs/constraints/table_test.cc
@@ -59,7 +59,7 @@ auto run_table_test_2(bool proofs, pair<int, int> r1, pair<int, int> r2, SimpleT
     Problem p;
     auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
     auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
-    p.post(Table{{v1, v2}, allowed});
+    p.post_named(Table{{v1, v2}, allowed}, "table_test");
 
     auto proof_name = proofs ? make_optional("table_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2});
@@ -85,7 +85,7 @@ auto run_table_test_3(bool proofs, pair<int, int> r1, pair<int, int> r2, pair<in
     auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
     auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
     auto v3 = p.create_integer_variable(Integer(r3.first), Integer(r3.second));
-    p.post(Table{{v1, v2, v3}, allowed});
+    p.post_named(Table{{v1, v2, v3}, allowed}, "table_test");
 
     auto proof_name = proofs ? make_optional("table_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3});
@@ -118,7 +118,7 @@ auto run_wildcard_table_test(bool proofs, pair<int, int> r1, pair<int, int> r2, 
     auto v1 = p.create_integer_variable(Integer(r1.first), Integer(r1.second));
     auto v2 = p.create_integer_variable(Integer(r2.first), Integer(r2.second));
     auto v3 = p.create_integer_variable(Integer(r3.first), Integer(r3.second));
-    p.post(Table{{v1, v2, v3}, allowed});
+    p.post_named(Table{{v1, v2, v3}, allowed}, "table_test");
 
     auto proof_name = proofs ? make_optional("table_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{v1, v2, v3});

--- a/gcs/constraints/value_precede.cc
+++ b/gcs/constraints/value_precede.cc
@@ -209,7 +209,7 @@ auto ValuePrecede::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} value_precede (", _name);
+    print(s, "{} value_precede (", _constraint_id);
     for (const auto & val : _chain)
         print(s, " {}", val);
     print(s, ") (");

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -875,10 +875,10 @@ auto NamesAndIDsTracker::s_expr_name_of(VariableConditionOperator op) const -> s
 {
     switch (op) {
         using enum VariableConditionOperator;
-    case Equal: return "eq";
-    case NotEqual: return "neq";
-    case GreaterEqual: return "geq";
-    case Less: return "lt";
+    case Equal: return "=";
+    case NotEqual: return "!=";
+    case GreaterEqual: return ">=";
+    case Less: return "<";
     }
 
     throw NonExhaustiveSwitch{};

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -832,8 +832,8 @@ auto NamesAndIDsTracker::s_expr_name_of(IntegerVariableID id) const -> string
 auto NamesAndIDsTracker::s_expr_render_of(IntegerVariableID id) const -> string
 {
     return overloaded{
-        [&](const ConstantIntegerVariableID & c) -> string { return "(maximize " + c.const_value.to_string() + ")"; },
-        [&](const SimpleIntegerVariableID & v) -> string { return "(maximize " + name_of(v) + ")"; },
+        [&](const ConstantIntegerVariableID & c) -> string { return "(minimize " + c.const_value.to_string() + ")"; },
+        [&](const SimpleIntegerVariableID & v) -> string { return "(minimize " + name_of(v) + ")"; },
         [&](const ViewOfIntegerVariableID & vv) -> string {
             stringstream name;
             name << "(";

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -708,12 +708,12 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning_negative_bit_of(SimpleOrProof
     if (_imp->verbose_names) {
         overloaded{
             [&](const SimpleIntegerVariableID & id) -> void {
-                string name = format("i[{}][neg]", name_of(id));
+                string name = format("i[{}][sign]", name_of(id));
                 _imp->xlits_to_verbose_names.emplace(result, name);
                 _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
             },
             [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
-                string name = format("p[{}_{}][neg]", id.index, name_of(id));
+                string name = format("p[{}_{}][sign]", id.index, name_of(id));
                 _imp->xlits_to_verbose_names.emplace(result, name);
                 _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
             }}

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -829,6 +829,21 @@ auto NamesAndIDsTracker::s_expr_name_of(IntegerVariableID id) const -> string
         .visit(id);
 }
 
+auto NamesAndIDsTracker::s_expr_render_of(IntegerVariableID id) const -> string
+{
+    return overloaded{
+        [&](const ConstantIntegerVariableID & c) -> string { return "(maximize " + c.const_value.to_string() + ")"; },
+        [&](const SimpleIntegerVariableID & v) -> string { return "(maximize " + name_of(v) + ")"; },
+        [&](const ViewOfIntegerVariableID & vv) -> string {
+            stringstream name;
+            name << "(";
+            name << (vv.negate_first ? "maximize" : "minimize") << " ";
+            name << name_of(vv.actual_variable) << ")";
+            return name.str();
+        }}
+        .visit(id);
+}
+
 auto NamesAndIDsTracker::s_expr_name_of(Literal lit) const -> string
 {
     return overloaded{

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -302,6 +302,11 @@ namespace gcs::innards
         [[nodiscard]] auto s_expr_name_of(IntegerVariableID id) const -> std::string;
 
         /**
+         * Get the s-expression rendering of a literal.
+         */
+        [[nodiscard]] auto s_expr_render_of(IntegerVariableID id) const -> std::string;
+
+        /**
          * Get the human-readable / s-expr name for a literal. Currently not sure about VariableConditionFrom<IntegerVariableID>
          */
         [[nodiscard]] auto s_expr_name_of(Literal lit) const -> std::string;

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -188,6 +188,32 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     return pair{first, second};
 }
 
+auto ProofModel::add_labelled_constraint(
+    const ConstraintID & constraint_id,
+    const string & role_fwd, const string & role_back,
+    const StringLiteral & constraint_name, const StringLiteral & rule,
+    const WPBSumLE & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
+    -> pair<optional<ProofLine>, optional<ProofLine>>
+{
+    names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
+
+    auto first = emit_constraint_label(constraint_id, role_fwd, advance_constraint_counter());
+    _imp->opb << first << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+
+    auto second = emit_constraint_label(constraint_id, role_back, advance_constraint_counter());
+    _imp->opb << second << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+
+    return pair{first, second};
+}
+
 auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<optional<ProofLine>, optional<ProofLine>>
 {

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -140,6 +140,23 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
 }
 
 auto ProofModel::add_labelled_constraint(
+    const ConstraintID & constraint_id, const string & role,
+    const StringLiteral & constraint_name, const StringLiteral & rule,
+    const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
+{
+    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
+    auto label = emit_constraint_label(constraint_id, role, advance_constraint_counter());
+    _imp->opb << label << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
+    _imp->opb << ";\n";
+    return label;
+}
+
+auto ProofModel::add_labelled_constraint(
     const ConstraintID & constraint_id,
     const string & role_fwd, const string & role_back,
     const StringLiteral & constraint_name, const StringLiteral & rule,
@@ -228,11 +245,32 @@ auto ProofModel::add_two_way_reified_constraint(const StringLiteral & constraint
     return {forward, reverse};
 }
 
+auto ProofModel::add_labelled_two_way_reified_constraint(
+    const ConstraintID & constraint_id,
+    const string & role,
+    const StringLiteral & constraint_name, const StringLiteral & rule,
+    const WPBSumLE & ineq, const ProofFlag & flag) -> pair<optional<ProofLine>, optional<ProofLine>>
+{
+    auto forward = add_labelled_constraint(constraint_id, role + "_fwd", constraint_name, rule, ineq, HalfReifyOnConjunctionOf{{flag}});
+    auto reverse = add_labelled_constraint(constraint_id, role + "_back", constraint_name, rule, negate_inequality(ineq), HalfReifyOnConjunctionOf{{! flag}});
+    return {forward, reverse};
+}
+
 auto ProofModel::create_proof_flag_fully_reifying(const string & flag_name,
     const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumLE & ineq) -> ProofFlag
 {
     auto flag = create_proof_flag(flag_name);
     add_two_way_reified_constraint(constraint_name, rule, ineq, flag);
+    return flag;
+}
+
+auto ProofModel::create_labelled_proof_flag_fully_reifying(
+    const ConstraintID & constraint_id, const string & role,
+    const string & flag_name, const StringLiteral & constraint_name, 
+    const StringLiteral & rule, const WPBSumLE & ineq) -> ProofFlag
+{
+    auto flag = create_proof_flag(flag_name);
+    add_labelled_two_way_reified_constraint(constraint_id, role, constraint_name, rule, ineq, flag);
     return flag;
 }
 

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -121,6 +121,34 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     return add_constraint(constraint_name, rule, move(sum) >= 1_i, nullopt);
 }
 
+auto ProofModel::add_labelled_constraint(
+    const ConstraintID & constraint_id, const string & role,
+    const StringLiteral & constraint_name, const StringLiteral & rule, 
+    const Literals & lits) -> std::optional<ProofLine>
+{
+    WPBSum sum;
+
+    for (auto & lit : lits) {
+        if (overloaded{
+                [&](const TrueLiteral &) { return true; },
+                [&](const FalseLiteral &) { return false; },
+                [&]<typename T_>(const VariableConditionFrom<T_> & cond) -> bool {
+                    sum += 1_i * cond;
+                    return false;
+                }}
+                .visit(simplify_literal(lit)))
+            return nullopt;
+    }
+
+    // put these in some kind of order
+    sort(sum.terms);
+
+    // remove duplicates
+    sum.terms.erase(unique(sum.terms).begin(), sum.terms.end());
+
+    return add_labelled_constraint(constraint_id, role, constraint_name, rule, move(sum) >= 1_i, nullopt);
+}
+
 auto ProofModel::add_constraint(const Literals & lits) -> std::optional<ProofLine>
 {
     return add_constraint("?", "?", lits);
@@ -251,8 +279,8 @@ auto ProofModel::add_labelled_two_way_reified_constraint(
     const StringLiteral & constraint_name, const StringLiteral & rule,
     const WPBSumLE & ineq, const ProofFlag & flag) -> pair<optional<ProofLine>, optional<ProofLine>>
 {
-    auto forward = add_labelled_constraint(constraint_id, role + "_fwd", constraint_name, rule, ineq, HalfReifyOnConjunctionOf{{flag}});
-    auto reverse = add_labelled_constraint(constraint_id, role + "_back", constraint_name, rule, negate_inequality(ineq), HalfReifyOnConjunctionOf{{! flag}});
+    auto forward = add_labelled_constraint(constraint_id, role + "[f]", constraint_name, rule, ineq, HalfReifyOnConjunctionOf{{flag}});
+    auto reverse = add_labelled_constraint(constraint_id, role + "[r]", constraint_name, rule, negate_inequality(ineq), HalfReifyOnConjunctionOf{{! flag}});
     return {forward, reverse};
 }
 

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -139,6 +139,30 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     return advance_constraint_counter();
 }
 
+auto ProofModel::add_labelled_constraint(
+    const ConstraintID & constraint_id,
+    const string & role_fwd, const string & role_back,
+    const StringLiteral & constraint_name, const StringLiteral & rule,
+    const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
+    -> pair<optional<ProofLine>, optional<ProofLine>>
+{
+    names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
+    auto first = emit_constraint_label(constraint_id, role_fwd, advance_constraint_counter());
+    _imp->opb << first << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+    auto second = emit_constraint_label(constraint_id, role_back, advance_constraint_counter());
+    _imp->opb << second << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+
+    return pair{first, second};
+}
+
 auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
 {
     return add_constraint("?", "?", ineq, half_reif);
@@ -414,4 +438,13 @@ auto ProofModel::minimise(const IntegerVariableID & var) -> void
 auto ProofModel::preserve(vector<IntegerVariableID> vars) -> void
 {
     _imp->preserved_variables = move(vars);
+}
+
+auto ProofModel::emit_constraint_label(
+    const ConstraintID & constraint_id, 
+    const string & role, 
+    const ProofLineNumber &) -> ProofLine
+{
+    // The leading @ is added elsewhere?
+    return ProofLineLabel("c[" + as_string(constraint_id) + "][" + role + "]");
 }

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -510,5 +510,5 @@ auto ProofModel::emit_constraint_label(
     const ProofLineNumber &) -> ProofLine
 {
     // The leading @ is added elsewhere?
-    return ProofLineLabel("c[" + as_string(constraint_id) + "][" + role + "]");
+    return ProofLineLabel("c[" + as_string(constraint_id) + "]" + (role == "" ? "" : "[" + role + "]"));
 }

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -119,6 +119,14 @@ namespace gcs::innards
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
             const Literals & lits) -> std::optional<ProofLine>;
+        
+        /**
+         * Add a labelledCNF definition to a Proof model.
+         */
+        auto add_labelled_constraint(
+            const ConstraintID & constraint_id, const std::string & role,
+            const StringLiteral & constraint_name, const StringLiteral & rule, 
+            const Literals & lits) -> std::optional<ProofLine>;
 
         /**
          * \brief Add a constraint with a label.  Constraint labels are emitted in the OPB file,

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -129,9 +129,15 @@ namespace gcs::innards
             const ConstraintID & constraint_id,
             const std::string & role_fwd, const std::string & role_back,
             const StringLiteral & constraint_name, const StringLiteral & rule,
-            const WPBSumEq & eq, const std::optional<HalfReifyOnConjunctionOf> & half_reif)
+            const WPBSumEq & eq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt)
             -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
 
+        auto add_labelled_constraint(
+            const ConstraintID & constraint_id,
+            const std::string & role_fwd, const std::string & role_back,
+            const StringLiteral & constraint_name, const StringLiteral & rule,
+            const WPBSumLE & eq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt)
+            -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
 
         /**
          * \brief Encode `flag ⇔ ineq` in OPB by emitting both halves of the equivalence:

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_MODEL_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_MODEL_HH
 
+#include <gcs/constraint.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
@@ -26,7 +27,6 @@ namespace gcs::innards
 
         char const * value;
     };
-
     class ProofModel
     {
     private:
@@ -38,6 +38,12 @@ namespace gcs::innards
         auto set_up_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
 
         auto set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
+
+        /**
+         * Emit a constraint label for the specified label and proof line number.
+         * Constraint labels are emitted in the OPB file, and can be referred to in proof rules.
+         */
+        auto emit_constraint_label(const ConstraintID &, const std::string &, const ProofLineNumber & ) -> ProofLine;
 
     public:
         /**
@@ -113,6 +119,19 @@ namespace gcs::innards
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
             const Literals & lits) -> std::optional<ProofLine>;
+
+        /**
+         * \brief Add a constraint with a label.  Constraint labels are emitted in the OPB file,
+          * and can be referred to in proof rules. The label must be unique among all constraints
+          * and not break any formatting rules.
+         */
+        auto add_labelled_constraint(
+            const ConstraintID & constraint_id,
+            const std::string & role_fwd, const std::string & role_back,
+            const StringLiteral & constraint_name, const StringLiteral & rule,
+            const WPBSumEq & eq, const std::optional<HalfReifyOnConjunctionOf> & half_reif)
+            -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+
 
         /**
          * \brief Encode `flag ⇔ ineq` in OPB by emitting both halves of the equivalence:

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -138,6 +138,12 @@ namespace gcs::innards
             const StringLiteral & constraint_name, const StringLiteral & rule,
             const WPBSumLE & eq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt)
             -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+        
+        auto add_labelled_constraint(
+            const ConstraintID & constraint_id, const std::string & role,
+            const StringLiteral & constraint_name, const StringLiteral & rule,
+            const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt)
+            -> std::optional<ProofLine>;
 
         /**
          * \brief Encode `flag ⇔ ineq` in OPB by emitting both halves of the equivalence:
@@ -164,6 +170,17 @@ namespace gcs::innards
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
             const WPBSumLE & ineq) -> ProofFlag;
+        
+        auto add_labelled_two_way_reified_constraint(
+            const ConstraintID & constraint_id,
+            const std::string & role,
+            const StringLiteral & constraint_name, const StringLiteral & rule,
+            const WPBSumLE & ineq, const ProofFlag & flag) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+
+        [[nodiscard]] auto create_labelled_proof_flag_fully_reifying(
+            const ConstraintID & constraint_id, const std::string & role,
+            const std::string & flag_name, const StringLiteral & constraint_name, 
+            const StringLiteral & rule, const WPBSumLE & ineq) -> ProofFlag;
 
         ///@}
 

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -140,7 +140,7 @@ auto Problem::create_integer_variable_vector(
     vector<IntegerVariableID> result;
     result.reserve(how_many);
     for (size_t n = 0; n < how_many; ++n)
-        result.push_back(create_integer_variable(lower, upper, name ? make_optional(*name + to_string(n)) : nullopt));
+        result.push_back(create_integer_variable(lower, upper, name ? make_optional(*name + to_string(n)) : nullopt));  // name + [n] ?
     return result;
 }
 

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -140,7 +140,7 @@ auto Problem::create_integer_variable_vector(
     vector<IntegerVariableID> result;
     result.reserve(how_many);
     for (size_t n = 0; n < how_many; ++n)
-        result.push_back(create_integer_variable(lower, upper, name ? make_optional(*name + "[" + to_string(n) + "]") : nullopt));
+        result.push_back(create_integer_variable(lower, upper, name ? make_optional(*name + to_string(n)) : nullopt));
     return result;
 }
 

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -158,14 +158,14 @@ auto Problem::create_state_for_new_search(
 auto Problem::post(const Constraint & c) -> void
 {
     auto cloned = c.clone();
-    cloned->set_name(NumberedConstraint{++_imp->next_constraint_number});
+    cloned->set_constraint_id(NumberedConstraint{++_imp->next_constraint_number});
     _imp->constraints.push_back(std::move(cloned));
 }
 
 auto Problem::post_named(const Constraint & c, const string & name) -> void
 {
     auto cloned = c.clone();
-    cloned->set_name(NamedConstraint{check_name(name)}); 
+    cloned->set_constraint_id(NamedConstraint{check_name(name)}); 
     _imp->constraints.push_back(std::move(cloned));
 }
 
@@ -198,7 +198,9 @@ auto Problem::create_propagators(State & state, ProofModel * const optional_proo
 {
     Propagators result;
     for (auto & c : _imp->constraints) {
+        auto cid = c->get_constraint_id();
         auto cc = c->clone();
+        cc->set_constraint_id(cid);
         move(*cc).install(result, state, optional_proof_model);
     }
 

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -188,10 +188,13 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
                     println(s_expr, "        ({})", c.s_exprify(optional_proof->model()));
                 }
                 println(s_expr, "    )");
+                // TODO: What about a simple solve?  We are still assuming either optimisation or enumeration.
                 if (problem.optional_minimise_variable())
-                    println(s_expr, ""); // TODO: "(minimise {})"
+                    println(s_expr, "    {}",
+                        optional_proof->model()->names_and_ids_tracker()
+                            .s_expr_render_of(*problem.optional_minimise_variable()));
                 else
-                    println(s_expr, "    (enumerate)");  // TODO: HACK! We are assuming either minimisation or enumeration
+                    println(s_expr, "    (enumerate)");
                 println(s_expr, ")");
             } catch (const ios_base::failure &) {
                 throw ProofError{"Error writing proof s-expr file to '" + *fn + "'"};

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -188,7 +188,6 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
                     println(s_expr, "        ({})", c.s_exprify(optional_proof->model()));
                 }
                 println(s_expr, "    )");
-                // TODO: What about a simple solve?  We are still assuming either optimisation or enumeration.
                 if (problem.optional_minimise_variable())
                     println(s_expr, "    {}",
                         optional_proof->model()->names_and_ids_tracker()

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -188,6 +188,10 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
                     println(s_expr, "        ({})", c.s_exprify(optional_proof->model()));
                 }
                 println(s_expr, "    )");
+                if (problem.optional_minimise_variable())
+                    println(s_expr, ""); // TODO: "(minimise {})"
+                else
+                    println(s_expr, "    (enumerate)");  // TODO: HACK! We are assuming either minimisation or enumeration
                 println(s_expr, ")");
             } catch (const ios_base::failure &) {
                 throw ProofError{"Error writing proof s-expr file to '" + *fn + "'"};

--- a/test/capture_encodings.py
+++ b/test/capture_encodings.py
@@ -436,6 +436,8 @@ def main() -> int:
             arg_sets = [["lex_gt"], ["lex_ge"], ["lex_lt"], ["lex_le"], 
                         ["lex_gt_fixed"], ["lex_ge_fixed"], ["lex_lt_fixed"], ["lex_le_fixed"], 
                         ["am1_eq"], ["am1_in_set"], ["al1_eq"],["al1_in_set"]]
+        elif "disjunctive_test" in test_bin.name:
+            arg_sets = [["strict"], ["nonstrict"]]
         else:
             arg_sets = [[]]
 

--- a/verification/verification_pipeline.sh
+++ b/verification/verification_pipeline.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Run the full verification pipeline. Stops at the first failure.
+# Usage: ./verification_pipeline.sh money
+
+set -euo pipefail
+
+CAKE_PB_CP="../../cakepb-dev/cp/cake_pb_cp"
+BIN="../build/$1"
+TRACE_FLAG="--trace-failed"
+
+function replace_nested_brackets() {
+    awk '{
+        result = ""
+        depth = 0
+        for (i = 1; i <= length($0); i++) {
+            c = substr($0, i, 1)
+            if (c == "[") {
+                depth++
+                result = result (depth > 1 ? "{" : "[")
+            } else if (c == "]") {
+                result = result (depth > 1 ? "}" : "]")
+                depth--
+            } else {
+                result = result c
+            }
+        }
+        print result
+    }' "$1"
+}
+
+if [[ "${1:-}" == "--trace-failed" ]]; then
+    TRACE_FLAG="--trace-failed"
+fi
+
+step() {
+    echo
+    echo "=== $1 ==="
+}
+
+step "1/5: generate OPB and proof"
+echo "$ $BIN --prove"
+"$BIN" --prove
+
+step "1.5/5: Replace square brackets with curly braces in OPB, PBP and SCP"
+replace_nested_brackets "$1.opb" > "$1.opb.tmp"
+mv "$1.opb.tmp" "$1.opb"
+replace_nested_brackets "$1.pbp" > "$1.pbp.tmp"
+mv "$1.pbp.tmp" "$1.pbp"
+sed -i '' 's/\[/\{/g; s/\]/\}/g' "$1.scp"
+
+step "2/5: verify original OPB against proof"
+echo "$ veripb $1.opb $1.pbp"
+veripb "$1.opb" "$1.pbp"
+
+step "3/5: produce verified OPB from SCP"
+echo "$ $CAKE_PB_CP $1.scp > $1.verifiedopb"
+"$CAKE_PB_CP" "$1.scp" > "$1.verifiedopb"
+
+# step "3.5/5: work around a bug where escape characters end up in the verifiedopb file"
+# echo "$ sed -i '' 's/\\\\//g' $1.verifiedopb"
+# sed -i '' 's/\\//g' "$1.verifiedopb"
+
+step "4/5: verify verified-OPB against proof, elaborating core"
+echo "$ veripb $1.verifiedopb $1.pbp --elaborate $1.corepb $TRACE_FLAG"
+veripb "$1.verifiedopb" "$1.pbp" --elaborate "$1.corepb" $TRACE_FLAG
+
+step "5/5: check core against SCP"
+echo "$ $CAKE_PB_CP $1.scp $1.corepb"
+"$CAKE_PB_CP" "$1.scp" "$1.corepb"
+
+echo
+step "END"


### PR DESCRIPTION
As per the "semantics_of_cp" document and issue #214, add support for labelled constraints, like this example for Abs:

```
@c[name][posge] X>=0 ==> X >= Y
@c[name][posle] X>=0 ==> X <= Y
@c[name][negle] X>=0 ==> -X <= Y
@c[name][negge] X>=0 ==> -X >= Y
```

I have implemented enough of this for the Abs example.  I have also renamed ConstraintName to ConstraintID to better reflect the intent and to avoid confusion with constraint (type) names.