### PR TITLE
Shared SExpr term model for .scp s-expressions

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(glasgow_constraint_solver
         innards/proofs/simplify_literal.cc
         innards/propagators.cc
         innards/reason.cc
+        innards/s_expr.cc
         innards/state.cc
         innards/variable_id_utils.cc
         presolvers/auto_table.cc
@@ -367,6 +368,10 @@ if(GCS_BUILD_TESTS)
     add_executable(interval_set_test innards/interval_set_test.cc)
     target_link_libraries(interval_set_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME interval_set_test COMMAND $<TARGET_FILE:interval_set_test>)
+
+    add_executable(s_expr_test innards/s_expr_test.cc)
+    target_link_libraries(s_expr_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME s_expr_test COMMAND $<TARGET_FILE:s_expr_test>)
 
     add_executable(integer_test integer_test.cc)
     target_link_libraries(integer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
@@ -31,7 +32,6 @@ using std::max;
 using std::min;
 using std::pair;
 using std::string;
-using std::stringstream;
 using std::unique_ptr;
 using std::vector;
 using std::ranges::sort;
@@ -295,11 +295,10 @@ auto Abs::install_propagators(Propagators & propagators) -> void
 
 auto Abs::s_exprify(const innards::ProofModel * const model) const -> string
 {
-    stringstream s;
-
-    print(s, "{} abs", _name);
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    return to_string(vector<SExpr>{
+        SExpr::atom(as_string(_name)),
+        SExpr::atom("abs"),
+        parse_s_expr(tracker.s_expr_name_of(_v1)),
+        parse_s_expr(tracker.s_expr_name_of(_v2))});
 }

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -18,6 +18,7 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
 #include <fmt/core.h>
@@ -37,6 +38,7 @@ using std::vector;
 using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
 using fmt::format;
@@ -296,9 +298,5 @@ auto Abs::install_propagators(Propagators & propagators) -> void
 auto Abs::s_exprify(const innards::ProofModel * const model) const -> string
 {
     auto & tracker = model->names_and_ids_tracker();
-    return to_string(vector<SExpr>{
-        SExpr::atom(as_string(_name)),
-        SExpr::atom("abs"),
-        parse_s_expr(tracker.s_expr_name_of(_v1)),
-        parse_s_expr(tracker.s_expr_name_of(_v2))});
+    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("abs"), tracker.s_expr_term_of(_v1), tracker.s_expr_term_of(_v2)}));
 }

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -14,6 +14,7 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
 #include <fmt/ostream.h>
@@ -55,8 +56,10 @@ using std::ranges::adjacent_find;
 using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -671,9 +674,6 @@ auto GACAllDifferent::s_exprify(const innards::ProofModel * const model) const -
     auto & tracker = model->names_and_ids_tracker();
     vector<SExpr> vars;
     for (const auto & var : _vars)
-        vars.push_back(parse_s_expr(tracker.s_expr_name_of(var)));
-    return to_string(vector<SExpr>{
-        SExpr::atom(as_string(_name)),
-        SExpr::atom("all_different"),
-        SExpr::list(std::move(vars))});
+        vars.push_back(tracker.s_expr_term_of(var));
+    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("all_different"), SExpr::list(std::move(vars))}));
 }

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/innards/variable_id_utils.hh>
 
@@ -44,15 +45,14 @@ using std::min;
 using std::nullopt;
 using std::optional;
 using std::pair;
-using std::ranges::adjacent_find;
-using std::ranges::sort;
 using std::shared_ptr;
 using std::string;
-using std::stringstream;
 using std::unique_ptr;
 using std::variant;
 using std::vector;
 using std::visit;
+using std::ranges::adjacent_find;
+using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -668,12 +668,12 @@ template auto gcs::innards::propagate_gac_all_different(
 
 auto GACAllDifferent::s_exprify(const innards::ProofModel * const model) const -> string
 {
-    stringstream s;
-
-    print(s, "{} all_different (", _name);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")");
-
-    return s.str();
+        vars.push_back(parse_s_expr(tracker.s_expr_name_of(var)));
+    return to_string(vector<SExpr>{
+        SExpr::atom(as_string(_name)),
+        SExpr::atom("all_different"),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -11,6 +11,7 @@
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
 #include <print>
 #else
 #include <fmt/ostream.h>
@@ -41,8 +42,10 @@ using std::ranges::adjacent_find;
 using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
 using std::print;
 #else
+using fmt::format;
 using fmt::print;
 #endif
 
@@ -173,9 +176,6 @@ auto VCAllDifferent::s_exprify(const innards::ProofModel * const model) const ->
     auto & tracker = model->names_and_ids_tracker();
     vector<SExpr> vars;
     for (const auto & var : _vars)
-        vars.push_back(parse_s_expr(tracker.s_expr_name_of(var)));
-    return to_string(vector<SExpr>{
-        SExpr::atom(as_string(_name)),
-        SExpr::atom("all_different"),
-        SExpr::list(std::move(vars))});
+        vars.push_back(tracker.s_expr_term_of(var));
+    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("all_different"), SExpr::list(std::move(vars))}));
 }

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <util/enumerate.hh>
 
 #include <version>
@@ -33,7 +34,6 @@ using std::is_same_v;
 using std::list;
 using std::pair;
 using std::string;
-using std::stringstream;
 using std::unique_ptr;
 using std::variant;
 using std::vector;
