### PR TITLE
Range/interval literals (staged, WIP)

### DIFF
--- a/dev_docs/range_literals.md
+++ b/dev_docs/range_literals.md
@@ -257,3 +257,17 @@ reasons, inferences, AND branching (today reasons and branching use it; inferenc
   verification is manual per constraint. An earlier note that Element was "proven by the suite"
   was unsubstantiated until checked directly (it does pass: `element_test <mode> --prove` with
   `GCS_RANGE_INFERENCES=1`).
+- **Two refuted "more elaborate proof" attempts for AllEqual n≥3** (the OPB is a *line* of n-1
+  consecutive `vars[i]=vars[i+1]`, not a star):
+  1. **Full pairwise (n²/2) OPB instead of the line** — *does not help* (10/40 still fail). The
+     failing backtrack step (`i₂≤4 ⟹ i₃≤4`) is across an equality that is *already adjacent* in
+     the line; UP can't cross it, and adding the other pairs doesn't change that. Not a
+     connectivity problem.
+  2. **Bridge lemmas durable at `Top` (unconditional) instead of `Temporary`** — *necessary but
+     insufficient* (13/40 still fail). They fire and resolve flags (the trail gets much further),
+     and are RUP-derivable at `Top` for a direct equality, but the residual failures are raw
+     var-to-var bound propagations *not mediated by any flag* (the solver's backtrack clauses,
+     e.g. `i₂==5 ∨ i₃==3`).
+  The only thing that would close it is durably materialising the order-atom covering of the
+  equalities (`(vᵢ≥k) ⟺ (vⱼ≥k)`) — exactly the O(width) covering range literals exist to avoid.
+  So for a multi-hop chain, "coalesce the inference" and "keep the proof cheap" are in tension.

--- a/dev_docs/range_literals.md
+++ b/dev_docs/range_literals.md
@@ -7,14 +7,20 @@ off) pending productionisation — see "Stage 3" below for the key finding (inte
 across a bit-sum equality need an explicit bridge proof, not RUP). The bridge now lives in a
 reusable free helper `justify_not_in_range_across_equality`
 (`gcs/constraints/innards/justify_not_in_range.{hh,cc}`) and is wired into `enforce_equality`,
-so **`Equals` and `Element` (index-fixed) both verify it gate-on**. Attempting to extend it to
-**`AllEqual` surfaced an axis-1/axis-2 coupling**: the bridge *inference* is sound, but
-coalescing a multi-variable chain's per-value removals into one range flag breaks *backtrack-
-clause* reconstruction (n≥3 fails; n==2 works) — see "Generalising across the family" below.
-Branch `range-literals`, draft PR #281.
+so `Equals` and `Element` (index-fixed) verify it gate-on **in isolation**. **CORRECTED (and
+the headline): this does NOT compose.** A star of plain `Equals` over three transitively-linked
+variables — no `AllEqual` involved — breaks gate-on identically. So interval *inference* across
+a bit-sum equality is a **general** limitation of the equality family, not an `AllEqual` bug:
+the moment ≥3 variables share an equality class, the backtracking invariant needs a *bound*
+threaded across the equality, which unit propagation cannot do. The two-variable tests pass only
+because two variables in isolation never raise that obligation. The full thesis-grounded
+explanation (which thesis properties we preserve vs lose, and why) is in
+**[`range_literals_theory.md`](range_literals_theory.md)** — read that first. Branch
+`range-literals`, draft PR #281.
 
 This document is the authoritative current-state summary. The git history and PR have the
-blow-by-blow; this is the settled picture so we don't re-derive it.
+blow-by-blow; this is the settled picture so we don't re-derive it. For the *theory* of why the
+equality family breaks, see [`range_literals_theory.md`](range_literals_theory.md).
 
 ## What a range literal is
 
@@ -103,9 +109,9 @@ interval across a primary bit-sum equality.* These are:
 
 | Constraint | Link | Bridge status (gate-on) |
 |---|---|---|
-| `Equals` / `ReifiedEquals` | `v1−v2==0` (via `enforce_equality`) | **works, verified** (the canonical case) |
-| `Element` (index fixed) | `result−array_var==0` (via `enforce_equality`) | **works, verified** (var/const/const2d/var2d, 61 instances) — shares `enforce_equality` |
-| `AllEqual` | `vars[i]−vars[i+1]==0` chain (witness) | **n==2 works; n≥3 breaks** on the axis-2 wall below |
+| `Equals` / `ReifiedEquals` | `v1−v2==0` (via `enforce_equality`) | verifies gate-on **in isolation only** (2 vars); breaks once 3+ vars are transitively linked (see [`range_literals_theory.md`](range_literals_theory.md)) |
+| `Element` (index fixed) | `result−array_var==0` (via `enforce_equality`) | same — verifies in isolation (61 instances), composes no better than `Equals` |
+| `AllEqual` | star `vars[0]−vars[i]==0` (via `enforce_equality`) | breaks gate-on for ≥3 vars — but this is the **general** equality-family limitation, *not* `AllEqual`-specific (a star of plain `Equals` breaks identically) |
 | `Abs` | `v2∓v1==0` reified on sign | not yet wired; needs a sign case-split + (image direction) two-sided exclusion — `justify_abs_hole` is the per-value form |
 
 Everything else is fine: constraints that channel via **eq-atoms / selectors** (Table, Regular,
@@ -148,37 +154,41 @@ The two bound-lemmas are now a reusable free helper,
 layer rather than baking into `ProofLogger`. It takes `(pruned, lo, hi, other, other_lo,
 other_hi)` so a sign-flipped link passes `[-hi, -lo]` — ready for `Abs`.
 
-### Generalising across the family: where it holds, and the axis-2 wall
+### Why interval inference does not compose across the equality family
 
-The bridge lives in `enforce_equality`, so **`Equals` and `Element` (index-fixed) both inherit
-it** and both verify gate-on (`Element`: var/const/const2d/var2d, 61 proof instances). Note the
-constraint tests are registered with `run_test_only.bash` — they do **not** run VeriPB in
-`ctest` — so gate-on verification is done by hand per constraint (`<test> <mode> --prove` with
-`GCS_RANGE_INFERENCES=1`); the green 324/324 `ctest` run is the gate-**off** default.
+> The full, thesis-grounded version of this is **[`range_literals_theory.md`](range_literals_theory.md)**.
+> This is the short operational summary.
 
-Extending to **`AllEqual` does not just work**, and the reason is instructive. The bridge
-*inference* (axis 1) is sound: with the chain reduced to a single equality (n==2) it verifies
-(0/40 stress runs). But for **n≥3 it fails intermittently** (random domains; reproduced on
-`domains=[(1,5),(2,6),(3,7)]`). The failing line is **not** the inference — it is a later
-**backtrack clause** (`i₃==4 ∨ i₂==5`). Its RUP needs unit propagation to chain a bound across
-the chain equalities (here `i₂≤4 ⟹ i₃≤4` across `i₂−i₃==0`). VeriPB's UP does **not** cross a
-bit-sum equality for free; it only does so via explicit binary channelling clauses. The
-gate-off per-value path leaves enough of those clauses behind (each `vars[i] != v ← witness != v`
-survives at `Current`); coalescing N removals into **one** range-flag conclusion plus
-**`Temporary`** bridge lemmas (deleted on backtrack) removes exactly the channelling the
-backtrack reconstruction relied on. `Equals`/`Element`/n==2-`AllEqual` survive because the
-pruned↔witness link is a **single direct equality** in the OPB, always available to RUP; a
-multi-hop chain's link is not.
+The bridge lives in `enforce_equality`, so `Equals` and `Element` (index-fixed) inherit it and
+both verify gate-on **when posted in isolation** (`Element`: var/const/const2d/var2d, 61 proof
+instances). Note the constraint tests are registered with `run_test_only.bash` — they do **not**
+run VeriPB in `ctest` — so gate-on verification is by hand per constraint; the green 324/324
+`ctest` run is the gate-**off** default.
 
-**The criterion, refined.** The bridge generalises wherever the interval removal crosses a
-*single direct equality* to the witness. It does **not** generalise for free across a *multi-hop
-equality chain*, because the coalesced inference (axis 1) starves the backtrack/hole machinery
-(axis 2) of the per-value channelling it implicitly used. This **couples** the two axes that the
-"two independent axes" model (above) treats as separate: independence holds for plain RUP
-inferences, but coalescing an inference can change which clauses survive into axis-2
-reconstruction. Making AllEqual (n≥3) work would need that cross-chain channelling preserved
-durably (e.g. emit the needed bound-implication clauses at a surviving level, or fall back to
-per-value when the witness is non-adjacent) — left as future work, not a quick recipe.
+**That isolation is load-bearing, and it was a trap.** Earlier drafts of this section concluded
+the break was `AllEqual`-specific (a "multi-hop chain" vs "single direct equality" distinction).
+That is **wrong**, and the experiments that disproved it:
+
+- Reducing `AllEqual` to a star of single-edge `enforce_equality` calls (every inference one
+  direct equality, exactly the `Equals` case) — still breaks gate-on.
+- Posting a **star of plain `Equals` constraints** over three transitively-linked variables, with
+  no `AllEqual` anywhere — breaks gate-on identically (same rate, same instances).
+
+So the limitation is **general to the equality family**: as soon as ≥3 variables share an
+equality class (via `AllEqual`, a chain/star of `Equals`, or `Equals`+`Element`), the solver's
+**backtracking justification** needs unit propagation to thread a *bound* from one variable to
+another across a bit-sum equality (e.g. `i₃≥3 ⟹ i₂≥3`). Unit propagation across a bit-sum
+equality moves **values** (Thm 2.8, bit-pinning) and **contradictions** (Thm 2.7/2.9), but
+**never a lone bound** — there is no theorem for it. The per-value world never needs the step
+(every obligation is a single value → 2.8); a wide interval literal asserts only order atoms,
+never pins bits, so its obligation is a bound and the step is required and missing. Two variables
+in isolation never raise it, which is the *only* reason `Equals`/`Element` pass their tests.
+
+In thesis terms (see the theory doc): we **preserve** Theorem 3.3 (intra-variable completeness,
+extended to interval literals) but **lose** Inv2 / Theorem 3.4 (the backtracking-RUP invariant)
+for any constraint that channels across a bit-sum equality. Restoring it needs a cross-variable
+Inv1 — `(x≥k) ⇔ (y≥k)` logged per equality at the boundary values in play — i.e. a *covering*,
+the per-value work interval literals exist to avoid, now needed globally across the family.
 
 ### Proof-size: width-independent inference, win for *wide* intervals (with caveats)
 
@@ -201,15 +211,17 @@ larger constraint DB vs faster RUP — entirely unmeasured).
 
 ### What is left to productionise
 
-1. **Generalise the bridge.** *Done:* home decided (free helper
-   `justify_not_in_range_across_equality` in `constraints/innards/`), wired via
-   `enforce_equality`, so `Equals` and `Element` (index-fixed) verify gate-on. *Blocked:*
-   `AllEqual` n≥3 hits the axis-2 wall (see "Generalising across the family") — needs durable
-   cross-chain channelling or a per-value fallback for non-adjacent witnesses. *Not started:*
-   `Abs` — the helper is sign-flip-ready (pass `[-hi, -lo]`), but Abs needs (a) the v2→v1
-   direction conditioned on the sign reification (only one of `v2=v1` / `v2=-v1` holds per
-   branch, like `justify_abs_hole`), and (b) the v1→v2 image direction's *two-sided* exclusion
-   (`v2∈[lo,hi]` ⟹ `v1∈[lo,hi]∪[-hi,-lo]`, so two bridge applications across the two preimages).
+1. **The equality family does not compose — design decision required, not a code task.** The
+   bridge helper is built and wired (`Equals`/`Element` verify in isolation), but interval
+   inference across a bit-sum equality is **unsafe for the whole equality family** once ≥3
+   variables share an equality class (general, not `AllEqual`-specific — see
+   [`range_literals_theory.md`](range_literals_theory.md)). The only known fix is a cross-variable
+   Inv1 (`(x≥k) ⇔ (y≥k)` per equality at boundary values) — a covering applied globally to the
+   family, the cost interval literals were meant to avoid. Until that's decided, `Equals` /
+   `Element` / `AllEqual` should keep `GCS_RANGE_INFERENCES` **off**, and interval inference
+   should target only the **eq-atom/selector-channelled** family (Table, Regular, GCC, Count, …),
+   where every cross-variable obligation stays a single value (2.8) and the problem never arises.
+   (`Abs` was the would-be next equality-family member; it is moot until this is resolved.)
 2. **Views.** `infer_not_in_range`'s single-line path is simple-var only; generalise (deview
    the range, or fall back cleanly). Relates to Stage 6.
 3. **Cost policy (Stage 5).** A width threshold (cf. `min_run_to_coalesce` for reasons) to pick
@@ -246,12 +258,19 @@ reasons, inferences, AND branching (today reasons and branching use it; inferenc
   constraints). For the equality family, the single line needs the **explicit bridge** above.
   #144's "the proof is per-value" instinct was right for those constraints, but the proof can
   still be made width-independent (constant lines) with the bridge — just not pure RUP.
