### PR TITLE
Annotated Assertions

### DIFF
--- a/examples/cake/cake.cc
+++ b/examples/cake/cake.cc
@@ -92,8 +92,9 @@ auto main(int argc, char * argv[]) -> int
                 variable_order::dom_then_deg(vector<IntegerVariableID>{banana, chocolate}),
                 value_order::largest_first())},
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()},
-                  true, options_vars.count("full-proof-encoding"))
+            ? make_optional(options_vars.count("full-proof-encoding")
+                      ? ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding()
+                      : ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}})
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -49,12 +50,13 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program options")                                                       //
-            ("help", "Display help information")                                                     //
-            ("prove", "Create a proof")                                                              //
-            ("proof-files-basename", "Basename for the .opb and .pbp files",                         //
-                cxxopts::value<string>()->default_value("crystal_maze"))                             //
-            ("stats", "Print solve statistics")                                                      //
+        options.add_options("Program options")                               //
+            ("help", "Display help information")                             //
+            ("prove", "Create a proof")                                      //
+            ("proof-files-basename", "Basename for the .opb and .pbp files", //
+                cxxopts::value<string>()->default_value("crystal_maze"))     //
+            ("stats", "Print solve statistics")                              //
+            ("assert", "Use annotated assertions")                           //
             ;
 
         options.add_options()             //
@@ -101,6 +103,12 @@ auto main(int argc, char * argv[]) -> int
         p.post(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")});
     }
 
+    auto proof_options = options_vars.contains("prove")
+        ? make_optional(options_vars.contains("assert")
+                  ? ProofOptions{options_vars["proof-files-basename"].as<string>()}.enable_assertions()
+                  : ProofOptions{options_vars["proof-files-basename"].as<string>()})
+        : nullopt;
+
     auto stats = solve_with(p,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
@@ -111,9 +119,7 @@ auto main(int argc, char * argv[]) -> int
                 return true;
             },
             .branch = branch_with(variable_order::dom_then_deg(xs), value_order::smallest_first())},
-        options_vars.contains("prove")
-            ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>())
-            : nullopt);
+        proof_options);
 
     if (options_vars.contains("stats"))
         print("{}", stats);

--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -3,6 +3,7 @@
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/problem.hh>
+#include <gcs/proof.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
@@ -105,7 +106,7 @@ auto main(int argc, char * argv[]) -> int
 
     auto proof_options = options_vars.contains("prove")
         ? make_optional(options_vars.contains("assert")
-                  ? ProofOptions{options_vars["proof-files-basename"].as<string>()}.enable_assertions()
+                  ? ProofOptions{options_vars["proof-files-basename"].as<string>()}.set_assertion_level(AssertionLevel::Inferences)
                   : ProofOptions{options_vars["proof-files-basename"].as<string>()})
         : nullopt;
 

--- a/examples/tutorial_proof/tutorial_proof.cc
+++ b/examples/tutorial_proof/tutorial_proof.cc
@@ -85,8 +85,9 @@ auto main(int argc, char * argv[]) -> int
             },
         },
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()},
-                  true, options_vars.count("full-proof-encoding"))
+            ? make_optional(options_vars.count("full-proof-encoding")
+                      ? ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding()
+                      : ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}})
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/abs/justify.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/interval_set.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -11,7 +12,6 @@
 
 #include <algorithm>
 #include <optional>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -131,7 +131,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     [logger, v1, v2, abs_nonneg_ge](const ReasonFunction &) -> void {
                         justify_abs_v2_ge_zero(*logger, v1, v2, *abs_nonneg_ge);
                     }},
-                ReasonFunction{});
+                ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
 
             auto v2_ub = state.upper_bound(v2);
 
@@ -144,7 +144,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
                         }},
-                    ReasonFunction{});
+                    ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
 
             // Symmetric flag-collision concern: skip when ub(v2) <= 0.
@@ -154,7 +154,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
                         }},
-                    ReasonFunction{});
+                    ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
 
             auto [v1_lb, v1_ub] = state.bounds(v1);
@@ -164,7 +164,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     [logger, v1, v2, v1_lb, v1_ub, big_m, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
                         justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, big_m, *abs_nonneg_le, *abs_neg_le, r);
                     }},
-                ReasonFunction{});
+                ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
         },
         InitialiserPriority::SimpleDefinition);
 
@@ -203,7 +203,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                             [logger, v1, v2, v1_lb, v1_ub, image_ub, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
                                 justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, image_ub, *abs_nonneg_le, *abs_neg_le, r);
                             }},
-                        ReasonFunction{[v1, v1_lb, v1_ub]() { return Reason{{v1 >= v1_lb, v1 <= v1_ub}}; }});
+                        ReasonFunction{[v1, v1_lb, v1_ub]() { return Reason{{v1 >= v1_lb, v1 <= v1_ub}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
 
                 if (v1_lb >= 1_i && v1_lb > v2_lb) {
@@ -212,7 +212,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                             [logger, v1, v2, v1_lb, abs_nonneg_ge](const ReasonFunction & r) -> void {
                                 justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonneg, v1_lb, *abs_nonneg_ge, r);
                             }},
-                        ReasonFunction{[v1, v1_lb]() { return Reason{v1 >= v1_lb}; }});
+                        ReasonFunction{[v1, v1_lb]() { return Reason{v1 >= v1_lb}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
                 else if (v1_ub <= -1_i && -v1_ub > v2_lb) {
                     inference.infer_greater_than_or_equal(logger, v2, -v1_ub,
@@ -220,7 +220,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                             [logger, v1, v2, v1_ub, abs_neg_ge](const ReasonFunction & r) -> void {
                                 justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonpos, -v1_ub, *abs_neg_ge, r);
                             }},
-                        ReasonFunction{[v1, v1_ub]() { return Reason{v1 <= v1_ub}; }});
+                        ReasonFunction{[v1, v1_ub]() { return Reason{v1 <= v1_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
             }
 
@@ -231,7 +231,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
                         }},
-                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }});
+                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
             if (-v2_ub > v1_lb) {
                 inference.infer_greater_than_or_equal(logger, v1, -v2_ub,
@@ -239,7 +239,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
                         }},
-                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }});
+                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
 
             // Interior pruning: remove values in v2 with no preimage in v1,
@@ -269,7 +269,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         JustifyExplicitlyThenRUP{[logger, v1, v2, val](const ReasonFunction & r) {
                             justify_abs_hole(*logger, r, v1, v2, val);
                         }},
-                        ReasonFunction{[v1, val]() { return Reason{{v1 != val, v1 != -val}}; }});
+                        ReasonFunction{[v1, val]() { return Reason{{v1 != val, v1 != -val}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
             }
 
@@ -292,7 +292,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     if (! state.in_domain(v1, val))
                         continue;
                     inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{},
-                        ReasonFunction{[v2, val]() { return Reason{v2 != abs(val)}; }});
+                        ReasonFunction{[v2, val]() { return Reason{v2 != abs(val)}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
             }
 

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -187,9 +187,10 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
         [vars = move(_sanitised_vars),
             vals = move(_compressed_vals),
             excluded = move(_sanitised_excluded),
-            value_am1_constraint_numbers = _value_am1_constraint_numbers](const State & state, auto & inference,
+            value_am1_constraint_numbers = _value_am1_constraint_numbers,
+            constraint_id = constraint_id()](const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState {
-            propagate_gac_all_different(vars, vals, excluded, *value_am1_constraint_numbers.get(), state, inference, logger);
+            propagate_gac_all_different(constraint_id, vars, vals, excluded, *value_am1_constraint_numbers.get(), state, inference, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_different/encoding.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/all_different/gac_all_different.hh>
 #include <gcs/constraints/all_different/justify.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -419,7 +420,7 @@ auto gcs::innards::propagate_gac_all_different(
         // nope. we've got a maximum cardinality matching that leaves at least
         // one thing on the left uncovered.
         auto [just, reason] = prove_matching_is_too_small(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger, edges, left_covered, matching);
-        return tracker.infer(logger, FalseLiteral{}, just, reason);
+        return tracker.infer(logger, FalseLiteral{}, just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent});
     }
 
     // we have a matching that uses every variable. however, some edges may
@@ -587,7 +588,7 @@ auto gcs::innards::propagate_gac_all_different(
 
         auto [just, reason] = prove_deletion_using_sccs(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger,
             edges_out_from_variable, edges_out_from_value, *representatives_for_scc[scc], components);
-        tracker.infer_all(logger, deletions_by_scc[scc], just, reason);
+        tracker.infer_all(logger, deletions_by_scc[scc], just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent});
     }
 }
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraint.hh>
 #include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/constraints/all_different/gac_all_different.hh>
 #include <gcs/constraints/all_different/justify.hh>
@@ -378,6 +379,7 @@ namespace
 }
 
 auto gcs::innards::propagate_gac_all_different(
+    const ConstraintID & constraint_id,
     const vector<IntegerVariableID> & vars,
     const vector<Integer> & vals,
     const vector<Integer> & excluded,
@@ -420,7 +422,7 @@ auto gcs::innards::propagate_gac_all_different(
         // nope. we've got a maximum cardinality matching that leaves at least
         // one thing on the left uncovered.
         auto [just, reason] = prove_matching_is_too_small(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger, edges, left_covered, matching);
-        return tracker.infer(logger, FalseLiteral{}, just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent});
+        return tracker.infer(logger, FalseLiteral{}, just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent, .hint_fields = hint_list(AssertionHintIdentifier::constraint_id, constraint_id)});
     }
 
     // we have a matching that uses every variable. however, some edges may
@@ -588,7 +590,7 @@ auto gcs::innards::propagate_gac_all_different(
 
         auto [just, reason] = prove_deletion_using_sccs(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger,
             edges_out_from_variable, edges_out_from_value, *representatives_for_scc[scc], components);
-        tracker.infer_all(logger, deletions_by_scc[scc], just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent});
+        tracker.infer_all(logger, deletions_by_scc[scc], just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent, .hint_fields = hint_list(AssertionHintIdentifier::constraint_id, constraint_id)});
     }
 }
 
@@ -645,15 +647,17 @@ auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
         constraint_id(),
         [vars = move(_sanitised_vars),
             vals = move(_compressed_vals),
-            value_am1_constraint_numbers = move(value_am1_constraint_numbers)](const State & state, auto & inference,
+            value_am1_constraint_numbers = move(value_am1_constraint_numbers),
+            constraint_id = constraint_id()](const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState {
-            propagate_gac_all_different(vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), state, inference, logger);
+            propagate_gac_all_different(constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), state, inference, logger);
             return PropagatorState::Enable;
         },
         triggers);
 }
 
 template auto gcs::innards::propagate_gac_all_different(
+    const ConstraintID & constraint_id,
     const std::vector<IntegerVariableID> & vars,
     const std::vector<Integer> & vals,
     const std::vector<Integer> & excluded,
@@ -663,6 +667,7 @@ template auto gcs::innards::propagate_gac_all_different(
     ProofLogger * const logger) -> void;
 
 template auto gcs::innards::propagate_gac_all_different(
+    const ConstraintID & constraint_id,
     const std::vector<IntegerVariableID> & vars,
     const std::vector<Integer> & vals,
     const std::vector<Integer> & excluded,

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -13,6 +13,7 @@
 #include <gcs/innards/state.hh>
 #include <gcs/innards/variable_id_utils.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -50,6 +51,7 @@ using std::optional;
 using std::pair;
 using std::shared_ptr;
 using std::string;
+using std::tuple;
 using std::unique_ptr;
 using std::variant;
 using std::vector;
@@ -193,16 +195,17 @@ namespace
     }
 
     auto prove_matching_is_too_small(
+        const ConstraintID & constraint_id,
         const vector<IntegerVariableID> & vars,
         const vector<Integer> & vals,
         const vector<Integer> & excluded,
         size_t n_right,
         map<Integer, ProofLine> & value_am1_constraint_numbers,
         const State & state,
-        ProofLogger & logger,
+        ProofLogger * const logger,
         const vector<pair<Left, Right>> & edges,
         const vector<uint8_t> & left_covered,
-        const vector<optional<Right>> & matching) -> pair<JustifyExplicitlyThenRUP, ReasonFunction>
+        const vector<optional<Right>> & matching) -> std::tuple<JustifyExplicitlyThenRUP, ReasonFunction, optional<AssertionAnnotation>>
     {
         vector<optional<Left>> inverse_matching(n_right, nullopt);
         for (const auto & [l, r] : enumerate(matching))
@@ -258,17 +261,33 @@ namespace
             if (hall_values[v.offset])
                 hall_value_nrs.push_back(vals[v.offset]);
 
-        return pair{JustifyExplicitlyThenRUP{
-                        [vars, &logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](const ReasonFunction &) -> void {
-                            justify_all_different_hall_set_or_violator(logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
-                        }},
+        optional<AssertionAnnotation> assertion_annotation;
+        if (logger && logger->get_assertion_level() != AssertionLevel::Off) {
+            vector<SExpr> hall_var_terms;
+            for (const auto & v : hall_variable_ids)
+                hall_var_terms.push_back(logger->names_and_ids_tracker().s_expr_term_of(v));
+            assertion_annotation = std::make_optional(AssertionAnnotation{
+                .hint_name = AssertionHintName::AllDifferent,
+                .hint_fields = hint_list(
+                    hint_list(AssertionHintIdentifier::constraint_id, constraint_id),
+                    hint_list(AssertionHintIdentifier::hall_vars, SExpr::list(move(hall_var_terms))),
+                    hint_list(AssertionHintIdentifier::hall_vals, hint_seq(hall_value_nrs)),
+                    hint_list(AssertionHintIdentifier::justifier, AssertionHintIdentifier::hall_set_or_violator))});
+        }
+
+        return tuple{
+            JustifyExplicitlyThenRUP{
+                [vars, logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](const ReasonFunction &) -> void {
+                    justify_all_different_hall_set_or_violator(*logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
+                }},
             ReasonFunction{[hall_variable_ids, excluded, &state]() -> Reason {
                 auto reason = generic_reason(state, hall_variable_ids)();
                 for (const auto & v : hall_variable_ids)
                     for (const auto & s : excluded)
                         reason.emplace_back(v != s);
                 return reason;
-            }}};
+            }},
+            assertion_annotation};
     }
 
     using Vertex = variant<Left, Right>;
