### PR TITLE
Thread an explicit ConstraintID through Propagators::install (stable constraint → propagator association, #315 enabler)

### DIFF
--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -25,6 +25,7 @@ namespace gcs
 
     struct CurrentlyUnnamedConstraint final
     {
+        [[nodiscard]] auto operator<=>(const CurrentlyUnnamedConstraint &) const = default;
         [[nodiscard]] auto as_string() const -> std::string
         {
             return "unnamed";

--- a/gcs/constraints/abs.cc
+++ b/gcs/constraints/abs.cc
@@ -174,6 +174,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
     // pruning, but the iteration is over gaps, not values.
     Triggers triggers{.on_change = {_v1, _v2}};
     propagators.install(
+        constraint_id(),
         [v1 = _v1, v2 = _v2,
             abs_nonneg_le = _abs_nonneg_lines.first,
             abs_nonneg_ge = _abs_nonneg_lines.second,

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -181,6 +181,7 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
         _value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
 
     propagators.install(
+        constraint_id(),
         [vars = move(_sanitised_vars),
             vals = move(_compressed_vals),
             excluded = move(_sanitised_excluded),

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -641,6 +641,7 @@ auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
 
     auto value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
     propagators.install(
+        constraint_id(),
         [vars = move(_sanitised_vars),
             vals = move(_compressed_vals),
             value_am1_constraint_numbers = move(value_am1_constraint_numbers)](const State & state, auto & inference,

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -158,6 +158,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
         values.push_back(start + Integer(i));
 
     propagators.install(
+        constraint_id(),
         [vars, start, values = move(values), value_am1s = _value_am1s](
             const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
             // Channeling: x_i = v  =>  x_v = i. If i is not in D(x_v), prune

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -157,6 +157,7 @@ auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
     triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 
     propagators.install(
+        constraint_id(),
         [unassigned_handle = _unassigned_handle](const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
             propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger);
             return PropagatorState::Enable;

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -72,8 +72,7 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
 
-    propagators.install([vars = move(_vars)](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [vars = move(_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         auto n = vars.size();
 
         // Tighten each var to [lo, hi] where lo is the largest lower bound
@@ -145,9 +144,7 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
         if (state.has_single_value(vars[0]))
             return PropagatorState::DisableUntilBacktrack;
 
-        return PropagatorState::Enable;
-    },
-        triggers);
+        return PropagatorState::Enable; }, triggers);
 }
 
 auto AllEqual::s_exprify(const ProofModel * const model) const -> string

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -124,6 +124,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
     });
 
     propagators.install(
+        constraint_id(),
         [vars = _vars, values_of_interest = _values_of_interest, how_many = _how_many, sum_line = _sum_line, am1_lines = am1_lines](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // partition variables to be 1) those that must not match, 2) those that must match, and 3) those

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -99,6 +99,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
     all_vars.push_back(_val);
 
     propagators.install(
+        constraint_id(),
         [vars = _vars, val = _val, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // For each candidate value v of `val`: if two or more vars

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -230,13 +230,11 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 
     // Infer succ[i] != i at top of search, but no other propagation defined here: use CircuitPrevent or CircuitSCC
     if (_succ.size() > 1) {
-        propagators.install([succ = _succ](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [succ = _succ](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             for (auto [idx, s] : enumerate(succ)) {
                 inference.infer_not_equal(logger, s, Integer(static_cast<long long>(idx)), JustifyUsingRUP{}, generic_reason(state, succ));
             }
-            return PropagatorState::DisableUntilBacktrack;
-        },
-            Triggers{});
+            return PropagatorState::DisableUntilBacktrack; }, Triggers{});
     }
 
     return pos_var_data;

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -93,6 +93,7 @@ auto CircuitPrevent::install(innards::Propagators & propagators, innards::State 
     Triggers triggers;
     triggers.on_instantiated = {_succ.begin(), _succ.end()};
     propagators.install(
+        constraint_id(),
         [succ = _succ, pvd = pos_var_data,
             unassigned_handle = unassigned_handle](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             propagate_circuit_using_prevent(succ, pvd, unassigned_handle, state, inference, logger);

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -669,8 +669,7 @@ namespace
             temp_p_line.emit(ctx.logger, ProofLevel::Temporary);
 
             add_sat(temp_p_line, leq_and_geq);
-            add_sat(temp_p_line, ctx.logger.emit_rup_proof_line(
-                WPBSum{} + -1_i * ctx.pos_var_data.at(next_node).var + 1_i * ctx.pos_var_data.at(middle).var >= Integer{-n + 1}, ProofLevel::Temporary));
+            add_sat(temp_p_line, ctx.logger.emit_rup_proof_line(WPBSum{} + -1_i * ctx.pos_var_data.at(next_node).var + 1_i * ctx.pos_var_data.at(middle).var >= Integer{-n + 1}, ProofLevel::Temporary));
             ctx.logger.emit_proof_comment("Step 4");
             temp_p_line.emit(ctx.logger, ProofLevel::Temporary);
 
@@ -698,8 +697,7 @@ namespace
             temp_p_line.emit(ctx.logger, ProofLevel::Temporary);
 
             add_sat(temp_p_line, geq_and_leq);
-            add_sat(temp_p_line, ctx.logger.emit_rup_proof_line(
-                WPBSum{} + -1_i * ctx.pos_var_data.at(middle).var + 1_i * ctx.pos_var_data.at(next_node).var >= Integer{-n + 1}, ProofLevel::Temporary));
+            add_sat(temp_p_line, ctx.logger.emit_rup_proof_line(WPBSum{} + -1_i * ctx.pos_var_data.at(middle).var + 1_i * ctx.pos_var_data.at(next_node).var >= Integer{-n + 1}, ProofLevel::Temporary));
             ctx.logger.emit_proof_comment("Step 7");
             temp_p_line.emit(ctx.logger, ProofLevel::Temporary);
 
@@ -760,9 +758,7 @@ namespace
             add_sat(p_line, shifted_pos_geq[last][count].backwards_reif_line);
             add_sat(p_line, ctx.flag_data[mid].greater_than[last].backwards_reif_line);
 
-            add_sat(p_line, ctx.logger.emit_rup_proof_line(
-                WPBSum{} + 1_i * ctx.flag_data[root].greater_than[last].flag + 1_i * ctx.flag_data[last].greater_than[root].flag >= 1_i,
-                ProofLevel::Temporary));
+            add_sat(p_line, ctx.logger.emit_rup_proof_line(WPBSum{} + 1_i * ctx.flag_data[root].greater_than[last].flag + 1_i * ctx.flag_data[last].greater_than[root].flag >= 1_i, ProofLevel::Temporary));
 
             p_line.emit(ctx.logger, ProofLevel::Temporary);
             exclusion_line = ctx.logger.emit_rup_proof_line_under_reason(ctx.reason,
@@ -1187,6 +1183,7 @@ auto CircuitSCC::install(Propagators & propagators, State & initial_state, Proof
     Triggers triggers;
     triggers.on_change = {_succ.begin(), _succ.end()};
     propagators.install(
+        constraint_id(),
         [succ = _succ,
             pos_var_data_handle = pos_var_data_handle,
             proof_flag_data_handle = proof_flag_data_handle,

--- a/gcs/constraints/comparison.cc
+++ b/gcs/constraints/comparison.cc
@@ -222,7 +222,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
         };
 
         Triggers triggers{.on_bounds = {_v1, _v2}};
-        install_reified_dispatcher(propagators, _evaluated_cond, _reif_cond, triggers,
+        install_reified_dispatcher(propagators, constraint_id(), _evaluated_cond, _reif_cond, triggers,
             std::move(enforce_constraint_must_hold),
             std::move(enforce_constraint_must_not_hold),
             std::move(infer_cond_when_undecided));

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -99,6 +99,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
     all_vars.push_back(_how_many);
 
     propagators.install(
+        constraint_id(),
         [vars = _vars, value_of_interest = _value_of_interest, how_many = _how_many, flags = _flags, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // check support for how many by seeing how many array values

--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -304,6 +304,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
             triggers.on_bounds.emplace_back(_lengths[i]);
 
     propagators.install(
+        constraint_id(),
         [starts = move(_starts), lengths_var = move(_lengths), heights_var = move(_heights),
             capacity_var = _capacity, active_tasks = move(_active_tasks),
             before_flags = move(_before_flags), after_flags = move(_after_flags),

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -223,6 +223,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         triggers.on_bounds.emplace_back(_starts[i]);
 
     propagators.install(
+        constraint_id(),
         [starts = move(_starts), lengths = move(_lengths),
             active_tasks = move(_active_tasks),
             before_flags = move(_before_flags), clause_lines = move(_clause_lines),

--- a/gcs/constraints/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d.cc
@@ -368,6 +368,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
     }
 
     propagators.install(
+        constraint_id(),
         [xs = move(_xs), ys = move(_ys), width_var = move(_widths), height_var = move(_heights),
             active_rects = move(_active_rects), before_x = move(_before_x), before_y = move(_before_y),
             clause_lines = move(_clause_lines), end_x = move(_end_x), end_y = move(_end_y),

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -264,9 +264,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             if (idx != fixed_dim)
                 index_triggers.on_change.emplace_back(var);
 
-        propagators.install([array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
-                                array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim, array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // for each index variable, update it to only contain values where
             // there's at least one supporting option. result_var's domain is
             // not modified by anything inside the loop body (the only infer_*
@@ -369,9 +367,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 }
             }
 
-            return PropagatorState::Enable;
-        },
-            index_triggers);
+            return PropagatorState::Enable; }, index_triggers);
     }
 
     if (_bounds_only) {
@@ -381,8 +377,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
         result_triggers.on_bounds.emplace_back(_result_var);
 
-        propagators.install([array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // bounds only, so the result variable has to be in the range
             // (rather than the union) of possible values
             vector<size_t> elem;
@@ -455,9 +450,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             if (highest_found && *highest_found < current_bounds.second)
                 infer_bound(*highest_found, false);
 
-            return PropagatorState::Enable;
-        },
-            result_triggers);
+            return PropagatorState::Enable; }, result_triggers);
     }
     else {
         Triggers result_triggers;
@@ -465,8 +458,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             result_triggers.on_change.insert(result_triggers.on_change.end(), all_array_vars.begin(), all_array_vars.end());
         result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
 
-        propagators.install([array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // the result variable has to be in the union of possible values
             vector<size_t> elem;
             IntervalSet<Integer> still_to_find_support_for = state.copy_of_values(result_var);
@@ -523,17 +515,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                     ReasonFunction{[=]() { return reason; }});
             }
 
-            return PropagatorState::Enable;
-        },
-            result_triggers);
+            return PropagatorState::Enable; }, result_triggers);
     }
 
     if (array_has_nonconstants) {
         Triggers equality_triggers;
         equality_triggers.on_change.insert(equality_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
         equality_triggers.on_change.emplace_back(_result_var);
-        propagators.install([array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // if there's only a single possible array variable left, it can only take values
             // that are present in the result variable
             bool index_is_fully_defined = true;
@@ -554,9 +543,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 enforce_equality(logger, result_var, array_var, state, inference, index_reason);
             }
 
-            return PropagatorState::Enable;
-        },
-            equality_triggers);
+            return PropagatorState::Enable; }, equality_triggers);
     }
 }
 

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -263,7 +263,7 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
 
     Triggers triggers;
     triggers.on_change = {_v1, _v2};
-    install_reified_dispatcher(propagators, _evaluated_cond, _cond, triggers,
+    install_reified_dispatcher(propagators, constraint_id(), _evaluated_cond, _cond, triggers,
         std::move(enforce_constraint_must_hold),
         std::move(enforce_constraint_must_not_hold),
         std::move(infer_cond_when_undecided));

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -115,6 +115,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
     all_vars.insert(all_vars.end(), _counts.begin(), _counts.end());
 
     propagators.install(
+        constraint_id(),
         [vars = _vars, values = _values, counts = _counts, count_lines = _count_lines, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto m = values.size();

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -193,6 +193,7 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
     all_vars.insert(all_vars.end(), _counts.begin(), _counts.end());
 
     propagators.install(
+        constraint_id(),
         [vars = _vars, values = _values, counts = _counts, closed = _closed, count_lines = _count_lines, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto m = values.size();

--- a/gcs/constraints/in.cc
+++ b/gcs/constraints/in.cc
@@ -152,6 +152,7 @@ auto In::install_propagators(Propagators & propagators) -> void
         triggers.on_change.emplace_back(V);
 
     propagators.install(
+        constraint_id(),
         [var = _var, var_vals = _var_vals, val_vals = _val_vals, selectors = _selectors](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Step 1: filter dom(var) — drop any value that no source supports.

--- a/gcs/constraints/increasing.cc
+++ b/gcs/constraints/increasing.cc
@@ -83,8 +83,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_bounds.insert(triggers.on_bounds.end(), _ordered_vars.begin(), _ordered_vars.end());
 
-    propagators.install([vars = move(_ordered_vars), step](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [vars = move(_ordered_vars), step](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         auto n = vars.size();
 
         // Forward sweep: lb(vars[i]) >= lb(vars[i-1]) + step.
@@ -130,9 +129,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
                 break;
             }
         }
-        return entailed ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable;
-    },
-        triggers);
+        return entailed ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable; }, triggers);
 }
 
 auto IncreasingChain::s_exprify(const ProofModel * const model) const -> string

--- a/gcs/constraints/innards/reified_dispatcher.hh
+++ b/gcs/constraints/innards/reified_dispatcher.hh
@@ -73,6 +73,10 @@ namespace gcs::innards
      * is now forced. This helper takes three callables and wires up the
      * dispatch and triggers.
      *
+     * `constraint_id` identifies the owning constraint (pass its
+     * `constraint_id()`), so the single installed dispatcher propagator is
+     * attributed to that constraint.
+     *
      * `enforce_constraint_must_hold(state, inference, logger, cond_lit)` and
      * `enforce_constraint_must_not_hold(state, inference, logger, cond_lit)`
      * each return a PropagatorState; they receive the cond literal (a
@@ -102,6 +106,7 @@ namespace gcs::innards
     template <typename EnforceMustHold_, typename EnforceMustNotHold_, typename InferCondWhenUndecided_>
     auto install_reified_dispatcher(
         Propagators & propagators,
+        const ConstraintID & constraint_id,
         const EvaluatedReificationCondition & initial_evaluated,
         const ReificationCondition & reif_cond,
         Triggers triggers,
@@ -117,6 +122,7 @@ namespace gcs::innards
         }
 
         propagators.install(
+            constraint_id,
             [reif_cond,
                 enforce_constraint_must_hold = std::move(enforce_constraint_must_hold),
                 enforce_constraint_must_not_hold = std::move(enforce_constraint_must_not_hold),

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -160,9 +160,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
     for (const auto & [i, _] : enumerate(_x))
         x_values.push_back(Integer(i) + _x_start);
 
-    propagators.install([x = _x, y = _y, x_start = _x_start, y_start = _y_start,
-                            x_values = move(x_values), x_value_am1s = _x_value_am1s](
-                            const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
         for (const auto & [i, x_i] : enumerate(x)) {
             for (auto x_i_value : state.each_value_mutable(x_i))
                 if (! state.in_domain(y.at((x_i_value - y_start).as_index()), Integer(i) + x_start))
@@ -181,9 +179,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
 
         propagate_gac_all_different(x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
 
-        return PropagatorState::Enable;
-    },
-        triggers);
+        return PropagatorState::Enable; }, triggers);
 }
 
 auto Inverse::s_exprify(const innards::ProofModel * const model) const -> std::string

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -652,6 +652,7 @@ auto Knapsack::install_propagators(Propagators & propagators) -> void
     triggers.on_change.insert(triggers.on_change.end(), _totals.begin(), _totals.end());
 
     propagators.install(
+        constraint_id(),
         [coeffs = move(_coeffs), vars = move(_vars), totals = move(_totals), eqns_lines = move(_eqns_lines)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             return knapsack(state, logger, inference, coeffs, vars, totals, eqns_lines);

--- a/gcs/constraints/lex.cc
+++ b/gcs/constraints/lex.cc
@@ -615,7 +615,7 @@ auto LexCompareGreaterThanOrMaybeEqual::install_propagators(Propagators & propag
             cond);
     };
 
-    install_reified_dispatcher(propagators, _evaluated_cond, _reif_cond, triggers,
+    install_reified_dispatcher(propagators, constraint_id(), _evaluated_cond, _reif_cond, triggers,
         std::move(enforce_constraint_must_hold),
         std::move(enforce_constraint_must_not_hold),
         std::move(infer_cond_when_undecided));

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -242,14 +242,11 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
             },
                 InitialiserPriority::Expensive);
 
-            propagators.install([data = data](
-                                    const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagators.install(constraint_id(), [data = data](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 if (data->has_value())
                     return propagate_extensional(data.get()->value(), state, inference, logger);
                 else
-                    return PropagatorState::DisableUntilBacktrack;
-            },
-                triggers);
+                    return PropagatorState::DisableUntilBacktrack; }, triggers);
         },
             sanitised_cv);
     }
@@ -271,11 +268,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
 
                 visit(
                     [&, modifier = modifier](const auto & lin) {
-                        propagators.install([modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](
-                                                const State & state, auto & inference, ProofLogger * const logger) {
-                            return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond);
-                        },
-                            triggers);
+                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond); }, triggers);
                     },
                     sanitised_cv);
             },
@@ -296,11 +289,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                     triggers.on_change.push_back(v);
 
                 visit([&, modifier = modifier](const auto & sanitised_cv) {
-                    propagators.install([sanitised_cv = sanitised_cv, value = _value + modifier, all_vars = move(all_vars)](
-                                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                        return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars);
-                    },
-                        triggers);
+                    propagators.install(constraint_id(), [sanitised_cv = sanitised_cv, value = _value + modifier, all_vars = move(all_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars); }, triggers);
                 },
                     sanitised_cv);
             },
@@ -318,86 +307,82 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 add_trigger_for(triggers, reif.cond);
 
                 visit([&, modifier = modifier](const auto & sanitised_cv) {
-                    propagators.install([sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line, all_vars = move(all_vars)](
-                                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                        return overloaded{
-                            [&](const evaluated_reif::MustHold & reif) {
-                                // we now know the condition definitely holds, so it's a linear equality
-                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond);
-                            },
+                    propagators.install(constraint_id(), [sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line, all_vars = move(all_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return overloaded{
+                                                                                                                                                                                                                                                                                      [&](const evaluated_reif::MustHold & reif) {
+                                                                                                                                                                                                                                                                                          // we now know the condition definitely holds, so it's a linear equality
+                                                                                                                                                                                                                                                                                          return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond);
+                                                                                                                                                                                                                                                                                      },
 
-                            [&](const evaluated_reif::MustNotHold &) {
-                                // we now know the condition definitely doesn't hold, so it's a linear not-equals
-                                return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars);
-                            },
+                                                                                                                                                                                                                                                                                      [&](const evaluated_reif::MustNotHold &) {
+                                                                                                                                                                                                                                                                                          // we now know the condition definitely doesn't hold, so it's a linear not-equals
+                                                                                                                                                                                                                                                                                          return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars);
+                                                                                                                                                                                                                                                                                      },
 
-                            [](const evaluated_reif::Deactivated &) {
-                                return PropagatorState::DisableUntilBacktrack;
-                            },
+                                                                                                                                                                                                                                                                                      [](const evaluated_reif::Deactivated &) {
+                                                                                                                                                                                                                                                                                          return PropagatorState::DisableUntilBacktrack;
+                                                                                                                                                                                                                                                                                      },
 
-                            [&](const evaluated_reif::Undecided & reif) {
-                                // we still don't know whether the condition holds. if we're down to a single unassigned
-                                // variable, we might have some information.
-                                auto single_unset = sanitised_cv.terms.end();
-                                Integer accum = 0_i;
-                                for (auto i = sanitised_cv.terms.begin(), i_end = sanitised_cv.terms.end(); i != i_end; ++i) {
-                                    auto val = state.optional_single_value(get_var(*i));
-                                    if (val)
-                                        accum += get_coeff(*i) * *val;
-                                    else {
-                                        if (single_unset != sanitised_cv.terms.end()) {
-                                            // at least two unset variables, do nothing for now
-                                            return PropagatorState::Enable;
-                                        }
-                                        else
-                                            single_unset = i;
-                                    }
-                                }
+                                                                                                                                                                                                                                                                                      [&](const evaluated_reif::Undecided & reif) {
+                                                                                                                                                                                                                                                                                          // we still don't know whether the condition holds. if we're down to a single unassigned
+                                                                                                                                                                                                                                                                                          // variable, we might have some information.
+                                                                                                                                                                                                                                                                                          auto single_unset = sanitised_cv.terms.end();
+                                                                                                                                                                                                                                                                                          Integer accum = 0_i;
+                                                                                                                                                                                                                                                                                          for (auto i = sanitised_cv.terms.begin(), i_end = sanitised_cv.terms.end(); i != i_end; ++i) {
+                                                                                                                                                                                                                                                                                              auto val = state.optional_single_value(get_var(*i));
+                                                                                                                                                                                                                                                                                              if (val)
+                                                                                                                                                                                                                                                                                                  accum += get_coeff(*i) * *val;
+                                                                                                                                                                                                                                                                                              else {
+                                                                                                                                                                                                                                                                                                  if (single_unset != sanitised_cv.terms.end()) {
+                                                                                                                                                                                                                                                                                                      // at least two unset variables, do nothing for now
+                                                                                                                                                                                                                                                                                                      return PropagatorState::Enable;
+                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                  else
+                                                                                                                                                                                                                                                                                                      single_unset = i;
+                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                          }
 
-                                if (single_unset == sanitised_cv.terms.end()) {
-                                    // every variable is assigned, so we know what the condition must be (if we're fully
-                                    // reified)
-                                    if (accum == value) {
-                                        if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
-                                        return PropagatorState::DisableUntilBacktrack;
-                                    }
-                                    else {
-                                        if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
-                                        return PropagatorState::DisableUntilBacktrack;
-                                    }
-                                }
-                                else {
-                                    // exactly one thing remaining. perhaps the value that would make the equality
-                                    // work doesn't occur in its domain?
-                                    Integer residual = value - accum;
-                                    if (0_i == residual % get_coeff(*single_unset)) {
-                                        Integer would_make_equal = residual / get_coeff(*single_unset);
-                                        if (! state.in_domain(get_var(*single_unset), would_make_equal)) {
-                                            // no way for the remaining variable to take that value, so the condition
-                                            // has to be false
-                                            if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
-                                            return PropagatorState::DisableUntilBacktrack;
-                                        }
-                                        else {
-                                            // could go either way, but this might change as more values are lost
-                                            return PropagatorState::Enable;
-                                        }
-                                    }
-                                    else {
-                                        // the value that would make the equality work isn't an integer, so the condition
-                                        // has to be false
-                                        if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
-                                        return PropagatorState::DisableUntilBacktrack;
-                                    }
-                                }
-                            }}
-                            .visit(test_reification_condition(state, cond));
-                    },
-                        triggers);
+                                                                                                                                                                                                                                                                                          if (single_unset == sanitised_cv.terms.end()) {
+                                                                                                                                                                                                                                                                                              // every variable is assigned, so we know what the condition must be (if we're fully
+                                                                                                                                                                                                                                                                                              // reified)
+                                                                                                                                                                                                                                                                                              if (accum == value) {
+                                                                                                                                                                                                                                                                                                  if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
+                                                                                                                                                                                                                                                                                                      inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                                                                                                                                                                                                                                                                                  return PropagatorState::DisableUntilBacktrack;
+                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                              else {
+                                                                                                                                                                                                                                                                                                  if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
+                                                                                                                                                                                                                                                                                                      inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                                                                                                                                                                                                                                                                                  return PropagatorState::DisableUntilBacktrack;
+                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                          else {
+                                                                                                                                                                                                                                                                                              // exactly one thing remaining. perhaps the value that would make the equality
+                                                                                                                                                                                                                                                                                              // work doesn't occur in its domain?
+                                                                                                                                                                                                                                                                                              Integer residual = value - accum;
+                                                                                                                                                                                                                                                                                              if (0_i == residual % get_coeff(*single_unset)) {
+                                                                                                                                                                                                                                                                                                  Integer would_make_equal = residual / get_coeff(*single_unset);
+                                                                                                                                                                                                                                                                                                  if (! state.in_domain(get_var(*single_unset), would_make_equal)) {
+                                                                                                                                                                                                                                                                                                      // no way for the remaining variable to take that value, so the condition
+                                                                                                                                                                                                                                                                                                      // has to be false
+                                                                                                                                                                                                                                                                                                      if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
+                                                                                                                                                                                                                                                                                                          inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                                                                                                                                                                                                                                                                                      return PropagatorState::DisableUntilBacktrack;
+                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                  else {
+                                                                                                                                                                                                                                                                                                      // could go either way, but this might change as more values are lost
+                                                                                                                                                                                                                                                                                                      return PropagatorState::Enable;
+                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                              else {
+                                                                                                                                                                                                                                                                                                  // the value that would make the equality work isn't an integer, so the condition
+                                                                                                                                                                                                                                                                                                  // has to be false
+                                                                                                                                                                                                                                                                                                  if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
+                                                                                                                                                                                                                                                                                                      inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                                                                                                                                                                                                                                                                                  return PropagatorState::DisableUntilBacktrack;
+                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                      }}
+                                                                                                                                                                                                                                                                                      .visit(test_reification_condition(state, cond)); }, triggers);
                 },
                     sanitised_cv);
             }}

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -191,7 +191,7 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
                 return reification_verdict::StillUndecided{};
         };
 
-        install_reified_dispatcher(propagators, _evaluated_cond, _reif_cond, triggers,
+        install_reified_dispatcher(propagators, constraint_id(), _evaluated_cond, _reif_cond, triggers,
             std::move(enforce_constraint_must_hold),
             std::move(enforce_constraint_must_not_hold),
             std::move(infer_cond_when_undecided));

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -48,7 +48,7 @@ namespace
         return result;
     }
 
-    auto install_propagators_logical(Propagators & propagators, const Literals & lits,
+    auto install_propagators_logical(Propagators & propagators, const ConstraintID & constraint_id, const Literals & lits,
         const Literal & full_reif, LiteralIs reif_state) -> void
     {
         using enum LiteralIs;
@@ -81,8 +81,7 @@ namespace
             return;
         }
 
-        propagators.install([lits = lits, full_reif = full_reif](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id, [lits = lits, full_reif = full_reif](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             switch (state.test_literal(full_reif)) {
             case DefinitelyTrue: {
                 for (auto & l : lits)
@@ -164,9 +163,7 @@ namespace
             }
             }
 
-            throw NonExhaustiveSwitch{};
-        },
-            triggers);
+            throw NonExhaustiveSwitch{}; }, triggers);
     }
 
     auto define_proof_model_logical(ProofModel & model, const Literals & lits,
@@ -252,7 +249,7 @@ auto And::define_proof_model(ProofModel & model) -> void
 
 auto And::install_propagators(Propagators & propagators) -> void
 {
-    install_propagators_logical(propagators, _lits, _full_reif, _reif_state);
+    install_propagators_logical(propagators, constraint_id(), _lits, _full_reif, _reif_state);
 }
 
 auto And::s_exprify(const innards::ProofModel * const model) const -> string
@@ -319,7 +316,7 @@ auto Or::install_propagators(Propagators & propagators) -> void
     Literals lits = _lits;
     for (auto & l : lits)
         l = ! l;
-    install_propagators_logical(propagators, move(lits), ! _full_reif, _reif_state);
+    install_propagators_logical(propagators, constraint_id(), move(lits), ! _full_reif, _reif_state);
 }
 
 auto Or::s_exprify(const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -102,8 +102,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
     for (const auto & v : _vars)
         triggers.on_change.emplace_back(v);
 
-    propagators.install([vars = _vars, result = _result, min = _min, selectors = _selectors](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [vars = _vars, result = _result, min = _min, selectors = _selectors](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         // result <= upper bound of each vars
         for (auto & var : vars) {
             auto var_bounds = state.bounds(var);
@@ -196,9 +195,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                         ReasonFunction{[=]() { return reason; }});
         }
 
-        return PropagatorState::Enable;
-    },
-        triggers);
+        return PropagatorState::Enable; }, triggers);
 }
 
 auto ArrayMinMax::s_exprify(const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/minus.cc
+++ b/gcs/constraints/minus.cc
@@ -160,6 +160,7 @@ auto Minus::install_propagators(Propagators & propagators) -> void
     triggers.on_bounds.insert(triggers.on_bounds.end(), {_a, _b, _result});
 
     propagators.install(
+        constraint_id(),
         [a = _a, b = _b, result = _result, sum_line = _sum_line](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             return propagate_minus(a, b, result, state, inference, logger, sum_line);

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -1243,10 +1243,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
 
     ConstraintStateHandle bit_products_handle = initial_state.add_persistent_constraint_state(bit_products);
 
-    propagators.install([v1 = _v1, v2 = _v2, v3 = _v3, bit_products_h = bit_products_handle,
-                            channelling_constraints = channelling_constraints,
-                            mag_var = mag_var, v3_eq_product_lines = v3_eq_product_lines, sign_lines = sign_lines](const State & state, auto & inference,
-                            ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [v1 = _v1, v2 = _v2, v3 = _v3, bit_products_h = bit_products_handle, channelling_constraints = channelling_constraints, mag_var = mag_var, v3_eq_product_lines = v3_eq_product_lines, sign_lines = sign_lines](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         vector<IntegerVariableID> all_vars = {v1, v2, v3};
 
         do {
@@ -1278,9 +1275,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
                 channelling_constraints, mag_var, v3_eq_product_lines, logger, bit_products, false, sign_lines);
         } while (inference.did_anything_since_last_call_inside_propagator());
 
-        return PropagatorState::Enable;
-    },
-        triggers);
+        return PropagatorState::Enable; }, triggers);
 }
 
 auto MultBC::s_exprify(const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -108,8 +108,7 @@ auto NValue::install_propagators(Propagators & propagators) -> void
     vector<IntegerVariableID> all_vars = _vars;
     all_vars.push_back(_n_values);
 
-    propagators.install([all_vars = move(all_vars), n_values = _n_values, vars = _vars](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [all_vars = move(all_vars), n_values = _n_values, vars = _vars](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         set<Integer> all_possible_values;
         for (const auto & var : vars) {
             for (auto v : state.each_value_immutable(var))
@@ -131,9 +130,7 @@ auto NValue::install_propagators(Propagators & propagators) -> void
         auto distinct_floor = vars.empty() ? 0_i : 1_i;
         inference.infer(logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{}, generic_reason(state, all_vars));
 
-        return PropagatorState::Enable;
-    },
-        triggers);
+        return PropagatorState::Enable; }, triggers);
 }
 
 auto NValue::s_exprify(const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -95,8 +95,7 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
     for (const auto & l : _lits)
         add_trigger_for(triggers, l);
 
-    propagators.install([lits = _lits](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [lits = _lits](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         long how_many_0 = 0, how_many_1 = 0, how_many_unknown = 0;
         optional<Literal> an_unknown;
         Reason reason;
@@ -137,9 +136,7 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
                 inference.infer(logger, *an_unknown, JustifyUsingRUP{}, ReasonFunction{[=]() { return reason; }});
                 return PropagatorState::DisableUntilBacktrack;
             }
-        }
-    },
-        triggers);
+        } }, triggers);
 }
 auto ParityOdd::s_exprify(const innards::ProofModel * const model) const -> string
 {

--- a/gcs/constraints/plus.cc
+++ b/gcs/constraints/plus.cc
@@ -147,6 +147,7 @@ auto Plus::install_propagators(Propagators & propagators) -> void
     triggers.on_bounds.insert(triggers.on_bounds.end(), {_a, _b, _result});
 
     propagators.install(
+        constraint_id(),
         [a = _a, b = _b, result = _result, sum_line = _sum_line](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             return propagate_plus(a, b, result, state, inference, logger, sum_line);

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -537,12 +537,9 @@ auto Regular::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
 
-    propagators.install([v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = _graph_idx, flags = move(_state_at_pos_flags), sr = _short_reasons](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = _graph_idx, flags = move(_state_at_pos_flags), sr = _short_reasons](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         propagate_regular(v, n, t, f, flags, g, state, inference, logger, sr);
-        return PropagatorState::Enable;
-    },
-        triggers);
+        return PropagatorState::Enable; }, triggers);
 }
 
 auto Regular::s_exprify(const ProofModel * const model) const -> string

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -939,6 +939,7 @@ auto SmartTable::install(Propagators & propagators, State & initial_state, Proof
     vector<Forest> forests = build_forests(_tuples);
 
     propagators.install(
+        constraint_id(),
         [selectors, vars = _vars, tuples = move(_tuples), forests = move(forests), pb_selectors = move(pb_selectors), short_reasons = _short_reasons](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto reason = generic_reason(state, vars);

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -80,7 +80,7 @@ auto ArgSort::install(Propagators & propagators, State & initial_state, ProofMod
         _witness = define_sortedness_proof_model(*optional_model, _x, y_ids);
     }
 
-    install_sortedness_propagator(propagators, _x, y_ids, _witness);
+    install_sortedness_propagator(propagators, constraint_id(), _x, y_ids, _witness);
 
     if (optional_model)
         define_proof_model(*optional_model);
@@ -195,8 +195,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     channel_triggers.on_bounds.insert(channel_triggers.on_bounds.end(), y_ids.begin(), y_ids.end());
     channel_triggers.on_change.insert(channel_triggers.on_change.end(), _p.begin(), _p.end());
 
-    propagators.install([x = _x, y = y_ids, p = _p, offset = _offset, n](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, y = y_ids, p = _p, offset = _offset, n](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         for (size_t j = 0; j < n; ++j) {
             auto [ylo, yhi] = state.bounds(y[j]);
 
@@ -235,9 +234,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
             }
         }
 
-        return PropagatorState::Enable;
-    },
-        channel_triggers);
+        return PropagatorState::Enable; }, channel_triggers);
 
     // Achievable-rank-set propagator: gives bounds(Z) consistency on p. Element
     // k's stable rank pos[k] (the number of elements before it) lies in
@@ -250,8 +247,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     rank_triggers.on_bounds.insert(rank_triggers.on_bounds.end(), _x.begin(), _x.end());
     rank_triggers.on_change.insert(rank_triggers.on_change.end(), _p.begin(), _p.end());
 
-    propagators.install([x = _x, p = _p, offset = _offset, n, witness = _witness](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, p = _p, offset = _offset, n, witness = _witness](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         for (size_t k = 0; k < n; ++k) {
             auto [lk, uk] = state.bounds(x[k]);
 
@@ -423,9 +419,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
             }
         }
 
-        return PropagatorState::Enable;
-    },
-        rank_triggers);
+        return PropagatorState::Enable; }, rank_triggers);
 
     // GAC on the all_different aspect of p (it is a permutation of the n
     // positions). Reuses the framework's matching/Hall propagator and its
@@ -440,12 +434,9 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     Triggers ad_triggers;
     ad_triggers.on_change.insert(ad_triggers.on_change.end(), _p.begin(), _p.end());
 
-    propagators.install([p = _p, vals = move(p_vals), am1_lines](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [p = _p, vals = move(p_vals), am1_lines](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         propagate_gac_all_different(p, vals, vector<Integer>{}, *am1_lines, state, inference, logger);
-        return PropagatorState::Enable;
-    },
-        ad_triggers);
+        return PropagatorState::Enable; }, ad_triggers);
 
     // No leaf-checking propagator is needed: once every x is fixed, each
     // element k's reachable-rank set collapses to the single stable rank, so the

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -957,7 +957,7 @@ namespace
     }
 }
 
