### PR TITLE
Cap pathological constraint-test runtimes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,10 @@ jobs:
       if: startsWith(matrix.os, 'macos')
 
     - name: Configure CMake
-      run: cmake --preset release -B ${{github.workspace}}/build
+      # Turn the constraint-test runtime caps off on the Ubuntu release runner
+      # so it does full-enumeration completeness checking; the macOS runners
+      # keep the (faster) capped defaults.
+      run: cmake --preset release -B ${{github.workspace}}/build ${{ matrix.os == 'ubuntu-24.04' && '-DGCS_TEST_CAP_DEFAULTS=OFF' || '' }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,17 @@ cmake -S . -B build -DGCS_ENABLE_VIEW_WRAP_SWEEP=ON
 The harness and `--view-wrap=N` / `--view-position=K` argv flags on each
 test are always built; only the ctest registrations are gated.
 
+By default the data-driven constraint tests run with generous per-solve
+solution/recursion caps (`GCS_TEST_CAP_DEFAULTS=ON`) so a pathological
+random instance can't dominate the parallel suite. A capped run checks
+soundness and the partial proof only, **not** completeness — so when
+working on a propagator, turn the caps off to get full enumeration
+checking:
+```shell
+cmake -S . -B build -DGCS_TEST_CAP_DEFAULTS=OFF
+```
+See `dev_docs/constraints.md` (Testing) for details.
+
 Format code with clang-format (all source is formatted this way).
 
 ## Compiler and Standard Library Support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,20 @@ option(GCS_ENABLE_EXAMPLES "Build examples" ${PROJECT_IS_TOP_LEVEL})
 option(GCS_BUILD_TESTS "Build GCS tests" ${PROJECT_IS_TOP_LEVEL})
 option(GCS_ENABLE_VIEW_WRAP_SWEEP "Register the view-wrap proof-verification sweep (many tests, most failing today; opt in when working on view proof logging)" OFF)
 
+# Runtime caps for data-driven constraint tests. When enabled, each registered
+# test gets generous per-solve solution/recursion caps in its environment so
+# that the occasional pathological random instance (huge solution count or
+# search tree, and hence huge proof) cannot dominate the suite runtime. A
+# capped solve verifies a partial proof and checks soundness only. Turn the
+# defaults OFF (e.g. on a CI lane) for full-enumeration completeness checking.
+option(GCS_TEST_CAP_DEFAULTS "Apply default solution/recursion caps to constraint tests to bound pathological runtimes" ON)
+# Defaults chosen empirically so the worst-case data-driven test (linear_ne)
+# stays well under ~1 minute of wall time when the suite runs fully parallel on
+# a 32-core machine; every other test is far below that. Raising them recovers
+# more completeness checking at the cost of a longer tail.
+set(GCS_TEST_MAX_SOLUTIONS "300" CACHE STRING "Default per-solve solution cap for data-driven constraint tests (when GCS_TEST_CAP_DEFAULTS)")
+set(GCS_TEST_MAX_RECURSIONS "1500" CACHE STRING "Default per-solve search-node cap for data-driven constraint tests (when GCS_TEST_CAP_DEFAULTS)")
+
 # Compiler flag checks always run so results are available for target-specific use.
 include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_MARCH_NATIVE CACHE)

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -581,6 +581,58 @@ This was the failure mode we hit twice when first splitting
 `comparison_test` and `linear_test`. Always verify the split with
 `ctest -j N` (not just running each entry solo) before committing.
 
