### PR TITLE
Structured Constraint::s_expr(); route .scp writing through it

### DIFF
--- a/dev_docs/scp_s_expr_migration.md
+++ b/dev_docs/scp_s_expr_migration.md
@@ -1,0 +1,77 @@
+# Migrating `s_exprify` → `s_expr` (structured `.scp` terms)
+
+## Where we are
+
+A constraint's `.scp` entry used to be produced by `Constraint::s_exprify()`,
+which returned a hand-built string (the body of the `(name op args...)` list,
+without the enclosing parentheses; `solve()` added those). Every constraint did
+its own string formatting, which gave inconsistent spacing and nothing for a
+`.scp` *reader* to share.
+
+We are moving to `Constraint::s_expr()`, which returns the term as a structured
+`innards::SExpr` (the full `(name op args...)` list). The stringification then
+happens once, centrally, in `innards::write_scp` (`gcs/innards/proofs/scp_writer.cc`),
+which is the sole `.scp` serialiser — `solve()` just calls it. The structured
+term is also what a future `.scp` reader will produce, so writer and reader share
+one representation and can be compared directly (`parse_s_expr(line) == c.s_expr()`).
+
+### Transitional bridge (current state)
+
+`Constraint` declares both methods, each with a default that derives it from the
+other (`gcs/constraint.cc`):
+
+- `s_expr()` default: `parse_s_expr("(" + s_exprify() + ")")`
+- `s_exprify()` default: `to_string(s_expr().as_list())` (body, no outer parens)
+
+So a constraint overrides **exactly one**. Un-migrated constraints keep their
+`s_exprify()` string override and get `s_expr()` via the bridge; migrated ones
+override `s_expr()` and get `s_exprify()` for free. Overriding *neither* recurses
+— don't (a constraint must define its `.scp` form somehow).
+
+Because `write_scp` goes through `s_expr()`, **every** constraint's output now
+passes through the parser, so it must be balanced, parseable s-expression text.
+Output is also canonicalised (single line, single-space) regardless of how the
+legacy string was formatted.
+
+Migrated so far: `abs`, the reified comparisons, GAC/VC `all_different`, `in`.
+
+## What's left
+
+Migrate the remaining 37 `s_exprify` overrides to `s_expr()` (build an `SExpr`
+instead of a string), then finish the cutover:
+
+1. Migrate each remaining constraint (list below) to override `s_expr()`.
+2. Resolve the **suspect forms** as they are migrated (don't enshrine them):
+   - **`GACArithmetic` double parentheses** — its `s_exprify()` already returns
+     `(name op ...)` *with* outer parens, so the writer double-wraps it to
+     `((name op ...))`. The bridge preserves this faithfully today; fix it when
+     migrating arithmetic (return the body, or a single list).
+   - **`element` index form `_4,0`** — the comma-joined `elem,idx` atom is
+     suspect and likely to change; decide its structured form when migrating
+     `element`.
+   - **Multi-line tabular constraints** (`table`, `smart_table`, `regular`,
+     `knapsack`, …) currently emit pretty multi-line strings; via the bridge
+     these are already canonicalised to one line. Confirm that's acceptable when
+     migrating them.
+3. Once **all** constraints override `s_expr()`:
+   - Make `s_expr()` pure virtual.
+   - Delete the bridge defaults and the `s_exprify()` method entirely (or keep a
+     single non-virtual `to_string(s_expr())` convenience if any caller wants the
+     string body).
+   - `write_scp` is already off `s_exprify()`, so no change there.
+
+## Bugs surfaced by routing the writer through the parser
+
+- **`inverse`, `arg_sort`** emitted a stray trailing `)` (they hand-wrote the
+  closing paren that `solve()` also adds), leaving the `.scp` unbalanced —
+  harmless only because nothing parsed it. Fixed in this change.
+
+## Remaining constraints (override still on `s_exprify`)
+
+all_different_except, symmetric_all_different, all_equal, among, arithmetic
+(Plus/Minus/Times/Div/Mod/Power — note double-paren above), at_most_one, circuit,
+count, cumulative, disjunctive, disjunctive_2d, element (comma form), equals,
+bounds/gac global_cardinality, increasing, inverse, knapsack, lex,
+lex_smart_table, linear_equality, linear_inequality, logical, min_max, minus,
+mult_bc, n_value, parity, plus, regular, seq_precede_chain, smart_table,
+arg_sort, sort, negative_table, table, value_precede.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(glasgow_constraint_solver
         innards/proofs/proof_logger.cc
         innards/proofs/proof_model.cc
         innards/proofs/proof_only_variables.cc
+        innards/proofs/scp_writer.cc
         innards/proofs/simplify_literal.cc
         innards/propagators.cc
         innards/reason.cc

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -1,15 +1,39 @@
 #include <gcs/constraint.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/s_expr.hh>
 
 using std::string;
 using std::variant;
 
 using namespace gcs;
+using namespace gcs::innards;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::format;
+#else
+using fmt::format;
+#endif
 
 Constraint::~Constraint() = default;
 
-namespace gcs {
-    auto as_string(const ConstraintName & name) -> std::string {
+// Bridge between the structured s_expr() and the legacy string s_exprify(). A
+// constraint overrides exactly one; the other is derived here. s_expr() is the
+// full `(name op args...)` list, s_exprify() is its body without the enclosing
+// parentheses (the `#` alternate form), so they wrap/unwrap one level.
+auto Constraint::s_expr(const innards::ProofModel * const model) const -> SExpr
+{
+    return parse_s_expr("(" + s_exprify(model) + ")");
+}
+
+auto Constraint::s_exprify(const innards::ProofModel * const model) const -> string
+{
+    return format("{:#}", s_expr(model));
+}
+
+namespace gcs
+{
+    auto as_string(const ConstraintName & name) -> std::string
+    {
         return visit([](const auto & n) { return n.as_string(); }, name);
     }
 }

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/innards/proofs/proof_model-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/s_expr-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
 
 #include <memory>
@@ -24,21 +25,30 @@ namespace gcs
 
     struct CurrentlyUnnamedConstraint final
     {
-        [[nodiscard]] auto as_string() const -> std::string { return "unnamed"; }
+        [[nodiscard]] auto as_string() const -> std::string
+        {
+            return "unnamed";
+        }
     };
 
     struct NumberedConstraint final
     {
         unsigned long long number;
         [[nodiscard]] auto operator<=>(const NumberedConstraint &) const = default;
-        [[nodiscard]] auto as_string() const -> std::string { return "_" + std::to_string(number); }
+        [[nodiscard]] auto as_string() const -> std::string
+        {
+            return "_" + std::to_string(number);
+        }
     };
 
     struct NamedConstraint final
     {
         std::string name;
         [[nodiscard]] auto operator<=>(const NamedConstraint &) const = default;
-        [[nodiscard]] auto as_string() const -> std::string { return name; }
+        [[nodiscard]] auto as_string() const -> std::string
+        {
+            return name;
+        }
     };
 
     using ConstraintName = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
@@ -72,8 +82,14 @@ namespace gcs
 
     public:
         virtual ~Constraint() = 0;
-        [[nodiscard]] auto name() const -> const ConstraintName & { return _name; }
-        auto set_name(ConstraintName name) -> void { _name = std::move(name); }
+        [[nodiscard]] auto name() const -> const ConstraintName &
+        {
+            return _name;
+        }
+        auto set_name(ConstraintName name) -> void
+        {
+            _name = std::move(name);
+        }
         /**
          * Called internally to install the constraint. A Constraint is expected
          * to define zero or more propagators, and to provide a description of
@@ -90,9 +106,27 @@ namespace gcs
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> = 0;
 
         /**
-         * Return an s-expr representation of the constraint. To be used internally.
+         * Return the constraint's `.scp` entry as an s-expression term: the
+         * list `(name op args...)`. This is the preferred representation --
+         * routing the writer through it (see innards::write_scp) means the
+         * stringification happens once, centrally, and the structured term can
+         * be compared against a parsed `.scp` line directly.
+         *
+         * A constraint must override **exactly one** of s_expr() (preferred) or
+         * the legacy s_exprify(): by default s_expr() parses s_exprify()'s
+         * string and s_exprify() prints s_expr(), so overriding neither would
+         * recurse. New constraints should override s_expr(); the remaining
+         * legacy s_exprify() overrides are being migrated across (see
+         * dev_docs/scp_s_expr_migration.md), after which s_exprify() goes away.
          */
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string = 0;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr;
+
+        /**
+         * Legacy string form: the body of s_expr() *without* the enclosing
+         * parentheses (the historical `Constraint::s_exprify` contract). \see
+         * s_expr.
+         */
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string;
     };
 }
 

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -295,8 +295,11 @@ auto Abs::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Abs::s_exprify(const innards::ProofModel * const model) const -> string
+auto Abs::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
-    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("abs"), tracker.s_expr_term_of(_v1), tracker.s_expr_term_of(_v2)}));
+    return SExpr::list({SExpr::atom(as_string(_name)),
+        SExpr::atom("abs"),
+        tracker.s_expr_term_of(_v1),
+        tracker.s_expr_term_of(_v2)});
 }

