### PR TITLE
Label equals/not_equals, lin_equals/lin_not_equals, and reified comparison

### DIFF
--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -93,26 +93,33 @@ auto ReifiedCompareLessThanOrMaybeEqual::prepare(Propagators &, State & initial_
 
 auto ReifiedCompareLessThanOrMaybeEqual::define_proof_model(ProofModel & model) -> void
 {
-    auto do_less = [&](IntegerVariableID v1, IntegerVariableID v2, optional<HalfReifyOnConjunctionOf> cond, bool or_equal, const StringLiteral & rule) {
-        model.add_constraint("ReifiedCompareLessThanOrMaybeEqual", rule, WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i), cond);
+    // `role` is the cake_pb_cp @c label role, or "" for the lines cake leaves
+    // unlabelled (an unconditional comparison is a single bare inequality).
+    auto do_less = [&](IntegerVariableID v1, IntegerVariableID v2, optional<HalfReifyOnConjunctionOf> cond, bool or_equal, const string & role, const StringLiteral & rule) {
+        auto ineq = WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i);
+        if (role.empty())
+            model.add_constraint("ReifiedCompareLessThanOrMaybeEqual", rule, ineq, cond);
+        else
+            model.add_labelled_constraint(as_string(_constraint_id), role, "ReifiedCompareLessThanOrMaybeEqual", rule, ineq, cond);
     };
 
     overloaded{
         [&](const reif::MustHold &) {
-            do_less(_v1, _v2, nullopt, _or_equal, "condition true");
+            do_less(_v1, _v2, nullopt, _or_equal, "", "condition true");
         },
         [&](const reif::MustNotHold &) {
-            do_less(_v2, _v1, nullopt, ! _or_equal, "condition false");
+            do_less(_v2, _v1, nullopt, ! _or_equal, "", "condition false");
         },
         [&](const reif::If & cond) {
-            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
+            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "", "if condition");
         },
         [&](const reif::NotIf & cond) {
-            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{cond.cond}}, ! _or_equal, "if condition");
+            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{cond.cond}}, ! _or_equal, "", "if condition");
         },
         [&](const reif::Iff & cond) {
-            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "if condition");
-            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{! cond.cond}}, ! _or_equal, "if not condition");
+            // cake_pb_cp labels the !cond half [f] and the cond half [r].
+            do_less(_v1, _v2, HalfReifyOnConjunctionOf{{cond.cond}}, _or_equal, "r", "if condition");
+            do_less(_v2, _v1, HalfReifyOnConjunctionOf{{! cond.cond}}, ! _or_equal, "f", "if not condition");
         }}
         .visit(_reif_cond);
 }

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -146,14 +146,16 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
 {
     overloaded{
         [&](const reif::MustHold &) {
-            model.add_constraint("ReifiedEquals", "equals option",
+            // cake_pb_cp: V1 = V2 split into le (V1 <= V2) and ge (V1 >= V2).
+            model.add_labelled_constraint(as_string(_constraint_id), "le", "ge", "ReifiedEquals", "equals option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) == 0_i);
         },
         [&](const reif::MustNotHold &) {
+            // cake_pb_cp: V1 != V2 split into gt (V1 > V2) and lt (V1 < V2).
             auto gtflag = model.create_proof_flag("gt");
-            model.add_constraint("ReifiedEquals", "greater option",
+            model.add_labelled_constraint(as_string(_constraint_id), "gt", "ReifiedEquals", "greater option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) >= 1_i, HalfReifyOnConjunctionOf{{gtflag}});
-            model.add_constraint("ReifiedEquals", "less option",
+            model.add_labelled_constraint(as_string(_constraint_id), "lt", "ReifiedEquals", "less option",
                 WPBSum{} + (1_i * _v1) + (-1_i * _v2) <= -1_i, HalfReifyOnConjunctionOf{{! gtflag}});
         },
         [&](const reif::If & reif) {

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -173,14 +173,16 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
 
     overloaded{
         [&](const reif::MustHold &) {
-            // condition is definitely true, it's just an inequality
-            _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
+            // condition is definitely true, it's just an inequality -- cake_pb_cp
+            // labels the equality halves le (sum <= value) / ge (sum >= value).
+            _proof_line = model.add_labelled_constraint(as_string(_constraint_id), "le", "ge", "ReifiedLinearEquality", "unconditional sum", terms == _value, nullopt);
         },
         [&](const reif::MustNotHold &) {
-            // condition is definitely false, the flag implies either greater or less
+            // condition is definitely false, the flag implies either greater or
+            // less -- cake_pb_cp labels them gt (sum > value) / lt (sum < value).
             auto neflag = model.create_proof_flag("linne");
-            model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
-            model.add_constraint("ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
+            model.add_labelled_constraint(as_string(_constraint_id), "gt", "ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{neflag}});
+            model.add_labelled_constraint(as_string(_constraint_id), "lt", "ReifiedLinearEquality", "less than option", terms <= _value - 1_i, HalfReifyOnConjunctionOf{{! neflag}});
         },
         [&](const reif::If & cond) {
             _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});


### PR DESCRIPTION
Extends the `@c` labelling to the equals, linear-equality, and reified-comparison families (all cake-encoded under their cake names).

## Labelled (orientation matches cake — no swaps except where noted)
- **equals** → `@c[id][le]`/`[ge]` (the `V1=V2` split), **not_equals** → `@c[id][gt]`/`[lt]`.
- **lin_equals** → `@c[id][le]`/`[ge]`, **lin_not_equals** → `@c[id][gt]`/`[lt]` (mirror the scalar forms).
- **reified comparison** (`*_iff`) → `@c[id][f]`/`[r]`. opbdiff's swap detector flagged `f`/`r` reversed; corrected (cond half = `r`, !cond half = `f`). `do_less` gained a role arg; the unconditional/If/NotIf cases stay unlabelled (cake doesn't `@c`-label those).

## Verified
- `not_equals`, `lin_not_equals`, `less_equal_iff` match cake under `--match-labels --ignore-aux-names`.
- Disjoint `equals` and infeasible `lin_equals` chains both `VERIFIED UNSATISFIABLE`.
- Full suite **294/294**.

## Deliberately not here
- The **reified equality** forms (`equals_iff`/`lin_equals_iff`): cake encodes them in 3 `@c` lines (`al1`/`ge`/`le`) where the solver emits 5 — a structural difference, being investigated as a possible "use cake's compact encoding" change rather than labelling.
- For `less_equal_iff` the `@c` lines match cake; the remaining OPB diff is the `[0,1]` condition variable's direct-vs-bits encoding (the Finding-1 cake-side item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)