### PR TITLE
scp: emit cake_pb_cp's operator names (+ fix greater orientation)

### DIFF
--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -233,16 +233,20 @@ auto ReifiedCompareLessThanOrMaybeEqual::s_expr(const ProofModel * const model) 
         [&](const auto &) -> string { throw UnexpectedException{"Unexpected reification type in s_expr"}; }}
                            .visit(_reif_cond);
 
-    string cmp = format("{}{}{}",
-        _vars_swapped ? "greater_than" : "less_than",
-        _or_equal ? "_equal" : "",
+    // cake_pb_cp's names: less_than / less_equal / greater_than / greater_equal.
+    string cmp = format("{}_{}{}",
+        _vars_swapped ? "greater" : "less",
+        _or_equal ? "equal" : "than",
         reif_suffix);
 
     vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(cmp)};
     if (auto cond = tracker.s_expr_term_of(_reif_cond))
         terms.push_back(std::move(*cond));
-    terms.push_back(tracker.s_expr_term_of(_v1));
-    terms.push_back(tracker.s_expr_term_of(_v2));
+    // The constraint enforces _v1 <op> _v2. cake reads "less A B" as A<=B but
+    // "greater A B" as A>=B, so for the greater form the operands are reversed:
+    // "greater _v2 _v1" reads as _v2 >= _v1, i.e. _v1 <= _v2.
+    terms.push_back(tracker.s_expr_term_of(_vars_swapped ? _v2 : _v1));
+    terms.push_back(tracker.s_expr_term_of(_vars_swapped ? _v1 : _v2));
 
     return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -203,10 +203,11 @@ auto ReifiedLinearInequality::s_exprify(const ProofModel * const model) const ->
 {
     stringstream s;
 
+    // cake_pb_cp's name for the <= form is lin_less_equal (not lin_less_than_equal).
     auto [rei, cons] = overloaded{
-        [&](const reif::MustHold &) { return make_pair(false, "lin_less_than_equal"); },
-        [&](const reif::If &) { return make_pair(true, "lin_less_than_equal_if"); },
-        [&](const reif::Iff &) { return make_pair(true, "lin_less_than_equal_iff"); },
+        [&](const reif::MustHold &) { return make_pair(false, "lin_less_equal"); },
+        [&](const reif::If &) { return make_pair(true, "lin_less_equal_if"); },
+        [&](const reif::Iff &) { return make_pair(true, "lin_less_equal_iff"); },
         [&](const auto &) { throw UnexpectedException{"Unexpected reification type in s_exprify"}; return make_pair(false, ""); }}
                            .visit(_reif_cond);
 

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1231,10 +1231,11 @@ auto NamesAndIDsTracker::s_expr_name_of(VariableConditionOperator op) const -> s
 {
     switch (op) {
         using enum VariableConditionOperator;
-    case Equal: return "eq";
-    case NotEqual: return "neq";
-    case GreaterEqual: return "geq";
-    case Less: return "lt";
+        // cake_pb_cp's reification-condition operators are symbols, not words.
+    case Equal: return "=";
+    case NotEqual: return "!=";
+    case GreaterEqual: return ">=";
+    case Less: return "<";
     }
 
     throw NonExhaustiveSwitch{};

--- a/gcs/innards/s_expr_test.cc
+++ b/gcs/innards/s_expr_test.cc
@@ -94,8 +94,8 @@ TEST_CASE("SExpr: the canonical forms the refactored constraints now emit")
     for (auto s : {
              "(_1 abs _2 _3)",
              "(_3 all_different (_1 _1 _2 _2))",
-             "(_1 less_than_equal _2 _3)",
-             "(_1 less_than_equal_iff (_2 neq 1) _3 _4)",
+             "(_1 less_equal _2 _3)",
+             "(_1 less_equal_iff (_2 != 1) _3 _4)",
              "(_5 in _2 (0 1 _3))"}) {
         CHECK(format("{}", parse_s_expr(s)) == s);
     }

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -115,13 +115,14 @@ namespace
         const auto & op = parts[1].as_atom();
         auto value = as_integer(parts[2]);
         using enum VariableConditionOperator;
-        if (op == "eq")
+        // cake_pb_cp's condition operators are symbols.
+        if (op == "=")
             return {var, Equal, value};
-        if (op == "neq")
+        if (op == "!=")
             return {var, NotEqual, value};
-        if (op == "geq")
+        if (op == ">=")
             return {var, GreaterEqual, value};
-        if (op == "lt")
+        if (op == "<")
             return {var, Less, value};
         throw ScpReadError{"unknown reification-condition operator '" + op + "'"};
     }
@@ -143,18 +144,18 @@ namespace
         return {not_equals ? ReificationCondition{reif::MustNotHold{}} : ReificationCondition{reif::MustHold{}}, false};
     }
 
