### PR TITLE
minizinc: fix optimisation, output terminators, and Challenge flags

### DIFF
--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <csignal>
+#include <cstdint>
 #include <cstdlib>
 #include <exception>
 #include <fstream>
@@ -205,6 +206,13 @@ auto main(int argc, char * argv[]) -> int
     try {
         options.add_options()("help", "Display help information")                                      //
             ("all-solutions,a", "Print all solutions, or solve an optimisation problem to optimality") //
+            ("intermediate,i", "Print intermediate solutions of an optimisation problem")              //
+            ("free-search,f", "Ignore the model's search annotations")                                 //
+            ("parallel,p", "Number of parallel threads (accepted but ignored; search is sequential)",  //
+                cxxopts::value<unsigned long long>())                                                  //
+            ("random-seed,r", "Random seed for randomised search heuristics",                          //
+                cxxopts::value<unsigned long long>())                                                  //
+            ("verbose,v", "Verbose output (accepted but ignored)")                                     //
             ("n-solutions,n", "Stop after this many solutions", cxxopts::value<unsigned long long>())  //
             ("statistics,s", "Print statistics")                                                       //
             ("timeout,t", "Timeout in ms", cxxopts::value<unsigned long long>())                       //
@@ -228,6 +236,11 @@ auto main(int argc, char * argv[]) -> int
     }
 
     bool all_solutions = options_vars.contains("all-solutions");
+    bool free_search = options_vars.contains("free-search");
+
+    optional<std::uint_fast32_t> random_seed;
+    if (options_vars.contains("random-seed"))
+        random_seed = static_cast<std::uint_fast32_t>(options_vars["random-seed"].as<unsigned long long>());
 
     optional<unsigned long long> solution_limit;
     if (options_vars.contains("n-solutions"))
@@ -759,13 +772,16 @@ auto main(int argc, char * argv[]) -> int
         }
 
         auto solve_method = fzn["solve"]["method"];
+        bool optimisation = false;
         if (solve_method == "satisfy") {
         }
         else if (solve_method == "minimize") {
             problem.minimise(data.integer_variables.at(fzn["solve"]["objective"]).first);
+            optimisation = true;
         }
         else if (solve_method == "maximize") {
             problem.maximise(data.integer_variables.at(fzn["solve"]["objective"]).first);
+            optimisation = true;
         }
         else
             throw FlatZincInterfaceError{format("Unknown solve method {} in {}", string{solve_method}, fznname)};
@@ -774,9 +790,9 @@ auto main(int argc, char * argv[]) -> int
             branch_with(variable_order::dom_then_deg(data.branch_variables), value_order::smallest_first()),
             branch_with(variable_order::dom_then_deg(data.all_variables), value_order::smallest_first()));
 