--- a/gcs/constraints/abs.hh
+++ b/gcs/constraints/abs.hh
@@ -35,7 +35,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
 
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -669,11 +669,13 @@ template auto gcs::innards::propagate_gac_all_different(
     EagerProofLoggingInferenceTracker & inference_tracker,
     ProofLogger * const logger) -> void;
 
-auto GACAllDifferent::s_exprify(const innards::ProofModel * const model) const -> string
+auto GACAllDifferent::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
     vector<SExpr> vars;
     for (const auto & var : _vars)
         vars.push_back(tracker.s_expr_term_of(var));
-    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("all_different"), SExpr::list(std::move(vars))}));
+    return SExpr::list({SExpr::atom(as_string(_name)),
+        SExpr::atom("all_different"),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -50,7 +50,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
 }

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -171,11 +171,13 @@ template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintState
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
     EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
 
-auto VCAllDifferent::s_exprify(const innards::ProofModel * const model) const -> string
+auto VCAllDifferent::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
     vector<SExpr> vars;
     for (const auto & var : _vars)
         vars.push_back(tracker.s_expr_term_of(var));
-    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("all_different"), SExpr::list(std::move(vars))}));
+    return SExpr::list({SExpr::atom(as_string(_name)),
+        SExpr::atom("all_different"),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -45,7 +45,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 #endif // GLASGOW_CONSTRAINT_SOLVER_VC_ALL_DIFFERENT_HH

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -222,7 +222,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
     }
 }
 
-auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const model) const -> std::string
+auto ReifiedCompareLessThanOrMaybeEqual::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
 
@@ -230,7 +230,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const mode
         [&](const reif::MustHold &) -> string { return ""; },
         [&](const reif::If &) -> string { return "_if"; },
         [&](const reif::Iff &) -> string { return "_iff"; },
-        [&](const auto &) -> string { throw UnexpectedException{"Unexpected reification type in s_exprify"}; }}
+        [&](const auto &) -> string { throw UnexpectedException{"Unexpected reification type in s_expr"}; }}
                            .visit(_reif_cond);
 
     string cmp = format("{}{}{}",
@@ -244,5 +244,5 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_exprify(const ProofModel * const mode
     terms.push_back(tracker.s_expr_term_of(_v1));
     terms.push_back(tracker.s_expr_term_of(_v2));
 
-    return format("{:#}", SExpr::list(std::move(terms)));
+    return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/comparison.hh
+++ b/gcs/constraints/comparison.hh
@@ -2,8 +2,8 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_COMPARISON_HH
 
 #include <gcs/constraint.hh>
-#include <gcs/innards/literal.hh>
 #include <gcs/constraints/innards/reified_state.hh>
+#include <gcs/innards/literal.hh>
 #include <gcs/integer.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
@@ -48,7 +48,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     /**

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -261,7 +261,7 @@ auto In::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto In::s_exprify(const ProofModel * const model) const -> string
+auto In::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
     vector<SExpr> vals;
@@ -269,5 +269,8 @@ auto In::s_exprify(const ProofModel * const model) const -> string
         vals.push_back(tracker.s_expr_term_of(v));
     for (const auto & v : _val_vals)
         vals.push_back(SExpr::atom(v.to_string()));
-    return format("{:#}", SExpr::list({SExpr::atom(as_string(_name)), SExpr::atom("in"), tracker.s_expr_term_of(_var), SExpr::list(std::move(vals))}));
+    return SExpr::list({SExpr::atom(as_string(_name)),
+        SExpr::atom("in"),
+        tracker.s_expr_term_of(_var),
+        SExpr::list(std::move(vals))});
 }

--- a/gcs/constraints/in.hh
+++ b/gcs/constraints/in.hh
@@ -40,7 +40,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -198,7 +198,10 @@ auto Inverse::s_exprify(const innards::ProofModel * const model) const -> std::s
     for (const auto & y : _y) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(y));
     }
-    print(s, ")\n          {} {})", _x_start, _y_start);
+    // Note: no trailing ')' here -- solve()/write_scp wraps the whole body in
+    // one pair of parentheses. The stray ')' this used to emit left the .scp
+    // unbalanced (harmless only because nothing parsed it).
+    print(s, ")\n          {} {}", _x_start, _y_start);
 
     return s.str();
 }

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -465,7 +465,10 @@ auto ArgSort::s_exprify(const ProofModel * const model) const -> string
     print(s, ")\n          (");
     for (const auto & v : _p)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, ")\n          {})", _offset);
+    // Note: no trailing ')' here -- solve()/write_scp wraps the whole body in
+    // one pair of parentheses. The stray ')' this used to emit left the .scp
+    // unbalanced (harmless only because nothing parsed it).
+    print(s, ")\n          {}", _offset);
 
     return s.str();
 }

--- a/gcs/innards/proofs/scp_writer.cc
+++ b/gcs/innards/proofs/scp_writer.cc
@@ -1,0 +1,55 @@
+#include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/scp_writer.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/problem.hh>
+
+#include <fstream>
+#include <ios>
+#include <ostream>
+#include <string>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using std::ios;
+using std::ios_base;
+using std::ofstream;
+using std::string;
+
+using namespace gcs;
+using namespace gcs::innards;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+auto gcs::innards::write_scp(const string & file_name, const Problem & problem, const ProofModel * const model) -> void
+{
+    try {
+        ofstream s_expr;
+        s_expr.exceptions(ios::failbit | ios::badbit);
+        s_expr.open(file_name);
+
+        println(s_expr, "(");
+        println(s_expr, "    (");
+        for (const auto & [_, l, u, n] : problem.each_variable_with_bounds_and_name())
+            println(s_expr, "        ({} {} {})", n, l, u);
+        println(s_expr, "    )");
+        println(s_expr, "    (");
+        for (const auto & c : problem.each_constraint())
+            println(s_expr, "        {}", c.s_expr(model));
+        println(s_expr, "    )");
+        println(s_expr, ")");
+    }
+    catch (const ios_base::failure &) {
+        throw ProofError{"Error writing proof s-expr file to '" + file_name + "'"};
+    }
+}

--- a/gcs/innards/proofs/scp_writer.hh
+++ b/gcs/innards/proofs/scp_writer.hh
@@ -1,0 +1,27 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_SCP_WRITER_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_SCP_WRITER_HH
+
+#include <gcs/innards/proofs/proof_model-fwd.hh>
+#include <gcs/problem-fwd.hh>
+
+#include <string>
+
+namespace gcs
+{
+    namespace innards
+    {
+        /**
+         * \brief Write the `.scp` (s-expression CP) description of `problem` to
+         * `file_name`.
+         *
+         * The file is the s-expression `( (var-decls) (constraints) )`, where
+         * each variable is `(name lb ub)` and each constraint is the term from
+         * Constraint::s_expr(). Throws ProofError on an I/O failure. This is the
+         * single place the `.scp` is serialised; constraints contribute only
+         * their own term.
+         */
+        auto write_scp(const std::string & file_name, const Problem & problem, const ProofModel * model) -> void;
+    }
+}
+
+#endif