@@ -170,12 +170,12 @@ template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintState
 
 auto VCAllDifferent::s_exprify(const innards::ProofModel * const model) const -> string
 {
-    stringstream s;
-
-    print(s, "{} all_different (", _name);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")");
-
-    return s.str();
+        vars.push_back(parse_s_expr(tracker.s_expr_name_of(var)));
+    return to_string(vector<SExpr>{
+        SExpr::atom(as_string(_name)),
+        SExpr::atom("all_different"),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/overloaded.hh>
@@ -30,8 +31,8 @@ using namespace gcs::innards;
 using std::nullopt;
 using std::optional;
 using std::string;
-using std::stringstream;
 using std::unique_ptr;
+using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::format;
@@ -223,7 +224,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
 
 auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const model) const -> std::string
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     auto reif = overloaded{
         [&](const reif::MustHold &) -> string { return ""; },
@@ -237,17 +238,11 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const mode
         _or_equal ? "_equal" : "",
         reif);
 
-    if (reif.empty()) {
-        print(s, "{} {} {} {}", _name, cmp,
-            model->names_and_ids_tracker().s_expr_name_of(_v1),
-            model->names_and_ids_tracker().s_expr_name_of(_v2));
-    }
-    else {
-        print(s, "{} {} {} {} {}", _name, cmp,
-            model->names_and_ids_tracker().s_expr_name_of(_reif_cond),
-            model->names_and_ids_tracker().s_expr_name_of(_v1),
-            model->names_and_ids_tracker().s_expr_name_of(_v2));
-    }
+    vector<SExpr> terms{SExpr::atom(as_string(_name)), SExpr::atom(cmp)};
+    if (! reif.empty())
+        terms.push_back(parse_s_expr(tracker.s_expr_name_of(_reif_cond)));
+    terms.push_back(parse_s_expr(tracker.s_expr_name_of(_v1)));
+    terms.push_back(parse_s_expr(tracker.s_expr_name_of(_v2)));
 
-    return s.str();
+    return to_string(terms);
 }

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -226,23 +226,23 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const mode
 {
     auto & tracker = model->names_and_ids_tracker();
 
-    auto reif = overloaded{
+    auto reif_suffix = overloaded{
         [&](const reif::MustHold &) -> string { return ""; },
         [&](const reif::If &) -> string { return "_if"; },
         [&](const reif::Iff &) -> string { return "_iff"; },
         [&](const auto &) -> string { throw UnexpectedException{"Unexpected reification type in s_exprify"}; }}
-                    .visit(_reif_cond);
+                           .visit(_reif_cond);
 
     string cmp = format("{}{}{}",
         _vars_swapped ? "greater_than" : "less_than",
         _or_equal ? "_equal" : "",
-        reif);
+        reif_suffix);
 
     vector<SExpr> terms{SExpr::atom(as_string(_name)), SExpr::atom(cmp)};
-    if (! reif.empty())
-        terms.push_back(parse_s_expr(tracker.s_expr_name_of(_reif_cond)));
-    terms.push_back(parse_s_expr(tracker.s_expr_name_of(_v1)));
-    terms.push_back(parse_s_expr(tracker.s_expr_name_of(_v2)));
+    if (auto cond = tracker.s_expr_term_of(_reif_cond))
+        terms.push_back(std::move(*cond));
+    terms.push_back(tracker.s_expr_term_of(_v1));
+    terms.push_back(tracker.s_expr_term_of(_v2));
 
-    return to_string(terms);
+    return format("{:#}", SExpr::list(std::move(terms)));
 }

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -34,7 +35,6 @@ using std::make_unique;
 using std::move;
 using std::optional;
 using std::string;
-using std::stringstream;
 using std::unique_ptr;
 using std::vector;
 using std::ranges::any_of;
@@ -263,14 +263,15 @@ auto In::install_propagators(Propagators & propagators) -> void
 
 auto In::s_exprify(const ProofModel * const model) const -> string
 {
-    stringstream s;
-
-    print(s, "{} in {} (", _name, model->names_and_ids_tracker().s_expr_name_of(_var));
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vals;
     for (const auto & v : _var_vals)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
+        vals.push_back(parse_s_expr(tracker.s_expr_name_of(v)));
     for (const auto & v : _val_vals)
-        print(s, " {}", v);
-    print(s, ")");
-
-    return s.str();
+        vals.push_back(SExpr::atom(v.to_string()));
+    return to_string(vector<SExpr>{
+        SExpr::atom(as_string(_name)),
+        SExpr::atom("in"),
+        parse_s_expr(tracker.s_expr_name_of(_var)),
+        SExpr::list(std::move(vals))});
 }

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -266,12 +266,8 @@ auto In::s_exprify(const ProofModel * const model) const -> string
     auto & tracker = model->names_and_ids_tracker();
     vector<SExpr> vals;
     for (const auto & v : _var_vals)
-        vals.push_back(parse_s_expr(tracker.s_expr_name_of(v)));
+        vals.push_back(tracker.s_expr_term_of(v));
     for (const auto & v : _val_vals)
         vals.push_back(SExpr::atom(v.to_string()));
-    return to_string(vector<SExpr>{
-        SExpr::atom(as_string(_name)),
-        SExpr::atom("in"),
-        parse_s_expr(tracker.s_expr_name_of(_var)),
-        SExpr::list(std::move(vals))});
+    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("in"), tracker.s_expr_term_of(_var), SExpr::list(std::move(vals))}));
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -44,6 +44,7 @@ using std::list;
 using std::map;
 using std::max;
 using std::min;
