### PR TITLE
Labelled constraint references: add_labelled_constraint + abs pilot

### DIFF
--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -30,10 +30,7 @@ auto Constraint::s_exprify(const innards::ProofModel * const model) const -> str
     return format("{:#}", s_expr(model));
 }
 
-namespace gcs
+auto gcs::as_string(const ConstraintID & constraint_id) -> std::string
 {
-    auto as_string(const ConstraintID & constraint_id) -> std::string
-    {
-        return visit([](const auto & n) { return n.as_string(); }, constraint_id);
-    }
+    return visit([](const auto & n) { return n.as_string(); }, constraint_id);
 }

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -32,8 +32,8 @@ auto Constraint::s_exprify(const innards::ProofModel * const model) const -> str
 
 namespace gcs
 {
-    auto as_string(const ConstraintName & name) -> std::string
+    auto as_string(const ConstraintID & constraint_id) -> std::string
     {
-        return visit([](const auto & n) { return n.as_string(); }, name);
+        return visit([](const auto & n) { return n.as_string(); }, constraint_id);
     }
 }

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -51,9 +51,12 @@ namespace gcs
         }
     };
 
-    using ConstraintName = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
+    // The *identity* of a constraint (`_1`, `_2`, or a caller-given name) -- not
+    // its type (`abs`, `all_different`, ...). Kept distinct from "name" because
+    // both readings of that word kept getting confused.
+    using ConstraintID = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
 
-    [[nodiscard]] auto as_string(const ConstraintName &) -> std::string;
+    [[nodiscard]] auto as_string(const ConstraintID &) -> std::string;
 
     /**
      * \brief Subclasses of Constraint give a high level way of defining
@@ -70,9 +73,9 @@ namespace gcs
     class [[nodiscard]] Constraint
     {
     protected:
-        ConstraintName _name;
-        Constraint() : _name(CurrentlyUnnamedConstraint{}) {};
-        explicit Constraint(ConstraintName name) : _name(std::move(name)) {};
+        ConstraintID _constraint_id;
+        Constraint() : _constraint_id(CurrentlyUnnamedConstraint{}) {};
+        explicit Constraint(ConstraintID constraint_id) : _constraint_id(std::move(constraint_id)) {};
         virtual auto define_proof_model(innards::ProofModel &) -> void {};
         virtual auto install_propagators(innards::Propagators &) -> void {};
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool
@@ -82,13 +85,13 @@ namespace gcs
 
     public:
         virtual ~Constraint() = 0;
-        [[nodiscard]] auto name() const -> const ConstraintName &
+        [[nodiscard]] auto constraint_id() const -> const ConstraintID &
         {
-            return _name;
+            return _constraint_id;
         }
-        auto set_name(ConstraintName name) -> void
+        auto set_constraint_id(ConstraintID constraint_id) -> void
         {
-            _name = std::move(name);
+            _constraint_id = std::move(constraint_id);
         }
         /**
          * Called internally to install the constraint. A Constraint is expected
@@ -130,23 +133,23 @@ namespace gcs
     };
 }
 
-// The following is needed to allow ConstraintName to be used in format strings.
+// The following is needed to allow ConstraintID to be used in format strings.
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 template <>
-struct std::formatter<gcs::ConstraintName> : std::formatter<std::string>
+struct std::formatter<gcs::ConstraintID> : std::formatter<std::string>
 {
-    auto format(const gcs::ConstraintName & name, std::format_context & ctx) const
+    auto format(const gcs::ConstraintID & constraint_id, std::format_context & ctx) const
     {
-        return std::formatter<std::string>::format(gcs::as_string(name), ctx);
+        return std::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
     }
 };
 #else
 template <>
-struct fmt::formatter<gcs::ConstraintName> : fmt::formatter<std::string>
+struct fmt::formatter<gcs::ConstraintID> : fmt::formatter<std::string>
 {
-    auto format(const gcs::ConstraintName & name, fmt::format_context & ctx) const
+    auto format(const gcs::ConstraintID & constraint_id, fmt::format_context & ctx) const
     {
-        return fmt::formatter<std::string>::format(gcs::as_string(name), ctx);
+        return fmt::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
     }
 };
 #endif

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -85,10 +85,22 @@ namespace gcs
 
     public:
         virtual ~Constraint() = 0;
+
+        /**
+         * \brief The constraint's identity --- `_1`, `_2`, or a caller-given
+         * name --- as set by Problem::post() / Problem::post_named(). This is the
+         * identity, not the type (e.g. `abs`); see ConstraintID.
+         */
         [[nodiscard]] auto constraint_id() const -> const ConstraintID &
         {
             return _constraint_id;
         }
