### PR TITLE
Migrate variable orderings to setup-then-select; wire dom_wdeg into solve (#315)

### DIFF
--- a/gcs/innards/proofs/range_witness_w1_test.cc
+++ b/gcs/innards/proofs/range_witness_w1_test.cc
@@ -22,15 +22,17 @@ namespace
     // Scripted first decision: where `var` is undecided and still has value 0,
     // branch var != 0 then var == 0 (only the root qualifies here); elsewhere fall
     // through to the default heuristic via branch_sequence.
-    auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchCallback
+    auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchHeuristic
     {
-        return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
-            return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
-                if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
-                    co_yield var != 0_i;
-                    co_yield var == 0_i;
-                }
-            }(state, var);
+        return [var](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
+                    if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
+                        co_yield var != 0_i;
+                        co_yield var == 0_i;
+                    }
+                }(state, var);
+            };
         };
     }
 }

--- a/gcs/innards/proofs/range_witness_w2_test.cc
+++ b/gcs/innards/proofs/range_witness_w2_test.cc
@@ -19,15 +19,17 @@ using std::vector;
 // one vocabulary mode do not transfer.
 namespace
 {
-    auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchCallback
+    auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchHeuristic
     {
-        return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
-            return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
-                if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
-                    co_yield var != 0_i;
-                    co_yield var == 0_i;
-                }
-            }(state, var);
+        return [var](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
+                    if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
+                        co_yield var != 0_i;
+                        co_yield var == 0_i;
+                    }
+                }(state, var);
+            };
         };
     }
 }

--- a/gcs/innards/proofs/range_witness_w3_test.cc
+++ b/gcs/innards/proofs/range_witness_w3_test.cc
@@ -17,15 +17,17 @@ using std::vector;
 // backtrack replay falsify it by unit propagation.
 namespace
 {
-    auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchCallback
+    auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchHeuristic
     {
-        return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
-            return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
-                if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
-                    co_yield var != 0_i;
-                    co_yield var == 0_i;
-                }
-            }(state, var);
+        return [var](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
+            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
+                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
+                    if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
+                        co_yield var != 0_i;
+                        co_yield var == 0_i;
+                    }
+                }(state, var);
+            };
         };
     }
 }

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -31,13 +31,14 @@ namespace
 {
     auto solve_subproblem(unsigned depth, SimpleTuples & tuples, const vector<IntegerVariableID> & vars,
         Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
+        const BranchCallback & branch_callback,
         ProofLogger * const logger, SimpleIntegerVariableID selector_var_id) -> void
     {
         if (logger)
             logger->enter_proof_level(depth + 1);
 
         if (propagators.propagate(this_branch_guess, state, logger)) {
-            auto brancher = branch_with(variable_order::dom_then_deg(vars), value_order::smallest_first())(state.current(), propagators);
+            auto brancher = branch_callback(state.current(), propagators);
             auto branch_iter = brancher.begin();
             if (branch_iter == brancher.end()) {
                 vector<Integer> tuple;
@@ -73,7 +74,7 @@ namespace
                     auto timestamp = state.new_epoch();
                     auto branch = *branch_iter;
                     state.guess(branch);
-                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch, logger, selector_var_id);
+                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch, branch_callback, logger, selector_var_id);
                     state.backtrack(timestamp);
                 }
             }
@@ -90,9 +91,13 @@ namespace
     }
 }
 
-auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
+auto AutoTable::run(Problem & problem, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
 {
     SimpleTuples tuples;
+
+    // dom_then_deg is stateless, so its setup is a no-op; build the per-node
+    // callback once and reuse it down the subproblem recursion.
+    auto branch_callback = branch_with(variable_order::dom_then_deg(_vars), value_order::smallest_first())(problem, initial_state, propagators);
 
     auto timestamp = initial_state.new_epoch(true);
     initial_state.guess(TrueLiteral{});
@@ -100,7 +105,7 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
     auto selector_var_id = initial_state.what_variable_id_will_be_created_next();
     if (logger)
         logger->emit_proof_comment("starting autotabulation");
-    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, logger, selector_var_id);
+    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, branch_callback, logger, selector_var_id);
 
     if (logger)
         logger->emit_proof_comment("creating autotable with " + to_string(tuples.size()) + " entries");

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -40,37 +40,46 @@ namespace
 
 using namespace gcs;
 