+using std::nullopt;
 using std::optional;
 using std::pair;
 using std::string;
@@ -1224,6 +1225,25 @@ auto NamesAndIDsTracker::s_expr_name_of(VariableConditionOperator op) const -> s
     }
 
     throw NonExhaustiveSwitch{};
+}
+
+auto NamesAndIDsTracker::s_expr_term_of(IntegerVariableID id) const -> SExpr
+{
+    // A variable / literal name is always a single, non-empty s-expression term
+    // (a bare atom like `_1`, or a list like a view `(-_1 + 17)`), so parsing it
+    // can't fail or be empty.
+    return parse_s_expr(s_expr_name_of(id));
+}
+
+auto NamesAndIDsTracker::s_expr_term_of(ReificationCondition cond) const -> optional<SExpr>
+{
+    // s_expr_name_of(ReificationCondition) returns "" for the unconditional
+    // cases (MustHold / MustNotHold); surface that as nullopt so callers don't
+    // have to know about the empty-string sentinel.
+    auto name = s_expr_name_of(cond);
+    if (name.empty())
+        return nullopt;
+    return parse_s_expr(name);
 }
 
 auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif) -> WPBSumLE

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/proofs/reification.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/proof.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
@@ -383,6 +384,22 @@ namespace gcs::innards
          * Get the human-readable / s-expr name for a condition operator
          */
         [[nodiscard]] auto s_expr_name_of(VariableConditionOperator op) const -> std::string;
