### PR TITLE
Add a regular-expression string constructor to Regular

### DIFF
--- a/examples/regex/regex.cc
+++ b/examples/regex/regex.cc
@@ -28,12 +28,13 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")                                                       //
-            ("help", "Display help information")                                                     //
-            ("prove", "Create a proof")                                                              //
-            ("proof-files-basename", "Basename for the .opb and .pbp files",                         //
-                cxxopts::value<string>()->default_value("regex"))                                    //
-            ("stats", "Print solve statistics")                                                      //
+        options.add_options("Program Options")                                                                 //
+            ("help", "Display help information")                                                               //
+            ("prove", "Create a proof")                                                                        //
+            ("proof-files-basename", "Basename for the .opb and .pbp files",                                   //
+                cxxopts::value<string>()->default_value("regex"))                                              //
+            ("regex", "Post the constraint from a regular-expression string instead of an explicit automaton") //
+            ("stats", "Print solve statistics")                                                                //
             ;
 
         options_vars = options.parse(argc, argv);
@@ -53,21 +54,25 @@ auto main(int argc, char * argv[]) -> int
     auto x = p.create_integer_variable_vector(5, 0_i, 2_i, "x");
 
     // Regular constraint for the language given by 00*11*00* + 2*
-    // 5 states 0..4, 3 possible values 0..2
-    vector<vector<long>> transitions(5, vector<long>(3, -1));
-    // Transitions
-    transitions[0][0] = 1;
-    transitions[0][2] = 4;
-    transitions[1][0] = 1;
-    transitions[1][1] = 2;
-    transitions[2][1] = 2;
-    transitions[2][0] = 3;
-    transitions[3][0] = 3;
-    transitions[4][2] = 4;
+    if (options_vars.contains("regex")) {
+        // The same language as a regular-expression string. It is compiled to an
+        // NFA over the variables' domain (0..2) inside the constraint.
+        p.post(Regular{x, "0 0* 1 1* 0 0* | 2 2*"});
+    }
+    else {
+        // The explicit automaton: 5 states 0..4, 3 possible values 0..2.
+        vector<vector<long>> transitions(5, vector<long>(3, -1));
+        transitions[0][0] = 1;
+        transitions[0][2] = 4;
+        transitions[1][0] = 1;
+        transitions[1][1] = 2;
+        transitions[2][1] = 2;
+        transitions[2][0] = 3;
+        transitions[3][0] = 3;
+        transitions[4][2] = 4;
 
-    auto regular = Regular{x, 5, transitions, {3, 4}};
-
-    p.post(regular);
+        p.post(Regular{x, 5, transitions, {3, 4}});
+    }
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(glasgow_constraint_solver
         constraints/parity.cc
         constraints/plus.cc
         constraints/regular.cc
+        constraints/regular_regex.cc
         constraints/seq_precede_chain.cc
         constraints/smart_table.cc
         constraints/table/negative_table.cc
@@ -363,6 +364,10 @@ if(GCS_BUILD_TESTS)
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)
+
+    add_executable(regular_regex_test constraints/regular_regex_test.cc)
+    target_link_libraries(regular_regex_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME regular_regex_test COMMAND $<TARGET_FILE:regular_regex_test>)
 
     add_executable(bits_encoding_test innards/proofs/bits_encoding_test.cc)
     target_link_libraries(bits_encoding_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/constraints/regular.cc
+++ b/gcs/constraints/regular.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/regular.hh>
+#include <gcs/constraints/regular_regex.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -18,8 +19,10 @@
 #include <any>
 #include <cstdio>
 #include <functional>
+#include <optional>
 #include <set>
 #include <sstream>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -32,6 +35,8 @@ using std::any_cast;
 using std::cmp_less;
 using std::ios;
 using std::move;
+using std::nullopt;
+using std::optional;
 using std::set;
 using std::string;
 using std::stringstream;
@@ -50,13 +55,15 @@ using fmt::print;
 
 namespace
 {
-    // Returns the next state for (state, val), or -1 if no transition exists.
-    // Treats both absent keys and explicit -1 values as disallowed transitions.
-    auto find_transition(const unordered_map<Integer, long> & state_transitions, Integer val) -> long
+    // Returns the set of next states for (state, val), or an empty set if no
+    // transition exists. A deterministic automaton is the special case where
+    // every non-empty set is a singleton.
+    auto find_transitions(const unordered_map<Integer, set<long>> & state_transitions, Integer val) -> const set<long> &
     {
+        static const set<long> none;
         auto it = state_transitions.find(val);
         if (it == state_transitions.end())
-            return -1L;
+            return none;
         return it->second;
     }
 
@@ -99,7 +106,7 @@ namespace
     }
 
     auto initialise_graph(RegularGraph & graph, const vector<IntegerVariableID> & vars,
-        const long num_states, const vector<unordered_map<Integer, long>> & transitions,
+        const long num_states, const vector<unordered_map<Integer, set<long>>> & transitions,
         const vector<long> & final_states, const vector<vector<ProofFlag>> & state_at_pos_flags,
         const State & state, const ReasonFunction & reason, ProofLogger * const logger)
     {
@@ -113,10 +120,11 @@ namespace
         for (unsigned long i = 0; i < num_vars; ++i) {
             for (auto val : state.each_value_immutable(vars[i])) {
                 for (const auto & q : graph.nodes[i]) {
-                    auto next_q = find_transition(transitions[q], val);
-                    if (next_q != -1) {
+                    const auto & next_states = find_transitions(transitions[q], val);
+                    if (! next_states.empty()) {
                         graph.states_supporting[i][val].insert(q);
-                        graph.nodes[i + 1].insert(next_q);
+                        for (const auto & next_q : next_states)
+                            graph.nodes[i + 1].insert(next_q);
                     }
                 }
             }
@@ -157,14 +165,18 @@ namespace
             for (auto val : state.each_value_mutable(vars[i])) {
                 set<long> states = graph.states_supporting[i][val];
                 for (const auto & q : states) {
-                    auto next_q = find_transition(transitions[q], val);
-                    if (next_q != -1 && graph.nodes[i + 1].contains(next_q)) {
-                        graph.out_edges[i][q][next_q].emplace(val);
-                        graph.out_deg[i][q]++;
-                        graph.in_edges[i + 1][next_q][q].emplace(val);
-                        graph.in_deg[i + 1][next_q]++;
-                        state_is_support[q] = 1;
+                    bool any_live_target = false;
+                    for (const auto & next_q : find_transitions(transitions[q], val)) {
+                        if (graph.nodes[i + 1].contains(next_q)) {
+                            graph.out_edges[i][q][next_q].emplace(val);
+                            graph.out_deg[i][q]++;
+                            graph.in_edges[i + 1][next_q][q].emplace(val);
+                            graph.in_deg[i + 1][next_q]++;
+                            any_live_target = true;
+                        }
                     }
+                    if (any_live_target)
+                        state_is_support[q] = 1;
                     else {
                         graph.states_supporting[i][val].erase(q);
                         if (logger)
@@ -186,6 +198,17 @@ namespace
         graph.initialised = true;
     }
 
+    // True if state l at position pos still has a live out-edge labelled val. For
+    // a DFA this is never the case once the single (l, val) edge is gone, but an
+    // NFA may have several edges on the same value.
+    auto still_supports(const RegularGraph & graph, const long pos, const long l, Integer val) -> bool
+    {
+        for (const auto & [next_q, vals] : graph.out_edges[pos][l])
+            if (vals.contains(val))
+                return true;
+        return false;
+    }
+
     auto decrement_outdeg(RegularGraph & graph, const long i, const long k, const vector<IntegerVariableID> & vars,
         const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonFunction & reason, ProofLogger * const logger) -> void
     {
@@ -195,10 +218,15 @@ namespace
                 auto l = edge.first;
                 graph.out_edges[i - 1][l].erase(k);
                 for (const auto & val : edge.second) {
-                    graph.states_supporting[i - 1][val].erase(l);
-                    if (logger)
-                        log_additional_inference(logger, {vars[i - 1] != val}, {! state_at_pos_flags[i - 1][l]}, state, reason,
-                            "dec outdeg inner");
+                    // For an NFA, l may still reach a live state on val via
+                    // another edge; only drop support (and justify doing so)
+                    // once no such edge remains.
+                    if (! still_supports(graph, i - 1, l, val)) {
+                        graph.states_supporting[i - 1][val].erase(l);
+                        if (logger)
+                            log_additional_inference(logger, {vars[i - 1] != val}, {! state_at_pos_flags[i - 1][l]}, state, reason,
+                                "dec outdeg inner");
+                    }
                     decrement_outdeg(graph, i - 1, l, vars, state_at_pos_flags, state, reason, logger);
                 }
             }
@@ -246,7 +274,7 @@ namespace
 
     auto propagate_regular(const vector<IntegerVariableID> & vars,
         const long num_states,
-        const vector<unordered_map<Integer, long>> & transitions,
+        const vector<unordered_map<Integer, set<long>>> & transitions,
         const vector<long> & final_states,
         const vector<vector<ProofFlag>> & state_at_pos_flags,
         const ConstraintStateHandle & graph_handle,
@@ -288,24 +316,28 @@ namespace
                 if (! graph.states_supporting[i][val].empty() && ! state.in_domain(vars[i], val)) {
 
                     for (const auto & q : graph.states_supporting[i][val]) {
-                        auto next_q = find_transition(transitions[q], val);
+                        // Remove every edge out of q that carries this value; an
+                        // NFA may have several. Collect them first to avoid
+                        // mutating out_edges[i][q] while iterating it.
+                        vector<long> next_qs;
+                        for (const auto & [next_q, vals] : graph.out_edges[i][q])
+                            if (vals.contains(val))
+                                next_qs.push_back(next_q);
 
-                        if (graph.out_edges[i][q].contains(next_q)) {
+                        for (const auto & next_q : next_qs) {
                             graph.out_edges[i][q][next_q].erase(val);
-
                             if (graph.out_edges[i][q][next_q].empty())
                                 graph.out_edges[i][q].erase(next_q);
+
+                            if (graph.in_edges[i + 1][next_q].contains(q)) {
+                                graph.in_edges[i + 1][next_q][q].erase(val);
+                                if (graph.in_edges[i + 1][next_q][q].empty())
+                                    graph.in_edges[i + 1][next_q].erase(q);
+                            }
+
+                            decrement_outdeg(graph, i, q, vars, state_at_pos_flags, state, reason, logger);
+                            decrement_indeg(graph, i + 1, next_q, vars, state_at_pos_flags, state, reason, logger);
                         }
-
-                        if (graph.in_edges[i + 1][next_q].contains(q)) {
-                            graph.in_edges[i + 1][next_q][q].erase(val);
-
-                            if (graph.in_edges[i + 1][next_q][q].empty())
-                                graph.in_edges[i + 1][next_q].erase(q);
-                        }
-
-                        decrement_outdeg(graph, i, q, vars, state_at_pos_flags, state, reason, logger);
-                        decrement_indeg(graph, i + 1, next_q, vars, state_at_pos_flags, state, reason, logger);
                     }
                     graph.states_supporting[i][val] = {};
                 }
@@ -329,36 +361,69 @@ namespace
     }
 }
 
+namespace
+{
+    // Records the alphabet (sorted transition keys) for proof logging and s_exprify.
+    auto symbols_of(const vector<unordered_map<Integer, set<long>>> & transitions) -> vector<Integer>
+    {
+        set<Integer> sym_set;
+        for (const auto & state_map : transitions)
+            for (const auto & [val, _] : state_map)
+                sym_set.insert(val);
+        return {sym_set.begin(), sym_set.end()};
+    }
+}
+
 Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f, bool sr) :
     _vars(move(v)),
     _num_states(n),
-    _transitions(move(t)),
+    _transitions(t.size()),
     _final_states(move(f)),
-    _short_reasons(sr)
+    _short_reasons(sr),
+    _regex(nullopt)
 {
-    set<Integer> sym_set;
-    for (const auto & state_map : _transitions)
-        for (const auto & [val, _] : state_map)
-            sym_set.insert(val);
-    _symbols.assign(sym_set.begin(), sym_set.end());
+    for (size_t q = 0; q < t.size(); ++q)
+        for (const auto & [val, target] : t[q])
+            if (target != -1L)
+                _transitions[q][val].insert(target);
+    _symbols = symbols_of(_transitions);
 }
 
 Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f, bool sr) :
     _vars(move(v)),
     _num_states(n),
-    _transitions(vector<unordered_map<Integer, long>>(n, unordered_map<Integer, long>{})),
+    _transitions(n),
     _final_states(move(f)),
-    _short_reasons(sr)
+    _short_reasons(sr),
+    _regex(nullopt)
 {
     for (size_t i = 0; i < transitions.size(); i++)
         for (size_t j = 0; j < transitions[i].size(); j++)
-            if (transitions[i][j] != -1)
-                _transitions[i][Integer(j)] = transitions[i][j];
-    set<Integer> sym_set;
-    for (const auto & state_map : _transitions)
-        for (const auto & [val, _] : state_map)
-            sym_set.insert(val);
-    _symbols.assign(sym_set.begin(), sym_set.end());
+            if (transitions[i][j] != -1L)
+                _transitions[i][Integer(j)].insert(transitions[i][j]);
+    _symbols = symbols_of(_transitions);
+}
+
+Regular::Regular(vector<IntegerVariableID> v, string regex, bool sr) :
+    _vars(move(v)),
+    _num_states(0),
+    _short_reasons(sr),
+    _regex(move(regex))
+{
+    // The automaton is compiled from the regex in prepare(), once the
+    // variables' domains (and hence the alphabet for "." and "[^...]") are known.
+}
+
+Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, set<long>>> t,
+    vector<long> f, vector<Integer> syms, bool sr, optional<string> regex) :
+    _vars(move(v)),
+    _num_states(n),
+    _transitions(move(t)),
+    _final_states(move(f)),
+    _short_reasons(sr),
+    _regex(move(regex)),
+    _symbols(move(syms))
+{
 }
 
 auto Regular::symbols() const -> const vector<Integer> &
@@ -368,7 +433,7 @@ auto Regular::symbols() const -> const vector<Integer> &
 
 auto Regular::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Regular>(_vars, _num_states, _transitions, _final_states, _short_reasons);
+    return unique_ptr<Constraint>(new Regular(_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex));
 }
 
 auto Regular::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
@@ -384,6 +449,28 @@ auto Regular::install(Propagators & propagators, State & initial_state, ProofMod
 
 auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
+    if (_regex) {
+        // Alphabet for "." and "[^...]": the contiguous min..max range over the
+        // union of the variables' domains, mirroring MiniZinc's semantics.
+        auto lo = Integer::max_value(), hi = Integer::min_value();
+        for (const auto & var : _vars)
+            for (const auto & val : initial_state.each_value_immutable(var)) {
+                if (val < lo)
+                    lo = val;
+                if (val > hi)
+                    hi = val;
+            }
+        vector<Integer> alphabet;
+        for (auto val = lo; val <= hi; ++val)
+            alphabet.push_back(val);
+
+        auto nfa = regex_to_nfa(*_regex, alphabet);
+        _num_states = nfa.num_states;
+        _transitions = move(nfa.transitions);
+        _final_states = move(nfa.final_states);
+        _symbols = symbols_of(_transitions);
+    }
+
     _graph_idx = initial_state.add_constraint_state(RegularGraph(_vars.size(), _num_states));
 
     // Build the OPB alphabet: the union of transition keys and each var's initial
@@ -426,15 +513,19 @@ auto Regular::define_proof_model(ProofModel & model) -> void
     for (size_t idx = 0; idx < _vars.size(); ++idx) {
         for (long q = 0; q < _num_states; ++q) {
             for (const auto & val : _opb_alphabet) {
-                auto new_q = find_transition(_transitions[q], val);
-                if (new_q == -1) {
-                    // No transition for q, v, so constrain ~(state_i = q /\ X_i = val)
+                const auto & targets = find_transitions(_transitions[q], val);
+                if (targets.empty()) {
+                    // No transition for (q, val), so constrain ~(state_i = q /\ X_i = val)
                     model.add_constraint(
                         WPBSum{} + 1_i * (_vars[idx] != val) + (1_i * ! _state_at_pos_flags[idx][q]) >= 1_i);
                 }
                 else {
-                    model.add_constraint(
-                        WPBSum{} + 1_i * ! _state_at_pos_flags[idx][q] + 1_i * (_vars[idx] != val) + 1_i * _state_at_pos_flags[idx + 1][new_q] >= 1_i);
+                    // state_i = q /\ X_i = val implies state_{i+1} is one of the
+                    // targets (a single target for a DFA, several for an NFA).
+                    auto clause = WPBSum{} + 1_i * ! _state_at_pos_flags[idx][q] + 1_i * (_vars[idx] != val);
+                    for (const auto & new_q : targets)
+                        clause += 1_i * _state_at_pos_flags[idx + 1][new_q];
+                    model.add_constraint(move(clause) >= 1_i);
                 }
             }
         }
@@ -468,7 +559,8 @@ auto Regular::s_exprify(const ProofModel * const model) const -> string
     for (size_t i = 0; i < _transitions.size(); i++) {
         print(s, "(");
         for (const auto & tran : _transitions[i]) {
-            print(s, " ({} {})", tran.first, tran.second);
+            for (const auto & target : tran.second)
+                print(s, " ({} {})", tran.first, target);
         }
         print(s, ")\n        ");
     }

--- a/gcs/constraints/regular.hh
+++ b/gcs/constraints/regular.hh
@@ -6,17 +6,24 @@
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
+#include <optional>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <vector>
 namespace gcs
 {
     /**
      * \brief Constrain that the sequence of variables is a member of the
-     * language recognised by the given Deterministic Finite Automaton,
-     * equivalent to a regex expression. "short_reasons" uses aliases for
+     * language recognised by the given finite automaton, equivalent to a regex
+     * expression. The automaton may be non-deterministic: each (state, value)
+     * pair maps to a set of next states. "short_reasons" uses aliases for
      * reasons when proof logging is enabled, which can result in shorter
      * proofs.
+     *
+     * The automaton may instead be given as a regular expression string, which
+     * is compiled to an NFA over the constrained variables' domains. The syntax
+     * matches MiniZinc/Gecode (see regular_regex.hh).
      *
      * \ingroup Constraints
      */
@@ -24,16 +31,24 @@ namespace gcs
     {
     private:
         const std::vector<IntegerVariableID> _vars;
-        const long _num_states;
-        std::vector<std::unordered_map<Integer, long>> _transitions;
-        const std::vector<long> _final_states;
+        long _num_states;
+        std::vector<std::unordered_map<Integer, std::set<long>>> _transitions;
+        std::vector<long> _final_states;
         const bool _short_reasons;
+        const std::optional<std::string> _regex;
         std::vector<Integer> _symbols;
         std::vector<std::vector<innards::ProofFlag>> _state_at_pos_flags;
         innards::ConstraintStateHandle _graph_idx;
         std::set<Integer> _opb_alphabet;
 
         [[nodiscard]] auto symbols() const -> const std::vector<Integer> &;
+
+        // Copy-style constructor used by clone(): takes the internal multi-target
+        // representation (and the regex, if any) directly.
+        Regular(std::vector<IntegerVariableID> vars, long num_states,
+            std::vector<std::unordered_map<Integer, std::set<long>>> transitions,
+            std::vector<long> final_states, std::vector<Integer> symbols,
+            bool short_reasons, std::optional<std::string> regex);
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
@@ -49,6 +64,14 @@ namespace gcs
             long num_states,
             std::vector<std::vector<long>> transitions,
             std::vector<long> final_states, bool sr = true);
+
+        /**
+         * \brief Constrain that the sequence of variables matches the given
+         * regular expression. The expression is compiled to an NFA over the
+         * contiguous min..max range of the variables' domains.
+         */
+        explicit Regular(std::vector<IntegerVariableID> vars,
+            std::string regex, bool short_reasons = true);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/regular_regex.cc
+++ b/gcs/constraints/regular_regex.cc
@@ -1,0 +1,564 @@
+#include <gcs/constraints/regular_regex.hh>
+#include <gcs/exception.hh>
+
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using gcs::Integer;
+using gcs::InvalidProblemDefinitionException;
+
+using std::make_unique;
+using std::map;
+using std::move;
+using std::pair;
+using std::queue;
+using std::set;
+using std::size_t;
+using std::string;
+using std::unique_ptr;
+using std::unordered_map;
+using std::vector;
+
+namespace
+{
+    // ---- Lexer -------------------------------------------------------------
+    //
+    // Tokens mirror libminizinc's regex lexer (lib/support/regex/lexer.lxx)
+    // exactly: whitespace is ignored, a run of digits is one integer symbol,
+    // and every other recognised character is a single token. Anything else is
+    // a hard error.
+    enum class Tok
+    {
+        Integer,
+        Union,      // |
+        Plus,       // +
+        Star,       // *
+        GroupOpen,  // (
+        GroupClose, // )
+        Optional,   // ?
+        QuantOpen,  // {
+        QuantClose, // }
+        Comma,      // ,
+        Any,        // .
+        ClassOpen,  // [
+        ClassClose, // ]
+        ClassRange, // -
+        ClassNeg,   // ^
+        End
+    };
+
+    struct Token
+    {
+        Tok kind;
+        Integer value = Integer{0};
+    };
+
+    auto tokenize(const string & s) -> vector<Token>
+    {
+        vector<Token> tokens;
+        for (size_t i = 0; i < s.size();) {
+            char c = s[i];
+            if (c == ' ' || c == '\t' || c == '\n') {
+                ++i;
+                continue;
+            }
+            if (c >= '0' && c <= '9') {
+                long long value = 0;
+                while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
+                    value = value * 10 + (s[i] - '0');
+                    ++i;
+                }
+                tokens.push_back({Tok::Integer, Integer{value}});
+                continue;
+            }
+            switch (c) {
+            case '|': tokens.push_back({Tok::Union}); break;
+            case '+': tokens.push_back({Tok::Plus}); break;
+            case '*': tokens.push_back({Tok::Star}); break;
+            case '(': tokens.push_back({Tok::GroupOpen}); break;
+            case ')': tokens.push_back({Tok::GroupClose}); break;
+            case '?': tokens.push_back({Tok::Optional}); break;
+            case '{': tokens.push_back({Tok::QuantOpen}); break;
+            case '}': tokens.push_back({Tok::QuantClose}); break;
+            case ',': tokens.push_back({Tok::Comma}); break;
+            case '.': tokens.push_back({Tok::Any}); break;
+            case '[': tokens.push_back({Tok::ClassOpen}); break;
+            case ']': tokens.push_back({Tok::ClassClose}); break;
+            case '-': tokens.push_back({Tok::ClassRange}); break;
+            case '^': tokens.push_back({Tok::ClassNeg}); break;
+            default:
+                throw InvalidProblemDefinitionException(
+                    string{"Illegal token in regular expression: '"} + c + "'");
+            }
+            ++i;
+        }
+        tokens.push_back({Tok::End});
+        return tokens;
+    }
+
+    // ---- Core AST ----------------------------------------------------------
+    //
+    // The grammar is normalised down to a tiny core: a symbol set (matches one
+    // value from the set), the empty word, concatenation, union, and Kleene
+    // star. Quantifiers and "?" are desugared into these during parsing, so
+    // both the automaton builder and the reference matcher stay small.
+    enum class Core
+    {
+        Empty,
+        Symbols,
+        Concat,
+        Union,
+        Star
+    };
+
+    struct CoreNode
+    {
+        Core op;
+        set<Integer> symbols;
+        vector<unique_ptr<CoreNode>> children;
+    };
+
+    using NodePtr = unique_ptr<CoreNode>;
+
+    auto make_empty() -> NodePtr
+    {
+        return make_unique<CoreNode>(Core::Empty);
+    }
+
+    auto make_symbols(set<Integer> symbols) -> NodePtr
+    {
+        auto n = make_unique<CoreNode>(Core::Symbols);
+        n->symbols = move(symbols);
+        return n;
+    }
+
+    auto make_binary(Core op, NodePtr a, NodePtr b) -> NodePtr
+    {
+        auto n = make_unique<CoreNode>(op);
+        n->children.push_back(move(a));
+        n->children.push_back(move(b));
+        return n;
+    }
+
+    auto make_concat(NodePtr a, NodePtr b) -> NodePtr
+    {
+        return make_binary(Core::Concat, move(a), move(b));
+    }
+
+    auto make_union(NodePtr a, NodePtr b) -> NodePtr
+    {
+        return make_binary(Core::Union, move(a), move(b));
+    }
+
+    auto make_star(NodePtr a) -> NodePtr
+    {
+        auto n = make_unique<CoreNode>(Core::Star);
+        n->children.push_back(move(a));
+        return n;
+    }
+
+    auto clone(const CoreNode & n) -> NodePtr
+    {
+        auto c = make_unique<CoreNode>(n.op);
+        c->symbols = n.symbols;
+        for (const auto & child : n.children)
+            c->children.push_back(clone(*child));
+        return c;
+    }
+
+    // n copies of atom concatenated; n == 0 is the empty word.
+    auto repeat_exact(const CoreNode & atom, long long n) -> NodePtr
+    {
+        if (n <= 0)
+            return make_empty();
+        auto result = clone(atom);
+        for (long long i = 1; i < n; ++i)
+            result = make_concat(move(result), clone(atom));
+        return result;
+    }
+
+    // atom repeated n or more times: atom^n followed by atom*.
+    auto repeat_at_least(const CoreNode & atom, long long n) -> NodePtr
+    {
+        return make_concat(repeat_exact(atom, n), make_star(clone(atom)));
+    }
+
+    // atom repeated between n and m times: atom^n followed by (m - n) optional atoms.
+    auto repeat_between(const CoreNode & atom, long long n, long long m) -> NodePtr
+    {
+        auto result = repeat_exact(atom, n);
+        for (long long i = n; i < m; ++i)
+            result = make_concat(move(result), make_union(clone(atom), make_empty()));
+        return result;
+    }
+
+    // ---- Parser ------------------------------------------------------------
+    //
+    // Recursive descent following the libminizinc grammar verbatim, with
+    // precedence quantifier > concatenation > union.
+    struct Parser
+    {
+        const vector<Token> & tokens;
+        const set<Integer> & alphabet;
+        size_t pos = 0;
+
+        [[nodiscard]] auto peek() const -> Tok
+        {
+            return tokens[pos].kind;
+        }
+
+        auto advance() -> Token
+        {
+            return tokens[pos++];
+        }
+
+        [[noreturn]] static auto fail(const string & message) -> void
+        {
+            throw InvalidProblemDefinitionException("Cannot parse regular expression: " + message);
+        }
+
+        auto expect(Tok kind, const string & what) -> Token
+        {
+            if (peek() != kind)
+                fail("expected " + what);
+            return advance();
+        }
+
+        static auto starts_atom(Tok kind) -> bool
+        {
+            return kind == Tok::Integer || kind == Tok::Any || kind == Tok::ClassOpen || kind == Tok::GroupOpen;
+        }
+
+        // expression : term | term "|" expression
+        auto parse_expression() -> NodePtr
+        {
+            auto term = parse_term();
+            if (peek() == Tok::Union) {
+                advance();
+                return make_union(move(term), parse_expression());
+            }
+            return term;
+        }
+
+        // term : factor | factor term
+        auto parse_term() -> NodePtr
+        {
+            auto factor = parse_factor();
+            if (starts_atom(peek()))
+                return make_concat(move(factor), parse_term());
+            return factor;
+        }
+
+        // factor : atom | atom "*" | atom "+" | atom "?" | atom "{" ... "}"
+        auto parse_factor() -> NodePtr
+        {
+            auto atom = parse_atom();
+            switch (peek()) {
+                using enum Tok;
+            case Star:
+                advance();
+                return make_star(move(atom));
+            case Plus: {
+                advance();
+                auto star = make_star(clone(*atom));
+                return make_concat(move(atom), move(star));
+            }
+            case Optional:
+                advance();
+                return make_union(move(atom), make_empty());
+            case QuantOpen:
+                advance();
+                return parse_quantifier(*atom);
+            default:
+                return atom;
+            }
+        }
+
+        // The "{" has already been consumed: "{" n "}" | "{" n "," "}" | "{" n "," m "}"
+        auto parse_quantifier(const CoreNode & atom) -> NodePtr
+        {
+            auto n = expect(Tok::Integer, "an integer after '{'").value.raw_value;
+            if (peek() == Tok::QuantClose) {
+                advance();
+                return repeat_exact(atom, n);
+            }
+            expect(Tok::Comma, "',' or '}' in quantifier");
+            if (peek() == Tok::QuantClose) {
+                advance();
+                return repeat_at_least(atom, n);
+            }
+            auto m = expect(Tok::Integer, "an integer after ',' in quantifier").value.raw_value;
+            expect(Tok::QuantClose, "'}' to close quantifier");
+            if (m < n)
+                fail("quantifier upper bound is below its lower bound");
+            return repeat_between(atom, n, m);
+        }
+
+        // atom : INTEGER | "." | "[" ... "]" | "(" expression ")"
+        auto parse_atom() -> NodePtr
+        {
+            switch (peek()) {
+                using enum Tok;
+            case Integer:
+                return make_symbols({advance().value});
+            case Any:
+                advance();
+                return make_symbols(alphabet);
+            case ClassOpen:
+                return parse_class();
+            case GroupOpen: {
+                advance();
+                auto inner = parse_expression();
+                expect(GroupClose, "')' to close group");
+                return inner;
+            }
+            default:
+                fail("expected a symbol, '.', '[' or '('");
+            }
+        }
+
+        // "[" set_items "]" or "[" "^" set_items "]"
+        auto parse_class() -> NodePtr
+        {
+            expect(Tok::ClassOpen, "'['");
+            bool negated = false;
+            if (peek() == Tok::ClassNeg) {
+                advance();
+                negated = true;
+            }
+            auto items = parse_set_items();
+            expect(Tok::ClassClose, "']' to close class");
+            if (! negated)
+                return make_symbols(move(items));
+
+            set<Integer> complement;
+            for (const auto & val : alphabet)
+                if (! items.contains(val))
+                    complement.insert(val);
+            return make_symbols(move(complement));
+        }
+
+        // set_items : set_item | set_item set_items ; set_item : INTEGER | INTEGER "-" INTEGER
+        auto parse_set_items() -> set<Integer>
+        {
+            set<Integer> items;
+            if (peek() != Tok::Integer)
+                fail("expected at least one value in a class");
+            while (peek() == Tok::Integer) {
+                auto from = advance().value;
+                if (peek() == Tok::ClassRange) {
+                    advance();
+                    auto to = expect(Tok::Integer, "an integer after '-' in a class").value;
+                    if (to < from)
+                        std::swap(from, to);
+                    for (auto val = from; val <= to; ++val)
+                        items.insert(val);
+                }
+                else
+                    items.insert(from);
+            }
+            return items;
+        }
+    };
+
+    auto parse_regex(const string & regex, const set<Integer> & alphabet) -> NodePtr
+    {
+        auto tokens = tokenize(regex);
+        Parser parser{tokens, alphabet};
+        auto node = parser.parse_expression();
+        parser.expect(Tok::End, "end of regular expression");
+        return node;
+    }
+
+    // ---- Thompson construction --------------------------------------------
+    //
+    // Builds an epsilon-NFA fragment-wise; each fragment has a single start and
+    // a single accept state.
+    struct ThompsonBuilder
+    {
+        vector<vector<long>> eps;
+        vector<vector<pair<Integer, long>>> sym;
+
+        auto add_state() -> long
+        {
+            eps.emplace_back();
+            sym.emplace_back();
+            return static_cast<long>(eps.size()) - 1;
+        }
+
+        struct Fragment
+        {
+            long start;
+            long accept;
+        };
+
+        auto build(const CoreNode & n) -> Fragment
+        {
+            switch (n.op) {
+                using enum Core;
+            case Empty: {
+                auto s = add_state(), a = add_state();
+                eps[s].push_back(a);
+                return {s, a};
+            }
+            case Symbols: {
+                auto s = add_state(), a = add_state();
+                for (const auto & symbol : n.symbols)
+                    sym[s].push_back({symbol, a});
+                return {s, a};
+            }
+            case Concat: {
+                auto x = build(*n.children[0]);
+                auto y = build(*n.children[1]);
+                eps[x.accept].push_back(y.start);
+                return {x.start, y.accept};
+            }
+            case Union: {
+                auto s = add_state(), a = add_state();
+                auto x = build(*n.children[0]);
+                auto y = build(*n.children[1]);
+                eps[s].push_back(x.start);
+                eps[s].push_back(y.start);
+                eps[x.accept].push_back(a);
+                eps[y.accept].push_back(a);
+                return {s, a};
+            }
+            case Star: {
+                auto s = add_state(), a = add_state();
+                auto x = build(*n.children[0]);
+                eps[s].push_back(x.start);
+                eps[s].push_back(a);
+                eps[x.accept].push_back(x.start);
+                eps[x.accept].push_back(a);
+                return {s, a};
+            }
+            }
+            throw gcs::NonExhaustiveSwitch{};
+        }
+    };
+
+    // Epsilon-elimination: keep transitions on the source's epsilon-closure and
+    // mark a state accepting if its closure contains the single accept state.
+    // Then keep only the states reachable from the start, renumbered with the
+    // start as 0.
+    auto build_nfa(const CoreNode & root) -> gcs::innards::RegexNfa
+    {
+        ThompsonBuilder builder;
+        auto fragment = builder.build(root);
+        auto start = fragment.start, accept = fragment.accept;
+
+        auto closure = [&](long q) -> set<long> {
+            set<long> seen{q};
+            vector<long> stack{q};
+            while (! stack.empty()) {
+                auto x = stack.back();
+                stack.pop_back();
+                for (auto y : builder.eps[x])
+                    if (seen.insert(y).second)
+                        stack.push_back(y);
+            }
+            return seen;
+        };
+
+        unordered_map<long, long> old_to_new;
+        vector<map<Integer, set<long>>> raw_transitions; // indexed by new id, targets are old ids
+        vector<char> is_final;
+        queue<long> to_visit;
+
+        old_to_new.emplace(start, 0);
+        to_visit.push(start);
+        while (! to_visit.empty()) {
+            auto q = to_visit.front();
+            to_visit.pop();
+
+            auto cl = closure(q);
+            map<Integer, set<long>> transitions;
+            for (auto p : cl)
+                for (const auto & [symbol, target] : builder.sym[p]) {
+                    transitions[symbol].insert(target);
+                    if (old_to_new.emplace(target, static_cast<long>(old_to_new.size())).second)
+                        to_visit.push(target);
+                }
+            raw_transitions.push_back(move(transitions));
+            is_final.push_back(cl.contains(accept) ? 1 : 0);
+        }
+
+        gcs::innards::RegexNfa nfa;
+        nfa.num_states = static_cast<long>(raw_transitions.size());
+        nfa.transitions.resize(raw_transitions.size());
+        for (size_t i = 0; i < raw_transitions.size(); ++i) {
+            for (const auto & [symbol, targets] : raw_transitions[i]) {
+                auto & destination = nfa.transitions[i][symbol];
+                for (auto target : targets)
+                    destination.insert(old_to_new.at(target));
+            }
+            if (is_final[i])
+                nfa.final_states.push_back(static_cast<long>(i));
+        }
+        return nfa;
+    }
+
+    // ---- Reference matcher -------------------------------------------------
+    //
+    // Returns every index j such that node matches sequence[start, j).
+    auto match_ends(const CoreNode & node, const vector<Integer> & sequence, size_t start) -> set<size_t>
+    {
+        switch (node.op) {
+            using enum Core;
+        case Empty:
+            return {start};
+        case Symbols:
+            if (start < sequence.size() && node.symbols.contains(sequence[start]))
+                return {start + 1};
+            return {};
+        case Concat: {
+            set<size_t> ends;
+            for (auto mid : match_ends(*node.children[0], sequence, start))
+                for (auto end : match_ends(*node.children[1], sequence, mid))
+                    ends.insert(end);
+            return ends;
+        }
+        case Union: {
+            auto ends = match_ends(*node.children[0], sequence, start);
+            for (auto end : match_ends(*node.children[1], sequence, start))
+                ends.insert(end);
+            return ends;
+        }
+        case Star: {
+            set<size_t> reachable{start};
+            vector<size_t> stack{start};
+            while (! stack.empty()) {
+                auto i = stack.back();
+                stack.pop_back();
+                for (auto j : match_ends(*node.children[0], sequence, i))
+                    if (reachable.insert(j).second)
+                        stack.push_back(j);
+            }
+            return reachable;
+        }
+        }
+        throw gcs::NonExhaustiveSwitch{};
+    }
+}
+
+auto gcs::innards::regex_to_nfa(const string & regex, const vector<Integer> & alphabet) -> RegexNfa
+{
+    set<Integer> alphabet_set(alphabet.begin(), alphabet.end());
+    auto root = parse_regex(regex, alphabet_set);
+    return build_nfa(*root);
+}
+
+auto gcs::innards::regex_reference_accepts(const string & regex, const vector<Integer> & alphabet,
+    const vector<Integer> & sequence) -> bool
+{
+    set<Integer> alphabet_set(alphabet.begin(), alphabet.end());
+    auto root = parse_regex(regex, alphabet_set);
+    return match_ends(*root, sequence, 0).contains(sequence.size());
+}

--- a/gcs/constraints/regular_regex.hh
+++ b/gcs/constraints/regular_regex.hh
@@ -1,0 +1,61 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGEX_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_REGEX_HH
+
+#include <gcs/integer.hh>
+
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief An epsilon-free non-deterministic finite automaton, as produced by
+     * regex_to_nfa.
+     *
+     * State 0 is the (single) initial state. transitions[q] maps each input
+     * symbol to the set of states reachable from q on that symbol (a missing key
+     * means no transition). final_states lists the accepting states. The Regular
+     * constraint consumes this directly: a deterministic automaton is just the
+     * special case where every transition target set is a singleton.
+     */
+    struct RegexNfa
+    {
+        long num_states;
+        std::vector<std::unordered_map<Integer, std::set<long>>> transitions;
+        std::vector<long> final_states;
+    };
+
+    /**
+     * \brief Compile a regular expression string into an epsilon-free NFA over
+     * the given alphabet.
+     *
+     * The syntax matches MiniZinc/Gecode's string regex exactly (see
+     * dev_docs and the libminizinc flex/bison grammar): integer literals,
+     * concatenation by juxtaposition, union "|", groups "()", wildcard ".",
+     * classes "[3-6 7]", negated classes "[^3 5]", and the quantifiers "*",
+     * "+", "?", "{n}", "{n,}", "{n,m}". Symbols are integers; multi-digit runs
+     * are a single symbol.
+     *
+     * \a alphabet is the set of values that "." and "[^...]" expand to: the
+     * caller passes the contiguous min..max range of the constrained variables'
+     * domains, mirroring MiniZinc's semantics. Literals and explicit class
+     * ranges are taken verbatim and are not clamped to the alphabet.
+     *
+     * Throws InvalidProblemDefinitionException if the string cannot be parsed.
+     */
+    [[nodiscard]] auto regex_to_nfa(const std::string & regex, const std::vector<Integer> & alphabet) -> RegexNfa;
+
+    /**
+     * \brief Reference regex matcher, used for testing.
+     *
+     * Parses the same syntax as regex_to_nfa and decides membership by directly
+     * interpreting the expression, independently of the NFA construction. Returns
+     * true iff \a sequence is in the language of \a regex over \a alphabet.
+     */
+    [[nodiscard]] auto regex_reference_accepts(const std::string & regex, const std::vector<Integer> & alphabet,
+        const std::vector<Integer> & sequence) -> bool;
+}
+
+#endif

--- a/gcs/constraints/regular_regex_test.cc
+++ b/gcs/constraints/regular_regex_test.cc
@@ -1,0 +1,190 @@
+#include <gcs/constraints/regular_regex.hh>
+#include <gcs/exception.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::set;
+using std::size_t;
+using std::string;
+using std::vector;
+
+namespace
+{
+    // Direct NFA simulation: the thing under test, kept independent of the
+    // reference matcher in regex_to_nfa's source.
+    auto nfa_accepts(const RegexNfa & nfa, const vector<Integer> & sequence) -> bool
+    {
+        set<long> active{0};
+        for (const auto & value : sequence) {
+            set<long> next;
+            for (auto q : active) {
+                auto it = nfa.transitions[static_cast<size_t>(q)].find(value);
+                if (it != nfa.transitions[static_cast<size_t>(q)].end())
+                    next.insert(it->second.begin(), it->second.end());
+            }
+            active = std::move(next);
+            if (active.empty())
+                return false;
+        }
+        for (auto f : nfa.final_states)
+            if (active.contains(f))
+                return true;
+        return false;
+    }
+
+    // Enumerate every sequence of length 0..max_len over the given symbols and
+    // assert the compiled NFA agrees with the reference matcher on each.
+    auto cross_check(const string & regex, const vector<Integer> & alphabet,
+        const vector<Integer> & enum_symbols, size_t max_len) -> void
+    {
+        auto nfa = regex_to_nfa(regex, alphabet);
+        vector<Integer> sequence;
+        auto recurse = [&](auto && self) -> void {
+            INFO("regex \"" << regex << "\" sequence length " << sequence.size());
+            CHECK(nfa_accepts(nfa, sequence) == regex_reference_accepts(regex, alphabet, sequence));
+            if (sequence.size() == max_len)
+                return;
+            for (const auto & symbol : enum_symbols) {
+                sequence.push_back(symbol);
+                self(self);
+                sequence.pop_back();
+            }
+        };
+        recurse(recurse);
+    }
+}
+
+TEST_CASE("Regex literal and concatenation")
+{
+    auto nfa = regex_to_nfa("1 2 3", {});
+    CHECK(nfa_accepts(nfa, {1_i, 2_i, 3_i}));
+    CHECK(! nfa_accepts(nfa, {1_i, 2_i}));
+    CHECK(! nfa_accepts(nfa, {1_i, 2_i, 3_i, 1_i}));
+    // "123" is a single multi-digit symbol, not the concatenation 1 2 3.
+    auto single = regex_to_nfa("123", {});
+    CHECK(nfa_accepts(single, {123_i}));
+    CHECK(! nfa_accepts(single, {1_i, 2_i, 3_i}));
+}
+
+TEST_CASE("Regex quantifier binds to the whole integer atom")
+{
+    // "12*" is (12)*, zero or more of the symbol twelve, per MiniZinc semantics.
+    auto nfa = regex_to_nfa("12*", {});
+    CHECK(nfa_accepts(nfa, {}));
+    CHECK(nfa_accepts(nfa, {12_i}));
+    CHECK(nfa_accepts(nfa, {12_i, 12_i}));
+    CHECK(! nfa_accepts(nfa, {1_i}));
+    CHECK(! nfa_accepts(nfa, {1_i, 2_i}));
+    cross_check("12*", {}, {1_i, 2_i, 12_i}, 3);
+}
+
+TEST_CASE("Regex concatenation binds tighter than union")
+{
+    // "7 6|8" parses as (7 6) | 8.
+    auto nfa = regex_to_nfa("7 6|8", {});
+    CHECK(nfa_accepts(nfa, {7_i, 6_i}));
+    CHECK(nfa_accepts(nfa, {8_i}));
+    CHECK(! nfa_accepts(nfa, {7_i}));
+    CHECK(! nfa_accepts(nfa, {7_i, 8_i}));
+    cross_check("7 6|8", {}, {6_i, 7_i, 8_i}, 3);
+}
+
+TEST_CASE("Regex groups")
+{
+    auto nfa = regex_to_nfa("7(6|8)", {});
+    CHECK(nfa_accepts(nfa, {7_i, 6_i}));
+    CHECK(nfa_accepts(nfa, {7_i, 8_i}));
+    CHECK(! nfa_accepts(nfa, {7_i}));
+    CHECK(! nfa_accepts(nfa, {6_i}));
+    cross_check("7(6|8)", {}, {6_i, 7_i, 8_i}, 3);
+}
+
+TEST_CASE("Regex star plus and optional")
+{
+    cross_check("0* 1 1* 0*", {}, {0_i, 1_i}, 5); // language 0*11*0*
+    auto plus = regex_to_nfa("4+", {});
+    CHECK(! nfa_accepts(plus, {}));
+    CHECK(nfa_accepts(plus, {4_i}));
+    CHECK(nfa_accepts(plus, {4_i, 4_i}));
+    auto opt = regex_to_nfa("5?", {});
+    CHECK(nfa_accepts(opt, {}));
+    CHECK(nfa_accepts(opt, {5_i}));
+    CHECK(! nfa_accepts(opt, {5_i, 5_i}));
+}
+
+TEST_CASE("Regex wildcard uses the supplied alphabet")
+{
+    // Caller passes the contiguous min..max range; here that models domain
+    // {0,2,4}, whose min..max is {0,1,2,3,4}.
+    vector<Integer> alphabet{0_i, 1_i, 2_i, 3_i, 4_i};
+    auto nfa = regex_to_nfa(".", alphabet);
+    CHECK(nfa_accepts(nfa, {3_i}));
+    CHECK(nfa_accepts(nfa, {0_i}));
+    CHECK(! nfa_accepts(nfa, {5_i}));
+    CHECK(! nfa_accepts(nfa, {}));
+    CHECK(! nfa_accepts(nfa, {1_i, 1_i}));
+    cross_check(". .", alphabet, {0_i, 1_i, 4_i, 5_i}, 3);
+}
+
+TEST_CASE("Regex classes and negated classes")
+{
+    auto cls = regex_to_nfa("[3-6 7]", {});
+    for (auto v : {3_i, 4_i, 5_i, 6_i, 7_i})
+        CHECK(nfa_accepts(cls, {v}));
+    CHECK(! nfa_accepts(cls, {2_i}));
+    CHECK(! nfa_accepts(cls, {8_i}));
+
+    // Reversed range is accepted and normalised.
+    auto reversed = regex_to_nfa("[5-3]", {});
+    for (auto v : {3_i, 4_i, 5_i})
+        CHECK(nfa_accepts(reversed, {v}));
+    CHECK(! nfa_accepts(reversed, {6_i}));
+
+    vector<Integer> alphabet{0_i, 1_i, 2_i, 3_i, 4_i};
+    auto neg = regex_to_nfa("[^2]", alphabet);
+    for (auto v : {0_i, 1_i, 3_i, 4_i})
+        CHECK(nfa_accepts(neg, {v}));
+    CHECK(! nfa_accepts(neg, {2_i}));
+    cross_check("[^2]", alphabet, {0_i, 2_i, 4_i, 5_i}, 2);
+}
+
+TEST_CASE("Regex counted quantifiers")
+{
+    auto exact = regex_to_nfa("1{3}", {});
+    CHECK(nfa_accepts(exact, {1_i, 1_i, 1_i}));
+    CHECK(! nfa_accepts(exact, {1_i, 1_i}));
+    CHECK(! nfa_accepts(exact, {1_i, 1_i, 1_i, 1_i}));
+
+    auto at_least = regex_to_nfa("9{2,}", {});
+    CHECK(! nfa_accepts(at_least, {9_i}));
+    CHECK(nfa_accepts(at_least, {9_i, 9_i}));
+    CHECK(nfa_accepts(at_least, {9_i, 9_i, 9_i}));
+
+    auto between = regex_to_nfa("7{1,3}", {});
+    CHECK(! nfa_accepts(between, {}));
+    CHECK(nfa_accepts(between, {7_i}));
+    CHECK(nfa_accepts(between, {7_i, 7_i, 7_i}));
+    CHECK(! nfa_accepts(between, {7_i, 7_i, 7_i, 7_i}));
+
+    cross_check("2{0,2} 3", {}, {2_i, 3_i}, 4);
+}
+
+TEST_CASE("Regex parse errors")
+{
+    CHECK_THROWS_AS(regex_to_nfa("1 & 2", {}), InvalidProblemDefinitionException);  // illegal token
+    CHECK_THROWS_AS(regex_to_nfa("", {}), InvalidProblemDefinitionException);       // empty
+    CHECK_THROWS_AS(regex_to_nfa("   ", {}), InvalidProblemDefinitionException);    // whitespace only
+    CHECK_THROWS_AS(regex_to_nfa("*1", {}), InvalidProblemDefinitionException);     // leading quantifier
+    CHECK_THROWS_AS(regex_to_nfa("(1", {}), InvalidProblemDefinitionException);     // unbalanced group
+    CHECK_THROWS_AS(regex_to_nfa("1)", {}), InvalidProblemDefinitionException);     // trailing token
+    CHECK_THROWS_AS(regex_to_nfa("1{3,1}", {}), InvalidProblemDefinitionException); // upper < lower
+    CHECK_THROWS_AS(regex_to_nfa("[]", {}), InvalidProblemDefinitionException);     // empty class
+}

--- a/gcs/constraints/regular_test.cc
+++ b/gcs/constraints/regular_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/constraints/regular.hh>
+#include <gcs/constraints/regular_regex.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -26,12 +27,12 @@ using std::flush;
 using std::make_optional;
 using std::nullopt;
 using std::pair;
-using std::ranges::find;
 using std::set;
 using std::string;
 using std::tuple;
 using std::unordered_map;
 using std::vector;
+using std::ranges::find;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -131,6 +132,63 @@ auto run_dup_regular_test(bool proofs, const string & label,
     check_results(proof_name, expected, actual);
 }
 
+// Regex-string form of the constraint. The oracle is the independent reference
+// matcher from regular_regex.hh, given the same contiguous min..max alphabet
+// that Regular::prepare derives from the variable domains.
+auto run_regular_regex_test(bool proofs, const string & label, const string & regex,
+    const vector<pair<int, int>> & var_ranges) -> void
+{
+    print(cerr, "regular regex {} \"{}\" {} vars{}", label, regex, var_ranges.size(), proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    int lo = var_ranges.front().first, hi = var_ranges.front().second;
+    for (const auto & [a, b] : var_ranges) {
+        lo = a < lo ? a : lo;
+        hi = b > hi ? b : hi;
+    }
+    vector<Integer> alphabet;
+    for (int v = lo; v <= hi; ++v)
+        alphabet.push_back(Integer(v));
+
+    auto accepts = [&](const vector<int> & seq) -> bool {
+        vector<Integer> as_integers;
+        for (int v : seq)
+            as_integers.push_back(Integer(v));
+        return gcs::innards::regex_reference_accepts(regex, alphabet, as_integers);
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [&](vector<int> seq) { return accepts(seq); }, var_ranges);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> vars;
+    for (const auto & [a, b] : var_ranges)
+        vars.push_back(p.create_integer_variable(Integer(a), Integer(b)));
+    p.post(Regular{vars, regex});
+
+    auto proof_name = proofs ? make_optional("regular_regex_test_" + label) : nullopt;
+    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_all_regex_tests(bool proofs) -> void
+{
+    // Deterministic: a fixed sequence.
+    run_regular_regex_test(proofs, "concat", "0 1 0", {{0, 1}, {0, 1}, {0, 1}});
+    // The 0*11*0* language from the Pesant example.
+    run_regular_regex_test(proofs, "star", "0* 1 1* 0*", {{0, 1}, {0, 1}, {0, 1}, {0, 1}});
+    // Genuine non-determinism: after reading a 1 the NFA can be in two states,
+    // exercising the disjunctive transition clause in the proof model.
+    run_regular_regex_test(proofs, "nfa_fanout", "1 2|1 3", {{1, 3}, {1, 3}});
+    // Wildcard expands to the domain's min..max.
+    run_regular_regex_test(proofs, "wildcard", "0 . 0", {{0, 1}, {0, 1}, {0, 1}});
+    // Counted quantifier with a trailing star.
+    run_regular_regex_test(proofs, "counted", "0{1,2} 1*", {{0, 1}, {0, 1}, {0, 1}});
+    // Negated class over an alphabet with a hole at the top of the range.
+    run_regular_regex_test(proofs, "negclass", "[^0] [^0]", {{0, 2}, {0, 2}});
+}
+
 auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -> void
 {
     // DFA: even number of 0s, binary alphabet {0,1}
@@ -194,11 +252,13 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
         {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},
         {1});
 
-    // Dup tests use bare variables (the harness duplicates a handle into
-    // several positions); only run them when no wrapping is in effect, to
-    // avoid duplicating the bare coverage under every wrap.
+    // Regex-string and dup tests use bare variables; only run them when no
+    // wrapping is in effect, to avoid duplicating the bare coverage under
+    // every wrap.
     if (! run_dup)
         return;
+
+    run_all_regex_tests(proofs);
 
     // Dup-variable cases: "even zeros" DFA with positions[0] reused.
     // {x, x, y} — two equal letters then y; "even zeros" wants total zeros


### PR DESCRIPTION
## What

`Regular` can now be posted from a **regex string** in addition to an explicit automaton:

```cpp
p.post(Regular{vars, "0+ 1+ 0+ | 2+"});
```

The syntax matches MiniZinc/Gecode exactly (the authoritative reference is libminizinc's flex/bison grammar, not the prose docs): integer literals, concatenation by juxtaposition, `|`, groups `()`, wildcard `.`, classes `[3-6 7]`, negated classes `[^3 5]`, and the `*` `+` `?` `{n}` `{n,}` `{n,m}` quantifiers. Two non-obvious semantics are replicated: `.`/`[^…]` expand over the domain's contiguous `min..max`, and literals are non-negative only.

## How

- **New, dependency-free compilation unit** `gcs/constraints/regular_regex.{hh,cc}`: a hand-written lexer + recursive-descent parser → Thompson construction → ε-elimination, producing an ε-free **NFA**. No subset construction, so the automaton stays linear in the regex size and avoids determinisation blow-up. (No Gecode dependency — MiniZinc's string regex is actually a Gecode-backed compiler builtin, which we deliberately don't pull in.)
- **`Regular` generalised to a multi-target transition table** (`set<long>` per `(state, value)`). The existing DFA constructors insert singletons, so a DFA is just the `k==1` special case. The propagator's layered-graph reachability and the proof model's transition clause (now a disjunction over the target set) handle `k>=1` uniformly. The regex is compiled to its NFA in `prepare()`, where the variable domains — and hence the alphabet for `.`/`[^…]` — are known.
- One genuinely-multi-target bug fixed along the way: `decrement_outdeg` now uses a `still_supports()` guard so a source state keeps its support (and emits no spurious justification) while any live edge on that value remains.

## Proof logging

No new VeriPB rule types — same layered-graph encoding; the regex never appears in the proof. The transition clause generalises to a disjunction over the NFA target set, and the multi-target RUP justifications are validated empirically (below). As with MiniZinc, regex→NFA compilation is trusted/unverified: the proof attests the automaton, not that the automaton matches the regex.

## Testing

- `regular_regex_test` (Catch2): exhaustive cross-check of the compiled NFA against an independent reference matcher over all short sequences, plus explicit precedence/semantics and parse-error cases — 383 assertions.
- `regular_test`: end-to-end regex cases including a **genuinely non-deterministic NFA** (`"1 2|1 3"`), all GAC-checked and veripb-verified (`COMPLETE ENUMERATION`).
- Existing DFA and `xcsp_regular` coverage unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)