@@ -285,17 +304,18 @@ namespace
     }
 
     auto prove_deletion_using_sccs(
+        const ConstraintID & constraint_id,
         const vector<IntegerVariableID> & vars,
         const vector<Integer> & vals,
         const vector<Integer> & excluded,
         size_t n_right,
         map<Integer, ProofLine> & value_am1_constraint_numbers,
         const State & state,
-        ProofLogger & logger,
+        ProofLogger * const logger,
         const vector<vector<Right>> & edges_out_from_variable,
         const vector<vector<Left>> & edges_out_from_value,
         const Right delete_value,
-        const vector<int> & components) -> pair<Justification, ReasonFunction>
+        const vector<int> & components) -> tuple<Justification, ReasonFunction, optional<AssertionAnnotation>>
     {
         // we know a hall set exists, but we have to find it. starting
         // from but not including the end of the edge we're deleting,
@@ -352,8 +372,16 @@ namespace
             // some other variable has been given this value
             if (edges_out_from_value[delete_value.offset].empty())
                 throw UnexpectedException{"missing edge out from value in trivial scc"};
-            else
-                return pair{JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}; }}};
+
+            optional<AssertionAnnotation> assertion_annotation;
+            if (logger && logger->get_assertion_level() != AssertionLevel::Off)
+                assertion_annotation = std::make_optional(AssertionAnnotation{
+                    .hint_name = AssertionHintName::AllDifferent,
+                    .hint_fields = hint_list(hint_list(AssertionHintIdentifier::constraint_id, constraint_id))});
+
+            return tuple{Justification{JustifyUsingRUP{}},
+                ReasonFunction{[=]() { return Reason{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}; }},
+                assertion_annotation};
         }
         else {
             // a hall set is at work
@@ -362,18 +390,33 @@ namespace
                 if (hall_right[v.offset])
                     hall_value_nrs.push_back(vals[v.offset]);
 
-            return pair{JustifyExplicitlyThenRUP{
-                            [vars, &logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](
-                                const ReasonFunction &) -> void {
-                                justify_all_different_hall_set_or_violator(logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
-                            }},
+            optional<AssertionAnnotation> assertion_annotation;
+            if (logger && logger->get_assertion_level() != AssertionLevel::Off) {
+                vector<SExpr> hall_var_terms;
+                for (const auto & v : hall_variable_ids)
+                    hall_var_terms.push_back(logger->names_and_ids_tracker().s_expr_term_of(v));
+                assertion_annotation = std::make_optional(AssertionAnnotation{
+                    .hint_name = AssertionHintName::AllDifferent,
+                    .hint_fields = hint_list(
+                        hint_list(AssertionHintIdentifier::constraint_id, constraint_id),
+                        hint_list(AssertionHintIdentifier::hall_vars, SExpr::list(move(hall_var_terms))),
+                        hint_list(AssertionHintIdentifier::hall_vals, hint_seq(hall_value_nrs)),
+                        hint_list(AssertionHintIdentifier::justifier, AssertionHintIdentifier::hall_set_or_violator))});
+            }
+
+            return tuple{Justification{JustifyExplicitlyThenRUP{
+                             [vars, logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](
+                                 const ReasonFunction &) -> void {
+                                 justify_all_different_hall_set_or_violator(*logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
+                             }}},
                 ReasonFunction{[hall_variable_ids, excluded, &state]() -> Reason {
                     auto reason = generic_reason(state, hall_variable_ids)();
                     for (const auto & v : hall_variable_ids)
                         for (const auto & s : excluded)
                             reason.emplace_back(v != s);
                     return reason;
-                }}};
+                }},
+                assertion_annotation};
         }
     }
 }
@@ -421,8 +464,8 @@ auto gcs::innards::propagate_gac_all_different(
     if (cmp_not_equal(count(left_covered.begin(), left_covered.end(), 1), vars.size())) {
         // nope. we've got a maximum cardinality matching that leaves at least
         // one thing on the left uncovered.
-        auto [just, reason] = prove_matching_is_too_small(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger, edges, left_covered, matching);
-        return tracker.infer(logger, FalseLiteral{}, just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent, .hint_fields = hint_list(AssertionHintIdentifier::constraint_id, constraint_id)});
+        auto [just, reason, annotation] = prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, edges, left_covered, matching);
+        return tracker.infer(logger, FalseLiteral{}, just, reason, annotation);
     }
 
     // we have a matching that uses every variable. however, some edges may
@@ -588,9 +631,9 @@ auto gcs::innards::propagate_gac_all_different(
         if (! representatives_for_scc[scc])
             continue;
 
-        auto [just, reason] = prove_deletion_using_sccs(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger,
+        auto [just, reason, annotation] = prove_deletion_using_sccs(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger,
             edges_out_from_variable, edges_out_from_value, *representatives_for_scc[scc], components);
-        tracker.infer_all(logger, deletions_by_scc[scc], just, reason, AssertionAnnotation{.hint_name = AssertionHintName::AllDifferent, .hint_fields = hint_list(AssertionHintIdentifier::constraint_id, constraint_id)});
+        tracker.infer_all(logger, deletions_by_scc[scc], just, reason, annotation);
     }
 }
 

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GAC_ALL_DIFFERENT_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GAC_ALL_DIFFERENT_HH
 
+#include <gcs/constraint.hh>
 #include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -17,6 +18,7 @@ namespace gcs
     namespace innards
     {
         auto propagate_gac_all_different(
+            const ConstraintID & constraint_id,
             const std::vector<IntegerVariableID> & vars,
             const std::vector<Integer> & vals,
             const std::vector<Integer> & excluded,

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -136,6 +136,8 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
         propagators.install_initialiser(
             [vars, start, n, value_am1s = _value_am1s](
                 const State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() >= AssertionLevel::Off)
+                    return;
                 for (Integer v = start; v < start + Integer(n); ++v) {
                     vector<IntegerVariableCondition> xieqvs;
                     for (const auto & var : vars)

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -162,7 +162,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
 
     propagators.install(
         constraint_id(),
-        [vars, start, values = move(values), value_am1s = _value_am1s](
+        [vars, start, values = move(values), value_am1s = _value_am1s, constraint_id = constraint_id()](
             const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
             // Channeling: x_i = v  =>  x_v = i. If i is not in D(x_v), prune
             // v from D(x_i). Single pass — Inverse(x, y) runs this in both
@@ -175,7 +175,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
                             [&]() { return Reason{vars.at((v - start).as_index()) != Integer(i) + start}; });
             }
 
-            propagate_gac_all_different(vars, values, vector<Integer>{}, *value_am1s.get(), state, inf, logger);
+            propagate_gac_all_different(constraint_id, vars, values, vector<Integer>{}, *value_am1s.get(), state, inf, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -111,7 +112,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
     auto am1_lines = make_shared<map<IntegerVariableID, ProofLine>>();
     propagators.install_initialiser([vars = _vars, values_of_interest = _values_of_interest, am1_lines = am1_lines](
                                         const State &, auto &, ProofLogger * const logger) -> void {
-        if (logger && values_of_interest.size() > 1) {
+        if (logger && values_of_interest.size() > 1 && logger->get_assertion_level() == AssertionLevel::Off) {
             for (auto & var : vars) {
                 vector<IntegerVariableCondition> var_eq_vois;
                 for (const auto & voi : values_of_interest)

--- a/gcs/constraints/arithmetic_test.cc
+++ b/gcs/constraints/arithmetic_test.cc
@@ -149,7 +149,7 @@ auto run_power_pinned_test(bool proofs, Integer base, Integer exp, pair<long lon
                 actual_results.insert(s(v3).raw_value);
                 return true;
             }},
-        proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}, true, false) : nullopt);
+        proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
 
     println(cerr, " got {} solutions", actual_results.size());
 

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -130,7 +130,7 @@ auto gcs::innards::circuit::prevent_small_cycles(
                     length++;
                     // Need to check this in case alldiff hasn't been fully propagated.
                     if (j == j0) {
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             output_cycle_to_proof(succ, j0, length, pos_var_data, state, *logger);
                         inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, succ));
                     }

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -45,7 +45,7 @@ namespace
                         cycle_length++;
                         if (j == j0) {
                             if (cmp_less(cycle_length, n)) {
-                                if (logger)
+                                if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                                     output_cycle_to_proof(succ, j0, cycle_length, pos_var_data, state, *logger);
                                 inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, succ));
                             }

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/circuit/circuit_base.hh>
 #include <gcs/constraints/circuit/circuit_scc.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/propagators.hh>
@@ -1041,7 +1042,7 @@ namespace
                         }
                     }
 
-                    inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, ReasonFunction{});
+                    inference.infer(logger, succ[node] != w, JustifyUsingRUP{}, ReasonFunction{});
                 }
                 data.lowlink[node] = pos_min(data.lowlink[node], data.visit_number[next_node]);
             }
@@ -1094,7 +1095,7 @@ namespace
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, from_node, options);
                             prove_reachable_set_too_small(ctx, succ[from_node] != Integer{to_node});
                         }
-                        inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, ReasonFunction{});
+                        inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{}, ReasonFunction{});
                     }
                 }
                 data.start_prev_subtree = data.end_prev_subtree + 1;

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -1040,9 +1040,11 @@ namespace
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                             prove_skipped_subtree(ctx, node, next_node, data.prev_subroot);
                         }
+                        inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, ReasonFunction{});
                     }
-
-                    inference.infer(logger, succ[node] != w, JustifyUsingRUP{}, ReasonFunction{});
+                    else {
+                        inference.infer(logger, succ[node] != w, JustifyUsingRUP{}, ReasonFunction{});
+                    }
                 }
                 data.lowlink[node] = pos_min(data.lowlink[node], data.visit_number[next_node]);
             }
@@ -1094,8 +1096,12 @@ namespace
 
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, from_node, options);
                             prove_reachable_set_too_small(ctx, succ[from_node] != Integer{to_node});
+                            inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, ReasonFunction{});
                         }
-                        inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{}, ReasonFunction{});
+                        else {
+
+                            inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{}, ReasonFunction{});
+                        }
                     }
                 }
                 data.start_prev_subtree = data.end_prev_subtree + 1;

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 
 #include <list>
@@ -1027,7 +1028,7 @@ namespace
                     back_edges.emplace_back(node, next_node);
                 }
                 else if (options.prune_skip && data.visit_number[next_node] < data.start_prev_subtree) {
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (next_node == data.root) {
                             logger->emit_proof_comment(format("Pruning edge to the root from a subtree other than the first ({}, {})", node, next_node));
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.prev_subroot, options);
@@ -1047,7 +1048,7 @@ namespace
         }
 
         if (data.lowlink[node] == data.visit_number[node]) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 logger->emit_proof_comment("More than one SCC");
                 auto ctx = SCCProofContext{state, *logger, reason, succ, proof_data, node, options};
                 prove_reachable_set_too_small(ctx);
@@ -1076,7 +1077,7 @@ namespace
                 auto back_edges = explore(state, inference, logger, reason, next_node, succ, data, proof_data, options);
 
                 if (back_edges.empty()) {
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         logger->emit_proof_comment("No back edges");
                         auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, next_node, options);
                         prove_reachable_set_too_small(ctx);
@@ -1087,7 +1088,7 @@ namespace
                     auto from_node = back_edges[0].first;
                     auto to_node = back_edges[0].second;
                     if (! state.optional_single_value(succ[from_node])) {
-                        if (logger) {
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                             logger->emit_proof_comment(format("Fix required back edge ({}, {}):", from_node, to_node));
 
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, from_node, options);
@@ -1103,7 +1104,7 @@ namespace
         }
 
         if (cmp_not_equal(data.count, succ.size())) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 logger->emit_proof_comment("Disconnected graph");
                 auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                 prove_reachable_set_too_small(ctx);
@@ -1114,7 +1115,7 @@ namespace
         if (options.prune_root && data.start_prev_subtree > 1) {
             for (const auto & v : state.each_value_mutable(succ[data.root])) {
                 if (data.visit_number[v.as_index()] < data.start_prev_subtree) {
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         logger->emit_proof_comment("Prune impossible edges from root node");
                         auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                         prove_reachable_set_too_small(ctx, succ[data.root] == v);

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <gcs/proof.hh>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -194,7 +195,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         [starts = _starts, lengths = _lengths, active_tasks = _active_tasks,
             per_task_t_lo = _per_task_t_lo, per_task_t_hi = _per_task_t_hi,
             bridge](State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger)
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                 return;
             for (auto i : active_tasks) {
                 if (lengths[i] == 0_i)
@@ -590,7 +591,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         }
 
                         auto justify = [&, j, chain](const ReasonFunction & reason) -> void {
-                            if (! logger)
+                            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                                 return;
                             for (size_t step = 0; step < chain.size(); ++step)
                                 emit_chain_step(j, chain[step].t, chain[step].k,

--- a/gcs/constraints/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <gcs/constraints/disjunctive_2d.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -11,6 +12,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <gcs/proof.hh>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -321,7 +323,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
             end_y = _end_y, active_rects = _active_rects, x_lo = _x_lo, x_hi = _x_hi, y_lo = _y_lo,
             y_hi = _y_hi, bridge_x, bridge_y](
             State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger)
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                 return;
             // "after" reifies on pos + size >= t+1; for a constant size that is
             // the single-variable pos >= t-size+1, for a variable size the
@@ -691,7 +693,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             break;
                     }
                     auto justify = [&, chain](const ReasonFunction & reason) -> void {
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             emit_proof(chain, +1, reason);
                     };
                     inference.infer_greater_than_or_equal(logger, free_pos[i], target,
@@ -716,7 +718,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             break;
                     }
                     auto justify = [&, chain](const ReasonFunction & reason) -> void {
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             emit_proof(chain, -1, reason);
                     };
                     inference.infer_less_than(logger, free_pos[i], target + 1_i,

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -282,35 +282,38 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         if (v1 == v2 && ! is_constant_variable(v1))
             return reification_verdict::MustHold{
                 .justification = JustifyUsingRUP{},
-                .reason = ReasonFunction{}};
+                .reason = ReasonFunction{},
+                .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {
             auto reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 == *value2}; }};
             if (*value1 == *value2)
-                return reification_verdict::MustHold{.justification = JustifyUsingRUP{}, .reason = reason};
+                return reification_verdict::MustHold{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             else
-                return reification_verdict::MustNotHold{.justification = JustifyUsingRUP{}, .reason = reason};
+                return reification_verdict::MustNotHold{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
         }
         else if (value1) {
             if (! state.in_domain(v2, *value1))
                 return reification_verdict::MustNotHold{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 != *value1}; }}};
+                    .reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 != *value1}; }},
+                    .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             return reification_verdict::StillUndecided{};
         }
         else if (value2) {
             if (! state.in_domain(v1, *value2))
                 return reification_verdict::MustNotHold{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{v2 == *value2, v1 != *value2}; }}};
+                    .reason = ReasonFunction{[=]() { return Reason{v2 == *value2, v1 != *value2}; }},
+                    .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             return reification_verdict::StillUndecided{};
         }
         else {
             // not equals is forced if there's no overlap between domains
             if (! state.domains_intersect(v1, v2)) {
                 auto [just, reason] = no_overlap_justification(state, logger, v1, v2, cond);
-                return reification_verdict::MustNotHold{.justification = just, .reason = reason};
+                return reification_verdict::MustNotHold{.justification = just, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             }
             return reification_verdict::StillUndecided{};
         }

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/innards/justify_not_in_range.hh>
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -46,13 +47,13 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 {
     auto val1 = state.optional_single_value(v1);
     if (val1) {
-        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 == *val1); return reason; }});
+        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 == *val1); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
         return PropagatorState::DisableUntilBacktrack;
     }
 
     auto val2 = state.optional_single_value(v2);
     if (val2) {
-        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 == *val2); return reason; }});
+        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 == *val2); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
         return PropagatorState::DisableUntilBacktrack;
     }
 
@@ -93,11 +94,12 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
                             auto r = base;
                             r.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
                             return r;
-                        }});
+                        }},
+                        AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
                 else
                     for (Integer val = lo; val <= hi; ++val)
                         inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{},
-                            ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(other != val); return reason; }});
+                            ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(other != val); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
             }
         };
 
@@ -107,10 +109,10 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
     else {
         auto bounds1 = state.bounds(v1), bounds2 = state.bounds(v2);
         if (bounds1 != bounds2) {
-            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 >= bounds1.first); return reason; }});
-            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 >= bounds2.first); return reason; }});
-            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 <= bounds1.second); return reason; }});
-            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 <= bounds2.second); return reason; }});
+            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 >= bounds1.first); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 >= bounds2.first); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 <= bounds1.second); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 <= bounds2.second); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
         }
     }
 
@@ -258,13 +260,13 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         auto value1 = state.optional_single_value(v1);
         if (value1) {
             inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v1 == *value1}}; }});
+                ReasonFunction{[=]() { return Reason{{cond, v1 == *value1}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
             inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v2 == *value2}}; }});
