### PR TITLE
read_scp + glasgow_scp_solver: solve a .scp (workflow 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ install(FILES
 if(GCS_ENABLE_EXAMPLES)
     add_subdirectory(examples)
     add_subdirectory(verified_encodings)
+    add_subdirectory(scp)
     add_subdirectory(minicp_benchmarks)
     add_subdirectory(test)
 endif()

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(glasgow_constraint_solver
         presolver.cc
         problem.cc
         proof.cc
+        scp_reader.cc
         search_heuristics.cc
         solve.cc
         stats.cc
@@ -373,6 +374,10 @@ if(GCS_BUILD_TESTS)
     add_executable(s_expr_test innards/s_expr_test.cc)
     target_link_libraries(s_expr_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME s_expr_test COMMAND $<TARGET_FILE:s_expr_test>)
+
+    add_executable(scp_reader_test scp_reader_test.cc)
+    target_link_libraries(scp_reader_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME scp_reader_test COMMAND $<TARGET_FILE:scp_reader_test>)
 
     add_executable(integer_test integer_test.cc)
     target_link_libraries(integer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -27,7 +27,6 @@ using std::make_optional;
 using std::move;
 using std::nullopt;
 using std::optional;
-using std::ranges::minmax_element;
 using std::regex;
 using std::regex_match;
 using std::size_t;
@@ -38,6 +37,7 @@ using std::tuple;
 using std::unique_ptr;
 using std::unordered_set;
 using std::vector;
+using std::ranges::minmax_element;
 
 NamingError::NamingError(const string & w) :
     _wat(w)
@@ -165,8 +165,22 @@ auto Problem::post(const Constraint & c) -> void
 auto Problem::post_named(const Constraint & c, const string & name) -> void
 {
     auto cloned = c.clone();
-    cloned->set_name(NamedConstraint{check_name(name)}); 
+    cloned->set_name(NamedConstraint{check_name(name)});
     _imp->constraints.push_back(std::move(cloned));
+}
+
+auto Problem::post_autonumbered(const Constraint & c, unsigned long long expected_number) -> void
+{
+    // Re-post a constraint that was auto-numbered `_expected_number` (e.g. when
+    // reading a .scp back in). The label is reproduced by Problem's own
+    // auto-numbering rather than passed as a name -- `_N` names are reserved, so
+    // post_named rejects them -- but we validate that the number Problem is
+    // about to assign matches, so any drift in post order fails loudly here
+    // instead of silently relabelling the constraint.
+    if (expected_number != _imp->next_constraint_number + 1)
+        throw NamingError{"asked to auto-number constraint _" + to_string(expected_number) +
+            ", but the next auto-number is _" + to_string(_imp->next_constraint_number + 1)};
+    post(c);
 }
 
 auto Problem::post(SumLessThanEqual<Weighted<IntegerVariableID>> expr) -> void

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -93,6 +93,19 @@ namespace gcs
         auto post_named(const Constraint &, const std::string &) -> void;
 
         /**
+         * \brief Add a clone of this Constraint that is expected to receive the
+         * auto-generated name `_expected_number`.
+         *
+         * Behaves like post(), but throws NamingError if Problem's own
+         * auto-numbering would not assign exactly `_expected_number`. Used when
+         * reconstructing a model from its `.scp` (see read_scp): auto-generated
+         * `_N` labels can't be passed to post_named (they are reserved), so they
+         * are reproduced by re-posting in order, and this checks that the order
+         * really does line up rather than silently relabelling.
+         */
+        auto post_autonumbered(const Constraint &, unsigned long long expected_number) -> void;
+
+        /**
          * \brief Post this expression as a LinearLessThanEqual constraint.
          */
         auto post(SumLessThanEqual<Weighted<IntegerVariableID>>) -> void;

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/equals.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/constraints/linear/linear_equality.hh>
 #include <gcs/constraints/linear/linear_inequality.hh>
@@ -125,6 +126,23 @@ namespace
         throw ScpReadError{"unknown reification-condition operator '" + op + "'"};
     }
 
+    // For the equals-style families (equals / not_equals and their lin_
+    // counterparts): map a keyword's reification suffix to a (condition, flipped)
+    // pair. `flipped` is the cosmetic not-equals-iff flag (ReifiedEquals::_neq /
+    // ReifiedLinearEquality::_flipped_cond). `cond_term` is only read when the
+    // form is reified (the (variable op value) triple).
+    auto equality_reification(bool not_equals, bool iff, bool half,
+        const map<string, IntegerVariableID> & variables, const SExpr & cond_term) -> std::pair<ReificationCondition, bool>
+    {
+        if (iff)
+            return {ReificationCondition{reif::Iff{resolve_condition(variables, cond_term)}}, not_equals};
+        if (half)
+            return {not_equals ? ReificationCondition{reif::NotIf{resolve_condition(variables, cond_term)}}
+                               : ReificationCondition{reif::If{resolve_condition(variables, cond_term)}},
+                false};
+        return {not_equals ? ReificationCondition{reif::MustNotHold{}} : ReificationCondition{reif::MustHold{}}, false};
+    }
+
     // The comparison family: (label <less|greater>_than[_equal][_if|_iff]
     // [(cond)] v1 v2). The keyword carries the swapped / or-equal / reification
     // flags that the general ReifiedCompareLessThanOrMaybeEqual constructor takes
@@ -202,19 +220,27 @@ namespace
         }
 
         // Equality family: lin_equals* and lin_not_equals*.
-        bool not_equals = op.starts_with("lin_not_equals");
-        ReificationCondition cond = reif::MustHold{};
-        bool flipped_cond = false;
-        if (iff) {
-            cond = reif::Iff{condition()};
-            flipped_cond = not_equals; // lin_not_equals_iff is Iff with a flipped condition
-        }
-        else if (half)
-            cond = not_equals ? ReificationCondition{reif::NotIf{condition()}} : ReificationCondition{reif::If{condition()}};
-        else if (not_equals)
-            cond = reif::MustNotHold{};
-
+        auto [cond, flipped_cond] = equality_reification(op.starts_with("lin_not_equals"), iff, half, variables, terms[2]);
         post_constraint(problem, ReifiedLinearEquality{std::move(coeff_vars), value, cond, false, flipped_cond}, label);
+    }
+
+    // The equals family: (label <equals|not_equals>[_if|_iff] [(cond)] v1 v2),
+    // reconstructed via the general ReifiedEquals constructor.
+    auto read_equals(Problem & problem, const map<string, IntegerVariableID> & variables,
+        const string & op, const vector<SExpr> & terms, const string & label) -> void
+    {
+        bool iff = op.ends_with("_iff");
+        bool half = ! iff && op.ends_with("_if");
+        bool reified = iff || half;
+
+        if (terms.size() != (reified ? 5u : 4u))
+            throw ScpReadError{"equals constraint '" + op + "' is (label op [(cond)] v1 v2)"};
+        std::size_t v1_index = reified ? 3 : 2;
+
+        auto [cond, neq] = equality_reification(op.starts_with("not_equals"), iff, half, variables, terms[2]);
+        post_constraint(problem,
+            ReifiedEquals{resolve_variable(variables, terms[v1_index]), resolve_variable(variables, terms[v1_index + 1]), cond, neq},
+            label);
     }
 }
 