-    // The comparison family: (label <less|greater>_than[_equal][_if|_iff]
-    // [(cond)] v1 v2). The keyword carries the swapped / or-equal / reification
-    // flags that the general ReifiedCompareLessThanOrMaybeEqual constructor takes
-    // directly, so this reconstructs exactly the object the writer serialised.
+    // The comparison family: (label <less|greater>_<than|equal>[_if|_iff]
+    // [(cond)] v1 v2), in cake_pb_cp's names. The keyword carries the swapped /
+    // or-equal / reification flags that the general
+    // ReifiedCompareLessThanOrMaybeEqual constructor takes directly, so this
+    // reconstructs exactly the object the writer serialised.
     auto read_comparison(Problem & problem, const map<string, IntegerVariableID> & variables,
         const string & op, const vector<SExpr> & terms, const string & label) -> void
     {
-        bool vars_swapped = op.starts_with("greater_than");
-        string rest = op.substr(vars_swapped ? sizeof("greater_than") - 1 : sizeof("less_than") - 1);
-        bool or_equal = rest.starts_with("_equal");
-        if (or_equal)
-            rest = rest.substr(sizeof("_equal") - 1);
+        bool vars_swapped = op.starts_with("greater_");
+        string rest = op.substr(vars_swapped ? sizeof("greater_") - 1 : sizeof("less_") - 1);
+        bool or_equal = rest.starts_with("equal");
+        rest = rest.substr(or_equal ? sizeof("equal") - 1 : sizeof("than") - 1);
         // `rest` is now "" (unconditional), "_if" (half-reified) or "_iff".
 
         ReificationCondition cond = reif::MustHold{};
@@ -176,15 +177,20 @@ namespace
             v1_index = 3;
         }
 
+        // "less A B" means A <op> B; "greater A B" means A >op B, i.e. B <op A.
+        // The base constructor enforces (first) <op> (second), so reverse the
+        // operands for the greater form to recover that.
+        auto first = resolve_variable(variables, terms[v1_index]);
+        auto second = resolve_variable(variables, terms[v1_index + 1]);
         post_constraint(problem,
             ReifiedCompareLessThanOrMaybeEqual{
-                resolve_variable(variables, terms[v1_index]),
-                resolve_variable(variables, terms[v1_index + 1]),
+                vars_swapped ? second : first,
+                vars_swapped ? first : second,
                 cond, or_equal, vars_swapped},
             label);
     }
 
-    // The linear family: (label lin_<equals|not_equals|less_than_equal>[_if|_iff]
+    // The linear family: (label lin_<equals|not_equals|lin_less_equal>[_if|_iff]
     // [(cond)] (c1 v1 c2 v2 ...) value). The keyword selects the constraint and
     // its reification, matching the general ReifiedLinear* constructors. (The
     // .scp does not record the GAC flag, so it defaults off; that affects
@@ -209,7 +215,7 @@ namespace
 
         auto condition = [&] { return resolve_condition(variables, terms[2]); };
 
-        if (op.starts_with("lin_less_than_equal")) {
+        if (op.starts_with("lin_less_equal")) {
             ReificationCondition cond = reif::MustHold{};
             if (iff)
                 cond = reif::Iff{condition()};
@@ -290,7 +296,7 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
             post_constraint(problem,
                 In{resolve_variable(variables, terms[2]), resolve_variable_list(variables, terms[3], "the in value list")}, label);
         }
-        else if (op.starts_with("less_than") || op.starts_with("greater_than")) {
+        else if (op.starts_with("less_") || op.starts_with("greater_")) {
             read_comparison(problem, variables, op, terms, label);
         }
         else if (op.starts_with("lin_")) {

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -109,14 +109,14 @@ TEST_CASE("read_scp: comparisons enumerate correctly")
 {
     for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 less_than X Y) ) )"))
         CHECK(s.at("X") < s.at("Y"));
-    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 less_than_equal X Y) ) )"))
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 less_equal X Y) ) )"))
         CHECK(s.at("X") <= s.at("Y"));
 }
 
 TEST_CASE("read_scp: a fully-reified comparison enumerates correctly")
 {
     // C == 1  iff  X <= Y.
-    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (C 0 1) ) ( (_1 less_than_equal_iff (C eq 1) X Y) ) )"))
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (C 0 1) ) ( (_1 less_equal_iff (C = 1) X Y) ) )"))
         CHECK((s.at("C") == 1) == (s.at("X") <= s.at("Y")));
 }
 
