### PR TITLE
Stage 0 (cont.): conflict-observation seam for dom/wdeg (#315)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -430,6 +430,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(state_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME state_test COMMAND $<TARGET_FILE:state_test>)
 
+    add_executable(conflict_observer_test innards/conflict_observer_test.cc)
+    target_link_libraries(conflict_observer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME conflict_observer_test COMMAND $<TARGET_FILE:conflict_observer_test>)
+
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)

--- a/gcs/innards/conflict_observer.hh
+++ b/gcs/innards/conflict_observer.hh
@@ -1,0 +1,55 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_CONFLICT_OBSERVER_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_CONFLICT_OBSERVER_HH
+
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state-fwd.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Watches propagation for conflicts (domain wipeouts) as they
+     * happen, so that a search heuristic can attribute each wipeout to the
+     * constraint --- and, later, the specific Reason --- that caused it.
+     *
+     * A borrowed observer is attached to the Propagators for the duration of a
+     * search (Propagators::set_conflict_observer). Whenever a propagator raises
+     * a contradiction, Propagators::propagate notifies the observer exactly once
+     * with the failing constraint and its scope. This is the write side of the
+     * dom/wdeg weighting seam (issue #315, Stage 0): the weighting value object
+     * will implement this interface. It is deliberately minimal and carries no
+     * query API of its own --- the brancher reads back weights by another path.
+     *
+     * \ingroup Innards
+     */
+    class ConflictObserver
+    {
+    public:
+        virtual ~ConflictObserver() = default;
+
+        /**
+         * \brief Called when a propagator wipes out a domain.
+         *
+         * \param constraint_index the dense constraint index of the failing
+         *   propagator, as from Propagators::constraint_index_of_propagator.
+         * \param scope the failing propagator's scope, as from
+         *   Propagators::scope_of_propagator: its variables, with views
+         *   resolved to the underlying simple variable and duplicates removed.
+         * \param reason the reason carried by the contradiction. The optional
+         *   is engaged whenever a contradiction occurred, but the ReasonFunction
+         *   it holds may itself be empty when the propagator supplied no reason;
+         *   it is evaluated lazily, only if the observer chooses to call it.
+         * \param state the current state, for querying variable domains.
+         */
+        virtual auto note_conflict(
+            int constraint_index,
+            const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<ReasonFunction> & reason,
+            const State & state) -> void = 0;
+    };
+}
+
+#endif