-auto gcs::innards::install_sortedness_propagator(Propagators & propagators,
+auto gcs::innards::install_sortedness_propagator(Propagators & propagators, const ConstraintID & constraint_id,
     const vector<IntegerVariableID> & x, const vector<IntegerVariableID> & y,
     const SortednessWitness & witness) -> void
 {
@@ -1088,19 +1088,15 @@ auto gcs::innards::install_sortedness_propagator(Propagators & propagators,
     triggers.on_bounds.insert(triggers.on_bounds.end(), x.begin(), x.end());
     triggers.on_bounds.insert(triggers.on_bounds.end(), y.begin(), y.end());
 
-    propagators.install([x, y, before = witness.before, pos = witness.pos, rank_lines = witness.rank_ge,
-                            rank_le_lines = witness.rank_le, inj_lines, al1_lines, anti_lines](
-                            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id, [x, y, before = witness.before, pos = witness.pos, rank_lines = witness.rank_ge, rank_le_lines = witness.rank_le, inj_lines, al1_lines, anti_lines](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         propagate_sortedness(x, y, before, pos, rank_lines, rank_le_lines, *inj_lines, *al1_lines, *anti_lines,
             state, inference, logger);
-        return PropagatorState::Enable;
-    },
-        triggers);
+        return PropagatorState::Enable; }, triggers);
 }
 
 auto Sort::install_propagators(Propagators & propagators) -> void
 {
-    install_sortedness_propagator(propagators, _x, _y, _witness);
+    install_sortedness_propagator(propagators, constraint_id(), _x, _y, _witness);
 }
 
 auto Sort::s_exprify(const ProofModel * const model) const -> string

--- a/gcs/constraints/sort/sortedness.hh
+++ b/gcs/constraints/sort/sortedness.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_SORT_SORTEDNESS_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_SORT_SORTEDNESS_HH
 
+#include <gcs/constraint.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
@@ -45,7 +46,7 @@ namespace gcs::innards
      * \brief Install the Mehlhorn-Thiel bounds-consistency propagator for
      * `y = sort(x)`, using the witness from define_sortedness_proof_model.
      */
-    auto install_sortedness_propagator(Propagators & propagators,
+    auto install_sortedness_propagator(Propagators & propagators, const ConstraintID & constraint_id,
         const std::vector<IntegerVariableID> & x, const std::vector<IntegerVariableID> & y,
         const SortednessWitness & witness) -> void;
 }

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -225,6 +225,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
             });
 
         propagators.install(
+            constraint_id(),
             [vars = move(_vars), tuples = move(tuples), watches = watches](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 const auto & tuple_data = depointinate(tuples);

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -190,11 +190,7 @@ auto Table::install_propagators(Propagators & propagators) -> void
             triggers.on_change.push_back(v);
         triggers.on_change.push_back(_selector);
 
-        propagators.install([table = ExtensionalData{_selector, move(_vars), move(tuples)}](
-                                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return propagate_extensional(table, state, inference, logger);
-        },
-            triggers);
+        propagators.install(constraint_id(), [table = ExtensionalData{_selector, move(_vars), move(tuples)}](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return propagate_extensional(table, state, inference, logger); }, triggers);
     },
         move(_tuples));
 }