+
+        /**
+         * Get the s-expr *term* for a variable: s_expr_name_of() parsed into an
+         * SExpr, so a view like `(-_1 + 17)` becomes a list rather than an atom.
+         * Prefer this over `parse_s_expr(s_expr_name_of(...))` at call sites so
+         * the wrap can't be forgotten.
+         */
+        [[nodiscard]] auto s_expr_term_of(IntegerVariableID id) const -> SExpr;
+
+        /**
+         * Get the s-expr term for a reification condition, or nullopt when the
+         * condition is unconditional (MustHold / MustNotHold). Keeps the
+         * "no condition" case explicit rather than leaking the empty string that
+         * the s_expr_name_of(ReificationCondition) overload returns.
+         */
+        [[nodiscard]] auto s_expr_term_of(ReificationCondition cond) const -> std::optional<SExpr>;
 
         /**
          * Get the human-readable name for a variable.

--- a/gcs/innards/s_expr.cc
+++ b/gcs/innards/s_expr.cc
@@ -1,0 +1,177 @@
+#include <gcs/innards/s_expr.hh>
+
+#include <utility>
+
+using std::get;
+using std::holds_alternative;
+using std::move;
+using std::string;
+using std::string_view;
+using std::vector;
+
+using namespace gcs::innards;
+
+SExprParseError::SExprParseError(const string & w) :
+    _wat("S-expression error: " + w)
+{
+}
+
+auto SExprParseError::what() const noexcept -> const char *
+{
+    return _wat.c_str();
+}
+
+SExpr::SExpr(string atom) :
+    _value(move(atom))
+{
+}
+
+SExpr::SExpr(vector<SExpr> list) :
+    _value(move(list))
+{
+}
+
+auto SExpr::atom(string a) -> SExpr
+{
+    return SExpr{move(a)};
+}
+
+auto SExpr::list(vector<SExpr> l) -> SExpr
+{
+    return SExpr{move(l)};
+}
+
+auto SExpr::is_atom() const -> bool
+{
+    return holds_alternative<string>(_value);
+}
+
+auto SExpr::is_list() const -> bool
+{
+    return holds_alternative<vector<SExpr>>(_value);
+}
+
+auto SExpr::as_atom() const -> const string &
+{
+    if (! is_atom())
+        throw SExprParseError{"expected an atom, found a list"};
+    return get<string>(_value);
+}
+
+auto SExpr::as_list() const -> const vector<SExpr> &
+{
+    if (! is_list())
+        throw SExprParseError{"expected a list, found an atom"};
+    return get<vector<SExpr>>(_value);
+}
+
+namespace
+{
+    auto is_space(char c) -> bool
+    {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+    }
+
+    // A whitespace- and parenthesis-delimited recursive-descent reader over a
+    // string_view. Everything that is neither whitespace nor a parenthesis is
+    // an atom character, so commas, comparison symbols, signs and underscores
+    // all fall inside atoms without special handling.
+    struct Reader final
+    {
+        string_view text;
+        string_view::size_type pos = 0;
+
+        auto skip_whitespace() -> void
+        {
+            while (pos < text.size() && is_space(text[pos]))
+                ++pos;
+        }
+
+        // True once only whitespace remains.
+        auto at_end() -> bool
+        {
+            skip_whitespace();
+            return pos >= text.size();
+        }
+
+        auto read_one() -> SExpr
+        {
+            skip_whitespace();
+            if (pos >= text.size())
+                throw SExprParseError{"unexpected end of input while expecting a term"};
+            if (text[pos] == ')')
+                throw SExprParseError{"unexpected ')'"};
+
+            if (text[pos] == '(') {
+                ++pos; // consume '('
+                vector<SExpr> children;
+                while (true) {
+                    skip_whitespace();
+                    if (pos >= text.size())
+                        throw SExprParseError{"unexpected end of input: unclosed '('"};
+                    if (text[pos] == ')') {
+                        ++pos; // consume ')'
+                        break;
+                    }
+                    children.push_back(read_one());
+                }
+                return SExpr::list(move(children));
+            }
+
+            auto start = pos;
+            while (pos < text.size() && ! is_space(text[pos]) && text[pos] != '(' && text[pos] != ')')
+                ++pos;
+            return SExpr::atom(string{text.substr(start, pos - start)});
+        }
+    };
+}
+
+auto gcs::innards::parse_s_expr(string_view text) -> SExpr
+{
+    Reader reader{text};
+    if (reader.at_end())
+        throw SExprParseError{"empty input"};
+    auto result = reader.read_one();
+    if (! reader.at_end())
+        throw SExprParseError{"trailing characters after a single top-level term"};
+    return result;
+}
+
+auto gcs::innards::parse_s_expr_seq(string_view text) -> vector<SExpr>
+{
+    Reader reader{text};
+    vector<SExpr> result;
+    while (! reader.at_end())
+        result.push_back(reader.read_one());
+    return result;
+}
+
+auto gcs::innards::to_string(const SExpr & expr) -> string
+{
+    if (expr.is_atom())
+        return expr.as_atom();
+
+    string result = "(";
+    bool first = true;
+    for (const auto & child : expr.as_list()) {
+        if (! first)
+            result += ' ';
+        first = false;
+        result += to_string(child);
+    }
+    result += ')';
+    return result;
+}
+
+auto gcs::innards::to_string(const vector<SExpr> & terms) -> string
+{
+    string result;
+    bool first = true;
+    for (const auto & term : terms) {
+        if (! first)
+            result += ' ';
+        first = false;
+        result += to_string(term);
+    }
+    return result;
+}

--- a/gcs/innards/s_expr.cc
+++ b/gcs/innards/s_expr.cc
@@ -146,32 +146,6 @@ auto gcs::innards::parse_s_expr_seq(string_view text) -> vector<SExpr>
     return result;
 }
 
-auto gcs::innards::to_string(const SExpr & expr) -> string
-{
-    if (expr.is_atom())
-        return expr.as_atom();
-
-    string result = "(";
-    bool first = true;
-    for (const auto & child : expr.as_list()) {
-        if (! first)
-            result += ' ';
-        first = false;
-        result += to_string(child);
-    }
-    result += ')';
-    return result;
-}
-
-auto gcs::innards::to_string(const vector<SExpr> & terms) -> string
-{
-    string result;
-    bool first = true;
-    for (const auto & term : terms) {
-        if (! first)
-            result += ' ';
-        first = false;
-        result += to_string(term);
-    }
-    return result;
-}
+// Rendering is provided by the std::formatter / fmt::formatter specialisation in
+// s_expr.hh, so there is no to_string() here (which would shadow std::to_string
+// inside gcs::innards).

--- a/gcs/innards/s_expr.hh
+++ b/gcs/innards/s_expr.hh
@@ -6,6 +6,13 @@
 #include <string_view>
 #include <variant>
 #include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#else
+#include <fmt/format.h>
+#endif
 
 namespace gcs::innards
 {
@@ -39,11 +46,14 @@ namespace gcs::innards
      * list. The model carries no further type information — meaning is imposed
      * by whoever consumes the term.
      *
-     * The point of routing both the writer (`Constraint::s_exprify`) and any
-     * reader through this one type is that `to_string(parse_s_expr(s)) == s`
-     * holds for every `s` already in the canonical form `to_string` emits, so
-     * "write an `.scp`, read it back, write it again" is identity by
-     * construction rather than by careful hand-formatting.
+     * An SExpr is rendered with `std::format` / `fmt::format`: `format("{}", e)`
+     * gives the canonical single-line form (an atom verbatim; a list as `(`, its
+     * space-separated children, `)`, with no padding, so `()` for the empty
+     * list). The alternate form `format("{:#}", e)` renders a *list* without its
+     * enclosing parentheses — the body of a constraint's `.scp` line. Because
+     * the writer and any reader share this one type, `format("{}",
+     * parse_s_expr(s)) == s` for every `s` already in canonical form, so "write
+     * an `.scp`, read it back, write it again" is identity by construction.
      */
     class SExpr final
     {
@@ -83,21 +93,86 @@ namespace gcs::innards
 
     /// \brief Parse zero or more whitespace-separated top-level s-expressions.
     [[nodiscard]] auto parse_s_expr_seq(std::string_view text) -> std::vector<SExpr>;
-
-    /**
-     * \brief Render `expr` canonically on a single line: an atom verbatim, a
-     * list as `(` followed by its space-separated children followed by `)`,
-     * with no padding next to the parentheses (so `()` for the empty list).
-     */
-    [[nodiscard]] auto to_string(const SExpr & expr) -> std::string;
-
-    /**
-     * \brief Render a sequence of terms as the space-separated body of a
-     * constraint line — each term via `to_string`, joined by single spaces,
-     * with no enclosing parentheses. This is what `Constraint::s_exprify`
-     * returns; `solve()` adds the surrounding `( ... )`.
-     */
-    [[nodiscard]] auto to_string(const std::vector<SExpr> & terms) -> std::string;
 }