@@ -269,6 +295,9 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
         }
         else if (op.starts_with("lin_")) {
             read_linear(problem, variables, op, terms, label);
+        }
+        else if (op.starts_with("equals") || op.starts_with("not_equals")) {
+            read_equals(problem, variables, op, terms, label);
         }
         else
             throw ScpReadError{"unsupported constraint operator '" + op + "'"};

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1,0 +1,144 @@
+#include <gcs/constraints/abs.hh>
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/in.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/problem.hh>
+#include <gcs/scp_reader.hh>
+
+#include <charconv>
+#include <utility>
+
+using std::map;
+using std::move;
+using std::string;
+using std::string_view;
+using std::vector;
+
+using namespace gcs;
+using namespace gcs::innards;
+
+ScpReadError::ScpReadError(const string & w) :
+    _wat("Error reading .scp: " + w)
+{
+}
+
+auto ScpReadError::what() const noexcept -> const char *
+{
+    return _wat.c_str();
+}
+
+namespace
+{
+    auto as_integer(const SExpr & e) -> Integer
+    {
+        const auto & a = e.as_atom();
+        long long value;
+        auto [ptr, ec] = std::from_chars(a.data(), a.data() + a.size(), value);
+        if (ec != std::errc{} || ptr != a.data() + a.size())
+            throw ScpReadError{"expected an integer, got '" + a + "'"};
+        return Integer{value};
+    }
+
+    // The children of a list term, or a clear error if `e` is an atom. `what`
+    // is taken by value (not const string &) so the -Wdangling-reference
+    // heuristic doesn't flag the returned reference, which is into `e`.
+    auto children_of(const SExpr & e, const char * what) -> const vector<SExpr> &
+    {
+        if (! e.is_list())
+            throw ScpReadError{string{"expected a list for "} + what};
+        return e.as_list();
+    }
+
+    // `_<digits>` is the form Problem auto-generates for unnamed constraints; it
+    // is reserved (Problem::check_name rejects it as a user name). Re-posting
+    // such a constraint unnamed reproduces the same label in `.scp` order.
+    auto is_auto_generated_label(const string & s) -> bool
+    {
+        if (s.size() < 2 || s[0] != '_')
+            return false;
+        for (auto i = s.begin() + 1; i != s.end(); ++i)
+            if (*i < '0' || *i > '9')
+                return false;
+        return true;
+    }
+
+    auto post_constraint(Problem & problem, const Constraint & constraint, const string & label) -> void
+    {
+        if (is_auto_generated_label(label))
+            problem.post(constraint);
+        else
+            problem.post_named(constraint, label);
+    }
+}
+
+auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVariableID>
+{
+    auto top = parse_s_expr(text);
+    const auto & sections = children_of(top, "the top-level (variables constraints) form");
+    if (sections.size() != 2)
+        throw ScpReadError{"top level must be exactly (variables constraints)"};
+
+    map<string, IntegerVariableID> variables;
+
+    // Variables: each declaration is (name lower upper).
+    for (const auto & decl : children_of(sections[0], "the variables section")) {
+        const auto & parts = children_of(decl, "a variable declaration");
+        if (parts.size() != 3)
+            throw ScpReadError{"a variable declaration must be (name lower upper)"};
+        auto name = parts[0].as_atom();
+        auto var = problem.create_integer_variable(as_integer(parts[1]), as_integer(parts[2]), name);
+        if (! variables.emplace(name, var).second)
+            throw ScpReadError{"duplicate variable name '" + name + "'"};
+    }
+
+    // Resolve an argument atom to a variable: a declared name, otherwise an
+    // integer constant.
+    auto resolve = [&](const SExpr & e) -> IntegerVariableID {
+        const auto & a = e.as_atom();
+        if (auto it = variables.find(a); it != variables.end())
+            return it->second;
+        return constant_variable(as_integer(e));
+    };
+
+    // Constraints: each is (label operator args...).
+    for (const auto & constraint : children_of(sections[1], "the constraints section")) {
+        const auto & terms = children_of(constraint, "a constraint");
+        if (terms.size() < 2)
+            throw ScpReadError{"a constraint must be (label operator ...)"};
+        const auto & label = terms[0].as_atom();
+        const auto & op = terms[1].as_atom();
+
+        if (op == "abs") {
+            if (terms.size() != 4)
+                throw ScpReadError{"abs takes two operands: (label abs v1 v2)"};
+            post_constraint(problem, Abs{resolve(terms[2]), resolve(terms[3])}, label);
+        }
+        else if (op == "all_different") {
+            if (terms.size() != 3)
+                throw ScpReadError{"all_different takes one list: (label all_different (vars...))"};
+            vector<IntegerVariableID> vars;
+            for (const auto & v : children_of(terms[2], "the all_different variable list"))
+                vars.push_back(resolve(v));
+            post_constraint(problem, AllDifferent{move(vars)}, label);
+        }
+        else if (op == "in") {
+            if (terms.size() != 4)
+                throw ScpReadError{"in takes a variable and a list: (label in var (values...))"};
+            auto var = resolve(terms[2]);
+            vector<IntegerVariableID> var_values;
+            vector<Integer> int_values;
+            for (const auto & v : children_of(terms[3], "the in value list")) {
+                const auto & a = v.as_atom();
+                if (auto it = variables.find(a); it != variables.end())
+                    var_values.push_back(it->second);
+                else
+                    int_values.push_back(as_integer(v));
+            }
+            post_constraint(problem, In{var, move(var_values), move(int_values)}, label);
+        }
+        else
+            throw ScpReadError{"unsupported constraint operator '" + op + "'"};
+    }
+
+    return variables;
+}

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -6,6 +6,7 @@
 #include <gcs/scp_reader.hh>
 
 #include <charconv>
