### PR TITLE
Remove unnecessary justification steps in initialiser

### DIFF
--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <iterator>
 #include <map>
-#include <optional>
 #include <sstream>
 #include <string>
 
@@ -129,16 +128,7 @@ auto AllDifferentExcept::define_proof_model(ProofModel & model) -> void
 auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicates && _sanitised_excluded.empty()) {
-        // Same shape as plain AllDifferent on duplicates: with empty excluded,
-        // the encoding's half-reified relaxation terms disappear and the
-        // duplicate pair's two constraints jointly force selector and
-        // !selector simultaneously. Install the shared clique-contradiction
-        // initialiser instead of the per-value path below; the propagator
-        // also can't run, so we early-return.
-        auto witness = _duplicate_selectors.empty()
-            ? std::nullopt
-            : std::optional{*_duplicate_selectors.begin()};
-        install_clique_duplicate_contradiction_initialiser(propagators, move(witness));
+        install_clique_duplicate_contradiction_initialiser(propagators);
         return;
     }
 

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -4,12 +4,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 
-#include <utility>
-
 using std::map;
-using std::move;
-using std::optional;
-using std::pair;
 using std::string;
 using std::to_string;
 using std::vector;
@@ -17,9 +12,8 @@ using std::vector;
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const string & constraint_id, const vector<gcs::IntegerVariableID> & vars) -> optional<pair<IntegerVariableID, ProofFlag>>
+auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const string & constraint_id, const vector<gcs::IntegerVariableID> & vars) -> void
 {
-    optional<pair<IntegerVariableID, ProofFlag>> duplicate_witness;
 
     for (unsigned i = 0; i < vars.size(); ++i)
         for (unsigned j = i + 1; j < vars.size(); ++j) {
@@ -30,41 +24,16 @@ auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const s
                 "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
             model.add_labelled_constraint(constraint_id, to_string(i) + "gt" + to_string(j),
                 "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
-
-            if (vars[i] == vars[j] && ! duplicate_witness)
-                duplicate_witness = pair{vars[i], selector};
         }
-
-    return duplicate_witness;
 }
 
 auto gcs::innards::install_clique_duplicate_contradiction_initialiser(
-    Propagators & propagators,
-    optional<pair<IntegerVariableID, ProofFlag>> duplicate_witness) -> void
+    Propagators & propagators) -> void
 {
     propagators.install_initialiser(
-        [duplicate_witness = move(duplicate_witness)](
+        [](
             State &, auto & inference, ProofLogger * const logger) -> void {
-            if (logger && duplicate_witness) {
-                const auto & selector = duplicate_witness->second;
-                inference.contradiction(logger,
-                    JustifyExplicitlyThenRUP{
-                        [logger, selector](const ReasonFunction &) -> void {
-                            // For the duplicated pair (i, j) with vars[i] = vars[j], the encoding
-                            // emitted:
-                            //   selector  -> (vars[i] - vars[j] <= -1)  i.e.  selector  -> false
-                            //   !selector -> (vars[j] - vars[i] <= -1)  i.e.  !selector -> false
-                            // RUP each polarity from its own half-reification, then RUP false.
-                            logger->emit(RUPProofRule{},
-                                WPBSum{} + 1_i * selector >= 1_i, ProofLevel::Temporary);
-                            logger->emit(RUPProofRule{},
-                                WPBSum{} + 1_i * (! selector) >= 1_i, ProofLevel::Temporary);
-                        }},
-                    ReasonFunction{});
-            }
-            else {
-                inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{});
-            }
+            inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{});
         },
         InitialiserPriority::SimpleDefinition);
 }

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -11,9 +11,7 @@
 #include <gcs/variable_id.hh>
 
 #include <map>
-#include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace gcs
@@ -23,13 +21,9 @@ namespace gcs
         // Emits the clique-of-not-equals encoding. Where the same variable
         // appears more than once in `vars`, the resulting pair-of-half-reified
         // constraints is jointly inconsistent — both polarities of the
-        // selector are forced false. If any duplicate pair is found, the
-        // return value carries one of the offending variables and its
-        // selector flag, which the caller can cite from a justification that
-        // derives contradiction explicitly (RUP alone cannot pick a polarity,
-        // since both half-reifications are non-unit).
+        // selector are forced false.
         auto define_clique_not_equals_encoding(ProofModel & model, const std::string & constraint_id,
-            const std::vector<IntegerVariableID> & vars) -> std::optional<std::pair<IntegerVariableID, ProofFlag>>;
+            const std::vector<IntegerVariableID> & vars) -> void;
 
         // Emits the AllDifferentExcept clique encoding. Where the same variable
         // appears more than once in `vars`, the resulting pair-of-half-reified
