### PR TITLE
Fix circuit index-offset bug causing spurious UNSAT (#249)

### DIFF
--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -37,6 +37,9 @@ set_tests_properties(minizinc-boolxor PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-cake COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cake false true)
 set_tests_properties(minizinc-cake PROPERTIES SKIP_RETURN_CODE 66)
 
+add_test(NAME minizinc-circuit COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ circuittest true true)
+set_tests_properties(minizinc-circuit PROPERTIES SKIP_RETURN_CODE 66)
+
 add_test(NAME minizinc-count COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ counttest true true)
 set_tests_properties(minizinc-count PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -628,10 +628,9 @@ auto main(int argc, char * argv[]) -> int
                 problem.post(Among{vars, *varmatch, varcount});
             }
             else if (id == "glasgow_circuit") {
+                // The mznlib redefinition has already shifted successors to be
+                // 0-based (Circuit expects a length-n array valued in 0..n-1).
                 const auto & vars = arg_as_array_of_var(data, args, 0);
-                vector<IntegerVariableID> vars_shifted;
-                for (const auto & v : vars)
-                    vars_shifted.push_back(v - 1_i);
                 problem.post(Circuit{vars});
             }
             else if (id == "glasgow_count_eq") {

--- a/minizinc/mznlib/fzn_circuit.mzn
+++ b/minizinc/mznlib/fzn_circuit.mzn
@@ -1,2 +1,7 @@
 predicate glasgow_circuit(array[int] of var int: x);
-predicate fzn_circuit(array[int] of var int: x) = glasgow_circuit([x[i] - 1 | i in index_set(x)]);
+
+% glasgow_circuit expects 0-based successors (a length-n array whose values are
+% in 0..n-1). FlatZinc circuit is defined over index_set(x) with successor values
+% in that same set, so shift by min(index_set(x)) rather than assuming 1-based.
+predicate fzn_circuit(array[int] of var int: x) =
+    glasgow_circuit([x[i] - min(index_set(x)) | i in index_set(x)]);

--- a/minizinc/tests/circuittest.mzn
+++ b/minizinc/tests/circuittest.mzn
@@ -1,0 +1,13 @@
+include "globals.mzn";
+
+% Indexed from 0 on purpose: the FlatZinc circuit predicate is defined over
+% index_set(x) with successor values in that same set, so a 0-based array must
+% not be shifted as if it were 1-based (regression test for the off-by-one that
+% turned satisfiable 0-based circuits into spurious UNSAT).
+array[0..3] of var 0..3: succ;
+
+constraint circuit(succ);
+
+solve satisfy;
+
+output ["ENUMSOL: " ++ show(succ)];


### PR DESCRIPTION
## Summary

Fixes #249 — `fzn-glasgow` wrongly reported **no solution** on the satisfiable
`is`/`vWQp9idqMs` instance (MiniZinc Challenge 2025); Gecode and Huub both prove
optimum **71168**.

**Root cause:** the mznlib `fzn_circuit` redefinition unconditionally subtracted
`1` from every successor, assuming a 1-based index set. MiniZinc's `circuit` is
defined over `index_set(x)` with successor values in that *same* set, so this
instance's **0-based** circuit (index_set `0..n-1`, values `0..n-1`) was shifted to
`-1..n-2`, leaving node `n-1` unreachable → the encoding became unsatisfiable.

## Diagnosis (proof logging earned its keep)

The buggy run concluded UNSAT at the **root with 0 propagations**, and VeriPB
**verified** that root contradiction against the OPB gcs emits. That cleanly split
the diagnosis: the *encoding itself* was unsatisfiable, so the bug was in the
frontend translation — **not** a circuit propagator soundness fault.

## Fix

- `mznlib/fzn_circuit.mzn`: shift by `min(index_set(x))` instead of hardcoded `1`,
  so any index base maps correctly onto the 0-based array `Circuit` expects
  (matches the canonical stdlib offset, e.g. Chuffed's `chuffed_circuit(x, min(index_set(x)))`).
- `fzn_glasgow.cc`: remove the dead `vars_shifted` block — it computed a *second*
  1-shift and then discarded it, posting the unshifted handles (a latent footgun).

After the fix gcs finds **and proves** optimum 71168, matching the references.

## Test

Adds `minizinc-circuit`: a **0-based** circuit enumeration + proof test. It diffs
glasgow's full enumeration against the default solver and runs VeriPB. Verified it
**fails** against the old `-1` shift and **passes** with the offset-aware one, so it
genuinely guards the regression. All existing minizinc/circuit ctests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)