+#include <optional>
 #include <utility>
 
 using std::map;
@@ -49,23 +50,29 @@ namespace
         return e.as_list();
     }
 
-    // `_<digits>` is the form Problem auto-generates for unnamed constraints; it
-    // is reserved (Problem::check_name rejects it as a user name). Re-posting
-    // such a constraint unnamed reproduces the same label in `.scp` order.
-    auto is_auto_generated_label(const string & s) -> bool
+    // If `s` is the form Problem auto-generates for unnamed constraints,
+    // `_<digits>`, return that number; otherwise nullopt.
+    auto auto_number_of(const string & s) -> std::optional<unsigned long long>
     {
         if (s.size() < 2 || s[0] != '_')
-            return false;
+            return std::nullopt;
         for (auto i = s.begin() + 1; i != s.end(); ++i)
             if (*i < '0' || *i > '9')
-                return false;
-        return true;
+                return std::nullopt;
+        unsigned long long number;
+        auto [ptr, ec] = std::from_chars(s.data() + 1, s.data() + s.size(), number);
+        if (ec != std::errc{})
+            throw ScpReadError{"constraint label '" + s + "' is out of range"};
+        return number;
     }
 
     auto post_constraint(Problem & problem, const Constraint & constraint, const string & label) -> void
     {
-        if (is_auto_generated_label(label))
-            problem.post(constraint);
+        // `_N` is reserved (post_named rejects it); reproduce it via
+        // post_autonumbered, which validates the number lines up. Anything else
+        // is a genuine name.
+        if (auto number = auto_number_of(label))
+            problem.post_autonumbered(constraint, *number);
         else
             problem.post_named(constraint, label);
     }

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -50,6 +50,26 @@ namespace
         return e.as_list();
     }
 
+    // Resolve an argument to a variable: a declared name, or an integer constant
+    // mapped to a ConstantIntegerVariableID. Anywhere a variable name may appear
+    // in a .scp, a constant integer may appear in its place.
+    auto resolve_variable(const map<string, IntegerVariableID> & variables, const SExpr & e) -> IntegerVariableID
+    {
+        const auto & a = e.as_atom();
+        if (auto it = variables.find(a); it != variables.end())
+            return it->second;
+        return constant_variable(as_integer(e));
+    }
+
+    // Resolve a list term to a vector of variables (the common case).
+    auto resolve_variable_list(const map<string, IntegerVariableID> & variables, const SExpr & list, const char * what) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> result;
+        for (const auto & e : children_of(list, what))
+            result.push_back(resolve_variable(variables, e));
+        return result;
+    }
+
     // If `s` is the form Problem auto-generates for unnamed constraints,
     // `_<digits>`, return that number; otherwise nullopt.
     auto auto_number_of(const string & s) -> std::optional<unsigned long long>
@@ -98,15 +118,6 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
             throw ScpReadError{"duplicate variable name '" + name + "'"};
     }
 
-    // Resolve an argument atom to a variable: a declared name, otherwise an
-    // integer constant.
-    auto resolve = [&](const SExpr & e) -> IntegerVariableID {
-        const auto & a = e.as_atom();
-        if (auto it = variables.find(a); it != variables.end())
-            return it->second;
-        return constant_variable(as_integer(e));
-    };
-
     // Constraints: each is (label operator args...).
     for (const auto & constraint : children_of(sections[1], "the constraints section")) {
         const auto & terms = children_of(constraint, "a constraint");
@@ -118,30 +129,20 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
         if (op == "abs") {
             if (terms.size() != 4)
                 throw ScpReadError{"abs takes two operands: (label abs v1 v2)"};
-            post_constraint(problem, Abs{resolve(terms[2]), resolve(terms[3])}, label);
+            post_constraint(problem, Abs{resolve_variable(variables, terms[2]), resolve_variable(variables, terms[3])}, label);
         }
         else if (op == "all_different") {
             if (terms.size() != 3)
                 throw ScpReadError{"all_different takes one list: (label all_different (vars...))"};
-            vector<IntegerVariableID> vars;
-            for (const auto & v : children_of(terms[2], "the all_different variable list"))
-                vars.push_back(resolve(v));
-            post_constraint(problem, AllDifferent{move(vars)}, label);
+            post_constraint(problem, AllDifferent{resolve_variable_list(variables, terms[2], "the all_different variable list")}, label);
         }
         else if (op == "in") {
             if (terms.size() != 4)
                 throw ScpReadError{"in takes a variable and a list: (label in var (values...))"};
-            auto var = resolve(terms[2]);
-            vector<IntegerVariableID> var_values;
-            vector<Integer> int_values;
-            for (const auto & v : children_of(terms[3], "the in value list")) {
-                const auto & a = v.as_atom();
-                if (auto it = variables.find(a); it != variables.end())
-                    var_values.push_back(it->second);
-                else
-                    int_values.push_back(as_integer(v));
-            }
-            post_constraint(problem, In{var, move(var_values), move(int_values)}, label);
+            // The value list is just a list of variables; an integer value is a
+            // ConstantIntegerVariableID, which In folds back into a constant.
+            post_constraint(problem,
+                In{resolve_variable(variables, terms[2]), resolve_variable_list(variables, terms[3], "the in value list")}, label);
         }
         else
             throw ScpReadError{"unsupported constraint operator '" + op + "'"};

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1,9 +1,12 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/problem.hh>
+#include <gcs/reification.hh>
 #include <gcs/scp_reader.hh>
+#include <gcs/variable_condition.hh>
 
 #include <charconv>
 #include <optional>
@@ -96,6 +99,69 @@ namespace
         else
             problem.post_named(constraint, label);
     }