+### Runtime caps for pathological random instances
+
+Splitting helps when *one constraint* is uniformly slow, but the
+data-driven tests have a second, nastier failure mode: the random data
+and random search order occasionally conspire to produce a single
+instance with a huge number of solutions or a huge search tree. Since
+every inference is proof-logged and checked by VeriPB, the proof for
+that instance balloons and VeriPB dominates the whole parallel suite —
+and because the data is unseeded, it happens only "every now and again".
+
+Two optional per-solve caps in the harness bound this, read from the
+environment so they apply suite-wide without editing each test:
+
+- `GCS_TEST_MAX_SOLUTIONS=N` — stop a solve after collecting `N` solutions;
+- `GCS_TEST_MAX_RECURSIONS=N` — stop a solve after visiting `N` internal
+  search nodes.
+
+When a cap fires, the solve stops early. The solver emits a partial but
+still VeriPB-checkable proof (`conclusion SAT` if a solution was seen,
+else `NONE` — the same mechanism `check_initialisation_only_for_tests`
+uses), and `check_results` automatically weakens its check: instead of
+`expected == actual` it verifies only that every solution the solver
+*did* produce is genuinely satisfying (`actual ⊆ expected`), then runs
+VeriPB on the partial proof. With neither variable set the behaviour is
+exactly the historical full-enumeration check.
+
+CMake bakes generous defaults into every registered test's environment
+(`GCS_TEST_CAP_DEFAULTS=ON`, with `GCS_TEST_MAX_SOLUTIONS`/
+`GCS_TEST_MAX_RECURSIONS` cache variables), chosen so the worst case
+stays well under a minute of parallel wall time. The Ubuntu release CI
+lane configures with `-DGCS_TEST_CAP_DEFAULTS=OFF` so it keeps doing full
+completeness checking.
+
+**When working on a propagator, build and test with the caps off.** A
+capped run only checks *soundness* (no spurious solutions) and the
+partial proof — it can no longer catch a propagator that *misses*
+solutions or *over-prunes*, which is exactly the class of bug you are
+most likely to introduce. Configure with:
+
+```shell
+cmake -S . -B build -DGCS_TEST_CAP_DEFAULTS=OFF
+```
+
+or, without reconfiguring, clear the variables for a single run:
+
+```shell
+GCS_TEST_MAX_SOLUTIONS= GCS_TEST_MAX_RECURSIONS= ./build/foo_test
+```
+
+The capped defaults are for keeping the *routine* parallel suite fast;
+correctness work wants the full enumeration check.
+
 ## Adding a new constraint: checklist
 
 1. Header file with class declaration, Doxygen comments, the standard

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -364,4 +364,15 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(pol_builder_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     target_compile_definitions(pol_builder_test PRIVATE CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS=1)
     add_test(NAME pol_builder_test COMMAND $<TARGET_FILE:pol_builder_test>)
+
+    # Apply the default runtime caps (see GCS_TEST_CAP_DEFAULTS) to every test
+    # registered above by setting them in each test's environment. Only the
+    # data-driven constraint tests read these variables; the rest ignore them
+    # harmlessly. Turning the option off (e.g. the Ubuntu release CI lane)
+    # leaves the environment untouched, giving full-enumeration checking.
+    if(GCS_TEST_CAP_DEFAULTS)
+        get_property(gcs_registered_tests DIRECTORY PROPERTY TESTS)
+        set_tests_properties(${gcs_registered_tests} PROPERTIES ENVIRONMENT
+            "GCS_TEST_MAX_SOLUTIONS=${GCS_TEST_MAX_SOLUTIONS};GCS_TEST_MAX_RECURSIONS=${GCS_TEST_MAX_RECURSIONS}")
+    endif()
 endif()

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -69,6 +69,47 @@ namespace gcs::test_innards
         return run_veripb("--help", ">/dev/null");
     }
 
