### PR TITLE
Define the lifetime contract for IntervalSet iteration generators

### DIFF
--- a/gcs/innards/interval_set.hh
+++ b/gcs/innards/interval_set.hh
@@ -27,6 +27,13 @@ namespace gcs::innards
      * Intervals are always maintained in sorted order with no two intervals touching
      * or overlapping.
      *
+     * The each*() iteration methods return generators that borrow the set's
+     * internal storage: the set (and, for each_interval_minus(), the \p other
+     * set too) must outlive the generator, and must not be modified while the
+     * generator is live. To modify a set based upon what an iteration finds,
+     * either iterate over a copy, or build a new set and move-assign it
+     * afterwards.
+     *
      * \tparam Int_ The integer type used for values and bounds. Must support arithmetic
      * and comparison operators, and construction from a literal zero or one.
      *
@@ -361,6 +368,9 @@ namespace gcs::innards
         /**
          * \brief Returns a generator that yields each value in the set in ascending order.
          *
+         * The generator borrows this set, which must outlive it and must not be
+         * modified while iterating; see the class documentation.
+         *
          * \sa each_reversed(), each_interval()
          */
         [[nodiscard]] auto each() const -> std::generator<Int_>
@@ -375,6 +385,9 @@ namespace gcs::innards
         /**
          * \brief Returns a generator that yields each stored interval as a
          * (lower, upper) pair, in ascending order.
+         *
+         * The generator borrows this set, which must outlive it and must not be
+         * modified while iterating; see the class documentation.
          *
          * \sa each(), each_gap_interval()
          */
@@ -391,6 +404,9 @@ namespace gcs::innards
          * and upper() that is not a member of the set, in ascending order.
          *
          * An empty or single-interval set has no gaps and yields nothing.
+         *
+         * The generator borrows this set, which must outlive it and must not be
+         * modified while iterating; see the class documentation.
          *
          * \sa each_gap_interval(), has_holes()
          */
@@ -417,6 +433,9 @@ namespace gcs::innards
          * each_gap(), which iterates <code>i = a; i != b; ++i</code>.
          *
          * An empty or single-interval set has no gaps and yields nothing.
+         *
+         * The generator borrows this set, which must outlive it and must not be
+         * modified while iterating; see the class documentation.
          *
          * \sa each_gap(), has_holes()
          */
@@ -450,11 +469,15 @@ namespace gcs::innards
          * yielded intervals can be expanded to per-value via a nested loop, or
          * later passed wholesale to an interval-level inference primitive.
          *
+         * The generator borrows both this set and \p other, which must outlive
+         * it and must not be modified while iterating; see the class
+         * documentation.
+         *
          * \sa each_interval(), each_gap_interval()
          */
         [[nodiscard]] auto each_interval_minus(const IntervalSet & other) const -> std::generator<std::pair<Int_, Int_>>
         {
-            return [](Intervals self_intervals, Intervals other_intervals) -> std::generator<std::pair<Int_, Int_>> {
+            return [](const Intervals & self_intervals, const Intervals & other_intervals) -> std::generator<std::pair<Int_, Int_>> {
                 auto j = other_intervals.begin();
                 for (auto i = self_intervals.begin(); i != self_intervals.end(); ++i) {
                     Int_ cur = i->first;
@@ -476,6 +499,9 @@ namespace gcs::innards
 
         /**
          * \brief Returns a generator that yields each value in the set in descending order.
+         *
+         * The generator borrows this set, which must outlive it and must not be
+         * modified while iterating; see the class documentation.
          *
          * \sa each()
          */


### PR DESCRIPTION
Closes #285, taking option 1 with one addition: as well as "generators borrow; the `IntervalSet` must outlive the generator", the set **must not be modified while a generator is live** — code that wants to modify based on what an iteration finds must either iterate over a copy, or build a new set and move-assign it afterwards.

Changes:

- The contract is stated once in the class documentation and echoed on each of the six `each*()` methods.
- `each_interval_minus()` now takes its operands by reference like the other five, instead of copying both interval lists into the coroutine frame. (It borrows *two* sets, `*this` and `other`; its doc says so explicitly.)

**Caller audit.** Since `each_interval_minus()` previously copied, existing callers could in principle have relied on modify-while-iterating; and the five by-reference generators could already have had lifetime or mutation bugs. I audited every call site of all six generators (`gcs/`, `examples/`, `xcsp/`, `minizinc/`, `python/`, `scp/`, tests):

| call site | iterated set | verdict |
|---|---|---|
| `state.cc` `copy_of_values` (×2) | local `raw` | safe — builds a separate `result` |
| `state.cc` `each_value_generator` (used by `each_value_immutable`/`_mutable`) | by-value coroutine parameter | safe — generator borrows the coroutine-owned copy |
| `current_state.cc` `each_value_reversed` | by-value coroutine parameter | safe — same pattern |
| `equals.cc` (×2), `min_max.cc`, `all_equal.cc`, `abs.cc` (×4), `count.cc` (×2) | locals from `state.copy_of_values()` | safe — loop bodies infer on live State domains, never on the iterated copies |
| `element.cc` | local `still_to_find_support_for` | safe — its `erase()` calls all happen in a phase that completes before the iteration starts |
| `proof_logger.cc` `forget_proof_level` | **live member** `_imp->proof_lines_by_level.at(depth)` | safe — loop body only writes raw `del` text to the stream (no `record_proof_line`), and `lines.clear()` runs after the generator is destroyed |
| `fzn_glasgow.cc` (×4) | `const auto &`-bound temporary from `arg_as_set_of_integer` | safe — lifetime-extended, loop bodies only post constraints |
| `interval_set_test.cc`, `state_test.cc` | locals | safe — mutations happen before iteration, loop bodies read-only |

I also grepped for the two dangerous shapes — generators stored into variables (`auto g = s.each()`) and generators chained off temporaries (`copy_of_values(v).each()`) — and found none. (The latter would actually be safe in a range-for under C++23's P2718 lifetime extension, but none exist regardless.)

No caller changes were needed. Full suite 325/325; `interval_set_test` 337 assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)