### PR TITLE
Label all_different clique not-equals lines @c[id][<i>lt<j>]/[<i>gt<j>]

### DIFF
--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -10,20 +10,26 @@ using std::map;
 using std::move;
 using std::optional;
 using std::pair;
+using std::string;
+using std::to_string;
 using std::vector;
 
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const vector<gcs::IntegerVariableID> & vars) -> optional<pair<IntegerVariableID, ProofFlag>>
+auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const string & constraint_id, const vector<gcs::IntegerVariableID> & vars) -> optional<pair<IntegerVariableID, ProofFlag>>
 {
     optional<pair<IntegerVariableID, ProofFlag>> duplicate_witness;
 
     for (unsigned i = 0; i < vars.size(); ++i)
         for (unsigned j = i + 1; j < vars.size(); ++j) {
             auto selector = model.create_proof_flag("notequals");
-            model.add_constraint("AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
-            model.add_constraint("AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
+            // cake_pb_cp labels the pair (i, j): @c[id][<i>lt<j>] is vars[i] < vars[j]
+            // (the "lower" half), @c[id][<i>gt<j>] is vars[i] > vars[j] ("higher").
+            model.add_labelled_constraint(constraint_id, to_string(i) + "lt" + to_string(j),
+                "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
+            model.add_labelled_constraint(constraint_id, to_string(i) + "gt" + to_string(j),
+                "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
 
             if (vars[i] == vars[j] && ! duplicate_witness)
                 duplicate_witness = pair{vars[i], selector};

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -28,7 +28,7 @@ namespace gcs
         // selector flag, which the caller can cite from a justification that
         // derives contradiction explicitly (RUP alone cannot pick a polarity,
         // since both half-reifications are non-unit).
-        auto define_clique_not_equals_encoding(ProofModel & model,
+        auto define_clique_not_equals_encoding(ProofModel & model, const std::string & constraint_id,
             const std::vector<IntegerVariableID> & vars) -> std::optional<std::pair<IntegerVariableID, ProofFlag>>;
 
         // Emits the AllDifferentExcept clique encoding. Where the same variable

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -626,7 +626,7 @@ auto GACAllDifferent::prepare(Propagators &, State & initial_state, ProofModel *
 
 auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    _duplicate_witness = define_clique_not_equals_encoding(model, _sanitised_vars);
+    _duplicate_witness = define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
 }
 
 auto GACAllDifferent::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -113,7 +113,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
                 WPBSum{} + 1_i * (_vars[j] != Integer(i) + _start) + 1_i * (_vars[i] == Integer(j) + _start) >= 1_i);
         }
 
-    _duplicate_witness = define_clique_not_equals_encoding(model, _vars);
+    _duplicate_witness = define_clique_not_equals_encoding(model, as_string(_constraint_id), _vars);
 
     // Per-value am1s for the alldiff hall-set / SCC justifications,
     // built once at the root.

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -144,7 +144,7 @@ auto VCAllDifferent::prepare(Propagators &, State & initial_state, ProofModel * 
 
 auto VCAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    _duplicate_witness = define_clique_not_equals_encoding(model, _sanitised_vars);
+    _duplicate_witness = define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
 }
 
 auto VCAllDifferent::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -176,7 +176,7 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
     else {
         // Still need to define the all different encoding.
         if (model)
-            define_clique_not_equals_encoding(*model, _succ);
+            define_clique_not_equals_encoding(*model, as_string(_constraint_id), _succ);
     }
 
     // Define encoding to eliminate sub-cycles

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -226,6 +226,25 @@ auto ProofModel::add_labelled_constraint(const string & label, const WPBSumLE & 
     return l;
 }
 
+auto ProofModel::add_labelled_constraint(const string & constraint_id, const string & role,
+    const StringLiteral & constraint_name, const StringLiteral & rule,
+    const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
+{
+    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
+    auto label = emit_constraint_label(constraint_id, role);
+    _imp->opb << label << " ";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
+    _imp->opb << ";\n";
+    advance_constraint_counter();
+    // emit_inequality_to negates the LE inequality to land in PB >= form.
+    names_and_ids_tracker().derive_deviewed_form_for(label, ineq.lhs, /*le_half=*/true);
+    return label;
+}
+
 auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<optional<ProofLine>, optional<ProofLine>>
 {

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -140,6 +140,17 @@ namespace gcs::innards
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::optional<ProofLine>;
 
         /**
+         * \brief Like add_constraint for a single inequality, but emits @c[id][role]
+         * and returns that label as the ProofLine, so the proof references it by
+         * label. The role must match what \c cake_pb_cp emits.
+         */
+        auto add_labelled_constraint(
+            const std::string & constraint_id, const std::string & role,
+            const StringLiteral & constraint_name, const StringLiteral & rule,
+            const WPBSumLE & ineq,
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::optional<ProofLine>;
+
+        /**
          * Add a CNF definition to a Proof model.
          */
         auto add_constraint(


### PR DESCRIPTION
Applies the `@c` labelling (from #271/#272) to `all_different`'s clique-of-not-equals encoding, the first **multi-pair** constraint to go through it.

## What's here
- Each pair `(i, j)` emits two half-reified inequalities; cake labels them `@c[id][<i>lt<j>]` (`vars[i] < vars[j]`, the "lower" half) and `@c[id][<i>gt<j>]` ("higher"). The `lt`/`gt` orientation matches cake directly — **no swap** (unlike abs).
- New single-inequality `add_labelled_constraint(id, role, name, rule, ineq, half_reif)` overload (mirrors the equality one; `c[id][role]`).
- Constraint id threaded through `define_clique_not_equals_encoding`, shared by gac/vc/symmetric all_different **and** circuit (4 call sites).

## Verification
- A bits-encoded UNSAT all_different (4 vars in `[0,2]`) **chain-verifies end-to-end**: `cake_pb_cp encode → veripb → VERIFIED UNSATISFIABLE`.
- Full suite **294/294**.

## Two known gaps (deeper than labelling, tracked in the spec, not fixed here)
1. **Direct-only vs bits variable encoding.** The solver uses its direct-only encoding for tiny domains (`[0,1]`); cake always uses bits, so the OPB constraint *count* differs and veripb rejects the chain for small-domain vars. Needs a `cake_pb_cp` change.
2. **Selector aux flag.** Solver `f[N][notequals]` vs cake's two-level `x[name][i_j]`, opposite polarity. Cosmetic for the chain (it verifies regardless — the proof cites the `@c` labels and the flag is existential), but a byte-match needs the solver to adopt cake's naming (which matches our own two-level-naming spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)