+    /**
+     * \name Runtime caps for pathological random test cases
+     *
+     * Some data-driven constraint tests occasionally generate an instance with
+     * a very large number of solutions or a very large search tree. Because the
+     * proof is logged and verified by VeriPB, these cases produce huge proofs
+     * and dominate the (parallel) test suite runtime.
+     *
+     * Two optional caps bound this, read from the environment so they can be
+     * applied suite-wide without editing each test:
+     *  - \c GCS_TEST_MAX_SOLUTIONS : stop a solve once this many solutions have
+     *    been collected;
+     *  - \c GCS_TEST_MAX_RECURSIONS : stop a solve once this many internal
+     *    search nodes (trace callbacks) have been visited.
+     *
+     * When a cap fires the solve stops early. The solver then emits a partial
+     * but still VeriPB-checkable proof (conclusion SAT or NONE — the same path
+     * used by check_initialisation_only_for_tests), and check_results() weakens
+     * its comparison to a soundness-only subset check (see last_run_truncated).
+     *
+     * An unset or empty variable means "no cap"; the default behaviour with
+     * neither variable set is exactly the historical full-enumeration check.
+     * @{
+     */
+    inline auto env_cap(const char * name) -> std::optional<unsigned long long>
+    {
+        if (auto v = std::getenv(name); v && *v)
+            return std::strtoull(v, nullptr, 10);
+        return std::nullopt;
+    }
+
+    /// Whether the most recent solve_for_tests*() call stopped early because a
+    /// cap fired. Set by solve_for_tests_with_callbacks(), read by
+    /// check_results(); single-threaded, one solve per check by construction.
+    inline auto last_run_truncated() -> bool &
+    {
+        static bool truncated = false;
+        return truncated;
+    }
+    /// @}
+
     template <typename ResultsSet_, typename IsSatisfying_, typename... Accumulated_>
     auto generate_expected(ResultsSet_ & expected, IsSatisfying_ is_satisfying, const std::tuple<Accumulated_...> & acc) -> void
     {
@@ -223,6 +264,26 @@ namespace gcs::test_innards
 #endif
         using std::cerr;
 
+        if (last_run_truncated()) {
+            // The solve was stopped early by a runtime cap, so `actual` holds
+            // only a subset of the solutions. Completeness is no longer
+            // checkable; verify soundness instead — every solution the solver
+            // produced must be genuinely satisfying (present in `expected`,
+            // which is built independently by the test's own oracle). The
+            // partial proof is still verified by VeriPB below.
+            for (const auto & item : actual)
+                if (! expected.contains(item)) {
+                    println(cerr, "truncated test run produced a spurious solution");
+                    println(cerr, "spurious: {}", item);
+                    throw UnexpectedException{"Truncated test run produced a solution not in expected"};
+                }
+            println(cerr, "[truncated run: {} of <= {} solutions checked sound]", actual.size(), expected.size());
+            if (proof_name)
+                if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
+                    throw UnexpectedException{"veripb verification failed"};
+            return;
+        }
+
         if (expected != actual) {
             println(cerr, "test did not produce expected results");
             println(cerr, "expected: {}", expected);
@@ -293,8 +354,34 @@ namespace gcs::test_innards
     template <typename SolutionCallback_, typename TraceCallback_>
     auto solve_for_tests_with_callbacks(Problem & p, const std::optional<std::string> & proof_name, const SolutionCallback_ & f, const TraceCallback_ & t) -> void
     {
+        // Apply the optional runtime caps (see env_cap). The wrappers count
+        // solutions / internal search nodes and return false to stop the solve
+        // once a cap is reached; `f` and `t` and these counters all outlive the
+        // synchronous solve_with() call below, so capture by reference is safe.
+        const auto max_solutions = env_cap("GCS_TEST_MAX_SOLUTIONS");
+        const auto max_recursions = env_cap("GCS_TEST_MAX_RECURSIONS");
+        last_run_truncated() = false;
+        unsigned long long solution_count = 0, node_count = 0;
+
+        auto capped_solution = [&](const CurrentState & s) -> bool {
+            if (max_solutions && solution_count >= *max_solutions) {
+                last_run_truncated() = true;
+                return false;
+            }
+            ++solution_count;
+            return f(s);
+        };
+        auto capped_trace = [&](const CurrentState & s) -> bool {
+            if (max_recursions && node_count >= *max_recursions) {
+                last_run_truncated() = true;
+                return false;
+            }
+            ++node_count;
+            return t(s);
+        };
+
         solve_with(p,
-            SolveCallbacks{.solution = f, .trace = t, .branch = random_branch_with_optional_seed(p)},
+            SolveCallbacks{.solution = capped_solution, .trace = capped_trace, .branch = random_branch_with_optional_seed(p)},
             proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}, true, false) : std::nullopt);
     }
 

--- a/gcs/constraints/knapsack_test.cc
+++ b/gcs/constraints/knapsack_test.cc
@@ -6,6 +6,7 @@
 #include <util/enumerate.hh>
 
 #include <cstdlib>
