### PR TITLE
Fix LinearEquality over constant-only terms reporting spurious UNSAT (#248)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -141,6 +141,7 @@ if(GCS_BUILD_TESTS)
     add_executable(knapsack_test constraints/knapsack_test.cc)
     add_executable(lex_test constraints/lex_test.cc)
     add_executable(linear_test constraints/linear/linear_test.cc)
+    add_executable(linear_constant_test constraints/linear/linear_constant_test.cc)
     add_executable(logical_test constraints/logical_test.cc)
     add_executable(min_max_test constraints/min_max_test.cc)
     add_executable(mult_bc_test constraints/mult_bc_test.cc)
@@ -160,7 +161,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test arithmetic_test at_most_one_test comparison_test
-            count_test cumulative_test disjunctive_test element_test equals_test in_test increasing_test inverse_test knapsack_test lex_test linear_test
+            count_test cumulative_test disjunctive_test element_test equals_test in_test increasing_test inverse_test knapsack_test lex_test linear_test linear_constant_test
             logical_test min_max_test mult_bc_test n_value_test parity_test
             plus_minus_test regular_test seq_precede_chain_test smart_table_test symmetric_all_different_test
             negative_table_test table_test value_precede_test)
@@ -189,6 +190,7 @@ if(GCS_BUILD_TESTS)
             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:element_test> ${mode})
     endforeach()
     add_test(NAME equals_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:equals_test>)
+    add_test(NAME linear_constant_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_constant_test>)
 
     # View-wrap sweep: feeds the constraint each variable as a ViewOfIntegerVariableID
     # (offset / negation / both) instead of a bare SimpleIntegerVariableID. The

--- a/gcs/constraints/linear/linear_constant_test.cc
+++ b/gcs/constraints/linear/linear_constant_test.cc
@@ -1,0 +1,96 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::nullopt;
+using std::set;
+using std::string;
+using std::tuple;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+// Regression test for the empty-sum-with-constant bug: a linear (in)equality
+// all of whose terms are constants tidies down to no variable terms, with the
+// constant part folded into `modifier`. The fixed-condition shortcut must then
+// compare the empty sum (0) against `value + modifier`, i.e. it holds iff
+// `modifier == -value`. The old code compared against `value` directly, which
+// reported the tautology 1*1 == 1 (from e.g. bool_lin_eq([1],[true],1)) as a
+// spurious contradiction -- a wrong UNSAT that VeriPB correctly rejected.
+
+namespace
+{
+    // Post `cons` over an otherwise-free x in 0..2; if the constant constraint is
+    // satisfiable the free x yields {0,1,2}, otherwise no solutions at all.
+    template <typename PostConstraint_>
+    auto run_constant_linear_test(bool proofs, const string & label, bool satisfiable, const PostConstraint_ & post) -> void
+    {
+        println(cerr, "linear constant: {}{}", label, proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<tuple<int>> expected;
+        if (satisfiable)
+            for (int x = 0; x <= 2; ++x)
+                expected.emplace(x);
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 2_i);
+        post(p);
+
+        set<tuple<int>> actual;
+        auto proof_name = proofs ? make_optional("linear_constant_test") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{x});
+        check_results(proof_name, expected, actual);
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+
+        // LinearEquality (condition definitely true): empty sum holds iff value + modifier == 0.
+        run_constant_linear_test(proofs, "1*1 == 1 (tautology)", true,
+            [](Problem & p) { p.post(LinearEquality{WeightedSum{} + 1_i * 1_c, 1_i}); });
+        run_constant_linear_test(proofs, "1*1 == 2 (contradiction)", false,
+            [](Problem & p) { p.post(LinearEquality{WeightedSum{} + 1_i * 1_c, 2_i}); });
+        run_constant_linear_test(proofs, "2*3 == 6 (tautology, coeff != 1)", true,
+            [](Problem & p) { p.post(LinearEquality{WeightedSum{} + 2_i * 3_c, 6_i}); });
+        run_constant_linear_test(proofs, "2*3 == 5 (contradiction, coeff != 1)", false,
+            [](Problem & p) { p.post(LinearEquality{WeightedSum{} + 2_i * 3_c, 5_i}); });
+
+        // LinearNotEquals (condition definitely false): empty sum is violated iff it would hold.
+        run_constant_linear_test(proofs, "1*1 != 1 (contradiction)", false,
+            [](Problem & p) { p.post(LinearNotEquals{WeightedSum{} + 1_i * 1_c, 1_i}); });
+        run_constant_linear_test(proofs, "1*1 != 2 (tautology)", true,
+            [](Problem & p) { p.post(LinearNotEquals{WeightedSum{} + 1_i * 1_c, 2_i}); });
+
+        // Mixed: a real variable term plus a constant term leaves a non-empty sum,
+        // so the constant is folded into the modifier but the normal propagation path runs.
+        run_constant_linear_test(proofs, "y(=5) + 3 == 8 (tautology, constant folded)", true,
+            [](Problem & p) {
+                auto y = p.create_integer_variable(5_i, 5_i, "y");
+                p.post(LinearEquality{WeightedSum{} + 1_i * y + 1_i * 3_c, 8_i});
+            });
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -254,8 +254,9 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
     else {
         overloaded{
             [&](const evaluated_reif::MustHold & reif) {
-                // condition is definitely true, an empty sum matches iff the modifiers sum to the value
-                if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier != _value) {
+                // condition is definitely true; with no variable terms left the sum is just
+                // the (folded-out) constant part, so the equality holds iff _value + modifier == 0
+                if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier != -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
                         inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }});
                     });