+                ReasonFunction{[=]() { return Reason{{cond, v2 == *value2}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -388,7 +388,7 @@ namespace gcs::test_innards
 
         solve_with(p,
             SolveCallbacks{.solution = capped_solution, .trace = capped_trace, .branch = random_branch_with_optional_seed(p)},
-            proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}, true, false) : std::nullopt);
+            proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}) : std::nullopt);
     }
 
     /**
@@ -404,7 +404,7 @@ namespace gcs::test_innards
             SolveCallbacks{
                 .trace = [](const CurrentState &) -> bool { return false; },
                 .branch = random_branch_with_optional_seed(p)},
-            std::make_optional<ProofOptions>(ProofFileNames{proof_name}, true, false));
+            std::make_optional<ProofOptions>(ProofFileNames{proof_name}));
 
         if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
             throw UnexpectedException{"veripb verification failed"};

--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -3,6 +3,10 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 
+#include <gcs/proof.hh>
+#include <util/enumerate.hh>
+
+#include <sstream>
 #include <type_traits>
 #include <variant>
 
@@ -21,6 +25,9 @@ template <typename Literal_>
     const vector<Literal_> & atoms,
     const function<auto(const Literal_ &, const Literal_ &)->ProofLine> & pair_ne) -> ProofLine
 {
+    if (logger.get_assertion_level() > AssertionLevel::Off)
+        return ProofLine{};
+
     if (atoms.size() < 2)
         // An at-most-one over fewer than two atoms is vacuous; the caller should
         // handle it directly rather than ask the helper to fold zero pairwise

--- a/gcs/constraints/innards/reified_dispatcher.hh
+++ b/gcs/constraints/innards/reified_dispatcher.hh
@@ -4,15 +4,16 @@
 
 #include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/constraints/innards/triggers.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/reification.hh>
 
+#include <optional>
 #include <util/overloaded.hh>
 
-#include <string>
 #include <utility>
 #include <variant>
 
@@ -38,6 +39,7 @@ namespace gcs::innards
         {
             Justification justification;
             ReasonFunction reason;
+            std::optional<AssertionAnnotation> assertion_hint = std::nullopt;
         };
 
         /**
@@ -47,6 +49,7 @@ namespace gcs::innards
         {
             Justification justification;
             ReasonFunction reason;
+            std::optional<AssertionAnnotation> assertion_hint = std::nullopt;
         };
     }
 
@@ -142,12 +145,12 @@ namespace gcs::innards
                             },
                             [&](const reification_verdict::MustHold & h) {
                                 if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                    inference.infer(logger, *lit, h.justification, h.reason);
+                                    inference.infer(logger, *lit, h.justification, h.reason, h.assertion_hint);
                                 return PropagatorState::DisableUntilBacktrack;
                             },
                             [&](const reification_verdict::MustNotHold & n) {
                                 if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                    inference.infer(logger, *lit, n.justification, n.reason);
+                                    inference.infer(logger, *lit, n.justification, n.reason, n.assertion_hint);
                                 return PropagatorState::DisableUntilBacktrack;
                             }}
                             .visit(infer_cond_when_undecided(state, inference, logger, reif.cond));

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -11,6 +11,7 @@
 #include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
 
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 
 #include <version>
@@ -149,6 +150,8 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
 
         propagators.install_initialiser([x = _x, x_start = _x_start, x_value_am1s = _x_value_am1s, build_am1s = build_am1s](
                                             const State & state, auto & inference, ProofLogger * const logger) -> void {
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                return;
             build_am1s(x, x_start, state, inference, logger, x_value_am1s);
         });
     }

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -164,7 +164,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
     for (const auto & [i, _] : enumerate(_x))
         x_values.push_back(Integer(i) + _x_start);
 
-    propagators.install(constraint_id(), [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s, constraint_id = constraint_id()](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
         for (const auto & [i, x_i] : enumerate(x)) {
             for (auto x_i_value : state.each_value_mutable(x_i))
                 if (! state.in_domain(y.at((x_i_value - y_start).as_index()), Integer(i) + x_start))
@@ -181,7 +181,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
                         [&]() { return Reason{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}; });
         }
 
-        propagate_gac_all_different(x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
+        propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
 
         return PropagatorState::Enable; }, triggers);
 }

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -575,20 +576,20 @@ namespace
             boundses.emplace_back(state.bounds(t));
 
         int temporary_proof_level = 0;
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             temporary_proof_level = logger->temporary_proof_level();
 
         vector<IntegerVariableID> reason_variables;
         reason_variables.insert(reason_variables.end(), vars.begin(), vars.end());
         reason_variables.insert(reason_variables.end(), totals.begin(), totals.end());
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             knapsack_gac<true>(state, logger, reason_variables, inference, committed_sums,
                 boundses, coeffs, totals, vars, undetermined_vars, eqn_lines);
         else
             knapsack_gac<false>(state, logger, reason_variables, inference, committed_sums,
                 boundses, coeffs, totals, vars, undetermined_vars, nullopt);
 
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->forget_proof_level(temporary_proof_level);
 
         return PropagatorState::Enable;

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -240,7 +240,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                                 State & state, auto & inference, ProofLogger * const logger) {
                 *data = build_table(coeff_vars, value, cond, state, logger);
                 if (! data->has_value())
-                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }});
+                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
             },
                 InitialiserPriority::Expensive);
 
@@ -259,7 +259,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // the (folded-out) constant part, so the equality holds iff _value + modifier == 0
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier != -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }});
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                     });
                 }
 
@@ -280,7 +280,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // the equality _value + modifier == 0 must NOT hold, so it is violated iff it does
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier == -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }});
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                     });
                 }
 
@@ -349,12 +349,12 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                     // reified)
                                     if (accum == value) {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                     else {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }
@@ -368,7 +368,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                             // no way for the remaining variable to take that value, so the condition
                                             // has to be false
                                             if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                                inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                             return PropagatorState::DisableUntilBacktrack;
                                         }
                                         else {
@@ -380,7 +380,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                         // the value that would make the equality work isn't an integer, so the condition
                                         // has to be false
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -12,6 +12,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 #include <util/overloaded.hh>
 
@@ -95,7 +96,7 @@ namespace
 
                 if (match) {
                     permitted.emplace_back(current.begin(), current.end());
-                    if (logger && ! logger->using_assertions()) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         Integer sel_value(permitted.size() - 1);
                         logger->names_and_ids_tracker().create_literals_for_introduced_variable_value(future_var_id, sel_value, "lineq");
                         trail += 1_i * (future_var_id == sel_value);
@@ -125,7 +126,7 @@ namespace
                 }
             }
 
-            if (logger && ! logger->using_assertions()) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 WPBSum backtrack = trail;
                 for (const auto & [idx, val] : enumerate(current))
                     backtrack += 1_i * (get_var(coeff_vars.terms[idx]) != val);
@@ -134,7 +135,7 @@ namespace
             }
         };
 
-        if (logger && ! logger->using_assertions())
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->emit_proof_comment("building GAC table for linear equality");
         search(logger);
 

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -95,7 +95,7 @@ namespace
 
                 if (match) {
                     permitted.emplace_back(current.begin(), current.end());
-                    if (logger) {
+                    if (logger && ! logger->using_assertions()) {
                         Integer sel_value(permitted.size() - 1);
                         logger->names_and_ids_tracker().create_literals_for_introduced_variable_value(future_var_id, sel_value, "lineq");
                         trail += 1_i * (future_var_id == sel_value);
@@ -125,7 +125,7 @@ namespace
                 }
             }
 
-            if (logger) {
+            if (logger && ! logger->using_assertions()) {
                 WPBSum backtrack = trail;
                 for (const auto & [idx, val] : enumerate(current))
                     backtrack += 1_i * (get_var(coeff_vars.terms[idx]) != val);
@@ -134,7 +134,7 @@ namespace
             }
         };
 
-        if (logger)
+        if (logger && ! logger->using_assertions())
             logger->emit_proof_comment("building GAC table for linear equality");
         search(logger);
 
@@ -270,7 +270,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
 
                 visit(
                     [&, modifier = modifier](const auto & lin) {
-                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond); }, triggers);
+                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality}); }, triggers);
                     },
                     sanitised_cv);
             },
@@ -313,7 +313,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                         return overloaded{
                             [&](const evaluated_reif::MustHold & reif) {
                                 // we now know the condition definitely holds, so it's a linear equality
-                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond);
+                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                             },
 
                             [&](const evaluated_reif::MustNotHold &) {

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/linear/justify.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -79,7 +80,8 @@ namespace
     auto infer(auto & inference, ProofLogger * const logger,
         const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars,
         int p, const SimpleIntegerVariableID & var, Integer remainder, const bool coeff, bool second_constraint_for_equality,
-        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> void
+        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+        const optional<AssertionAnnotation> & assertion_hint) -> void
     {
         if (coeff) {
             if (bounds[p].second >= (1_i + remainder)) {
@@ -87,7 +89,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else {
@@ -96,7 +98,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
     }
@@ -104,7 +106,8 @@ namespace
     auto infer(auto & inference, ProofLogger * const logger,
         const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars,
         int p, const SimpleIntegerVariableID & var, Integer remainder, const Integer coeff, bool second_constraint_for_equality,
-        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> void
+        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+        const optional<AssertionAnnotation> & assertion_hint) -> void
     {
         // lots of conditionals to get the rounding right...
         if (coeff > 0_i && remainder >= 0_i) {
@@ -113,7 +116,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff > 0_i && remainder < 0_i) {
@@ -123,7 +126,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff < 0_i && remainder >= 0_i) {
@@ -132,7 +135,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff < 0_i && remainder < 0_i) {
@@ -142,7 +145,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else
@@ -152,7 +155,8 @@ namespace
 
 auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, const State & state,
     auto & inference, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState
 {
     vector<pair<Integer, Integer>> bounds;
     bounds.reserve(coeff_vars.terms.size());
@@ -193,7 +197,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
         Integer remainder = value - lower_without_me;
 
         infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv),
-            false, proof_line, add_to_reason);
+            false, proof_line, add_to_reason, assertion_hint);
         bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
         if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -230,7 +234,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
             Integer inv_remainder = -value - inv_lower_without_me;
 
             infer(inference, logger, bounds, coeff_vars, p, get_var(cv), inv_remainder, negate(get_coeff_or_bool(cv)),
-                true, proof_line, add_to_reason);
+                true, proof_line, add_to_reason, assertion_hint);
             bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
             if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -247,27 +251,33 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
 
 template auto gcs::innards::propagate_linear(const SumOf<Weighted<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<SimpleIntegerVariableID> & coeff_vars,
     Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<Weighted<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<SimpleIntegerVariableID> & coeff_vars,
     Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer value, const State & state,
     auto & inference, ProofLogger * const logger,

--- a/gcs/constraints/linear/propagate.hh
+++ b/gcs/constraints/linear/propagate.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/expression.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
@@ -21,7 +22,8 @@ namespace gcs::innards
     auto propagate_linear(const auto & terms, Integer, const State &, auto & inference_tracker,
         ProofLogger * const logger, bool equality,
         const std::optional<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & proof_line,
-        const std::optional<Literal> & add_to_reason) -> PropagatorState;
+        const std::optional<Literal> & add_to_reason,
+        const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> PropagatorState;
 
     /**
      * \brief Propagate a not-equals

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <gcs/constraints/regular/regex.hh>
 #include <gcs/constraints/regular/regular.hh>
 #include <gcs/exception.hh>
@@ -8,6 +9,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -92,7 +94,7 @@ namespace
     auto log_additional_inference(ProofLogger * const logger, const vector<Literal> & literals, const vector<ProofFlag> & proof_flags,
         const State &, const ReasonFunction & reason, string comment = "") -> void
     {
-        if (logger) {
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
             // Trying to cut down on repeated code
             if (! comment.empty())
                 logger->emit_proof_comment(comment);
@@ -113,7 +115,7 @@ namespace
     {
         auto num_vars = vars.size();
 
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->emit_proof_comment("Initialising graph");
 
         // Forward phase: accumulate
@@ -130,7 +132,7 @@ namespace
                 }
             }
 
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 for (long next_q = 0; next_q < num_states; ++next_q) {
                     if (graph.nodes[i + 1].contains(next_q)) continue;
                     // Want to eliminate this node i.e. prove !state[i+1][next_q]
@@ -180,7 +182,7 @@ namespace
                         state_is_support[q] = 1;
                     else {
                         graph.states_supporting[i][val].erase(q);
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             log_additional_inference(logger, {vars[i] != val}, {! state_at_pos_flags[i][q]}, state, reason);
                     }
                 }
@@ -190,7 +192,7 @@ namespace
             for (const auto & q : gn) {
                 if (! state_is_support[q]) {
                     graph.nodes[i].erase(q);
-                    if (logger)
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                         log_additional_inference(logger, {}, {! state_at_pos_flags[i][q]}, state, reason, "back pass");
                 }
             }
@@ -224,7 +226,7 @@ namespace
                     // once no such edge remains.
                     if (! still_supports(graph, i - 1, l, val)) {
                         graph.states_supporting[i - 1][val].erase(l);
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             log_additional_inference(logger, {vars[i - 1] != val}, {! state_at_pos_flags[i - 1][l]}, state, reason,
                                 "dec outdeg inner");
                     }
@@ -232,7 +234,7 @@ namespace
                 }
             }
             graph.in_edges[i][k] = {};
-            if (logger)
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                 log_additional_inference(logger, {}, {! state_at_pos_flags[i][k]}, state, reason, "dec outdeg");
         }
     }
@@ -243,7 +245,7 @@ namespace
     {
         graph.in_deg[i][k]--;
         if (graph.in_deg[i][k] == 0 && cmp_less(i, graph.in_deg.size() - 1)) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 // Again, want to eliminate this node i.e. prove !state[i][k]
                 for (const auto & q : graph.nodes[i - 1]) {
                     // So first eliminate each previous state/variable combo

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -8,6 +8,7 @@
 #include <gcs/innards/s_expr.hh>
 
 #include <algorithm>
+#include <gcs/proof.hh>
 #include <map>
 #include <set>
 #include <sstream>
@@ -194,7 +195,7 @@ namespace
                         [&](Integer val) { return val > dom_1[0]; });
                     copy_if(dom_1, back_inserter(new_dom_1),
                         [&](Integer val) { return val < dom_2[dom_2.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_2.size() < dom_2.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_2) >= (dom_1[0] + 1_i),
                                 state, inference, singleton_reason(binary_entry.var_1 >= dom_1[0]));
@@ -208,7 +209,7 @@ namespace
                         [&](Integer val) { return val >= dom_1[0]; });
                     copy_if(dom_1, back_inserter(new_dom_1),
                         [&](Integer val) { return val <= dom_2[dom_2.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_2.size() < dom_2.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_2) >= (dom_1[0]), state, inference, singleton_reason(binary_entry.var_1 >= dom_1[0]));
                         if (new_dom_1.size() < dom_1.size())
@@ -219,7 +220,7 @@ namespace
                     set_intersection(dom_1, dom_2, back_inserter(new_dom_1));
                     new_dom_2 = new_dom_1;
 
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         // This one seems particularly annoying. Is it necessary? - not sure
                         if (new_dom_1.size() < dom_1.size()) {
                             vector<Integer> discarded_dom1;
@@ -242,14 +243,14 @@ namespace
                     if (dom_1.size() == 1) {
                         new_dom_1 = dom_1;
                         set_difference(dom_2, dom_1, back_inserter(new_dom_2));
-                        if (logger && new_dom_2.size() < dom_2.size()) {
+                        if (logger && new_dom_2.size() < dom_2.size() && logger->get_assertion_level() == AssertionLevel::Off) {
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_2) != (dom_1[0]), state, inference, singleton_reason(binary_entry.var_1 == dom_1[0]));
                         }
                     }
                     else if (dom_2.size() == 1) {
                         new_dom_2 = dom_2;
                         set_difference(dom_1, dom_2, back_inserter(new_dom_1));
-                        if (logger && new_dom_1.size() < dom_1.size()) {
+                        if (logger && new_dom_1.size() < dom_1.size() && logger->get_assertion_level() == AssertionLevel::Off) {
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_1) != (dom_2[0]), state, inference, singleton_reason(binary_entry.var_2 == dom_2[0]));
                         }
                     }
@@ -263,7 +264,7 @@ namespace
                         [&](Integer val) { return val > dom_2[0]; });
                     copy_if(dom_2, back_inserter(new_dom_2),
                         [&](Integer val) { return val < dom_1[dom_1.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_1.size() < dom_1.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_1) >= (dom_2[0] + 1_i), state, inference, singleton_reason(binary_entry.var_2 >= dom_2[0]));
                         if (new_dom_2.size() < dom_2.size())
@@ -275,7 +276,7 @@ namespace
                         [&](Integer val) { return val >= dom_2[0]; });
                     copy_if(dom_2, back_inserter(new_dom_2),
                         [&](Integer val) { return val <= dom_1[dom_1.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_1.size() < dom_1.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_1) >= (dom_2[0]), state, inference, singleton_reason(binary_entry.var_2 >= dom_2[0]));
                         if (new_dom_2.size() < dom_2.size())
@@ -521,7 +522,7 @@ namespace
         }
 
         if (! some_tuple_still_feasible) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 auto justf = [&](const ReasonFunction & reason) -> void {
                     for (unsigned int tuple_idx = 0; tuple_idx < tuples.size(); ++tuple_idx) {
                         logger->emit_rup_proof_line_under_reason(
@@ -542,7 +543,7 @@ namespace
             }
             return;
         }
-        if (logger) {
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
 
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/smart_table.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -539,7 +540,7 @@ namespace
                 // }
             }
             else {
-                inference.contradiction(logger, NoJustificationNeeded{}, reason);
+                inference.contradiction(logger, JustifyUsingRUP{}, reason);
             }
             return;
         }
@@ -567,7 +568,7 @@ namespace
         else {
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {
-                    inference.infer_not_equal(logger, var, value, NoJustificationNeeded{}, ReasonFunction{});
+                    inference.infer_not_equal(logger, var, value, JustifyUsingRUP{}, ReasonFunction{});
                 }
             }
         }

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -435,8 +435,8 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     Triggers ad_triggers;
     ad_triggers.on_change.insert(ad_triggers.on_change.end(), _p.begin(), _p.end());
 
-    propagators.install(constraint_id(), [p = _p, vals = move(p_vals), am1_lines](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        propagate_gac_all_different(p, vals, vector<Integer>{}, *am1_lines, state, inference, logger);
+    propagators.install(constraint_id(), [p = _p, vals = move(p_vals), am1_lines, constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagate_gac_all_different(constraint_id, p, vals, vector<Integer>{}, *am1_lines, state, inference, logger);
         return PropagatorState::Enable; }, ad_triggers);
 
     // No leaf-checking propagator is needed: once every x is fixed, each

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -10,6 +10,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 
 #include <version>
@@ -981,7 +982,7 @@ auto gcs::innards::install_sortedness_propagator(Propagators & propagators, cons
             rank_ge = witness.rank_ge, rank_le = witness.rank_le, pos = witness.pos,
             inj_lines, al1_lines, anti_lines](
             State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger)
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                 return;
 
             // Totality + antisymmetry. The reverse (resp. forward) halves of the

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -23,6 +23,8 @@ namespace gcs::innards
         InitialBound,
         BoundLink,
         Backtrack,
+        SolxBlock,
+        SoliImprove,
     };
 
     /**
@@ -49,6 +51,10 @@ namespace gcs::innards
             return s << "BoundLink";
         case AssertionHintName::Backtrack:
             return s << "Backtrack";
+        case AssertionHintName::SolxBlock:
+            return s << "SolxBlock";
+        case AssertionHintName::SoliImprove:
+            return s << "SolxBlock";
         }
     }
     /**

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -4,11 +4,23 @@
 
 #include <gcs/constraint_id.hh>
 #include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/integer.hh>
-#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <ostream>
+#include <string>
 #include <utility>
-#include <variant>
-#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/core.h>
+using fmt::format;
+#endif
+
 namespace gcs::innards
 {
 
@@ -61,28 +73,73 @@ namespace gcs::innards
         case AssertionHintName::SoliImprove:
             return s << "SoliImprove";
         }
+        return s;
     }
 
     /**
-     * \brief Kewords that can be used in assertion hint.
+     * \brief Keywords that can be used in an assertion hint.
      *
      * \ingroup Innards
-     * */
+     */
     enum class AssertionHintIdentifier
     {
+        constraint_id,
         // Todo
     };
 