-auto gcs::branch_with(BranchVariableSelector var, BranchValueGenerator val) -> BranchCallback
+auto gcs::branch_with(BranchVariableHeuristic var, BranchValueGenerator val) -> BranchHeuristic
 {
-    return [var = move(var), val = move(val)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, const innards::Propagators & p,
-                   BranchVariableSelector select_var, BranchValueGenerator make_val_gen) -> generator<IntegerVariableCondition> {
-            auto branch_var = select_var(s, p);
-            if (branch_var)
-                return make_val_gen(s, p, *branch_var);
-            else
-                return []() -> generator<IntegerVariableCondition> { co_return; }();
-        }(s, p, move(var), move(val));
+    return [var = move(var), val = move(val)](const Problem & problem, innards::State & state, innards::Propagators & propagators) -> BranchCallback {
+        // Run the variable heuristic's per-search setup once, then reuse the
+        // resulting selector at every node.
+        auto select_var = var(problem, state, propagators);
+        return [select_var = move(select_var), val = val](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
+            return [](const CurrentState & s, const innards::Propagators & p,
+                       BranchVariableSelector select_var, BranchValueGenerator make_val_gen) -> generator<IntegerVariableCondition> {
+                auto branch_var = select_var(s, p);
+                if (branch_var)
+                    return make_val_gen(s, p, *branch_var);
+                else
+                    return []() -> generator<IntegerVariableCondition> { co_return; }();
+            }(s, p, select_var, val);
+        };
     };
 }
 
-auto gcs::branch_sequence(BranchCallback a, BranchCallback b) -> BranchCallback
+auto gcs::branch_sequence(BranchHeuristic a, BranchHeuristic b) -> BranchHeuristic
 {
-    return [a = move(a), b = move(b)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a, BranchCallback b) -> generator<IntegerVariableCondition> {
-            auto gen_a = a(s, p);
-            auto iter_a = gen_a.begin();
-            if (iter_a != gen_a.end()) {
-                for (; iter_a != gen_a.end(); ++iter_a)
-                    co_yield *iter_a;
-            }
-            else {
-                auto gen_b = b(s, p);
-                auto iter_b = gen_b.begin();
-                for (; iter_b != gen_b.end(); ++iter_b)
-                    co_yield *iter_b;
-            }
-        }(s, p, move(a), move(b));
+    return [a = move(a), b = move(b)](const Problem & problem, innards::State & state, innards::Propagators & propagators) -> BranchCallback {
+        auto callback_a = a(problem, state, propagators);
+        auto callback_b = b(problem, state, propagators);
+        return [callback_a = move(callback_a), callback_b = move(callback_b)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
+            return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a, BranchCallback b) -> generator<IntegerVariableCondition> {
+                auto gen_a = a(s, p);
+                auto iter_a = gen_a.begin();
+                if (iter_a != gen_a.end()) {
+                    for (; iter_a != gen_a.end(); ++iter_a)
+                        co_yield *iter_a;
+                }
+                else {
+                    auto gen_b = b(s, p);
+                    auto iter_b = gen_b.begin();
+                    for (; iter_b != gen_b.end(); ++iter_b)
+                        co_yield *iter_b;
+                }
+            }(s, p, callback_a, callback_b);
+        };
     };
 }
 
@@ -92,53 +101,68 @@ namespace
             }
         };
     }
