### PR TITLE
Add ArrayParam<C> own/share/borrow handle; use it in Element and Table

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -132,6 +132,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(problem_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME problem_test COMMAND $<TARGET_FILE:problem_test>)
 
+    add_executable(array_param_test array_param_test.cc)
+    target_link_libraries(array_param_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME array_param_test COMMAND $<TARGET_FILE:array_param_test>)
+
     add_executable(abs_test constraints/abs_test.cc)
     add_executable(all_different_test constraints/all_different_test.cc)
     add_executable(all_different_except_test constraints/all_different/all_different_except_test.cc)

--- a/gcs/array_param.hh
+++ b/gcs/array_param.hh
@@ -1,0 +1,79 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ARRAY_PARAM_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ARRAY_PARAM_HH
+
+#include <initializer_list>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief A constructor parameter holding array-like data a constraint will
+     * read, with caller-chosen ownership.
+     *
+     * The same handle accepts three forms, so a constraint needs only one
+     * parameter rather than a pointer plus a lifetime contract:
+     *   - **owned**: a container moved in (`{a, b, c}` or `std::move(vec)`),
+     *   - **shared**: a `std::shared_ptr<const C>` reused across constraints
+     *     without copying the data,
+     *   - **borrowed**: a raw `const C *` to storage the caller keeps alive.
+     *
+     * Access is pointer-like (`operator*` / `operator->`) and branch-free in
+     * every mode. Borrowing aliases an empty `shared_ptr`, which allocates no
+     * control block and takes no ownership -- so, exactly as with a raw pointer,
+     * the borrowed storage must outlive every use of this handle (and any copy
+     * of it, e.g. one captured by a propagator). Copying the handle is cheap (a
+     * `shared_ptr` copy), so clone() shares rather than duplicating the data.
+     *
+     * \ingroup Core
+     */
+    template <typename C_>
+    class ArrayParam
+    {
+    private:
+        std::shared_ptr<const C_> _data;
+
+    public:
+        ArrayParam(C_ owned) :
+            _data(std::make_shared<const C_>(std::move(owned)))
+        {
+        }
+
+        ArrayParam(std::initializer_list<typename C_::value_type> owned) :
+            _data(std::make_shared<const C_>(owned))
+        {
+        }
+
+        ArrayParam(std::shared_ptr<const C_> shared) :
+            _data(std::move(shared))
+        {
+        }
+
+        ArrayParam(const C_ * borrowed) :
+            _data(std::shared_ptr<const C_>{}, borrowed)
+        {
+        }
+
+        [[nodiscard]] auto operator*() const -> const C_ &
+        {
+            return *_data;
+        }
+
+        [[nodiscard]] auto operator->() const -> const C_ *
+        {
+            return _data.get();
+        }
+    };
+
+    /**
+     * \brief Convenience spelling of the common case, an ArrayParam over a
+     * `std::vector<T>` (e.g. `VectorArrayParam<IntegerVariableID>`).
+     *
+     * \ingroup Core
+     */
+    template <typename T_>
+    using VectorArrayParam = ArrayParam<std::vector<T_>>;
+}
+
+#endif