-- **CORRECTED:** "the bridge generalises to the whole equality family by sharing
-  `enforce_equality`." Only the **single-direct-equality** members do (Equals, Element-index-
-  fixed, n==2 AllEqual). `AllEqual` n≥3 breaks — not in the inference, but because coalescing
-  couples axis 1 and axis 2 (see "Generalising across the family"). Do not assume a constraint
-  with interval-removal-across-equality is bridge-ready without checking its *backtrack* clauses
-  gate-on, not just the inference.
+- **CORRECTED (twice — note the trajectory, it's a cautionary tale):** first we thought "the
+  bridge generalises to the whole equality family"; then, after `AllEqual` n≥3 broke, we thought
+  it was a *single-direct-equality vs multi-hop-chain* distinction (Equals/Element/n==2 fine,
+  longer chains not). **Both wrong.** A star of single-edge `Equals` calls breaks; a star of
+  *plain `Equals` constraints* with no `AllEqual` breaks identically. The real boundary is
+  **2 variables vs ≥3 in an equality class**, and it is a *general* property of interval
+  inference across a bit-sum equality, not a chain/witness/coalescing artifact. The earlier
+  "axis-2 coupling" / "multi-hop" framing was a wrong turn — the cause is that UP cannot thread
+  a bound across a bit-sum equality (Thms 2.7/2.8/2.9 give value-crossings and contradictions,
+  not bound propagation), so the backtracking invariant (Inv2 / Thm 3.4) cannot hold. See
+  [`range_literals_theory.md`](range_literals_theory.md). **Lesson:** an interval inference that
+  verifies for an isolated 2-variable constraint tells you *nothing* about composition; check ≥3
+  variables in one equality class.
 - **CORRECTED:** "the constraint suite (324/324) verifies the bridge." The constraint tests use
   `run_test_only.bash` (no VeriPB) and the suite default is gate-**off**; gate-on bridge
   verification is manual per constraint. An earlier note that Element was "proven by the suite"
@@ -268,6 +287,13 @@ reasons, inferences, AND branching (today reasons and branching use it; inferenc
      and are RUP-derivable at `Top` for a direct equality, but the residual failures are raw
      var-to-var bound propagations *not mediated by any flag* (the solver's backtrack clauses,
      e.g. `i₂==5 ∨ i₃==3`).
-  The only thing that would close it is durably materialising the order-atom covering of the
-  equalities (`(vᵢ≥k) ⟺ (vⱼ≥k)`) — exactly the O(width) covering range literals exist to avoid.
-  So for a multi-hop chain, "coalesce the inference" and "keep the proof cheap" are in tension.
+  3. **Star OPB + funnel every inference single-hop through the hub** (`AllEqual` rewritten as
+     n−1 single-edge `enforce_equality` calls, cost-neutral on the default path) — *does not help*
+     (9/40 still fail), and crucially it reduces `AllEqual` to *literally* the `Equals` code, so
+     it proved the inference justification was never the problem.
+  All three confirm the same thing the theory doc explains: it is not connectivity, not durability,
+  not how the inference is justified. UP cannot thread a bound across a bit-sum equality at all
+  (Thms 2.7/2.8/2.9 give value-crossings and contradictions, never a lone bound), so the
+  backtracking invariant cannot hold once ≥3 variables share an equality class. The only known fix
+  is the cross-variable covering `(vᵢ≥k) ⟺ (vⱼ≥k)` — applied across the whole equality family, not
+  just `AllEqual`.

--- a/dev_docs/range_literals.md
+++ b/dev_docs/range_literals.md
@@ -1,7 +1,11 @@
 # Range / interval literals — design and status
 
-Status: foundation **done and green**. The whole constraint test suite (225 tests) verifies
-under `reject_random_interval` branching. Branch `range-literals`, draft PR #281.
+Status: foundation **done and green** (reasons + `reject_random_interval` branching; full suite
+verifies). Stage-3 **`infer_not_in_range` primitives built and committed** (green, unused by
+default); the single-line range *inference* itself is behind `GCS_RANGE_INFERENCES` (default
+off) pending productionisation — see "Stage 3" below for the key finding (interval inferences
+across a bit-sum equality need an explicit bridge proof, not RUP). Branch `range-literals`,
+draft PR #281.
 
 This document is the authoritative current-state summary. The git history and PR have the
 blow-by-blow; this is the settled picture so we don't re-derive it.
@@ -58,28 +62,134 @@ keep them separate.
 - Proof tests: `invar_test`, `range_reason_test`, `range_branch_test`
   (`gcs/innards/proofs/`).
 
-## What is left (productionization, no unknowns)
+## Stage 3 — `infer_not_in_range` (issue #144): status and the key finding
 
-- **Stage 3 — `infer_not_in_range` / `infer_in_range` (issue #144).** A range removal is ONE
-  emitted proof line `~[lo,hi]` (the per-value `x != v` follow by RUP, free) — overturning
-  #144's "must emit per-value", which assumed an *unreified* range Boolean. Plan: add
-  `IntervalSet::erase_range`; `State::infer_not_in_range` (erase + emit one `~need_invar` step
-  via `emit_rup_proof_line_under_reason` — needs InferenceTracker support for a range-flag
-  inference, which is not a standard `Literal` infer); trivial `infer_in_range` (two bound
-  infers); apply at `equals.cc:65`, `min_max.cc:179`, `element.cc:477` (at equals the per-value
-  reason `(v2 != val)` coalesces to `~[v2 in lo..hi]`, a range-to-range inference); bench proof
-  size. Soundness in search relies on the containment from axis 2.
-- **Stage 6 — generality.** Fold ranges into `IntegerVariableCondition` / make them
-  user-facing, retiring the dev-time `BranchGuess`-only scope.
+**Built and committed (general, view-safe, green; unused by default):**
 
-## Dead ends — do NOT revisit
+- **`IntervalSet::erase_range(lo, hi)`** — closed-range removal in one merge-walk pass, with
+  unit tests. (`gcs/innards/interval_set.hh`, `interval_set_test.cc`.)
+- **`State::infer_not_in_range` + `change_state_for_not_in_range`** — view-aware single-pass
+  domain mutation, returns the right `Inference`. A genuine win on the **non-proof** solve
+  path (one `erase_range` instead of N `erase`s). (`state.hh/.cc`.)
+- **`InferenceTracker::infer_not_in_range` + `track_range_impl`** (both tracker classes) and
+  **`ProofLogger::infer_not_in_range`** — proof-side plumbing for a *range-flag* inference
+  (a `~need_invar` conclusion, not a standard `Literal` infer). Plain simple vars get the
+  single-line conclusion; views/constants fall back to per-value. (`inference_tracker.hh`,
+  `proof_logger.hh/.cc`.)
+
+### THE KEY FINDING: inferring an interval needs its *own* proof — RUP alone is not enough
+
+The Stage-3 plan above (now corrected) claimed a range removal is ONE proof line `~[lo,hi]`
+**by RUP**, the per-value `x != v` following free from the chain. **This is false for the
+constraints that actually do interval removals.** Empirically (VeriPB `--trace-failed`) and
+from McIlree's thesis:
+
+- A range flag `[X in lo..hi]` asserts only X's **order atoms** (`X>=lo ∧ ¬(X>=hi+1)`). With
+  `lo<hi`, **Theorem 2.8 never fires** (it pins bits only for `sum=A ∧ sum<=A`, a single
+  value), so a range assertion **never pins X's bits**.
+- Constraints that prune an interval do so *across a cross-variable link*. If that link is a
+  **bit-sum equality** `X−Y==0`, the range flag's order atoms can't cross it (UP can't do the
+  cross-variable linear step), so `~[X in lo..hi]` is **not RUP**. The per-value version works
+  only because asserting `X=v` (an *eq* atom) pins X's bits via Thm 2.8, which then channel to Y.
+
+**Audit of scope (who is affected).** The break is exactly: *constraints that prune an interior
+interval across a primary bit-sum equality.* These are:
+
+| Constraint | Link | Notes |
+|---|---|---|
+| `Equals` / `ReifiedEquals` | `v1−v2==0` (via `enforce_equality`) | the canonical case |
+| `Element` (index fixed) | `result−array_var==0` (via `enforce_equality`) | same helper |
+| `AllEqual` | `vars[i]−vars[i+1]==0` (witness) | each_interval_minus |
+| `Abs` | `v2∓v1==0` reified on sign | also needs a sign case-split; `justify_abs_hole` already does the per-value version |
+
+Everything else is fine: constraints that channel via **eq-atoms / selectors** (Table, Regular,
+GCC, Count, Among, In, Inverse, MinMax, AtMostOne, ValuePrecede, Circuit, AllDifferent) have
+reasons that *forward-propagate* `X≠v`, so their interval removals **are** RUP as a single line
+(consistent with thesis Justification Procedure 3.3). The bit-*arithmetic* constraints that
+can't channel cheaply (Linear, Comparison, Plus, …) are bounds-consistent and never do interior
+removals, so the question doesn't arise. (Note: `Abs` *does* do interior removal — earlier audit
+said otherwise and was wrong; ArgSort/SmartTable have bit-sum equalities but reified *behind
+selectors*, so they forward-propagate and are fine.)
+
+### The fix that works: an explicit bridge (case-split, each case RUP)
+
+RUP-as-a-single-*line* was the wrong bar. A short **explicit** justification collapses the
+interval into one conclusion, on the **unmodified** bit-sum model — no re-encoding. To remove
+`[lo,hi]` from `v1` because `v2` lacks it (`v1=v2`):
+
+```
+flag := [v1 in lo..hi]
+1)  ~flag ∨ (v2 ≥ lo)        # RUP: ¬ gives flag ∧ v2≤lo−1; with v1=v2 this is the
+2)  ~flag ∨ ¬(v2 ≥ hi+1)     #      Theorem 2.9 (contradictory binary sums) configuration
+⇒  ~flag                     # RUP from (1),(2) + the disjunctive reason ~[v2 in lo..hi]
+```
+
+The case-split is the point: the *disjunctive* reason never hands UP an opposing bound, but each
+lemma's negation does, triggering Thm 2.9. This is literally Justification Procedure 3.2
+(Comparison) materialising each bound across the equality; `justify_abs_hole` is the per-value
+sign-split form of the same idea. **Verified** end-to-end with VeriPB: full `equals_test` (plain
++ reified) passes with the bridge wired in.
+
+This is exercised behind an env flag, **`GCS_RANGE_INFERENCES` (default off)**, in `equals.cc`
+(simple vars only; views/constants stay per-value), with a dedicated proof test
+`range_infer_test`. Default behaviour is byte-identical to before.
+
+### Proof-size: width-independent inference, win for *wide* intervals (with caveats)
+
+The inference is 3 lines (2 lemmas + conclusion) regardless of interval width. Measured
+(VeriPB line counts, `Equals` with a hole):
+
+- narrow ranges (widths 1–7, `equals_test`): **1306 vs 1269** — slight *loss*.
+- one wide hole (width 21): **445 vs 582** — ~24% *win*.
+
+The catch is a per-flag fixed cost: `need_invar` emits the reification + **O(width) laminar
+containment edges** (the axis-2 backtrack machinery). So it's break-even for narrow intervals,
+a win for wide ones. **But** that fixed cost amortises: in the `equals_test` proof, 23 distinct
+range flags carry **932 references (~40× reuse each)** — mostly from `reject_random_interval`
+branching, which mints and reuses the same flags. So the realistic marginal cost of a range
+removal (reusing an existing flag) is ~3 lines vs O(width) per-value. The one-shot probe above
+is the un-amortised worst case. **Not yet measured:** a realistic instance with recurring *wide*
+removals; the effect of hoisting the bridge lemmas to `Top` (they are search-independent facts,
+so they would amortise too, dropping the marginal cost toward 1 line); and **verify time** (a
+larger constraint DB vs faster RUP — entirely unmeasured).
+
+### What is left to productionise
+
+1. **Generalise the bridge** to the rest of the family (`Element` index-fixed, `AllEqual`,
+   `Abs`+sign-split) and decide the home for it — a shared `enforce_equality` justification.
+2. **Views.** `infer_not_in_range`'s single-line path is simple-var only; generalise (deview
+   the range, or fall back cleanly). Relates to Stage 6.
+3. **Cost policy (Stage 5).** A width threshold (cf. `min_run_to_coalesce` for reasons) to pick
+   range-vs-per-value, since narrow ranges are break-even. Then the gate can come off.
+4. **Hoist the bridge lemmas to `Top`** so they amortise across reuse; measure proof-size AND
+   verify-time on a structured benchmark.
+5. **Reason side is also an interval.** The reason `v2 != lo..hi` is the symmetric half; the
+   Stage-2 `coalesce_holes_in_reason` already rewrites it to `~[v2 in lo..hi]` (gated by
+   `GCS_RANGE_REASONS`). Building it as a native range literal (no loop, no coalescing pass)
+   is the Stage-6 generality.
+6. **`infer_in_range`** (issue #144's companion) — two bound infers; deferred, no clean caller
+   after line drift. Add only when a real consumer appears.
+
+## Stage 6 — generality
+
+Fold ranges into `IntegerVariableCondition` / make them user-facing, retiring the dev-time
+`BranchGuess`-only scope. This is the unifying step: one range-literal abstraction shared by
+reasons, inferences, AND branching (today reasons and branching use it; inferences are the new
+`GCS_RANGE_INFERENCES` path).
+
+## Dead ends / corrected claims — do NOT revisit
 
 - "The order chain alone is enough, no covering needed." True only for axis 1. The hole/
-  backtrack axis genuinely needs containment; this was proven by `reject_random_interval`
-  failing on Count/among/element before containment was added.
+  backtrack axis genuinely needs containment; proven by `reject_random_interval` failing on
+  Count/among/element before containment was added.
 - For the branching wall, none of these is the fix: per-propagator explicit conflict
   justification; a bound-touching branching discipline; "it's a fundamental UP limitation".
   The fix is the containment edges (axis 2).
 - Covering edges *between range literals* (`parent -> OR children`) are unnecessary — the chain
   gives those deductions. Only *containment* (`child -> parent`) is needed, and only on axis 2.
-- The #144 overturn is delivered by the **reification + chain**, not by the containment.
+- **CORRECTED:** the old claim "a range *inference* is ONE line by RUP, overturning #144" is
+  **wrong** for the bit-sum-equality family (Equals/AllEqual/Abs/Element-index-fixed). RUP
+  suffices only when the constraint's link forward-propagates `X≠v` (eq-atom/selector channelled
+  constraints). For the equality family, the single line needs the **explicit bridge** above.
+  #144's "the proof is per-value" instinct was right for those constraints, but the proof can
+  still be made width-independent (constant lines) with the bridge — just not pure RUP.

--- a/dev_docs/range_literals.md
+++ b/dev_docs/range_literals.md
@@ -1,0 +1,85 @@
+# Range / interval literals — design and status
+
+Status: foundation **done and green**. The whole constraint test suite (225 tests) verifies
+under `reject_random_interval` branching. Branch `range-literals`, draft PR #281.
+
+This document is the authoritative current-state summary. The git history and PR have the
+blow-by-blow; this is the settled picture so we don't re-derive it.
+
+## What a range literal is
+
+A range ("in") literal `[x in a..b]` is a fresh proof-only `ProofFlag`, **reified to the
+variable's two order cuts**:
+
+    [x in a..b]  <=>  (x >= a) AND NOT (x >= b+1)
+
+It is a "wide equality literal" — an equality atom `x = v` is exactly the singleton `[v,v]`.
+Created lazily, in one place: `NamesAndIDsTracker::need_invar(id, lo, hi)`. All consumers
+(reasons, inferences, branching) go through it, so they all inherit its linking.
+
+## The two-axis model (the key idea)
+
+There are two independent linking needs. Conflating them is what caused several false starts;
+keep them separate.
+
+1. **Bound / inference axis — the order chain (Inv1) is sufficient. No covering.**
+   Every range<->range and range<->order *deduction*, and every *inference* of a range
+   literal (or of `x != v` from `~[lo,hi]`), is RUP from the boundary-EO reification + the
+   existing gevar order chain. This is because a `rup` check asserts the negation of its
+   conclusion, which hands UP a bound that walks the chain. `need_gevar` already maintains the
+   chain. Nothing extra is needed here.
+
+2. **Hole / backtrack axis — needs laminar containment.**
+   An interval *reject decision* `~[a,b]` (branching, or a removed-but-now-load-bearing hole)
+   has no conclusion to hand UP a bound, so the chain does **not** forward-propagate it. A
+   backtrack clause whose conflict is written over the `eq`/sub-range atoms inside `[a,b]` is
+   then not RUP. Fix: **laminar containment edges `child -> parent`** for every nested literal
+   — sub-ranges down to `eq` singletons at the leaves — so `~[a,b] -> ~child -> ... -> ~eq[v]`
+   propagates transitively. Each edge is itself RUP from the boundary-EO + chain, so emitted as
+   a `rup` line at `ProofLevel::Top`. Overlapping (non-nested) ranges need no edge; they
+   connect via shared leaves.
+
+## What is implemented
+
+- **`need_invar` + reification + containment** — `gcs/innards/proofs/names_and_ids_tracker.cc`.
+  Containment is maintained by `link_immediate_containment` (private), which emits only
+  immediate-parent/child (Hasse) edges; bidirectional with `need_direct_encoding_for` (a new
+  `eq` atom links to its containing ranges). Width-1 branch picks use the `eq` atom directly
+  (no singleton flag).
+- **Range literals in reasons** — `ProofLogger::reason_to_lits` and the other reason sites
+  coalesce a run of `var != v` into one `~need_invar` literal, env-gated by `GCS_RANGE_REASONS`
+  (off by default). `gcs/innards/proofs/proof_logger.cc`.
+- **Interval branching** — `BranchGuess = variant<Literal, IntegerVariableRangeGuess>`
+  (`gcs/branch_guess.hh`) threaded through the *guess channel only* (`State::guess/guesses`,
+  `solve.cc` recurse/backtrack, `Propagators::propagate`, `auto_table`). A range guess maps to
+  one `need_invar` flag in the backtrack clause. `value_order::reject_random_interval`.
+- **Test default** — `constraints_test_utils.hh` branches with `reject_random_interval`, so the
+  suite stress-tests this on every constraint.
+- Proof tests: `invar_test`, `range_reason_test`, `range_branch_test`
+  (`gcs/innards/proofs/`).
+
+## What is left (productionization, no unknowns)
+
+- **Stage 3 — `infer_not_in_range` / `infer_in_range` (issue #144).** A range removal is ONE
+  emitted proof line `~[lo,hi]` (the per-value `x != v` follow by RUP, free) — overturning
+  #144's "must emit per-value", which assumed an *unreified* range Boolean. Plan: add
+  `IntervalSet::erase_range`; `State::infer_not_in_range` (erase + emit one `~need_invar` step
+  via `emit_rup_proof_line_under_reason` — needs InferenceTracker support for a range-flag
+  inference, which is not a standard `Literal` infer); trivial `infer_in_range` (two bound
+  infers); apply at `equals.cc:65`, `min_max.cc:179`, `element.cc:477` (at equals the per-value
+  reason `(v2 != val)` coalesces to `~[v2 in lo..hi]`, a range-to-range inference); bench proof
+  size. Soundness in search relies on the containment from axis 2.
+- **Stage 6 — generality.** Fold ranges into `IntegerVariableCondition` / make them
+  user-facing, retiring the dev-time `BranchGuess`-only scope.
+
+## Dead ends — do NOT revisit
+
+- "The order chain alone is enough, no covering needed." True only for axis 1. The hole/
+  backtrack axis genuinely needs containment; this was proven by `reject_random_interval`
+  failing on Count/among/element before containment was added.
+- For the branching wall, none of these is the fix: per-propagator explicit conflict
+  justification; a bound-touching branching discipline; "it's a fundamental UP limitation".
+  The fix is the containment edges (axis 2).
+- Covering edges *between range literals* (`parent -> OR children`) are unnecessary — the chain
+  gives those deductions. Only *containment* (`child -> parent`) is needed, and only on axis 2.
+- The #144 overturn is delivered by the **reification + chain**, not by the containment.

--- a/dev_docs/range_literals.md
+++ b/dev_docs/range_literals.md
@@ -4,8 +4,14 @@ Status: foundation **done and green** (reasons + `reject_random_interval` branch
 verifies). Stage-3 **`infer_not_in_range` primitives built and committed** (green, unused by
 default); the single-line range *inference* itself is behind `GCS_RANGE_INFERENCES` (default
 off) pending productionisation — see "Stage 3" below for the key finding (interval inferences
-across a bit-sum equality need an explicit bridge proof, not RUP). Branch `range-literals`,
-draft PR #281.
+across a bit-sum equality need an explicit bridge proof, not RUP). The bridge now lives in a
+reusable free helper `justify_not_in_range_across_equality`
+(`gcs/constraints/innards/justify_not_in_range.{hh,cc}`) and is wired into `enforce_equality`,
+so **`Equals` and `Element` (index-fixed) both verify it gate-on**. Attempting to extend it to
+**`AllEqual` surfaced an axis-1/axis-2 coupling**: the bridge *inference* is sound, but
+coalescing a multi-variable chain's per-value removals into one range flag breaks *backtrack-
+clause* reconstruction (n≥3 fails; n==2 works) — see "Generalising across the family" below.
+Branch `range-literals`, draft PR #281.
 
 This document is the authoritative current-state summary. The git history and PR have the
 blow-by-blow; this is the settled picture so we don't re-derive it.
@@ -95,12 +101,12 @@ from McIlree's thesis:
 **Audit of scope (who is affected).** The break is exactly: *constraints that prune an interior
 interval across a primary bit-sum equality.* These are:
 
-| Constraint | Link | Notes |
+| Constraint | Link | Bridge status (gate-on) |
 |---|---|---|
-| `Equals` / `ReifiedEquals` | `v1−v2==0` (via `enforce_equality`) | the canonical case |
-| `Element` (index fixed) | `result−array_var==0` (via `enforce_equality`) | same helper |
-| `AllEqual` | `vars[i]−vars[i+1]==0` (witness) | each_interval_minus |
-| `Abs` | `v2∓v1==0` reified on sign | also needs a sign case-split; `justify_abs_hole` already does the per-value version |
+| `Equals` / `ReifiedEquals` | `v1−v2==0` (via `enforce_equality`) | **works, verified** (the canonical case) |
+| `Element` (index fixed) | `result−array_var==0` (via `enforce_equality`) | **works, verified** (var/const/const2d/var2d, 61 instances) — shares `enforce_equality` |
+| `AllEqual` | `vars[i]−vars[i+1]==0` chain (witness) | **n==2 works; n≥3 breaks** on the axis-2 wall below |
+| `Abs` | `v2∓v1==0` reified on sign | not yet wired; needs a sign case-split + (image direction) two-sided exclusion — `justify_abs_hole` is the per-value form |
 
 Everything else is fine: constraints that channel via **eq-atoms / selectors** (Table, Regular,
 GCC, Count, Among, In, Inverse, MinMax, AtMostOne, ValuePrecede, Circuit, AllDifferent) have
@@ -130,9 +136,49 @@ lemma's negation does, triggering Thm 2.9. This is literally Justification Proce
 sign-split form of the same idea. **Verified** end-to-end with VeriPB: full `equals_test` (plain
 + reified) passes with the bridge wired in.
 
-This is exercised behind an env flag, **`GCS_RANGE_INFERENCES` (default off)**, in `equals.cc`
-(simple vars only; views/constants stay per-value), with a dedicated proof test
-`range_infer_test`. Default behaviour is byte-identical to before.
+This is exercised behind an env flag, **`GCS_RANGE_INFERENCES` (default off)**, in
+`enforce_equality` (simple vars only; views/constants stay per-value), with a dedicated proof
+test `range_infer_test`. Default behaviour is byte-identical to before (the bridge lambda is
+only reached when the gate is on).
+
+The two bound-lemmas are now a reusable free helper,
+`gcs::innards::justify_not_in_range_across_equality`
+(`gcs/constraints/innards/justify_not_in_range.{hh,cc}`): `ProofLogger &` first, matching the
+`abs/justify`, `linear/justify`, … convention, so it travels with the scoopable proof-pattern
+layer rather than baking into `ProofLogger`. It takes `(pruned, lo, hi, other, other_lo,
+other_hi)` so a sign-flipped link passes `[-hi, -lo]` — ready for `Abs`.
+
+### Generalising across the family: where it holds, and the axis-2 wall
+
+The bridge lives in `enforce_equality`, so **`Equals` and `Element` (index-fixed) both inherit
+it** and both verify gate-on (`Element`: var/const/const2d/var2d, 61 proof instances). Note the
+constraint tests are registered with `run_test_only.bash` — they do **not** run VeriPB in
+`ctest` — so gate-on verification is done by hand per constraint (`<test> <mode> --prove` with
+`GCS_RANGE_INFERENCES=1`); the green 324/324 `ctest` run is the gate-**off** default.
+
+Extending to **`AllEqual` does not just work**, and the reason is instructive. The bridge
+*inference* (axis 1) is sound: with the chain reduced to a single equality (n==2) it verifies
+(0/40 stress runs). But for **n≥3 it fails intermittently** (random domains; reproduced on
+`domains=[(1,5),(2,6),(3,7)]`). The failing line is **not** the inference — it is a later
+**backtrack clause** (`i₃==4 ∨ i₂==5`). Its RUP needs unit propagation to chain a bound across
+the chain equalities (here `i₂≤4 ⟹ i₃≤4` across `i₂−i₃==0`). VeriPB's UP does **not** cross a
+bit-sum equality for free; it only does so via explicit binary channelling clauses. The
+gate-off per-value path leaves enough of those clauses behind (each `vars[i] != v ← witness != v`
+survives at `Current`); coalescing N removals into **one** range-flag conclusion plus
+**`Temporary`** bridge lemmas (deleted on backtrack) removes exactly the channelling the
+backtrack reconstruction relied on. `Equals`/`Element`/n==2-`AllEqual` survive because the
+pruned↔witness link is a **single direct equality** in the OPB, always available to RUP; a
+multi-hop chain's link is not.
+
+**The criterion, refined.** The bridge generalises wherever the interval removal crosses a
+*single direct equality* to the witness. It does **not** generalise for free across a *multi-hop
+equality chain*, because the coalesced inference (axis 1) starves the backtrack/hole machinery
+(axis 2) of the per-value channelling it implicitly used. This **couples** the two axes that the
+"two independent axes" model (above) treats as separate: independence holds for plain RUP
+inferences, but coalescing an inference can change which clauses survive into axis-2
+reconstruction. Making AllEqual (n≥3) work would need that cross-chain channelling preserved
+durably (e.g. emit the needed bound-implication clauses at a surviving level, or fall back to
+per-value when the witness is non-adjacent) — left as future work, not a quick recipe.
 
 ### Proof-size: width-independent inference, win for *wide* intervals (with caveats)
 
@@ -155,8 +201,15 @@ larger constraint DB vs faster RUP — entirely unmeasured).
 
 ### What is left to productionise
 