-        if (fzn["solve"].contains("ann")) {
+        if ((! free_search) && fzn["solve"].contains("ann")) {
             function<optional<BranchCallback>(const nlohmann::json &)> parse_search;
-            parse_search = [&data, &parse_search](const nlohmann::json & ann) -> optional<BranchCallback> {
+            parse_search = [&data, &parse_search, &random_seed](const nlohmann::json & ann) -> optional<BranchCallback> {
                 if (ann["id"] == "bool_search" || ann["id"] == "int_search") {
                     auto args = ann["args"];
                     vector<IntegerVariableID> vars = arg_as_array_of_var(data, args, 0);
@@ -816,7 +832,9 @@ auto main(int argc, char * argv[]) -> int
                     else if (val_heuristic == "indomain_split")
                         val = value_order::split_smallest_first();
                     else if (val_heuristic == "indomain_split_random")
-                        val = value_order::split_random();
+                        val = random_seed ? value_order::split_random(*random_seed) : value_order::split_random();
+                    else if (val_heuristic == "indomain_random")
+                        val = random_seed ? value_order::random(*random_seed) : value_order::random();
                     else {
                         println(cerr, "Warning: treating unknown int_search value heuristic {} as indomain instead", val_heuristic);
                         val = value_order::smallest_first();
@@ -868,10 +886,11 @@ auto main(int argc, char * argv[]) -> int
             proof_options.emplace(basename);
         }
 
-        bool completed = false;
+        bool completed = false, any_solution = false;
         auto stats = solve_with(problem,
             SolveCallbacks{
                 .solution = [&](const CurrentState & s) -> bool {
+                    any_solution = true;
                     for (const string name : fzn["output"]) {
                         if (data.integer_variables.contains(name)) {
                             auto vardata = data.integer_variables.at(name);
@@ -908,9 +927,12 @@ auto main(int argc, char * argv[]) -> int
                         if (--*solution_limit == 0)
                             return false;
                     }
-                    else if (! all_solutions)
+                    else if ((! all_solutions) && (! optimisation))
                         return false;
 
+                    // For optimisation, keep searching: each subsequent solution
+                    // strictly improves the objective, until the search is complete
+                    // (optimality proven) or aborted (timeout / signal).
                     return true;
                 },
                 .branch = brancher,
@@ -927,7 +949,19 @@ auto main(int argc, char * argv[]) -> int
         }
 
         if (completed) {
-            println(cout, "==========");
+            // Search space fully explored. With at least one solution this means
+            // all solutions enumerated (satisfaction) or optimality proven
+            // (optimisation); with none it means the problem is unsatisfiable.
+            if (any_solution)
+                println(cout, "==========");
+            else
+                println(cout, "=====UNSATISFIABLE=====");
+            cout << flush;
+        }
+        else if (! any_solution) {
+            // Search was aborted (timeout / signal) before finding any solution
+            // and before proving unsatisfiability.
+            println(cout, "=====UNKNOWN=====");
             cout << flush;
         }
 

--- a/minizinc/glasgow-for-debugging.msc
+++ b/minizinc/glasgow-for-debugging.msc
@@ -6,7 +6,7 @@
     "mznlib": "mznlib",
     "executable": "false",
     "tags": ["cp", "int"],
-    "stdFlags": ["-a", "-n", "-s", "-t"],
+    "stdFlags": ["-a", "-f", "-i", "-n", "-p", "-r", "-s", "-t", "-v"],
     "extraFlags": [["--prove", "Write a proof to this file (suffix .opb and .pbp will be added)", "string", ""]]
 }
 

--- a/minizinc/glasgow-for-tests.msc
+++ b/minizinc/glasgow-for-tests.msc
@@ -6,7 +6,7 @@
     "mznlib": "mznlib",
     "executable": "fzn-glasgow",
     "tags": ["cp", "int"],
-    "stdFlags": ["-a", "-n", "-s", "-t"],
+    "stdFlags": ["-a", "-f", "-i", "-n", "-p", "-r", "-s", "-t", "-v"],
     "extraFlags": [["--prove", "Write a proof to this file (suffix .opb and .pbp will be added)", "string", ""]],
     "inputType": "JSON"
 }

--- a/minizinc/glasgow.msc
+++ b/minizinc/glasgow.msc
@@ -6,7 +6,7 @@
     "mznlib": "mznlib",
     "executable": "minizinc/../build/fzn-glasgow",
     "tags": ["cp", "int"],
-    "stdFlags": ["-a", "-n", "-s", "-t"],
+    "stdFlags": ["-a", "-f", "-i", "-n", "-p", "-r", "-s", "-t", "-v"],
     "extraFlags": [["--prove", "Write a proof to this file (suffix .opb and .pbp will be added)", "string", ""]],
     "inputType": "JSON"
 }

--- a/minizinc/mznlib/fzn_strictly_decreasing_int.mzn
+++ b/minizinc/mznlib/fzn_strictly_decreasing_int.mzn
@@ -1,0 +1,1 @@
+predicate fzn_strictly_decreasing_int(array[int] of var int: x) = glasgow_strictly_increasing_int(reverse(x));


### PR DESCRIPTION
First step towards a MiniZinc Challenge-capable FlatZinc frontend. This is the "Tier 0" plumbing/correctness pass (Docker packaging and native global_cardinality deliberately out of scope — see below).

## Correctness fixes

- **Optimisation ran to first-feasible only.** The solution callback returned `false` after the first solution unless `-a` was given, and `solve.cc` treats a `false` return as a full-search abort — so `minimize`/`maximize` reported the first feasible assignment and never optimised or proved optimality (i.e. it scored ~0 on the entire COP half of the Challenge, which invokes solvers without `-a`). Now we only stop-after-first for *satisfaction*; optimisation keeps searching, streaming improving solutions, until optimality is proven or the search is aborted.

- **Output terminators were wrong.** Unsatisfiable instances printed `==========` and aborted (timed-out) searches printed nothing. A new `any_solution` flag now drives correct `=====UNSATISFIABLE=====` / `=====UNKNOWN=====` output, with `==========` reserved for full enumeration / proven optimality.

## Standard flags

Added the FlatZinc flags the Challenge driver uses, and advertised them in `stdFlags` across all three `.msc` files (needed for class eligibility — the classes are upward-inclusive):

- `-f` — free search (ignore the model's search annotations)
- `-i` — intermediate solutions
- `-p N` — parallel thread count (accepted but ignored; search is sequential)
- `-r N` — random seed (threaded into the randomised value heuristics; adds an `indomain_random` mapping)
- `-v` — verbose (accepted but ignored)

## mznlib

- Added `fzn_strictly_decreasing_int` (mirrors `fzn_decreasing_int`) — the only missing ordering redefinition.

## Testing

- All 55 `minizinc-*` ctests pass.
- Manually verified through the `minizinc` 2.9.7 driver: optimisation (with/without `-i`) streams improving solutions and proves the optimum; UNSAT → `=====UNSATISFIABLE=====`; all-solutions → `==========`; short timeout → `=====UNKNOWN=====`; `strictly_decreasing`; annotation-honoured vs `-f`; `-p 4 -r 42`.

## Out of scope (intentionally)

- **Docker packaging / default-solver registration** — deferred to submission time; the exact base image and mechanism change each year.
- **Native flow-based `global_cardinality`** — no GCC propagator exists yet; that's constraint work, not frontend plumbing. The stdlib decomposition already routes through our `Count`.

## Note for review

Optimisation now streams intermediate solutions even without `-i`. This is conventional CP-solver behaviour (Gecode/Chuffed do the same) and within spec, and the Challenge always passes `-i` regardless. If strict `-i`-gating is preferred, buffering the last solution is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)