+
+// SExpr is rendered through the formatting machinery rather than a free
+// to_string(), both because that is how the rest of the codebase formats and to
+// avoid a to_string() overload in gcs::innards shadowing std::to_string. The
+// optional '#' flag drops a list's enclosing parentheses (the constraint body).
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+template <>
+struct std::formatter<gcs::innards::SExpr>
+{
+    bool bare = false;
+
+    constexpr auto parse(std::format_parse_context & ctx)
+    {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it == '#') {
+            bare = true;
+            ++it;
+        }
+        if (it != ctx.end() && *it != '}')
+            throw std::format_error{"invalid format spec for SExpr (only '#' is accepted)"};
+        return it;
+    }
+
+    auto format(const gcs::innards::SExpr & expr, std::format_context & ctx) const
+    {
+        auto out = ctx.out();
+        if (expr.is_atom())
+            return std::format_to(out, "{}", expr.as_atom());
+        if (! bare)
+            *out++ = '(';
+        bool first = true;
+        for (const auto & child : expr.as_list()) {
+            if (! first)
+                *out++ = ' ';
+            first = false;
+            out = std::format_to(out, "{}", child);
+        }
+        if (! bare)
+            *out++ = ')';
+        return out;
+    }
+};
+#else
+template <>
+struct fmt::formatter<gcs::innards::SExpr>
+{
+    bool bare = false;
+
+    constexpr auto parse(fmt::format_parse_context & ctx) -> decltype(ctx.begin())
+    {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it == '#') {
+            bare = true;
+            ++it;
+        }
+        if (it != ctx.end() && *it != '}')
+            throw fmt::format_error{"invalid format spec for SExpr (only '#' is accepted)"};
+        return it;
+    }
+
+    auto format(const gcs::innards::SExpr & expr, fmt::format_context & ctx) const -> decltype(ctx.out())
+    {
+        auto out = ctx.out();
+        if (expr.is_atom())
+            return fmt::format_to(out, "{}", expr.as_atom());
+        if (! bare)
+            *out++ = '(';
+        bool first = true;
+        for (const auto & child : expr.as_list()) {
+            if (! first)
+                *out++ = ' ';
+            first = false;
+            out = fmt::format_to(out, "{}", child);
+        }
+        if (! bare)
+            *out++ = ')';
+        return out;
+    }
+};
+#endif
 
 #endif

--- a/gcs/innards/s_expr.hh
+++ b/gcs/innards/s_expr.hh
@@ -1,0 +1,103 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_HH
+
+#include <exception>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Thrown when text cannot be parsed as an s-expression, or when an
+     * SExpr is inspected as the wrong kind (atom vs list).
+     *
+     * \ingroup Innards
+     */
+    class SExprParseError : public std::exception
+    {
+    private:
+        std::string _wat;
+
+    public:
+        explicit SExprParseError(const std::string &);
+
+        [[nodiscard]] virtual auto what() const noexcept -> const char * override;
+    };
+
+    /**
+     * \brief A term in the `.scp` s-expression grammar: either an *atom* (an
+     * indivisible token, stored verbatim) or a *list* of sub-terms.
+     *
+     * The `.scp` files the solver writes (and, in the verified-encoding
+     * workflows, reads back) are plain s-expressions: whitespace and
+     * parentheses are the only delimiters, and every other maximal run of
+     * characters is an atom. Atoms therefore uniformly cover variable names
+     * (`_1`), integers (`-3`), operator keywords (`all_different`) and
+     * comparison symbols (`>=`); a view such as `(-_1 + 17)` is a three-element
+     * list. The model carries no further type information — meaning is imposed
+     * by whoever consumes the term.
+     *
+     * The point of routing both the writer (`Constraint::s_exprify`) and any
+     * reader through this one type is that `to_string(parse_s_expr(s)) == s`
+     * holds for every `s` already in the canonical form `to_string` emits, so
+     * "write an `.scp`, read it back, write it again" is identity by
+     * construction rather than by careful hand-formatting.
+     */
+    class SExpr final
+    {
+    private:
+        std::variant<std::string, std::vector<SExpr>> _value;
+
+    public:
+        explicit SExpr(std::string atom);
+        explicit SExpr(std::vector<SExpr> list);
+
+        [[nodiscard]] static auto atom(std::string) -> SExpr;
+        [[nodiscard]] static auto list(std::vector<SExpr>) -> SExpr;
+
+        [[nodiscard]] auto is_atom() const -> bool;
+        [[nodiscard]] auto is_list() const -> bool;
+
+        /// The atom's text. Throws SExprParseError if this is a list.
+        [[nodiscard]] auto as_atom() const -> const std::string &;
+        /// The list's children. Throws SExprParseError if this is an atom.
+        [[nodiscard]] auto as_list() const -> const std::vector<SExpr> &;
+
+        [[nodiscard]] auto operator==(const SExpr &) const -> bool = default;
+    };
+
+    /**
+     * \brief Parse exactly one s-expression from `text`, ignoring leading and
+     * trailing whitespace.
+     *
+     * Throws SExprParseError if `text` is empty, malformed (e.g. unbalanced
+     * parentheses), or contains more than one top-level term. A bare name such
+     * as `_1` parses as an atom; a parenthesised name such as a view or a
+     * reification condition `(_2 neq 1)` parses as the corresponding list, so
+     * this is also the right way to turn a rendered variable / literal name
+     * (from NamesAndIDsTracker::s_expr_name_of) into a term.
+     */
+    [[nodiscard]] auto parse_s_expr(std::string_view text) -> SExpr;
+
+    /// \brief Parse zero or more whitespace-separated top-level s-expressions.
+    [[nodiscard]] auto parse_s_expr_seq(std::string_view text) -> std::vector<SExpr>;
+
+    /**
+     * \brief Render `expr` canonically on a single line: an atom verbatim, a
+     * list as `(` followed by its space-separated children followed by `)`,
+     * with no padding next to the parentheses (so `()` for the empty list).
+     */
+    [[nodiscard]] auto to_string(const SExpr & expr) -> std::string;
+
+    /**
+     * \brief Render a sequence of terms as the space-separated body of a
+     * constraint line — each term via `to_string`, joined by single spaces,
+     * with no enclosing parentheses. This is what `Constraint::s_exprify`
+     * returns; `solve()` adds the surrounding `( ... )`.
+     */
+    [[nodiscard]] auto to_string(const std::vector<SExpr> & terms) -> std::string;
+}
+
+#endif