--- a/gcs/constraints/value_precede.cc
+++ b/gcs/constraints/value_precede.cc
@@ -168,6 +168,7 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
             triggers.on_change.push_back(v);
 
         propagators.install(
+            constraint_id(),
             [vars = _vars, s, t](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 auto n = vars.size();

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -11,6 +11,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <unordered_map>
 #include <utility>
 
 using namespace gcs;
@@ -33,6 +37,18 @@ namespace
     {
         vector<pair<int, int>> ids_and_masks;
     };
+
+    // ConstraintID structural equality (CurrentlyUnnamedConstraint,
+    // NumberedConstraint, NamedConstraint all compare) backs the dense-index
+    // map below; hashing its string form is enough, since equality is checked
+    // structurally on the variant.
+    struct ConstraintIDHash
+    {
+        auto operator()(const ConstraintID & id) const -> std::size_t
+        {
+            return std::hash<std::string>{}(as_string(id));
+        }
+    };
 }
 
 struct Propagators::Imp
@@ -50,6 +66,14 @@ struct Propagators::Imp
     unsigned long long total_propagations = 0, effectful_propagations = 0, contradicting_propagations = 0;
     vector<TriggerIDs> iv_triggers;
     vector<long> degrees;
+
+    // The constraint each propagator belongs to. propagator_constraint_index is
+    // indexed by propagator id and gives a dense constraint index; constraint_ids
+    // is the inverse (dense index -> ConstraintID); constraint_index_of_id assigns
+    // a fresh dense index on first sight of each ConstraintID.
+    vector<int> propagator_constraint_index;
+    vector<ConstraintID> constraint_ids;
+    std::unordered_map<ConstraintID, int, ConstraintIDHash> constraint_index_of_id;
 };
 
 Propagators::Propagators() :
