### PR TITLE
dom/wdeg brancher: variable_order::dom_wdeg (#315)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -439,6 +439,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(variable_weighting_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME variable_weighting_test COMMAND $<TARGET_FILE:variable_weighting_test>)
 
+    add_executable(search_heuristics_test search_heuristics_test.cc)
+    target_link_libraries(search_heuristics_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME search_heuristics_test COMMAND $<TARGET_FILE:search_heuristics_test>)
+
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -173,6 +173,40 @@ auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> Branch
     });
 }
 
+auto gcs::variable_order::dom_wdeg(const Problem & problem, optional<WeightingState> initial) -> BranchVariableHeuristic
+{
+    return dom_wdeg(problem.all_normal_variables(), move(initial));
+}
+
+auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<WeightingState> initial) -> BranchVariableHeuristic
+{
+    return [vars = move(vars), initial = move(initial)](
+               const Problem &, innards::State &, innards::Propagators & propagators) -> BranchVariableSelector {
+        auto weighting = make_shared<ClassicDomWDeg>(propagators);
+        if (initial)
+            weighting->load(*initial, propagators);
+        propagators.set_conflict_observer(weighting.get());
+
+        return variable_order::in_order_of(vars,
+            [weighting](const CurrentState & state, const innards::Propagators & p,
+                const IntegerVariableID & a, const IntegerVariableID & b) -> bool {
+                // Minimise dom(x)/W(x), cross-multiplied to avoid division: a
+                // variable with W(x)=0 (in no constraint with two or more
+                // unassigned variables) then sorts last for free. Tie-break on
+                // highest degree, matching dom_then_deg.
+                auto dom_a = static_cast<double>(state.domain_size(a).raw_value);
+                auto dom_b = static_cast<double>(state.domain_size(b).raw_value);
+                auto w_a = weighting->weighted_degree_of(state, p, a);
+                auto w_b = weighting->weighted_degree_of(state, p, b);
+                auto lhs = dom_a * w_b;
+                auto rhs = dom_b * w_a;
+                if (lhs != rhs)
+                    return lhs < rhs;
+                return p.degree_of(a) > p.degree_of(b);
+            });
+    };
+}
+
 auto gcs::variable_order::with_smallest_value(const Problem & problem) -> BranchVariableSelector
 {
     return with_smallest_value(problem.all_normal_variables());

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -1,11 +1,15 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SEARCH_HEURISTICS_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SEARCH_HEURISTICS_HH
 
+#include <gcs/innards/state-fwd.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
+#include <gcs/variable_weighting.hh>
 
 #include <cstdint>
 #include <functional>
+#include <optional>
+#include <vector>
 
 namespace gcs
 {
@@ -27,6 +31,25 @@ namespace gcs
      */
     using BranchVariableSelector = std::function<std::optional<IntegerVariableID>(
         const CurrentState &, const innards::Propagators &)>;
+
+    /**
+     * A variable-ordering heuristic that needs per-search setup before it can
+     * select: given a search's Problem, State, and Propagators, it does any
+     * one-time setup (for example a stateful heuristic constructing its weights
+     * and attaching itself as a conflict observer) and returns the
+     * BranchVariableSelector to branch with. Called once per search; in a
+     * parallel search, once per thread with that thread's own State and
+     * Propagators. A stateless ordering simply ignores the arguments and returns
+     * its selector.
+     *
+     * Currently only gcs::variable_order::dom_wdeg() returns one of these; the
+     * other gcs::variable_order:: orderings still return a BranchVariableSelector
+     * directly, pending a later migration to this shape.
+     *
+     * \ingroup SearchHeuristics
+     */
+    using BranchVariableHeuristic = std::function<BranchVariableSelector(
+        const Problem &, innards::State &, innards::Propagators &)>;
 
     /**
      * Given a branch variable, how do we branch on it? Usually this will be used via the gcs::branch_with()
@@ -123,6 +146,40 @@ namespace gcs
          * \sa gcs::branch_with()
          */
         [[nodiscard]] auto dom_then_deg(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+
+        /**
+         * \brief dom/wdeg: branch on the non-assigned variable minimising
+         * dom(x)/W(x), where W(x) is the weighted degree from a dynamic
+         * constraint weighting (classic dom/wdeg: Boussemart, Hemery, Lecoutre,
+         * Sais, ECAI 2004).
+         *
+         * Returns a BranchVariableHeuristic, not a bare selector: at search start
+         * it constructs a ClassicDomWDeg weighting (one weight per constraint,
+         * initialised to 1, bumped on each domain wipeout), attaches it as the
+         * Propagators' conflict observer, and returns the selector. Weights start
+         * uniform, so at the root the heuristic orders by dom(x)/degree(x) and it
+         * specialises towards hard constraints as conflicts accumulate. Ties are
+         * broken on highest constraint degree, and a variable with W(x)=0 (in no
+         * constraint with two or more unassigned variables) is least preferred.
+         *
+         * An optional initial WeightingState seeds the weights --- for carrying
+         * weights across searches or injecting proof-mined weights. Value
+         * ordering is chosen separately, as usual via gcs::branch_with().
+         *
+         * \ingroup SearchHeuristics
+         * \sa WeightingState
+         */
+        [[nodiscard]] auto dom_wdeg(const Problem &,
+            std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
+
+        /**
+         * \brief dom/wdeg over an explicit list of variables.
+         *
+         * \ingroup SearchHeuristics
+         * \sa gcs::variable_order::dom_wdeg(const Problem &, std::optional<WeightingState>)
+         */
+        [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
+            std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
          * Branch on non-assigned variables in this order.

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -1,0 +1,112 @@
+#include <gcs/constraint.hh>
+#include <gcs/current_state.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/variable_id.hh>
+#include <gcs/variable_weighting.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    auto a_propagator_that_does_nothing()
+    {
+        return [](const State &, auto &, ProofLogger * const) -> PropagatorState { return PropagatorState::Enable; };
+    }
+}
+
+// dom_wdeg's setup only uses the Propagators (it ignores the Problem and State),
+// so these tests drive it with a hand-built State + Propagators and an empty
+// dummy Problem for the unused argument, which gives full control over domains,
+// scopes, and weights.
+
+TEST_CASE("dom_wdeg orders by dom/W, with a zero-weight variable last")
+{
+    Problem dummy;
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4
+    auto b = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4
+    auto c = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4
+    auto d = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4, in no constraint
+    auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
+
+    Propagators propagators;
+    // a is in one constraint, b in two, c in three (each paired with x); weights
+    // are uniform at the root, so W(a)=1, W(b)=2, W(c)=3 and W(d)=0.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{4}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{5}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{6}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+
+    // dom/W: a=4/1=4, b=4/2=2, c=4/3 -> c is smallest.
+    auto selector = variable_order::dom_wdeg({a, b, c})(dummy, state, propagators);
+    auto picked = selector(state.current(), propagators);
+    REQUIRE(picked.has_value());
+    CHECK(*picked == IntegerVariableID{c});
+
+    // d has weighted degree 0, so dom/W is infinite: it is least preferred and a
+    // (finite ratio) wins.
+    auto with_isolated = variable_order::dom_wdeg({d, a})(dummy, state, propagators);
+    auto picked_isolated = with_isolated(state.current(), propagators);
+    REQUIRE(picked_isolated.has_value());
+    CHECK(*picked_isolated == IntegerVariableID{a});
+}
+
+TEST_CASE("dom_wdeg seeded weights change the choice")
+{
+    Problem dummy;
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto b = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto c = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{4}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{5}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{6}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+
+    // Without a seed, c wins (as above). Seeding a's only constraint heavily
+    // makes W(a)=10, so dom/W a=0.4 is now the smallest and a wins instead.
+    WeightingState seed;
+    seed.set_weight(NumberedConstraint{1}, 10.0);
+
+    auto selector = variable_order::dom_wdeg({a, b, c}, seed)(dummy, state, propagators);
+    auto picked = selector(state.current(), propagators);
+    REQUIRE(picked.has_value());
+    CHECK(*picked == IntegerVariableID{a});
+}
+
+TEST_CASE("dom_wdeg tie-breaks on degree")
+{
+    Problem dummy;
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto b = state.allocate_integer_variable_with_state(0_i, 3_i);
+
+    Propagators propagators;
+    // Both share the single constraint, so W(a)=W(b)=1 and dom/W ties. But a is
+    // registered on an extra trigger, giving it the higher degree, so the
+    // tie-break prefers it.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(),
+        Triggers{.on_change = {a, b}, .on_bounds = {a}});
+
+    REQUIRE(propagators.degree_of(a) > propagators.degree_of(b));
+
+    auto selector = variable_order::dom_wdeg({a, b})(dummy, state, propagators);
+    auto picked = selector(state.current(), propagators);
+    REQUIRE(picked.has_value());
+    CHECK(*picked == IntegerVariableID{a});
+}


### PR DESCRIPTION
## What

The **dom/wdeg brancher** for issue #315: `variable_order::dom_wdeg`, built on the Stage 1
weighting foundation (#321).

> Stacked on #321 → #318 → `main`. Bases auto-retarget as each lands.

## Changes (two commits)

1. **`variable_order::dom_wdeg` + a new `BranchVariableHeuristic` type.**
   - `BranchVariableHeuristic = function<BranchVariableSelector(const Problem&, State&, Propagators&)>`
     — the "do per-search setup, then return the selector" shape a *stateful* heuristic needs.
     Called once per search; in a parallel search, once per thread with that thread's own
     `State`/`Propagators`, each owning its own weighting.
   - `dom_wdeg(...)`'s setup constructs a `ClassicDomWDeg` (optionally seeded from an initial
     `WeightingState`), attaches it as the `Propagators`' conflict observer, and returns a
     selector that branches on the variable minimising `dom(x)/W(x)` — cross-multiplied
     (`dom(a)·W(b) < dom(b)·W(a)`) so there's no division and a `W=0` variable sorts last for
     free, with a highest-degree tie-break matching `dom_then_deg`. Weights start uniform, so
     at the root it orders by `dom(x)/degree(x)` and specialises as conflicts accumulate.
2. **Test** (`gcs/search_heuristics_test.cc`) — drives the selector directly: root ordering by
   `dom/W` with a zero-weight variable last; a seeded `WeightingState` shifting the choice to
   the now-heaviest variable; and the degree tie-break.

## Deliberately not done here

- The other `variable_order::*` orderings still return a bare `BranchVariableSelector`. The
  per-node branch hook (`BranchCallback` / `SolveCallbacks::branch`) is typed
  `(const CurrentState&, const Propagators&)` — **const** `Propagators`, no `Problem` — so it
  can't host a stateful heuristic's setup; migrating cleanly means lifting setup into
  `solve_with` and changing `SolveCallbacks` + `branch_with` + the example call sites. That
  migration (and the build-once `solve_with` restructure, and the public way to *select*
  `dom_wdeg`) is a deliberate later step, once the interface has settled — kept out of this PR
  to avoid churning the public API and the ~7 examples while it might still move. So `dom_wdeg`
  is **not yet wired into `solve_with`'s defaults**; it is exercised directly for now.

## Verification

Built under **GCC 15.2 and clang 21**; the new test and the full `ctest` suite pass. No
behaviour or proof change (no consumer wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)