+    inline auto as_string(AssertionHintIdentifier identifier) -> std::string
+    {
+        switch (identifier) {
+        case AssertionHintIdentifier::constraint_id:
+            return "constraint_id";
+        }
+        return "";
+    }
+
     /**
-     * \brief The allowed field types that can appear in the
-     * hints section of an annotated assertion.
+     * \brief Render a single hint field as an s-expression atom.
      *
      * \ingroup Innards
-     * \sa AssertionAnnotation
      */
-    using AssertionHintField = std::variant<AssertionHintIdentifier, ProofLineLabel, ConstraintID, Integer, IntegerVariableID>;
+    inline auto hint_sexpr(SExpr expr) -> SExpr
+    {
+        return expr;
+    }
 
-    using AssertionHintRecord = std::variant<AssertionHintField, std::vector<AssertionHintField>, std::pair<AssertionHintField, std::vector<AssertionHintField>>>;
+    inline auto hint_sexpr(AssertionHintIdentifier identifier) -> SExpr
+    {
+        return SExpr::atom(as_string(identifier));
+    }
+
+    inline auto hint_sexpr(const ProofLineLabel & label) -> SExpr
+    {
+        return SExpr::atom("@" + label.label);
+    }
+
+    inline auto hint_sexpr(const ConstraintID & id) -> SExpr
+    {
+        return SExpr::atom(as_string(id));
+    }
+
+    inline auto hint_sexpr(Integer value) -> SExpr
+    {
+        return SExpr::atom(value.to_string());
+    }
+
+    // NB: To put a variable in a hint, pass names_and_ids_tracker().s_expr_term_of(var)
+
+    /**
+     * \brief Build an s-expression hint from an arbitrary mix of fields and
+     * nested hint lists. This is intended to cover every conceivable hint shape, even if
+     * we're not in practice using the full generality at the moment.
+     *
+     * \ingroup Innards
+     */
+    template <typename... Ts_>
+    inline auto hint_list(Ts_ &&... xs) -> SExpr
+    {
+        return SExpr::list({hint_sexpr(std::forward<Ts_>(xs))...});
+    }
 
     /**
      * \brief An annotation for an annotated assertion step.
@@ -93,11 +150,11 @@ namespace gcs::innards
     {
         std::vector<ProofLineLabel> derivable_from = {};
         AssertionHintName hint_name = AssertionHintName::None;
-        std::vector<AssertionHintRecord> hint_fields = {};
+        std::optional<SExpr> hint_fields = std::nullopt;
     };
 
     /**
-     * \brief An assertion annotated can be written to an ostream.
+     * \brief An assertion annotation can be written to an ostream.
      *
      * \ingroup Innards
      */
@@ -108,6 +165,8 @@ namespace gcs::innards
             s << id_or_label << " ";
         }
         s << ":" << annotation.hint_name << ":";
+        if (annotation.hint_fields)
+            s << format("{}", *annotation.hint_fields);
         return s;
     }
 

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -13,10 +13,13 @@ namespace gcs::innards
      * \ingroup Innards
      * \sa AssertionAnnotation
      */
-    enum AssertionHintName
+    enum class AssertionHintName
     {
         None,
-        AllDifferent
+        AllDifferent,
+        ReifiedEquals,
+        Abs,
+        ReifiedLinearEquality
     };
 
     /**

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -2,7 +2,12 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ASSERTION_HINTS_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ASSERTION_HINTS_HH
 
+#include <gcs/constraint_id.hh>
 #include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+#include <utility>
+#include <variant>
 #include <vector>
 namespace gcs::innards
 {
@@ -54,9 +59,20 @@ namespace gcs::innards
         case AssertionHintName::SolxBlock:
             return s << "SolxBlock";
         case AssertionHintName::SoliImprove:
-            return s << "SolxBlock";
+            return s << "SoliImprove";
         }
     }
+
+    /**
+     * \brief Kewords that can be used in assertion hint.
+     *
+     * \ingroup Innards
+     * */
+    enum class AssertionHintIdentifier
+    {
+        // Todo
+    };
+
     /**
      * \brief The allowed field types that can appear in the
      * hints section of an annotated assertion.
@@ -64,10 +80,9 @@ namespace gcs::innards
      * \ingroup Innards
      * \sa AssertionAnnotation
      */
-    enum AssertionHintField
-    {
-        // Hint field types will go here
-    };
+    using AssertionHintField = std::variant<AssertionHintIdentifier, ProofLineLabel, ConstraintID, Integer, IntegerVariableID>;
+
+    using AssertionHintRecord = std::variant<AssertionHintField, std::vector<AssertionHintField>, std::pair<AssertionHintField, std::vector<AssertionHintField>>>;
 
     /**
      * \brief An annotation for an annotated assertion step.
@@ -78,7 +93,7 @@ namespace gcs::innards
     {
         std::vector<ProofLineLabel> derivable_from = {};
         AssertionHintName hint_name = AssertionHintName::None;
-        std::vector<AssertionHintField> hint_fields = {};
+        std::vector<AssertionHintRecord> hint_fields = {};
     };
 
     /**

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -11,6 +11,7 @@
 #include <ostream>
 #include <string>
 #include <utility>
+#include <vector>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -84,7 +85,10 @@ namespace gcs::innards
     enum class AssertionHintIdentifier
     {
         constraint_id,
-        // Todo
+        hall_vars,
+        hall_vals,
+        justifier,
+        hall_set_or_violator,
     };
 
     inline auto as_string(AssertionHintIdentifier identifier) -> std::string
@@ -92,6 +96,14 @@ namespace gcs::innards
         switch (identifier) {
         case AssertionHintIdentifier::constraint_id:
             return "constraint_id";
+        case AssertionHintIdentifier::hall_vars:
+            return "hall_vars";
+        case AssertionHintIdentifier::hall_vals:
+            return "hall_vals";
+        case AssertionHintIdentifier::justifier:
+            return "justifier";
+        case AssertionHintIdentifier::hall_set_or_violator:
+            return "hall_set_or_violator";
         }
         return "";
     }
@@ -139,6 +151,20 @@ namespace gcs::innards
     inline auto hint_list(Ts_ &&... xs) -> SExpr
     {
         return SExpr::list({hint_sexpr(std::forward<Ts_>(xs))...});
+    }
+
+    /**
+     * \brief Build an s-expression list from a runtime range
+     *
+     * \ingroup Innards
+     */
+    template <typename Range_>
+    inline auto hint_seq(const Range_ & xs) -> SExpr
+    {
+        std::vector<SExpr> children;
+        for (const auto & x : xs)
+            children.push_back(hint_sexpr(x));
+        return SExpr::list(std::move(children));
     }
 
     /**

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -19,9 +19,35 @@ namespace gcs::innards
         AllDifferent,
         ReifiedEquals,
         Abs,
-        ReifiedLinearEquality
+        ReifiedLinearEquality,
+        InitialBound,
+        BoundLink,
     };
 
+    /**
+     * \brief An assertion hint can be written as a string
+     *
+     * \ingroup Innards
+     */
+    inline auto operator<<(std::ostream & s, AssertionHintName hint_name) -> std::ostream &
+    {
+        switch (hint_name) {
+        case AssertionHintName::None:
+            return s << "None";
+        case AssertionHintName::AllDifferent:
+            return s << "AllDifferent";
+        case AssertionHintName::ReifiedEquals:
+            return s << "ReifiedEquals";
+        case AssertionHintName::Abs:
+            return s << "Abs";
+        case AssertionHintName::ReifiedLinearEquality:
+            return s << "ReifiedLinearEquality";
+        case AssertionHintName::InitialBound:
+            return s << "InitialBound";
+        case AssertionHintName::BoundLink:
+            return s << "BoundLink";
+        }
+    }
     /**
      * \brief The allowed field types that can appear in the
      * hints section of an annotated assertion.
@@ -45,6 +71,21 @@ namespace gcs::innards
         AssertionHintName hint_name = AssertionHintName::None;
         std::vector<AssertionHintField> hint_fields = {};
     };
+
+    /**
+     * \brief An assertion annotated can be written to an ostream.
+     *
+     * \ingroup Innards
+     */
+    inline auto operator<<(std::ostream & s, AssertionAnnotation annotation) -> std::ostream &
+    {
+        s << ":";
+        for (const auto & id_or_label : annotation.derivable_from) {
+            s << id_or_label << " ";
+        }
+        s << ":" << annotation.hint_name << ":";
+        return s;
+    }
 
 } // namespace gcs::innards
 #endif

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -15,7 +15,8 @@ namespace gcs::innards
      */
     enum AssertionHintName
     {
-        // Hint names types will go here
+        None,
+        AllDifferent
     };
 
     /**
@@ -37,9 +38,9 @@ namespace gcs::innards
      */
     struct AssertionAnnotation
     {
-        std::vector<ProofLineLabel> derivable_from;
-        AssertionHintName hint_name;
-        std::vector<AssertionHintField> hint_fields;
+        std::vector<ProofLineLabel> derivable_from = {};
+        AssertionHintName hint_name = AssertionHintName::None;
+        std::vector<AssertionHintField> hint_fields = {};
     };
 
 } // namespace gcs::innards

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -22,6 +22,7 @@ namespace gcs::innards
         ReifiedLinearEquality,
         InitialBound,
         BoundLink,
+        Backtrack,
     };
 
     /**
@@ -29,7 +30,7 @@ namespace gcs::innards
      *
      * \ingroup Innards
      */
-    inline auto operator<<(std::ostream & s, AssertionHintName hint_name) -> std::ostream &
+    inline auto operator<<(std::ostream & s, const AssertionHintName & hint_name) -> std::ostream &
     {
         switch (hint_name) {
         case AssertionHintName::None:
@@ -46,6 +47,8 @@ namespace gcs::innards
             return s << "InitialBound";
         case AssertionHintName::BoundLink:
             return s << "BoundLink";
+        case AssertionHintName::Backtrack:
+            return s << "Backtrack";
         }
     }
     /**
@@ -77,7 +80,7 @@ namespace gcs::innards
      *
      * \ingroup Innards
      */
-    inline auto operator<<(std::ostream & s, AssertionAnnotation annotation) -> std::ostream &
+    inline auto operator<<(std::ostream & s, const AssertionAnnotation & annotation) -> std::ostream &
     {
         s << ":";
         for (const auto & id_or_label : annotation.derivable_from) {

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -1,0 +1,46 @@
+
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ASSERTION_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ASSERTION_HINTS_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <vector>
+namespace gcs::innards
+{
+
+    /**
+     * \brief The allowed names for annotated assertions.
+     *
+     * \ingroup Innards
+     * \sa AssertionAnnotation
+     */
+    enum AssertionHintName
+    {
+        // Hint names types will go here
+    };
+
+    /**
+     * \brief The allowed field types that can appear in the
+     * hints section of an annotated assertion.
+     *
+     * \ingroup Innards
+     * \sa AssertionAnnotation
+     */
+    enum AssertionHintField
+    {
+        // Hint field types will go here
+    };
+
+    /**
+     * \brief An annotation for an annotated assertion step.
+     *
+     * \ingroup Innards
+     */
+    struct AssertionAnnotation
+    {
+        std::vector<ProofLineLabel> derivable_from;
+        AssertionHintName hint_name;
+        std::vector<AssertionHintField> hint_fields;
+    };
+
+} // namespace gcs::innards
+#endif

--- a/gcs/innards/extensional_utils.cc
+++ b/gcs/innards/extensional_utils.cc
@@ -1,7 +1,12 @@
+#include <cmath>
 #include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state-fwd.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/proof.hh>
 
 using std::vector;
 using std::visit;
@@ -59,6 +64,7 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
 {
     // check whether selectable tuples are still feasible
     visit([&](const auto & tuples) {
+        auto none_feasible = true;
         for (auto tuple_idx : state.each_value_mutable(table.selector)) {
             bool is_feasible = true;
             for (unsigned idx = 0; idx < table.vars.size(); ++idx)
@@ -67,9 +73,18 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                     break;
                 }
 
-            if (! is_feasible)
+            if (is_feasible)
+                none_feasible = false;
+            else if (logger && logger->get_assertion_level() != AssertionLevel::Off && state.has_single_value(table.selector))
+                // Last selector val so infeasible -> we need an explicit contradiction at higher assertion levels
+                // since there's no table for the implicit one.
+                inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, table.vars));
+            else
                 inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, ReasonFunction{});
         }
+        if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
+            // selector already empty on entry
+            inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, table.vars));
     },
         table.tuples);
 