--- a/gcs/array_param_test.cc
+++ b/gcs/array_param_test.cc
@@ -1,0 +1,58 @@
+#include <gcs/array_param.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <vector>
+
+using namespace gcs;
+
+using std::make_shared;
+using std::shared_ptr;
+using std::vector;
+
+TEST_CASE("ArrayParam: owned construction moves data in")
+{
+    vector<int> v{1, 2, 3};
+    ArrayParam<vector<int>> a{std::move(v)};
+    CHECK(*a == vector<int>{1, 2, 3});
+    CHECK(a->size() == 3);
+}
+
+TEST_CASE("ArrayParam: initializer_list construction")
+{
+    ArrayParam<vector<int>> a{4, 5, 6};
+    CHECK(*a == vector<int>{4, 5, 6});
+}
+
+TEST_CASE("ArrayParam: shared construction reuses the same storage")
+{
+    auto shared = make_shared<const vector<int>>(vector<int>{7, 8});
+    ArrayParam<vector<int>> a{shared};
+    ArrayParam<vector<int>> b{shared};
+    // Both handles point at the one shared vector, with no copy.
+    CHECK(&*a == shared.get());
+    CHECK(&*b == shared.get());
+    CHECK(shared.use_count() == 3); // shared + a + b
+}
+
+TEST_CASE("ArrayParam: borrowed construction owns nothing")
+{
+    vector<int> external{9, 10, 11};
+    ArrayParam<vector<int>> a{&external};
+    // Aliases external storage directly; no copy, no ownership.
+    CHECK(&*a == &external);
+    CHECK(*a == vector<int>{9, 10, 11});
+}
+
+TEST_CASE("ArrayParam: copying a handle shares, and a copy outlives the original")
+{
+    ArrayParam<vector<int>> original{vector<int>{1, 2, 3}};
+    const vector<int> * data = &*original;
+    {
+        ArrayParam<vector<int>> copy = original;
+        CHECK(&*copy == data); // copy points at the same storage
+    }
+    // original still valid after the copy is gone.
+    CHECK(*original == vector<int>{1, 2, 3});
+}

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -72,11 +72,11 @@ namespace
 }
 
 template <typename EntryType_, unsigned dimensions_>
-NDimensionalElement<EntryType_, dimensions_>::NDimensionalElement(IntegerVariableID var, IndexVariables i, IndexStarts s, Array * a, bool b) :
+NDimensionalElement<EntryType_, dimensions_>::NDimensionalElement(IntegerVariableID var, IndexVariables i, IndexStarts s, Array a, bool b) :
     _result_var(var),
     _index_vars(move(i)),
     _index_starts(move(s)),
-    _array(a),
+    _array(move(a)),
     _bounds_only(b)
 {
     check_array_dimensions(*_array, _array->size());

--- a/gcs/constraints/element.hh
+++ b/gcs/constraints/element.hh
@@ -1,9 +1,11 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ELEMENT_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ELEMENT_HH
 
+#include <gcs/array_param.hh>
 #include <gcs/constraint.hh>
 #include <gcs/variable_id.hh>
 
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -30,7 +32,11 @@ namespace gcs
     class NDimensionalElement : public Constraint
     {
     public:
-        using Array = const innards::MakeNDVector<EntryType_, dimensions_>::Type;
+        using ArrayData = typename innards::MakeNDVector<EntryType_, dimensions_>::Type;
+        // The handle callers pass: an owned container, a shared_ptr<const ...> to
+        // reuse one array across constraints, or a borrowed pointer to storage
+        // the caller keeps alive (the latter matches the old `Array *` API).
+        using Array = ArrayParam<ArrayData>;
         using IndexVariables = std::vector<IntegerVariableID>;
         using IndexStarts = std::vector<Integer>;
 
@@ -38,7 +44,7 @@ namespace gcs
         IntegerVariableID _result_var;
         IndexVariables _index_vars;
         IndexStarts _index_starts;
-        Array * _array;
+        Array _array;
         bool _bounds_only;
         bool _array_has_nonconstants = false;
         bool _has_empty_dim = false;
@@ -49,7 +55,7 @@ namespace gcs
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     protected:
-        explicit NDimensionalElement(IntegerVariableID result_var, IndexVariables, IndexStarts, Array *, bool bounds_only);
+        explicit NDimensionalElement(IntegerVariableID result_var, IndexVariables, IndexStarts, Array, bool bounds_only);
 
     public:
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
@@ -60,13 +66,13 @@ namespace gcs
     class Element : public NDimensionalElement<IntegerVariableID, 1>
     {
     public:
-        explicit Element(IntegerVariableID var, IntegerVariableID zero_idx, Array * array, bool bounds_only = false) :
-            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, array, bounds_only)
+        explicit Element(IntegerVariableID var, IntegerVariableID zero_idx, Array array, bool bounds_only = false) :
+            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, std::move(array), bounds_only)
         {
         }
 
-        explicit Element(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array * array, bool bounds_only = false) :
-            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, array, bounds_only)
+        explicit Element(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array array, bool bounds_only = false) :
+            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, std::move(array), bounds_only)
         {
         }
     };
