### PR TITLE
Make the MiniZinc test scripts actually check solver exit status

### DIFF
--- a/minizinc/run_fzn_json_test.bash
+++ b/minizinc/run_fzn_json_test.bash
@@ -10,31 +10,34 @@
 # Reads   <minizincdir>/tests/json/<testname>.fzn       (JSON FlatZinc input)
 # against <minizincdir>/tests/json/<testname>.expected  (sorted solver output)
 
+set -euo pipefail
+
 fznglasgow=$1
 minizincdir=$2
 testname=$3
 
-export PATH=$HOME/.cargo/bin:$PATH
+export PATH="$HOME/.cargo/bin:$PATH"
 
 jsondir=$minizincdir/tests/json
 infile=$jsondir/$testname.fzn
 
-$fznglasgow -a "$infile" | tee $testname.fzn.out || exit 1
+"$fznglasgow" -a "$infile" | tee "$testname.fzn.out" || exit 1
 
 # Sort the output so the comparison is independent of solution enumeration
 # order; VeriPB below independently certifies the result is complete.
-sort < $testname.fzn.out > $testname.fzn.sols
-if ! diff -u <(sort < $jsondir/$testname.expected) $testname.fzn.sols ; then
+sort < "$testname.fzn.out" > "$testname.fzn.sols"
+if ! diff -u <(sort < "$jsondir/$testname.expected") "$testname.fzn.sols" ; then
     echo "found unexpected solver output"
     exit 2
 fi
 
 if veripb --help >/dev/null 2>&1 ; then
-    $fznglasgow -a --prove $testname "$infile" || exit 3
-    if ! veripb $testname.opb $testname.pbp ; then
+    "$fznglasgow" -a --prove "$testname" "$infile" || exit 3
+    if ! veripb "$testname.opb" "$testname.pbp" ; then
         echo "Rerunning last 100 lines of proof verification in trace mode..."
-        echo '$ ' veripb --trace `readlink -f $testname.opb` `readlink -f $testname.pbp`
-        veripb --trace $testname.opb $testname.pbp 2>&1 | tail -n100
+        echo '$ ' veripb --trace "$(readlink -f "$testname.opb")" "$(readlink -f "$testname.pbp")"
+        # the trace rerun fails again by construction; we still want exit 4
+        veripb --trace "$testname.opb" "$testname.pbp" 2>&1 | tail -n100 || true
         exit 4
     fi
 fi

--- a/minizinc/run_minizinc_test.bash
+++ b/minizinc/run_minizinc_test.bash
@@ -1,47 +1,61 @@
 #!/bin/bash
 
-builddir=$(dirname $1 )
+# Differential-tests a model against MiniZinc's default solver: runs
+# <minizincdir>/tests/<testname>.mzn through both fzn-glasgow and MiniZinc's
+# default solver, and diffs the solutions (all of them if <enumeration> is
+# true, otherwise just the final objective value). If <doproofs> is true and
+# veripb is available, also reruns with --prove and verifies the proof.
+# Skips (exit 66, the ctest SKIP_RETURN_CODE) if minizinc is not installed.
+#
+# Usage: run_minizinc_test.bash <fzn-glasgow> <minizincdir> <testname> <enumeration> <doproofs>
+
+set -euo pipefail
+
+builddir=$(dirname "$1")
 minizincdir=$2
 testname=$3
 enumeration=$4
 doproofs=$5
 
-export PATH=$builddir:$HOME/.local/bin:$PATH
+export PATH="$builddir:$HOME/.local/bin:$PATH"
 
-if ! which minizinc ; then
+if ! command -v minizinc ; then
     echo "can't run minizinc, skipping test" 1>&2
     exit 66
 fi
 
-minizinc --solver $minizincdir/glasgow-for-tests.msc --fzn $testname.fzn -a $minizincdir/tests/$testname.mzn | tee $testname.glasgow.out || exit 1
-minizinc -a $minizincdir/tests/$testname.mzn | tee $testname.default.out || exit 2
+minizinc --solver "$minizincdir/glasgow-for-tests.msc" --fzn "$testname.fzn" -a "$minizincdir/tests/$testname.mzn" | tee "$testname.glasgow.out" || exit 1
+minizinc -a "$minizincdir/tests/$testname.mzn" | tee "$testname.default.out" || exit 2
 
 if [[ "$enumeration" == "true" ]] ; then