@@ -85,8 +100,9 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                     }
                 }
 
-                if (! supported)
+                if (! supported) {
                     inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{}, generic_reason(state, table.vars));
+                }
             }
         }
     },

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -34,7 +34,7 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
 
-        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> assertion_hints = std::nullopt) -> void
+        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason, assertion_hints);
         }
@@ -51,12 +51,12 @@ namespace gcs::innards
 
         auto operator=(const InferenceTrackerBase &) -> InferenceTrackerBase & = delete;
 
-        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> assertion_hints = std::nullopt) -> void
+        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             track(logger, _state.infer(lit), lit, why, reason, assertion_hints);
         }
 
-        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> assertion_hints = std::nullopt) -> void
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             if (logger)
                 logger->infer(FalseLiteral{}, why, reason, assertion_hints);
@@ -64,53 +64,53 @@ namespace gcs::innards
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer(lit), lit, why, reason);
+            track(logger, _state.infer(lit), lit, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_equal(var, value), var == value, why, reason);
+            track(logger, _state.infer_equal(var, value), var == value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_not_equal(var, value), var != value, why, reason);
+            track(logger, _state.infer_not_equal(var, value), var != value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_less_than(var, value), var < value, why, reason);
+            track(logger, _state.infer_less_than(var, value), var < value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, reason);
+            track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             // The conclusion is the ordinary range condition; the state update
             // batches the whole removal into one erase_range pass.
             if (lo > hi)
                 return;
-            track(logger, _state.infer_not_in_range(var, lo, hi), not_in_range(var, lo, hi), why, reason);
+            track(logger, _state.infer_not_in_range(var, lo, hi), not_in_range(var, lo, hi), why, reason, assertion_hints);
         }
 
-        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             // For JustifyExplicitlyThenRUP: enter the temporary proof level once,
             // run the explicit scaffolding once, then RUP each inference under the
             // shared scaffolding. Without this, each infer() would enter and exit
             // its own temporary level, wiping the scaffolding before subsequent
             // inferences can use it.
-            if (logger && std::holds_alternative<JustifyExplicitlyThenRUP>(why)) {
+            if (logger && ! logger->using_assertions() && std::holds_alternative<JustifyExplicitlyThenRUP>(why)) {
                 // The scaffolding is shared across the batch, but each inference's
                 // RUP is only emitted if it actually changes something (track_impl
                 // drops NoChange). If *every* inference is already entailed, no RUP
@@ -137,7 +137,7 @@ namespace gcs::innards
             }
             else {
                 for (const auto & lit : lits)
-                    infer(logger, lit, why, reason);
+                    infer(logger, lit, why, reason, assertion_hints);
             }
         }
 

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -1,14 +1,14 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_INFERENCE_TRACKER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_INFERENCE_TRACKER_HH
 
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/state.hh>
 
-#include <algorithm>
 #include <deque>
-#include <type_traits>
+#include <optional>
 #include <utility>
 #include <version>
 
@@ -34,9 +34,9 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
 
-        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
+        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> assertion_hints = std::nullopt) -> void
         {
-            return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason);
+            return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason, assertion_hints);
         }
 
     public:
@@ -51,15 +51,15 @@ namespace gcs::innards
 
         auto operator=(const InferenceTrackerBase &) -> InferenceTrackerBase & = delete;
 
-        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer(lit), lit, why, reason);
+            track(logger, _state.infer(lit), lit, why, reason, assertion_hints);
         }
 
-        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason) -> void
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> assertion_hints = std::nullopt) -> void
         {
             if (logger)
-                logger->infer(FalseLiteral{}, why, reason);
+                logger->infer(FalseLiteral{}, why, reason, assertion_hints);
             throw TrackedPropagationFailed{};
         }
 
@@ -172,7 +172,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &) -> void
+        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &, const std::optional<AssertionAnnotation> &) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -214,7 +214,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
+        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -224,7 +224,7 @@ namespace gcs::innards
             case Inference::BoundsChanged:
             case Inference::Instantiated:
                 if (logger)
-                    logger->infer(lit, just, reason);
+                    logger->infer(lit, just, reason, assertion_hints);
 
                 overloaded{
                     [&](const TrueLiteral &) {},

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -110,7 +110,7 @@ namespace gcs::innards
             // shared scaffolding. Without this, each infer() would enter and exit
             // its own temporary level, wiping the scaffolding before subsequent
             // inferences can use it.
-            if (logger && ! logger->using_assertions() && std::holds_alternative<JustifyExplicitlyThenRUP>(why)) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off && std::holds_alternative<JustifyExplicitlyThenRUP>(why)) {
                 // The scaffolding is shared across the batch, but each inference's
                 // RUP is only emitted if it actually changes something (track_impl
                 // drops NoChange). If *every* inference is already entailed, no RUP

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -248,7 +248,7 @@ namespace gcs::innards
 
             [[unlikely]] case Inference::Contradiction:
                 if (logger)
-                    logger->infer(lit, just, reason);
+                    logger->infer(lit, just, reason, assertion_hints);
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
                 throw TrackedPropagationFailed{};

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -629,18 +629,21 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         }
     }
 
-    if (_imp->assertion_level <= AssertionLevel::Links)
-        // Reverse direction: see the matching block in need_gevar above.
-        if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
-            if (auto it = _imp->views_of_variable.find(*sid_ptr); it != _imp->views_of_variable.end()) {
-                auto views_copy = it->second;
-                for (const auto & view_pid : views_copy) {
-                    const auto & view = _imp->view_proof_only_to_view.at(view_pid);
-                    Integer v_value = view.negate_first ? view.then_add - v : v + view.then_add;
-                    need_direct_encoding_for(view_pid, v_value);
-                }
+    // Nothing beyond this point needs to be emmitted at AssertionLevel::Links
+    if (_imp->assertion_level > AssertionLevel::Links)
+        return;
+
+    // Reverse direction: see the matching block in need_gevar above.
+    if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
+        if (auto it = _imp->views_of_variable.find(*sid_ptr); it != _imp->views_of_variable.end()) {
+            auto views_copy = it->second;
+            for (const auto & view_pid : views_copy) {
+                const auto & view = _imp->view_proof_only_to_view.at(view_pid);
+                Integer v_value = view.negate_first ? view.then_add - v : v + view.then_add;
+                need_direct_encoding_for(view_pid, v_value);
             }
         }
+    }
 
     // Link this new eq atom (a singleton [v, v]) to its immediate range containers,
     // so a rejected container propagates ~(id == v). Most variables never have any
@@ -889,7 +892,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
 
 auto NamesAndIDsTracker::link_immediate_containment(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void
 {
-    if (! _imp->logger)
+    if (! _imp->logger || _imp->logger->get_assertion_level() > AssertionLevel::Links) // Should be unreachable at AssertionLevel::Links anyway
         return;
 
     auto tree_it = _imp->containment_trees.find(id);
@@ -961,11 +964,20 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     _imp->variable_conditions_to_x.emplace(in_range(id, lo, hi), x);
     _imp->variable_conditions_to_x.emplace(not_in_range(id, lo, hi), ! x);
 
-    auto lines = visit([&](const auto & id) {
-        return _imp->logger->emit_red_proof_lines_reifying(
-            WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, in_range(id, lo, hi), ProofLevel::Top);
-    },
-        id);
+    auto will_define = _imp->logger->get_assertion_level() <= AssertionLevel::Definitions;
+    // Struggling to get clang-format to behave here...
+    auto lines = will_define //
+        ? visit([&](const auto & id) {
+              return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, in_range(id, lo, hi), ProofLevel::Top);
+          },
+              id)
+        : make_pair(ProofLine{}, ProofLine{});
+
+    _imp->invars_that_exist[id].emplace(pair{lo, hi}, lines);
+
+    // No containment tree apparatus needed at higher assertion levels.
+    if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+        return;
 
     // Containment edges let a rejected literal propagate down to the literals a
     // conflict is written over; the order chain alone does not give this. The
@@ -979,8 +991,6 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     }
     link_immediate_containment(id, lo, hi);
     _imp->containment_trees[id].insert(lo, hi);