+
+    // A reification condition is the triple (variable op value), where op is the
+    // s_expr_name_of(VariableConditionOperator) spelling.
+    auto resolve_condition(const map<string, IntegerVariableID> & variables, const SExpr & triple) -> IntegerVariableCondition
+    {
+        const auto & parts = children_of(triple, "a reification condition");
+        if (parts.size() != 3)
+            throw ScpReadError{"a reification condition must be (variable op value)"};
+        auto var = resolve_variable(variables, parts[0]);
+        const auto & op = parts[1].as_atom();
+        auto value = as_integer(parts[2]);
+        using enum VariableConditionOperator;
+        if (op == "eq")
+            return {var, Equal, value};
+        if (op == "neq")
+            return {var, NotEqual, value};
+        if (op == "geq")
+            return {var, GreaterEqual, value};
+        if (op == "lt")
+            return {var, Less, value};
+        throw ScpReadError{"unknown reification-condition operator '" + op + "'"};
+    }
+
+    // The comparison family: (label <less|greater>_than[_equal][_if|_iff]
+    // [(cond)] v1 v2). The keyword carries the swapped / or-equal / reification
+    // flags that the general ReifiedCompareLessThanOrMaybeEqual constructor takes
+    // directly, so this reconstructs exactly the object the writer serialised.
+    auto read_comparison(Problem & problem, const map<string, IntegerVariableID> & variables,
+        const string & op, const vector<SExpr> & terms, const string & label) -> void
+    {
+        bool vars_swapped = op.starts_with("greater_than");
+        string rest = op.substr(vars_swapped ? sizeof("greater_than") - 1 : sizeof("less_than") - 1);
+        bool or_equal = rest.starts_with("_equal");
+        if (or_equal)
+            rest = rest.substr(sizeof("_equal") - 1);
+        // `rest` is now "" (unconditional), "_if" (half-reified) or "_iff".
+
+        ReificationCondition cond = reif::MustHold{};
+        std::size_t v1_index = 2;
+        if (rest.empty()) {
+            if (terms.size() != 4)
+                throw ScpReadError{"comparison '" + op + "' is (label op v1 v2)"};
+        }
+        else {
+            if (terms.size() != 5)
+                throw ScpReadError{"reified comparison '" + op + "' is (label op (cond) v1 v2)"};
+            auto condition = resolve_condition(variables, terms[2]);
+            if (rest == "_if")
+                cond = reif::If{condition};
+            else if (rest == "_iff")
+                cond = reif::Iff{condition};
+            else
+                throw ScpReadError{"unknown comparison '" + op + "'"};
+            v1_index = 3;
+        }
+
+        post_constraint(problem,
+            ReifiedCompareLessThanOrMaybeEqual{
+                resolve_variable(variables, terms[v1_index]),
+                resolve_variable(variables, terms[v1_index + 1]),
+                cond, or_equal, vars_swapped},
+            label);
+    }
 }
 
 auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVariableID>
@@ -143,6 +209,9 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
             // ConstantIntegerVariableID, which In folds back into a constant.
             post_constraint(problem,
                 In{resolve_variable(variables, terms[2]), resolve_variable_list(variables, terms[3], "the in value list")}, label);
+        }
+        else if (op.starts_with("less_than") || op.starts_with("greater_than")) {
+            read_comparison(problem, variables, op, terms, label);
         }
         else
             throw ScpReadError{"unsupported constraint operator '" + op + "'"};

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -2,6 +2,9 @@
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/in.hh>
+#include <gcs/constraints/linear/linear_equality.hh>
+#include <gcs/constraints/linear/linear_inequality.hh>
+#include <gcs/expression.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/problem.hh>
 #include <gcs/reification.hh>
@@ -162,6 +165,57 @@ namespace
                 cond, or_equal, vars_swapped},
             label);
     }
+
+    // The linear family: (label lin_<equals|not_equals|less_than_equal>[_if|_iff]
+    // [(cond)] (c1 v1 c2 v2 ...) value). The keyword selects the constraint and
+    // its reification, matching the general ReifiedLinear* constructors. (The
+    // .scp does not record the GAC flag, so it defaults off; that affects
+    // propagation strength, not the solution set or the written .scp.)
+    auto read_linear(Problem & problem, const map<string, IntegerVariableID> & variables,
+        const string & op, const vector<SExpr> & terms, const string & label) -> void
+    {
+        bool iff = op.ends_with("_iff");
+        bool half = ! iff && op.ends_with("_if");
+        bool reified = iff || half;
+
+        if (terms.size() != (reified ? 5u : 4u))
+            throw ScpReadError{"linear constraint '" + op + "' has the wrong number of parts"};
+
+        const auto & pairs = children_of(terms[reified ? 3 : 2], "the linear coefficient/variable list");
+        if (pairs.size() % 2 != 0)
+            throw ScpReadError{"the linear coefficient/variable list must alternate coefficient and variable"};
+        WeightedSum coeff_vars;
+        for (std::size_t i = 0; i + 1 < pairs.size(); i += 2)
+            coeff_vars += as_integer(pairs[i]) * resolve_variable(variables, pairs[i + 1]);
+        auto value = as_integer(terms[reified ? 4 : 3]);
+
+        auto condition = [&] { return resolve_condition(variables, terms[2]); };
+
+        if (op.starts_with("lin_less_than_equal")) {
+            ReificationCondition cond = reif::MustHold{};
+            if (iff)
+                cond = reif::Iff{condition()};
+            else if (half)
+                cond = reif::If{condition()};
+            post_constraint(problem, ReifiedLinearInequality{std::move(coeff_vars), value, cond}, label);
+            return;
+        }
+
+        // Equality family: lin_equals* and lin_not_equals*.
+        bool not_equals = op.starts_with("lin_not_equals");
+        ReificationCondition cond = reif::MustHold{};
+        bool flipped_cond = false;
+        if (iff) {
+            cond = reif::Iff{condition()};
+            flipped_cond = not_equals; // lin_not_equals_iff is Iff with a flipped condition
+        }
+        else if (half)
+            cond = not_equals ? ReificationCondition{reif::NotIf{condition()}} : ReificationCondition{reif::If{condition()}};
+        else if (not_equals)
+            cond = reif::MustNotHold{};
+
+        post_constraint(problem, ReifiedLinearEquality{std::move(coeff_vars), value, cond, false, flipped_cond}, label);
+    }
 }
 
 auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVariableID>