@@ -146,7 +146,7 @@ TEST_CASE("read_scp: linear constraints enumerate correctly")
     for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) ) ( (_1 lin_equals (1 X 1 Y) 3) ) )"))
         CHECK(s.at("X") + s.at("Y") == 3);
     // X - Y <= 1
-    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) ) ( (_1 lin_less_than_equal (1 X -1 Y) 1) ) )"))
+    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) ) ( (_1 lin_less_equal (1 X -1 Y) 1) ) )"))
         CHECK(s.at("X") - s.at("Y") <= 1);
     // X + Y != 2
     for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) ) ( (_1 lin_not_equals (1 X 1 Y) 2) ) )"))
@@ -156,7 +156,7 @@ TEST_CASE("read_scp: linear constraints enumerate correctly")
 TEST_CASE("read_scp: a reified linear constraint enumerates correctly")
 {
     // C == 1  iff  X + Y == 3.
-    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) (C 0 1) ) ( (_1 lin_equals_iff (C eq 1) (1 X 1 Y) 3) ) )"))
+    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) (C 0 1) ) ( (_1 lin_equals_iff (C = 1) (1 X 1 Y) 3) ) )"))
         CHECK((s.at("C") == 1) == (s.at("X") + s.at("Y") == 3));
 }
 
@@ -196,7 +196,7 @@ TEST_CASE("read_scp: equals and not_equals enumerate correctly")
 TEST_CASE("read_scp: a reified equals enumerates correctly")
 {
     // C == 1  iff  X == Y.
-    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (C 0 1) ) ( (_1 equals_iff (C eq 1) X Y) ) )"))
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (C 0 1) ) ( (_1 equals_iff (C = 1) X Y) ) )"))
         CHECK((s.at("C") == 1) == (s.at("X") == s.at("Y")));
 }
 


### PR DESCRIPTION
cake encodes comparisons, the full linear family (inequalities included), and reified `_if`/`_iff` forms — but under different `.scp` operator names than the solver wrote, which is why earlier probes (using the solver's names) reported "unsupported". This conforms the solver to cake's names, in both the `.scp` writers and `read_scp`.

## Name reconciliation
| Solver wrote | cake's name |
|---|---|
| `less_than_equal` / `greater_than_equal` | `less_equal` / `greater_equal` |
| `lin_less_than_equal` | `lin_less_equal` |
| condition ops `eq` `neq` `geq` `lt` | symbols `=` `!=` `>=` `<` |

(`less_than`/`greater_than`, `lin_equals`/`lin_not_equals`, `equals`/`not_equals` already agreed.)

## Plus an orientation fix
The first comparison chain surfaced a latent bug: cake reads `greater A B` as `A ≥ B`, but the solver rendered *and* parsed the greater form with base-order operands, so `greater_equal X Y` round-tripped as `X ≤ Y`. The base constraint enforces `_v1 <op> _v2`, so the greater form must reverse the operands (`greater _v2 _v1` reads as `_v1 ≤ _v2`). Writer and reader now both do, and `read_scp` round-trips stay byte-identical.

## Verified
Bits-encoded UNSAT instances, `cake_pb_cp encode → veripb`:
- `less_equal`, `greater_equal`, `greater_than`, `lin_less_equal` → **VERIFIED UNSATISFIABLE**.
- Reified forms encode with symbol conditions; reader round-trips byte-identical.
- Full suite **294/294**.

This makes the whole comparison + linear-inequality + reified surface chain-eligible (subject only to the small-domain direct-vs-bits encoding item still with the CakePB authors). Only `in` remains genuinely unencoded by cake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)