-
-    _imp->invars_that_exist[id].emplace(pair{lo, hi}, lines);
 }
 
 auto NamesAndIDsTracker::append_cell_literal_to(WPBSum & sum, SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void
@@ -996,6 +1006,9 @@ auto NamesAndIDsTracker::append_cell_literal_to(WPBSum & sum, SimpleOrProofOnlyI
 
 auto NamesAndIDsTracker::ensure_partition_cut(SimpleOrProofOnlyIntegerVariableID id, Integer p) -> void
 {
+    if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+        return;
+
     auto & boundaries = _imp->interval_partitions.at(id);
     if (boundaries.contains(p))
         return;
@@ -1030,6 +1043,9 @@ auto NamesAndIDsTracker::ensure_partition_cut(SimpleOrProofOnlyIntegerVariableID
 
 auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariableID id, Integer request_lo, Integer request_hi) -> void
 {
+    if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+        return;
+
     auto [lb, ub] = _imp->integer_variable_definition_bounds.at(id);
     auto & boundaries = _imp->interval_partitions[id];
     boundaries.insert(lb);
@@ -1093,9 +1109,10 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
     auto [lb, ub] = _imp->integer_variable_definition_bounds.at(id);
     auto span_lo = max(lo, lb), span_hi = min(hi, ub);
 
-    if (span_lo > span_hi) {
+    if (span_lo > span_hi || _imp->assertion_level > AssertionLevel::Links) {
         // Entirely outside: the reification plus the bound axioms already falsify
-        // it, so there is nothing to cover.
+        // it, so there is nothing to cover;
+        // ...OR we are at a higher assertion level that doesn't need covering apparatus in the first place.
         define_plain_invar(id, lo, hi);
         return as_literal();
     }
@@ -1157,13 +1174,20 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
         v_lo, v_hi, name, IntegerVariableProofRepresentation::Bits);
 
     Integer s_coeff = view.negate_first ? -1_i : 1_i;
-    auto [link_le, link_ge] = _imp->model->add_constraint(StringLiteral{"view link"}, StringLiteral{"definitional"},
-        WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add);
+
+    auto will_define = (_imp->assertion_level <= AssertionLevel::Definitions);
+    auto [link_le, link_ge] = will_define //
+        ? _imp->model->add_constraint(StringLiteral{"view link"}, StringLiteral{"definitional"},
+              WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add)
+        : make_pair(ProofLine{}, ProofLine{});
 
     _imp->view_proof_only_vars.emplace(view, v_id);
     _imp->view_proof_only_to_view.emplace(v_id, view);
     _imp->view_link_ids.emplace(v_id, pair{link_le, link_ge});
     _imp->views_of_variable[view.actual_variable].push_back(v_id);
+
+    if (_imp->assertion_level > AssertionLevel::Links) // No further linking needed at higher assertion levels.
+        return v_id;
 
     // Backfill: if X atoms already exist when this view is registered,
     // trigger the matching V atoms now so the V<->X link is emitted for

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <exception>
 #include <fstream>
+#include <gcs/proof.hh>
 #include <list>
 #include <map>
 #include <set>
@@ -138,12 +139,14 @@ struct NamesAndIDsTracker::Imp
     bool first_varmap_entry = true;
     bool finalised = false;
     bool verbose_names;
+    AssertionLevel assertion_level = AssertionLevel::Off;
 };
 
 NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) :
     _imp(make_unique<Imp>())
 {
     _imp->verbose_names = proof_options.verbose_names;
+    _imp->assertion_level = proof_options.assertion_level;
 
     if (proof_options.proof_file_names.variables_map_file) {
         _imp->variables_map_file_name = *proof_options.proof_file_names.variables_map_file;
@@ -520,7 +523,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     ProofLine forwards_line, reverse_line;
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first == v) {
         // it's a lower bound
-        if (_imp->logger && ! _imp->logger->using_assertions()) { // Don't bother defining literals if using assertions
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Definitions) {
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i,
                     id == v, ProofLevel::Top);
@@ -540,7 +543,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second == v) {
         // it's an upper bound
-        if (_imp->logger && ! _imp->logger->using_assertions()) {
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Definitions) {
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, ProofLevel::Top);
                 forwards_line = _f_line;
@@ -559,7 +562,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else {
         // neither a lower nor an upper bound
-        if (_imp->logger && ! _imp->logger->using_assertions())
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Definitions)
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(
                     WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i,
@@ -616,25 +619,28 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             // channelling between the proof-only encoding and the actual
             // variable. See the matching pattern in need_gevar's bound links.
             emit_proof_line_now_or_at_start([v_cond, x_cond](ProofLogger * const logger) {
-                if (logger->using_assertions())
-                    return; // literal definitions aren't emitted under annotated assertions
-                logger->emit_rup_proof_line(WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top);
-                logger->emit_rup_proof_line(WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top);
+                if (logger->get_assertion_level() > AssertionLevel::Links)
+                    return;
+
+                auto assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top);
+                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top);
             });
         }
     }
 
-    // Reverse direction: see the matching block in need_gevar above.
-    if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
-        if (auto it = _imp->views_of_variable.find(*sid_ptr); it != _imp->views_of_variable.end()) {
-            auto views_copy = it->second;
-            for (const auto & view_pid : views_copy) {
-                const auto & view = _imp->view_proof_only_to_view.at(view_pid);
-                Integer v_value = view.negate_first ? view.then_add - v : v + view.then_add;
-                need_direct_encoding_for(view_pid, v_value);
+    if (_imp->assertion_level <= AssertionLevel::Links)
+        // Reverse direction: see the matching block in need_gevar above.
+        if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
+            if (auto it = _imp->views_of_variable.find(*sid_ptr); it != _imp->views_of_variable.end()) {
+                auto views_copy = it->second;
+                for (const auto & view_pid : views_copy) {
+                    const auto & view = _imp->view_proof_only_to_view.at(view_pid);
+                    Integer v_value = view.negate_first ? view.then_add - v : v + view.then_add;
+                    need_direct_encoding_for(view_pid, v_value);
+                }
             }
         }
-    }
 
     // Link this new eq atom (a singleton [v, v]) to its immediate range containers,
     // so a rejected container propagates ~(id == v). Most variables never have any
@@ -665,7 +671,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     _imp->variable_conditions_to_x.emplace(id < v, ! gevar);
 
     // gevar -> bits
-    if (_imp->logger && _imp->logger->using_assertions()) {
+    if (_imp->logger && _imp->assertion_level > AssertionLevel::Definitions) {
         _imp->gevars_that_exist[id].emplace(v, make_pair(ProofLine{}, ProofLine{})); // Don't output geqvar definitions if using assertions
     }
     else if (_imp->logger) {
@@ -700,7 +706,10 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
 
     auto fix_bound = [&](bool negated) {
         if (_imp->logger) {
-            ProofRule assert_or_rup = _imp->logger->using_assertions() ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+            if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+                return;
+
+            ProofRule assert_or_rup = _imp->logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
             auto annotation = AssertionAnnotation{.hint_name = AssertionHintName::InitialBound};
             visit([&](auto id) { _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i, ProofLevel::Top, annotation); }, id);
         }
@@ -743,11 +752,16 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
                 emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) { 
-            			ProofRule assert_or_rup = logger->using_assertions() ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+						if (logger->get_assertion_level() > AssertionLevel::Links)
+							return;
+            			ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
 						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
-                if (_imp->logger && _imp->logger->using_assertions()) {
+                if (_imp->assertion_level > AssertionLevel::Links) {
+                    return;
+                }
+                else if (_imp->assertion_level == AssertionLevel::Links) {
                     auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
                     emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
                 }
@@ -765,11 +779,16 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
                 emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) { 
-            			ProofRule assert_or_rup = logger->using_assertions() ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+						if (logger->get_assertion_level() > AssertionLevel::Links)
+							return;
+            			ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
 						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
-                if (_imp->logger && _imp->logger->using_assertions()) {
+                if (_imp->assertion_level > AssertionLevel::Links) {
+                    return;
+                }
+                else if (_imp->assertion_level == AssertionLevel::Links) {
                     auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
                     emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
                 }
@@ -802,12 +821,29 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     // Both lines queued via emit_proof_line_now_or_at_start so they land at
     // the top of the proof, alongside the standard order-encoding chain
     // links, rather than as extra OPB axioms.
+    if (_imp->assertion_level > AssertionLevel::Links)
+        return;
+
     if (auto pid_ptr = std::get_if<ProofOnlySimpleIntegerVariableID>(&id)) {
         auto view_it = _imp->view_proof_only_to_view.find(*pid_ptr);
         if (view_it != _imp->view_proof_only_to_view.end()) {
             const auto & view = view_it->second;
             Integer x_threshold = view.negate_first ? view.then_add - v + 1_i : v - view.then_add;
             need_gevar(view.actual_variable, x_threshold);
+            if (_imp->assertion_level == AssertionLevel::Links) {
+                // Definitions are omitted at this level, instead assert the view links that the
+                // pol lines below would derive.
+                auto v_atom = (*pid_ptr >= v);
+                auto x_atom = (view.actual_variable >= x_threshold);
+                auto x_cond = view.negate_first ? ! x_atom : x_atom;
+                auto d1 = WPBSum{} + 1_i * ! v_atom + 1_i * x_cond >= 1_i;
+                auto d2 = WPBSum{} + 1_i * ! x_cond + 1_i * v_atom >= 1_i;
+                emit_proof_line_now_or_at_start([d1, d2, link_hint](ProofLogger * const logger) {
+                    logger->emit(AssertProofRule{}, d1, ProofLevel::Top, link_hint);
+                    logger->emit(AssertProofRule{}, d2, ProofLevel::Top, link_hint);
+                });
+                return;
+            }
 
             auto v_defs = _imp->gevars_that_exist[id].at(v);
             auto x_defs = _imp->gevars_that_exist[SimpleOrProofOnlyIntegerVariableID{view.actual_variable}].at(x_threshold);

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1287,6 +1287,8 @@ auto NamesAndIDsTracker::derive_deviewed_form_for(const ProofLine & v_form_line,
     if (view_contributions.empty())
         return;
 
+    if (_imp->assertion_level > AssertionLevel::Links)
+        return;
     // Build the pol expression. For each view contribution:
     //   opb_form_coefficient > 0 (positive V in OPB):  add `|coeff| * link_le`.
     //   opb_form_coefficient < 0 (negative V in OPB):  add `|coeff| * link_ge`.

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_line-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/proof_only_variables-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/variable_id_utils.hh>
@@ -964,7 +965,7 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     _imp->variable_conditions_to_x.emplace(in_range(id, lo, hi), x);
     _imp->variable_conditions_to_x.emplace(not_in_range(id, lo, hi), ! x);
 
-    auto will_define = _imp->logger->get_assertion_level() <= AssertionLevel::Definitions;
+    auto will_define = _imp->logger->get_assertion_level() <= AssertionLevel::Links;
     // Struggling to get clang-format to behave here...
     auto lines = will_define //
         ? visit([&](const auto & id) {
@@ -1422,6 +1423,28 @@ auto NamesAndIDsTracker::pb_file_string_for(const XLiteral & lit) const -> strin
 auto NamesAndIDsTracker::pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> string
 {
     return pb_file_string_for(xliteral_for(cond));
+}
+
+auto NamesAndIDsTracker::bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> string
+{
+    auto it = _imp->integer_variable_bits_to_size_and_proof_vars.find(var);
+    if (it == _imp->integer_variable_bits_to_size_and_proof_vars.end())
+        throw ProofError("missing bits");
+
+    const auto & [negative_coeff, bits] = it->second;
+
+    bool sign_bit_set = (negative_coeff != 0_i) && (value < 0_i);
+    Integer remainder = sign_bit_set ? value - negative_coeff : value;
+
+    string result;
+    for (const auto & [coeff, lit] : bits) {
+        bool bit_is_one = (coeff < 0_i) ? sign_bit_set : ((remainder / coeff) % 2_i == 1_i);
+        if (! result.empty())
+            result += " ";
+        result += pb_file_string_for(bit_is_one ? lit : ! lit);
+    }
+
+    return result;
 }
 
 auto NamesAndIDsTracker::xliteral_for(const ProofFlag & flag) const -> const XLiteral

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1176,7 +1176,7 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
 
     Integer s_coeff = view.negate_first ? -1_i : 1_i;
 
-    auto will_define = (_imp->assertion_level <= AssertionLevel::Definitions);
+    auto will_define = true;              // We do need to define views properly in the model!
     auto [link_le, link_ge] = will_define //
         ? _imp->model->add_constraint(StringLiteral{"view link"}, StringLiteral{"definitional"},
               WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add)

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -523,7 +523,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     ProofLine forwards_line, reverse_line;
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first == v) {
         // it's a lower bound
-        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Definitions) {
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i,
                     id == v, ProofLevel::Top);
@@ -543,7 +543,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second == v) {
         // it's an upper bound
-        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Definitions) {
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, ProofLevel::Top);
                 forwards_line = _f_line;
@@ -562,7 +562,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else {
         // neither a lower nor an upper bound
-        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Definitions)
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links)
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(
                     WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i,

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1,7 +1,9 @@
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/interval_tree.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_line-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
@@ -518,7 +520,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     ProofLine forwards_line, reverse_line;
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first == v) {
         // it's a lower bound
-        if (_imp->logger) {
+        if (_imp->logger && ! _imp->logger->using_assertions()) { // Don't bother defining literals if using assertions
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i,
                     id == v, ProofLevel::Top);
@@ -527,7 +529,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             },
                 id);
         }
-        else {
+        else if (! _imp->logger) {
             visit([&](const auto & id) {
                 forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
                 reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
@@ -538,7 +540,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second == v) {
         // it's an upper bound
-        if (_imp->logger) {
+        if (_imp->logger && ! _imp->logger->using_assertions()) {
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, ProofLevel::Top);
                 forwards_line = _f_line;
@@ -546,7 +548,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             },
                 id);
         }
-        else {
+        else if (! _imp->logger) {
             visit([&](const auto & id) {
                 forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
                 reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
@@ -557,7 +559,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else {
         // neither a lower nor an upper bound
-        if (_imp->logger)
+        if (_imp->logger && ! _imp->logger->using_assertions())
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(
                     WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i,
@@ -566,7 +568,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
                 reverse_line = _r_line;
             },
                 id);
-        else {
+        else if (! _imp->logger) {
             visit([&](const auto & id) {
                 forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
                 reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
@@ -606,7 +608,16 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             ProofVariableCondition v_cond{*pid_ptr, VariableConditionOperator::Equal, v};
             IntegerVariableID x_var{view.actual_variable};
             auto x_cond = (x_var == x_threshold);
+            // Always queue this (it delays to proof start when the logger
+            // isn't attached yet during model building); decide whether to
+            // emit based on using_assertions() *inside* the lambda, when the
+            // logger definitely exists. Guarding on _imp->logger out here
+            // drops the step entirely during model building, losing the
+            // channelling between the proof-only encoding and the actual
+            // variable. See the matching pattern in need_gevar's bound links.
             emit_proof_line_now_or_at_start([v_cond, x_cond](ProofLogger * const logger) {
+                if (logger->using_assertions())
+                    return; // literal definitions aren't emitted under annotated assertions
                 logger->emit_rup_proof_line(WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top);
                 logger->emit_rup_proof_line(WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top);
             });
@@ -654,11 +665,12 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     _imp->variable_conditions_to_x.emplace(id < v, ! gevar);
 
     // gevar -> bits
-    if (_imp->logger) {
-        _imp->gevars_that_exist[id].emplace(v, visit([&](const auto & id) {
-            return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Top);
-        },
-                                                   id));
+    if (_imp->logger && _imp->logger->using_assertions()) {
+        _imp->gevars_that_exist[id].emplace(v, make_pair(ProofLine{}, ProofLine{})); // Don't output geqvar definitions if using assertions
+    }
+    else if (_imp->logger) {
+        auto def_lines = visit([&](const auto & id) { return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Top); }, id);
+        _imp->gevars_that_exist[id].emplace(v, def_lines);
     }
     else {
         // Label the two halves @i[name][ge<v>][f]/[r] to match cake_pb_cp, but
@@ -686,20 +698,24 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     // is it a bound?
     auto bounds = _imp->integer_variable_definition_bounds.find(id);
 
+    auto fix_bound = [&](bool negated) {
+        if (_imp->logger) {
+            ProofRule assert_or_rup = _imp->logger->using_assertions() ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+            auto annotation = AssertionAnnotation{.hint_name = AssertionHintName::InitialBound};
+            visit([&](auto id) { _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i, ProofLevel::Top, annotation); }, id);
+        }
+        else
+            visit([&](auto id) { _imp->model->add_constraint(WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i); }, id);
+    };
+
     // lower?
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first >= v) {
-        if (_imp->logger)
-            visit([&](auto id) { _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * (id >= v) >= 1_i, ProofLevel::Top); }, id);
-        else
-            visit([&](auto id) { _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i); }, id);
+        fix_bound(false);
     }
 
     // upper?
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second < v) {
-        if (_imp->logger)
-            visit([&](auto id) { _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * ! (id >= v) >= 1_i, ProofLevel::Top); }, id);
-        else
-            visit([&](auto id) { _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i); }, id);
+        fix_bound(true);
     }
 
     auto & other_gevars = _imp->gevars_that_exist.at(id);
@@ -721,15 +737,24 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     };
 
     // implied by the next highest gevar, if there is one?
+    auto link_hint = AssertionAnnotation{.hint_name = AssertionHintName::BoundLink};
     if (higher_gevar != other_gevars.end()) {
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con](ProofLogger * const logger) { logger->emit_rup_proof_line(c, ProofLevel::Top); });
+                emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) { 
+            			ProofRule assert_or_rup = logger->using_assertions() ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
-                auto pol = make_pol_chain_line(id >= v, ! (id >= higher_gevar->first));
-                emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                if (_imp->logger && _imp->logger->using_assertions()) {
+                    auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
+                    emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
+                }
+                else {
+                    auto pol = make_pol_chain_line(id >= v, ! (id >= higher_gevar->first));
+                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                }
             }}
             .visit(id);
     }
@@ -739,11 +764,19 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con](ProofLogger * const logger) { logger->emit_rup_proof_line(c, ProofLevel::Top); });
+                emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) { 
+            			ProofRule assert_or_rup = logger->using_assertions() ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
-                auto pol = make_pol_chain_line(id >= prev(this_gevar)->first, ! (id >= v));
-                emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                if (_imp->logger && _imp->logger->using_assertions()) {
+                    auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
+                    emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
+                }
+                else {
+                    auto pol = make_pol_chain_line(id >= prev(this_gevar)->first, ! (id >= v));
+                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                }
             }}
             .visit(id);
     }

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/proofs/reification.hh>

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -320,6 +320,11 @@ namespace gcs::innards
         [[nodiscard]] auto pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> std::string;
 
         /**
+         * Return a string form of the exact literals specifying a bit assignment for var == val, an alternative way to witness solutions.
+         */
+        [[nodiscard]] auto bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> std::string;
+
+        /**
          * Return the raw proof literal representing a proof flag, for writing to a model or log.
          */
         [[nodiscard]] auto xliteral_for(const ProofFlag &) const -> const XLiteral;

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -175,22 +175,43 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
 
     _imp->proof << (optional_minimise_variable_and_value ? "soli" : "solx");
 
-    for (const auto & [var, val] : all_variables_and_values)
+    WPBSum blocking_sum{};
+
+    for (const auto & [var, val] : all_variables_and_values) {
+        if (! optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Links)
+            blocking_sum += 1_i * (var != val);
+
         overloaded{
             [&](const ConstantIntegerVariableID &) {
             },
             [&](const SimpleIntegerVariableID & var) {
-                _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(var == val);
+                if (_imp->assertion_level > AssertionLevel::Definitions)
+                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(var, val);
+                else
+                    _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(var == val);
             },
             [&](const ViewOfIntegerVariableID & var) {
-                _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(deview(var == val));
+                if (_imp->assertion_level > AssertionLevel::Definitions) {
+                    auto actual = deview(var == val);
+                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(actual.var, actual.value);
+                }
+                else
+                    _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(deview(var == val));
             }}
             .visit(var);
+    }
 
     _imp->proof << ";\n";
     record_proof_line(advance_proof_line_number(), ProofLevel::Top);
 
-    if (optional_minimise_variable_and_value)
+    if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
+        // soli and no links => have to assert the objective improving constraint
+        visit([&](const auto & id) {
+            emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = AssertionHintName::SoliImprove});
+        },
+            optional_minimise_variable_and_value->first);
+    else if (optional_minimise_variable_and_value)
+        // normal soli, emit e line for trimmer
         visit([&](const auto & id) {
             _imp->proof << "e ";
             emit_inequality_to(names_and_ids_tracker(), WPBSum{} + 1_i * id <= optional_minimise_variable_and_value->second - 1_i, _imp->proof);
@@ -199,6 +220,11 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
         },
             optional_minimise_variable_and_value->first);
+    else if (_imp->assertion_level > AssertionLevel::Definitions) {
+        // solx and no links => have to assert the blocking constraint
+        emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = AssertionHintName::SolxBlock});
+    }
+    // nothing needs done for solx below AssertionLevel::Links
 }
 
 auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
@@ -303,7 +329,9 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
     if (_imp->assertion_level > AssertionLevel::Inferences)
         return;
 