-1. **Generalise the bridge** to the rest of the family (`Element` index-fixed, `AllEqual`,
-   `Abs`+sign-split) and decide the home for it — a shared `enforce_equality` justification.
+1. **Generalise the bridge.** *Done:* home decided (free helper
+   `justify_not_in_range_across_equality` in `constraints/innards/`), wired via
+   `enforce_equality`, so `Equals` and `Element` (index-fixed) verify gate-on. *Blocked:*
+   `AllEqual` n≥3 hits the axis-2 wall (see "Generalising across the family") — needs durable
+   cross-chain channelling or a per-value fallback for non-adjacent witnesses. *Not started:*
+   `Abs` — the helper is sign-flip-ready (pass `[-hi, -lo]`), but Abs needs (a) the v2→v1
+   direction conditioned on the sign reification (only one of `v2=v1` / `v2=-v1` holds per
+   branch, like `justify_abs_hole`), and (b) the v1→v2 image direction's *two-sided* exclusion
+   (`v2∈[lo,hi]` ⟹ `v1∈[lo,hi]∪[-hi,-lo]`, so two bridge applications across the two preimages).
 2. **Views.** `infer_not_in_range`'s single-line path is simple-var only; generalise (deview
    the range, or fall back cleanly). Relates to Stage 6.
 3. **Cost policy (Stage 5).** A width threshold (cf. `min_run_to_coalesce` for reasons) to pick
@@ -193,3 +246,14 @@ reasons, inferences, AND branching (today reasons and branching use it; inferenc
   constraints). For the equality family, the single line needs the **explicit bridge** above.
   #144's "the proof is per-value" instinct was right for those constraints, but the proof can
   still be made width-independent (constant lines) with the bridge — just not pure RUP.
+- **CORRECTED:** "the bridge generalises to the whole equality family by sharing
+  `enforce_equality`." Only the **single-direct-equality** members do (Equals, Element-index-
+  fixed, n==2 AllEqual). `AllEqual` n≥3 breaks — not in the inference, but because coalescing
+  couples axis 1 and axis 2 (see "Generalising across the family"). Do not assume a constraint
+  with interval-removal-across-equality is bridge-ready without checking its *backtrack* clauses
+  gate-on, not just the inference.
+- **CORRECTED:** "the constraint suite (324/324) verifies the bridge." The constraint tests use
+  `run_test_only.bash` (no VeriPB) and the suite default is gate-**off**; gate-on bridge
+  verification is manual per constraint. An earlier note that Element was "proven by the suite"
+  was unsubstantiated until checked directly (it does pass: `element_test <mode> --prove` with
+  `GCS_RANGE_INFERENCES=1`).

--- a/dev_docs/range_literals_theory.md
+++ b/dev_docs/range_literals_theory.md
@@ -1,0 +1,223 @@
+# Interval ("in") literals and the proof framework: what we preserve and what we lose
+
+**Audience.** This is written for someone who knows McIlree's thesis — the binary
+encoding `BinEnc(X)`, atomic literals `x≥v` / `x=v` and their definition constraints
+(3.23)–(3.26), the intra-variable invariant **Inv1** and Theorems **3.2**/**3.3**, the
+cross-variable Theorems **2.7**/**2.8**/**2.9**, and the backtracking invariants
+**Inv2**/**Inv3** with **Theorem 3.4** — but *not* the range-literal work built on top of
+it. It explains (1) the extra object we added to the encoding, (2) which thesis properties
+that object preserves, (3) the one it does not, and (4) why that single gap breaks interval
+*inference* for `Equals`, and hence for `Element` and `AllEqual`, while leaving reasons and
+branching untouched.
+
+The short version: **we preserve everything *intra-variable* — Theorem 3.3 generalises
+cleanly to interval literals — but the framework's *cross-variable* propagation is governed
+entirely by Theorems 2.7/2.8/2.9, and those give us value-crossings and two-bound
+contradictions, never one-sided bound propagation. The per-value world never needs that
+missing step; interval literals do, and so they cannot keep the backtracking invariant
+(Inv2 / Theorem 3.4) for a constraint that prunes across a bit-sum equality.**
+
+---
+
+## 1. Recap of the machinery we build on
+
+Two layers of the thesis matter here.
+
+**Intra-variable (one CP variable's atoms).** For a single variable `X`, the order atoms
+`x≥v` form a chain maintained by **Inv1** (Corollary 3.1: `x≥v ⇒ x≥w` is RUP for `v ≥ w`).
+Given Inv1, Theorem **3.3** ("complete propagation of implied atomic literals") says: for any
+restriction `R` of `X`'s atoms, if `F↾R` does not unit-propagate to contradiction, then *every*
+literal in `ImpLits(dom_R(X))` propagates by UP or is already in `R`. Theorem **3.2** is the
+companion: if `dom_R(X) = ∅`, `F↾R` unit-propagates to contradiction. Both are statements
+about **one variable in isolation**; the eq atom `x=v` is the special case where `dom_R(X)`
+is the singleton `{v}`.
+
+**Cross-variable (between two binary sums).** Everything that crosses from one variable to
+another goes through exactly three theorems:
+
+- **2.7** — *contradictory bounds on one binary sum* (`Σ2ⁱℓᵢ ≥ A` and `Σ2ⁱℓᵢ ≤ B`, `A > B`)
+  unit-propagate to contradiction.
+- **2.8** — *equality of a binary sum to a single value* (`Σ2ⁱℓᵢ ≥ A` and `Σ2ⁱℓᵢ ≤ A`)
+  unit-propagates to a **fixed assignment of all the bits** with `Σ2ⁱρ(ℓᵢ) = A`. This is
+  bit-pinning: knowing the value pins every bit.
+- **2.9** — a *contradictory cross-variable configuration* of two binary sums
+  unit-propagates to contradiction.
+
+A constraint justifies a propagation by combining intra-variable 3.3 on each variable with
+its own cross-variable channelling. For an **equality** `X = Y` encoded as the bit-sum
+`BinEnc(X) − BinEnc(Y) == 0`, the *only* cross-variable channelling available is 2.8 (a value
+crosses) and 2.7/2.9 (a contradiction crosses). The thesis is explicit (Example 2.14, "Generalised
+versions of Theorem 2.9 do not always hold") that this is the frontier — there is no general
+rule for propagating an arbitrary linear fact across a binary-sum equality.
+
+**Backtracking.** Whenever the solver backtracks it logs a *backtracking justification*
+`Bt := Σ dᵢ ≥ 1` (3.40), the negation of the decisions on the current path. For these to be
+checkable they must be RUP, and the thesis guarantees this via **Inv2/Inv3** and **Theorem
+3.4**, summarised by the Gocht invariant the thesis quotes:
+
+> *any variable-value deletion that is known to the CP solver … must be visible to the proof
+> verifier either through unit propagation, or through reverse unit propagation of the
+> backtrack clause.*
+
+Concretely (Inv2): if the solver reached a conflict, `Ft ∪ {¬Bt}` must unit-propagate to
+contradiction. This is the load-bearing requirement below.
+
+---
+
+## 2. The new object: interval ("in") literals
+
+We add one kind of literal. An **interval literal** `[x in a..b]` is a fresh proof variable,
+**reified to the variable's two boundary cuts** ("boundary-EO"):
+
+    [x in a..b]  ⇔  (x≥a) ∧ ¬(x≥b+1)
+
+with both directions logged as definition constraints, exactly analogous to (3.23)–(3.26) for
+`x≥v` and `x=v`. It is a **generalised equality atom**: the eq atom `x=v` is precisely the
+singleton `[x in v..v]`, whose boundary cuts are `(x≥v) ∧ ¬(x≥v+1)`.
+
+We also maintain a **laminar containment** invariant between interval literals on the same
+variable — for nested intervals (down to the eq atoms at the leaves), `child ⇒ parent` is
+logged by RUP. This is the inter-literal analogue of Inv1: it lets a restriction that forces
+`x` into a sub-interval propagate up to the containing intervals, and lets the negation of an
+interval propagate down to the eq atoms it covers.
+
+That is the entire addition: a wider class of "implied atomic literals" for each variable,
+reified onto the existing order atoms, with an Inv1-style chain to keep them linked.
+
+---
+
+## 3. What is preserved — everything intra-variable
+
+Because an interval literal is reified onto order atoms and linked by containment, it is a
+genuine **implied atomic literal in the sense of Theorem 3.3**, and that theorem generalises
+without change:
+
+- **Inv1, Corollary 3.1, Lemma 3.2, Lemma 3.3, Theorem 3.2** are untouched — they are
+  statements about the order atoms `x≥v`, which interval literals only reify, never alter.
+- **Theorem 3.3 extends to interval literals.** With boundary-EO and containment maintained
+  as invariants (the way Inv1 is maintained for the order chain), for a single variable `X`
+  and any restriction `R` (which may now mention interval literals), every implied atomic
+  literal — *including* the implied interval literals — propagates by UP or conflicts. The
+  forward direction `(x≥a) ∧ ¬(x≥b+1) ⇒ [x in a..b]` and the reverse
+  `[x in a..b] ⇒ (x≥a) ∧ ¬(x≥b+1)` are exactly the Def⇐/Def⇒ pair, and containment supplies
+  the nesting.
+
+This preserved property is precisely why the parts of the system that live **on one variable
+at a time** all verify:
+
+- **Reasons** — coalescing a run of `x ≠ v` in a reason into a single `¬[x in lo..hi]` is sound
+  and RUP because it is an intra-variable restatement (Theorem 3.3 on `x`).
+- **Interval branching** — a decision/`reject` of `[x in a..b]` and the backtrack clause over it
+  are intra-variable; the containment chain gives the needed propagation (this is the
+  hole/backtrack "axis" of the design, fixed by containment).
+- **Single-variable inference of an interval literal** is RUP for the same reason.
+
+Nothing in §§1–3 is in question.
+
+---
+
+## 4. What is **not** preserved — cross-variable bound propagation
+
+The gap is entirely cross-variable, and it is a gap that *already exists* in the thesis
+framework — interval literals merely stop us from dodging it.
+
+Across a bit-sum equality `X = Y`, the thesis gives us:
+
+| have | theorem | what crosses |
+|---|---|---|
+| `X = v` (a single value) | 2.8 | the value: `Y`'s bits get pinned to `v` |
+| `X ≥ v` **and** `Y ≤ v−1` (two opposing bounds) | 2.7 / 2.9 | a *contradiction* |
+
+What we do **not** have is the forward step:
+
+> from `X ≥ k` alone, derive `Y ≥ k`.
+
+This is not an oversight to be patched — there is no theorem for it, and (Example 2.14) the
+obvious generalisation of 2.9 is false. A single bound `X ≥ k` does **not** pin `X`'s bits
+(2.8 needs a value, not a bound), so the equality constraint has nothing to propagate from;
+2.7/2.9 only fire once the *opposing* bound is also present, and then only to produce `0 ≥ 1`.
+Unit propagation across a binary-sum equality moves **values and contradictions, never a lone
+bound.**
+
+The per-value world never has to make that move. Every cross-variable obligation it raises is
+of the form `X = v` or `X ≠ v` — a single value — and so it is always a 2.8 crossing. **An
+interval literal `[x in a..b]` with `a < b` asserts only the order atoms `x≥a`, `¬x≥b+1`; it
+never pins bits** (2.8 fires only when `a = b`). So the instant a cross-variable obligation has
+to pass through a wide interval literal, it becomes a *bound* obligation, the missing forward
+step is required, UP stalls, and the obligation is not visible to the verifier.
+
+In thesis terms: **interval literals preserve Theorem 3.3 but cannot preserve Inv2 (Theorem
+3.4) for a constraint that channels across a bit-sum equality**, because Inv2 demands that the
+solver's deletions be reconstructible by UP under `¬Bt`, and reconstructing a bound across the
+equality is exactly the step 2.7/2.8/2.9 do not provide.
+
+---
+
+## 5. Why this breaks Equals — and hence Element and AllEqual
+
+Take `Equals(X, Y)`, encoded as `BinEnc(X) − BinEnc(Y) == 0`. Its propagator removes from `X`
+any value `Y` lacks. There are two distinct proof obligations, and only the first is fine.
+
+**(a) The forward inference is fine.** Removing the interval `[lo,hi]` from `X` because `Y`
+lacks it is logged with an explicit *bridge*: two bound-lemmas
+`¬[x in lo..hi] ∨ (y ≥ lo)` and `¬[x in lo..hi] ∨ ¬(y ≥ hi+1)`, each RUP because its negation
+supplies *both* opposing bounds and so triggers 2.9, followed by the conclusion
+`¬[x in lo..hi]` by RUP. This is just Justification Procedure 3.2 (Comparison) materialising
+each bound as a 2.9 contradiction. It verifies. The single-line interval inference is real.
+
+**(b) The backtracking obligation is not.** The framework (Theorem 3.4 / Inv2) requires that at
+every backtrack, `Ft ∪ {¬Bt}` unit-propagate to contradiction — every deletion the solver used
+to reach the conflict must be visible under `¬Bt`. Whether this holds depends on whether those
+deletions are *values* (2.8-visible) or *bounds* (need the missing forward step):
+
+- With **two variables in isolation**, a conflict is reached by pinning or excluding values on
+  `X` and `Y`; every obligation is a value, 2.8 carries it across the single equality, Inv2
+  holds. This is why `equals_test` and `element_test` pass gate-on — they only ever post a
+  single equality over two variables.
+
+- With **three or more variables in one equality class** — `AllEqual`, a chain/star of `Equals`,
+  or `Equals` composed with `Element` — the backtrack clauses range over several variables, and
+  reconstructing the conflict requires a **bound to be threaded from one variable to another
+  through a shared variable** (empirically: "`i₃ ≥ 3`, therefore `i₂ ≥ 3`" across `i₃ = hub = i₂`).
+  In the per-value world this still decomposes into value-crossings (2.8) and Inv2 holds; once an
+  interval literal is in play the obligation is a bound, the forward step has no theorem, UP
+  stalls, `Ft ∪ {¬Bt}` does not reach contradiction, Inv2 fails, and the backtrack clause is not
+  RUP. VeriPB rejects it.
+
+So the failure is **not** specific to `AllEqual` and **not** a defect in any propagator's
+justification. It is a property of the encoding: interval literals are order-atom-only, hence
+2.8-invisible, and the moment three variables share a bit-sum equality the backtracking
+invariant needs the one cross-variable step the framework does not have. `Element`
+(index-fixed: `result − array_var == 0`) and `AllEqual` (a class of equalities) "do similar
+things" to `Equals` and inherit the same fate. The two-variable tests give false confidence:
+the property holds *in isolation* and is lost *under composition*.
+
+---
+
+## 6. Summary
+
+| Property (thesis) | Status with interval literals | Why |
+|---|---|---|
+| Inv1, Cor 3.1, Lemma 3.2/3.3, Thm 3.2 | **preserved** | unchanged statements about order atoms |
+| Thm 3.3 (intra-variable completeness) | **preserved, extended** | interval literals are implied atomic literals via boundary-EO + containment |
+| 2.8 value-crossing of an equality | **preserved for eq atoms** | singletons `[x in v..v]` still pin bits |
+| 2.8 crossing for a *wide* interval | **n/a — never held** | `[x in a..b]`, `a<b`, asserts bounds only; no bit-pinning |
+| forward bound propagation across `X=Y` | **never held; now needed** | not implied by 2.7/2.8/2.9 (cf. Example 2.14) |
+| Inv2 / Thm 3.4 backtracking-RUP, equality family, ≥3 vars | **lost** | conflict reconstruction needs the missing forward step |
+| Inv2 / Thm 3.4, eq-atom/selector-channelled constraints | **preserved** | their channelling delivers per-value (2.8-visible) literals for 3.3 to reassemble |
+
+**Consequence.** Interval *inference* is sound to enable only where every cross-variable
+obligation stays a single value — i.e. for constraints whose channelling is per-value
+(eq-atom / selector channelled: Table, Regular, GCC, Count, …), where Theorem 3.3 reassembles
+the per-value literals and no bound is ever threaded across a bit-sum equality. For the
+**equality family** (`Equals` / `Element` / `AllEqual`, all built on `BinEnc(X) − BinEnc(Y) ==
+0`), interval removals do **not** compose past two variables, because the backtracking invariant
+requires forward bound propagation across the equality and the framework provides only
+value-crossing (2.8) and contradiction (2.7/2.9). Interval **reasons** and interval **branching**
+are unaffected — they are intra-variable, and §3 covers them.
+
+Restoring the equality family would mean supplying the missing cross-variable step explicitly:
+a cross-variable analogue of Inv1, `(x≥k) ⇔ (y≥k)` logged for every equality at the boundary
+values in play. That is a "covering" — exactly the per-value work interval literals were
+introduced to avoid — now required globally across the equality family rather than locally.
+Whether that trade is worth making is a design decision, not a bug fix.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -371,6 +371,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(reification_test PRIVATE glasgow_constraint_solver)
     add_test(NAME reification_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:reification_test>)
 
+    add_executable(invar_test innards/proofs/invar_test.cc)
+    target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME invar_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)
+
     add_executable(interval_set_test innards/interval_set_test.cc)
     target_link_libraries(interval_set_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME interval_set_test COMMAND $<TARGET_FILE:interval_set_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(glasgow_constraint_solver
         constraints/global_cardinality/justify.cc
         constraints/in.cc
         constraints/increasing.cc
+        constraints/innards/justify_not_in_range.cc
         constraints/innards/recover_am1.cc
         constraints/innards/reified_state.cc
         constraints/innards/triggers.cc

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -375,6 +375,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
     add_test(NAME invar_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)
 
+    add_executable(range_reason_test innards/proofs/range_reason_test.cc)
+    target_link_libraries(range_reason_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME range_reason_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_reason_test>)
+
     add_executable(interval_set_test innards/interval_set_test.cc)
     target_link_libraries(interval_set_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME interval_set_test COMMAND $<TARGET_FILE:interval_set_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -383,6 +383,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
     add_test(NAME range_branch_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)
 
+    add_executable(range_infer_test innards/proofs/range_infer_test.cc)
+    target_link_libraries(range_infer_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME range_infer_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_infer_test>)
+
     add_executable(interval_set_test innards/interval_set_test.cc)
     target_link_libraries(interval_set_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME interval_set_test COMMAND $<TARGET_FILE:interval_set_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -379,6 +379,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(range_reason_test PRIVATE glasgow_constraint_solver)
     add_test(NAME range_reason_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_reason_test>)
 
+    add_executable(range_branch_test innards/proofs/range_branch_test.cc)
+    target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME range_branch_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)
+
     add_executable(interval_set_test innards/interval_set_test.cc)
     target_link_libraries(interval_set_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME interval_set_test COMMAND $<TARGET_FILE:interval_set_test>)

--- a/gcs/branch_guess.hh
+++ b/gcs/branch_guess.hh
@@ -1,0 +1,59 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_BRANCH_GUESS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_BRANCH_GUESS_HH
+
+#include <gcs/innards/literal.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_condition.hh>
+#include <gcs/variable_id.hh>
+
+#include <variant>
+
+namespace gcs
+{
+    /**
+     * \brief A branching decision to accept or reject a contiguous interval of a
+     * variable's domain.
+     *
+     * `within == true` means "branch var into [lower, upper]"; `within == false`
+     * means "branch var out of [lower, upper]" (a genuine disjunctive decision for
+     * an interior interval). Kept distinct from Literal so range branching stays out
+     * of the general literal-handling code; on the proof side it maps to a single
+     * range ("in") literal via NamesAndIDsTracker::need_invar.
+     *
+     * \ingroup SearchHeuristics
+     */
+    struct IntegerVariableRangeGuess final
+    {
+        SimpleIntegerVariableID var;
+        Integer lower;
+        Integer upper;
+        bool within;
+
+        [[nodiscard]] auto operator<=>(const IntegerVariableRangeGuess &) const = default;
+    };
+
+    [[nodiscard]] inline auto operator!(const IntegerVariableRangeGuess & g) -> IntegerVariableRangeGuess
+    {
+        return IntegerVariableRangeGuess{g.var, g.lower, g.upper, ! g.within};
+    }
+
+    /**
+     * \brief A single branching decision: either an ordinary Literal (a variable
+     * condition such as equals / not-equals / bound, or true/false) or an interval
+     * accept/reject.
+     *
+     * A Literal (and hence an IntegerVariableCondition) converts to a BranchGuess
+     * implicitly, so existing value-ordering heuristics that `co_yield var == v` keep
+     * working unchanged.
+     *
+     * \ingroup SearchHeuristics
+     */
+    using BranchGuess = std::variant<innards::Literal, IntegerVariableRangeGuess>;
+
+    [[nodiscard]] inline auto operator!(const BranchGuess & g) -> BranchGuess
+    {
+        return std::visit([](const auto & x) -> BranchGuess { return ! x; }, g);
+    }
+}
+
+#endif

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -9,7 +9,9 @@
 
 #include <util/overloaded.hh>
 
+#include <cstdlib>
 #include <sstream>
+#include <variant>
 #include <vector>
 
 #include <version>
@@ -57,20 +59,56 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
         // Symmetric difference: remove from each side anything not present in
         // the other. Materialise both domains once and walk via merge —
         // O(intervals(v1) + intervals(v2) + |output|) instead of the
-        // O(|domain| × intervals(other)) per-value membership scan. The
-        // per-value loop inside the yielded interval still fires one
-        // infer_not_equal per value (same as before); a future
-        // infer_not_in_interval primitive could collapse it further.
+        // O(|domain| × intervals(other)) per-value membership scan.
         auto v1_set = state.copy_of_values(v1);
         auto v2_set = state.copy_of_values(v2);
 
-        for (auto [lo, hi] : v1_set.each_interval_minus(v2_set))
-            for (Integer val = lo; val <= hi; ++val)
-                inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 != val); return reason; }});
+        // Stage-3 experiment, off by default (GCS_RANGE_INFERENCES). Default path is
+        // the per-value loop: one infer_not_equal per removed value, each RUP.
+        //
+        // When enabled, collapse each contiguous removed interval into ONE
+        // ~[pruned in lo..hi] proof line. RUP alone cannot do this across the bit-sum
+        // equality v1=v2 (a range flag pins only the variable's order atoms, never its
+        // bits, so it can't cross the equality), so we first emit two bound-lemmas
+        // [pruned in lo..hi] -> other>=lo and -> other<=hi. Each lemma IS RUP: its
+        // negation supplies an opposing bound that, together with the equality, is the
+        // Theorem 2.9 (contradictory binary sums) configuration -- this is exactly
+        // Justification Procedure 3.2 (Comparison) materialising a bound across the
+        // equality. The conclusion ~[pruned in lo..hi] then follows by RUP from the two
+        // lemmas plus the (disjunctive) reason. The inference is width-independent (two
+        // lemmas + one conclusion regardless of |lo..hi|); see dev_docs/range_literals.md
+        // for the proof-size characterisation. Range literals exist only for plain
+        // integer variables, so views/constants always take the per-value path.
+        static const bool range_inferences = std::getenv("GCS_RANGE_INFERENCES") != nullptr;
+        auto both_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v1}) &&
+            std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v2});
+        auto use_range = range_inferences && logger != nullptr && both_simple;
 
