### PR TITLE
Cumulative: reject negative variable durations/demands/capacity

### DIFF
--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -64,9 +64,9 @@ Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<IntegerVariableI
 {
     if (_starts.size() != _lengths.size() || _starts.size() != _heights.size())
         throw InvalidProblemDefinitionException{"Cumulative: starts, lengths, heights must have the same size"};
-    // Constant non-negativity can be checked here. Variable lengths/heights/
-    // capacity carry the modelling assumption d, r, b >= 0 (mirroring MiniZinc);
-    // their domains are not available until prepare().
+    // Constant non-negativity is checked here; variable lengths/heights/
+    // capacity are checked in prepare(), where their domains first become
+    // available.
     if (is_constant_variable(_capacity) && const_value_of(_capacity) < 0_i)
         throw InvalidProblemDefinitionException{"Cumulative: capacity must be non-negative"};
     for (const auto & l : _lengths)
@@ -103,6 +103,19 @@ auto Cumulative::install(Propagators & propagators, State & initial_state, Proof
 auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     auto n = _starts.size();
+
+    // Non-negativity for variable durations/demands/capacity (constants are
+    // checked in the constructor): a negative length/height/capacity has no
+    // sensible cumulative interpretation, so reject it now that the domains are
+    // available rather than producing nonsense.
+    for (const auto & l : _lengths)
+        if (! is_constant_variable(l) && initial_state.lower_bound(l) < 0_i)
+            throw InvalidProblemDefinitionException{"Cumulative: lengths must be non-negative"};
+    for (const auto & h : _heights)
+        if (! is_constant_variable(h) && initial_state.lower_bound(h) < 0_i)
+            throw InvalidProblemDefinitionException{"Cumulative: heights must be non-negative"};
+    if (! is_constant_variable(_capacity) && initial_state.lower_bound(_capacity) < 0_i)
+        throw InvalidProblemDefinitionException{"Cumulative: capacity must be non-negative"};
 
     // Resolve snapshots used by define_proof_model and the propagator. For a
     // variable length/height, _*_vals[i] is a placeholder 0 (the propagator

--- a/gcs/constraints/cumulative_test.cc
+++ b/gcs/constraints/cumulative_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/exception.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -421,9 +422,47 @@ namespace
     }
 }
 
+namespace
+{
+    // Regression: a *variable* duration/demand/capacity whose domain dips below
+    // zero is a modelling error with no sensible cumulative interpretation. The
+    // constructor only sees constants, so the check happens in prepare() (at
+    // install time, when the domains are finally available); installing is
+    // driven here by calling solve(). Mirrors the constant-size checks in the
+    // constructor and the Disjunctive2D sibling fix.
+    auto expect_negative_size_throws(const char * label, pair<int, int> len, pair<int, int> ht,
+        pair<int, int> cap) -> bool
+    {
+        Problem p;
+        auto s = p.create_integer_variable(0_i, 3_i, "s");
+        auto length = p.create_integer_variable(Integer{len.first}, Integer{len.second}, "len");
+        auto height = p.create_integer_variable(Integer{ht.first}, Integer{ht.second}, "ht");
+        auto capacity = p.create_integer_variable(Integer{cap.first}, Integer{cap.second}, "cap");
+        p.post(Cumulative{vector<IntegerVariableID>{s}, vector<IntegerVariableID>{length},
+            vector<IntegerVariableID>{height}, capacity});
+        try {
+            solve(p, [](const CurrentState &) { return true; });
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        println(cerr, "{}: expected InvalidProblemDefinitionException", label);
+        return false;
+    }
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+
+    // Negative variable sizes must be rejected at install time (constants are
+    // rejected by the constructor).
+    bool negative_checks_ok = true;
+    negative_checks_ok &= expect_negative_size_throws("negative length", {-1, 2}, {1, 1}, {1, 1});
+    negative_checks_ok &= expect_negative_size_throws("negative height", {1, 2}, {-1, 1}, {1, 1});
+    negative_checks_ok &= expect_negative_size_throws("negative capacity", {1, 2}, {1, 1}, {-1, 1});
+    if (! negative_checks_ok)
+        return EXIT_FAILURE;
 
     // Start-variable positions wrapped by the single-position sweep. The
     // fixed and random data top out at 4 tasks, so a single-position index


### PR DESCRIPTION
## The bug

`Cumulative` accepts variable durations, demands, and capacity. The constructor validates **constant** sizes for non-negativity:

```cpp
if (is_constant_variable(_capacity) && const_value_of(_capacity) < 0_i)
    throw InvalidProblemDefinitionException{"Cumulative: capacity must be non-negative"};
// ... same for lengths, heights
```

…but for variable sizes it deferred with a comment — *"Variable lengths/heights/capacity carry the modelling assumption d, r, b >= 0 … their domains are not available until prepare()"* — and **`prepare()` never enforced it**. A variable duration/demand/capacity whose domain dips below zero would silently produce nonsense rather than being rejected.

This is the same bug pattern fixed for `Disjunctive2D` in #260 (where variable rectangle sizes were unchecked). It surfaced while auditing the Disjunctive/Cumulative family for the same issue.

## The fix

Add the missing check in `prepare()` (where the domains are finally available), mirroring the constructor's constant checks and the Disjunctive2D fix: a negative variable length/height/capacity now throws `InvalidProblemDefinitionException` at install time.

**1D `Disjunctive` is unaffected** — its lengths are a `std::vector<Integer>` (constant-only), already fully checked in the constructor; there are no variable sizes to miss.

## Testing

- Adds a regression test covering negative variable length, height, and capacity (each expected to throw at install/solve time).
- Existing `cumulative_test` unchanged and green (400 solutions, 68 VeriPB-verified proofs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)