### PR TITLE
Stage 1 foundation: dom/wdeg weighting value object + classic scheme (#315)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -435,6 +435,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(conflict_observer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME conflict_observer_test COMMAND $<TARGET_FILE:conflict_observer_test>)
 
+    add_executable(variable_weighting_test variable_weighting_test.cc)
+    target_link_libraries(variable_weighting_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME variable_weighting_test COMMAND $<TARGET_FILE:variable_weighting_test>)
+
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(glasgow_constraint_solver
         stats.cc
         variable_condition.cc
         variable_id.cc
+        variable_weighting.cc
         constraints/abs.cc
         constraints/abs/justify.cc
         constraints/all_different/all_different_except.cc

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -6,6 +6,7 @@
 #include <gcs/innards/s_expr-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <variant>
@@ -166,5 +167,17 @@ struct fmt::formatter<gcs::ConstraintID> : fmt::formatter<std::string>
     }
 };
 #endif
+
+// Lets ConstraintID be used as a key in unordered containers (the weighting
+// state map, the dense-index map in Propagators). Equality on the variant is
+// structural; hashing its string form agrees with that.
+template <>
+struct std::hash<gcs::ConstraintID>
+{
+    [[nodiscard]] auto operator()(const gcs::ConstraintID & constraint_id) const -> std::size_t
+    {
+        return std::hash<std::string>{}(gcs::as_string(constraint_id));
+    }
+};
 
 #endif

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -31,7 +31,7 @@ using std::swap;
 using std::to_underlying;
 using std::vector;
 using std::visit;