+
+    auto in_order_of_selector(vector<IntegerVariableID> vars, variable_order::VariableComparator comp) -> BranchVariableSelector
+    {
+        return [vars = move(vars), comp = move(comp)](
+                   const CurrentState & state, const innards::Propagators & propagators) -> optional<IntegerVariableID> {
+            optional<IntegerVariableID> result;
+            for (auto & v : vars) {
+                auto size = state.domain_size(v);
+                if (size < 2_i)
+                    continue;
+                if ((! result) || comp(state, propagators, v, *result))
+                    result = v;
+            }
+            return result;
+        };
+    }
+
+    // Wrap a stateless selector (one needing no per-search setup) as a
+    // BranchVariableHeuristic: the setup ignores its arguments and just returns
+    // the selector.
+    auto as_heuristic(BranchVariableSelector selector) -> BranchVariableHeuristic
+    {
+        return [selector = move(selector)](const Problem &, innards::State &, innards::Propagators &) -> BranchVariableSelector {
+            return selector;
+        };
+    }
 }
 
-auto gcs::variable_order::random(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::random(const Problem & problem) -> BranchVariableHeuristic
 {
     return variable_order::random(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::random(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::random(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
-    return random_variable_selector(move(vars), make_shared_rng());
+    return as_heuristic(random_variable_selector(move(vars), make_shared_rng()));
 }
 
-auto gcs::variable_order::random(const Problem & problem, uint_fast32_t seed) -> BranchVariableSelector
+auto gcs::variable_order::random(const Problem & problem, uint_fast32_t seed) -> BranchVariableHeuristic
 {
     return variable_order::random(problem.all_normal_variables(), seed);
 }
 
-auto gcs::variable_order::random(vector<IntegerVariableID> vars, uint_fast32_t seed) -> BranchVariableSelector
+auto gcs::variable_order::random(vector<IntegerVariableID> vars, uint_fast32_t seed) -> BranchVariableHeuristic
 {
-    return random_variable_selector(move(vars), make_shared_rng(seed));
+    return as_heuristic(random_variable_selector(move(vars), make_shared_rng(seed)));
 }
 
-auto gcs::variable_order::in_order_of(const Problem & problem, VariableComparator comp) -> BranchVariableSelector
+auto gcs::variable_order::in_order_of(const Problem & problem, VariableComparator comp) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(problem.all_normal_variables(), move(comp));
 }
 
-auto gcs::variable_order::in_order_of(vector<IntegerVariableID> vars, VariableComparator comp) -> BranchVariableSelector
+auto gcs::variable_order::in_order_of(vector<IntegerVariableID> vars, VariableComparator comp) -> BranchVariableHeuristic
 {
-    return [vars = move(vars), comp = move(comp)](
-               const CurrentState & state, const innards::Propagators & propagators) -> optional<IntegerVariableID> {
-        optional<IntegerVariableID> result;
-        for (auto & v : vars) {
-            auto size = state.domain_size(v);
-            if (size < 2_i)
-                continue;
-            if ((! result) || comp(state, propagators, v, *result))
-                result = v;
-        }
-        return result;
-    };
+    return as_heuristic(in_order_of_selector(move(vars), move(comp)));
 }
 
-auto gcs::variable_order::in_order(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::in_order(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
-    return [vars = move(vars)](
-               const CurrentState & state, const innards::Propagators &) -> optional<IntegerVariableID> {
+    return as_heuristic([vars = move(vars)](
+                            const CurrentState & state, const innards::Propagators &) -> optional<IntegerVariableID> {
         for (auto & v : vars) {
             auto size = state.domain_size(v);
             if (size < 2_i)
@@ -146,27 +170,27 @@ auto gcs::variable_order::in_order(vector<IntegerVariableID> vars) -> BranchVari
             return v;
         }
         return nullopt;
-    };
+    });
 }
 
-auto gcs::variable_order::dom(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::dom(const Problem & problem) -> BranchVariableHeuristic
 {
     return dom(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::dom(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::dom(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(vars, [](const CurrentState & state, const innards::Propagators &, const IntegerVariableID & a, const IntegerVariableID & b) {
         return state.domain_size(a) < state.domain_size(b);
     });
 }
 
-auto gcs::variable_order::dom_then_deg(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::dom_then_deg(const Problem & problem) -> BranchVariableHeuristic
 {
     return dom_then_deg(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(vars, [](const CurrentState & state, const innards::Propagators & p, const IntegerVariableID & a, const IntegerVariableID & b) {
         return tuple{state.domain_size(a), -p.degree_of(a)} < tuple{state.domain_size(b), -p.degree_of(b)};
@@ -187,7 +211,7 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<Weig
             weighting->load(*initial, propagators);
         propagators.set_conflict_observer(weighting.get());
 
-        return variable_order::in_order_of(vars,
+        return in_order_of_selector(vars,
             [weighting](const CurrentState & state, const innards::Propagators & p,
                 const IntegerVariableID & a, const IntegerVariableID & b) -> bool {
                 // Minimise dom(x)/W(x), cross-multiplied to avoid division: a
@@ -207,12 +231,12 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<Weig
     };
 }
 
-auto gcs::variable_order::with_smallest_value(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::with_smallest_value(const Problem & problem) -> BranchVariableHeuristic
 {
     return with_smallest_value(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::with_smallest_value(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::with_smallest_value(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(vars, [](const CurrentState & state, const innards::Propagators &, const IntegerVariableID & a, const IntegerVariableID & b) {
         return state.lower_bound(a) < state.lower_bound(b);

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -40,11 +40,8 @@ namespace gcs
      * BranchVariableSelector to branch with. Called once per search; in a
      * parallel search, once per thread with that thread's own State and
      * Propagators. A stateless ordering simply ignores the arguments and returns
-     * its selector.
-     *
-     * Currently only gcs::variable_order::dom_wdeg() returns one of these; the
-     * other gcs::variable_order:: orderings still return a BranchVariableSelector
-     * directly, pending a later migration to this shape.
+     * its selector; a stateful one (gcs::variable_order::dom_wdeg) uses them.
+     * Every gcs::variable_order:: ordering returns one of these.
      *
      * \ingroup SearchHeuristics
      */
@@ -65,20 +62,20 @@ namespace gcs
         const CurrentState &, const innards::Propagators &, const IntegerVariableID &)>;
 
     /**
-     * Combine a BranchVariableSelector from gcs::variable_order:: with a BranchValueGenerator
-     * from gcs::value_order:: to produce a BranchCallback for SolveCallbacks.
+     * Combine a BranchVariableHeuristic from gcs::variable_order:: with a BranchValueGenerator
+     * from gcs::value_order:: to produce a BranchHeuristic for SolveCallbacks.
      *
      * \ingroup SearchHeuristics
      */
-    [[nodiscard]] auto branch_with(BranchVariableSelector, BranchValueGenerator) -> BranchCallback;
+    [[nodiscard]] auto branch_with(BranchVariableHeuristic, BranchValueGenerator) -> BranchHeuristic;
 
     /**
-     * Combine two BranchCallback instances, first trying the first instance, and if it returns
-     * nullopt, instead trying the second instance.
+     * Combine two BranchHeuristic instances, first trying the first instance, and if it returns
+     * nullopt, instead trying the second instance. (Both are set up once per search.)
      *
      * \ingroup SearchHeuristics
      */
-    [[nodiscard]] auto branch_sequence(BranchCallback, BranchCallback) -> BranchCallback;
+    [[nodiscard]] auto branch_sequence(BranchHeuristic, BranchHeuristic) -> BranchHeuristic;
 
     /**
      * Variable ordering heuristics.
@@ -103,7 +100,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto in_order_of(const Problem &, VariableComparator) -> BranchVariableSelector;
+        [[nodiscard]] auto in_order_of(const Problem &, VariableComparator) -> BranchVariableHeuristic;
 
         /**
          * Branch on the smallest non-assigned variable wrt this comparator.
@@ -111,7 +108,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto in_order_of(std::vector<IntegerVariableID>, VariableComparator) -> BranchVariableSelector;
+        [[nodiscard]] auto in_order_of(std::vector<IntegerVariableID>, VariableComparator) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain.
@@ -119,7 +116,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto dom(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain.
@@ -127,7 +124,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto dom(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain, tie-breaking on highest
@@ -136,7 +133,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom_then_deg(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto dom_then_deg(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain, tie-breaking on highest
@@ -145,7 +142,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom_then_deg(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto dom_then_deg(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * \brief dom/wdeg: branch on the non-assigned variable minimising
@@ -187,7 +184,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto in_order(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto in_order(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the smallest value in its domain.
@@ -195,7 +192,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_smallest_value(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto with_smallest_value(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the smallest value in its domain.
@@ -203,7 +200,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_smallest_value(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto with_smallest_value(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the largest value in its domain.
@@ -211,7 +208,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_largest_value(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto with_largest_value(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the largest value in its domain.
@@ -219,7 +216,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_largest_value(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto with_largest_value(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, seeded non-deterministically.
@@ -227,7 +224,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto random(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, seeded non-deterministically.
@@ -235,7 +232,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto random(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, with an explicit seed for
@@ -244,7 +241,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(const Problem &, std::uint_fast32_t seed) -> BranchVariableSelector;
+        [[nodiscard]] auto random(const Problem &, std::uint_fast32_t seed) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, with an explicit seed for
@@ -253,7 +250,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(std::vector<IntegerVariableID>, std::uint_fast32_t seed) -> BranchVariableSelector;
+        [[nodiscard]] auto random(std::vector<IntegerVariableID>, std::uint_fast32_t seed) -> BranchVariableHeuristic;
     }
 
     /**

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -1,9 +1,11 @@
 #include <gcs/constraint.hh>
+#include <gcs/constraints/equals.hh>
 #include <gcs/current_state.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
 #include <gcs/variable_id.hh>
 #include <gcs/variable_weighting.hh>
 
@@ -109,4 +111,28 @@ TEST_CASE("dom_wdeg tie-breaks on degree")
     auto picked = selector(state.current(), propagators);
     REQUIRE(picked.has_value());
     CHECK(*picked == IntegerVariableID{a});
+}
+
+TEST_CASE("dom_wdeg wired into solve_with finds every solution")
+{
+    // An all-different triangle over {1,2,3}: the six permutations. dom/wdeg only
+    // changes branch order, so a complete search must still enumerate them all --
+    // this exercises the whole wiring: selection via callbacks.branch, the
+    // once-per-search setup in solve_with, and the conflict observer driving the
+    // weights during search.
+    Problem problem;
+    auto a = problem.create_integer_variable(1_i, 3_i);
+    auto b = problem.create_integer_variable(1_i, 3_i);
+    auto c = problem.create_integer_variable(1_i, 3_i);
+    problem.post(NotEquals{a, b});
+    problem.post(NotEquals{b, c});
+    problem.post(NotEquals{a, c});
+
+    int solutions = 0;
+    solve_with(problem,
+        SolveCallbacks{
+            .solution = [&](const CurrentState &) -> bool { ++solutions; return true; },
+            .branch = branch_with(variable_order::dom_wdeg(problem), value_order::smallest_first())});
+
+    CHECK(solutions == 6);
 }

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -32,6 +32,7 @@ namespace
     auto solve_with_state(unsigned long long depth, Stats & stats, Problem & problem,
         Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
         SolveCallbacks & callbacks,
+        const BranchCallback & branch_callback,
         ProofLogger * const logger,
         bool & this_subtree_contains_solution,
         Integer & number_of_solutions,
@@ -54,10 +55,7 @@ namespace
             if (optional_abort_flag && optional_abort_flag->load())
                 return false;
 
-            auto create_branch_generator = callbacks.branch
-                ? callbacks.branch
-                : branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
-            auto branch_generator = create_branch_generator(state.current(), propagators);
+            auto branch_generator = branch_callback(state.current(), propagators);
             auto branch_iter = branch_generator.begin();
 
             if (branch_iter == branch_generator.end()) {
@@ -93,7 +91,7 @@ namespace
                     state.guess(guess);
                     bool child_contains_solution = false;
                     if (! solve_with_state(depth + 1, stats, problem, propagators, state, guess,
-                            callbacks, logger, child_contains_solution, number_of_solutions, objective_value, optional_abort_flag))
+                            callbacks, branch_callback, logger, child_contains_solution, number_of_solutions, objective_value, optional_abort_flag))
                         result = false;
 
                     if (child_contains_solution)
@@ -179,7 +177,18 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
         bool child_contains_solution = false;
         Integer number_of_solutions = 0_i;
         optional<Integer> objective_value = nullopt;
-        if (solve_with_state(0, stats, problem, propagators, state, nullopt, callbacks, optional_proof ? optional_proof->logger() : nullptr,
+
+        // Run the branching heuristic's per-search setup once, now that
+        // propagators (and any presolver-added constraints) are final, so a
+        // stateful heuristic sizes and attaches itself correctly; the resulting
+        // per-node BranchCallback is reused throughout the search.
+        auto branch_heuristic = callbacks.branch
+            ? callbacks.branch
+            : branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
+        auto branch_callback = branch_heuristic(problem, state, propagators);
+
+        if (solve_with_state(0, stats, problem, propagators, state, nullopt, callbacks, branch_callback,
+                optional_proof ? optional_proof->logger() : nullptr,
                 child_contains_solution, number_of_solutions, objective_value, optional_abort_flag)) {
             if (optional_proof) {
                 if (problem.optional_minimise_variable()) {

--- a/gcs/solve.hh
+++ b/gcs/solve.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SOLVE_HH
 
 #include <gcs/current_state.hh>
+#include <gcs/innards/state-fwd.hh>
 #include <gcs/problem.hh>
 #include <gcs/proof.hh>
 #include <gcs/stats.hh>
@@ -54,6 +55,24 @@ namespace gcs
     using BranchCallback = std::function<std::generator<IntegerVariableCondition>(const CurrentState &, const innards::Propagators &)>;
 
     /**
+     * \brief The branching heuristic for gcs::solve_with(): given a search's
+     * Problem, State, and Propagators, it does any one-time per-search setup and
+     * returns the per-node BranchCallback to branch with.
+     *
+     * solve_with() calls it exactly once, after propagators are built, so a
+     * stateful heuristic (for example dom/wdeg) can construct its state and
+     * attach itself as a conflict observer before search begins; the returned
+     * BranchCallback is then reused at every node. A stateless heuristic ignores
+     * the arguments and returns its callback. gcs::branch_with() produces one of
+     * these from a gcs::variable_order:: heuristic and a gcs::value_order::
+     * generator.
+     *
+     * \ingroup SolveCallbacks
+     * \sa SearchHeuristics
+     */
+    using BranchHeuristic = std::function<BranchCallback(const Problem &, innards::State &, innards::Propagators &)>;
+
+    /**
      * \brief Called by gcs::solve_with() after the proof has been started.
      *
      * \ingroup SolveCallbacks
@@ -79,7 +98,7 @@ namespace gcs
     {
         SolutionCallback solution = SolutionCallback{};
         TraceCallback trace = TraceCallback{};
-        BranchCallback branch = BranchCallback{};
+        BranchHeuristic branch = BranchHeuristic{};
         AfterProofStartedCallback after_proof_started = AfterProofStartedCallback{};
         CompletedCallback completed = CompletedCallback{};
     };

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -841,13 +841,13 @@ auto main(int argc, char * argv[]) -> int
         else
             throw FlatZincInterfaceError{format("Unknown solve method {} in {}", string{solve_method}, fznname)};
 
-        BranchCallback brancher = branch_sequence(
+        BranchHeuristic brancher = branch_sequence(
             branch_with(variable_order::dom_then_deg(data.branch_variables), value_order::smallest_first()),
             branch_with(variable_order::dom_then_deg(data.all_variables), value_order::smallest_first()));
 
         if ((! free_search) && fzn["solve"].contains("ann")) {
-            function<optional<BranchCallback>(const nlohmann::json &)> parse_search;
-            parse_search = [&data, &parse_search, &random_seed](const nlohmann::json & ann) -> optional<BranchCallback> {
+            function<optional<BranchHeuristic>(const nlohmann::json &)> parse_search;
+            parse_search = [&data, &parse_search, &random_seed](const nlohmann::json & ann) -> optional<BranchHeuristic> {
                 if (ann["id"] == "bool_search" || ann["id"] == "int_search") {
                     auto args = ann["args"];
                     vector<IntegerVariableID> vars = arg_as_array_of_var(data, args, 0);
@@ -855,7 +855,7 @@ auto main(int argc, char * argv[]) -> int
                     string val_heuristic = args[2];
                     string method = args[3];
 
-                    BranchVariableSelector var;
+                    BranchVariableHeuristic var;
                     if (var_heuristic == "first_fail")
                         var = variable_order::dom(vars);
                     else if (var_heuristic == "input_order")
@@ -902,7 +902,7 @@ auto main(int argc, char * argv[]) -> int
                     return branch_with(var, val);
                 }
                 else if (ann["id"] == "seq_search") {
-                    optional<BranchCallback> branch_seq;
+                    optional<BranchHeuristic> branch_seq;
                     for (const auto & sub_ann : ann["args"][0]) {
                         auto subsearch = parse_search(sub_ann);
                         if (subsearch) {


### PR DESCRIPTION
## What

The interface migration that makes **dom/wdeg a first-class, selectable variable ordering** —
and, with it, the `solve_with` build-once restructure. This is the deferred wiring step from the
dom/wdeg brancher PR (#322); after this, `dom_wdeg` actually runs in a solve.

> Stacked on #322 → #321 → #318 → `main`. @mmcilree — this touches the solve path (`SolveCallbacks`,
> `branch_with`, `solve.cc`) that #302 also touches; happy to coordinate the rebase order.

## Changes (two commits)

1. **Migrate variable-ordering heuristics to the setup→select shape.**
   - Every `gcs::variable_order::*` ordering now returns a `BranchVariableHeuristic`
     (`function<BranchVariableSelector(const Problem&, State&, Propagators&)>`) instead of a bare
     `BranchVariableSelector`. A stateful ordering (dom_wdeg) does its per-search setup here; a
     stateless one is wrapped via a small `as_heuristic()` helper.
   - `branch_with` returns a `BranchHeuristic` (`function<BranchCallback(const Problem&, State&,
     Propagators&)>`), `branch_sequence` chains `BranchHeuristic`s, and `SolveCallbacks::branch` is
     a `BranchHeuristic`.
   - **`solve_with` runs the heuristic's setup exactly once**, after propagators (and any
     presolver-added constraints) are final, and reuses the resulting per-node `BranchCallback` at
     every node. Previously the brancher was rebuilt every node — which would have reconstructed a
     stateful weighting (losing its accumulated weights) on each recursion. The autotabulation
     presolver gets the same once-then-reuse treatment, and the MiniZinc frontend's
     search-annotation branchers move to the new types.
2. **End-to-end test** — an all-different triangle solved under `dom_wdeg` enumerates all six
   permutations, exercising selection via `callbacks.branch`, the once-per-search setup, and the
   conflict observer driving the weights.

## Behaviour-preserving

Stateless orderings wrap their existing selector, so the default search and every example/test
that builds a brancher with `branch_with(variable_order::X, value_order::Y)` are unchanged — those
call sites compile as-is (the input and output types moved together). Full `ctest` is unchanged at
329/329.

`dom_wdeg` is now selectable like any other ordering:
```cpp
solve_with(problem, SolveCallbacks{
    .branch = branch_with(variable_order::dom_wdeg(problem), value_order::smallest_first())});
```

## Deliberately not here

- The MiniZinc `dom_w_deg` search annotation still maps to `dom_then_deg` (as before): wiring it to
  real `dom_wdeg` raises a multi-observer question (several stateful branchers in a `seq_search`
  would share one `Propagators` observer slot), which is its own follow-up.
- Per-thread RNG independence for `variable_order::random` under the new per-thread-call model is
  unchanged (still a shared RNG, as before) — a separate, minor concern.

## Verification

Built under **GCC 15.2 and clang 21** (all targets — library, examples, MiniZinc frontend, tests);
`ctest` 329/329; the new end-to-end test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)