### PR TITLE
Bring README and CLAUDE.md back in step with the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ This is a C++23 constraint programming solver with a key focus on **proof loggin
 - `gcs/current_state.hh` — `CurrentState`: read-only view of variable values in solution callbacks
 - `gcs/integer.hh` — `Integer` type wrapper (use `0_i`, `100_i` literals)
 - `gcs/variable_id.hh` — `IntegerVariableID` and related lightweight handle types
-- `gcs/constraints/` — all user-facing constraint types (e.g. `LinearLessEqual`, `AllDifferent`, `Table`, etc.)
+- `gcs/constraints/` — all user-facing constraint types (e.g. `LinearLessThanEqual`, `AllDifferent`, `Table`, etc.)
 - `gcs/gcs.hh` — convenience header including the full public API
 
 ### Innards (`gcs/innards/`)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Manually Solving a Constraint Optimisation Problem
 
 Let's start by <a
 href="https://www.minizinc.org/doc-2.5.5/en/modelling.html#an-arithmetic-optimisation-example">making
-some cakes</a>. This example is a cut-down version of ``examples/cake/cake.cc``. We start by
+some cakes</a>. This example is based upon ``examples/cake/cake.cc``. We start by
 including the header file and namespace,
 
 ```cpp
@@ -178,6 +178,10 @@ including the header file and namespace,
 
 using namespace gcs;
 ```
+
+Here ``<gcs/gcs.hh>`` is a convenience header that pulls in the entire public API. The programs in
+the ``examples/`` directory instead use granular includes, such as ``<gcs/problem.hh>`` and
+``<gcs/solve.hh>``; either style works.
 
 Now, we need a `Problem` instance. A constraint satisfaction problem consists of a number of
 variables, each of which has a domain of possible values, together with a set of constraints which
@@ -209,7 +213,7 @@ similar restrictions. Here we are making use of some convenience overloads; we c
 verbose, and have written these constraints like:
 
 ```cpp
-p.post(LinearLessEqual{WeightedSum{{{250_i, banana}, {200_i, chocolate}}}, 4000_i});
+p.post(LinearLessThanEqual{WeightedSum{{{250_i, banana}, {200_i, chocolate}}}, 4000_i});
 ```
 
 Next, we need to define our profit variable, which we want to maximise because capitalism. If we get
@@ -261,8 +265,8 @@ solve_with(p,
 The ``examples/`` directory contains example programs that show how to use the solver as a program
 author. It is probably best to start with ``examples/cake/cake.cc`` for a complete version of this
 example, ``examples/crystal_maze/crystal_maze.cc`` and ``examples/sudoku/sudoku.cc`` for everyone's
-favourite first two constraint programming problems, and ``examples/magic_square/magic_square.cc``
-for some magic.
+favourite first two constraint programming problems, and ``examples/money/money.cc`` for sending
+more money.
 
 Proof Logging
 -------------

--- a/examples/regular_random/regular_random.cc
+++ b/examples/regular_random/regular_random.cc
@@ -124,8 +124,6 @@ auto main(int argc, char * argv[]) -> int
     }
 
     std::mt19937 rng(seed);
-    // cout << "Seed for random DFAs for Regular: " << seed << endl;
-    //    mt19937 rng(0); // Switch to this to have it the same every time.
     auto p = Problem{};
     post_random_regular(p, n, rng, short_reasons);
 


### PR DESCRIPTION
Fixes the four documentation-drift items from #290:

1. **`LinearLessEqual` → `LinearLessThanEqual`** in the README tutorial's "verbose" snippet and in CLAUDE.md's constraint-types list. The corrected tutorial snippet now compiles (verified with `-fsyntax-only` against the tree's headers).
2. **Dead `examples/magic_square/magic_square.cc` pointer** repointed at `examples/money/money.cc` (SEND+MORE=MONEY).
3. **Tutorial include mismatch**: kept `<gcs/gcs.hh>` as the simple on-ramp, added a sentence noting the example programs use granular includes, and softened "cut-down version of `cake.cc`" to "based upon".
4. **Stale commented-out lines in `regular_random.cc`** removed. This includes the adjacent `// mt19937 rng(0)` line as well as the flagged `cout` line — the seed is already printed under `--stats`, and fixed-seed runs are available via `--seed`.

Closes #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)