@@ -90,10 +114,15 @@ auto Propagators::define_bound(const State & state, ProofModel * const optional_
     }
 }
 
-auto Propagators::install(PropagationFunction && f, const Triggers & triggers) -> void
+auto Propagators::install(const ConstraintID & constraint_id, PropagationFunction && f, const Triggers & triggers) -> void
 {
     int id = _imp->propagation_functions.size();
     _imp->propagation_functions.emplace_back(move(f));
+
+    auto [it, inserted] = _imp->constraint_index_of_id.try_emplace(constraint_id, static_cast<int>(_imp->constraint_ids.size()));
+    if (inserted)
+        _imp->constraint_ids.push_back(constraint_id);
+    _imp->propagator_constraint_index.push_back(it->second);
 
     for (const auto & v : triggers.on_change) {
         trigger_on_change(v, id);
@@ -338,4 +367,19 @@ auto Propagators::degree_of(IntegerVariableID var) const -> long
             return 0;
         }}
         .visit(var);
+}
+
+auto Propagators::number_of_constraints() const -> std::size_t
+{
+    return _imp->constraint_ids.size();
+}
+
+auto Propagators::constraint_index_of_propagator(int propagator_id) const -> int
+{
+    return _imp->propagator_constraint_index[propagator_id];
+}
+
+auto Propagators::constraint_id_for_index(int constraint_index) const -> const ConstraintID &
+{
+    return _imp->constraint_ids[constraint_index];
 }

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -1,13 +1,14 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROPAGATORS_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROPAGATORS_HH
 