--- a/gcs/innards/s_expr_test.cc
+++ b/gcs/innards/s_expr_test.cc
@@ -4,6 +4,15 @@
 
 #include <string>
 #include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/format.h>
+using fmt::format;
+#endif
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -16,7 +25,7 @@ TEST_CASE("SExpr: an atom round-trips")
     auto e = parse_s_expr("_1");
     CHECK(e.is_atom());
     CHECK(e.as_atom() == "_1");
-    CHECK(to_string(e) == "_1");
+    CHECK(format("{}", e) == "_1");
 }
 
 TEST_CASE("SExpr: a flat list round-trips canonically")
@@ -26,7 +35,7 @@ TEST_CASE("SExpr: a flat list round-trips canonically")
     REQUIRE(e.as_list().size() == 4);
     CHECK(e.as_list()[0].as_atom() == "_1");
     CHECK(e.as_list()[1].as_atom() == "abs");
-    CHECK(to_string(e) == "(_1 abs _2 _3)");
+    CHECK(format("{}", e) == "(_1 abs _2 _3)");
 }
 
 TEST_CASE("SExpr: incidental whitespace is normalised away")
@@ -34,10 +43,10 @@ TEST_CASE("SExpr: incidental whitespace is normalised away")
     // Leading/trailing/inner spacing, tabs and newlines all collapse to the
     // single canonical form: this is exactly the messy hand-formatting the
     // old string-built s_exprify produced (e.g. "( 0 3)").
-    CHECK(to_string(parse_s_expr("(   0    3 )")) == "(0 3)");
-    CHECK(to_string(parse_s_expr("  (_1   all_different ( _1 _1 _2 _2))  ")) ==
+    CHECK(format("{}", parse_s_expr("(   0    3 )")) == "(0 3)");
+    CHECK(format("{}", parse_s_expr("  (_1   all_different ( _1 _1 _2 _2))  ")) ==
         "(_1 all_different (_1 _1 _2 _2))");
-    CHECK(to_string(parse_s_expr("(a\n\tb\r\n c)")) == "(a b c)");
+    CHECK(format("{}", parse_s_expr("(a\n\tb\r\n c)")) == "(a b c)");
 }
 
 TEST_CASE("SExpr: nested lists round-trip")
@@ -47,7 +56,7 @@ TEST_CASE("SExpr: nested lists round-trip")
     REQUIRE(e.is_list());
     REQUIRE(e.as_list().size() == 2);
     CHECK(e.as_list()[0].is_list());
-    CHECK(to_string(e) == s);
+    CHECK(format("{}", e) == s);
 }
 
 TEST_CASE("SExpr: the empty list")
@@ -55,8 +64,8 @@ TEST_CASE("SExpr: the empty list")
     auto e = parse_s_expr("()");
     REQUIRE(e.is_list());
     CHECK(e.as_list().empty());
-    CHECK(to_string(e) == "()");
-    CHECK(to_string(parse_s_expr("(  )")) == "()");
+    CHECK(format("{}", e) == "()");
+    CHECK(format("{}", parse_s_expr("(  )")) == "()");
 }
 
 TEST_CASE("SExpr: a view parses as a list and re-renders identically")
@@ -64,14 +73,14 @@ TEST_CASE("SExpr: a view parses as a list and re-renders identically")
     // s_expr_name_of renders a ViewOfIntegerVariableID as "(-_1 + 17)" /
     // "(_2 + 0)"; that textual form already is canonical s-expr spacing, so a
     // constraint line embedding a view round-trips exactly.
-    CHECK(to_string(parse_s_expr("(-_1 + 17)")) == "(-_1 + 17)");
-    CHECK(to_string(parse_s_expr("(_2 + 0)")) == "(_2 + 0)");
-    CHECK(to_string(parse_s_expr("(_1 abs (-_1 + 17) _2)")) == "(_1 abs (-_1 + 17) _2)");
+    CHECK(format("{}", parse_s_expr("(-_1 + 17)")) == "(-_1 + 17)");
+    CHECK(format("{}", parse_s_expr("(_2 + 0)")) == "(_2 + 0)");
+    CHECK(format("{}", parse_s_expr("(_1 abs (-_1 + 17) _2)")) == "(_1 abs (-_1 + 17) _2)");
 }
 
 TEST_CASE("SExpr: reification-condition triples, signs, symbols and commas are atoms-in-lists")
 {
-    CHECK(to_string(parse_s_expr("(_2 neq 1)")) == "(_2 neq 1)");
+    CHECK(format("{}", parse_s_expr("(_2 neq 1)")) == "(_2 neq 1)");
     CHECK(parse_s_expr("-3").as_atom() == "-3");
     CHECK(parse_s_expr(">=").as_atom() == ">=");
     CHECK(parse_s_expr("*").as_atom() == "*");
@@ -88,7 +97,7 @@ TEST_CASE("SExpr: the canonical forms the refactored constraints now emit")
              "(_1 less_than_equal _2 _3)",
              "(_1 less_than_equal_iff (_2 neq 1) _3 _4)",
              "(_5 in _2 (0 1 _3))"}) {
-        CHECK(to_string(parse_s_expr(s)) == s);
+        CHECK(format("{}", parse_s_expr(s)) == s);
     }
 }
 