@@ -74,13 +80,13 @@ namespace gcs
     class Element2D : public NDimensionalElement<IntegerVariableID, 2>
     {
     public:
-        explicit Element2D(IntegerVariableID var, IntegerVariableID zero_idx_1, IntegerVariableID zero_idx_2, Array * array, bool bounds_only = false) :
-            NDimensionalElement(var, {{zero_idx_1, zero_idx_2}}, {{0_i, 0_i}}, array, bounds_only)
+        explicit Element2D(IntegerVariableID var, IntegerVariableID zero_idx_1, IntegerVariableID zero_idx_2, Array array, bool bounds_only = false) :
+            NDimensionalElement(var, {{zero_idx_1, zero_idx_2}}, {{0_i, 0_i}}, std::move(array), bounds_only)
         {
         }
 
-        explicit Element2D(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx1, std::pair<IntegerVariableID, Integer> idx2, Array * array, bool bounds_only = false) :
-            NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, array, bounds_only)
+        explicit Element2D(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx1, std::pair<IntegerVariableID, Integer> idx2, Array array, bool bounds_only = false) :
+            NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, std::move(array), bounds_only)
         {
         }
     };
@@ -88,13 +94,13 @@ namespace gcs
     class ElementConstantArray : public NDimensionalElement<Integer, 1>
     {
     public:
-        explicit ElementConstantArray(IntegerVariableID var, IntegerVariableID zero_idx, Array * array, bool bounds_only = true) :
-            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, array, bounds_only)
+        explicit ElementConstantArray(IntegerVariableID var, IntegerVariableID zero_idx, Array array, bool bounds_only = true) :
+            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, std::move(array), bounds_only)
         {
         }
 
-        explicit ElementConstantArray(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array * array, bool bounds_only = true) :
-            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, array, bounds_only)
+        explicit ElementConstantArray(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array array, bool bounds_only = true) :
+            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, std::move(array), bounds_only)
         {
         }
     };
@@ -102,13 +108,13 @@ namespace gcs
     class Element2DConstantArray : public NDimensionalElement<Integer, 2>
     {
     public:
-        explicit Element2DConstantArray(IntegerVariableID var, IntegerVariableID idx1, IntegerVariableID idx2, Array * array, bool bounds_only = true) :
-            NDimensionalElement(var, {{idx1, idx2}}, {{0_i, 0_i}}, array, bounds_only)
+        explicit Element2DConstantArray(IntegerVariableID var, IntegerVariableID idx1, IntegerVariableID idx2, Array array, bool bounds_only = true) :
+            NDimensionalElement(var, {{idx1, idx2}}, {{0_i, 0_i}}, std::move(array), bounds_only)
         {
         }
 
-        explicit Element2DConstantArray(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx1, std::pair<IntegerVariableID, Integer> idx2, Array * array, bool bounds_only = true) :
-            NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, array, bounds_only)
+        explicit Element2DConstantArray(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx1, std::pair<IntegerVariableID, Integer> idx2, Array array, bool bounds_only = true) :
+            NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, std::move(array), bounds_only)
         {
         }
     };

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -52,15 +52,9 @@ using fmt::println;
 namespace
 {
     template <typename T_>
-    auto depointinate(const std::shared_ptr<const T_> & t) -> const T_ &
+    auto depointinate(const ArrayParam<T_> & t) -> const T_ &
     {
         return *t;
-    }
-
-    template <typename T_>
-    auto depointinate(const T_ & t) -> const T_ &
-    {
-        return t;
     }
 
     auto tuple_entry_as_string(Integer i) -> string

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -87,15 +87,9 @@ namespace
     }
 
     template <typename T_>