+#include <gcs/constraint.hh>
 #include <gcs/expression.hh>
 #include <gcs/extensional.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/literal.hh>
-#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/problem.hh>
@@ -203,8 +204,16 @@ namespace gcs::innards
          * constraints are called at least once when search starts, even if no
          * Triggers are specified, and a constraint may be called even if its
          * trigger condition is not met.
+         *
+         * The ConstraintID identifies which posted constraint this propagator
+         * belongs to (the same identity the proof log uses); pass the owning
+         * Constraint's constraint_id(). Several propagators may share one
+         * ConstraintID. This is recorded so that, for example, a search
+         * heuristic can attribute a domain wipeout back to a constraint. It is
+         * passed explicitly rather than held as mutable "current constraint"
+         * state so it cannot be mis-sequenced.
          */
-        auto install(PropagationFunction &&, const Triggers & trigger_vars) -> void;
+        auto install(const ConstraintID & constraint_id, PropagationFunction &&, const Triggers & trigger_vars) -> void;
 
         /**
          * Install an initialiser, which will be called once just before search
@@ -286,6 +295,28 @@ namespace gcs::innards
          * How many constraints is this variable involved in?
          */
         auto degree_of(IntegerVariableID) const -> long;
+
+        /**
+         * How many distinct constraints (by ConstraintID) installed at least
+         * one propagator? Equivalently, the number of valid dense constraint
+         * indices, which run from zero to this minus one.
+         */
+        [[nodiscard]] auto number_of_constraints() const -> std::size_t;
+
+        /**
+         * The dense constraint index of the propagator with the given id (as
+         * supplied to a propagation function and used internally by propagate).
+         * Propagators sharing a ConstraintID share an index; indices are
+         * assigned densely in order of first sight of each ConstraintID.
+         */
+        [[nodiscard]] auto constraint_index_of_propagator(int propagator_id) const -> int;
+
+        /**
+         * The ConstraintID for a dense constraint index, as returned by
+         * constraint_index_of_propagator. The inverse of the first-sight
+         * indexing.
+         */
+        [[nodiscard]] auto constraint_id_for_index(int constraint_index) const -> const ConstraintID &;
 
         ///@}
     };

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -120,10 +120,8 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
 
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
-    propagators.install([data = move(data)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        return propagate_extensional(data, state, inference, logger);
-    },
-        triggers);
+    // A presolver-derived propagator has no posted-constraint identity of its own.
+    propagators.install(CurrentlyUnnamedConstraint{}, [data = move(data)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return propagate_extensional(data, state, inference, logger); }, triggers);
 
     return true;
 }


