### PR TITLE
DRY exception boilerplate behind a shared MessageException base

### DIFF
--- a/gcs/current_state.cc
+++ b/gcs/current_state.cc
@@ -11,13 +11,8 @@ using std::string;
 using std::vector;
 
 VariableDoesNotHaveUniqueValue::VariableDoesNotHaveUniqueValue(const string & w) :
-    _wat(w + " does not have a unique value")
+    MessageException(w + " does not have a unique value")
 {
-}
-
-auto VariableDoesNotHaveUniqueValue::what() const noexcept -> const char *
-{
-    return _wat.c_str();
 }
 
 CurrentState::CurrentState(State & state) :

--- a/gcs/current_state.hh
+++ b/gcs/current_state.hh
@@ -1,12 +1,12 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CURRENT_STATE_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CURRENT_STATE_HH
 
+#include <gcs/exception.hh>
 #include <gcs/innards/interval_set-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
-#include <exception>
 #include <functional>
 #include <memory>
 #include <version>
@@ -29,15 +29,10 @@ namespace gcs
      *
      * \ingroup Core
      */
-    class VariableDoesNotHaveUniqueValue : public std::exception
+    class VariableDoesNotHaveUniqueValue : public MessageException
     {
-    private:
-        std::string _wat;
-
     public:
         explicit VariableDoesNotHaveUniqueValue(const std::string &);
-
-        virtual auto what() const noexcept -> const char * override;
     };
 
     /**

--- a/gcs/exception.cc
+++ b/gcs/exception.cc
@@ -12,29 +12,30 @@ using fmt::format;
 
 using namespace gcs;
 
+using std::move;
 #if __has_include(<source_location>) && __cpp_lib_source_location
 using std::source_location;
 #endif
 using std::string;
 
-UnexpectedException::UnexpectedException(const string & w) :
-    _wat("unexpected problem: " + w)
+MessageException::MessageException(string wat) :
+    _wat(move(wat))
 {
 }
 
-auto UnexpectedException::what() const noexcept -> const char *
+auto MessageException::what() const noexcept -> const char *
 {
     return _wat.c_str();
+}
+
+UnexpectedException::UnexpectedException(const string & w) :
+    MessageException("unexpected problem: " + w)
+{
 }
 
 InvalidProblemDefinitionException::InvalidProblemDefinitionException(const string & w) :
-    _wat("invalid problem definition: " + w)
+    MessageException("invalid problem definition: " + w)
 {
-}
-
-auto InvalidProblemDefinitionException::what() const noexcept -> const char *
-{
-    return _wat.c_str();
 }
 
 #if __has_include(<source_location>) && __cpp_lib_source_location

--- a/gcs/exception.hh
+++ b/gcs/exception.hh
@@ -12,20 +12,43 @@
 namespace gcs
 {
     /**
+     * \brief Base class for every exception this library throws, holding the
+     * message returned by what().
+     *
+     * Cannot be thrown directly: catch one of the concrete types where
+     * possible, or this to handle any solver-related failure uniformly.
+     *
+     * \sa UnexpectedException
+     * \sa InvalidProblemDefinitionException
+     * \sa NamingError
+     * \sa VariableDoesNotHaveUniqueValue
+     * \sa ScpReadError
+     * \sa innards::ProofError
+     *
+     * \ingroup Core
+     */
+    class MessageException : public std::exception
+    {
+    private:
+        std::string _wat;
+
+    protected:
+        explicit MessageException(std::string);
+
+    public:
+        [[nodiscard]] virtual auto what() const noexcept -> const char * override;
+    };
+
+    /**
      * \brief Thrown if something has gone wrong. This usually indicates a bug
      * in the solver.
      *
      * \ingroup Core
      */
-    class UnexpectedException : public std::exception
+    class UnexpectedException : public MessageException
     {
-    private:
-        std::string _wat;
-
     public:
         explicit UnexpectedException(const std::string &);
-
-        virtual auto what() const noexcept -> const char * override;
     };
 
     /**
@@ -36,15 +59,10 @@ namespace gcs
      *
      * \ingroup Core
      */
-    class InvalidProblemDefinitionException : public std::exception
+    class InvalidProblemDefinitionException : public MessageException
     {
-    private:
-        std::string _wat;
-
     public:
         explicit InvalidProblemDefinitionException(const std::string &);
-
-        virtual auto what() const noexcept -> const char * override;
     };
 
     /**

--- a/gcs/innards/proofs/proof_error.cc
+++ b/gcs/innards/proofs/proof_error.cc
@@ -6,11 +6,6 @@ using namespace gcs::innards;
 using std::string;
 
 ProofError::ProofError(const string & w) :
-    _wat("unexpected problem: " + w)
+    MessageException("unexpected problem: " + w)
 {
-}
-
-auto ProofError::what() const noexcept -> const char *
-{
-    return _wat.c_str();
 }

--- a/gcs/innards/proofs/proof_error.hh
+++ b/gcs/innards/proofs/proof_error.hh
@@ -12,15 +12,10 @@ namespace gcs::innards
      *
      * \ingroup Innards
      */