@@ -212,6 +266,9 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
         }
         else if (op.starts_with("less_than") || op.starts_with("greater_than")) {
             read_comparison(problem, variables, op, terms, label);
+        }
+        else if (op.starts_with("lin_")) {
+            read_linear(problem, variables, op, terms, label);
         }
         else
             throw ScpReadError{"unsupported constraint operator '" + op + "'"};

--- a/gcs/scp_reader.hh
+++ b/gcs/scp_reader.hh
@@ -1,0 +1,52 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SCP_READER_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SCP_READER_HH
+
+#include <gcs/problem-fwd.hh>
+#include <gcs/variable_id.hh>
+
+#include <exception>
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace gcs
+{
+    /**
+     * \brief Thrown when a `.scp` (s-expression CP) description cannot be turned
+     * into a Problem: malformed structure, an unknown constraint, or a
+     * constraint this reader does not yet support.
+     *
+     * \ingroup Core
+     */
+    class ScpReadError : public std::exception
+    {
+    private:
+        std::string _wat;
+
+    public:
+        explicit ScpReadError(const std::string &);
+
+        [[nodiscard]] virtual auto what() const noexcept -> const char * override;
+    };
+
+    /**
+     * \brief Populate `problem` from the `.scp` (s-expression CP) description in
+     * `text`: create its variables and post its constraints.
+     *
+     * This is the inverse of the `.scp` the solver writes under `--prove`, and
+     * the basis of the "trusted producer" workflow (a `.scp` is the input). A
+     * `.scp` written by the solver and read back here re-creates an equivalent
+     * Problem; constraint labels are preserved via Problem::post_named.
+     *
+     * Only a starter set of constraints is supported so far (`abs`,
+     * `all_different`, `in`); an unsupported operator raises ScpReadError rather
+     * than being silently dropped. Throws ScpReadError (or SExprParseError) on
+     * malformed input.
+     *
+     * \returns A map from each variable's `.scp` name to its IntegerVariableID,
+     * so a caller can report solution values by name.
+     */
+    auto read_scp(Problem & problem, std::string_view text) -> std::map<std::string, IntegerVariableID>;
+}
+
+#endif

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/equals.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/current_state.hh>
@@ -176,6 +177,45 @@ TEST_CASE("read_scp: linear constraints survive write -> read -> write unchanged
     Problem rebuilt;
     read_scp(rebuilt, scp_a);
     auto scp_b = prove_to_scp(rebuilt, "scp_reader_lin_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+}
+
+TEST_CASE("read_scp: equals and not_equals enumerate correctly")
+{
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 equals X Y) ) )"))
+        CHECK(s.at("X") == s.at("Y"));
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 not_equals X Y) ) )"))
+        CHECK(s.at("X") != s.at("Y"));
+    // not_equals against a constant, the way crystal_maze uses it.
+    for (const auto & s : enumerate("( ( (X -2 2) ) ( (_1 not_equals X 0) ) )"))
+        CHECK(s.at("X") != 0);
+}
+
+TEST_CASE("read_scp: a reified equals enumerates correctly")
+{
+    // C == 1  iff  X == Y.
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (C 0 1) ) ( (_1 equals_iff (C eq 1) X Y) ) )"))
+        CHECK((s.at("C") == 1) == (s.at("X") == s.at("Y")));
+}
+
+TEST_CASE("read_scp: equals constraints survive write -> read -> write unchanged")
+{
+    Problem original;
+    auto x = original.create_integer_variable(-2_i, 2_i, "X");
+    auto y = original.create_integer_variable(-2_i, 2_i, "Y");
+    auto z = original.create_integer_variable(-2_i, 2_i, "Z");
+    auto c = original.create_integer_variable(0_i, 1_i, "C");
+    original.post(Equals{x, y});
+    original.post(NotEquals{x, constant_variable(0_i)}); // against a constant
+    original.post(EqualsIff{x, z, c == 1_i});
+    original.post(NotEqualsIff{y, z, c == 1_i}); // _neq path
+    auto scp_a = prove_to_scp(original, "scp_reader_eq_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_eq_b");
 
     CHECK(scp_a == scp_b);
     CHECK_FALSE(scp_a.empty());

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -1,0 +1,144 @@
+#include <gcs/constraints/abs.hh>
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/in.hh>
+#include <gcs/current_state.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/integer.hh>
+#include <gcs/problem.hh>
+#include <gcs/proof.hh>
+#include <gcs/scp_reader.hh>
+#include <gcs/solve.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+
+using namespace gcs;
+
+using std::map;
+using std::set;
+using std::string;
+using std::string_view;
+
+namespace
+{
+    // Read a .scp, enumerate every solution, and return the set of solutions as
+    // name -> value maps.
+    auto enumerate(string_view scp) -> set<map<string, long long>>
+    {
+        Problem problem;
+        auto variables = read_scp(problem, scp);
+
+        set<map<string, long long>> solutions;
+        solve_with(problem,
+            SolveCallbacks{.solution = [&](const CurrentState & state) -> bool {
+                map<string, long long> solution;
+                for (const auto & [name, id] : variables)
+                    solution.emplace(name, state(id).raw_value);
+                solutions.insert(std::move(solution));
+                return true;
+            }});
+        return solutions;
+    }
+}
+
+TEST_CASE("read_scp: abs enumerates correctly")
+{
+    auto solutions = enumerate(R"(
+        (
+            ( (X -3 3) (Y 0 3) )
+            ( (_1 abs X Y) )
+        ))");
+
+    CHECK(solutions.size() == 7);
+    for (const auto & s : solutions)
+        CHECK(s.at("Y") == std::abs(s.at("X")));
+}
+
+TEST_CASE("read_scp: all_different enumerates correctly")
+{
+    auto solutions = enumerate(R"(
+        (
+            ( (A 0 1) (B 0 1) )
+            ( (_1 all_different (A B)) )
+        ))");
+
+    CHECK(solutions == set<map<string, long long>>{{{"A", 0}, {"B", 1}}, {{"A", 1}, {"B", 0}}});
+}
+
+TEST_CASE("read_scp: in with a mix of integer and variable values")
+{
+    // V in {0, 3} (constants) or = W (a variable).
+    auto solutions = enumerate(R"(
+        (
+            ( (V 0 5) (W 0 5) )
+            ( (_1 in V (0 3 W)) )
+        ))");
+
+    for (const auto & s : solutions)
+        CHECK((s.at("V") == 0 || s.at("V") == 3 || s.at("V") == s.at("W")));
+    // Every (V, W) with V in {0,3} (6 W values each) plus V == W (the rest).
+    CHECK(! solutions.empty());
+}
+
+TEST_CASE("read_scp: constraint labels and variable names round-trip via the map")
+{
+    Problem problem;
+    auto variables = read_scp(problem, "( ( (X 0 1) (Y 0 1) ) ( (_1 abs X Y) ) )");
+    CHECK(variables.size() == 2);
+    CHECK(variables.contains("X"));
+    CHECK(variables.contains("Y"));
+}
+
+namespace
+{
+    // --prove a problem to `basename`, returning the .scp it wrote.
+    auto prove_to_scp(Problem & problem, const std::string & basename) -> std::string
+    {
+        solve_with(problem, SolveCallbacks{},
+            std::make_optional<ProofOptions>(ProofFileNames{basename}, true, false));
+        std::ifstream in{basename + ".scp"};
+        std::string scp{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+        for (auto ext : {".opb", ".pbp", ".scp", ".varmap"})
+            std::remove((basename + ext).c_str());
+        return scp;
+    }
+}
+
+TEST_CASE("read_scp: a solver-written .scp survives write -> read -> write unchanged")
+{
+    // Build a problem, write its canonical .scp, read it back, write again, and
+    // check the two .scp files are byte-identical -- the round-trip invariant.
+    Problem original;
+    auto x = original.create_integer_variable(-3_i, 3_i, "X");
+    auto y = original.create_integer_variable(0_i, 3_i, "Y");
+    auto z = original.create_integer_variable(0_i, 3_i, "Z");
+    original.post(Abs{x, y});
+    original.post(In{x, std::vector<Integer>{-3_i, -1_i, 1_i, 3_i}});
+    original.post(AllDifferent{std::vector<IntegerVariableID>{y, z}});
+    auto scp_a = prove_to_scp(original, "scp_reader_roundtrip_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_roundtrip_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+}
+
+TEST_CASE("read_scp: unsupported and malformed input throws")
+{
+    CHECK_THROWS_AS(enumerate("( ( (X 0 1) ) ( (_1 frobnicate X) ) )"), ScpReadError);
+    CHECK_THROWS_AS(enumerate("( ( (X 0 1) ) )"), ScpReadError);        // not (vars constraints)
+    CHECK_THROWS_AS(enumerate("( ( (X 0) ) ( ) )"), ScpReadError);      // bad var decl
+    CHECK_THROWS_AS(enumerate("( ( (X zero 1) ) ( ) )"), ScpReadError); // non-integer bound
+    CHECK_THROWS_AS(enumerate("not an s-expr ("), innards::SExprParseError);
+}

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -2,7 +2,9 @@
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/in.hh>
+#include <gcs/constraints/linear.hh>
 #include <gcs/current_state.hh>
+#include <gcs/expression.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/integer.hh>
 #include <gcs/problem.hh>
@@ -132,6 +134,48 @@ TEST_CASE("read_scp: comparisons survive write -> read -> write unchanged")
     Problem rebuilt;
     read_scp(rebuilt, scp_a);
     auto scp_b = prove_to_scp(rebuilt, "scp_reader_cmp_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+}
+
+TEST_CASE("read_scp: linear constraints enumerate correctly")
+{
+    // X + Y == 3
+    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) ) ( (_1 lin_equals (1 X 1 Y) 3) ) )"))
+        CHECK(s.at("X") + s.at("Y") == 3);
+    // X - Y <= 1
+    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) ) ( (_1 lin_less_than_equal (1 X -1 Y) 1) ) )"))
+        CHECK(s.at("X") - s.at("Y") <= 1);
+    // X + Y != 2
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 lin_not_equals (1 X 1 Y) 2) ) )"))
+        CHECK(s.at("X") + s.at("Y") != 2);
+}
+
+TEST_CASE("read_scp: a reified linear constraint enumerates correctly")
+{
+    // C == 1  iff  X + Y == 3.
+    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) (C 0 1) ) ( (_1 lin_equals_iff (C eq 1) (1 X 1 Y) 3) ) )"))
+        CHECK((s.at("C") == 1) == (s.at("X") + s.at("Y") == 3));
+}
+
+TEST_CASE("read_scp: linear constraints survive write -> read -> write unchanged")
+{
+    Problem original;
+    auto x = original.create_integer_variable(-2_i, 2_i, "X");
+    auto y = original.create_integer_variable(-2_i, 2_i, "Y");
+    auto z = original.create_integer_variable(-2_i, 2_i, "Z");
+    auto c = original.create_integer_variable(0_i, 1_i, "C");
+    original.post(LinearEquality{WeightedSum{} + 1_i * x + 1_i * y, 1_i});
+    original.post(LinearLessThanEqual{WeightedSum{} + 1_i * x + -1_i * z, 2_i});
+    original.post(LinearNotEquals{WeightedSum{} + 2_i * y, 0_i});
+    original.post(LinearEqualityIff{WeightedSum{} + 1_i * x + 1_i * z, 1_i, c == 1_i});
+    original.post(LinearNotEqualsIff{WeightedSum{} + 1_i * y + 1_i * z, 0_i, c == 1_i}); // flipped_cond path
+    auto scp_a = prove_to_scp(original, "scp_reader_lin_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_lin_b");
 
     CHECK(scp_a == scp_b);
     CHECK_FALSE(scp_a.empty());

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -134,6 +134,13 @@ TEST_CASE("read_scp: a solver-written .scp survives write -> read -> write uncha
     CHECK_FALSE(scp_a.empty());
 }
 
+TEST_CASE("read_scp: an out-of-order auto-number is rejected, not silently relabelled")
+{
+    // A single constraint labelled _2 would auto-number to _1 on re-post, so
+    // post_autonumbered rejects the mismatch instead of quietly changing it.
+    CHECK_THROWS_AS(enumerate("( ( (X 0 1) (Y 0 1) ) ( (_2 abs X Y) ) )"), NamingError);
+}
+
 TEST_CASE("read_scp: unsupported and malformed input throws")
 {
     CHECK_THROWS_AS(enumerate("( ( (X 0 1) ) ( (_1 frobnicate X) ) )"), ScpReadError);

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/current_state.hh>
 #include <gcs/innards/s_expr.hh>
@@ -48,6 +49,18 @@ namespace
             }});
         return solutions;
     }