-    auto depointinate(const std::shared_ptr<const T_> & t) -> const T_ &
+    auto depointinate(const ArrayParam<T_> & t) -> const T_ &
     {
         return *t;
-    }
-
-    template <typename T_>
-    auto depointinate(const T_ & t) -> const T_ &
-    {
-        return t;
     }
 
     auto tuple_entry_as_string(Integer i) -> string

--- a/gcs/extensional.hh
+++ b/gcs/extensional.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_EXTENSIONAL_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_EXTENSIONAL_HH
 
+#include <gcs/array_param.hh>
 #include <gcs/integer.hh>
 
 #include <memory>
@@ -83,8 +84,7 @@ namespace gcs
      * \sa gcs::Table
      * \ingroup Extensional
      */
-    using ExtensionalTuples = std::variant<SimpleTuples, SharedSimpleTuples,
-        WildcardTuples, SharedWildcardTuples>;
+    using ExtensionalTuples = std::variant<ArrayParam<SimpleTuples>, ArrayParam<WildcardTuples>>;
 }
 
 #endif

--- a/gcs/innards/extensional_utils.cc
+++ b/gcs/innards/extensional_utils.cc
@@ -48,7 +48,7 @@ namespace
     }
 
     template <typename T_>
-    auto get_tuple_value(const std::shared_ptr<const T_> & t, unsigned tuple_idx, unsigned entry)
+    auto get_tuple_value(const ArrayParam<T_> & t, unsigned tuple_idx, unsigned entry)
     {
         return get_tuple_value(*t, tuple_idx, entry);
     }


### PR DESCRIPTION
Constraints that take array-like data want three things at once: a convenient call site, the option to **reuse** one array across constraints without copying, and **no needless copies**. Today Element takes a raw `Array *` (borrow only, caller manages lifetime) and Table takes a 4-way `variant<{value, shared_ptr<const>} × {Simple, Wildcard}>`. Neither offers all three, and Element's raw pointer is a lifetime footgun (it's what forced the `Problem::keep_array` workaround on the scp-reader branch).

## `ArrayParam<C>`
One handle, three forms, chosen by the caller:
- **owned** — a container moved in (`{a, b, c}` or `std::move(vec)`)
- **shared** — a `std::shared_ptr<const C>` reused across constraints, no copy
- **borrowed** — a raw `const C *` to caller-owned storage (exactly the old `Array *`)

Access is pointer-like (`operator*`/`operator->`) and branch-free in every mode. Borrow uses the **aliasing `shared_ptr` constructor** from an empty `shared_ptr`, so it allocates no control block and takes no ownership — identical cost and lifetime contract to a raw pointer. Copying the handle is a `shared_ptr` copy, so `clone()` **shares** the data rather than deep-copying it (Table's variant used to deep-copy owned tuples on every clone).

## Element
`Array` becomes `ArrayParam<ArrayData>`. Every existing call site passes `&vec`, which binds the borrow ctor **unchanged** — no caller edits. The propagators capture the handle by value, so for owned/shared data the array is kept alive by refcount instead of relying on external storage.

## Table
`ExtensionalTuples` becomes `variant<ArrayParam<SimpleTuples>, ArrayParam<WildcardTuples>>` (two alternatives, was four). The per-file `depointinate` / `get_tuple_value` helpers collapse to a single `ArrayParam` overload. Construction sites pass an owned `SimpleTuples`/`WildcardTuples` or a `shared_ptr`, converting implicitly as before. No explicit variant-alternative access existed anywhere, so the consumption code (all `visit`-based) is otherwise untouched.

## Tests
New `array_param_test` covers own/share/borrow/initializer-list and share-on-copy. Full suite builds clean; table / element / extensional / smart_table / skyscraper tests pass (36/36 in the focused sweep).

Follow-up: rebase the scp-reader branch (#279) onto this and drop `Problem::keep_array` — the reader just constructs an owning `ArrayParam`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)