### PR TITLE
Batch of small code-cleanup nits (#286, #291, #287, #296)

### DIFF
--- a/gcs/current_state.hh
+++ b/gcs/current_state.hh
@@ -136,7 +136,7 @@ namespace gcs
         /**
          * \brief Returns a generator that gives each value in the variable's domain.
          */
-        auto each_value(const IntegerVariableID) const -> std::generator<Integer>;
+        [[nodiscard]] auto each_value(const IntegerVariableID) const -> std::generator<Integer>;
 
         /**
          * \brief Returns a generator that gives each value in the variable's
@@ -144,7 +144,7 @@ namespace gcs
          *
          * \sa CurrentState::each_value()
          */
-        auto each_value_reversed(const IntegerVariableID) const -> std::generator<Integer>;
+        [[nodiscard]] auto each_value_reversed(const IntegerVariableID) const -> std::generator<Integer>;
 
         /**
          * \brief Returns the values in a variable's domain, in an interval set representation. Usually
@@ -152,7 +152,7 @@ namespace gcs
          *
          * \sa CurrentState::each_value()
          */
-        auto copy_of_values(const IntegerVariableID) const -> innards::IntervalSet<Integer>;
+        [[nodiscard]] auto copy_of_values(const IntegerVariableID) const -> innards::IntervalSet<Integer>;
 
         ///@}
     };

--- a/gcs/gcs.hh
+++ b/gcs/gcs.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_GCS_HH
-#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_GCS_HH 1
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_GCS_HH
 
+#include <gcs/array_param.hh>
 #include <gcs/constraint.hh>
 #include <gcs/current_state.hh>
 #include <gcs/exception.hh>
@@ -9,6 +10,7 @@
 #include <gcs/integer.hh>
 #include <gcs/problem.hh>
 #include <gcs/proof.hh>
+#include <gcs/reification.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 #include <gcs/stats.hh>

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -41,6 +41,7 @@ using std::generator;
 using std::ios;
 using std::ios_base;
 using std::list;
+using std::make_unique;
 using std::map;
 using std::max;
 using std::min;
@@ -115,7 +116,7 @@ struct NamesAndIDsTracker::Imp
 };
 
 NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) :
-    _imp(new Imp{})
+    _imp(make_unique<Imp>())
 {
     _imp->verbose_names = proof_options.verbose_names;
 

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -24,6 +24,7 @@ using std::flush;
 using std::fstream;
 using std::ios;
 using std::ios_base;
+using std::make_unique;
 using std::map;
 using std::optional;
 using std::ostream;
@@ -103,7 +104,7 @@ struct ProofLogger::Imp
 };
 
 ProofLogger::ProofLogger(const ProofOptions & proof_options, NamesAndIDsTracker & t) :
-    _imp(new Imp{t})
+    _imp(make_unique<Imp>(t))
 {
     _imp->proof_file = proof_options.proof_file_names.proof_file;
     _imp->proof_lines_by_level.resize(2);

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -35,6 +35,7 @@ using std::fstream;
 using std::ios;
 using std::ios_base;
 using std::istreambuf_iterator;
+using std::make_unique;
 using std::nullopt;
 using std::ofstream;
 using std::optional;
@@ -78,7 +79,7 @@ struct ProofModel::Imp
 };
 
 ProofModel::ProofModel(const ProofOptions & proof_options, NamesAndIDsTracker & t) :
-    _imp(new Imp{t})
+    _imp(make_unique<Imp>(t))
 {
     _imp->opb_file = proof_options.proof_file_names.opb_file;
     _imp->always_use_full_encoding = proof_options.always_use_full_encoding;

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -17,6 +17,7 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::atomic;
+using std::make_unique;
 using std::move;
 using std::optional;
 using std::pair;
@@ -52,7 +53,7 @@ struct Propagators::Imp
 };
 
 Propagators::Propagators() :
-    _imp(new Imp())
+    _imp(make_unique<Imp>())
 {
 }
 

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -19,6 +19,7 @@ using std::function;
 using std::generator;
 using std::list;
 using std::make_optional;
+using std::make_unique;
 using std::move;
 using std::nullopt;
 using std::optional;
@@ -100,7 +101,7 @@ struct State::Imp
 };
 
 State::State() :
-    _imp(new Imp{})
+    _imp(make_unique<Imp>())
 {
     _imp->integer_variable_states.emplace_back();
     _imp->constraint_states.emplace_back();

--- a/gcs/integer.hh
+++ b/gcs/integer.hh
@@ -100,12 +100,12 @@ namespace gcs
 
         ///@}
 
-        static inline constexpr auto min_value() -> const Integer
+        static inline constexpr auto min_value() -> Integer
         {
             return Integer(std::numeric_limits<decltype(raw_value)>::min());
         }
 
-        static inline constexpr auto max_value() -> const Integer
+        static inline constexpr auto max_value() -> Integer
         {
             return Integer(std::numeric_limits<decltype(raw_value)>::max());
         }

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -24,6 +24,7 @@ using namespace gcs::innards;
 using std::deque;
 using std::generator;
 using std::make_optional;
+using std::make_unique;
 using std::move;
 using std::nullopt;
 using std::optional;
@@ -63,7 +64,7 @@ struct Problem::Imp
 };
 
 Problem::Problem() :