-        for (auto [lo, hi] : v2_set.each_interval_minus(v1_set))
-            for (Integer val = lo; val <= hi; ++val)
-                inference.infer_not_equal(logger, v2, val, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 != val); return reason; }});
+        auto bridge = [logger](const auto & pruned, const auto & other, Integer lo, Integer hi, const ReasonFunction & r) {
+            auto flag = logger->names_and_ids_tracker().need_invar(std::get<SimpleIntegerVariableID>(IntegerVariableID{pruned}), lo, hi);
+            logger->emit_rup_proof_line_under_reason(r, WPBSum{} + 1_i * ! flag + 1_i * (other >= lo) >= 1_i, ProofLevel::Temporary);
+            logger->emit_rup_proof_line_under_reason(r, WPBSum{} + 1_i * ! flag + 1_i * (other < hi + 1_i) >= 1_i, ProofLevel::Temporary);
+        };
+
+        auto prune = [&](const auto & pruned, const auto & other, const IntervalSet<Integer> & pruned_set, const IntervalSet<Integer> & other_set) {
+            for (auto [lo, hi] : pruned_set.each_interval_minus(other_set)) {
+                if (use_range)
+                    inference.infer_not_in_range(logger, pruned, lo, hi,
+                        JustifyExplicitlyThenRUP{[=](const ReasonFunction & r) { bridge(pruned, other, lo, hi, r); }},
+                        ReasonFunction{[=, reason = reason]() mutable {
+                            for (Integer val = lo; val <= hi; ++val)
+                                reason.emplace_back(other != val);
+                            return reason;
+                        }});
+                else
+                    for (Integer val = lo; val <= hi; ++val)
+                        inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{},
+                            ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(other != val); return reason; }});
+            }
+        };
+
+        prune(v1, v2, v1_set, v2_set);
+        prune(v2, v1, v2_set, v1_set);
     }
     else {
         auto bounds1 = state.bounds(v1), bounds2 = state.bounds(v2);

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -81,6 +81,14 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
         // for the proof-size characterisation. Range literals exist only for plain
         // integer variables, so views/constants always take the per-value path.
         static const bool range_inferences = std::getenv("GCS_RANGE_INFERENCES") != nullptr;
+        // THROWAWAY EXPERIMENT (design exploration for the range-literal rewrite):
+        // with GCS_RANGE_REASONS also set, build the reason as ONE native
+        // ~[other in lo..hi] flag instead of a per-value run of other != val.
+        // The per-value eq atoms for the covered values then never come into
+        // existence at all -- previously they were materialised by proof-naming
+        // the reason literals, and the reason-resolution coalescer (which this
+        // path now bypasses) merely rewrote the emitted lines after the fact.
+        static const bool native_range_reasons = std::getenv("GCS_RANGE_REASONS") != nullptr;
         auto both_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v1}) &&
             std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v2});
         auto use_range = range_inferences && logger != nullptr && both_simple;