-    class ProofError : public std::exception
+    class ProofError : public MessageException
     {
-    private:
-        std::string _wat;
-
     public:
         explicit ProofError(const std::string &);
-
-        virtual auto what() const noexcept -> const char * override;
     };
 }
 

--- a/gcs/innards/s_expr.cc
+++ b/gcs/innards/s_expr.cc
@@ -12,13 +12,8 @@ using std::vector;
 using namespace gcs::innards;
 
 SExprParseError::SExprParseError(const string & w) :
-    _wat("S-expression error: " + w)
+    MessageException("S-expression error: " + w)
 {
-}
-
-auto SExprParseError::what() const noexcept -> const char *
-{
-    return _wat.c_str();
 }
 
 SExpr::SExpr(string atom) :

--- a/gcs/innards/s_expr.hh
+++ b/gcs/innards/s_expr.hh
@@ -1,9 +1,9 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_S_EXPR_HH
 
+#include <gcs/exception.hh>
 #include <gcs/innards/s_expr-fwd.hh>
 
-#include <exception>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -24,15 +24,10 @@ namespace gcs::innards
      *
      * \ingroup Innards
      */
-    class SExprParseError : public std::exception
+    class SExprParseError : public MessageException
     {
-    private:
-        std::string _wat;
-
     public:
         explicit SExprParseError(const std::string &);
-
-        [[nodiscard]] virtual auto what() const noexcept -> const char * override;
     };
 
     /**

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -41,13 +41,8 @@ using std::vector;
 using std::ranges::minmax_element;
 
 NamingError::NamingError(const string & w) :
-    _wat(w)
+    MessageException(w)
 {
-}
-
-auto NamingError::what() const noexcept -> const char *
-{
-    return _wat.c_str();
 }
 
 struct Problem::Imp

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROBLEM_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/exception.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
@@ -38,15 +39,10 @@ namespace gcs
      *
      * \ingroup Core
      */
-    class NamingError : public std::exception
+    class NamingError : public MessageException
     {
-    private:
-        std::string _wat;
-
     public:
         explicit NamingError(const std::string &);
-
-        virtual auto what() const noexcept -> const char * override;
     };
 
     /**

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -28,13 +28,8 @@ using namespace gcs;
 using namespace gcs::innards;
 
 ScpReadError::ScpReadError(const string & w) :
-    _wat("Error reading .scp: " + w)
+    MessageException("Error reading .scp: " + w)
 {
-}
-
-auto ScpReadError::what() const noexcept -> const char *
-{
-    return _wat.c_str();
 }
 
 namespace

--- a/gcs/scp_reader.hh
+++ b/gcs/scp_reader.hh
@@ -1,10 +1,10 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SCP_READER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SCP_READER_HH
 
+#include <gcs/exception.hh>
 #include <gcs/problem-fwd.hh>
 #include <gcs/variable_id.hh>
 
-#include <exception>
 #include <map>
 #include <string>
 #include <string_view>
@@ -18,15 +18,10 @@ namespace gcs
      *
      * \ingroup Core
      */
-    class ScpReadError : public std::exception
+    class ScpReadError : public MessageException
     {
-    private:
-        std::string _wat;
-
     public:
         explicit ScpReadError(const std::string &);
-
-        [[nodiscard]] virtual auto what() const noexcept -> const char * override;
     };
 
     /**


### PR DESCRIPTION
Closes #307.

The issue listed four types with the duplicated `std::string _wat;` + constructor + `what()` triplet; a sweep found three more with the identical pattern, so all seven now derive from a shared base:

- `UnexpectedException`, `InvalidProblemDefinitionException` (`gcs/exception.hh`)
- `NamingError` (`gcs/problem.hh`)
- `VariableDoesNotHaveUniqueValue` (`gcs/current_state.hh`)
- `ScpReadError` (`gcs/scp_reader.hh`)
- `innards::ProofError`, `innards::SExprParseError`

`MessageException : std::exception` lives in `gcs/exception.hh`, holds the string, and implements `what()`. Its constructor is protected, so it is a vocabulary type for catching, not throwing. `NonExhaustiveSwitch` and `UnimplementedException` already routed through `UnexpectedException` and are unchanged.

On the issue's second question (whether the user-facing types should move into one header): I kept each type in its home header, where the Doxygen context lives next to the class that throws it, and instead added `\sa` cross-references on the base listing every deriving type. Moving them seemed like churn without a clear win — happy to revisit if you'd prefer consolidation.

Message text is byte-identical to before: each derived constructor passes its composed string (raw for `NamingError`, prefix for the `exception.hh` pair / `ScpReadError` / `ProofError` / `SExprParseError`, suffix for `VariableDoesNotHaveUniqueValue`) to the base. Verified with a standalone probe: static-asserts that all nine types derive from the base and that it isn't externally constructible, plus real throw sites (illegal variable name, `LessThan{x, x}`) caught as `MessageException` with the expected messages. Full suite 322/322.

Stacked on #306 (both touch `gcs/current_state.hh`); the base will retarget to main when that merges. Net −30 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)