--- a/gcs/innards/conflict_observer_test.cc
+++ b/gcs/innards/conflict_observer_test.cc
@@ -1,0 +1,177 @@
+#include <gcs/constraint.hh>
+#include <gcs/innards/conflict_observer.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/variable_id.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::nullopt;
+using std::optional;
+using std::vector;
+
+namespace
+{
+    // Records every conflict it is told about, so a test can check which
+    // constraint (and scope) a wipeout was attributed to.
+    struct RecordingObserver final : ConflictObserver
+    {
+        struct Call
+        {
+            int constraint_index;
+            vector<SimpleIntegerVariableID> scope;
+            bool reason_present;
+            bool reason_non_empty;
+        };
+
+        vector<Call> calls;
+
+        auto note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> & scope,
+            const optional<ReasonFunction> & reason, const State &) -> void override
+        {
+            calls.push_back(Call{constraint_index, scope, reason.has_value(),
+                reason.has_value() && static_cast<bool>(*reason)});
+        }
+    };
+
+    // A do-nothing propagator, written as a fresh lambda at each install site
+    // (the PropagationFunction constructor wants the closure by value), used as
+    // an innocent bystander constraint that must not be blamed for a wipeout.
+    auto a_propagator_that_does_nothing()
+    {
+        return [](const State &, auto &, ProofLogger * const) -> PropagatorState { return PropagatorState::Enable; };
+    }
+}
+
+TEST_CASE("Conflict observer attributes a wipeout to the failing constraint, not a bystander")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 1_i);
+
+    Propagators propagators;
+    // Constraint _1: innocent, triggers on x only. Dense constraint index 0.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x}});
+    // Constraint _2: explicitly contradicts, with a non-empty reason. It is
+    // registered second, so its propagator (id 1) runs after the bystander and
+    // it gets dense constraint index 1. Its scope triggers on x and y, plus a
+    // view of x (x + 1) that must resolve back to x and deduplicate away.
+    propagators.install(
+        NumberedConstraint{2},
+        [x, y](const State & inner_state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.contradiction(logger, JustifyUsingRUP{},
+                generic_reason(inner_state, vector<IntegerVariableID>{x, y}));
+        },
+        Triggers{.on_change = {x, y}, .on_bounds = {x + 1_i}});
+
+    RecordingObserver observer;
+    propagators.set_conflict_observer(&observer);
+
+    auto no_contradiction = propagators.propagate(nullopt, state, nullptr);
+
+    CHECK_FALSE(no_contradiction);
+    REQUIRE(observer.calls.size() == 1);
+
+    const auto & call = observer.calls.front();
+    // The blame falls on _2 (dense index 1), never on the bystander _1.
+    CHECK(call.constraint_index == 1);
+    CHECK(propagators.constraint_id_for_index(call.constraint_index) == ConstraintID{NumberedConstraint{2}});
+    // Scope is the failing propagator's scope: x and y, with the x + 1 view
+    // resolved and deduplicated.
+    CHECK(call.scope == vector<SimpleIntegerVariableID>{x, y});
+    // The reason was carried through, engaged and non-empty.
+    CHECK(call.reason_present);
+    CHECK(call.reason_non_empty);
+}
+
+TEST_CASE("Conflict observer fires for an inference-driven wipeout")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
+
+    Propagators propagators;
+    // The contradiction here comes not from an explicit contradiction() call but
+    // from an inference that empties x's domain (the Contradiction case inside
+    // the tracker), exercising the other reason-stash path.
+    propagators.install(
+        NumberedConstraint{7},
+        [x](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.infer_greater_than_or_equal(logger, x, 5_i, JustifyUsingRUP{}, ReasonFunction{});
+            return PropagatorState::Enable;
+        },
+        Triggers{.on_bounds = {x}});
+
+    RecordingObserver observer;
+    propagators.set_conflict_observer(&observer);
+
+    auto no_contradiction = propagators.propagate(nullopt, state, nullptr);
+
+    CHECK_FALSE(no_contradiction);
+    REQUIRE(observer.calls.size() == 1);
+
+    const auto & call = observer.calls.front();
+    CHECK(call.constraint_index == 0);
+    CHECK(propagators.constraint_id_for_index(call.constraint_index) == ConstraintID{NumberedConstraint{7}});
+    CHECK(call.scope == vector<SimpleIntegerVariableID>{x});
+    // An empty ReasonFunction was supplied: the optional is engaged, but the
+    // function it holds is empty.
+    CHECK(call.reason_present);
+    CHECK_FALSE(call.reason_non_empty);
+}
+
+TEST_CASE("Propagation without a conflict observer still detects the wipeout")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
+
+    Propagators propagators;
+    propagators.install(
+        NumberedConstraint{1},
+        [](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{});
+        },
+        Triggers{.on_change = {x}});
+
+    // No observer attached: the propagate() notification is guarded and must not
+    // be reached, but the contradiction is still reported.
+    CHECK(propagators.conflict_observer() == nullptr);
+    CHECK_FALSE(propagators.propagate(nullopt, state, nullptr));
+}
+
+TEST_CASE("Propagator scope and variable-to-constraint adjacency")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    // Constraint index 0, propagator 0: over x and y (with a duplicate and a
+    // view of y to check deduplication / view resolution).
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(),
+        Triggers{.on_change = {x, y}, .on_bounds = {y, -y}});
+    // Constraint index 1, propagator 1: over y and z.
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(),
+        Triggers{.on_change = {y, z}});
+
+    CHECK(propagators.scope_of_propagator(0) == vector<SimpleIntegerVariableID>{x, y});
+    CHECK(propagators.scope_of_propagator(1) == vector<SimpleIntegerVariableID>{y, z});
+
+    // x is only in constraint 0; y is in both; z is only in constraint 1.
+    CHECK(propagators.constraint_indices_of_variable(x) == vector<int>{0});
+    CHECK(propagators.constraint_indices_of_variable(y) == vector<int>{0, 1});
+    CHECK(propagators.constraint_indices_of_variable(z) == vector<int>{1});
+
+    // A variable no propagator triggers on has no constraints.
+    auto unused = state.allocate_integer_variable_with_state(0_i, 0_i);
+    CHECK(propagators.constraint_indices_of_variable(unused).empty());
+}

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <version>
@@ -34,6 +35,13 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
 