--- a/gcs/innards/s_expr-fwd.hh
+++ b/gcs/innards/s_expr-fwd.hh
@@ -1,0 +1,9 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_FWD_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_FWD_HH
+
+namespace gcs::innards
+{
+    class SExpr;
+}
+
+#endif

--- a/gcs/innards/s_expr.hh
+++ b/gcs/innards/s_expr.hh
@@ -1,6 +1,8 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_HH
 
+#include <gcs/innards/s_expr-fwd.hh>
+
 #include <exception>
 #include <string>
 #include <string_view>

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -3,6 +3,7 @@
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/scp_writer.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/proof.hh>
@@ -11,41 +12,20 @@
 
 #include <util/enumerate.hh>
 
-#include <fstream>
 #include <string>
-#include <version>
-
-#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-#include <format>
-#include <print>
-#else
-#include <fmt/core.h>
-#include <fmt/ostream.h>
-#endif
 
 using namespace gcs;
 using namespace gcs::innards;
 
 using std::atomic;
-using std::ios;
-using std::ios_base;
 using std::max;
 using std::nullopt;
-using std::ofstream;
 using std::optional;
 using std::pair;
 using std::vector;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::steady_clock;
-
-#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-using std::format;
-using std::println;
-#else
-using fmt::format;
-using fmt::println;
-#endif
 
 namespace
 {
@@ -172,27 +152,8 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
         optional_proof->logger()->start_proof(*optional_proof->model());
         optional_proof->model()->names_and_ids_tracker().emit_delayed_proof_steps();
 
-        if (auto & fn = optional_proof_options->proof_file_names.s_expr_file) {
-            try {
-                ofstream s_expr;
-                s_expr.exceptions(ios::failbit | ios::badbit);
-                s_expr.open(*fn);
-                println(s_expr, "(");
-                println(s_expr, "    (");
-                for (const auto & [_, l, u, n] : problem.each_variable_with_bounds_and_name()) {
-                    println(s_expr, "        ({} {} {})", n, l, u);
-                }
-                println(s_expr, "    )");
-                println(s_expr, "    (");
-                for (const auto & c : problem.each_constraint()) {
-                    println(s_expr, "        ({})", c.s_exprify(optional_proof->model()));
-                }
-                println(s_expr, "    )");
-                println(s_expr, ")");
-            } catch (const ios_base::failure &) {
-                throw ProofError{"Error writing proof s-expr file to '" + *fn + "'"};
-            }
-        }
+        if (auto & fn = optional_proof_options->proof_file_names.s_expr_file)
+            write_scp(*fn, problem, optional_proof->model());
     }
 
     if (callbacks.after_proof_started)