+
+    // --prove a problem to `basename`, returning the .scp it wrote.
+    auto prove_to_scp(Problem & problem, const std::string & basename) -> std::string
+    {
+        solve_with(problem, SolveCallbacks{},
+            std::make_optional<ProofOptions>(ProofFileNames{basename}, true, false));
+        std::ifstream in{basename + ".scp"};
+        std::string scp{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+        for (auto ext : {".opb", ".pbp", ".scp", ".varmap"})
+            std::remove((basename + ext).c_str());
+        return scp;
+    }
 }
 
 TEST_CASE("read_scp: abs enumerates correctly")
@@ -89,6 +102,41 @@ TEST_CASE("read_scp: in with a mix of integer and variable values")
     CHECK(! solutions.empty());
 }
 
+TEST_CASE("read_scp: comparisons enumerate correctly")
+{
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 less_than X Y) ) )"))
+        CHECK(s.at("X") < s.at("Y"));
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 less_than_equal X Y) ) )"))
+        CHECK(s.at("X") <= s.at("Y"));
+}
+
+TEST_CASE("read_scp: a fully-reified comparison enumerates correctly")
+{
+    // C == 1  iff  X <= Y.
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (C 0 1) ) ( (_1 less_than_equal_iff (C eq 1) X Y) ) )"))
+        CHECK((s.at("C") == 1) == (s.at("X") <= s.at("Y")));
+}
+
+TEST_CASE("read_scp: comparisons survive write -> read -> write unchanged")
+{
+    Problem original;
+    auto x = original.create_integer_variable(-2_i, 2_i, "X");
+    auto y = original.create_integer_variable(-2_i, 2_i, "Y");
+    auto z = original.create_integer_variable(-2_i, 2_i, "Z");
+    auto c = original.create_integer_variable(0_i, 1_i, "C");
+    original.post(LessThanEqual{x, y});              // plain, or_equal
+    original.post(GreaterThan{y, z});                // operands swapped on write
+    original.post(LessThanEqualIff{x, z, c == 1_i}); // fully reified, with a condition
+    auto scp_a = prove_to_scp(original, "scp_reader_cmp_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_cmp_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+}
+
 TEST_CASE("read_scp: a constant integer can stand in for a variable anywhere")
 {
     // An abs operand that is a constant: Y = |3|.
@@ -107,21 +155,6 @@ TEST_CASE("read_scp: constraint labels and variable names round-trip via the map
     CHECK(variables.size() == 2);
     CHECK(variables.contains("X"));
     CHECK(variables.contains("Y"));
-}
-
-namespace
-{
-    // --prove a problem to `basename`, returning the .scp it wrote.
-    auto prove_to_scp(Problem & problem, const std::string & basename) -> std::string
-    {
-        solve_with(problem, SolveCallbacks{},
-            std::make_optional<ProofOptions>(ProofFileNames{basename}, true, false));
-        std::ifstream in{basename + ".scp"};
-        std::string scp{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
-        for (auto ext : {".opb", ".pbp", ".scp", ".varmap"})
-            std::remove((basename + ext).c_str());
-        return scp;
-    }
 }
 
 TEST_CASE("read_scp: a solver-written .scp survives write -> read -> write unchanged")

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -89,6 +89,17 @@ TEST_CASE("read_scp: in with a mix of integer and variable values")
     CHECK(! solutions.empty());
 }
 
+TEST_CASE("read_scp: a constant integer can stand in for a variable anywhere")
+{
+    // An abs operand that is a constant: Y = |3|.
+    CHECK(enumerate("( ( (Y 0 5) ) ( (_1 abs 3 Y) ) )") ==
+        set<map<string, long long>>{{{"Y", 3}}});
+
+    // A constant member of all_different: A, 1, B all distinct, so A,B in {0,2}.
+    auto all_diff = enumerate("( ( (A 0 2) (B 0 2) ) ( (_1 all_different (A 1 B)) ) )");
+    CHECK(all_diff == set<map<string, long long>>{{{"A", 0}, {"B", 2}}, {{"A", 2}, {"B", 0}}});
+}
+
 TEST_CASE("read_scp: constraint labels and variable names round-trip via the map")
 {
     Problem problem;

--- a/scp/CMakeLists.txt
+++ b/scp/CMakeLists.txt
@@ -1,0 +1,7 @@
+# glasgow_scp_solver: a standalone client that solves a problem given as a
+# `.scp` (s-expression CP) file (workflow 3). Reads the model with read_scp from
+# the core library; the .scp is the input rather than a --prove by-product.
+add_executable(glasgow_scp_solver glasgow_scp_solver.cc)
+target_link_libraries(glasgow_scp_solver PRIVATE glasgow_constraint_solver)
+target_link_libraries(glasgow_scp_solver PRIVATE cxxopts)
+target_link_libraries(glasgow_scp_solver PRIVATE gcs_fmt)

--- a/scp/glasgow_scp_solver.cc
+++ b/scp/glasgow_scp_solver.cc
@@ -1,0 +1,114 @@
+#include <gcs/current_state.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+#include <gcs/scp_reader.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <string>
+
+#include <cxxopts.hpp>
+
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using namespace gcs;
+
+using std::cerr;
+using std::cout;
+using std::ifstream;
+using std::istreambuf_iterator;
+using std::make_optional;
+using std::map;
+using std::nullopt;
+using std::string;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+// Workflow 3: solve a problem given as a `.scp` (s-expression CP) file. The
+// .scp is the *input* (e.g. produced by another solver's --prove, or by a
+// higher-level translator), and with --prove the run emits a proof that, via
+// cake_pb_cp, is verified against that same .scp. See gcs/scp_reader.hh.
+auto main(int argc, char * argv[]) -> int
+{
+    cxxopts::Options options("glasgow_scp_solver", "Solve a .scp (s-expression CP) problem");
+    cxxopts::ParseResult options_vars;
+
+    try {
+        options.add_options()                                                //
+            ("help", "Display help information")                             //
+            ("prove", "Create a proof")                                      //
+            ("proof-files-basename", "Basename for the .opb and .pbp files", //
+                cxxopts::value<string>()->default_value("scp"))              //
+            ("all", "Find all solutions rather than just the first")         //
+            ("stats", "Print solve statistics")                              //
+            ("file", "The .scp file to solve", cxxopts::value<string>())     //
+            ;
+        options.parse_positional({"file"});
+        options.positional_help("scp-file.scp");
+        options_vars = options.parse(argc, argv);
+    }
+    catch (const cxxopts::exceptions::exception & e) {
+        println(cerr, "Error: {}", e.what());
+        println(cerr, "Try {} --help", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (options_vars.contains("help") || ! options_vars.contains("file")) {
+        println("Usage: {} [options] scp-file.scp", argv[0]);
+        cout << options.help() << std::endl;
+        return options_vars.contains("help") ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+
+    auto file_name = options_vars["file"].as<string>();
+    ifstream infile{file_name};
+    if (! infile) {
+        println(cerr, "Error: could not open '{}'", file_name);
+        return EXIT_FAILURE;
+    }
+    string text{istreambuf_iterator<char>{infile}, istreambuf_iterator<char>{}};
+
+    Problem problem;
+    map<string, IntegerVariableID> variables;
+    try {
+        variables = read_scp(problem, text);
+    }
+    catch (const std::exception & e) {
+        println(cerr, "Error: {}", e.what());
+        return EXIT_FAILURE;
+    }
+
+    bool find_all = options_vars.contains("all");
+    auto stats = solve_with(problem,
+        SolveCallbacks{
+            .solution = [&](const CurrentState & state) -> bool {
+                for (const auto & [name, id] : variables)
+                    print("{}={} ", name, state(id));
+                println("");
+                return find_all;
+            }},
+        options_vars.contains("prove")
+            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()}, true, false)
+            : nullopt);
+
+    if (options_vars.contains("stats"))
+        print("{}", stats);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Off `main` (independent — builds on #266's `parse_s_expr`, no dependency on #267/#268). Delivers **workflow 3**: the `.scp` as *input* rather than a `--prove` by-product.

## What's here
- **`gcs/scp_reader.{hh,cc}`** — `read_scp(Problem &, text)` builds a `Problem` from a `.scp` by parsing it with `parse_s_expr` and dispatching on the operator keyword. Starter set: `abs`, `all_different`, `in`; an unknown operator raises `ScpReadError` rather than being silently dropped. It sits at the **public** level (unlike the proof-model-bound `write_scp`) because it only needs the public `Problem` API. Constraint labels are preserved — auto-generated `_N` labels are re-posted unnamed (`Problem` reproduces them in post order; they're reserved and rejected by `post_named`), real names via `post_named`.
- **`scp/glasgow_scp_solver.cc`** — a standalone client (à la `fzn-glasgow`) that reads a `.scp` file, solves, and optionally `--prove`s.
- **`scp_reader_test`** — per-constraint enumeration checks, error paths, and the **round-trip invariant**: a solver-written `.scp`, read back and re-written, is byte-identical.

## Verified
```
$ glasgow_scp_solver --all --prove model.scp     # all_different(A,B,C) over [0,2]
A=0 B=1 C=2 ... A=2 B=1 C=0
$ veripb scp.opb scp.pbp
s VERIFIED COMPLETE ENUMERATION OF 6 SOLUTIONS
```
Full suite green (293/293).

## Notes
- New top-level `scp/` dir mirrors the existing `minizinc/` frontend; happy to relocate if you'd prefer it elsewhere.
- Constraint coverage grows as we go (comparison/linear next) — the dispatch is a simple `if/else` on the operator, easy to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)