### PR TITLE
Simplify CurrentState ownership to unique_ptr<State>

### DIFF
--- a/gcs/current_state.cc
+++ b/gcs/current_state.cc
@@ -5,9 +5,8 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::generator;
-using std::make_optional;
+using std::make_unique;
 using std::move;
-using std::optional;
 using std::string;
 using std::vector;
 
@@ -26,9 +25,9 @@ CurrentState::CurrentState(State & state) :
 {
 }
 
-CurrentState::CurrentState(optional<State> && s) :
-    _state_copy(make_unique<optional<State>>(move(s))),
-    _full_state(**_state_copy)
+CurrentState::CurrentState(State && s) :
+    _state_copy(make_unique<State>(move(s))),
+    _full_state(*_state_copy)
 {
 }
 
@@ -38,7 +37,7 @@ CurrentState::CurrentState(CurrentState &&) = default;
 
 auto CurrentState::clone() const -> CurrentState
 {
-    return CurrentState{make_optional(_full_state.clone())};
+    return CurrentState{_full_state.clone()};
 }
 
 auto CurrentState::operator()(const IntegerVariableID & v) const -> Integer

--- a/gcs/current_state.hh
+++ b/gcs/current_state.hh
@@ -9,7 +9,6 @@
 #include <exception>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <version>
 
 #ifdef __cpp_lib_generator
@@ -53,10 +52,10 @@ namespace gcs
     class CurrentState
     {
     private:
-        std::unique_ptr<std::optional<innards::State>> _state_copy;
+        std::unique_ptr<innards::State> _state_copy;
         innards::State & _full_state;
 
-        explicit CurrentState(std::optional<innards::State> &&);
+        explicit CurrentState(innards::State &&);
 
     public:
         /**


### PR DESCRIPTION
Item 5 of #291: `CurrentState::_state_copy` was `unique_ptr<optional<State>>`, whose inner `optional` adds a third representable state — a non-null pointer to `nullopt` — on top of the two the `unique_ptr` already provides.

I checked whether that third state is relied on anywhere: it isn't, and it can't be. The only owning construction is `clone()`, which always passes an engaged optional, and the private constructor immediately dereferences `**_state_copy`, so a disengaged optional would have been UB anyway. The borrowing constructor (`State &`) leaves the pointer null. No other code constructs the owning form (the constructor is private with no friends).

So this simplifies to `unique_ptr<State>`. The incomplete-type concern doesn't bite: `unique_ptr` handles the forward-declared `State` fine since the destructor and move constructor are defined out-of-line. One non-obvious knock-on: the old code's unqualified `make_unique` was found by ADL on `std::optional`; with `State` as the argument that lookup fails, so `using std::make_unique;` is added.

Since nothing in the repo exercises `CurrentState::clone()` (it's public API only), I verified the owning path with a standalone probe: clone six solutions in the callback, move-construct the owning clones, and read values and domain sizes after the solve — all correct.

Full suite: 322/322 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)