+        // The reason supplied with the contradiction that ended this tracker's
+        // life, stashed before the throw so it is reachable at the catch site
+        // (a conflict observer may want to know which literals were implicated).
+        // Engaged whenever a contradiction has been raised; the ReasonFunction
+        // it holds may itself be empty if the caller supplied no reason.
+        std::optional<ReasonFunction> _last_contradiction_reason;
+
         auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
         {
             return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason);
@@ -58,6 +66,7 @@ namespace gcs::innards
 
         [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason) -> void
         {
+            _last_contradiction_reason = reason;
             if (logger)
                 logger->infer(FalseLiteral{}, why, reason);
             throw TrackedPropagationFailed{};
@@ -135,8 +144,18 @@ namespace gcs::innards
         auto reset() -> void
         {
             _inferences.clear();
+            _last_contradiction_reason.reset();
             _did_anything_since_last_call_inside_propagator = false;
             _did_anything_since_last_call_by_propagation_queue = false;
+        }
+
+        // The reason of the contradiction that ended this tracker's life, valid
+        // at the catch site after propagate() unwinds a TrackedPropagationFailed.
+        // Has no value if no contradiction was raised; the held ReasonFunction
+        // may be empty if the caller supplied none.
+        [[nodiscard]] auto last_contradiction_reason() const -> const std::optional<ReasonFunction> &
+        {
+            return _last_contradiction_reason;
         }
 
         auto did_anything_since_last_call_by_propagation_queue() -> bool
@@ -155,7 +174,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &) -> void
+        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction & reason) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -185,6 +204,7 @@ namespace gcs::innards
                 break;
 
             [[unlikely]] case Inference::Contradiction:
+                _last_contradiction_reason = reason;
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
                 throw TrackedPropagationFailed{};
@@ -230,6 +250,7 @@ namespace gcs::innards
                 break;
 
             [[unlikely]] case Inference::Contradiction:
+                _last_contradiction_reason = reason;
                 if (logger)
                     logger->infer(lit, just, reason);
                 _did_anything_since_last_call_by_propagation_queue = true;

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -1,4 +1,5 @@
 #include <gcs/exception.hh>
+#include <gcs/innards/conflict_observer.hh>
 #include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -84,6 +85,11 @@ struct Propagators::Imp
     // install(), used by a conflict observer / weighted-degree heuristic.
     vector<vector<SimpleIntegerVariableID>> propagator_scope;
     vector<vector<int>> var_constraint_indices;
+
+    // A borrowed conflict observer, notified when a propagator wipes out a
+    // domain (see propagate). Set once at search start via set_conflict_observer;
+    // the caller owns it. nullptr when there is no observer.
+    ConflictObserver * conflict_observer = nullptr;
 };
 
 Propagators::Propagators() :
@@ -307,6 +313,13 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         catch (const TrackedPropagationFailed &) {
             contradiction = true;
             ++_imp->contradicting_propagations;
+            // Exactly one propagator contradiction ends each propagate(), so this
+            // fires at most once per call. Non-propagator contradiction paths
+            // (initialisers, the objective bound) never reach here, so they are
+            // not attributed to any constraint.
+            if (_imp->conflict_observer)
+                _imp->conflict_observer->note_conflict(_imp->propagator_constraint_index[propagator_id],
+                    _imp->propagator_scope[propagator_id], tracker.last_contradiction_reason(), state);
         }
 
         if (contradiction || (optional_abort_flag && optional_abort_flag->load()))
@@ -439,4 +452,14 @@ auto Propagators::constraint_indices_of_variable(SimpleIntegerVariableID var) co
         return none;
     }
     return _imp->var_constraint_indices[var.index];
+}
+
+auto Propagators::set_conflict_observer(ConflictObserver * observer) -> void
+{
+    _imp->conflict_observer = observer;
+}
+
+auto Propagators::conflict_observer() const -> ConflictObserver *
+{
+    return _imp->conflict_observer;
 }

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -30,6 +30,7 @@ using std::swap;
 using std::to_underlying;
 using std::vector;
 using std::visit;