@@ -96,9 +105,9 @@ TEST_CASE("SExpr: parsing is idempotent under print-then-reparse")
 {
     for (auto s : {"x", "()", "(a (b c) ((d)) e)", "(  messy   ( spacing ) )", "(-_1 + 17)"}) {
         auto once = parse_s_expr(s);
-        auto twice = parse_s_expr(to_string(once));
+        auto twice = parse_s_expr(format("{}", once));
         CHECK(once == twice);
-        CHECK(to_string(once) == to_string(twice));
+        CHECK(format("{}", once) == format("{}", twice));
     }
 }
 
@@ -119,16 +128,18 @@ TEST_CASE("SExpr: a sequence of top-level terms")
     CHECK(parse_s_expr_seq("   ").empty());
 }
 
-TEST_CASE("SExpr: a term sequence renders as an unbracketed, space-joined body")
+TEST_CASE("SExpr: the '#' alternate form drops a list's enclosing parentheses")
 {
     // This is the shape Constraint::s_exprify returns; solve() wraps it in ().
-    vector<SExpr> body{
-        SExpr::atom("_1"),
+    auto body = SExpr::list({SExpr::atom("_1"),
         SExpr::atom("abs"),
         parse_s_expr("_2"),
-        parse_s_expr("(-_1 + 17)")};
-    CHECK(to_string(body) == "_1 abs _2 (-_1 + 17)");
-    CHECK(to_string(vector<SExpr>{}) == "");
+        parse_s_expr("(-_1 + 17)")});
+    CHECK(format("{:#}", body) == "_1 abs _2 (-_1 + 17)");
+    CHECK(format("{}", body) == "(_1 abs _2 (-_1 + 17))");
+    // Only the outermost list loses its parentheses; nested lists keep theirs.
+    CHECK(format("{:#}", parse_s_expr("(a (b c) d)")) == "a (b c) d");
+    CHECK(format("{:#}", SExpr::list({})) == "");
 }
 
 TEST_CASE("SExpr: malformed input throws")

