### PR TITLE
fzn frontend: parse constants in var-arrays (#243) and variable linear rhs (#245)

### DIFF
--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -161,11 +161,16 @@ namespace
         }
         else if (a.is_array()) {
             vector<IntegerVariableID> result;
-            for (const auto & v : a)
+            for (const auto & v : a) {
                 if (v.is_string())
                     result.push_back(data.integer_variables.at(v).first);
+                else if (v.is_number())
+                    result.push_back(ConstantIntegerVariableID{Integer{static_cast<long long>(v)}});
+                else if (v.is_boolean())
+                    result.push_back(ConstantIntegerVariableID{static_cast<bool>(v) ? 1_i : 0_i});
                 else
                     throw FlatZincInterfaceError{format("Don't know how to parse entry {} in array of variables", v.dump())};
+            }
             return result;
         }
         else {
@@ -414,13 +419,21 @@ auto main(int argc, char * argv[]) -> int
             else if (id == "int_lin_eq" || id == "int_lin_le" || id == "int_lin_ne" || id == "bool_lin_eq" || id == "bool_lin_le") {
                 auto coeffs = arg_as_array_of_integer(data, args, 0);
                 const auto & vars = arg_as_array_of_var(data, args, 1);
-                Integer total{static_cast<long long>(args.at(2))};
                 if (coeffs->size() != vars.size())
                     throw FlatZincInterfaceError{format("Array length mismatch in {} in {}", id, fznname)};
 
                 SumOf<Weighted<IntegerVariableID>> terms;
                 for (size_t c = 0; c < coeffs->size(); ++c)
                     terms += (*coeffs)[c] * vars[c];
+
+                // The right-hand side is a constant in most linear constraints, but some
+                // (notably bool_lin_eq, whose sum is a var int) pass a variable. Move a
+                // variable rhs onto the left with coefficient -1 and compare against 0.
+                Integer total{0_i};
+                if (args.at(2).is_number())
+                    total = Integer{static_cast<long long>(args.at(2))};
+                else
+                    terms += -1_i * arg_as_var(data, args, 2);
 
                 if (id.ends_with("_eq"))
                     problem.post(LinearEquality{terms, total});


### PR DESCRIPTION
Two small FlatZinc-frontend parser robustness fixes surfaced by MiniZinc Challenge coverage benchmarking (gcs-benchmarks Phase 0). Both are confined to `minizinc/fzn_glasgow.cc`.

## #243 — integer/boolean constants in array-of-variable arguments
`arg_as_array_of_var` only accepted string entries (variable names); a constant (e.g. `-1`) inside an array-of-vars threw `Don't know how to parse entry -1 in array of variables`. Now wraps numeric/boolean literals as `ConstantIntegerVariableID`, mirroring `arg_as_var`. **Closes #243.**

Verified: `Unit-Commitment`, `ihtc-2024-marte`, `is` now flatten and run instead of erroring.

## #245 — variable right-hand side in linear constraints
`bool_lin_eq`'s sum `c` is a `var int` per the FlatZinc spec, but the `int_lin_*`/`bool_lin_*` handler read `args[2]` unconditionally as a constant (`static_cast<long long>`), crashing with `type must be number, but is string`. A variable rhs is now moved to the LHS with coefficient `-1` and compared against `0`.

Verified: a hand-built var-rhs `bool_lin_eq([2,3],[b1,b2],s)` enumerates exactly the correct solution set `{(0,0,0),(1,0,2),(0,1,3),(1,1,5)}`; constant-rhs handling is unchanged.

## Testing
- All 55 `minizinc-*` ctests pass.
- Direct enumeration checks for both fixes (above).

## Important caveat — a separate soundness bug remains
Fixing the #245 parse error unmasked a **separate, pre-existing soundness bug**: with parsing fixed, `gt-sort` now *runs* but returns `UNSATISFIABLE`, whereas Gecode and Huub both prove optimum **79**. The var-rhs transform itself is verified correct (above), so the wrong result comes from elsewhere in `gt-sort`'s large `sort` decomposition (bisection of a 263 MB FlatZinc needed). Filed as a separate issue; **not** addressed here. So this PR resolves the #245 *parse failure* but does not make `gt-sort` correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)