-    grep -q '^ENUMSOL:' < $testname.glasgow.out || exit 3
-    grep '^ENUMSOL:' < $testname.glasgow.out | sort > $testname.glasgow.sols
-    grep '^ENUMSOL:' < $testname.default.out | sort > $testname.default.sols
+    grep -q '^ENUMSOL:' < "$testname.glasgow.out" || exit 3
+    grep '^ENUMSOL:' < "$testname.glasgow.out" | sort > "$testname.glasgow.sols"
+    # tolerate grep finding nothing: an empty default-solver solution set
+    # shows up as a difference in the diff below
+    grep '^ENUMSOL:' < "$testname.default.out" | sort > "$testname.default.sols" || true
 
-    if ! diff -u $testname.glasgow.sols $testname.default.sols ; then
+    if ! diff -u "$testname.glasgow.sols" "$testname.default.sols" ; then
         echo "found different enumeration solutions"
         exit 4
     fi
 else
-    grep -q '^OPTSOL:' < $testname.glasgow.out || exit 5
-    grep '^OPTSOL:' < $testname.glasgow.out | tail -n1 > $testname.glasgow.sols
-    grep '^OPTSOL:' < $testname.default.out | tail -n1 > $testname.default.sols
+    grep -q '^OPTSOL:' < "$testname.glasgow.out" || exit 5
+    grep '^OPTSOL:' < "$testname.glasgow.out" | tail -n1 > "$testname.glasgow.sols"
+    grep '^OPTSOL:' < "$testname.default.out" | tail -n1 > "$testname.default.sols" || true
 
-    if ! diff -u $testname.glasgow.sols $testname.default.sols ; then
+    if ! diff -u "$testname.glasgow.sols" "$testname.default.sols" ; then
         echo "found different objective solutions"
         exit 6
     fi
 fi
 
-if [[ $doproofs == "true" ]] && veripb --help >/dev/null ; then
-    minizinc --solver $minizincdir/glasgow-for-tests.msc -a $minizincdir/tests/$testname.mzn --prove $testname | tee $testname.glasgow.out || exit 7
-    if ! veripb $testname.opb $testname.pbp ; then
+if [[ "$doproofs" == "true" ]] && veripb --help >/dev/null ; then
+    minizinc --solver "$minizincdir/glasgow-for-tests.msc" -a "$minizincdir/tests/$testname.mzn" --prove "$testname" | tee "$testname.glasgow.out" || exit 7
+    if ! veripb "$testname.opb" "$testname.pbp" ; then
         echo "Rerunning last 100 lines of proof verification in trace mode..."
-        echo '$ ' veripb --trace `readlink -f $testname.opb` `readlink -f $testname.pbp`
-        veripb --trace $testname.opb $testname.pbp 2>&1 | tail -n100
+        echo '$ ' veripb --trace "$(readlink -f "$testname.opb")" "$(readlink -f "$testname.pbp")"
+        # the trace rerun fails again by construction; we still want exit 8
+        veripb --trace "$testname.opb" "$testname.pbp" 2>&1 | tail -n100 || true
         exit 8
     fi
 fi


### PR DESCRIPTION
Fixes #295: in `run_minizinc_test.bash` the solver invocations pipe into `tee`, so the `|| exit 1/2/7` guards checked `tee`'s exit status, not minizinc's — a failing solver slipped past and was only caught incidentally (and misattributed) by the downstream `ENUMSOL`/`OPTSOL` greps.

Changes, per the issue:

- `set -euo pipefail` at the top, making the explicit guards live.
- All expansions quoted; `which` → `command -v`; backticks → `$(...)`.
- Header comment explaining the differential test against MiniZinc's default solver and the exit-66 skip (ctest's `SKIP_RETURN_CODE`).
- **`run_fzn_json_test.bash` had the same `tee`-masked guard**, so it gets the identical treatment.

Two pipefail interactions needed care:

- The failing-`veripb` trace rerun is expected to fail again; it gets an explicit `|| true` so the intended `exit 8`/`exit 4` is still reached.
- The default-solver solution greps tolerate an empty match (`|| true`), so a solver disagreement still surfaces through the informative `diff` (exit 4/6) rather than as a bare grep failure.

Verification:

- All **67 `minizinc-*` ctest cases pass** with the strict scripts and veripb available — pipefail surfaces no previously masked failure.
- Negative test: with a deliberately broken solver, the old script exited 3 (downstream grep, misattributed) / the json script exited 2; the new scripts exit 1 from the guard. The skip path still exits 66 when `minizinc` is absent from `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)