+#include <functional>
 #include <iostream>
 #include <random>
 #include <set>
@@ -67,7 +68,29 @@ auto run_knapsack_test(bool proofs, pair<int, int> valrange, const vector<vector
 
         return sums == profits;
     };
-    build_expected(expected, is_satisfying, vector{coeffs[0].size(), valrange}, bounds);
+    // Enumerate only the `taken` assignments. The total/profit variables are
+    // functionally determined (the constraint forces each total to equal its
+    // weighted sum), so compute them rather than enumerating their ranges and
+    // filtering with `sums == profits`. The latter made build_expected the
+    // dominant cost on this test, since totals range up to ~1000.
+    auto n_items = coeffs[0].size();
+    std::vector<int> taken(n_items);
+    std::function<auto(std::size_t)->void> enumerate_taken = [&](std::size_t pos) -> void {
+        if (pos == n_items) {
+            std::vector<int> sums(coeffs.size(), 0);
+            for (std::size_t i = 0; i < coeffs.size(); ++i)
+                for (std::size_t k = 0; k < n_items; ++k)
+                    sums[i] += coeffs[i][k] * taken[k];
+            if (is_satisfying(taken, sums))
+                expected.emplace(taken, sums);
+            return;
+        }
+        for (int v = valrange.first; v <= valrange.second; ++v) {
+            taken[pos] = v;
+            enumerate_taken(pos + 1);
+        }
+    };
+    enumerate_taken(0);
 
     println(cerr, " expecting {} solutions", expected.size());
 


### PR DESCRIPTION
## Problem

Some data-driven constraint tests occasionally generate a random instance with a huge number of solutions or a huge search tree. Because every inference is proof-logged and checked by VeriPB, these rare cases produce enormous proofs and dominate the parallel suite runtime.

Measured on the core suite (`-j32`, this 32-core machine, fresh randomness): the worst data-driven tests have a heavy nondeterministic tail — e.g. `linear_ne` ranged 14s→**170s** across runs (a single bad run ≈ 30% of the whole core suite's CPU); `count` 1→40s; `element_var2d` 0.1→20s. Decomposition showed these are **proof-bound**: veripb is 75–90% of the time, and proof size scales with solutions + search nodes (single solves hit 18k solutions / 42k nodes).

## What this does

Two optional, environment-driven **per-solve caps** in the shared test harness:
- `GCS_TEST_MAX_SOLUTIONS` — stop once this many solutions are collected;
- `GCS_TEST_MAX_RECURSIONS` — stop once this many internal search nodes are visited.

When a cap fires, the solve stops early, the solver emits a partial but still VeriPB-checkable proof (`conclusion SAT`/`NONE` — the same path `check_initialisation_only_for_tests` already uses), and `check_results()` weakens to a **soundness-only subset check** (every produced solution must be genuinely satisfying; the partial proof is still verified). With neither variable set, behaviour is exactly the old full-enumeration check — **a no-op by default**.

CMake applies generous defaults (**300 solutions / 1500 nodes**) to every registered test via `GCS_TEST_CAP_DEFAULTS` (ON). Values chosen empirically so the worst case (`linear_ne`) stays well under ~1 minute of parallel wall time (max ~30s at these caps vs 170s uncapped); every other test is far below.

- The **Ubuntu release CI lane** configures with `-DGCS_TEST_CAP_DEFAULTS=OFF` → full-enumeration completeness checking preserved on CI.
- macOS release lanes and local runs use the faster capped defaults. Sanitize lane unchanged (capped).

Also fixes **knapsack_test's oracle** — the one blow-up the caps don't touch (it's oracle-bound, not proof-bound). `build_expected` enumerated the wide total/profit ranges (up to ~1000 each) and filtered by `sums == profits`, making it the dominant cost (3–8s). The totals are functionally determined, so it now computes them from the `taken` assignment.

## Results

Core suite wall **71s → 35s**; worst single capped test well under the ~1 minute budget. **100% pass both capped and uncapped.** Both changed sources compile under GCC 15.2 and clang 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)