-using std::ranges::find;
+using std::ranges::contains;
 
 namespace
 {
@@ -135,14 +135,15 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
     // Record this propagator's scope (its trigger variables, views resolved and
     // deduplicated) and add it to each variable's constraint adjacency.
     auto & scope = _imp->propagator_scope.emplace_back();
+    scope.reserve(triggers.on_change.size() + triggers.on_bounds.size() + triggers.on_instantiated.size());
     auto add_to_scope = [&](IntegerVariableID var) {
         overloaded{
             [&](const SimpleIntegerVariableID & v) {
-                if (find(scope, v) == scope.end())
+                if (! contains(scope, v))
                     scope.push_back(v);
             },
             [&](const ViewOfIntegerVariableID & v) {
-                if (find(scope, v.actual_variable) == scope.end())
+                if (! contains(scope, v.actual_variable))
                     scope.push_back(v.actual_variable);
             },
             [&](const ConstantIntegerVariableID &) {
@@ -160,7 +161,7 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         if (_imp->var_constraint_indices.size() <= v.index)
             _imp->var_constraint_indices.resize(v.index + 1);
         auto & indices = _imp->var_constraint_indices[v.index];
-        if (find(indices, constraint_index) == indices.end())
+        if (! contains(indices, constraint_index))
             indices.push_back(constraint_index);
     }
 
@@ -168,7 +169,7 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         _imp->constraint_scope.resize(constraint_index + 1);
     auto & cscope = _imp->constraint_scope[constraint_index];
     for (const auto & v : scope)
-        if (find(cscope, v) == cscope.end())
+        if (! contains(cscope, v))
             cscope.push_back(v);
 
     for (const auto & v : triggers.on_change) {

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -39,18 +39,6 @@ namespace
     {
         vector<pair<int, int>> ids_and_masks;
     };
-
-    // ConstraintID structural equality (CurrentlyUnnamedConstraint,
-    // NumberedConstraint, NamedConstraint all compare) backs the dense-index
-    // map below; hashing its string form is enough, since equality is checked
-    // structurally on the variant.
-    struct ConstraintIDHash
-    {
-        auto operator()(const ConstraintID & id) const -> std::size_t
-        {
-            return std::hash<std::string>{}(as_string(id));
-        }
-    };
 }
 
 struct Propagators::Imp
@@ -75,16 +63,19 @@ struct Propagators::Imp
     // a fresh dense index on first sight of each ConstraintID.
     vector<int> propagator_constraint_index;
     vector<ConstraintID> constraint_ids;
-    std::unordered_map<ConstraintID, int, ConstraintIDHash> constraint_index_of_id;
+    std::unordered_map<ConstraintID, int> constraint_index_of_id;
 
     // The scope of each propagator (indexed by propagator id): its trigger
     // variables with views resolved to the underlying simple variable and
     // duplicates removed. var_constraint_indices is the transpose aggregated by
     // constraint: indexed by variable index, the deduplicated dense constraint
-    // indices that variable participates in. Built alongside the triggers in
-    // install(), used by a conflict observer / weighted-degree heuristic.
+    // indices that variable participates in. constraint_scope is the union of a
+    // constraint's propagators' scopes (indexed by dense constraint index), used
+    // for the |fut|>1 weighted-degree filter. All built alongside the triggers
+    // in install().
     vector<vector<SimpleIntegerVariableID>> propagator_scope;
     vector<vector<int>> var_constraint_indices;
+    vector<vector<SimpleIntegerVariableID>> constraint_scope;
 
     // A borrowed conflict observer, notified when a propagator wipes out a
     // domain (see propagate). Set once at search start via set_conflict_observer;
@@ -172,6 +163,13 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         if (find(indices, constraint_index) == indices.end())
             indices.push_back(constraint_index);
     }
+
+    if (_imp->constraint_scope.size() <= static_cast<std::size_t>(constraint_index))
+        _imp->constraint_scope.resize(constraint_index + 1);
+    auto & cscope = _imp->constraint_scope[constraint_index];
+    for (const auto & v : scope)
+        if (find(cscope, v) == cscope.end())
+            cscope.push_back(v);
 
     for (const auto & v : triggers.on_change) {
         trigger_on_change(v, id);
@@ -452,6 +450,11 @@ auto Propagators::constraint_indices_of_variable(SimpleIntegerVariableID var) co
         return none;
     }
     return _imp->var_constraint_indices[var.index];
+}
+
+auto Propagators::scope_of_constraint(int constraint_index) const -> const vector<SimpleIntegerVariableID> &
+{
+    return _imp->constraint_scope[constraint_index];
 }
 
 auto Propagators::set_conflict_observer(ConflictObserver * observer) -> void

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -336,6 +336,14 @@ namespace gcs::innards
          */
         [[nodiscard]] auto constraint_indices_of_variable(SimpleIntegerVariableID) const -> const std::vector<int> &;
 
+        /**
+         * The scope of the constraint with the given dense index: the union of
+         * its propagators' scopes (views resolved, deduplicated). Used to count
+         * how many of a constraint's variables are still unassigned (the
+         * |fut|>1 filter in a weighted-degree heuristic).
+         */
+        [[nodiscard]] auto scope_of_constraint(int constraint_index) const -> const std::vector<SimpleIntegerVariableID> &;
+
         ///@}
 
         /**

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -1,0 +1,123 @@
+#include <gcs/current_state.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/variable_weighting.hh>
+
+#include <util/overloaded.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <optional>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::max;
+using std::nullopt;
+using std::optional;
+using std::size_t;
+using std::unordered_map;
+using std::vector;
+
+auto WeightingState::weight_of(const ConstraintID & constraint_id) const -> double
+{
+    auto it = _constraint_weights.find(constraint_id);
+    return it == _constraint_weights.end() ? 0.0 : it->second;
+}
+
+auto WeightingState::optional_weight_of(const ConstraintID & constraint_id) const -> optional<double>
+{
+    auto it = _constraint_weights.find(constraint_id);
+    if (it == _constraint_weights.end())
+        return nullopt;
+    return it->second;
+}
+
+auto WeightingState::set_weight(const ConstraintID & constraint_id, double weight) -> void
+{
+    _constraint_weights[constraint_id] = weight;
+}
+
+auto WeightingState::merge(const WeightingState & other, MergePolicy policy) -> void
+{
+    for (const auto & [constraint_id, their_weight] : other._constraint_weights) {
+        auto & my_weight = _constraint_weights[constraint_id];
+        switch (policy) {
+            using enum MergePolicy;
+        case Sum:
+            my_weight += their_weight;
+            break;
+        case Max:
+            my_weight = max(my_weight, their_weight);
+            break;
+        case Average:
+            my_weight = (my_weight + their_weight) / 2.0;
+            break;
+        }
+    }
+}
+
+auto WeightingState::constraint_weights() const -> const unordered_map<ConstraintID, double> &
+{
+    return _constraint_weights;
+}
+
+ClassicDomWDeg::ClassicDomWDeg(const Propagators & propagators) :
+    _weights(propagators.number_of_constraints(), 1.0)
+{
+}
+
+auto ClassicDomWDeg::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
+    const optional<ReasonFunction> &, const State &) -> void
+{
+    _weights[constraint_index] += 1.0;
+}
+
+auto ClassicDomWDeg::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
+    IntegerVariableID var) const -> double
+{
+    auto simple = overloaded{
+        [](const SimpleIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v; },
+        [](const ViewOfIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v.actual_variable; },
+        [](const ConstantIntegerVariableID &) -> optional<SimpleIntegerVariableID> { return nullopt; }}
+                      .visit(var);
+
+    if (! simple)
+        return 0.0;
+
+    double total = 0.0;
+    for (const auto & constraint_index : propagators.constraint_indices_of_variable(*simple)) {
+        // Only constraints with at least two unassigned variables count; we just
+        // need to know whether that threshold is met, so stop counting at two.
+        int futures = 0;
+        for (const auto & v : propagators.scope_of_constraint(constraint_index)) {
+            if (! state.has_single_value(v))
+                if (++futures >= 2)
+                    break;
+        }
+        if (futures >= 2)
+            total += _weights[constraint_index];
+    }
+    return total;
+}
+
+auto ClassicDomWDeg::on_restart() -> void
+{
+    // Classic dom/wdeg keeps its weights across restarts; CHS-style smoothing is
+    // a different scheme. Nothing to do.
+}
+
+auto ClassicDomWDeg::snapshot(const Propagators & propagators) const -> WeightingState
+{
+    WeightingState result;
+    for (size_t c = 0; c < _weights.size(); ++c)
+        result.set_weight(propagators.constraint_id_for_index(static_cast<int>(c)), _weights[c]);
+    return result;
+}
+
+auto ClassicDomWDeg::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    _weights.assign(propagators.number_of_constraints(), 1.0);
+    for (size_t c = 0; c < _weights.size(); ++c)
+        if (auto weight = state.optional_weight_of(propagators.constraint_id_for_index(static_cast<int>(c))))
+            _weights[c] = *weight;
+}

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -1,0 +1,163 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_VARIABLE_WEIGHTING_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_VARIABLE_WEIGHTING_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/innards/conflict_observer.hh>
+#include <gcs/innards/propagators-fwd.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace gcs
+{
+    class CurrentState;
+
+    /**
+     * \brief A portable, copyable snapshot of per-constraint weights, keyed by
+     * ConstraintID.
+     *
+     * This is the value-object seam of the dom/wdeg design: a VariableWeighting
+     * can be snapshotted out to one of these, a fresh one loaded from it, and two
+     * merged. Being keyed by the stable ConstraintID --- the identity a proof log
+     * also names --- rather than a live dense index, it survives leaving one
+     * search/thread and entering another: the basis for share-nothing parallel
+     * sync and for seeding a search with proof-mined weights.
+     *
+     * v1 holds only global per-constraint weights; a per-(constraint, variable)
+     * map for AbsCon-local schemes is a later additive extension.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class WeightingState
+    {
+    public:
+        /**
+         * \brief How two WeightingStates combine, for parallel/merge sync.
+         */
+        enum class MergePolicy
+        {
+            Sum,
+            Max,
+            Average
+        };
+
+        /**
+         * The weight recorded for a constraint, or 0.0 if it has none.
+         */
+        [[nodiscard]] auto weight_of(const ConstraintID &) const -> double;
+
+        /**
+         * The weight recorded for a constraint, or nullopt if it has none.
+         */
+        [[nodiscard]] auto optional_weight_of(const ConstraintID &) const -> std::optional<double>;
+
+        /**
+         * Set (or overwrite) the weight for a constraint.
+         */
+        auto set_weight(const ConstraintID &, double) -> void;
+
+        /**
+         * Combine another WeightingState into this one. For every constraint in
+         * \p other, this one's weight (taken as 0 if absent) is combined with
+         * other's under \p policy: Sum adds, Max keeps the larger, Average takes
+         * the mean. Constraints present only in this one are left unchanged.
+         */
+        auto merge(const WeightingState & other, MergePolicy policy) -> void;
+
+        /**
+         * The full ConstraintID -> weight map, for iteration / serialisation.
+         */
+        [[nodiscard]] auto constraint_weights() const -> const std::unordered_map<ConstraintID, double> &;
+
+    private:
+        std::unordered_map<ConstraintID, double> _constraint_weights;
+    };
+
+    /**
+     * \brief Live, per-search variable weighting: what a dom/wdeg-style brancher
+     * reads, and what propagation notifies on a conflict.
+     *
+     * Implements innards::ConflictObserver (the write side, fired by
+     * Propagators::propagate on a domain wipeout) and adds weighted_degree_of
+     * (the read side, summed by the brancher). A VariableWeighting is owned by
+     * the search driver (solve_with, or a parallel orchestrator), borrowed by
+     * State for the write side and captured by the brancher for the read side.
+     * Implementations store weights densely by constraint index for speed;
+     * snapshot()/load() bridge that to the portable, ConstraintID-keyed
+     * WeightingState.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class VariableWeighting : public innards::ConflictObserver
+    {
+    public:
+        ~VariableWeighting() override = default;
+
+        /**
+         * The weighted degree W(x) of a variable, to be combined with dom(x) by
+         * the brancher. Sums the live weight over the constraints the variable
+         * is in that still have at least two unassigned variables (the |fut|>1
+         * filter).
+         */
+        [[nodiscard]] virtual auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double = 0;
+
+        /**
+         * Called at each restart boundary (for smoothing / decay schemes).
+         * Inert until restarts land.
+         */
+        virtual auto on_restart() -> void = 0;
+
+        /**
+         * Read the live weights out into a portable WeightingState.
+         */
+        [[nodiscard]] virtual auto snapshot(const innards::Propagators & propagators) const -> WeightingState = 0;
+
+        /**
+         * Replace the live weights with those from a WeightingState (constraints
+         * absent from it revert to the scheme's default).
+         */
+        virtual auto load(const WeightingState & state, const innards::Propagators & propagators) -> void = 0;
+    };
+
+    /**
+     * \brief Classic dom/wdeg (Boussemart, Hemery, Lecoutre, Sais, ECAI 2004):
+     * one weight per constraint, initialised to 1, bumped by 1 on every domain
+     * wipeout.
+     *
+     * weighted_degree_of(x) sums w(c) over the constraints on x with at least two
+     * unassigned variables, so at the root --- every weight 1, every variable
+     * unassigned --- it equals the variable's degree, and the heuristic starts
+     * out like dom_then_deg and specialises as conflicts accumulate.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class ClassicDomWDeg final : public VariableWeighting
+    {
+    public:
+        /**
+         * One weight per constraint (Propagators::number_of_constraints), each
+         * initialised to 1.
+         */
+        explicit ClassicDomWDeg(const innards::Propagators & propagators);
+
+        auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
+
+        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+
+        auto on_restart() -> void override;
+
+        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
+
+        auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
+
+    private:
+        std::vector<double> _weights;
+    };
+}
+
+#endif

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -1,0 +1,176 @@
+#include <gcs/constraint.hh>
+#include <gcs/current_state.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/variable_id.hh>
+#include <gcs/variable_weighting.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::nullopt;
+using std::vector;
+
+namespace
+{
+    // A do-nothing propagator, written fresh at each install site (the
+    // PropagationFunction constructor wants the closure by value), to give a
+    // constraint a scope without any real propagation behaviour.
+    auto a_propagator_that_does_nothing()
+    {
+        return [](const State &, auto &, ProofLogger * const) -> PropagatorState { return PropagatorState::Enable; };
+    }
+}
+
+TEST_CASE("ClassicDomWDeg starts at the variable's degree")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+
+    // Every weight is 1 and every variable is unassigned, so weighted_degree_of
+    // is just the number of constraints each variable is in.
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 2.0);
+    CHECK(weighting.weighted_degree_of(current, propagators, y) == 2.0);
+    CHECK(weighting.weighted_degree_of(current, propagators, z) == 2.0);
+
+    // A view resolves to its underlying variable; a constant is in no constraints.
+    CHECK(weighting.weighted_degree_of(current, propagators, x + 1_i) == 2.0);
+    CHECK(weighting.weighted_degree_of(current, propagators, constant_variable(4_i)) == 0.0);
+}
+
+TEST_CASE("ClassicDomWDeg bumps the failing constraint's weight")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+
+    // Conflict on constraint _1 (dense index 0): w(_1) goes 1 -> 2.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 3.0); // w(_1)=2 + w(_3)=1
+    CHECK(weighting.weighted_degree_of(current, propagators, y) == 3.0); // w(_1)=2 + w(_2)=1
+    CHECK(weighting.weighted_degree_of(current, propagators, z) == 2.0); // w(_2)=1 + w(_3)=1, unchanged
+
+    // Weights accumulate and are not tied to search state (no backtrack resets
+    // them): a second conflict on _1 takes it to 3.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 4.0); // w(_1)=3 + w(_3)=1
+}
+
+TEST_CASE("ClassicDomWDeg counts only constraints with at least two unassigned variables")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(5_i, 5_i); // already fixed
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    // _1 over {x, y}: y is fixed, so only one unassigned variable -> excluded.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    // _2 over {x, z}: two unassigned -> counted.
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 1.0);
+
+    // Even bumping the excluded constraint's weight does not change x's score,
+    // because the |fut|>1 filter drops it.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 1.0);
+}
+
+TEST_CASE("ClassicDomWDeg snapshot and load round-trip")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+    weighting.note_conflict(0, {}, nullopt, state); // w(_1)=2
+    weighting.note_conflict(2, {}, nullopt, state); // w(_3)=2
+
+    auto snap = weighting.snapshot(propagators);
+    CHECK(snap.weight_of(NumberedConstraint{1}) == 2.0);
+    CHECK(snap.weight_of(NumberedConstraint{2}) == 1.0);
+    CHECK(snap.weight_of(NumberedConstraint{3}) == 2.0);
+    // An identity not in the model has no weight.
+    CHECK(snap.optional_weight_of(NamedConstraint{"absent"}) == nullopt);
+    CHECK(snap.weight_of(NamedConstraint{"absent"}) == 0.0);
+
+    // Loading the snapshot into a fresh weighting reproduces the scores.
+    ClassicDomWDeg reloaded{propagators};
+    reloaded.load(snap, propagators);
+    CHECK(reloaded.weighted_degree_of(current, propagators, x) == weighting.weighted_degree_of(current, propagators, x));
+    CHECK(reloaded.weighted_degree_of(current, propagators, y) == weighting.weighted_degree_of(current, propagators, y));
+    CHECK(reloaded.weighted_degree_of(current, propagators, z) == weighting.weighted_degree_of(current, propagators, z));
+}
+
+TEST_CASE("WeightingState merge policies")
+{
+    WeightingState a;
+    a.set_weight(NumberedConstraint{1}, 3.0);
+    a.set_weight(NumberedConstraint{2}, 5.0);
+
+    WeightingState b;
+    b.set_weight(NumberedConstraint{2}, 1.0);
+    b.set_weight(NumberedConstraint{3}, 7.0);
+
+    SECTION("sum")
+    {
+        auto m = a;
+        m.merge(b, WeightingState::MergePolicy::Sum);
+        CHECK(m.weight_of(NumberedConstraint{1}) == 3.0); // only in a, unchanged
+        CHECK(m.weight_of(NumberedConstraint{2}) == 6.0); // 5 + 1
+        CHECK(m.weight_of(NumberedConstraint{3}) == 7.0); // 0 + 7
+    }
+
+    SECTION("max")
+    {
+        auto m = a;
+        m.merge(b, WeightingState::MergePolicy::Max);
+        CHECK(m.weight_of(NumberedConstraint{1}) == 3.0);
+        CHECK(m.weight_of(NumberedConstraint{2}) == 5.0); // max(5, 1)
+        CHECK(m.weight_of(NumberedConstraint{3}) == 7.0); // max(0, 7)
+    }
+
+    SECTION("average")
+    {
+        auto m = a;
+        m.merge(b, WeightingState::MergePolicy::Average);
+        CHECK(m.weight_of(NumberedConstraint{1}) == 3.0); // only in a, unchanged
+        CHECK(m.weight_of(NumberedConstraint{2}) == 3.0); // (5 + 1) / 2
+        CHECK(m.weight_of(NumberedConstraint{3}) == 3.5); // (0 + 7) / 2
+    }
+}