-    _imp(new Imp{})
+    _imp(make_unique<Imp>())
 {
 }
 

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -195,7 +195,7 @@ namespace gcs
 
         [[nodiscard]] auto each_presolver() const -> std::generator<Presolver &>;
 
-        auto all_normal_variables() const -> const std::vector<IntegerVariableID> &;
+        [[nodiscard]] auto all_normal_variables() const -> const std::vector<IntegerVariableID> &;
 
         [[nodiscard]] auto each_constraint() const -> std::generator<const Constraint &>;
 

--- a/gcs/proof.cc
+++ b/gcs/proof.cc
@@ -6,6 +6,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_unique;
 using std::string;
 
 ProofFileNames::ProofFileNames(const std::string & s) :
@@ -43,7 +44,7 @@ struct Proof::Imp
 };
 
 Proof::Proof(const ProofOptions & o) :
-    _imp(new Imp{o})
+    _imp(make_unique<Imp>(o))
 {
     _imp->tracker.start_writing_model(model());
 }

--- a/gcs/variable_id.hh
+++ b/gcs/variable_id.hh
@@ -194,7 +194,8 @@ struct std::hash<gcs::ViewOfIntegerVariableID>
     [[nodiscard]] inline auto operator()(const gcs::ViewOfIntegerVariableID & v) const -> std::size_t
     {
         return hash<gcs::SimpleIntegerVariableID>{}(v.actual_variable) ^
-            hash<gcs::Integer>{}(v.then_add);
+            hash<gcs::Integer>{}(v.then_add) ^
+            hash<bool>{}(v.negate_first);
     }
 };
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -90,12 +90,11 @@ public:
 
 namespace
 {
-    static atomic<bool> abort_flag{false}, was_terminated{false};
+    static atomic<bool> abort_flag{false};
 
     auto sig_int_or_term_handler(int) -> void
     {
         abort_flag.store(true);
-        was_terminated.store(true);
     }
 
     struct ExtractedData
@@ -306,6 +305,8 @@ auto main(int argc, char * argv[]) -> int
             }
             else if (var_type == "int") {
                 if (! vardata.contains("domain")) {
+                    // Halve the bounds so there is headroom for sums and products of
+                    // unbounded variables to stay within Integer without overflowing.
                     auto var = problem.create_integer_variable(Integer::min_value() / 2_i, Integer::max_value() / 2_i, name);
                     data.integer_variables.emplace(name, pair{var, false});
                     if ((! vardata.contains("defined")) || (! vardata["defined"].get<bool>()))


### PR DESCRIPTION
A batch of small, low-risk cleanups from the "claude" + "code cleanup" auditor issues. Each commit is scoped to one issue and only takes the items I could verify as safe and uncontroversial; the larger/judgement items are explicitly left out (noted per commit and below) for separate decisions. Full `sanitize` build is green and representative tests pass under VeriPB.

### Done

**#286 — integer.hh / variable_id.hh nits**
- Drop the meaningless top-level `const` on `Integer::min_value()` / `max_value()` return types.
- Include `negate_first` in `std::hash<ViewOfIntegerVariableID>` (the defaulted `operator<=>` already compares it).

**#291 — public-API consistency**
- `[[nodiscard]]` on `Problem::all_normal_variables()` and `CurrentState::each_value()` / `each_value_reversed()` / `copy_of_values()`.
- Drop the stray `1` from the `gcs.hh` include-guard `#define`.
- Add `array_param.hh` and `reification.hh` to the `gcs.hh` umbrella (previously only reachable transitively).

**#287 — make_unique over `unique_ptr(new …)`**
- Convert the seven `_imp(new Imp{…})` PIMPL initialisers to `make_unique`.

**#296 — fzn_glasgow.cc**
- Remove the write-only `was_terminated` atomic.
- Document why unbounded int vars use `min_value()/2 … max_value()/2`.

### Deliberately skipped (need a human call)

- **#286**: `.clang-format` `Standard:` bump — `c++23` isn't a valid clang-format value, and `Latest` reformats **47 files**. The `_i` UDL narrowing check is a behaviour change.
- **#291**: shared exception base class (refactor); the "redundant" `SolveCallbacks` initialisers are **not** redundant — they suppress `-Wmissing-field-initializers` at designated-init call sites (removing them regresses a clean build to a warning); `_state_copy` double-wrap needs a behaviour check.
- **#287**: `regular.cc` clone() — `Regular`'s constructor is **private**, so `make_unique` can't call it (the build catches this); `element.cc` clone() is aggregate brace-init (needs a C++23 P0960 per-site call).
- **#296**: RAII rewrite of the triplicated timeout teardown; `fmt::join` / `arg_as_array` ownership nits; the output-loop "copy" nit is a non-win (JSON elements — `const auto&` breaks `format()`, `const string&` constructs the same temporary).
- **#284** (dedup `track_impl`): a 1–2h CRTP refactor of the proof-critical inference tracker — not in the "easy" bucket.
- **#293** (tidy `test/`): file relocation, README content, and a run-vs-manual policy decision — judgement, not mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)