@@ -94,14 +102,25 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 
         auto prune = [&](const auto & pruned, const auto & other, const IntervalSet<Integer> & pruned_set, const IntervalSet<Integer> & other_set) {
             for (auto [lo, hi] : pruned_set.each_interval_minus(other_set)) {
-                if (use_range)
+                // A width-1 "range" flag would be an unlinked doppelganger of the eq
+                // atom (same boundary cuts, different Boolean): downstream reasons
+                // written over eq atoms can never unit-propagate through it. Mirror
+                // reject_random_interval and only take the range path for hi > lo.
+                if (use_range && hi > lo) {
+                    auto per_value_reason = ReasonFunction{[=, reason = reason]() mutable {
+                        for (Integer val = lo; val <= hi; ++val)
+                            reason.emplace_back(other != val);
+                        return reason;
+                    }};
+                    auto interval_reason = ReasonFunction{[=, reason = reason]() mutable {
+                        reason.emplace_back(! logger->names_and_ids_tracker().need_invar(
+                            std::get<SimpleIntegerVariableID>(IntegerVariableID{other}), lo, hi));
+                        return reason;
+                    }};
                     inference.infer_not_in_range(logger, pruned, lo, hi,
                         JustifyExplicitlyThenRUP{[=](const ReasonFunction & r) { bridge(pruned, other, lo, hi, r); }},
-                        ReasonFunction{[=, reason = reason]() mutable {
-                            for (Integer val = lo; val <= hi; ++val)
-                                reason.emplace_back(other != val);
-                            return reason;
-                        }});
+                        native_range_reasons ? interval_reason : per_value_reason);
+                }
                 else
                     for (Integer val = lo; val <= hi; ++val)
                         inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{},

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/equals.hh>
+#include <gcs/constraints/innards/justify_not_in_range.hh>
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -85,9 +86,10 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
         auto use_range = range_inferences && logger != nullptr && both_simple;
 
         auto bridge = [logger](const auto & pruned, const auto & other, Integer lo, Integer hi, const ReasonFunction & r) {
-            auto flag = logger->names_and_ids_tracker().need_invar(std::get<SimpleIntegerVariableID>(IntegerVariableID{pruned}), lo, hi);
-            logger->emit_rup_proof_line_under_reason(r, WPBSum{} + 1_i * ! flag + 1_i * (other >= lo) >= 1_i, ProofLevel::Temporary);
-            logger->emit_rup_proof_line_under_reason(r, WPBSum{} + 1_i * ! flag + 1_i * (other < hi + 1_i) >= 1_i, ProofLevel::Temporary);
+            // Plain equality pruned = other, so the flag forces other into the same [lo, hi].
+            justify_not_in_range_across_equality(*logger, r,
+                std::get<SimpleIntegerVariableID>(IntegerVariableID{pruned}), lo, hi,
+                IntegerVariableID{other}, lo, hi);
         };
 
         auto prune = [&](const auto & pruned, const auto & other, const IntervalSet<Integer> & pruned_set, const IntervalSet<Integer> & other_set) {

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -13,10 +13,12 @@
 #include <util/enumerate.hh>
 
 #include <algorithm>
+#include <cstdlib>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
+#include <variant>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -154,6 +156,33 @@ auto In::install_propagators(Propagators & propagators) -> void
     propagators.install(
         [var = _var, var_vals = _var_vals, val_vals = _val_vals, selectors = _selectors](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            // THROWAWAY EXPERIMENT (range-literal design exploration, see equals.cc):
+            // for a pure value-list In on a plain variable, conclude each contiguous
+            // unsupported run as a single ~[var in lo..hi] flag instead of per-value
+            // var != v inferences, so the per-value eq atoms never come into
+            // existence. Width-1 runs keep the eq-atom path.
+            static const bool range_inferences = std::getenv("GCS_RANGE_INFERENCES") != nullptr;
+            const auto * simple_var = std::get_if<SimpleIntegerVariableID>(&var);
+            if (range_inferences && logger != nullptr && simple_var && var_vals.empty() && selectors.empty()) {
+                vector<Integer> drop;
+                for (auto v : state.each_value_immutable(var))
+                    if (! binary_search(val_vals, v))
+                        drop.push_back(v);
+                for (size_t i = 0; i < drop.size();) {
+                    auto j = i;
+                    while (j + 1 < drop.size() && drop[j + 1] == drop[j] + 1_i)
+                        ++j;
+                    if (j > i)
+                        inference.infer_not_in_range(logger, *simple_var, drop[i], drop[j],
+                            JustifyUsingRUP{}, ReasonFunction{});
+                    else
+                        inference.infer_not_equal(logger, var, drop[i], JustifyUsingRUP{},
+                            ReasonFunction{[]() { return Reason{}; }});
+                    i = j + 1;
+                }
+                return PropagatorState::Enable;
+            }
+
             // Step 1: filter dom(var) — drop any value that no source supports.
             for (auto v : state.each_value_mutable(var)) {
                 if (binary_search(val_vals, v))

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -29,7 +29,8 @@
 #include <variant>
 
 template <typename... Ts_>
-struct std::formatter<std::variant<Ts_...>> : std::formatter<std::string> {
+struct std::formatter<std::variant<Ts_...>> : std::formatter<std::string>
+{
     template <typename FormatContext_>
     auto format(const std::variant<Ts_...> & v, FormatContext_ & ctx) const
     {
@@ -344,6 +345,13 @@ namespace gcs::test_innards
     }
 
     /// Build the random branching pair, honouring --seed if set.
+    ///
+    /// NB: value_order::reject_random_interval cannot be the default yet. It
+    /// verifies for bound-based constraints (see range_branch_test) but breaks
+    /// backtrack-clause RUP for constraints whose conflicts depend on interior
+    /// holes (Count, among, element-var): an interval reject that moves no bound
+    /// leaves a hole that unit propagation cannot see, so the backtrack clause is
+    /// not RUP-derivable (an Inv3 violation, not fixable by covering constraints).
     inline auto random_branch_with_optional_seed(const Problem & p)
     {
         if (auto seed = get_seed())
@@ -740,17 +748,29 @@ namespace gcs::test_innards
     };
 
     /// No wrap: hand the test a bare SimpleIntegerVariableID.
-    [[nodiscard]] constexpr inline auto view_none() -> ViewWrap { return {true, false, 0}; }
+    [[nodiscard]] constexpr inline auto view_none() -> ViewWrap
+    {
+        return {true, false, 0};
+    }
 
     /// Wrap as `var + k`. With k = 0 this still constructs a
     /// ViewOfIntegerVariableID, exercising the view layer transparently.
-    [[nodiscard]] constexpr inline auto view_offset(int k) -> ViewWrap { return {false, false, k}; }
+    [[nodiscard]] constexpr inline auto view_offset(int k) -> ViewWrap
+    {
+        return {false, false, k};
+    }
 
     /// Wrap as `-var`.
-    [[nodiscard]] constexpr inline auto view_neg() -> ViewWrap { return {false, true, 0}; }
+    [[nodiscard]] constexpr inline auto view_neg() -> ViewWrap
+    {
+        return {false, true, 0};
+    }
 
     /// Wrap as `-var + k`.
-    [[nodiscard]] constexpr inline auto view_neg_offset(int k) -> ViewWrap { return {false, true, k}; }
+    [[nodiscard]] constexpr inline auto view_neg_offset(int k) -> ViewWrap
+    {
+        return {false, true, k};
+    }
 
     /**
      * \brief The canonical sweep over view forms for the proof-view audit.
@@ -780,15 +800,23 @@ namespace gcs::test_innards
         return {
             view_none(),
             view_offset(0),
-            view_offset(1), view_offset(-1),
-            view_offset(5), view_offset(-5),
-            view_offset(6), view_offset(-6),
-            view_offset(17), view_offset(-17),
+            view_offset(1),
+            view_offset(-1),
+            view_offset(5),
+            view_offset(-5),
+            view_offset(6),
+            view_offset(-6),
+            view_offset(17),
+            view_offset(-17),
             view_neg(),
-            view_neg_offset(1), view_neg_offset(-1),
-            view_neg_offset(5), view_neg_offset(-5),
-            view_neg_offset(6), view_neg_offset(-6),
-            view_neg_offset(17), view_neg_offset(-17),
+            view_neg_offset(1),
+            view_neg_offset(-1),
+            view_neg_offset(5),
+            view_neg_offset(-5),
+            view_neg_offset(6),
+            view_neg_offset(-6),
+            view_neg_offset(17),
+            view_neg_offset(-17),
         };
     }
 

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -344,19 +344,17 @@ namespace gcs::test_innards
         seed_storage() = std::nullopt;
     }
 
-    /// Build the random branching pair, honouring --seed if set.
-    ///
-    /// NB: value_order::reject_random_interval cannot be the default yet. It
-    /// verifies for bound-based constraints (see range_branch_test) but breaks
-    /// backtrack-clause RUP for constraints whose conflicts depend on interior
-    /// holes (Count, among, element-var): an interval reject that moves no bound
-    /// leaves a hole that unit propagation cannot see, so the backtrack clause is
-    /// not RUP-derivable (an Inv3 violation, not fixable by covering constraints).
+    /// Build the random branching pair, honouring --seed if set. Uses
+    /// reject_random_interval so every constraint test exercises (and VeriPB-checks)
+    /// interval/range branching, including backtrack clauses over interval-reject
+    /// decisions. This relies on the laminar containment edges maintained by
+    /// need_invar so an interval reject propagates to the (eq/range) atoms a
+    /// constraint's conflict depends on.
     inline auto random_branch_with_optional_seed(const Problem & p)
     {
         if (auto seed = get_seed())
-            return branch_with(variable_order::random(p, *seed), value_order::random_out(*seed + 1));
-        return branch_with(variable_order::random(p), value_order::random_out());
+            return branch_with(variable_order::random(p, *seed), value_order::reject_random_interval(*seed + 1));
+        return branch_with(variable_order::random(p), value_order::reject_random_interval());
     }
 
     template <typename SolutionCallback_, typename TraceCallback_>

--- a/gcs/constraints/innards/justify_not_in_range.cc
+++ b/gcs/constraints/innards/justify_not_in_range.cc
@@ -1,0 +1,29 @@
+#include <gcs/constraints/innards/justify_not_in_range.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+auto gcs::innards::justify_not_in_range_across_equality(
+    ProofLogger & logger,
+    const ReasonFunction & reason,
+    const SimpleIntegerVariableID & pruned,
+    Integer lo,
+    Integer hi,
+    IntegerVariableID other,
+    Integer other_lo,
+    Integer other_hi) -> void
+{
+    // The range flag, reified to pruned's two order cuts (see need_invar).
+    auto flag = logger.names_and_ids_tracker().need_invar(pruned, lo, hi);
+
+    // ~flag \/ other >= other_lo. Negation is flag /\ other <= other_lo - 1; with
+    // the equality linking pruned and other, that lower bound on pruned contradicts
+    // the upper bound forced on other (Theorem 2.9), so the lemma is RUP.
+    logger.emit_rup_proof_line_under_reason(reason,
+        WPBSum{} + 1_i * ! flag + 1_i * (other >= other_lo) >= 1_i, ProofLevel::Temporary);
+
+    // ~flag \/ other <= other_hi, written with the strict < form the encoding uses.
+    logger.emit_rup_proof_line_under_reason(reason,
+        WPBSum{} + 1_i * ! flag + 1_i * (other < other_hi + 1_i) >= 1_i, ProofLevel::Temporary);
+}

--- a/gcs/constraints/innards/justify_not_in_range.hh
+++ b/gcs/constraints/innards/justify_not_in_range.hh
@@ -1,0 +1,47 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_JUSTIFY_NOT_IN_RANGE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_JUSTIFY_NOT_IN_RANGE_HH
+
+#include <gcs/innards/proofs/proof_logger.hh>
+
+namespace gcs::innards
+{
+    // Bridge a range ("in") inference across an equality-type link, so that a
+    // single ~[pruned in lo..hi] conclusion becomes RUP where per-line RUP alone
+    // cannot reach it.
+    //
+    // The range flag [pruned in lo..hi] asserts only pruned's *order* atoms
+    // (pruned >= lo and not pruned >= hi+1). With lo < hi it never pins pruned's
+    // bits (McIlree thesis Theorem 2.8 fires only for a single value), so the flag
+    // cannot cross a bit-sum equality by unit propagation: ~[pruned in lo..hi] is
+    // not RUP on its own. This helper supplies the missing case-split. It emits the
+    // two bound-lemmas
+    //
+    //     ~[pruned in lo..hi]  \/  other >= other_lo
+    //     ~[pruned in lo..hi]  \/  other <  other_hi + 1
+    //
+    // each of which *is* RUP: its negation hands unit propagation an opposing bound
+    // on `other` which, together with the equality linking pruned and other already
+    // in the model, is the contradictory-binary-sums configuration of Theorem 2.9.
+    // The caller then concludes ~[pruned in lo..hi] by RUP from these two lemmas and
+    // the (disjunctive) reason. This is Justification Procedure 3.2 (Comparison)
+    // materialising each bound across the equality; justify_abs_hole is the
+    // per-value sign-split form of the same idea.
+    //
+    // [other_lo, other_hi] are the bounds the flag forces on `other` through the
+    // link: for a plain equality pruned = other they are [lo, hi]; for a sign-flip
+    // pruned = -other they are [-hi, -lo]. The result is width-independent (two
+    // lemmas regardless of hi - lo). `other` must be order-encoded (a plain integer
+    // variable) and equality-linked to `pruned` in the proof model. Pass the same
+    // reason the caller hands to infer_not_in_range. See dev_docs/range_literals.md.
+    auto justify_not_in_range_across_equality(
+        ProofLogger & logger,
+        const ReasonFunction & reason,
+        const SimpleIntegerVariableID & pruned,
+        Integer lo,
+        Integer hi,
+        IntegerVariableID other,
+        Integer other_lo,
+        Integer other_hi) -> void;
+}
+
+#endif

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -39,6 +39,18 @@ namespace gcs::innards
             return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason);
         }
 
+        // Record a range inference's variable in the propagation queue. Mirrors the
+        // per-variable bookkeeping in track_impl, but takes the variable directly
+        // (a range conclusion has no Literal to read it back from).
+        auto record_range_var(const IntegerVariableID & var, const Inference inf) -> void
+        {
+            overloaded{
+                [&](const SimpleIntegerVariableID & v) { _inferences.emplace_back(v, inf); },
+                [&](const ViewOfIntegerVariableID & v) { _inferences.emplace_back(v.actual_variable, inf); },
+                [&](const ConstantIntegerVariableID &) {}}
+                .visit(var);
+        }
+
     public:
         explicit InferenceTrackerBase(State & s) :
             _state(s),
@@ -91,6 +103,16 @@ namespace gcs::innards
         auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
         {
             track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, reason);
+        }
+
+        template <IntegerVariableIDLike VarType_>
+        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const Justification & why, const ReasonFunction & reason) -> void
+        {
+            // The conclusion `var not in [lo, hi]` has no single Literal, so this does
+            // not go through track()/logger->infer(); the derived track_range_impl
+            // records the queue entry and (for proof logging) emits the one-line
+            // range conclusion via logger->infer_not_in_range.
+            static_cast<Actual_ *>(this)->track_range_impl(logger, _state.infer_not_in_range(var, lo, hi), IntegerVariableID{var}, lo, hi, why, reason);
         }
 
         auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const ReasonFunction & reason) -> void
@@ -180,6 +202,27 @@ namespace gcs::innards
                 throw TrackedPropagationFailed{};
             }
         }
+
+        auto track_range_impl(ProofLogger * const, const Inference inf, const IntegerVariableID & var, Integer, Integer, const Justification &, const ReasonFunction &) -> void
+        {
+            switch (inf) {
+            case Inference::NoChange:
+                break;
+
+            case Inference::InteriorValuesChanged:
+            case Inference::BoundsChanged:
+            case Inference::Instantiated:
+                record_range_var(var, inf);
+                _did_anything_since_last_call_by_propagation_queue = true;
+                _did_anything_since_last_call_inside_propagator = true;
+                break;
+
+            [[unlikely]] case Inference::Contradiction:
+                _did_anything_since_last_call_by_propagation_queue = true;
+                _did_anything_since_last_call_inside_propagator = true;
+                throw TrackedPropagationFailed{};
+            }
+        }
     };
 
     class EagerProofLoggingInferenceTracker : public InferenceTrackerBase<EagerProofLoggingInferenceTracker>
@@ -222,6 +265,31 @@ namespace gcs::innards
             [[unlikely]] case Inference::Contradiction:
                 if (logger)
                     logger->infer(lit, just, reason);
+                _did_anything_since_last_call_by_propagation_queue = true;
+                _did_anything_since_last_call_inside_propagator = true;
+                throw TrackedPropagationFailed{};
+            }
+        }
+
+        auto track_range_impl(ProofLogger * const logger, const Inference inf, const IntegerVariableID & var, Integer lo, Integer hi, const Justification & just, const ReasonFunction & reason) -> void
+        {
+            switch (inf) {
+            case Inference::NoChange:
+                break;
+
+            case Inference::InteriorValuesChanged:
+            case Inference::BoundsChanged:
+            case Inference::Instantiated:
+                if (logger)
+                    logger->infer_not_in_range(var, lo, hi, just, reason);
+                record_range_var(var, inf);
+                _did_anything_since_last_call_by_propagation_queue = true;
+                _did_anything_since_last_call_inside_propagator = true;
+                break;
+
+            [[unlikely]] case Inference::Contradiction:
+                if (logger)
+                    logger->infer_not_in_range(var, lo, hi, just, reason);
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
                 throw TrackedPropagationFailed{};

--- a/gcs/innards/interval_set.hh
+++ b/gcs/innards/interval_set.hh
@@ -221,6 +221,59 @@ namespace gcs::innards
         }
 
         /**
+         * \brief Removes every value in the closed interval [\p lo, \p hi].
+         *
+         * The whole contiguous range is removed in a single merge-walk over the
+         * stored intervals: <code>O(intervals)</code> with at most one insertion
+         * (when the range falls in the interior of a single interval, splitting
+         * it in two). This is the range analogue of erase(): erasing a singleton
+         * [v, v] is equivalent to erase(v).
+         *
+         * If \p lo > \p hi, or the range is disjoint from the set, does nothing.
+         *
+         * \sa erase(), erase_less_than(), erase_greater_than()
+         */
+        auto erase_range(Int_ lo, Int_ hi) -> void
+        {
+            if (lo > hi)
+                return;
+
+            for (auto iter = intervals.begin(); iter != intervals.end();) {
+                if (iter->second < lo) {
+                    // Entirely below the range; nothing to remove here.
+                    ++iter;
+                }
+                else if (iter->first > hi) {
+                    // This and every later interval are entirely above the range.
+                    return;
+                }
+                else {
+                    bool keep_left = iter->first < lo;   // [first, lo-1] survives
+                    bool keep_right = iter->second > hi; // [hi+1, second] survives
+                    if (keep_left && keep_right) {
+                        // 4..9 erase 6..7 -> 4..5 8..9
+                        auto right = std::pair{hi + Int_(1), iter->second};
+                        iter->second = lo - Int_(1);
+                        intervals.insert(next(iter), right);
+                        return;
+                    }
+                    else if (keep_left) {
+                        iter->second = lo - Int_(1);
+                        ++iter;
+                    }
+                    else if (keep_right) {
+                        iter->first = hi + Int_(1);
+                        return;
+                    }
+                    else {
+                        // Fully covered by the range; drop it.
+                        iter = intervals.erase(iter);
+                    }
+                }
+            }
+        }
+
+        /**
          * \brief Removes all values strictly less than \p value.
          *
          * Equivalent to intersecting the set with [value, +inf).

--- a/gcs/innards/interval_set_test.cc
+++ b/gcs/innards/interval_set_test.cc
@@ -8,8 +8,8 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::pair;
-using std::ranges::reverse;
 using std::vector;
+using std::ranges::reverse;
 
 namespace
 {
@@ -156,6 +156,101 @@ TEST_CASE("Poking more holes")
         CHECK(set.contains(i) == (i == 1 || i == 2 || i == 4 || i == 5));
 }
 
+TEST_CASE("Erase range interior split")
+{
+    IntervalSet<int> set(5, 10);
+    set.erase_range(7, 8);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{5, 6}, {9, 10}});
+    for (int i = 5; i <= 10; ++i)
+        CHECK(set.contains(i) == (i != 7 && i != 8));
+}
+
+TEST_CASE("Erase range trims left")
+{
+    IntervalSet<int> set(5, 10);
+    set.erase_range(3, 7);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{8, 10}});
+}
+
+TEST_CASE("Erase range trims right")
+{
+    IntervalSet<int> set(5, 10);
+    set.erase_range(8, 12);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{5, 7}});
+}
+
+TEST_CASE("Erase range exactly the interval")
+{
+    IntervalSet<int> set(5, 10);
+    set.erase_range(5, 10);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{});
+}
+
+TEST_CASE("Erase range covering the interval")
+{
+    IntervalSet<int> set(5, 10);
+    set.erase_range(3, 12);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{});
+}
+
+TEST_CASE("Erase singleton range matches erase")
+{
+    IntervalSet<int> set(5, 10);
+    set.erase_range(7, 7);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{5, 6}, {8, 10}});
+}
+
+TEST_CASE("Erase range entirely below or above is a no-op")
+{
+    IntervalSet<int> below(5, 10), above(5, 10), inverted(5, 10);
+    below.erase_range(1, 3);
+    above.erase_range(12, 15);
+    inverted.erase_range(8, 6); // lo > hi
+    CHECK(intervals_of(below) == vector<pair<int, int>>{{5, 10}});
+    CHECK(intervals_of(above) == vector<pair<int, int>>{{5, 10}});
+    CHECK(intervals_of(inverted) == vector<pair<int, int>>{{5, 10}});
+}
+
+TEST_CASE("Erase range falling in a gap is a no-op")
+{
+    IntervalSet<int> set;
+    set.insert_at_end(1, 4);
+    set.insert_at_end(8, 10);
+    set.erase_range(5, 7);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{1, 4}, {8, 10}});
+}
+
+TEST_CASE("Erase range spanning multiple intervals")
+{
+    IntervalSet<int> set;
+    set.insert_at_end(1, 4);
+    set.insert_at_end(8, 10);
+    set.insert_at_end(14, 20);
+    set.erase_range(3, 15);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{1, 2}, {16, 20}});
+    for (int i = 1; i <= 20; ++i)
+        CHECK(set.contains(i) == (i == 1 || i == 2 || (i >= 16 && i <= 20)));
+}
+
+TEST_CASE("Erase range dropping whole intervals and trimming ends")
+{
+    IntervalSet<int> set;
+    set.insert_at_end(1, 4);
+    set.insert_at_end(8, 10);
+    set.insert_at_end(14, 20);
+    set.erase_range(2, 18);
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{1, 1}, {19, 20}});
+}
+
+TEST_CASE("Erase range ending exactly in a gap leaves later intervals")
+{
+    IntervalSet<int> set;
+    set.insert_at_end(1, 4);
+    set.insert_at_end(8, 10);
+    set.erase_range(3, 6); // ends at 6, in the gap before 8..10
+    CHECK(intervals_of(set) == vector<pair<int, int>>{{1, 2}, {8, 10}});
+}
+
 TEST_CASE("Wipeout from below")
 {
     IntervalSet<int> set(5, 10);
@@ -255,8 +350,8 @@ TEST_CASE("Size across multiple intervals")
 TEST_CASE("Contains out-of-range values")
 {
     IntervalSet<int> set(5, 10);
-    CHECK(! set.contains(4));   // before lower(), hits u > value early exit
-    CHECK(! set.contains(11));  // after upper(), falls through loop
+    CHECK(! set.contains(4));  // before lower(), hits u > value early exit
+    CHECK(! set.contains(11)); // after upper(), falls through loop
 }
 
 TEST_CASE("Contains in a gap")
@@ -275,10 +370,10 @@ TEST_CASE("Erase value not in set")
     IntervalSet<int> set(1, 10);
     set.erase(3); // {[1,2],[4,10]}
 
-    set.erase(0);  // before lower() — hits iter->first > value on first interval
+    set.erase(0); // before lower() — hits iter->first > value on first interval
     CHECK(intervals_of(set) == vector<pair<int, int>>{{1, 2}, {4, 10}});
 
-    set.erase(3);  // in the gap — hits iter->first > value when reaching [4,10]
+    set.erase(3); // in the gap — hits iter->first > value when reaching [4,10]
     CHECK(intervals_of(set) == vector<pair<int, int>>{{1, 2}, {4, 10}});
 
     set.erase(11); // after upper() — loop falls through
@@ -385,8 +480,10 @@ TEST_CASE("Each reversed")
     // {[1,3],[6,10]}
 
     vector<int> fwd, rev;
-    for (auto v : set.each()) fwd.push_back(v);
-    for (auto v : set.each_reversed()) rev.push_back(v);
+    for (auto v : set.each())
+        fwd.push_back(v);
+    for (auto v : set.each_reversed())
+        rev.push_back(v);
 
     auto expected = fwd;
     reverse(expected);

--- a/gcs/innards/proofs/invar_test.cc
+++ b/gcs/innards/proofs/invar_test.cc
@@ -1,0 +1,58 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+// Stage-1 check for proof-only range ("in") literals: introduce overlapping ranges
+// in an adversarial order (cuts repeatedly inserted into the middle of the order
+// chain, exercising additive Inv1 maintenance), then have VeriPB verify the key
+// range-literal deductions by RUP. No covering/containment constraints are emitted --
+// a range literal is just a wide equality literal reified against its two order cuts.
+auto main() -> int
+{
+    ProofOptions proof_options{"invar_test"};
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+
+    // One integer variable X, domain [0, 30]. All cuts below are interior.
+    auto x = model.create_proof_only_integer_variable(0_i, 30_i, "x", IntegerVariableProofRepresentation::Bits);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    // Adversarial introduction order: each range inserts cuts into the middle of the
+    // existing chain. cuts after each line: {10,21} -> {10,18,21} -> {10,13,18,21} ->
+    // (reuse) -> {10,13,15,16,18,21}.
+    auto r_10_20 = tracker.need_invar(x, 10_i, 20_i); // [10,20]
+    auto r_10_17 = tracker.need_invar(x, 10_i, 17_i); // [10,17]
+    auto r_13_20 = tracker.need_invar(x, 13_i, 20_i); // [13,20]
+    auto r_13_17 = tracker.need_invar(x, 13_i, 17_i); // [13,17] = [10,17] cap [13,20]
+    auto r_15_15 = tracker.need_invar(x, 15_i, 15_i); // singleton (== equality) inside [13,17]
+
+    // Idempotency: re-requesting an existing range returns the same flag, with no
+    // second definition emitted.
+    auto r_10_17_again = tracker.need_invar(x, 10_i, 17_i);
+    if (r_10_17_again != r_10_17)
+        return 1;
+
+    // (a) negative covering (the Stage-0 headline): ~[10,17] AND ~[13,20] |- ~[10,20].
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * r_10_17 + 1_i * r_13_20 + 1_i * ! r_10_20 >= 1_i, ProofLevel::Current);
+
+    // positive intersection: [10,17] AND [13,20] |- [13,17].
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * ! r_10_17 + 1_i * ! r_13_20 + 1_i * r_13_17 >= 1_i, ProofLevel::Current);
+
+    // singleton containment: [15,15] |- [13,17].
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * ! r_15_15 + 1_i * r_13_17 >= 1_i, ProofLevel::Current);
+
+    logger.conclude_none();
+    tracker.finalise();
+
+    return 0;
+}

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -73,6 +73,10 @@ struct NamesAndIDsTracker::Imp
     map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, Integer>> integer_variable_definition_bounds;
     map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> gevars_that_exist;
     map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> eqvars_that_exist;
+    // Range ("in") literals [lo, hi]: a proof-only flag meaning lo <= var <= hi,
+    // keyed by (lo, hi). Defined as a "wide equality literal" reified against the
+    // variable's own two order cuts; see need_invar.
+    map<SimpleOrProofOnlyIntegerVariableID, map<pair<Integer, Integer>, pair<ProofFlag, pair<ProofLine, ProofLine>>>> invars_that_exist;
 
     map<ViewOfIntegerVariableID, ProofOnlySimpleIntegerVariableID> view_proof_only_vars;
     map<ProofOnlySimpleIntegerVariableID, ViewOfIntegerVariableID> view_proof_only_to_view;
@@ -748,6 +752,33 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             }
         }
     }
+}
+
+auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> ProofFlag
+{
+    auto & for_this_var = _imp->invars_that_exist[id];
+    if (auto it = for_this_var.find(pair{lo, hi}); it != for_this_var.end())
+        return it->second.first;
+
+    // A range literal is a "wide equality literal": [lo, hi] <=> (id >= lo) AND NOT (id >= hi+1).
+    // Ensure both order-encoding cuts exist; need_gevar also threads them into the order chain
+    // (Inv1), which is the only linking range-literal propagation needs -- no covering required.
+    need_gevar(id, lo);
+    need_gevar(id, hi + 1_i);
+
+    auto flag = create_proof_flag("in_" + name_of(id) + "_" + to_string(lo.raw_value) + "_" + to_string(hi.raw_value));
+
+    if (! _imp->logger)
+        throw UnimplementedException{"range literals during model writing are not yet supported"};
+
+    auto lines = visit([&](const auto & id) {
+        return _imp->logger->emit_red_proof_lines_reifying(
+            WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, flag, ProofLevel::Top);
+    },
+        id);
+
+    for_this_var.emplace(pair{lo, hi}, pair{flag, lines});
+    return flag;
 }
 
 auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> ProofOnlySimpleIntegerVariableID

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -585,18 +585,9 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         }
     }
 
-    // Laminar containment (Phase A): symmetric to need_invar -- link this new eq atom to every
-    // existing range that contains it, so a reject of that range forward-propagates ~(id == v).
-    if (_imp->logger)
-        if (auto rit = _imp->invars_that_exist.find(id); rit != _imp->invars_that_exist.end())
-            for (const auto & range_entry : rit->second) {
-                auto [a, b] = range_entry.first;
-                if (a <= v && v <= b)
-                    visit([&](const auto & id) {
-                        _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * (id != v) + 1_i * range_entry.second.first >= 1_i, ProofLevel::Top);
-                    },
-                        id);
-            }
+    // Laminar containment: symmetric to need_invar -- link this new eq atom (a singleton [v, v])
+    // to its immediate range containers so a reject of one forward-propagates ~(id == v).
+    link_immediate_containment(id, v, v, v);
 }
 
 auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
@@ -767,6 +758,71 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     }
 }
 
+auto NamesAndIDsTracker::link_immediate_containment(SimpleOrProofOnlyIntegerVariableID id,
+    Integer lo, Integer hi, const variant<ProofFlag, Integer> & self_term) -> void
+{
+    if (! _imp->logger)
+        return;
+
+    auto strictly_contains = [](Integer alo, Integer ahi, Integer blo, Integer bhi) {
+        return alo <= blo && bhi <= ahi && (alo < blo || bhi < ahi);
+    };
+
+    // Existing range/eq literals on id as intervals with their (negatable) proof term. An eq
+    // atom is the singleton [v, v]; a range container is always a range (an eq can't strictly
+    // contain anything), so a parent term is always a ProofFlag.
+    struct ExistingLit
+    {
+        Integer lo, hi;
+        variant<ProofFlag, Integer> term;
+    };
+    vector<ExistingLit> existing;
+    if (auto rit = _imp->invars_that_exist.find(id); rit != _imp->invars_that_exist.end())
+        for (const auto & e : rit->second)
+            existing.push_back({e.first.first, e.first.second, e.second.first});
+    if (auto eqit = _imp->eqvars_that_exist.find(id); eqit != _imp->eqvars_that_exist.end())
+        for (const auto & e : eqit->second)
+            existing.push_back({e.first, e.first, e.first});
+
+    // Emit a child -> parent containment edge (~child OR parent_flag) as a rup line at Top.
+    auto emit_edge = [&](const variant<ProofFlag, Integer> & child, const ProofFlag & parent_flag) {
+        overloaded{
+            [&](const ProofFlag & cf) {
+                _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * ! cf + 1_i * parent_flag >= 1_i, ProofLevel::Top);
+            },
+            [&](const Integer & v) {
+                visit([&](const auto & id) {
+                    _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * (id != v) + 1_i * parent_flag >= 1_i, ProofLevel::Top);
+                },
+                    id);
+            }}
+            .visit(child);
+    };
+
+    // self -> minimal (immediate) range containers
+    for (const auto & p : existing) {
+        if (! strictly_contains(p.lo, p.hi, lo, hi))
+            continue;
+        auto is_minimal = none_of(existing.begin(), existing.end(), [&](const ExistingLit & q) {
+            return strictly_contains(p.lo, p.hi, q.lo, q.hi) && strictly_contains(q.lo, q.hi, lo, hi);
+        });
+        if (is_minimal)
+            emit_edge(self_term, std::get<ProofFlag>(p.term));
+    }
+
+    // maximal (immediate) contained literals -> self, only when self is a range (a flag).
+    if (auto self_flag = std::get_if<ProofFlag>(&self_term))
+        for (const auto & c : existing) {
+            if (! strictly_contains(lo, hi, c.lo, c.hi))
+                continue;
+            auto is_maximal = none_of(existing.begin(), existing.end(), [&](const ExistingLit & m) {
+                return strictly_contains(lo, hi, m.lo, m.hi) && strictly_contains(m.lo, m.hi, c.lo, c.hi);
+            });
+            if (is_maximal)
+                emit_edge(c.term, *self_flag);
+        }
+}
+
 auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> ProofFlag
 {
     auto & for_this_var = _imp->invars_that_exist[id];
@@ -790,27 +846,12 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
     },
         id);
 
-    // Laminar containment (Phase A, over-linked): link this range to every existing NESTED
-    // literal, so a reject decision (~flag) forward-propagates ~(contained literal). The chain
-    // alone does not give this (a ~[range] decision does not propagate without a handle), but it
-    // is needed for backtrack clauses over interval-reject branching. Each edge is RUP from the
-    // boundary-EO + chain, so emitted as a rup line at Top. Over-linked: all nested pairs, both
-    // ranges and eq atoms (the singleton leaves); overlapping non-nested ranges get no edge.
-    for (const auto & [other_bounds, other_flag_and_lines] : for_this_var) {
-        auto [a, b] = other_bounds;
-        const auto & other_flag = other_flag_and_lines.first;
-        if (lo <= a && b <= hi) // other range is inside the new one: other -> new
-            _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * ! other_flag + 1_i * flag >= 1_i, ProofLevel::Top);
-        else if (a <= lo && hi <= b) // new range is inside the other: new -> other
-            _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * ! flag + 1_i * other_flag >= 1_i, ProofLevel::Top);
-    }
-    if (auto eqit = _imp->eqvars_that_exist.find(id); eqit != _imp->eqvars_that_exist.end())
-        for (const auto & eq_entry : eqit->second)
-            if (lo <= eq_entry.first && eq_entry.first <= hi) // eq atom inside the range: (id == v) -> flag
-                visit([&](const auto & id) {
-                    _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * (id != eq_entry.first) + 1_i * flag >= 1_i, ProofLevel::Top);
-                },
-                    id);
+    // Laminar containment: link this range to its immediate neighbours so a reject decision
+    // (~flag) forward-propagates ~(contained literal). The chain alone does not give this (a
+    // ~[range] decision does not propagate without a handle), but it is needed for backtrack
+    // clauses over interval-reject branching. (Note: call before the emplace below so the new
+    // range is not in invars_that_exist yet.)
+    link_immediate_containment(id, lo, hi, flag);
 
     for_this_var.emplace(pair{lo, hi}, pair{flag, lines});
     return flag;

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -584,6 +584,19 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             }
         }
     }
+
+    // Laminar containment (Phase A): symmetric to need_invar -- link this new eq atom to every
+    // existing range that contains it, so a reject of that range forward-propagates ~(id == v).
+    if (_imp->logger)
+        if (auto rit = _imp->invars_that_exist.find(id); rit != _imp->invars_that_exist.end())
+            for (const auto & range_entry : rit->second) {
+                auto [a, b] = range_entry.first;
+                if (a <= v && v <= b)
+                    visit([&](const auto & id) {
+                        _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * (id != v) + 1_i * range_entry.second.first >= 1_i, ProofLevel::Top);
+                    },
+                        id);
+            }
 }
 
 auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
@@ -762,7 +775,7 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
 
     // A range literal is a "wide equality literal": [lo, hi] <=> (id >= lo) AND NOT (id >= hi+1).
     // Ensure both order-encoding cuts exist; need_gevar also threads them into the order chain
-    // (Inv1), which is the only linking range-literal propagation needs -- no covering required.
+    // (Inv1), which gives all range<->range and range<->order RUP deductions.
     need_gevar(id, lo);
     need_gevar(id, hi + 1_i);
 
@@ -776,6 +789,28 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
             WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, flag, ProofLevel::Top);
     },
         id);
+
+    // Laminar containment (Phase A, over-linked): link this range to every existing NESTED
+    // literal, so a reject decision (~flag) forward-propagates ~(contained literal). The chain
+    // alone does not give this (a ~[range] decision does not propagate without a handle), but it
+    // is needed for backtrack clauses over interval-reject branching. Each edge is RUP from the
+    // boundary-EO + chain, so emitted as a rup line at Top. Over-linked: all nested pairs, both
+    // ranges and eq atoms (the singleton leaves); overlapping non-nested ranges get no edge.
+    for (const auto & [other_bounds, other_flag_and_lines] : for_this_var) {
+        auto [a, b] = other_bounds;
+        const auto & other_flag = other_flag_and_lines.first;
+        if (lo <= a && b <= hi) // other range is inside the new one: other -> new
+            _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * ! other_flag + 1_i * flag >= 1_i, ProofLevel::Top);
+        else if (a <= lo && hi <= b) // new range is inside the other: new -> other
+            _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * ! flag + 1_i * other_flag >= 1_i, ProofLevel::Top);
+    }
+    if (auto eqit = _imp->eqvars_that_exist.find(id); eqit != _imp->eqvars_that_exist.end())
+        for (const auto & eq_entry : eqit->second)
+            if (lo <= eq_entry.first && eq_entry.first <= hi) // eq atom inside the range: (id == v) -> flag
+                visit([&](const auto & id) {
+                    _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * (id != eq_entry.first) + 1_i * flag >= 1_i, ProofLevel::Top);
+                },
+                    id);
 
     for_this_var.emplace(pair{lo, hi}, pair{flag, lines});
     return flag;

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -72,6 +72,14 @@ namespace gcs::innards
 
         auto emit_proof_line_now_or_at_start(const std::function<auto(ProofLogger * const)->void> &) -> void;
 
+        // Emit laminar containment edges between a newly-introduced literal [lo, hi] (a range
+        // flag, or an eq atom passed as its Integer value) and the IMMEDIATE neighbours in the
+        // containment order among existing range/eq literals on `id`: minimal range containers
+        // above (self -> parent) and, when self is a range, maximal contained literals below
+        // (child -> self). Skip-level edges are left to transitivity. Each edge is a rup line.
+        auto link_immediate_containment(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi,
+            const std::variant<ProofFlag, Integer> & self_term) -> void;
+
     public:
         /**
          * \name Constructors, destructors, and the like.

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -192,6 +192,24 @@ namespace gcs::innards
         auto need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID, Integer) -> void;
 
         /**
+         * Say that we will need the range ("in") literal [lo, hi] for a variable: a
+         * single proof-only Boolean flag meaning `lo <= var <= hi`. Returns that flag,
+         * idempotent on (id, lo, hi).
+         *
+         * The range literal is a "wide equality literal", defined as
+         * `flag <=> (var >= lo) AND NOT (var >= hi+1)`, reified against the variable's
+         * own two order-encoding cuts. Ensures those cuts exist via need_gevar, which
+         * also threads them into the order chain (Inv1). That chain alone is what makes
+         * range-literal propagation complete — no covering/containment constraints are
+         * needed (established by the Stage-0 spike; range literals behave exactly like
+         * equality literals with a wider gap, so Theorem 3.3 carries over).
+         *
+         * Currently only implemented during the proof-logging phase; throws
+         * UnimplementedException if called during model writing, until a caller needs it.
+         */
+        [[nodiscard]] auto need_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> ProofFlag;
+
+        /**
          * Say that we are going to need an at-least-one constraint for a
          * variable.
          */

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -7,6 +7,8 @@
 #include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/state.hh>
 
+#include <cstddef>
+#include <cstdlib>
 #include <deque>
 #include <fstream>
 #include <sstream>
@@ -40,6 +42,65 @@ using namespace gcs::innards;
 namespace
 {
     const auto INDENT_WIDTH = 5;
+
+    // If `lit` is `var != v` on a plain (non-view, non-constant) integer variable,
+    // return (var, v); otherwise nullopt. Used to coalesce runs of domain holes in a
+    // reason into a single range literal.
+    [[nodiscard]] auto as_simple_not_equal(const ProofLiteralOrFlag & lit) -> std::optional<std::pair<SimpleIntegerVariableID, Integer>>
+    {
+        const auto * pl = std::get_if<ProofLiteral>(&lit);
+        if (! pl)
+            return std::nullopt;
+        const auto * l = std::get_if<Literal>(pl);
+        if (! l)
+            return std::nullopt;
+        const auto * cond = std::get_if<IntegerVariableCondition>(l);
+        if (! cond || cond->op != VariableConditionOperator::NotEqual)
+            return std::nullopt;
+        const auto * svar = std::get_if<SimpleIntegerVariableID>(&cond->var);
+        if (! svar)
+            return std::nullopt;
+        return std::pair{*svar, cond->value};
+    }
+
+    // Optionally coalesce a maximal run of `var != lo, var != lo+1, ..., var != hi` for a
+    // plain variable into a single negated range literal ~[lo,hi]. Off by default; enabled
+    // by the GCS_RANGE_REASONS environment variable. This is semantically transparent --
+    // the range literal is a wide equality literal over the same two order cuts, so every
+    // reasoned inference's RUP check is unaffected; it only shrinks the reason (and the
+    // per-value eq vars it would otherwise need). The fixed run-length threshold is a
+    // placeholder for the Stage 5 cost policy. Applied wherever a reason is resolved.
+    auto coalesce_holes_in_reason(NamesAndIDsTracker & tracker, Reason & reason) -> void
+    {
+        static const bool enabled = std::getenv("GCS_RANGE_REASONS") != nullptr;
+        static const long long min_run_to_coalesce = 3;
+        if (! enabled)
+            return;
+
+        Reason coalesced;
+        for (std::size_t i = 0; i < reason.size();) {
+            if (auto neq = as_simple_not_equal(reason[i])) {
+                auto [var, lo] = *neq;
+                auto hi = lo;
+                std::size_t j = i + 1;
+                for (; j < reason.size(); ++j) {
+                    auto next = as_simple_not_equal(reason[j]);
+                    if (next && next->first == var && next->second == hi + 1_i)
+                        hi = next->second;
+                    else
+                        break;
+                }
+                if ((hi - lo).raw_value + 1 >= min_run_to_coalesce) {
+                    coalesced.emplace_back(! tracker.need_invar(var, lo, hi));
+                    i = j;
+                    continue;
+                }
+            }
+            coalesced.emplace_back(reason[i]);
+            ++i;
+        }
+        reason = std::move(coalesced);
+    }
 
     [[nodiscard]] auto deview(const VariableConditionFrom<ViewOfIntegerVariableID> & cond) -> VariableConditionFrom<SimpleIntegerVariableID>
     {
@@ -265,6 +326,9 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
                 reason_literals = reason();
 
             if (reason_literals)
+                coalesce_holes_in_reason(names_and_ids_tracker(), *reason_literals);
+
+            if (reason_literals)
                 names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
 
             if (! is_literally_true(lit)) {
@@ -287,6 +351,9 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
             optional<Reason> reason_literals;
             if (reason)
                 reason_literals = reason();
+
+            if (reason_literals)
+                coalesce_holes_in_reason(names_and_ids_tracker(), *reason_literals);
 
             HalfReifyOnConjunctionOf reif{};
             if (reason_literals) {
@@ -325,6 +392,9 @@ auto ProofLogger::reason_to_lits(const ReasonFunction & reason) -> Reason
     optional<Reason> reason_literals;
     if (reason)
         reason_literals = reason();
+
+    if (reason_literals)
+        coalesce_holes_in_reason(names_and_ids_tracker(), *reason_literals);
 
     if (reason_literals)
         names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
@@ -421,6 +491,8 @@ auto ProofLogger::emit_under_reason(
     optional<Reason> reason_literals;
     if (reason)
         reason_literals = reason();
+    if (reason_literals)
+        coalesce_holes_in_reason(names_and_ids_tracker(), *reason_literals);
     if (reason_literals)
         names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
 

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -239,12 +239,20 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             optional_minimise_variable_and_value->first);
 }
 
-auto ProofLogger::backtrack(const vector<Literal> & lits) -> void
+auto ProofLogger::backtrack(const vector<BranchGuess> & guesses) -> void
 {
     _imp->proof << "% backtracking\n";
     WPBSum backtrack;
-    for (const auto & lit : lits)
-        backtrack += 1_i * ! lit;
+    for (const auto & guess : guesses)
+        overloaded{
+            [&](const Literal & lit) { backtrack += 1_i * ! lit; },
+            [&](const IntegerVariableRangeGuess & r) {
+                // ~guess as a single range ("in") literal: need_invar gives the flag
+                // meaning var in [lo,hi]; negate it iff the guess was the accept branch.
+                auto flag = names_and_ids_tracker().need_invar(r.var, r.lower, r.upper);
+                backtrack += 1_i * (r.within ? ! flag : flag);
+            }}
+            .visit(guess);
     emit_rup_proof_line(move(backtrack) >= 1_i, ProofLevel::Current);
 }
 

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -395,6 +395,76 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
         .visit(why);
 }
 
+auto ProofLogger::infer_not_in_range(const IntegerVariableID & var, Integer lo, Integer hi,
+    const Justification & why, const ReasonFunction & reason) -> void
+{
+    if (lo > hi)
+        return;
+
+    // Only a plain integer variable has a single range ("in") literal to negate.
+    // Views and constants fall back to per-value removal: each `var != val` is still
+    // RUP from the same reason (via the laminar containment edges down to the eq
+    // atoms), it is just not coalesced into one line.
+    const auto * simple = std::get_if<SimpleIntegerVariableID>(&var);
+    if (! simple) {
+        for (Integer val = lo; val <= hi; ++val)
+            infer(var != val, why, reason);
+        return;
+    }
+
+    // Emit the single conclusion line `~[var in lo..hi] >= 1`, reified on the
+    // (coalesced) reason, with the requested proof rule. Mirrors the rup / assert
+    // branches of infer(), but the conclusion is the negation of the range flag.
+    auto emit_negated_range = [&](const string & rule) {
+        log_stacktrace();
+        optional<Reason> reason_literals;
+        if (reason)
+            reason_literals = reason();
+
+        if (reason_literals)
+            coalesce_holes_in_reason(names_and_ids_tracker(), *reason_literals);
+
+        if (reason_literals)
+            names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
+
+        auto flag = names_and_ids_tracker().need_invar(*simple, lo, hi);
+
+        WPBSum terms;
+        terms += 1_i * ! flag;
+        HalfReifyOnConjunctionOf reif{};
+        if (reason_literals)
+            reif = *reason_literals;
+
+        write_indent();
+        _imp->proof << rule;
+        emit_inequality_to(names_and_ids_tracker(), reify(move(terms) >= 1_i, reif), _imp->proof);
+        _imp->proof << ";\n";
+        record_proof_line(advance_proof_line_number(), ProofLevel::Current);
+    };
+
+    overloaded{
+        [&](const JustifyUsingRUP &) {
+            emit_negated_range("rup ");
+        },
+        [&](const AssertRatherThanJustifying &) {
+            emit_negated_range("a ");
+        },
+        [&](const JustifyExplicitlyOnly & x) {
+            auto t = temporary_proof_level();
+            x.add_proof_steps(reason);
+            forget_proof_level(t);
+        },
+        [&](const JustifyExplicitlyThenRUP & x) {
+            auto t = temporary_proof_level();
+            x.add_proof_steps(reason);
+            infer_not_in_range(var, lo, hi, JustifyUsingRUP{}, reason);
+            forget_proof_level(t);
+        },
+        [&](const NoJustificationNeeded &) {
+        }}
+        .visit(why);
+}
+
 auto ProofLogger::reason_to_lits(const ReasonFunction & reason) -> Reason
 {
     optional<Reason> reason_literals;

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_LOGGER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_LOGGER_HH
 
+#include <gcs/branch_guess.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_line.hh>
@@ -93,7 +94,7 @@ namespace gcs::innards
         /**
          * Log that we are backtracking.
          */
-        auto backtrack(const std::vector<Literal> & guesses) -> void;
+        auto backtrack(const std::vector<BranchGuess> & guesses) -> void;
 
         /**
          * Log that we have reached an unsatisfiable conclusion at the end of the proof.

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -132,6 +132,19 @@ namespace gcs::innards
         auto infer(const Literal & lit, const Justification & why, const ReasonFunction & reason) -> void;
 
         /**
+         * Log, if necessary, that we have inferred that \p var takes no value in the
+         * closed interval [lo, hi]. For a plain integer variable this is a single
+         * proof line `~[var in lo..hi] >= 1` (the negation of the range "in" literal;
+         * see NamesAndIDsTracker::need_invar) emitted under the reason, in place of
+         * one `var != v` line per removed value: the per-value facts follow from it by
+         * RUP via the laminar containment edges, so they need not be written out. Views
+         * and constants fall back to per-value emission (still correct, not coalesced).
+         * Justification handling mirrors infer().
+         */
+        auto infer_not_in_range(const IntegerVariableID & var, Integer lo, Integer hi,
+            const Justification & why, const ReasonFunction & reason) -> void;
+
+        /**
          * \brief Return the current <em>active proof level</em> &mdash; the
          * integer depth used to tag proof lines.
          *

--- a/gcs/innards/proofs/range_branch_test.cc
+++ b/gcs/innards/proofs/range_branch_test.cc
@@ -1,0 +1,26 @@
+#include <gcs/constraints/equals.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+
+using namespace gcs;
+
+// Stage-4 controlled check: a small enumeration solved with reject_random_interval
+// branching, so backtrack clauses over interval-reject decisions get VeriPB-checked.
+auto main() -> int
+{
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 4_i, "x");
+    auto y = p.create_integer_variable(0_i, 4_i, "y");
+    p.post(NotEquals{x, y});
+
+    solve_with(
+        p,
+        SolveCallbacks{
+            .solution = [](const CurrentState &) -> bool { return true; },
+            .branch = branch_with(variable_order::random(p, 1), value_order::reject_random_interval(1))},
+        ProofOptions{"range_branch_test"});
+
+    return 0;
+}

--- a/gcs/innards/proofs/range_infer_test.cc
+++ b/gcs/innards/proofs/range_infer_test.cc
@@ -1,0 +1,47 @@
+#include <gcs/constraints/equals.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <vector>
+
+using namespace gcs;
+using std::vector;
+
+// Stage-3 check for the single-line range inference (GCS_RANGE_INFERENCES). A plain
+// Equals(x, y) where each side carries a contiguous hole, so the propagator removes the
+// non-shared interval from each. With the range-inference path enabled this removal is a
+// single ~[x in lo..hi] proof line, justified across the *unmodified* bit-sum equality by
+// two bound-lemmas (each RUP via Theorem 2.9 / Justification Procedure 3.2) plus an RUP
+// conclusion -- demonstrating that an interval of infer_not_equal can be collapsed into a
+// single infer_not_in_range without re-encoding Equals. run_test_and_verify then has
+// VeriPB check the whole proof. The hole on x is deliberately wide so the inference's
+// width-independence is exercised on a non-trivial interval.
+auto main() -> int
+{
+    ::setenv("GCS_RANGE_INFERENCES", "1", 1);
+
+    Problem p;
+
+    // x misses the wide block [10..30]; y misses [3..6]. Each side loses an interval to
+    // the other: x drops [3..6] (absent from x already, so this side is small) and y
+    // drops the wide [10..30] (absent from x).
+    vector<Integer> xd, yd;
+    for (int i = 0; i <= 40; ++i) {
+        if (i < 10 || i > 30)
+            xd.push_back(Integer{i});
+        if (i < 3 || i > 6)
+            yd.push_back(Integer{i});
+    }
+    auto x = p.create_integer_variable(xd, "x");
+    auto y = p.create_integer_variable(yd, "y");
+
+    p.post(Equals{x, y});
+
+    solve(
+        p, [](const CurrentState &) -> bool { return true; },
+        ProofOptions{"range_infer_test"});
+
+    return 0;
+}

--- a/gcs/innards/proofs/range_reason_test.cc
+++ b/gcs/innards/proofs/range_reason_test.cc
@@ -1,0 +1,44 @@
+#include <gcs/constraints/element.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <vector>
+
+using namespace gcs;
+using std::vector;
+
+// Stage-2 integration check for range literals in reasons. A real solve whose
+// generic_reason sees a contiguous domain hole of length >= 3, which forces the
+// hole-coalescing path in ProofLogger::reason_to_lits to mint a single range
+// literal ~[lo,hi] in place of per-value `idx != v` facts. Coalescing is enabled
+// unconditionally here (so the test always exercises it, independent of how it is
+// run); the run_test_and_verify harness then has VeriPB check the whole proof, so
+// a broken coalesced reason would fail verification.
+auto main() -> int
+{
+    ::setenv("GCS_RANGE_REASONS", "1", 1);
+
+    Problem p;
+
+    // Index variable with a built-in contiguous hole [3..8] (six missing values).
+    auto idx = p.create_integer_variable(vector<Integer>{0_i, 1_i, 2_i, 9_i, 10_i, 11_i, 12_i}, "idx");
+    auto res = p.create_integer_variable(0_i, 12_i, "res");
+
+    // res = array[idx] with a distinct constant per index. The array entries at the
+    // holed indices 3..8 have no support, so res loses those values -- each removal
+    // justified by a reason over idx's holed domain, the coalescing target. GAC
+    // (bounds_only = false) is needed to take the per-value-removal path.
+    vector<Integer> array;
+    for (int i = 0; i <= 12; ++i)
+        array.push_back(Integer{i});
+
+    p.post(ElementConstantArray{res, idx, array, false});
+
+    solve(
+        p, [](const CurrentState &) -> bool { return true; },
+        ProofOptions{"range_reason_test"});
+
+    return 0;
+}

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -141,7 +141,7 @@ auto Propagators::initialise(State & state, ProofLogger * const logger) const ->
     return true;
 }
 
-auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofLogger * const logger, atomic<bool> * optional_abort_flag) const -> bool
+auto Propagators::propagate(const optional<BranchGuess> & lit, State & state, ProofLogger * const logger, atomic<bool> * optional_abort_flag) const -> bool
 {
     auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) {
         if (v.index < _imp->iv_triggers.size()) {
@@ -177,21 +177,28 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
     else {
         _imp->enqueued_end = 0;
         overloaded{
-            [&](const TrueLiteral &) {},
-            [&](const FalseLiteral &) {},
-            [&](const IntegerVariableCondition & cond) {
+            [&](const Literal & l) {
                 overloaded{
-                    [&](const SimpleIntegerVariableID & var) {
-                        // trigger all propagators on this var, even if we might not actually
-                        // have instantiated it. bit ugly but easier than tracking.
-                        requeue(var, Inference::Instantiated);
-                    },
-                    [&](const ConstantIntegerVariableID &) {
-                    },
-                    [&](const ViewOfIntegerVariableID & var) {
-                        requeue(var.actual_variable, Inference::Instantiated);
+                    [&](const TrueLiteral &) {},
+                    [&](const FalseLiteral &) {},
+                    [&](const IntegerVariableCondition & cond) {
+                        overloaded{
+                            [&](const SimpleIntegerVariableID & var) {
+                                // trigger all propagators on this var, even if we might not actually
+                                // have instantiated it. bit ugly but easier than tracking.
+                                requeue(var, Inference::Instantiated);
+                            },
+                            [&](const ConstantIntegerVariableID &) {
+                            },
+                            [&](const ViewOfIntegerVariableID & var) {
+                                requeue(var.actual_variable, Inference::Instantiated);
+                            }}
+                            .visit(cond.var);
                     }}
-                    .visit(cond.var);
+                    .visit(l);
+            },
+            [&](const IntegerVariableRangeGuess & r) {
+                requeue(r.var, Inference::Instantiated);
             }}
             .visit(*lit);
     }

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -1,13 +1,14 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROPAGATORS_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROPAGATORS_HH
 
+#include <gcs/branch_guess.hh>
 #include <gcs/expression.hh>
 #include <gcs/extensional.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/literal.hh>
-#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/problem.hh>
@@ -253,7 +254,7 @@ namespace gcs::innards
          * Propagate every constraint, until either a fixed point or a contradiction is reached. If no guess
          * is supplied, requeue every constraint before we start.
          */
-        [[nodiscard]] auto propagate(const std::optional<Literal> & guess,
+        [[nodiscard]] auto propagate(const std::optional<BranchGuess> & guess,
             State &, ProofLogger * const, std::atomic<bool> * optional_abort_flag = nullptr) const -> bool;
 
         /**

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -202,6 +202,27 @@ auto State::change_state_for_greater_than_or_equal(const SimpleIntegerVariableID
     return Inference::BoundsChanged;
 }
 
+auto State::change_state_for_not_in_range(const SimpleIntegerVariableID & var, Integer lo, Integer hi) -> Inference
+{
+    if (lo > hi)
+        return Inference::NoChange;
+    auto & set = state_of(var);
+    auto old_lower = set.lower(), old_upper = set.upper();
+    // Cheap rejects first: the range cannot touch the domain if it sits entirely
+    // outside the current bounds, and need not change anything if it falls wholly
+    // in a gap (contains_any_of is O(intervals)).
+    if (hi < old_lower || lo > old_upper)
+        return Inference::NoChange;
+    if (! set.contains_any_of(IntervalSet<Integer>{lo, hi}))
+        return Inference::NoChange;
+    set.erase_range(lo, hi);
+    if (set.empty())
+        return Inference::Contradiction;
+    if (set.lower() == set.upper())
+        return Inference::Instantiated;
+    return (set.lower() != old_lower || set.upper() != old_upper) ? Inference::BoundsChanged : Inference::InteriorValuesChanged;
+}
+
 namespace
 {
     auto infer_equal_on_constant(Integer const_value, Integer value) -> Inference
@@ -299,6 +320,23 @@ auto State::infer_greater_than_or_equal(const VarType_ & var, Integer value) -> 
         auto adjusted = value - then_add;
         return visit_actual(actual_var, [&](const SimpleIntegerVariableID & v) { return change_state_for_greater_than_or_equal(v, adjusted); }, [&](const ConstantIntegerVariableID & v) { return infer_greater_than_or_equal_on_constant(v.const_value, adjusted); });
     }
+}
+
+template <IntegerVariableIDLike VarType_>
+auto State::infer_not_in_range(const VarType_ & var, Integer lo, Integer hi) -> Inference
+{
+    if (lo > hi)
+        return Inference::NoChange;
+    auto [actual_var, negate_first, then_add] = deview(var);
+    // Map [lo, hi] from the view's frame back to the actual variable's frame. A
+    // negated view reverses the order, so the endpoints swap; the result is still
+    // a contiguous closed interval [alo, ahi] with alo <= ahi.
+    auto alo = negate_first ? then_add - hi : lo - then_add;
+    auto ahi = negate_first ? then_add - lo : hi - then_add;
+    return visit_actual(
+        actual_var,
+        [&](const SimpleIntegerVariableID & v) { return change_state_for_not_in_range(v, alo, ahi); },
+        [&](const ConstantIntegerVariableID & v) { return (alo <= v.const_value && v.const_value <= ahi) ? Inference::Contradiction : Inference::NoChange; });
 }
 
 auto State::guess(const BranchGuess & guess) -> void
@@ -758,4 +796,9 @@ namespace gcs
     template auto State::infer_greater_than_or_equal(const SimpleIntegerVariableID &, Integer) -> Inference;
     template auto State::infer_greater_than_or_equal(const ViewOfIntegerVariableID &, Integer) -> Inference;
     template auto State::infer_greater_than_or_equal(const ConstantIntegerVariableID &, Integer) -> Inference;
+
+    template auto State::infer_not_in_range(const IntegerVariableID &, Integer, Integer) -> Inference;
+    template auto State::infer_not_in_range(const SimpleIntegerVariableID &, Integer, Integer) -> Inference;
+    template auto State::infer_not_in_range(const ViewOfIntegerVariableID &, Integer, Integer) -> Inference;
+    template auto State::infer_not_in_range(const ConstantIntegerVariableID &, Integer, Integer) -> Inference;
 }

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -92,7 +92,7 @@ struct State::Imp
     list<vector<ConstraintState>> constraint_states{};
     vector<ConstraintState> persistent_constraint_states{};
     list<vector<function<auto()->void>>> on_backtracks{};
-    vector<Literal> guesses{};
+    vector<BranchGuess> guesses{};
     vector<Literal> extra_proof_conditions{};
 
     optional<IntegerVariableID> optional_minimise_variable{};
@@ -301,19 +301,35 @@ auto State::infer_greater_than_or_equal(const VarType_ & var, Integer value) -> 
     }
 }
 
-auto State::guess(const Literal & lit) -> void
+auto State::guess(const BranchGuess & guess) -> void
 {
-    switch (infer(lit)) {
-    case Inference::NoChange:
-    case Inference::BoundsChanged:
-    case Inference::InteriorValuesChanged:
-    case Inference::Instantiated:
-        _imp->guesses.push_back(lit);
-        return;
+    auto contradicted = false;
+    auto note = [&](Inference inf) {
+        if (inf == Inference::Contradiction)
+            contradicted = true;
+    };
 
-    case Inference::Contradiction:
+    overloaded{
+        [&](const Literal & lit) { note(infer(lit)); },
+        [&](const IntegerVariableRangeGuess & r) {
+            // Accept [lo,hi] = (var >= lo) and (var <= hi); reject [lo,hi] = remove
+            // each value in turn. The reject branch is the genuinely disjunctive one;
+            // its proof is handled at backtrack via the range literal, not here.
+            if (r.within) {
+                note(infer(r.var >= r.lower));
+                note(infer(r.var < r.upper + 1_i));
+            }
+            else {
+                for (auto v = r.lower; v <= r.upper; ++v)
+                    note(infer(r.var != v));
+            }
+        }}
+        .visit(guess);
+
+    if (contradicted)
         throw UnexpectedException{"couldn't infer a branch variable"};
-    }
+
+    _imp->guesses.push_back(guess);
 }
 
 auto State::add_extra_proof_condition(const Literal & lit) -> void
@@ -581,9 +597,9 @@ auto State::backtrack(Timestamp t) -> void
     }
 }
 
-auto State::guesses() const -> generator<Literal>
+auto State::guesses() const -> generator<BranchGuess>
 {
-    return [](const auto & extra_proof_conditions, const auto & guesses) -> generator<Literal> {
+    return [](const auto & extra_proof_conditions, const auto & guesses) -> generator<BranchGuess> {
         for (auto & g : extra_proof_conditions)
             co_yield g;
         for (auto & g : guesses)

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_STATE_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_STATE_HH
 
+#include <gcs/branch_guess.hh>
 #include <gcs/current_state.hh>
 #include <gcs/innards/interval_set.hh>
 #include <gcs/innards/literal.hh>
@@ -203,12 +204,12 @@ namespace gcs::innards
         ///@{
 
         /**
-         * Guess that the specified Literal holds. Does not deal with
-         * backtracking directly.
+         * Guess that the specified branch decision holds (a variable condition,
+         * or an interval accept/reject). Does not deal with backtracking directly.
          *
          * \sa State::new_epoch()
          */
-        auto guess(const Literal & lit) -> void;
+        auto guess(const BranchGuess & guess) -> void;
 
         /**
          * Add an additional proof condition, similar to guess except that it
@@ -223,7 +224,7 @@ namespace gcs::innards
          *
          * \sa State::guess()
          */
-        auto guesses() const -> std::generator<Literal>;
+        auto guesses() const -> std::generator<BranchGuess>;
 
         /**
          * Create a new epoch, that can be backtracked to. Only legal if we are in a fully

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -100,6 +100,10 @@ namespace gcs::innards
             const SimpleIntegerVariableID & var,
             Integer value) -> Inference;
 
+        [[nodiscard]] auto change_state_for_not_in_range(
+            const SimpleIntegerVariableID & var,
+            Integer lo, Integer hi) -> Inference;
+
         [[nodiscard]] inline auto state_of(const SimpleIntegerVariableID &) -> IntervalSet<Integer> &;
         [[nodiscard]] inline auto state_of(const SimpleIntegerVariableID &) const -> const IntervalSet<Integer> &;
 
@@ -195,6 +199,17 @@ namespace gcs::innards
          */
         template <IntegerVariableIDLike VarType_>
         [[nodiscard]] auto infer_greater_than_or_equal(const VarType_ &, Integer value) -> Inference;
+
+        /**
+         * Infer that a given IntegerVariableID or more specific type must not take
+         * any value in the closed interval [lo, hi]. The whole contiguous range is
+         * removed in a single pass (see IntervalSet::erase_range). Performance and
+         * clarity overload for a run of infer_not_equal() calls over a contiguous
+         * range; see InferenceTracker::infer_not_in_range for the matching
+         * single-proof-line range inference. A range with lo > hi is a no-op.
+         */
+        template <IntegerVariableIDLike VarType_>
+        [[nodiscard]] auto infer_not_in_range(const VarType_ &, Integer lo, Integer hi) -> Inference;
 
         ///@}
 

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -30,7 +30,7 @@ AutoTable::AutoTable(const vector<IntegerVariableID> & v) :
 namespace
 {
     auto solve_subproblem(unsigned depth, SimpleTuples & tuples, const vector<IntegerVariableID> & vars,
-        Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
+        Propagators & propagators, State & state, const optional<BranchGuess> & this_branch_guess,
         ProofLogger * const logger, SimpleIntegerVariableID selector_var_id) -> void
     {
         if (logger)
@@ -81,9 +81,9 @@ namespace
 
         if (logger) {
             logger->enter_proof_level(depth);
-            vector<Literal> guesses;
-            for (const auto & lit : state.guesses())
-                guesses.push_back(lit);
+            vector<BranchGuess> guesses;
+            for (const auto & g : state.guesses())
+                guesses.push_back(g);
             logger->backtrack(guesses);
             logger->forget_proof_level(depth + 1);
         }

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -235,8 +235,16 @@ namespace
                         std::swap(i, j);
                     auto lo = values.at(i);
                     auto hi = values.at(j);
-                    co_yield IntegerVariableRangeGuess{*svar, lo, hi, false};
-                    co_yield IntegerVariableRangeGuess{*svar, lo, hi, true};
+                    if (lo == hi) {
+                        // A width-1 interval is just an equality atom; branch on it directly so
+                        // the decision already lives on the atom constraints reason with.
+                        co_yield var != lo;
+                        co_yield var == lo;
+                    }
+                    else {
+                        co_yield IntegerVariableRangeGuess{*svar, lo, hi, false};
+                        co_yield IntegerVariableRangeGuess{*svar, lo, hi, true};
+                    }
                 }
                 else {
                     uniform_int_distribution<size_t> dist(0, values.size() - 1);

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -42,22 +42,22 @@ using namespace gcs;
 
 auto gcs::branch_with(BranchVariableSelector var, BranchValueGenerator val) -> BranchCallback
 {
-    return [var = move(var), val = move(val)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
+    return [var = move(var), val = move(val)](const CurrentState & s, const innards::Propagators & p) -> generator<BranchGuess> {
         return [](const CurrentState & s, const innards::Propagators & p,
-                   BranchVariableSelector select_var, BranchValueGenerator make_val_gen) -> generator<IntegerVariableCondition> {
+                   BranchVariableSelector select_var, BranchValueGenerator make_val_gen) -> generator<BranchGuess> {
             auto branch_var = select_var(s, p);
             if (branch_var)
                 return make_val_gen(s, p, *branch_var);
             else
-                return []() -> generator<IntegerVariableCondition> { co_return; }();
+                return []() -> generator<BranchGuess> { co_return; }();
         }(s, p, move(var), move(val));
     };
 }
 
 auto gcs::branch_sequence(BranchCallback a, BranchCallback b) -> BranchCallback
 {
-    return [a = move(a), b = move(b)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a, BranchCallback b) -> generator<IntegerVariableCondition> {
+    return [a = move(a), b = move(b)](const CurrentState & s, const innards::Propagators & p) -> generator<BranchGuess> {
+        return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a, BranchCallback b) -> generator<BranchGuess> {
             auto gen_a = a(s, p);
             auto iter_a = gen_a.begin();
             if (iter_a != gen_a.end()) {
@@ -189,8 +189,8 @@ namespace
 {
     auto random_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
-        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
                 vector<Integer> values;
                 for (auto v : s.each_value(var))
                     values.push_back(v);
@@ -203,8 +203,8 @@ namespace
 
     auto random_out_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
-        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
                 vector<Integer> values;
                 for (auto v : s.each_value(var))
                     values.push_back(v);
@@ -212,6 +212,38 @@ namespace
                 auto val = values.at(dist(*rand));
                 co_yield var != val;
                 co_yield var == val;
+            }(rand, s, var);
+        };
+    }
+
+    auto reject_random_interval_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
+    {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
+                vector<Integer> values;
+                for (auto v : s.each_value(var))
+                    values.push_back(v);
+                // An interior interval needs a plain variable and at least three
+                // values (so lo/hi can both be strictly inside the bounds, making the
+                // reject branch a genuine hole). Otherwise fall back to a value reject.
+                const auto * svar = std::get_if<SimpleIntegerVariableID>(&var);
+                if (svar && values.size() >= 3) {
+                    uniform_int_distribution<size_t> dist(1, values.size() - 2);
+                    auto i = dist(*rand);
+                    auto j = dist(*rand);
+                    if (i > j)
+                        std::swap(i, j);
+                    auto lo = values.at(i);
+                    auto hi = values.at(j);
+                    co_yield IntegerVariableRangeGuess{*svar, lo, hi, false};
+                    co_yield IntegerVariableRangeGuess{*svar, lo, hi, true};
+                }
+                else {
+                    uniform_int_distribution<size_t> dist(0, values.size() - 1);
+                    auto val = values.at(dist(*rand));
+                    co_yield var != val;
+                    co_yield var == val;
+                }
             }(rand, s, var);
         };
     }
@@ -237,10 +269,20 @@ auto gcs::value_order::random_out(uint_fast32_t seed) -> BranchValueGenerator
     return random_out_value_generator(make_shared_rng(seed));
 }
 
+auto gcs::value_order::reject_random_interval() -> BranchValueGenerator
+{
+    return reject_random_interval_value_generator(make_shared_rng());
+}
+
+auto gcs::value_order::reject_random_interval(uint_fast32_t seed) -> BranchValueGenerator
+{
+    return reject_random_interval_value_generator(make_shared_rng(seed));
+}
+
 auto gcs::value_order::smallest_in() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             auto value = s.lower_bound(var);
             co_yield var == value;
             co_yield var != value;
@@ -250,8 +292,8 @@ auto gcs::value_order::smallest_in() -> BranchValueGenerator
 
 auto gcs::value_order::smallest_out() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             auto value = s.lower_bound(var);
             co_yield var != value;
             co_yield var == value;
@@ -261,8 +303,8 @@ auto gcs::value_order::smallest_out() -> BranchValueGenerator
 
 auto gcs::value_order::smallest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             for (auto v : s.each_value(var))
                 co_yield var == v;
         }(s, var);
@@ -271,8 +313,8 @@ auto gcs::value_order::smallest_first() -> BranchValueGenerator
 
 auto gcs::value_order::split_smallest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             auto mid = s.domain_size(var) / 2_i;
             auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
             co_yield var <= v;
@@ -283,8 +325,8 @@ auto gcs::value_order::split_smallest_first() -> BranchValueGenerator
 
 auto gcs::value_order::split_largest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             auto mid = s.domain_size(var) / 2_i;
             auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
             co_yield var > v;
@@ -297,8 +339,8 @@ namespace
 {
     auto split_random_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
-        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
                 auto mid = s.domain_size(var) / 2_i;
                 auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
                 if (uniform_int_distribution(0, 1)(*rand) == 0) {
@@ -326,8 +368,8 @@ auto gcs::value_order::split_random(uint_fast32_t seed) -> BranchValueGenerator
 
 auto gcs::value_order::largest_in() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             auto value = s.upper_bound(var);
             co_yield var == value;
             co_yield var != value;
@@ -337,8 +379,8 @@ auto gcs::value_order::largest_in() -> BranchValueGenerator
 
 auto gcs::value_order::largest_out() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             auto value = s.upper_bound(var);
             co_yield var != value;
             co_yield var == value;
@@ -348,8 +390,8 @@ auto gcs::value_order::largest_out() -> BranchValueGenerator
 
 auto gcs::value_order::largest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             for (auto v : s.each_value_reversed(var))
                 co_yield var == v;
         }(s, var);
@@ -358,8 +400,8 @@ auto gcs::value_order::largest_first() -> BranchValueGenerator
 
 auto gcs::value_order::median() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchGuess> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchGuess> {
             vector<Integer> values;
             for (auto v : s.each_value(var))
                 values.push_back(v);

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -38,7 +38,7 @@ namespace gcs
      *
      * \ingroup SearchHeuristics
      */
-    using BranchValueGenerator = std::function<std::generator<IntegerVariableCondition>(
+    using BranchValueGenerator = std::function<std::generator<BranchGuess>(
         const CurrentState &, const innards::Propagators &, const IntegerVariableID &)>;
 
     /**
@@ -307,6 +307,25 @@ namespace gcs
          * \ingroup SearchHeuristics
          */
         [[nodiscard]] auto random_out(std::uint_fast32_t seed) -> BranchValueGenerator;
+
+        /**
+         * Reject a random (interior) interval of the variable's domain, then accept
+         * it. A silly heuristic for solving, but a deliberate stress test for
+         * interval/range branching: the reject branch is a genuinely disjunctive
+         * decision. Falls back to a value branch for variables with fewer than three
+         * domain values.
+         *
+         * \ingroup SearchHeuristics
+         */
+        [[nodiscard]] auto reject_random_interval() -> BranchValueGenerator;
+
+        /**
+         * Reject a random (interior) interval of the variable's domain, then accept
+         * it, with an explicit seed for reproducible debugging.
+         *
+         * \ingroup SearchHeuristics
+         */
+        [[nodiscard]] auto reject_random_interval(std::uint_fast32_t seed) -> BranchValueGenerator;
 
         /**
          * Accept then reject the median value in the domain.

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -30,7 +30,7 @@ using std::chrono::steady_clock;
 namespace
 {
     auto solve_with_state(unsigned long long depth, Stats & stats, Problem & problem,
-        Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
+        Propagators & propagators, State & state, const optional<BranchGuess> & this_branch_guess,
         SolveCallbacks & callbacks,
         ProofLogger * const logger,
         bool & this_subtree_contains_solution,
@@ -84,7 +84,7 @@ namespace
                 if (optional_abort_flag && optional_abort_flag->load())
                     return false;
 
-                auto recurse = [&](const Literal & guess) -> bool {
+                auto recurse = [&](const BranchGuess & guess) -> bool {
                     if (optional_abort_flag && optional_abort_flag->load())
                         return false;
 
@@ -115,9 +115,9 @@ namespace
 
         if (logger) {
             logger->enter_proof_level(depth);
-            vector<Literal> guesses;
-            for (const auto & lit : state.guesses())
-                guesses.push_back(lit);
+            vector<BranchGuess> guesses;
+            for (const auto & g : state.guesses())
+                guesses.push_back(g);
             logger->backtrack(guesses);
             logger->forget_proof_level(depth + 1);
         }

--- a/gcs/solve.hh
+++ b/gcs/solve.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SOLVE_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SOLVE_HH
 
+#include <gcs/branch_guess.hh>
 #include <gcs/current_state.hh>
 #include <gcs/problem.hh>
 #include <gcs/proof.hh>
@@ -42,14 +43,15 @@ namespace gcs
 
     /**
      * \brief Called by gcs::solve_with() to determine branching when
-     * searching, should return a generator of IntegerVariableCondition
-     * instances that corresponds to a complete branching choice, or
-     * that yields nothing if every variable is instantiated.
+     * searching, should return a generator of BranchGuess instances (each an
+     * IntegerVariableCondition or an interval accept/reject) that corresponds to a
+     * complete branching choice, or that yields nothing if every variable is
+     * instantiated.
      *
      * \ingroup SolveCallbacks
      * \sa SearchHeuristics
      */
-    using BranchCallback = std::function<std::generator<IntegerVariableCondition>(const CurrentState &, const innards::Propagators &)>;
+    using BranchCallback = std::function<std::generator<BranchGuess>(const CurrentState &, const innards::Propagators &)>;
 
     /**
      * \brief Called by gcs::solve_with() after the proof has been started.


### PR DESCRIPTION
**Status: draft / WIP.** Staged work toward first-class range ("in") literals `[x in a..b]` in the CP→PB proof encoding, usable in reasons, inferences, and branching.

### Foundation (done, green)
The whole constraint test suite verifies under `reject_random_interval` branching — VeriPB checks a proof for every constraint while the solver branches by accepting/rejecting random *intervals*. A range literal is reified to its two order cuts: `[a,b] ⇔ (x≥a) ∧ ¬(x≥b+1)`. Two linking axes:
1. **Bound / RUP axis** — the order chain (Inv1) gives range↔range and range↔order deductions on a single variable. No covering needed.
2. **Hole / backtrack axis** — an interval *reject* `¬[a,b]` moves no bound; the chain won't forward-propagate it. Fixed by **laminar containment** (`child → parent` edges down to `eq` leaves), each a `rup` line.

### Stage 3 — `infer_not_in_range` (issue #144): the key finding
Goal: collapse an interval of per-value `infer_not_equal` into one `infer_not_in_range`. **Built and committed** (general, view-safe, green, unused by default): `IntervalSet::erase_range`; `State::infer_not_in_range`; `InferenceTracker`/`ProofLogger::infer_not_in_range`.

**The single-line range *inference* is NOT pure RUP for the constraints that actually do interval removals.** A range flag asserts only *order* atoms; with `lo<hi`, **Theorem 2.8 never pins bits**, so `~[X in lo..hi]` can't cross a **bit-sum equality** `X−Y==0` by RUP (the per-value version works only because asserting `X=v` pins bits). Confirmed via VeriPB `--trace-failed` + McIlree's thesis.

**Scope audited** — the break is exactly *interior interval removal across a primary bit-sum equality*:

| Affected (bit-sum equality) | Unaffected (eq-atom/selector channelled — forward-propagate) |
|---|---|
| `Equals`/`ReifiedEquals`, `Element` (index fixed), `AllEqual`, `Abs` | Table, Regular, GCC, Count, Among, In, Inverse, MinMax, AtMostOne, ValuePrecede, Circuit, AllDifferent |

(Bounds-consistent arithmetic constraints — Linear, Comparison, Plus — never do interior removals, so the question doesn't arise.)

**The fix that works — an explicit bridge (case-split, each case RUP), no re-encoding.** To remove `[lo,hi]` from `v1` because `v2` lacks it (`v1=v2`):
```
1)  ~[v1 in lo..hi] ∨ (v2 ≥ lo)      # RUP: ¬ gives the Theorem 2.9 contradictory-binary-sums config
2)  ~[v1 in lo..hi] ∨ ¬(v2 ≥ hi+1)   #      across the equality (the case-split supplies the opposing bound)
⇒  ~[v1 in lo..hi]                    # RUP from (1),(2) + the disjunctive reason ~[v2 in lo..hi]
```
This is Justification Procedure 3.2 (Comparison) materialising each bound across the equality; `justify_abs_hole` is the per-value sign-split form. **Verified** end to end (full `equals_test`, unmodified bit-sum model). Wired behind **`GCS_RANGE_INFERENCES` (default off)**, with a `range_infer_test`. **Default behaviour byte-identical; full suite 324/324.**

**Proof size** — width-independent inference (3 lines). Measured: narrow ranges break-even (1306 vs 1269), wide hole a ~24% win (445 vs 582). The per-flag `need_invar` setup (reification + O(width) containment) amortises heavily — 23 flags / 932 references (~40× reuse) in `equals_test`. Hoisting the bridge lemmas to `Top` and verify-time effects are not yet measured.

### Stage 3b — the bridge helper, and the headline result
The two bound-lemmas are a **reusable free helper** `gcs::innards::justify_not_in_range_across_equality` (`gcs/constraints/innards/justify_not_in_range.{hh,cc}`), `ProofLogger&` first (the `abs/justify`, `linear/justify` convention, so it travels with the scoopable proof-pattern layer). It lives in `enforce_equality`, so `Equals` and `Element` (index-fixed) inherit it and verify gate-on **when posted in isolation** (`Element`: 61 instances).

**Headline: interval inference does NOT compose across the equality family — and this is general, not `AllEqual`-specific.** A star of plain `Equals` constraints over three transitively-linked variables, with no `AllEqual` anywhere, breaks gate-on identically (same rate, same instances). Reducing `AllEqual` to literally n−1 single-edge `Equals` calls breaks too. So the inference justification was never the problem. The cause: once ≥3 variables share an equality class, the solver's **backtracking justification** needs unit propagation to thread a *bound* across a bit-sum equality (e.g. `i₃≥3 ⟹ i₂≥3`), and UP across a bit-sum equality moves only **values** (Thm 2.8 bit-pinning) and **contradictions** (Thm 2.7/2.9), **never a lone bound** (cf. the thesis's own Example 2.14). Per-value removals never raise the obligation (every one is a single value); a wide interval literal asserts only order atoms, never pins bits, so its obligation is a bound and the missing step is forced. **Two variables in isolation never trigger it — which is the only reason `Equals`/`Element` pass their tests.**

In thesis terms: we **preserve** Theorem 3.3 (intra-variable completeness, extended to interval literals — hence reasons/inference/branching work) but **lose** Inv2 / Theorem 3.4 (the backtracking-RUP invariant) for any constraint that channels across a bit-sum equality. Full thesis-grounded write-up: **`dev_docs/range_literals_theory.md`** (preserved-vs-lost table, the why, the cautionary history). Three refuted "fixes" (pairwise OPB, durable `Top` lemmas, single-hop star) are recorded in `dev_docs/range_literals.md`.

### Status / what's left
- **No code changes pending.** The bridge helper + `infer_not_in_range` primitives are committed; `GCS_RANGE_INFERENCES` stays **off** by default; the 324/324 `ctest` (gate-off) is unchanged. Awaiting review of the theory doc before deciding direction.
- **Decision, not a code task:** interval inference across the equality family needs a cross-variable Inv1 (`(x≥k) ⇔ (y≥k)` per equality at boundary values) — a *covering*, applied family-wide, i.e. the per-value work interval literals exist to avoid. Worth it or not is a design call.
- **Unaffected and usable now:** interval **reasons** (`GCS_RANGE_REASONS`) and interval **branching** (`reject_random_interval`) — both intra-variable, both green.
- **Safe target for interval inference (if pursued):** the eq-atom/selector-channelled family (Table, Regular, GCC, Count, …), where every cross-variable obligation stays a single value and the problem never arises.

Full settled write-up: `dev_docs/range_literals.md` (status/design) and `dev_docs/range_literals_theory.md` (the theory). Relates to #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)