### PR DESCRIPTION
## What

Split the **stable constraint → propagator association** out of #315 (the dom/wdeg search-heuristics RFC) and land it on its own. This is the "core enabler" engine change described there: give `Propagators::install` an explicit `ConstraintID` argument so the engine records which posted constraint each propagator belongs to.

It's mechanical and touches every constraint's install site, so it's separated from the actual heuristic work (which will take a while) and kept deliberately small to merge quickly — minimising repeated merge churn against in-flight branches.

## Change

- `Propagators::install(...)` gains a leading `const ConstraintID &` argument. Each constraint passes its own `constraint_id()` — the same identity the proof log uses. It is an explicit argument, **not** a stateful "current constraint" setter, so it cannot be mis-sequenced.
- `Propagators` records a dense `int ↔ ConstraintID` map (propagators sharing a `ConstraintID` share a dense index, assigned on first sight), exposed via:
  - `number_of_constraints()`
  - `constraint_index_of_propagator(int propagator_id)`
  - `constraint_id_for_index(int constraint_index)`
- Three shared install helpers (`install_reified_dispatcher`, `install_sortedness_propagator`, `install_propagators_logical`) gain a forwarded `ConstraintID` parameter; their callers pass `constraint_id()`.
- The `AutoTable` presolver has no posted-constraint identity, so it passes `CurrentlyUnnamedConstraint{}`. `CurrentlyUnnamedConstraint` gains a defaulted `<=>` so `ConstraintID` is usable as a map key.

## Scope

Deliberately minimal — just the association + accessors. The propagator→scope / variable→constraint adjacency, the contradiction-`Reason` stash, the `State`-borrowed weighting pointer, and the weighting schemes all stay with #315 proper. **The new accessors have no consumer yet** — they are scaffolding for the heuristic work.

## No proof impact

No constraint's identity or proof model changes, so OPB/proof output is byte-identical. The full `ctest` suite passes, including the VeriPB proof-verifying tests.

## Notes for review

- Most of the per-constraint diff is just `constraint_id()` threaded into each `propagators.install(...)` call; a handful of single-`return` propagation lambdas get re-flowed onto one line by clang-format.
- Built and tested under **both GCC 15 and clang 21**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)