### PR DESCRIPTION
## What

The **Stage 1 foundation** for dom/wdeg (issue #315): the weighting value object, the live
weighting interface, and the classic scheme — unit-tested in isolation. **No brancher and no
`solve_with` wiring yet** (agreed scope); the new types have no consumer, so nothing about
search or proofs changes.

> Stacked on #318 (`conflict-observation-seam`), which is itself stacked on #317. Bases will
> auto-retarget as each lands; rebase onto `main` if `main` is rebased in the process.

## Changes (three commits)

1. **`Propagators::scope_of_constraint` + a shared `std::hash<ConstraintID>`.**
   - `scope_of_constraint(constraint_index)` returns the union of a constraint's propagators'
     scopes (views resolved, deduped), built in `install()` next to the Stage-0 adjacency. The
     weighted-degree filter needs it to count a constraint's unassigned variables.
   - `std::hash<gcs::ConstraintID>` (hashing `as_string`) moves into `constraint.hh`, so
     `ConstraintID` can key an `unordered_map` without a bespoke functor; `Propagators` drops
     its local `ConstraintIDHash` and uses it.
2. **`gcs/variable_weighting.{hh,cc}` — the value object, interface, and classic scheme.**
   - `WeightingState` — a portable, copyable `ConstraintID → weight` value object (the seam for
     share-nothing parallel sync and proof-mined seeding): `weight_of` / `set_weight`, and
     `merge(other, policy)` over `Sum` / `Max` / `Average`.
   - `VariableWeighting` — the live per-search interface. It **is** an `innards::ConflictObserver`
     (the Stage-0 write side, `note_conflict` on a wipeout) plus `weighted_degree_of` (the read
     side the brancher will sum), `on_restart` (inert until restarts), and `snapshot()` / `load()`
     bridging dense-by-constraint-index storage to the `ConstraintID`-keyed `WeightingState`.
   - `ClassicDomWDeg` — one weight per constraint, **initialised to 1** and bumped by 1 on each
     wipeout. `weighted_degree_of(x)` sums `w(c)` over `x`'s constraints with at least two
     unassigned variables (the `|fut|>1` filter), so at the root it equals the variable's degree
     and the heuristic starts out like `dom_then_deg`.
3. **`gcs/variable_weighting_test.cc`** — degree-at-root, per-constraint increment + accumulation,
   the `|fut|>1` filter, `snapshot → load` round-trip, and the three `merge` policies.

## Decisions baked in (from the design pass on #315)

- First PR is **foundation only** — brancher and config surface come later.
- `WeightingState` is **global-per-constraint only** for now; the per-`(constraint, variable)`
  AbsCon-local map is a later additive extension (chosen to keep the serialisation format minimal).
- Initial weight **1** (so initial weighted degree = static degree — same thing, per-constraint).
- `weighted_degree_of` sums **distinct constraints** via the adjacency (filtered to `|fut|>1`),
  not `degree_of` (which counts trigger occurrences); `degree_of` will be the brancher's tie-break.

## Deferred / notes

- The `dom_wdeg` brancher and the `solve_with` config surface (how you select the scheme, inject an
  initial `WeightingState`) are the next, more user-facing step — held for review.
- `variable_weighting.hh` is intentionally **not** yet in `gcs.hh`; it gains that once there's a
  wired consumer.
- When `ca.cd` / CHS land (Stage 2), the dense-storage + `weighted_degree_of` + `snapshot`/`load`
  common to all global schemes can be factored into a shared base; left concrete for now with one
  scheme in hand.

## Verification

Built under **GCC 15.2 and clang 21**; the new unit tests and the full `ctest` suite pass; **zero
proof impact** (no constraint identity or proof model changes, no consumer wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)