### PR DESCRIPTION
Stacked on #266 (base is `scp-term-model`; review/merge that first). A second, independent branch off #266 — orthogonal to #267.

Answers the design question "should `s_exprify` return structure instead of every constraint stringifying?": **yes** — and as a single `SExpr` (the full `(name op args...)` list), not a `vector<SExpr>`, so the enclosing parens are part of the value and the writer needs no manual wrapping.

## What's here
- **`Constraint::s_expr() -> innards::SExpr`** — the preferred form. The stringification now happens once, centrally, in **`innards::write_scp`** (`gcs/innards/proofs/scp_writer.{hh,cc}`), which is the sole `.scp` serialiser; `solve()` just calls it (its inline block and now-dead `<fstream>`/`ofstream`/format usings are gone).
- **Transitional bridge** — `Constraint` declares both `s_expr()` and `s_exprify()`, each defaulting to the other, so a constraint overrides **exactly one**. `abs`, the reified comparisons, GAC/VC `all_different` and `in` override `s_expr()`; the other 37 keep `s_exprify()` and bridge across. Plan to finish (migrate the rest, resolve suspect forms, then make `s_expr()` pure and delete `s_exprify()`) in **`dev_docs/scp_s_expr_migration.md`**.
- **`s_expr-fwd.hh`** — forward declaration via the `-fwd.hh` convention.

## Bugs surfaced & fixed
Routing every constraint through the parser means output must be balanced, parseable s-expressions. This caught a pre-existing bug: **`inverse` and `arg_sort` emitted a stray trailing `)`** (the closing paren `solve()` already adds), leaving their `.scp` unbalanced — harmless before only because nothing parsed it. Fixed both. (`GACArithmetic`'s double parentheses are faithfully preserved by the bridge and noted for the arithmetic migration.)

## Safety
Only `.scp` text changes (now canonical, single-line); the OPB/proof are untouched. **Full suite green (292/292).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)