+using std::ranges::find;
 
 namespace
 {
@@ -74,6 +75,15 @@ struct Propagators::Imp
     vector<int> propagator_constraint_index;
     vector<ConstraintID> constraint_ids;
     std::unordered_map<ConstraintID, int, ConstraintIDHash> constraint_index_of_id;
+
+    // The scope of each propagator (indexed by propagator id): its trigger
+    // variables with views resolved to the underlying simple variable and
+    // duplicates removed. var_constraint_indices is the transpose aggregated by
+    // constraint: indexed by variable index, the deduplicated dense constraint
+    // indices that variable participates in. Built alongside the triggers in
+    // install(), used by a conflict observer / weighted-degree heuristic.
+    vector<vector<SimpleIntegerVariableID>> propagator_scope;
+    vector<vector<int>> var_constraint_indices;
 };
 
 Propagators::Propagators() :
@@ -122,7 +132,40 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
     auto [it, inserted] = _imp->constraint_index_of_id.try_emplace(constraint_id, static_cast<int>(_imp->constraint_ids.size()));
     if (inserted)
         _imp->constraint_ids.push_back(constraint_id);
-    _imp->propagator_constraint_index.push_back(it->second);
+    int constraint_index = it->second;
+    _imp->propagator_constraint_index.push_back(constraint_index);
+
+    // Record this propagator's scope (its trigger variables, views resolved and
+    // deduplicated) and add it to each variable's constraint adjacency.
+    auto & scope = _imp->propagator_scope.emplace_back();
+    auto add_to_scope = [&](IntegerVariableID var) {
+        overloaded{
+            [&](const SimpleIntegerVariableID & v) {
+                if (find(scope, v) == scope.end())
+                    scope.push_back(v);
+            },
+            [&](const ViewOfIntegerVariableID & v) {
+                if (find(scope, v.actual_variable) == scope.end())
+                    scope.push_back(v.actual_variable);
+            },
+            [&](const ConstantIntegerVariableID &) {
+            }}
+            .visit(var);
+    };
+    for (const auto & v : triggers.on_change)
+        add_to_scope(v);
+    for (const auto & v : triggers.on_bounds)
+        add_to_scope(v);
+    for (const auto & v : triggers.on_instantiated)
+        add_to_scope(v);
+
+    for (const auto & v : scope) {
+        if (_imp->var_constraint_indices.size() <= v.index)
+            _imp->var_constraint_indices.resize(v.index + 1);
+        auto & indices = _imp->var_constraint_indices[v.index];
+        if (find(indices, constraint_index) == indices.end())
+            indices.push_back(constraint_index);
+    }
 
     for (const auto & v : triggers.on_change) {
         trigger_on_change(v, id);
@@ -382,4 +425,18 @@ auto Propagators::constraint_index_of_propagator(int propagator_id) const -> int
 auto Propagators::constraint_id_for_index(int constraint_index) const -> const ConstraintID &
 {
     return _imp->constraint_ids[constraint_index];
+}
+
+auto Propagators::scope_of_propagator(int propagator_id) const -> const vector<SimpleIntegerVariableID> &
+{
+    return _imp->propagator_scope[propagator_id];
+}
+
+auto Propagators::constraint_indices_of_variable(SimpleIntegerVariableID var) const -> const vector<int> &
+{
+    if (var.index >= _imp->var_constraint_indices.size()) {
+        static const vector<int> none;
+        return none;
+    }
+    return _imp->var_constraint_indices[var.index];
 }

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -20,6 +20,8 @@
 
 namespace gcs::innards
 {
+    class ConflictObserver;
+
     class PropagationFunctionImplBase
     {
     public:
@@ -333,6 +335,33 @@ namespace gcs::innards
          * constraint — the adjacency a weighted-degree heuristic sums over.
          */
         [[nodiscard]] auto constraint_indices_of_variable(SimpleIntegerVariableID) const -> const std::vector<int> &;
+
+        ///@}
+
+        /**
+         * \name Conflict observation
+         */
+        ///@{
+
+        /**
+         * Attach a borrowed conflict observer, notified by propagate() whenever
+         * a propagator wipes out a domain. The observer is borrowed: the caller
+         * owns it and must keep it alive for the duration of the search. Pass
+         * nullptr to detach. A conflict is a Propagators event (it carries the
+         * failing constraint's index, scope, and reason, all from here), so the
+         * observer lives with the rest of the conflict-observation machinery
+         * rather than on State.
+         *
+         * \sa ConflictObserver
+         */
+        auto set_conflict_observer(ConflictObserver * observer) -> void;
+
+        /**
+         * The conflict observer currently attached, or nullptr if none.
+         *
+         * \sa Propagators::set_conflict_observer()
+         */
+        [[nodiscard]] auto conflict_observer() const -> ConflictObserver *;
 
         ///@}
     };

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -318,6 +318,22 @@ namespace gcs::innards
          */
         [[nodiscard]] auto constraint_id_for_index(int constraint_index) const -> const ConstraintID &;
 
+        /**
+         * The scope of the propagator with the given id: its trigger variables
+         * (across all trigger kinds) with views resolved to their underlying
+         * simple variable and duplicates removed. Indexed by propagator id.
+         */
+        [[nodiscard]] auto scope_of_propagator(int propagator_id) const -> const std::vector<SimpleIntegerVariableID> &;
+
+        /**
+         * The dense constraint indices of every constraint the given variable
+         * participates in (it appears in the scope of one of that constraint's
+         * propagators), deduplicated. Empty for a variable that no propagator
+         * triggers on. This is scope_of_propagator transposed and aggregated by
+         * constraint — the adjacency a weighted-degree heuristic sums over.
+         */
+        [[nodiscard]] auto constraint_indices_of_variable(SimpleIntegerVariableID) const -> const std::vector<int> &;
+
         ///@}
     };
 }