@@ -43,15 +37,8 @@ namespace gcs
 
         // Install a SimpleDefinition-priority contradiction initialiser that
         // proves the input was unsatisfiable because of a duplicate variable
-        // in a clique-of-not-equals encoding. If proof logging is enabled and
-        // a witness selector is supplied, the initialiser cites it
-        // explicitly: it RUPs `selector` and `!selector` from the two
-        // half-reifications the encoding emitted, then RUPs false. Otherwise
-        // it just contradicts via plain RUP, which is enough when not
-        // logging proofs.
-        auto install_clique_duplicate_contradiction_initialiser(
-            Propagators & propagators,
-            std::optional<std::pair<IntegerVariableID, ProofFlag>> duplicate_witness) -> void;
+        // in a clique-of-not-equals encoding.
+        auto install_clique_duplicate_contradiction_initialiser(Propagators & propagators) -> void;
     }
 }
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -626,13 +626,13 @@ auto GACAllDifferent::prepare(Propagators &, State & initial_state, ProofModel *
 
 auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    _duplicate_witness = define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
+    define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
 }
 
 auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_witness));
+        install_clique_duplicate_contradiction_initialiser(propagators);
         return;
     }
 

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -39,7 +39,6 @@ namespace gcs
         std::vector<IntegerVariableID> _sanitised_vars;
         std::vector<Integer> _compressed_vals;
         bool _has_duplicate_vars = false;
-        std::optional<std::pair<IntegerVariableID, innards::ProofFlag>> _duplicate_witness;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -113,7 +113,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
                 WPBSum{} + 1_i * (_vars[j] != Integer(i) + _start) + 1_i * (_vars[i] == Integer(j) + _start) >= 1_i);
         }
 
-    _duplicate_witness = define_clique_not_equals_encoding(model, as_string(_constraint_id), _vars);
+    define_clique_not_equals_encoding(model, as_string(_constraint_id), _vars);
 
     // Per-value am1s for the alldiff hall-set / SCC justifications,
     // built once at the root.
@@ -123,7 +123,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
 auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_witness));
+        install_clique_duplicate_contradiction_initialiser(propagators);
         return;
     }
 

--- a/gcs/constraints/all_different/symmetric_all_different.hh
+++ b/gcs/constraints/all_different/symmetric_all_different.hh
@@ -37,7 +37,6 @@ namespace gcs
         Integer _start;
         std::shared_ptr<std::map<Integer, innards::ProofLine>> _value_am1s;
         bool _has_duplicate_vars = false;
-        std::optional<std::pair<IntegerVariableID, innards::ProofFlag>> _duplicate_witness;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -21,7 +21,6 @@
 #include <functional>
 #include <list>
 #include <optional>
-#include <sstream>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -144,13 +143,13 @@ auto VCAllDifferent::prepare(Propagators &, State & initial_state, ProofModel * 
 
 auto VCAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    _duplicate_witness = define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
+    define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
 }
 
 auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators, move(_duplicate_witness));
+        install_clique_duplicate_contradiction_initialiser(propagators);
         return;
     }
 

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -34,7 +34,6 @@ namespace gcs
         std::vector<IntegerVariableID> _sanitised_vars;
         innards::ConstraintStateHandle _unassigned_handle;
         bool _has_duplicate_vars = false;
-        std::optional<std::pair<IntegerVariableID, innards::ProofFlag>> _duplicate_witness;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/all_different_test.cc
+++ b/gcs/constraints/all_different_test.cc
@@ -86,7 +86,7 @@ auto run_all_different_test(bool proofs, const ViewWrapConfig & view_cfg,
 // flavours: the consequence-contradiction path runs the standard
 // clique-of-not-equals encoding (which emits a self-contradicting
 // half-reified pair for the duplicated variable) and a contradiction
-// initialiser that cites one duplicated pair's selector flag.
+// initialiser that derives false by plain RUP.
 template <typename AllDifferentVariant_>
 auto run_alldiff_dup_test(bool proofs, const vector<vector<int>> & unique_domains,
     const vector<int> & positions, const string & flavour) -> void


### PR DESCRIPTION
Just fixing things while I see it. 

Claude's implementation of the duplicate literal contradiction had a lot of unnecessary apparatus to do
```
rup ~[selector] >= 1
rup [selector >= 1
rup >= 1
```

this involved storing/passing "duplication witnesses" in order to rup exactly the selector for the duplicate variable. None of this is necessary. 

If there's a duplicate variable then the lines
```
[selector] => x[i] - x[j] >= 1
~[selector] => x[j] - x[i] >= 1
```
collapse down to
```
[selector] => 0 >= 1
~[selector] => 0 >= 1
```
so we have a contradiction by UP already and a JustifyUsingRUP is sufficient.