--- a/gcs/innards/s_expr_test.cc
+++ b/gcs/innards/s_expr_test.cc
@@ -1,0 +1,148 @@
+#include <gcs/innards/s_expr.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::string;
+using std::vector;
+
+TEST_CASE("SExpr: an atom round-trips")
+{
+    auto e = parse_s_expr("_1");
+    CHECK(e.is_atom());
+    CHECK(e.as_atom() == "_1");
+    CHECK(to_string(e) == "_1");
+}
+
+TEST_CASE("SExpr: a flat list round-trips canonically")
+{
+    auto e = parse_s_expr("(_1 abs _2 _3)");
+    REQUIRE(e.is_list());
+    REQUIRE(e.as_list().size() == 4);
+    CHECK(e.as_list()[0].as_atom() == "_1");
+    CHECK(e.as_list()[1].as_atom() == "abs");
+    CHECK(to_string(e) == "(_1 abs _2 _3)");
+}
+
+TEST_CASE("SExpr: incidental whitespace is normalised away")
+{
+    // Leading/trailing/inner spacing, tabs and newlines all collapse to the
+    // single canonical form: this is exactly the messy hand-formatting the
+    // old string-built s_exprify produced (e.g. "( 0 3)").
+    CHECK(to_string(parse_s_expr("(   0    3 )")) == "(0 3)");
+    CHECK(to_string(parse_s_expr("  (_1   all_different ( _1 _1 _2 _2))  ")) ==
+        "(_1 all_different (_1 _1 _2 _2))");
+    CHECK(to_string(parse_s_expr("(a\n\tb\r\n c)")) == "(a b c)");
+}
+
+TEST_CASE("SExpr: nested lists round-trip")
+{
+    auto s = "((_4 _5) (_6 _7))";
+    auto e = parse_s_expr(s);
+    REQUIRE(e.is_list());
+    REQUIRE(e.as_list().size() == 2);
+    CHECK(e.as_list()[0].is_list());
+    CHECK(to_string(e) == s);
+}
+
+TEST_CASE("SExpr: the empty list")
+{
+    auto e = parse_s_expr("()");
+    REQUIRE(e.is_list());
+    CHECK(e.as_list().empty());
+    CHECK(to_string(e) == "()");
+    CHECK(to_string(parse_s_expr("(  )")) == "()");
+}
+
+TEST_CASE("SExpr: a view parses as a list and re-renders identically")
+{
+    // s_expr_name_of renders a ViewOfIntegerVariableID as "(-_1 + 17)" /
+    // "(_2 + 0)"; that textual form already is canonical s-expr spacing, so a
+    // constraint line embedding a view round-trips exactly.
+    CHECK(to_string(parse_s_expr("(-_1 + 17)")) == "(-_1 + 17)");
+    CHECK(to_string(parse_s_expr("(_2 + 0)")) == "(_2 + 0)");
+    CHECK(to_string(parse_s_expr("(_1 abs (-_1 + 17) _2)")) == "(_1 abs (-_1 + 17) _2)");
+}
+
+TEST_CASE("SExpr: reification-condition triples, signs, symbols and commas are atoms-in-lists")
+{
+    CHECK(to_string(parse_s_expr("(_2 neq 1)")) == "(_2 neq 1)");
+    CHECK(parse_s_expr("-3").as_atom() == "-3");
+    CHECK(parse_s_expr(">=").as_atom() == ">=");
+    CHECK(parse_s_expr("*").as_atom() == "*");
+    // The element index form "_4,0" is a single atom (the comma is an ordinary
+    // atom character). NOTE: this comma form is suspect and likely to change.
+    CHECK(parse_s_expr("_4,0").as_atom() == "_4,0");
+}
+
+TEST_CASE("SExpr: the canonical forms the refactored constraints now emit")
+{
+    for (auto s : {
+             "(_1 abs _2 _3)",
+             "(_3 all_different (_1 _1 _2 _2))",
+             "(_1 less_than_equal _2 _3)",
+             "(_1 less_than_equal_iff (_2 neq 1) _3 _4)",
+             "(_5 in _2 (0 1 _3))"}) {
+        CHECK(to_string(parse_s_expr(s)) == s);
+    }
+}
+
+TEST_CASE("SExpr: parsing is idempotent under print-then-reparse")
+{
+    for (auto s : {"x", "()", "(a (b c) ((d)) e)", "(  messy   ( spacing ) )", "(-_1 + 17)"}) {
+        auto once = parse_s_expr(s);
+        auto twice = parse_s_expr(to_string(once));
+        CHECK(once == twice);
+        CHECK(to_string(once) == to_string(twice));
+    }
+}
+
+TEST_CASE("SExpr: structural equality ignores formatting but respects shape")
+{
+    CHECK(parse_s_expr("( a b )") == parse_s_expr("(a   b)"));
+    CHECK_FALSE(parse_s_expr("(a b)") == parse_s_expr("(a (b))"));
+    CHECK_FALSE(parse_s_expr("a") == parse_s_expr("(a)"));
+}
+
+TEST_CASE("SExpr: a sequence of top-level terms")
+{
+    auto seq = parse_s_expr_seq("(a b)  c\n(d)");
+    REQUIRE(seq.size() == 3);
+    CHECK(seq[0].is_list());
+    CHECK(seq[1].as_atom() == "c");
+    CHECK(seq[2].is_list());
+    CHECK(parse_s_expr_seq("   ").empty());
+}
+
+TEST_CASE("SExpr: a term sequence renders as an unbracketed, space-joined body")
+{
+    // This is the shape Constraint::s_exprify returns; solve() wraps it in ().
+    vector<SExpr> body{
+        SExpr::atom("_1"),
+        SExpr::atom("abs"),
+        parse_s_expr("_2"),
+        parse_s_expr("(-_1 + 17)")};
+    CHECK(to_string(body) == "_1 abs _2 (-_1 + 17)");
+    CHECK(to_string(vector<SExpr>{}) == "");
+}
+
+TEST_CASE("SExpr: malformed input throws")
+{
+    CHECK_THROWS_AS(parse_s_expr(""), SExprParseError);
+    CHECK_THROWS_AS(parse_s_expr("   "), SExprParseError);
+    CHECK_THROWS_AS(parse_s_expr("(a b"), SExprParseError); // unclosed
+    CHECK_THROWS_AS(parse_s_expr("a)"), SExprParseError);   // stray close
+    CHECK_THROWS_AS(parse_s_expr(")"), SExprParseError);
+    CHECK_THROWS_AS(parse_s_expr("a b"), SExprParseError); // two top-level terms
+}
+
+TEST_CASE("SExpr: as_atom / as_list on the wrong kind throws")
+{
+    CHECK_THROWS_AS(parse_s_expr("(a)").as_atom(), SExprParseError);
+    CHECK_THROWS_AS(parse_s_expr("a").as_list(), SExprParseError);
+}


### PR DESCRIPTION
First step of the verified-encoding (CakePB) work: give `.scp` writing — and, later, reading — a single shared grammar so "write an `.scp`, read it back, write it again" is identity by construction, instead of every `Constraint::s_exprify` hand-building a line with format strings (which produced inconsistent spacing across constraints and gave a future reader nothing to share).

## What's here
- **`gcs/innards/s_expr.{hh,cc}`** — an `SExpr` term type (atom | list), a whitespace/parenthesis tokenising parser (`parse_s_expr` / `parse_s_expr_seq`) and a canonical single-line printer (`to_string`). The grammar is fully generic, so signs, comparison symbols, commas and reification-condition triples are atoms/lists with no special cases; a view like `(-_1 + 17)` parses as a list and re-renders identically. `to_string(parse_s_expr(s)) == s` for any `s` already in canonical form.
- **Refactored** `Abs`, the reified comparisons, GAC/VC `AllDifferent`, and `In` onto it. This also normalises their output to canonical spacing (`In` now emits `(0 3)` not `( 0 3)`; `all_different` `(_1 _2)` not `( _1 _2)`).
- **`gcs/innards/s_expr_test.cc`** — 60 assertions: parser/printer, the exact canonical forms these constraints emit, idempotence, structural equality, error paths.

## Safety
The change only touches `.scp` text, not the OPB or proof, so existing constraint tests are unaffected. `abs_test` still verifies under veripb; `comparison`/`all_different`/`in` pass.

First in a small stack; the verified-encoding chain (sign-bit alignment + a `cake_pb_cp` end-to-end example) stacks on top in #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