+
+        /**
+         * \brief Set the constraint's identity. Called internally by Problem when
+         * the constraint is posted (and when its install-time clone is made), so
+         * its proof labels match the name written to the `.scp`.
+         */
         auto set_constraint_id(ConstraintID constraint_id) -> void
         {
             _constraint_id = std::move(constraint_id);

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -94,9 +94,9 @@ auto Abs::define_proof_model(ProofModel & model) -> void
 {
     // Labels match cake_pb_cp's: the non-negative case is @c[name][posle]/[posge]
     // (V2 = V1 split into <= and >=), the negative case [negle]/[negge].
-    _abs_nonneg_lines = model.add_labelled_constraint(as_string(_name), "posle", "posge",
+    _abs_nonneg_lines = model.add_labelled_constraint(as_string(_constraint_id), "posle", "posge",
         "Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-    _abs_neg_lines = model.add_labelled_constraint(as_string(_name), "negle", "negge",
+    _abs_neg_lines = model.add_labelled_constraint(as_string(_constraint_id), "negle", "negge",
         "Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
 }
 
@@ -302,7 +302,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
 auto Abs::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
-    return SExpr::list({SExpr::atom(as_string(_name)),
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
         SExpr::atom("abs"),
         tracker.s_expr_term_of(_v1),
         tracker.s_expr_term_of(_v2)});

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -92,8 +92,12 @@ auto Abs::install(Propagators & propagators, State &, ProofModel * const optiona
 
 auto Abs::define_proof_model(ProofModel & model) -> void
 {
-    _abs_nonneg_lines = model.add_constraint("Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-    _abs_neg_lines = model.add_constraint("Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
+    // Labels match cake_pb_cp's: the non-negative case is @c[name][posle]/[posge]
+    // (V2 = V1 split into <= and >=), the negative case [negle]/[negge].
+    _abs_nonneg_lines = model.add_labelled_constraint(as_string(_name), "posle", "posge",
+        "Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
+    _abs_neg_lines = model.add_labelled_constraint(as_string(_name), "negle", "negge",
+        "Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
 }
 
 auto Abs::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -35,12 +35,12 @@ using std::make_unique;
 using std::map;
 using std::move;
 using std::next;
-using std::ranges::sort;
 using std::shared_ptr;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -206,7 +206,7 @@ auto AllDifferentExcept::s_exprify(const ProofModel * const model) const -> stri
 {
     stringstream s;
 
-    print(s, "{} all_different_except (", _name);
+    print(s, "{} all_different_except (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -675,7 +675,7 @@ auto GACAllDifferent::s_expr(const innards::ProofModel * const model) const -> S
     vector<SExpr> vars;
     for (const auto & var : _vars)
         vars.push_back(tracker.s_expr_term_of(var));
-    return SExpr::list({SExpr::atom(as_string(_name)),
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
         SExpr::atom("all_different"),
         SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -31,13 +31,13 @@ using std::make_shared;
 using std::make_unique;
 using std::map;
 using std::move;
-using std::ranges::adjacent_find;
-using std::ranges::sort;
 using std::shared_ptr;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::adjacent_find;
+using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -108,11 +108,9 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
     for (size_t i = 0; i < n; ++i)
         for (size_t j = i + 1; j < n; ++j) {
             model.add_constraint("SymmetricAllDifferent", "x_i = j -> x_j = i",
-                WPBSum{} + 1_i * (_vars[i] != Integer(j) + _start)
-                    + 1_i * (_vars[j] == Integer(i) + _start) >= 1_i);
+                WPBSum{} + 1_i * (_vars[i] != Integer(j) + _start) + 1_i * (_vars[j] == Integer(i) + _start) >= 1_i);
             model.add_constraint("SymmetricAllDifferent", "x_j = i -> x_i = j",
-                WPBSum{} + 1_i * (_vars[j] != Integer(i) + _start)
-                    + 1_i * (_vars[i] == Integer(j) + _start) >= 1_i);
+                WPBSum{} + 1_i * (_vars[j] != Integer(i) + _start) + 1_i * (_vars[i] == Integer(j) + _start) >= 1_i);
         }
 
     _duplicate_witness = define_clique_not_equals_encoding(model, _vars);
@@ -141,12 +139,10 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
                     vector<IntegerVariableCondition> xieqvs;
                     for (const auto & var : vars)
                         xieqvs.push_back(var != v);
-                    value_am1s->emplace(v, recover_am1<IntegerVariableCondition>(
-                                               *logger, ProofLevel::Top, xieqvs,
-                                               [&](const IntegerVariableCondition & c1, const IntegerVariableCondition & c2) -> ProofLine {
-                                                   return logger->emit(RUPProofRule{},
-                                                       WPBSum{} + 1_i * c1 + 1_i * c2 >= 1_i, ProofLevel::Temporary);
-                                               }));
+                    value_am1s->emplace(v, recover_am1<IntegerVariableCondition>(*logger, ProofLevel::Top, xieqvs, [&](const IntegerVariableCondition & c1, const IntegerVariableCondition & c2) -> ProofLine {
+                        return logger->emit(RUPProofRule{},
+                            WPBSum{} + 1_i * c1 + 1_i * c2 >= 1_i, ProofLevel::Temporary);
+                    }));
                 }
             });
     }
@@ -185,7 +181,7 @@ auto SymmetricAllDifferent::s_exprify(const ProofModel * const model) const -> s
 {
     stringstream s;
 
-    print(s, "{} symmetric_all_different (", _name);
+    print(s, "{} symmetric_all_different (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", _start);

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -177,7 +177,7 @@ auto VCAllDifferent::s_expr(const innards::ProofModel * const model) const -> SE
     vector<SExpr> vars;
     for (const auto & var : _vars)
         vars.push_back(tracker.s_expr_term_of(var));
-    return SExpr::list({SExpr::atom(as_string(_name)),
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
         SExpr::atom("all_different"),
         SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -153,7 +153,7 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
 auto AllEqual::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} all_equal", _name);
+    print(s, "{} all_equal", _constraint_id);
     for (const auto & v : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     return s.str();

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -310,7 +310,7 @@ auto Among::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} among (", _name);
+    print(s, "{} among (", _constraint_id);
     for (const auto & var : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     }

--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -123,7 +123,7 @@ auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) cons
     case ArithmeticOperator::Power: op_str = "power"; break;
     }
     stringstream s;
-    print(s, "({} {} {} {} {})", _name, op_str,
+    print(s, "({} {} {} {} {})", _constraint_id, op_str,
         model->names_and_ids_tracker().s_expr_name_of(_v1),
         model->names_and_ids_tracker().s_expr_name_of(_v2),
         model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -148,7 +148,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
 auto AtMostOne::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} at_most_one (", _name);
+    print(s, "{} at_most_one (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));
@@ -198,7 +198,7 @@ auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_sta
 auto AtMostOneSmartTable::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} at_most_one_smart_table (", _name);
+    print(s, "{} at_most_one_smart_table (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -246,7 +246,7 @@ auto CircuitBase::s_exprify(const innards::ProofModel * const model) const -> st
 {
     stringstream s;
 
-    print(s, "{} circuit (", _name);
+    print(s, "{} circuit (", _constraint_id);
     for (const auto & var : _succ)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -238,7 +238,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_expr(const ProofModel * const model) 
         _or_equal ? "_equal" : "",
         reif_suffix);
 
-    vector<SExpr> terms{SExpr::atom(as_string(_name)), SExpr::atom(cmp)};
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(cmp)};
     if (auto cond = tracker.s_expr_term_of(_reif_cond))
         terms.push_back(std::move(*cond));
     terms.push_back(tracker.s_expr_term_of(_v1));

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -237,7 +237,7 @@ auto Count::s_exprify(const ProofModel * const model) const -> std::string
 {
     stringstream s;
 
-    print(s, "{} count (", _name);
+    print(s, "{} count (", _constraint_id);
     for (const auto & v : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -645,7 +645,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
 auto Cumulative::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} cumulative (", _name);
+    print(s, "{} cumulative (", _constraint_id);
     for (const auto & v : _starts)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     print(s, " ) ( ");

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -687,7 +687,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 auto Disjunctive::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} disjunctive{} (", _name, _strict ? "_strict" : "");
+    print(s, "{} disjunctive{} (", _constraint_id, _strict ? "_strict" : "");
     for (const auto & v : _starts)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     print(s, " ) ( ");

--- a/gcs/constraints/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d.cc
@@ -794,7 +794,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
 auto Disjunctive2D::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} disjunctive2d{} (", _name, _strict ? "_strict" : "");
+    print(s, "{} disjunctive2d{} (", _constraint_id, _strict ? "_strict" : "");
     for (const auto & v : _xs)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     print(s, " ) ( ");

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -604,7 +604,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const ProofModel * 
         }
     };
 
-    print(s, "{} element (", _name);
+    print(s, "{} element (", _constraint_id);
 
     print_array(s, *_array, print_array);
 

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -314,7 +314,7 @@ auto ReifiedEquals::s_exprify(const innards::ProofModel * const model) const -> 
             return _neq ? "not_equals_iff" : "equals_iff";
         }}.visit(_cond);
 
-    print(s, "{} {}", _name, constraint_type);
+    print(s, "{} {}", _constraint_id, constraint_type);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_cond));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -415,7 +415,7 @@ auto BoundsGlobalCardinality::s_exprify(const ProofModel * const model) const ->
 {
     stringstream s;
 
-    print(s, "{} boundsglobalcardinality{} (", _name, _closed ? "closed" : "");
+    print(s, "{} boundsglobalcardinality{} (", _constraint_id, _closed ? "closed" : "");
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -632,7 +632,7 @@ auto GACGlobalCardinality::s_exprify(const ProofModel * const model) const -> st
 {
     stringstream s;
 
-    print(s, "{} gacglobalcardinality{} (", _name, _closed ? "closed" : "");
+    print(s, "{} gacglobalcardinality{} (", _constraint_id, _closed ? "closed" : "");
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -269,7 +269,7 @@ auto In::s_expr(const ProofModel * const model) const -> SExpr
         vals.push_back(tracker.s_expr_term_of(v));
     for (const auto & v : _val_vals)
         vals.push_back(SExpr::atom(v.to_string()));
-    return SExpr::list({SExpr::atom(as_string(_name)),
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
         SExpr::atom("in"),
         tracker.s_expr_term_of(_var),
         SExpr::list(std::move(vals))});

--- a/gcs/constraints/increasing.cc
+++ b/gcs/constraints/increasing.cc
@@ -143,7 +143,7 @@ auto IncreasingChain::s_exprify(const ProofModel * const model) const -> string
         ? (_descending ? "strictly_decreasing" : "strictly_increasing")
         : (_descending ? "decreasing" : "increasing");
 
-    print(s, "{} {}", _name, keyword);
+    print(s, "{} {}", _constraint_id, keyword);
     for (const auto & v : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
 

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -190,7 +190,7 @@ auto Inverse::s_exprify(const innards::ProofModel * const model) const -> std::s
 {
     stringstream s;
 
-    print(s, "{} inverse\n          (", _name);
+    print(s, "{} inverse\n          (", _constraint_id);
     for (const auto & x : _x) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(x));
     }

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -663,7 +663,7 @@ auto Knapsack::s_exprify(const innards::ProofModel * const model) const -> strin
 {
     stringstream s;
 
-    print(s, "{} knapsack\n            (", _name);
+    print(s, "{} knapsack\n            (", _constraint_id);
     for (const auto & cs : _coeffs) {
         print(s, "\n                (");
         for (const auto & c : cs)

--- a/gcs/constraints/lex.cc
+++ b/gcs/constraints/lex.cc
@@ -638,7 +638,7 @@ auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const innards::ProofModel * co
         _or_equal ? "_equal" : "",
         reif_suffix);
 
-    print(s, "{} {}", _name, cmp);
+    print(s, "{} {}", _constraint_id, cmp);
 
     auto cond_lit = overloaded{
         [](const reif::MustHold &) -> optional<IntegerVariableCondition> { return nullopt; },

--- a/gcs/constraints/lex_smart_table.cc
+++ b/gcs/constraints/lex_smart_table.cc
@@ -69,7 +69,7 @@ auto LexSmartTable::s_exprify(const innards::ProofModel * const model) const -> 
 {
     stringstream s;
 
-    print(s, "{} lex (", _name);
+    print(s, "{} lex (", _constraint_id);
     for (const auto & var : _vars_1)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") (");

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -1,6 +1,6 @@
-#include <gcs/constraints/linear/linear_equality.hh>
 #include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/constraints/innards/triggers.hh>
+#include <gcs/constraints/linear/linear_equality.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/exception.hh>
@@ -415,7 +415,7 @@ auto ReifiedLinearEquality::s_exprify(const ProofModel * const model) const -> s
         [&](const reif::NotIf &) { return make_pair(true, "lin_not_equals_if"); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", _name, cons);
+    print(s, "{} {}", _constraint_id, cons);
     if (rei) {
         print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
     }

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -1,6 +1,6 @@
-#include <gcs/constraints/linear/linear_inequality.hh>
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/constraints/innards/reified_state.hh>
+#include <gcs/constraints/linear/linear_inequality.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -210,7 +210,7 @@ auto ReifiedLinearInequality::s_exprify(const ProofModel * const model) const ->
         [&](const auto &) { throw UnexpectedException{"Unexpected reification type in s_exprify"}; return make_pair(false, ""); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", _name, cons);
+    print(s, "{} {}", _constraint_id, cons);
     if (rei) {
         print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
     }

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -259,7 +259,7 @@ auto And::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} and (", _name);
+    print(s, "{} and (", _constraint_id);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }
@@ -326,7 +326,7 @@ auto Or::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} or (", _name);
+    print(s, "{} or (", _constraint_id);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -205,7 +205,7 @@ auto ArrayMinMax::s_exprify(const innards::ProofModel * const model) const -> st
 {
     stringstream s;
 
-    print(s, "{} {} (", _name, _min ? "min" : "max");
+    print(s, "{} {} (", _constraint_id, _min ? "min" : "max");
     for (const auto & v : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     }

--- a/gcs/constraints/minus.cc
+++ b/gcs/constraints/minus.cc
@@ -171,7 +171,7 @@ auto Minus::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} minus (", _name);
+    print(s, "{} minus (", _constraint_id);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -1287,7 +1287,7 @@ auto MultBC::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} multiply (", _name);
+    print(s, "{} multiply (", _constraint_id);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v3));

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -140,7 +140,7 @@ auto NValue::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} nvalue (", _name);
+    print(s, "{} nvalue (", _constraint_id);
     for (const auto & var : _vars) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     }

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -145,7 +145,7 @@ auto ParityOdd::s_exprify(const innards::ProofModel * const model) const -> stri
 {
     stringstream s;
 
-    print(s, "{} xor (", _name);
+    print(s, "{} xor (", _constraint_id);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }

--- a/gcs/constraints/plus.cc
+++ b/gcs/constraints/plus.cc
@@ -158,7 +158,7 @@ auto Plus::s_exprify(const innards::ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} plus (", _name);
+    print(s, "{} plus (", _constraint_id);
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
     print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));
@@ -166,4 +166,3 @@ auto Plus::s_exprify(const innards::ProofModel * const model) const -> string
 
     return s.str();
 }
-

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -549,7 +549,7 @@ auto Regular::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} regular (", _name);
+    print(s, "{} regular (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ") {}\n       (", _num_states);

--- a/gcs/constraints/seq_precede_chain.cc
+++ b/gcs/constraints/seq_precede_chain.cc
@@ -86,7 +86,7 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
 auto SeqPrecedeChain::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
-    print(s, "{} seq_precede_chain (", _name);
+    print(s, "{} seq_precede_chain (", _constraint_id);
     for (const auto & var : _vars)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
     print(s, ")");

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -966,7 +966,7 @@ auto SmartTable::s_exprify(const ProofModel * const model) const -> string
 
     stringstream s;
 
-    print(s, "{} smart_table (\n        (", _name);
+    print(s, "{} smart_table (\n        (", _constraint_id);
 
     for (const auto & tuple : _tuples) {
         for (const auto & entry : tuple) {

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -459,7 +459,7 @@ auto ArgSort::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} arg_sort\n          (", _name);
+    print(s, "{} arg_sort\n          (", _constraint_id);
     for (const auto & v : _x)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     print(s, ")\n          (");

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -1107,7 +1107,7 @@ auto Sort::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} sort\n          (", _name);
+    print(s, "{} sort\n          (", _constraint_id);
     for (const auto & v : _x)
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
     print(s, ")\n          (");

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -307,7 +307,7 @@ auto NegativeTable::s_exprify(const innards::ProofModel * const model) const -> 
 {
     stringstream s;
 
-    print(s, "{} negative_table", _name);
+    print(s, "{} negative_table", _constraint_id);
     println(s, "(");
 
     println(s, "    (");

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -209,7 +209,7 @@ auto Table::s_exprify(const innards::ProofModel * const model) const -> std::str
 {
     stringstream s;
 
-    print(s, "{} table", _name);
+    print(s, "{} table", _constraint_id);
     println(s, "(");
 
     println(s, "    (");

--- a/gcs/constraints/value_precede.cc
+++ b/gcs/constraints/value_precede.cc
@@ -209,7 +209,7 @@ auto ValuePrecede::s_exprify(const ProofModel * const model) const -> string
 {
     stringstream s;
 
-    print(s, "{} value_precede (", _name);
+    print(s, "{} value_precede (", _constraint_id);
     for (const auto & val : _chain)
         print(s, " {}", val);
     print(s, ") (");

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -97,6 +97,12 @@ auto ProofModel::advance_constraint_counter() -> ProofLineNumber
     return ProofLineNumber{++_imp->number_of_constraints.number};
 }
 
+auto ProofModel::emit_constraint_label(const string & constraint_id, const string & role) -> ProofLine
+{
+    // The leading @ is added when a ProofLineLabel is written to the stream.
+    return ProofLineLabel{"c[" + constraint_id + "]" + (role.empty() ? "" : "[" + role + "]")};
+}
+
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> std::optional<ProofLine>
 {
     WPBSum sum;
@@ -172,6 +178,37 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     names_and_ids_tracker().derive_deviewed_form_for(second, eq.lhs, /*le_half=*/false);
 
     return pair{first, second};
+}
+
+auto ProofModel::add_labelled_constraint(
+    const string & constraint_id, const string & role_le, const string & role_ge,
+    const StringLiteral & constraint_name, const StringLiteral & rule,
+    const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
+    -> pair<optional<ProofLine>, optional<ProofLine>>
+{
+    names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
+
+    auto le = emit_constraint_label(constraint_id, role_le);
+    _imp->opb << le << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+    advance_constraint_counter();
+    // LE half: emit_inequality_to negates coefficients on emit.
+    names_and_ids_tracker().derive_deviewed_form_for(le, eq.lhs, /*le_half=*/true);
+
+    auto ge = emit_constraint_label(constraint_id, role_ge);
+    _imp->opb << ge << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+    advance_constraint_counter();
+    // GE half: see the unlabelled add_constraint above for the double-negation note.
+    names_and_ids_tracker().derive_deviewed_form_for(ge, eq.lhs, /*le_half=*/false);
+
+    return pair{le, ge};
 }
 
 auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -35,6 +35,10 @@ namespace gcs::innards
 
         auto advance_constraint_counter() -> ProofLineNumber;
 
+        // Build the constraint label `c[constraint_id][role]` (printed with a
+        // leading @). Credit: design from philrod1's constraint-labels branch.
+        auto emit_constraint_label(const std::string & constraint_id, const std::string & role) -> ProofLine;
+
         auto set_up_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
 
         auto set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
@@ -103,6 +107,25 @@ namespace gcs::innards
         auto add_constraint(
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
+            const WPBSumEq & eq,
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+
+        /**
+         * \brief Like add_constraint for an equality, but emits an @label on each
+         * half --- \c c[constraint_id][role_le] on the LE half and \c [role_ge]
+         * on the GE half --- and returns those labels, so the proof references
+         * the halves by label rather than by line number. The labels must match
+         * what \c cake_pb_cp emits for this constraint.
+         *
+         * Returns `{LE-half, GE-half}`, as the unlabelled overload does.
+         *
+         * Part of moving every constraint reference off line numbers and onto
+         * labels. Credit: design from philrod1's constraint-labels branch.
+         */
+        auto add_labelled_constraint(
+            const std::string & constraint_id,
+            const std::string & role_le, const std::string & role_ge,
+            const StringLiteral & constraint_name, const StringLiteral & rule,
             const WPBSumEq & eq,
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
 

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -36,7 +36,7 @@ namespace gcs::innards
         auto advance_constraint_counter() -> ProofLineNumber;
 
         // Build the constraint label `c[constraint_id][role]` (printed with a
-        // leading @). Credit: design from philrod1's constraint-labels branch.
+        // leading @).
         auto emit_constraint_label(const std::string & constraint_id, const std::string & role) -> ProofLine;
 
         auto set_up_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
@@ -120,7 +120,7 @@ namespace gcs::innards
          * Returns `{LE-half, GE-half}`, as the unlabelled overload does.
          *
          * Part of moving every constraint reference off line numbers and onto
-         * labels. Credit: design from philrod1's constraint-labels branch.
+         * labels.
          */
         auto add_labelled_constraint(
             const std::string & constraint_id,

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -213,6 +213,9 @@ auto Problem::create_propagators(State & state, ProofModel * const optional_proo
     Propagators result;
     for (auto & c : _imp->constraints) {
         auto cc = c->clone();
+        // clone() does not carry the name, but define_proof_model needs it to
+        // build @c[name][...] labels matching the .scp (and cake), so copy it.
+        cc->set_name(c->name());
         move(*cc).install(result, state, optional_proof_model);
     }
 

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -213,8 +213,9 @@ auto Problem::create_propagators(State & state, ProofModel * const optional_proo
     Propagators result;
     for (auto & c : _imp->constraints) {
         auto cc = c->clone();
-        // clone() does not carry the constraint id, but define_proof_model needs
-        // it to build @c[id][...] labels matching the .scp (and cake), so copy it.
+        // clone() is deliberately id-agnostic; each post/install site sets the id.
+        // post() assigns a fresh number; here we preserve the original's, since
+        // define_proof_model builds @c[id][...] labels that must match the .scp.
         cc->set_constraint_id(c->constraint_id());
         move(*cc).install(result, state, optional_proof_model);
     }

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -158,14 +158,14 @@ auto Problem::create_state_for_new_search(
 auto Problem::post(const Constraint & c) -> void
 {
     auto cloned = c.clone();
-    cloned->set_name(NumberedConstraint{++_imp->next_constraint_number});
+    cloned->set_constraint_id(NumberedConstraint{++_imp->next_constraint_number});
     _imp->constraints.push_back(std::move(cloned));
 }
 
 auto Problem::post_named(const Constraint & c, const string & name) -> void
 {
     auto cloned = c.clone();
-    cloned->set_name(NamedConstraint{check_name(name)});
+    cloned->set_constraint_id(NamedConstraint{check_name(name)});
     _imp->constraints.push_back(std::move(cloned));
 }
 
@@ -213,9 +213,9 @@ auto Problem::create_propagators(State & state, ProofModel * const optional_proo
     Propagators result;
     for (auto & c : _imp->constraints) {
         auto cc = c->clone();
-        // clone() does not carry the name, but define_proof_model needs it to
-        // build @c[name][...] labels matching the .scp (and cake), so copy it.
-        cc->set_name(c->name());
+        // clone() does not carry the constraint id, but define_proof_model needs
+        // it to build @c[id][...] labels matching the .scp (and cake), so copy it.
+        cc->set_constraint_id(c->constraint_id());
         move(*cc).install(result, state, optional_proof_model);
     }
 


### PR DESCRIPTION
First step of the labels/line-order work: start referencing OPB constraints by `@label` (matching `cake_pb_cp`'s OPB) instead of by line number, which only lines up by coincidence today.

Design from **philrod1's `constraint-labels` branch (#236)**, reimplemented against current `main` (which has since gained the term model, `s_expr`/`scp` round-trip, and the deviewed-form machinery).

## What's here
- **`ProofModel::add_labelled_constraint`** (equality) + **`emit_constraint_label`**: emit `@c[name][role]` on each half of an equality and return those *labels* as the `ProofLine`s, so every downstream `pol`/RUP reference to the halves is by `@label`. The line counter still advances (the OPB constraint count veripb enforces is unchanged); only the returned *reference* changes.
- **`create_propagators` name-copy**: `clone()` doesn't carry the constraint name, so `define_proof_model` saw `c[unnamed][...]` while the `.scp` said `_1`. Copy the original's name onto the install-time clone (also philrod1's fix).
- **abs** uses it with cake's exact roles: `posle`/`posge` (non-negative case), `negle`/`negge` (negative case).

## Verification
- `abs_test` self-verifies (54 cases, all `VERIFIED`).
- The cake chain still reports `VERIFIED UNSATISFIABLE`.
- `opbdiff --match-labels` matches abs's four `@c` lines against cake's (the `@i` variable-encoding lines differ because the solver doesn't label those *yet* — next increment).
- Full suite **294/294**.

## Next
The `@i` variable-encoding labels and the remaining ~27 `add_constraint` capture sites follow; once no site captures the bare `add_constraint` return, it can become `void` so a number reference is unrepresentable. The per-constraint label roles are catalogued in the encoding spec (captured from cake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)