-    if (_imp->assertion_level >= AssertionLevel::Definitions && annotation) {
+    if ((_imp->assertion_level <= AssertionLevel::Definitions && annotation) || _imp->assertion_level >= AssertionLevel::Links) {
+        // At AssertionLevel::Definitions we can assert some inferences and not others (since the needed constraints for the justifications will
+        // still be present). At higher levels, we need to assert all inferences.
         if (! is_literally_true(lit)) {
             emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
         }

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -328,7 +328,7 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
     if (_imp->assertion_level > AssertionLevel::Inferences)
         return;
 
-    if ((_imp->assertion_level <= AssertionLevel::Definitions && annotation) || _imp->assertion_level >= AssertionLevel::Links) {
+    if ((_imp->assertion_level == AssertionLevel::Definitions && annotation) || _imp->assertion_level >= AssertionLevel::Links) {
         // At AssertionLevel::Definitions we can assert some inferences and not others (since the needed constraints for the justifications will
         // still be present). At higher levels, we need to assert all inferences.
         if (! is_literally_true(lit)) {

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -1,10 +1,13 @@
 #include <cstdio>
+#include <gcs/expression.hh>
 #include <gcs/innards/interval_set.hh>
 #include <gcs/innards/proofs/emit_inequality_to.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/state.hh>
 
@@ -12,6 +15,7 @@
 #include <cstdlib>
 #include <deque>
 #include <fstream>
+#include <optional>
 #include <sstream>
 
 #include <version>
@@ -110,6 +114,7 @@ struct ProofLogger::Imp
     string proof_file;
     fstream proof;
     int current_indent = 0;
+    bool use_annotated_assertions;
 
     Imp(NamesAndIDsTracker & t) :
         tracker(t)
@@ -122,6 +127,7 @@ ProofLogger::ProofLogger(const ProofOptions & proof_options, NamesAndIDsTracker 
 {
     _imp->proof_file = proof_options.proof_file_names.proof_file;
     _imp->proof_lines_by_level.resize(2);
+    _imp->use_annotated_assertions = proof_options.use_annotated_assertions;
 }
 
 ProofLogger::~ProofLogger() = default;
@@ -261,7 +267,7 @@ auto ProofLogger::conclude_none() -> void
 }
 
 auto ProofLogger::infer(const Literal & lit, const Justification & why,
-    const ReasonFunction & reason) -> void
+    const ReasonFunction & reason, const optional<AssertionAnnotation> & annotation) -> void
 {
     // A range conclusion on a view (folding views into the interval machinery is
     // deferred) or on a plain variable without a bits encoding (no order cuts to
@@ -291,51 +297,22 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
             .visit(simplify_literal(names_and_ids_tracker(), lit));
     };
 
+    if (_imp->use_annotated_assertions && annotation) {
+        if (! is_literally_true(lit)) {
+            emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason);
+        }
+        return;
+    }
+
     overloaded{
         [&]([[maybe_unused]] const JustifyUsingRUP & j) {
-            log_stacktrace();
-            need_lit();
-            optional<Reason> reason_literals;
-            if (reason)
-                reason_literals = reason();
-
-            if (reason_literals)
-                names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
-
             if (! is_literally_true(lit)) {
-                WPBSum terms;
-                HalfReifyOnConjunctionOf reif{};
-                if (reason_literals)
-                    reif = *reason_literals;
-
-                terms += 1_i * lit;
-                write_indent();
-                _imp->proof << "rup ";
-                emit_inequality_to(names_and_ids_tracker(), reify(move(terms) >= 1_i, reif), _imp->proof);
-                _imp->proof << ";\n";
-                record_proof_line(advance_proof_line_number(), ProofLevel::Current);
+                emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current);
             }
         },
         [&]([[maybe_unused]] const AssertRatherThanJustifying & j) {
-            log_stacktrace();
-            need_lit();
-            optional<Reason> reason_literals;
-            if (reason)
-                reason_literals = reason();
-
-            HalfReifyOnConjunctionOf reif{};
-            if (reason_literals) {
-                names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
-                reif = *reason_literals;
-            }
             if (! is_literally_true(lit)) {
-                WPBSum terms;
-                terms += 1_i * lit;
-                write_indent();
-                _imp->proof << "a ";
-                emit_inequality_to(names_and_ids_tracker(), reify(move(terms) >= 1_i, reif), _imp->proof);
-                _imp->proof << ";\n";
-                record_proof_line(advance_proof_line_number(), ProofLevel::Current);
+                emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason);
             }
         },
         [&](const JustifyExplicitlyOnly & x) {

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -20,6 +20,7 @@
 #include <optional>
 #include <sstream>
 
+#include <variant>
 #include <version>
 #ifdef __cpp_lib_stacktrace
 #include <stacktrace>
@@ -331,7 +332,7 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
     if ((_imp->assertion_level == AssertionLevel::Definitions && annotation) || _imp->assertion_level >= AssertionLevel::Links) {
         // At AssertionLevel::Definitions we can assert some inferences and not others (since the needed constraints for the justifications will
         // still be present). At higher levels, we need to assert all inferences.
-        if (! is_literally_true(lit)) {
+        if (! is_literally_true(lit) && ! std::holds_alternative<NoJustificationNeeded>(why)) {
             emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
         }
         return;

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -722,3 +722,8 @@ auto ProofLogger::write_indent() -> void
         _imp->proof << ' ';
     }
 }
+
+auto ProofLogger::using_assertions() -> bool
+{
+    return _imp->use_annotated_assertions;
+}

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -192,8 +192,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             },
             [&](const ViewOfIntegerVariableID & var) {
                 if (_imp->assertion_level > AssertionLevel::Definitions) {
-                    auto actual = deview(var == val);
-                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(actual.var, actual.value);
+                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(*names_and_ids_tracker().find_view(var), val);
                 }
                 else
                     _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(deview(var == val));
@@ -249,8 +248,8 @@ auto ProofLogger::end_proof() -> void
 auto ProofLogger::conclude_unsatisfiable(bool is_optimisation) -> void
 {
     _imp->proof << "% asserting contradiction\n";
-    _imp->proof << "rup >= 1 ;\n";
-    record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+    auto assert_or_rup = _imp->assertion_level == AssertionLevel::Backtracking ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+    emit(assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Top);
     _imp->proof << "output NONE;\n";
     if (is_optimisation)
         _imp->proof << "conclusion BOUNDS INF INF;\n";
@@ -452,7 +451,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
     // Note: no automatic deview-derivation here. Runtime RUP/red emissions
     // happen many times per propagator inference and per-call deview
     // derivation explodes proof size on tests with many view-using
-    // constraints. Callers that need the deview-form of a runtime-emitted
+    // constraints. Callers that need the deview-form of a runtime-mitted
     // constraint use the explicit `*_then_deview` variant (see
     // `emit_rup_proof_line_under_reason_then_deview`).
     return line;

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -299,7 +299,7 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
 
     if (_imp->use_annotated_assertions && annotation) {
         if (! is_literally_true(lit)) {
-            emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason);
+            emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
         }
         return;
     }
@@ -368,7 +368,7 @@ auto ProofLogger::emit_proof_comment(const string & s) -> void
     _imp->proof << "% " << s << '\n';
 }
 
-auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> ProofLine
+auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level, std::optional<AssertionAnnotation> assertion_hint) -> ProofLine
 {
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     log_stacktrace();
@@ -407,7 +407,11 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
                 rule_line << ";";
             }
         },
-        [&](const AssertProofRule &) { rule_line << ";"; }}
+        [&](const AssertProofRule &) {
+			if (assertion_hint) {
+				rule_line << *assertion_hint;
+	 		}
+			rule_line << ";"; }}
         .visit(rule);
 
     auto line = emit_proof_line(rule_line.str(), level);
@@ -422,7 +426,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
 
 auto ProofLogger::emit_under_reason(
     const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
-    ProofLevel level, const ReasonFunction & reason) -> ProofLine
+    ProofLevel level, const ReasonFunction & reason, std::optional<AssertionAnnotation> assertion_hint) -> ProofLine
 {
     optional<Reason> reason_literals;
     if (reason)
@@ -464,7 +468,12 @@ auto ProofLogger::emit_under_reason(
 				rule_line << relative_proof_line(*rule.line, _imp->proof_line.number) << " ";
 				rule_line << " ;";
 			} else { rule_line << ";"; } },
-        [&](const AssertProofRule &) { rule_line << ";"; }}
+        [&](const AssertProofRule &) { 
+			if (assertion_hint) {
+				rule_line << *assertion_hint;
+	 		}
+
+			rule_line << ";"; }}
         .visit(rule);
 
     auto line = emit_proof_line(rule_line.str(), level);

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -1,5 +1,6 @@
 #include <cstdio>
 #include <gcs/expression.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/interval_set.hh>
 #include <gcs/innards/proofs/emit_inequality_to.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -10,6 +11,7 @@
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/proof.hh>
 
 #include <cstddef>
 #include <cstdlib>
@@ -114,7 +116,7 @@ struct ProofLogger::Imp
     string proof_file;
     fstream proof;
     int current_indent = 0;
-    bool use_annotated_assertions;
+    AssertionLevel assertion_level;
 
     Imp(NamesAndIDsTracker & t) :
         tracker(t)
@@ -127,7 +129,7 @@ ProofLogger::ProofLogger(const ProofOptions & proof_options, NamesAndIDsTracker 
 {
     _imp->proof_file = proof_options.proof_file_names.proof_file;
     _imp->proof_lines_by_level.resize(2);
-    _imp->use_annotated_assertions = proof_options.use_annotated_assertions;
+    _imp->assertion_level = proof_options.assertion_level;
 }
 
 ProofLogger::~ProofLogger() = default;
@@ -205,7 +207,8 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     WPBSum backtrack;
     for (const auto & guess : guesses)
         backtrack += 1_i * ! guess;
-    emit_rup_proof_line(move(backtrack) >= 1_i, ProofLevel::Current);
+    auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+    emit(assert_or_rup, move(backtrack) >= 1_i, ProofLevel::Current, AssertionAnnotation{.hint_name = AssertionHintName::Backtrack});
 }
 
 auto ProofLogger::end_proof() -> void
@@ -297,7 +300,10 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
             .visit(simplify_literal(names_and_ids_tracker(), lit));
     };
 
-    if (_imp->use_annotated_assertions && annotation) {
+    if (_imp->assertion_level > AssertionLevel::Inferences)
+        return;
+
+    if (_imp->assertion_level >= AssertionLevel::Definitions && annotation) {
         if (! is_literally_true(lit)) {
             emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
         }
@@ -368,7 +374,7 @@ auto ProofLogger::emit_proof_comment(const string & s) -> void
     _imp->proof << "% " << s << '\n';
 }
 
-auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level, std::optional<AssertionAnnotation> assertion_hint) -> ProofLine
+auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     log_stacktrace();
@@ -426,7 +432,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
 
 auto ProofLogger::emit_under_reason(
     const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
-    ProofLevel level, const ReasonFunction & reason, std::optional<AssertionAnnotation> assertion_hint) -> ProofLine
+    ProofLevel level, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
     optional<Reason> reason_literals;
     if (reason)
@@ -732,7 +738,7 @@ auto ProofLogger::write_indent() -> void
     }
 }
 
-auto ProofLogger::using_assertions() -> bool
+auto ProofLogger::get_assertion_level() -> AssertionLevel
 {
-    return _imp->use_annotated_assertions;
+    return _imp->assertion_level;
 }

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -179,7 +179,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
     WPBSum blocking_sum{};
 
     for (const auto & [var, val] : all_variables_and_values) {
-        if (! optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Links)
+        if (! optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
             blocking_sum += 1_i * (var != val);
 
         overloaded{
@@ -329,7 +329,7 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
     if (_imp->assertion_level > AssertionLevel::Inferences)
         return;
 
-    if ((_imp->assertion_level == AssertionLevel::Definitions && annotation) || _imp->assertion_level >= AssertionLevel::Links) {
+    if (_imp->assertion_level != AssertionLevel::Off) {
         // At AssertionLevel::Definitions we can assert some inferences and not others (since the needed constraints for the justifications will
         // still be present). At higher levels, we need to assert all inferences.
         if (! is_literally_true(lit) && ! std::holds_alternative<NoJustificationNeeded>(why)) {

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -249,7 +249,7 @@ auto ProofLogger::end_proof() -> void
 auto ProofLogger::conclude_unsatisfiable(bool is_optimisation) -> void
 {
     _imp->proof << "% asserting contradiction\n";
-    auto assert_or_rup = _imp->assertion_level == AssertionLevel::Backtracking ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+    auto assert_or_rup = _imp->assertion_level >= AssertionLevel::Inferences ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
     emit(assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Top);
     _imp->proof << "output NONE;\n";
     if (is_optimisation)

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -247,12 +247,12 @@ namespace gcs::innards
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level) -> ProofLine;
+        auto emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, std::optional<AssertionAnnotation> assertion_hint = std::nullopt) -> ProofLine;
 
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &) -> ProofLine;
+        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &, std::optional<AssertionAnnotation> assertion_hint = std::nullopt) -> ProofLine;
 
         /**
          * Emit a RUP proof step for the specified expression, not subject to

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_LOGGER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_LOGGER_HH
 
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_line.hh>
@@ -14,6 +15,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace gcs::innards
@@ -129,8 +131,9 @@ namespace gcs::innards
          * variable is a single proof line `~[var in lo..hi] >= 1` emitted under the
          * reason, in place of one `var != v` line per removed value; views and
          * direct-only-encoded variables fall back to per-value emission.
+         * Also pass an assertion annotation.
          */
-        auto infer(const Literal & lit, const Justification & why, const ReasonFunction & reason) -> void;
+        auto infer(const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & annotation = std::nullopt) -> void;
 
         /**
          * \brief Return the current <em>active proof level</em> &mdash; the

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -329,6 +329,11 @@ namespace gcs::innards
          * Write a number of spaces equal to current_indent.
          */
         auto write_indent() -> void;
+
+        /**
+         * Get whether the logger is using annotated assertions instead of full justifications.
+         */
+        auto using_assertions() -> bool;
     };
 }
 

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -247,12 +247,12 @@ namespace gcs::innards
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, std::optional<AssertionAnnotation> assertion_hint = std::nullopt) -> ProofLine;
+        auto emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> ProofLine;
 
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &, std::optional<AssertionAnnotation> assertion_hint = std::nullopt) -> ProofLine;
+        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &, const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> ProofLine;
 
         /**
          * Emit a RUP proof step for the specified expression, not subject to
@@ -331,9 +331,10 @@ namespace gcs::innards
         auto write_indent() -> void;
 
         /**
-         * Get whether the logger is using annotated assertions instead of full justifications.
+         * Get the level enum controlling how much of the proof will be asserted
+         * instead of fully justified.
          */
-        auto using_assertions() -> bool;
+        auto get_assertion_level() -> AssertionLevel;
     };
 }
 

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -33,7 +33,7 @@ namespace
         Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
         ProofLogger * const logger, SimpleIntegerVariableID selector_var_id) -> void
     {
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->enter_proof_level(depth + 1);
 
         if (propagators.propagate(this_branch_guess, state, logger)) {
@@ -44,7 +44,7 @@ namespace
                 for (auto & var : vars)
                     tuple.push_back(state(var));
 
-                if (logger) {
+                if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                     logger->emit_proof_comment("new table entry found");
 
                     Integer sel_value(tuples.size());
@@ -79,7 +79,7 @@ namespace
             }
         }
 
-        if (logger) {
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
             logger->enter_proof_level(depth);
             vector<Literal> guesses;
             for (const auto & g : state.guesses())
@@ -98,11 +98,11 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
     initial_state.guess(TrueLiteral{});
 
     auto selector_var_id = initial_state.what_variable_id_will_be_created_next();
-    if (logger)
+    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
         logger->emit_proof_comment("starting autotabulation");
     solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, logger, selector_var_id);
 
-    if (logger)
+    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
         logger->emit_proof_comment("creating autotable with " + to_string(tuples.size()) + " entries");
 
     initial_state.backtrack(timestamp);
@@ -115,7 +115,7 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
         throw UnexpectedException{"something went horribly wrong with variable IDs when autotabulating"};
 
     ExtensionalData data{selector, _vars, move(tuples)};
-    if (logger)
+    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
         logger->emit_proof_comment("finished autotabulation");
 
     Triggers triggers;

--- a/gcs/proof.cc
+++ b/gcs/proof.cc
@@ -3,11 +3,69 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/proof.hh>
 
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#include <version>
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+using std::print;
+#else
+#include <fmt/core.h>
+using fmt::print;
+#endif
+
 using namespace gcs;
 using namespace gcs::innards;
 
 using std::make_unique;
+using std::nullopt;
+using std::optional;
 using std::string;
+
+namespace
+{
+    /**
+     * Read an AssertionLevel from the GCS_ASSERTION_LEVEL environment variable, if set.
+     * Accepts either the enum names (case-insensitive) or their numeric values; an
+     * unrecognised value is ignored with a warning.
+     */
+    [[nodiscard]] auto assertion_level_from_env() -> optional<AssertionLevel>
+    {
+        const auto * const env = std::getenv("GCS_ASSERTION_LEVEL");
+        if (! env || ! *env)
+            return nullopt;
+
+        string value{env};
+        if (value == "Off" || value == "off" || value == "0")
+            return AssertionLevel::Off;
+        else if (value == "Definitions" || value == "definitions" || value == "1")
+            return AssertionLevel::Definitions;
+        else if (value == "Links" || value == "links" || value == "2")
+            return AssertionLevel::Links;
+        else if (value == "Inferences" || value == "inferences" || value == "3")
+            return AssertionLevel::Inferences;
+        else if (value == "Backtracking" || value == "backtracking" || value == "4")
+            return AssertionLevel::Backtracking;
+
+        print(stderr, "Ignoring unrecognised GCS_ASSERTION_LEVEL value '{}'\n", value);
+        return nullopt;
+    }
+
+    /**
+     * Apply any environment-variable overrides to a copy of the given ProofOptions.
+     * Environment variables act as defaults only: an option set explicitly in code
+     * takes precedence.
+     */
+    [[nodiscard]] auto with_env_overrides(ProofOptions options) -> ProofOptions
+    {
+        if (! options.assertion_level_set_explicitly)
+            if (auto level = assertion_level_from_env())
+                options.assertion_level = *level;
+        return options;
+    }
+}
 
 ProofFileNames::ProofFileNames(const std::string & s) :
     opb_file(s + ".opb"),
@@ -42,7 +100,7 @@ struct Proof::Imp
 };
 
 Proof::Proof(const ProofOptions & o) :
