### PR TITLE
Variable-encoding @i labels + abs fully matches cake

### DIFF
--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -92,11 +92,12 @@ auto Abs::install(Propagators & propagators, State &, ProofModel * const optiona
 
 auto Abs::define_proof_model(ProofModel & model) -> void
 {
-    // Labels match cake_pb_cp's: the non-negative case is @c[name][posle]/[posge]
-    // (V2 = V1 split into <= and >=), the negative case [negle]/[negge].
-    _abs_nonneg_lines = model.add_labelled_constraint(as_string(_constraint_id), "posle", "posge",
+    // Labels match cake_pb_cp's. cake names the V2 >= V1 half [posle] and the
+    // V2 <= V1 half [posge] (i.e. its le/ge track the slack direction, opposite
+    // to V2-vs-V1), so the roles go (LE-half, GE-half) = (posge, posle).
+    _abs_nonneg_lines = model.add_labelled_constraint(as_string(_constraint_id), "posge", "posle",
         "Abs", "non-negative", WPBSum{} + 1_i * _v2 + -1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 >= 0_i});
-    _abs_neg_lines = model.add_labelled_constraint(as_string(_constraint_id), "negle", "negge",
+    _abs_neg_lines = model.add_labelled_constraint(as_string(_constraint_id), "negge", "negle",
         "Abs", "negative", WPBSum{} + 1_i * _v2 + 1_i * _v1 == 0_i, HalfReifyOnConjunctionOf{_v1 < 0_i});
 }
 

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -599,10 +599,23 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                                                    id));
     }
     else {
-        _imp->gevars_that_exist[id].emplace(v, visit([&](const auto & id) {
-            return pair{
-                _imp->model->add_constraint(WPBSum{} + (1_i * id) >= v, {{id >= v}}).value(),
-                _imp->model->add_constraint(WPBSum{} + (-1_i * id) >= -v + 1_i, {{id < v}}).value()};
+        // Label the two halves @i[name][ge<v>][f]/[r] to match cake_pb_cp, but
+        // only where it is safe: a real (non-proof-only) variable, a name without
+        // `[` (vector names nest brackets the @label parser rejects), and v >= 0
+        // (a negative v would put a `-` in the role). The first emitted half (the
+        // id>=v reif, carrying ~ge..) is cake's [r]; the second is [f].
+        const auto & name = name_of(id);
+        bool can_label = std::holds_alternative<SimpleIntegerVariableID>(id) && name.find('[') == string::npos && v >= 0_i;
+        string ge_label = can_label ? "i[" + name + "][ge" + to_string(v.raw_value) + "]" : "";
+        _imp->gevars_that_exist[id].emplace(v, visit([&](const auto & vid) -> pair<ProofLine, ProofLine> {
+            if (can_label)
+                return pair{
+                    _imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}).value(),
+                    _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}}).value()};
+            else
+                return pair{
+                    _imp->model->add_constraint(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}).value(),
+                    _imp->model->add_constraint(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}}).value()};
         },
                                                    id));
         ++_imp->model_variables;

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -211,6 +211,21 @@ auto ProofModel::add_labelled_constraint(
     return pair{le, ge};
 }
 
+auto ProofModel::add_labelled_constraint(const string & label, const WPBSumLE & ineq,
+    const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
+{
+    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    ProofLineLabel l{label};
+    _imp->opb << l << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
+    _imp->opb << ";\n";
+    advance_constraint_counter();
+    return l;
+}
+
 auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<optional<ProofLine>, optional<ProofLine>>
 {

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -360,13 +360,24 @@ auto ProofModel::set_up_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableI
     names_and_ids_tracker().track_bits(id, negative_bit_coeff, bits);
     _imp->model_variables += bits.size();
 
+    // @i[name][lb]/[ub] labels match cake_pb_cp, but only for a real variable
+    // with a label-safe name: views / proof-only variables are not in cake's OPB,
+    // and a `[` in the name (e.g. a vector variable box[0]) nests brackets that
+    // veripb's @label parser rejects. The bracket guard is temporary -- nested
+    // brackets are coming in a future cake_pb_cp release.
+    bool labelled = std::holds_alternative<SimpleIntegerVariableID>(id) && name.find('[') == string::npos;
+
     // lower bound
+    if (labelled)
+        _imp->opb << ProofLineLabel{"i[" + name + "][lb]"} << " ";
     for (auto & [coeff, var] : bits)
         _imp->opb << coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
     _imp->opb << ">= " << lower << " ;\n";
     advance_constraint_counter();
 
     // upper bound
+    if (labelled)
+        _imp->opb << ProofLineLabel{"i[" + name + "][ub]"} << " ";
     for (auto & [coeff, var] : bits)
         _imp->opb << -coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
     _imp->opb << ">= " << -upper << " ;\n";

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -130,6 +130,16 @@ namespace gcs::innards
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
 
         /**
+         * \brief Add a single inequality under a caller-supplied @label, returning
+         * that label as the ProofLine. `label` is the full label body (e.g.
+         * \c i[X][ge0][f]); used for the variable-encoding @i labels, whose shape
+         * (\c i[name][...][f|r]) the caller builds rather than the c[id][role] form.
+         */
+        auto add_labelled_constraint(
+            const std::string & label, const WPBSumLE & ineq,
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::optional<ProofLine>;
+
+        /**
          * Add a CNF definition to a Proof model.
          */
         auto add_constraint(


### PR DESCRIPTION
Stacked follow-up to #271. Brings the solver's OPB into full `@label` agreement with `cake_pb_cp` for `abs` — every constraint now matches by label, not just as a set.

## What's here
- **Bound lines `@i[name][lb]`/`@i[name][ub]`** in `set_up_bits_variable_encoding`.
- **abs `le`/`ge` role-swap fix.** `opbdiff --match-labels` flagged abs's four `@c` lines as differing even though `--unordered` matched the OPBs as a set. It was **not** a big-M divergence (the constraints and their M values are identical) — cake assigns `[posle]` to the `V2 >= V1` half and `[posge]` to the `V2 <= V1` half (its `le`/`ge` track the slack direction, opposite to V2-vs-V1). Roles corrected to `(posge, posle)` / `(negge, negle)`.
- **Reified `ge>=v` lines `@i[name][ge<v>][f]`/`[r]`**, via a new `ProofModel::add_labelled_constraint(label, ineq, half_reif)` (emits one inequality under a caller-built `@label`, since the `@i` family's shape differs from `c[id][role]`) and a guarded branch in `need_gevar`.

## Label-safety guard
`@i` labels are emitted only where they're both correct and parseable: a **real** (non-proof-only) variable, a name without `[` (vector vars like `box[0]` nest brackets), and `v >= 0` for `ge<v>` (a negative `v` would put a `-` in the role). Views / proof-only vars and bracketed names are skipped — their generated names contain characters veripb's `@label` parser rejects (fine in `i[…]`/`p[…]` *literals*, not in labels). The `[` guard lifts once nested-bracket labels ship in cake_pb_cp.

## Result
`opbdiff --match-labels` reports the solver's and cake's `abs` OPBs **semantically equivalent across all 10 constraints**; the workflow-2 chain still VERIFIES UNSATISFIABLE; full suite **294/294**.

Follow-ups (not here): the same labelling for the other cake-covered constraints (`all_different`, `equals`/`not_equals`, linear), then routing the remaining `add_constraint` capture sites through labels and finally making the bare `add_constraint` return `void`. `eqK` reified literals and the proof-time gevar path are intentionally left unlabelled (cake doesn't put those in the OPB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)