### PR TITLE
Write the objective / (enumerate) as the final .scp element (unblocks SAT chains)

### DIFF
--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1241,6 +1241,17 @@ auto NamesAndIDsTracker::s_expr_name_of(VariableConditionOperator op) const -> s
     throw NonExhaustiveSwitch{};
 }
 
+auto NamesAndIDsTracker::s_expr_render_of(IntegerVariableID id) const -> string
+{
+    return overloaded{
+        [&](const ConstantIntegerVariableID & c) -> string { return "(minimize " + c.const_value.to_string() + ")"; },
+        [&](const SimpleIntegerVariableID & v) -> string { return "(minimize " + name_of(v) + ")"; },
+        [&](const ViewOfIntegerVariableID & vv) -> string {
+            return "(" + string{vv.negate_first ? "maximize" : "minimize"} + " " + name_of(vv.actual_variable) + ")";
+        }}
+        .visit(id);
+}
+
 auto NamesAndIDsTracker::s_expr_term_of(IntegerVariableID id) const -> SExpr
 {
     // A variable / literal name is always a single, non-empty s-expression term

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -386,6 +386,13 @@ namespace gcs::innards
         [[nodiscard]] auto s_expr_name_of(VariableConditionOperator op) const -> std::string;
 
         /**
+         * Render an objective variable as the final `.scp` element:
+         * `(minimize <name>)` or `(maximize <name>)`, matching cake_pb_cp's
+         * spelling (a view that negates its variable becomes a maximize).
+         */
+        [[nodiscard]] auto s_expr_render_of(IntegerVariableID id) const -> std::string;
+
+        /**
          * Get the s-expr *term* for a variable: s_expr_name_of() parsed into an
          * SExpr, so a view like `(-_1 + 17)` becomes a list rather than an atom.
          * Prefer this over `parse_s_expr(s_expr_name_of(...))` at call sites so

--- a/gcs/innards/proofs/scp_writer.cc
+++ b/gcs/innards/proofs/scp_writer.cc
@@ -1,5 +1,7 @@
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/proofs/scp_writer.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/problem.hh>
@@ -47,6 +49,14 @@ auto gcs::innards::write_scp(const string & file_name, const Problem & problem, 
         for (const auto & c : problem.each_constraint())
             println(s_expr, "        {}", c.s_expr(model));
         println(s_expr, "    )");
+        // The final element is the objective, or (enumerate) for a satisfaction /
+        // enumeration problem. cake_pb_cp uses it to decide whether to emit a
+        // `preserved:` set -- which veripb needs to log/exclude solutions, so
+        // without it only refutation (UNSAT) proofs verify through the chain.
+        if (auto objective = problem.optional_minimise_variable())
+            println(s_expr, "    {}", model->names_and_ids_tracker().s_expr_render_of(*objective));
+        else
+            println(s_expr, "    (enumerate)");
         println(s_expr, ")");
     }
     catch (const ios_base::failure &) {

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -253,9 +253,12 @@ namespace
 auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVariableID>
 {
     auto top = parse_s_expr(text);
-    const auto & sections = children_of(top, "the top-level (variables constraints) form");
-    if (sections.size() != 2)
-        throw ScpReadError{"top level must be exactly (variables constraints)"};
+    const auto & sections = children_of(top, "the top-level (variables constraints [objective]) form");
+    // The optional third element is the objective / (enumerate) directive; this
+    // reader solves and enumerates, so it is accepted but not acted on (an
+    // objective would need the client to optimise rather than enumerate).
+    if (sections.size() != 2 && sections.size() != 3)
+        throw ScpReadError{"top level must be (variables constraints) or (variables constraints objective)"};
 
     map<string, IntegerVariableID> variables;
 


### PR DESCRIPTION
Resolves the `preserved:` blocker, so **SAT/enumeration** proofs verify through the cake chain — not just refutations.

cake_pb_cp uses a third top-level `.scp` element (the objective, or `(enumerate)` for a satisfaction/enumeration problem) to decide whether to emit a `preserved:` set. veripb needs that set to log and exclude solutions (`solx`); without it, only UNSAT proofs verified through the chain.

## Changes
- `write_scp` now emits `(minimize <var>)` / `(maximize <var>)` when the problem has an objective, else `(enumerate)`. Ports `s_expr_render_of` from **philrod1's** `constraint-labels` branch (he'd worked this out).
- `read_scp` accepts the optional third element (this reader solves/enumerates, so an objective is read but not acted on).

## Verified
- A SAT enumeration chain (`less_equal` over `[0,2]`) now gives **`VERIFIED COMPLETE ENUMERATION OF 6 SOLUTIONS`** through `cake_pb_cp` + veripb.
- The abs **UNSAT** chain still `VERIFIED UNSATISFIABLE`.
- Full suite **294/294**.

This is what unblocks broad workflow-2 coverage: reified forms, comparisons, etc. (almost all SAT) can now be chain-verified by enumeration, which makes the planned regression harness far more useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)