### PR DESCRIPTION
## What

Completes **Stage 0** of the dom/wdeg search-heuristics work (issue #315) — the engine
seam shared by both the weighting and the (later) nogood/restart work. PR #317 landed the
first checkbox (an explicit `ConstraintID` on `Propagators::install`); this adds the rest
of the conflict-observation half. Nothing user-visible yet: with no observer attached,
behaviour and proofs are unchanged.

> Stacked on #317 (`stable-constraint-propagator-id`). The base will retarget to `main`
> once #317 merges; if `main` is rebased in the process, this branch wants a quick rebase
> so the diff shows only its four commits.

## Changes (four self-contained commits)

1. **Propagator scope + variable→constraint adjacency.** `Propagators` records, per
   installed propagator, its scope — the trigger variables across all trigger kinds, with
   views resolved to the underlying simple variable and duplicates removed — and the
   transpose aggregated by constraint (per variable, the deduplicated dense indices of the
   constraints it is in). Exposed via `scope_of_propagator()` and
   `constraint_indices_of_variable()`.
2. **Stash the contradiction's reason.** Before throwing `TrackedPropagationFailed`, the
   inference tracker records the `ReasonFunction`, in all three paths (the explicit
   `contradiction()` and the `Contradiction` case of both `track_impl` overloads),
   independent of the logger. Reachable at the catch site via `last_contradiction_reason()`;
   cleared by `reset()`. Cost is one `std::function` copy per failed propagate; the reason
   is evaluated only if a consumer asks.
3. **ConflictObserver + notification.** A minimal `ConflictObserver` interface
   (`gcs/innards/conflict_observer.hh`) with one `note_conflict(constraint index, scope,
   reason, state)` hook. `Propagators` carries a borrowed `ConflictObserver*`
   (`set_conflict_observer()`). When a propagator wipes out a domain,
   `Propagators::propagate` notifies the observer exactly once. Non-propagator contradiction
   paths (initialisers, the objective bound) don't reach the notification, so they are not
   attributed to any constraint. The observer lives on `Propagators` (not `State`): a
   conflict is a `Propagators` event and the index/scope/reason it carries all originate
   here, so the whole conflict-observation seam stays in one place and `State` stays about
   domains.
4. **Crafted-wipeout test** (`gcs/innards/conflict_observer_test.cc`): a recording observer
   confirms a wipeout is blamed on the failing constraint's `ConstraintID` and scope, never
   on an innocent bystander; that both contradiction paths fire and carry the reason
   (engaged, empty vs non-empty as supplied); that propagation with no observer still
   detects the contradiction; and that the scope/adjacency accessors resolve views,
   deduplicate, and give the right per-variable adjacency.

## Scope / forward-looking

These accessors and the observer have **no consumer yet** — they are the scaffolding the
Stage 1 weighting object will build on (`VariableWeighting` will implement
`ConflictObserver`). Deliberately left for Stage 1: the value object, the schemes, the
`dom_wdeg` brancher, and the `solve_with` wiring. One open question recorded for Stage 1 —
the brancher's read path (a `CurrentState` view vs. passing the weighting to the brancher
directly); the write side added here precludes neither.

## No proof impact

No constraint identity or proof model changes, so OPB/proof output is byte-identical. Full
`ctest` passes (including the VeriPB proof-verifying tests). Built under **both GCC 15.2 and
clang 21**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)