-    _imp(make_unique<Imp>(o))
+    _imp(make_unique<Imp>(with_env_overrides(o)))
 {
     _imp->tracker.start_writing_model(model());
 }

--- a/gcs/proof.cc
+++ b/gcs/proof.cc
@@ -22,10 +22,8 @@ ProofOptions::ProofOptions(const std::string & f) :
 {
 }
 
-ProofOptions::ProofOptions(const ProofFileNames & f, bool v, bool a) :
-    proof_file_names(f),
-    verbose_names(v),
-    always_use_full_encoding(a)
+ProofOptions::ProofOptions(const ProofFileNames & f) :
+    proof_file_names(f)
 {
 }
 

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -38,13 +38,32 @@ namespace gcs
     struct ProofOptions final
     {
         explicit ProofOptions(const std::string &);
-        explicit ProofOptions(const ProofFileNames &, bool, bool);
+        explicit ProofOptions(const ProofFileNames &);
         ProofOptions(const ProofOptions &) = default;
 
         ProofFileNames proof_file_names;       ///< Filenames for OPB, proof, and mapping files
         bool verbose_names = true;             ///< Use verbose names in proofs?
         bool always_use_full_encoding = false; ///< Always write the full variable encoding to the OPB file
         bool use_annotated_assertions = false; ///< Only write annotated assertions instead of full justifications.
+
+        /// Write annotated assertions instead of full justifications.
+        ProofOptions & enable_assertions()
+        {
+            use_annotated_assertions = true;
+            return *this;
+        }
+        /// Always write the full variable encoding to the OPB file.
+        ProofOptions & enable_full_encoding()
+        {
+            always_use_full_encoding = true;
+            return *this;
+        }
+        /// Set whether to use verbose names in proofs.
+        ProofOptions & set_verbose_names(bool v)
+        {
+            verbose_names = v;
+            return *this;
+        }
     };
 
     class Proof

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -58,11 +58,13 @@ namespace gcs
         bool verbose_names = true;             ///< Use verbose names in proofs?
         bool always_use_full_encoding = false; ///< Always write the full variable encoding to the OPB file
         AssertionLevel assertion_level = AssertionLevel::Off;
+        bool assertion_level_set_explicitly = false; ///< Was assertion_level set in code (so it overrides the env var)?
 
         /// Write annotated assertions instead of full justifications.
         ProofOptions & set_assertion_level(AssertionLevel a = AssertionLevel::Inferences)
         {
             assertion_level = a;
+            assertion_level_set_explicitly = true;
             return *this;
         }
         /// Always write the full variable encoding to the OPB file.

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -44,6 +44,7 @@ namespace gcs
         ProofFileNames proof_file_names;       ///< Filenames for OPB, proof, and mapping files
         bool verbose_names = true;             ///< Use verbose names in proofs?
         bool always_use_full_encoding = false; ///< Always write the full variable encoding to the OPB file
+        bool use_annotated_assertions = false; ///< Only write annotated assertions instead of full justifications.
     };
 
     class Proof

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -30,6 +30,19 @@ namespace gcs
     };
 
     /**
+     * \brief Mode setting for annotated assertions. Each option involves successively less
+     * justification.
+     */
+    enum class AssertionLevel
+    {
+        Off = 0,      /// Justify everything; no annotated assertions
+        Definitions,  /// Justify backtracking, links, definitions; assert inferences
+        Links,        /// Justify backtracking; assert inferences & links; omit definitions
+        Inferences,   /// Assert backtracking & inferences; omit links & definitions
+        Backtracking, /// Assert backtracking only; omit everything else
+    };
+
+    /**
      * \brief Options for a Problem telling it how to produce a proof.
      *
      * \sa Problem
@@ -44,18 +57,18 @@ namespace gcs
         ProofFileNames proof_file_names;       ///< Filenames for OPB, proof, and mapping files
         bool verbose_names = true;             ///< Use verbose names in proofs?
         bool always_use_full_encoding = false; ///< Always write the full variable encoding to the OPB file
-        bool use_annotated_assertions = false; ///< Only write annotated assertions instead of full justifications.
+        AssertionLevel assertion_level = AssertionLevel::Off;
 
         /// Write annotated assertions instead of full justifications.
-        ProofOptions & enable_assertions()
+        ProofOptions & set_assertion_level(AssertionLevel a = AssertionLevel::Inferences)
         {
-            use_annotated_assertions = true;
+            assertion_level = a;
             return *this;
         }
         /// Always write the full variable encoding to the OPB file.
-        ProofOptions & enable_full_encoding()
+        ProofOptions & enable_full_encoding(bool e = true)
         {
-            always_use_full_encoding = true;
+            always_use_full_encoding = e;
             return *this;
         }
         /// Set whether to use verbose names in proofs.

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -61,7 +61,7 @@ namespace
     auto prove_to_scp(Problem & problem, const std::string & basename) -> std::string
     {
         solve_with(problem, SolveCallbacks{},
-            std::make_optional<ProofOptions>(ProofFileNames{basename}, true, false));
+            std::make_optional<ProofOptions>(ProofFileNames{basename}));
         std::ifstream in{basename + ".scp"};
         std::string scp{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
         for (auto ext : {".opb", ".pbp", ".scp", ".varmap"})

--- a/scp/glasgow_scp_solver.cc
+++ b/scp/glasgow_scp_solver.cc
@@ -104,7 +104,7 @@ auto main(int argc, char * argv[]) -> int
                 return find_all;
             }},
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()}, true, false)
+            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()})
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/verified_encodings/abs/abs.cc
+++ b/verified_encodings/abs/abs.cc
@@ -94,7 +94,7 @@ auto main(int argc, char * argv[]) -> int
                 return true;
             }},
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()}, true, false)
+            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()})
             : nullopt);
 
     if (options_vars.contains("stats"))


### PR DESCRIPTION
Okay, I believe this is now in a state where I'm happy for it to be Claudited (Claudified? Claudicated? Claudificated?).

## Purpose of these changes 

We are working towards having an external justifier tool that will read a proof with annotated assertions and fill in PB justifications, and also trim the proof. This should hopefully both speed up end-to-end verification time and make it easier to implement proof logging in other solvers. 

As a step towards this, we would like the Glasgow Constraint Solver to have a mode where it asserts all its inferences with annotations sufficient to reconstruct the proof later.

## Implementation Notes

### Assertion Levels
I've decided it will be useful to have several degrees to which assertions will replace proof steps. This is controlled via an ordered enum (lower = more explicit/real derivations, higher = more assertions/omissions). Specifically
- `AssertionLevel::Off`: current behaviour, everything is justified, no assertions. 
- `AsserionLevel::Definitions`: inferences are asserted, no intermediate ad-hoc justification steps are output, but atomic literals and their definitions + links are still derived as normal in the proof, backtracks are still RUP, solutions are logged as normal.
-  `AssertionLevel::Links`: same as Definitions, except the redundance steps introducing geq vars reified on the bit encoding are omitted, and soli/solx now use the full bit assignment rather than eqvars, and assert the blocking constraint. Note that eqvar definitions `x[eq5] <=> x[ge5] /\ ~x[ge6]` are considered "links" for the purpose of this definition.
- `AssertionLevel::Inferences`: no "linking" constraints are output: so no chaining constraints for geqvars,  no containment/covering for range literals, no view linking and no eqvar definitions. This obviously breaks the standard invariants for backtracking search so backtracking steps are asserted at this level
- `AssertionLevel::Backtracking`: only backtracking and solution logging steps are output, asserted. This matches the first level of the Flippo et al. multi-stage framework.

This is controlled by an env var for now, for convenience. If we eventually standardise a command line interface, we could use have a standard `--assertion-level` option.

Some "footguns" (to use Claudespeak):
-  For solution logging to work at AssertionLevel::Links and above, changes are needed to the way VeriPB deals with enumeration proofs, since the asserted constraints in the proof might not necessarily be satisfied by UP. I have an outstanding [work item](https://gitlab.com/MIAOresearch/software/veripb-dev/-/work_items/188) and [merge request](https://gitlab.com/MIAOresearch/software/veripb-dev/-/merge_requests/188) in the VeriPB repo and I think in principle it should be fine to change `solx` semantics to only require constraints 
in the core set to be satisfied.
- I've had to manually add guard statements `if (logger && logger->get_assertion_level() == AssertionLevel:Off)` to everywhere in the solver that emits ad-hoc proof steps outside of infer() or contradiction(). Hopefully I've caught them all.
- `propagate_extensional` is a bit tricky as it relies on the not-real selector variable domain wipeout to justify backtracking and uses `NoJustificationNeeded{}`. The naive approach will either cause a crash (if I try to write something to do with the selector variable without defining it), or a proof logging failure (backtrack rup won't succeed as there's no wipeout of any of the actual variables). I've changed this to explicitly assert a conflict justification when the selector is wiped out, which fixes the problem.
- Similarly, a couple of other places where `NoJustificationNeeded` is used (circuit) need to be special-cased.
- The final rup contradiction line needs to be asserted at `AssertionLevel::Inferences` and above, easy to miss since was old code that doesn't use emit and literally just wrote the string `"rup >= 1;"`.
- I was hoping I could make it possible to assert some inferences and not others (so we can compare immediate vs. deferred justification at some point). This should in theory work at `AssertionLevel::Definitions` (only), but we would need some global method of controlling which assertions were output. Just using the presence of annotation alone to decide whether to output assertions doesn't work, because an un-annotated inference might depend on ad-hoc logging statements (e.g. a gac inference for linear equality) that isn't being logged above `AssertionLevel:Off`.
- The scp tests fail at higher assertion levels. This is because they are looking for the string "s VERIFIED" and veripb outputs "s UNDER ASSERTIONS". This is probably fine.  All other tests succeed at all assertion levels.

### Assertion Hints
I've made up some data structures for actually creating hints. I'm happy with s-expressions as the format. 

Overall, I'd like:
- maximum flexibility for the hint shape - I don't know exactly yet what the external justifier will need and so I'll probably add and remove things as I go along.
- Easy to construct: I've tried to generify some hint_list() constructors for making S expressions.
- Hard to put completely arbitrary data into unilaterally:
    - The hints are going to effectively define the API of the justifier, and will ideally be standardised across solvers that use it.  
    - This is why I've gone for enum specifications all in one place, in addition to attempting to avoid allocated strings in the hints. 
    - However, if there's another way to make a clear API reference while decentralising the hint data definitions, great. 
- Low/zero cost when AssertionHints are not used. This I don't think I currently achieve particularly well - obviously, the enum allocations and empty vectors are low cost, but to extend what I've done to all the constraints would need a lot of guarding to ensure AssertionHins

I'm not massively wedded to the exact implementation details, though, if it can be improved, great!

Which brings me nicely on to...

## Thoughts for Claude

### Re #347
- I'm on board with the more ambitious refactor idea that solves `Reason` and `AssertionHint` allocation problems at once. 
- I'm not entirely sure about string_view for hints though. I guess it solves the allocation problem and avoids big long enums, but it still allows for arbitrary keywords in hints, whereas I'd rather have it constrained to match the justifier API in one place somewhere.
    - Possibly even one day, the Justifier codebase will provide lightweight libraries in different programming languages that define the unified assertion annotation language. It would be good to design with something like this in mind.

### Re the additional annotation fields
The reason for hint_name as a special colon-separated field separate from the rest of the assertion hints is to give something for vanilla VeriPB to parse, e.g. for a statistics feature or a richer UNDER ASSERTIONS output. It might be nice for veripb to say a bit about what "types" of assertions were used and that's what this field designates. 

Similarly, the reason for derived_from is mostly future-proofing. For now, derived_from won't really be used by the justifier, but in other uses of annotated-assertion, it might be used by a trimmer to determine how to trim assertions properly. For GCS, it could be used if we get to a point where we want to assert some part of a justification (rather than asserting an inference as a whole). In that case, we might want to specify what intermediate derived constraints will be used to derive the assertion, and might become more usable if/when constraint group labels are implemented in VeriPB.

### More things for Claude to do
In addition to #347 refactoring it would be good for Claude to do the tedious work of adding assertion hints everywhere in the solver. 

I'd have a couple of preferences/recommendations for this:
- A lot of Assertion hints will probably have a master hint shape for the whole propagator and then individual inference types will modify it slightly. It would be good to abstract over this interface (some nice builder methods for assertion annotations perhaps).
- Every assertion annotation requires a name, which should correspond to the *model-level* "thing" that explains where the assertion is coming from. So even if we're in a propagate_all_different, if it comes from circuit, it should say circuit. 
- Most (if not all) assertions should specify the constraint_id responsible for the inference in the hints. It'd be good if there was a clean/default way to thread this through. What I've done so far for `gac_all_different` is awkward.
- Many (but not all) assertions will have a main (justifier keyword) pair. E.g. for `propagate_gac_all_different` we have `(justifier hall_set_or_violator)`. This will correspond to the actual justifier function being called, but may not be necessary for every constraint. I would have an easy way to add this "justifier dispatch" keyword but I wouldn't bother adding it for every inference prematurely, as lots of things probably aren't going to need it: for constraints where there's only one way to justify, the constraint id/name will likely be enough.
- I've been a bit sloppy with names: to be consistent, an assertion "annotation" refer to the full 3-field structure, whereas assertion "hints" refers to just the last field.

**IMPORTANT INFO FOR CLAUDE**: If testing proofs at higher assertion levels, main branch VeriPB will fail at the moment, because the assertion_hints feature and the solx behaviour fix are currently outstanding MRs in the development repo. For testing, I have made a temporary branch in VeriPB-dev `temp/annotated-assertions-and-sol-fix` - this is what you should build VeriPB from if building on top of the work in this branch.  

I'm happy for this to be merged and then for Claude to build on top of it, or for Claude to pull in / reuse bits of this branch. Your call @ciaranm. Either way I would like commits based directly on work in the branch credited to me ;-)