@@ -278,8 +279,9 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
             },
 
             [&](const evaluated_reif::MustNotHold & reif) {
-                // condition is definitely false on a full reification, an empty sum matches iff the modifiers sum to something other than the value
-                if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier == _value) {
+                // condition is definitely false on a full reification; with no variable terms left
+                // the equality _value + modifier == 0 must NOT hold, so it is violated iff it does
+                if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier == -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
                         inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }});
                     });


### PR DESCRIPTION
## Summary

Fixes #248 — `fzn-glasgow` returned **UNSATISFIABLE** on satisfiable `gt-sort`
instances (Gecode and Huub prove optimum **79**).

**Root cause** (an engine bug, dormant until #247 exposed it): in
`ReifiedLinearEquality::install_propagators`, when a linear equality has no
variable terms left (all terms are constants, folded into `modifier` by
`tidy_up_linear`), the empty-sum shortcut compared `modifier` against the bare
`_value`. Everywhere else the effective RHS is `_value + modifier`, so an empty
sum (= 0) is satisfiable iff `_value + modifier == 0`, i.e. `modifier == -_value`.
The missing negation made the tautology `1*1 == 1` register as a contradiction
(real contradictions like `1*1 == 2` only passed by luck).

`gt-sort`'s `sort` decomposition emits `bool_lin_eq([1],[true],1)`; since #247 a
`true` literal becomes a `ConstantIntegerVariableID`, producing exactly such an
all-constant equality → spurious root UNSAT.

## Diagnosis (proof logging, again)

The search tree was trivial — **0 nodes / 0 failures / 0 propagations** — so I
proof-logged it. Unlike #249 (where VeriPB *verified* the root UNSAT, pointing at
the encoding), here VeriPB **rejected** the proof: the contradiction was *not*
RUP-derivable from the OPB. That isolated it as an **unsound propagation**, not a
bad encoding. Greedy minimisation reduced it to a single constraint —
`bool_lin_eq([1],[true],1)`, the tautology `1*1 == 1` — which alone makes the
solver report UNSAT.

## Fix

Compare against `-_value` in both the `MustHold` and `MustNotHold` empty-sum
checks. After the fix, the minimal `1*1 == 1` case is SAT with a VeriPB-verified
proof, and `gt-sort` no longer wrongly reports UNSAT (it now searches; the
remaining slowness on the 263 MB `sort` decomposition is the separate #251).

## Test

Adds `linear_constant_test`: tautology/contradiction cases for `LinearEquality`
and `LinearNotEquals` over constant terms (both polarities, a coefficient ≠ 1
case, and a real-variable-plus-constant sanity case), each proof-verified.
Confirmed it **fails** against the old sign and **passes** with the fix. Full
suite (268 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)