### PR TITLE
Stage 2 (part 1): Conflict-History Search + scheme selector (#315)

### DIFF
--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -197,16 +197,25 @@ auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> Branch
     });
 }
 
-auto gcs::variable_order::dom_wdeg(const Problem & problem, optional<WeightingState> initial) -> BranchVariableHeuristic
+auto gcs::variable_order::dom_wdeg(const Problem & problem, WeightingScheme scheme, optional<WeightingState> initial) -> BranchVariableHeuristic
 {
-    return dom_wdeg(problem.all_normal_variables(), move(initial));
+    return dom_wdeg(problem.all_normal_variables(), scheme, move(initial));
 }
 
-auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<WeightingState> initial) -> BranchVariableHeuristic
+auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingScheme scheme, optional<WeightingState> initial) -> BranchVariableHeuristic
 {
-    return [vars = move(vars), initial = move(initial)](
+    return [vars = move(vars), scheme, initial = move(initial)](
                const Problem &, innards::State &, innards::Propagators & propagators) -> BranchVariableSelector {
-        auto weighting = make_shared<ClassicDomWDeg>(propagators);
+        shared_ptr<VariableWeighting> weighting;
+        switch (scheme) {
+            using enum WeightingScheme;
+        case Classic:
+            weighting = make_shared<ClassicDomWDeg>(propagators);
+            break;
+        case Chs:
+            weighting = make_shared<ConflictHistorySearch>(propagators);
+            break;
+        }
         if (initial)
             weighting->load(*initial, propagators);
         propagators.set_conflict_observer(weighting.get());

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -212,8 +212,10 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingSche
         case Classic:
             weighting = make_shared<ClassicDomWDeg>(propagators);
             break;
-        case Chs:
-            weighting = make_shared<ConflictHistorySearch>(propagators);
+        case ConflictHistorySearch:
+            // Qualified: the WeightingScheme::ConflictHistorySearch enumerator
+            // (via using enum) otherwise shadows the class of the same name.
+            weighting = make_shared<gcs::ConflictHistorySearch>(propagators);
             break;
         }
         if (initial)

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -147,35 +147,36 @@ namespace gcs
         /**
          * \brief dom/wdeg: branch on the non-assigned variable minimising
          * dom(x)/W(x), where W(x) is the weighted degree from a dynamic
-         * constraint weighting (classic dom/wdeg: Boussemart, Hemery, Lecoutre,
-         * Sais, ECAI 2004).
+         * constraint weighting.
          *
          * Returns a BranchVariableHeuristic, not a bare selector: at search start
-         * it constructs a ClassicDomWDeg weighting (one weight per constraint,
-         * initialised to 1, bumped on each domain wipeout), attaches it as the
-         * Propagators' conflict observer, and returns the selector. Weights start
-         * uniform, so at the root the heuristic orders by dom(x)/degree(x) and it
-         * specialises towards hard constraints as conflicts accumulate. Ties are
-         * broken on highest constraint degree, and a variable with W(x)=0 (in no
-         * constraint with two or more unassigned variables) is least preferred.
+         * it constructs the weighting for the chosen WeightingScheme, attaches it
+         * as the Propagators' conflict observer, and returns the selector. Ties
+         * are broken on highest constraint degree, and a variable with W(x)=0 (in
+         * no constraint with two or more unassigned variables) is least preferred.
          *
-         * An optional initial WeightingState seeds the weights --- for carrying
-         * weights across searches or injecting proof-mined weights. Value
-         * ordering is chosen separately, as usual via gcs::branch_with().
+         * \p scheme selects the weighting (default WeightingScheme::Classic, the
+         * original dom/wdeg). An optional initial WeightingState seeds the weights
+         * --- for carrying weights across searches or injecting proof-mined
+         * weights. Value ordering is chosen separately, as usual via
+         * gcs::branch_with().
          *
          * \ingroup SearchHeuristics
          * \sa WeightingState
+         * \sa WeightingScheme
          */
         [[nodiscard]] auto dom_wdeg(const Problem &,
+            WeightingScheme scheme = WeightingScheme::Classic,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
          * \brief dom/wdeg over an explicit list of variables.
          *
          * \ingroup SearchHeuristics
-         * \sa gcs::variable_order::dom_wdeg(const Problem &, std::optional<WeightingState>)
+         * \sa gcs::variable_order::dom_wdeg(const Problem &, WeightingScheme, std::optional<WeightingState>)
          */
         [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
+            WeightingScheme scheme = WeightingScheme::Classic,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -121,7 +121,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
-    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::Chs);
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::ConflictHistorySearch);
 
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -10,6 +10,7 @@
 #include <gcs/variable_weighting.hh>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <optional>
 
@@ -85,7 +86,7 @@ TEST_CASE("dom_wdeg seeded weights change the choice")
     WeightingState seed;
     seed.set_weight(NumberedConstraint{1}, 10.0);
 
-    auto selector = variable_order::dom_wdeg({a, b, c}, seed)(dummy, state, propagators);
+    auto selector = variable_order::dom_wdeg({a, b, c}, WeightingScheme::Classic, seed)(dummy, state, propagators);
     auto picked = selector(state.current(), propagators);
     REQUIRE(picked.has_value());
     CHECK(*picked == IntegerVariableID{a});
@@ -120,6 +121,8 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::Chs);
+
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);
     auto b = problem.create_integer_variable(1_i, 3_i);
@@ -132,7 +135,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     solve_with(problem,
         SolveCallbacks{
             .solution = [&](const CurrentState &) -> bool { ++solutions; return true; },
-            .branch = branch_with(variable_order::dom_wdeg(problem), value_order::smallest_first())});
+            .branch = branch_with(variable_order::dom_wdeg(problem, scheme), value_order::smallest_first())});
 
     CHECK(solutions == 6);
 }

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -5,6 +5,7 @@
 #include <util/overloaded.hh>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <optional>
 
@@ -14,9 +15,21 @@ using namespace gcs::innards;
 using std::max;
 using std::nullopt;
 using std::optional;
+using std::pow;
 using std::size_t;
 using std::unordered_map;
 using std::vector;
+
+namespace
+{
+    // Conflict-History Search tunables (Habet & Terrioux). These are defaults to
+    // be auto-tuned, not design choices.
+    constexpr double chs_alpha_initial = 0.4;
+    constexpr double chs_alpha_minimum = 0.06;
+    constexpr double chs_alpha_decay = 1.0e-6;
+    constexpr double chs_delta = 1.0e-4;
+    constexpr double chs_smoothing_base = 0.995;
+}
 
 auto WeightingState::weight_of(const ConstraintID & constraint_id) const -> double
 {
@@ -61,18 +74,18 @@ auto WeightingState::constraint_weights() const -> const unordered_map<Constrain
     return _constraint_weights;
 }
 
-ClassicDomWDeg::ClassicDomWDeg(const Propagators & propagators) :
-    _weights(propagators.number_of_constraints(), 1.0)
+DenseConstraintWeighting::DenseConstraintWeighting(const Propagators & propagators, double default_weight) :
+    _weights(propagators.number_of_constraints(), default_weight),
+    _default_weight(default_weight)
 {
 }
 
-auto ClassicDomWDeg::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
-    const optional<ReasonFunction> &, const State &) -> void
+auto DenseConstraintWeighting::contribution_of(int constraint_index) const -> double
 {
-    _weights[constraint_index] += 1.0;
+    return _weights[constraint_index];
 }
 
-auto ClassicDomWDeg::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
+auto DenseConstraintWeighting::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
     IntegerVariableID var) const -> double
 {
     auto simple = overloaded{
@@ -95,9 +108,36 @@ auto ClassicDomWDeg::weighted_degree_of(const CurrentState & state, const Propag
                     break;
         }
         if (futures >= 2)
-            total += _weights[constraint_index];
+            total += contribution_of(constraint_index);
     }
     return total;
+}
+
+auto DenseConstraintWeighting::snapshot(const Propagators & propagators) const -> WeightingState
+{
+    WeightingState result;
+    for (size_t c = 0; c < _weights.size(); ++c)
+        result.set_weight(propagators.constraint_id_for_index(static_cast<int>(c)), _weights[c]);
+    return result;
+}
+
+auto DenseConstraintWeighting::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    _weights.assign(propagators.number_of_constraints(), _default_weight);
+    for (size_t c = 0; c < _weights.size(); ++c)
+        if (auto weight = state.optional_weight_of(propagators.constraint_id_for_index(static_cast<int>(c))))
+            _weights[c] = *weight;
+}
+
+ClassicDomWDeg::ClassicDomWDeg(const Propagators & propagators) :
+    DenseConstraintWeighting(propagators, 1.0)
+{
+}
+
+auto ClassicDomWDeg::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
+    const optional<ReasonFunction> &, const State &) -> void
+{
+    _weights[constraint_index] += 1.0;
 }
 
 auto ClassicDomWDeg::on_restart() -> void
@@ -106,18 +146,41 @@ auto ClassicDomWDeg::on_restart() -> void
     // a different scheme. Nothing to do.
 }
 
-auto ClassicDomWDeg::snapshot(const Propagators & propagators) const -> WeightingState
+ConflictHistorySearch::ConflictHistorySearch(const Propagators & propagators) :
+    DenseConstraintWeighting(propagators, 0.0),
+    _conflict_of(propagators.number_of_constraints(), 0),
+    _alpha(chs_alpha_initial)
 {
-    WeightingState result;
-    for (size_t c = 0; c < _weights.size(); ++c)
-        result.set_weight(propagators.constraint_id_for_index(static_cast<int>(c)), _weights[c]);
-    return result;
 }
 
-auto ClassicDomWDeg::load(const WeightingState & state, const Propagators & propagators) -> void
+auto ConflictHistorySearch::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
+    const optional<ReasonFunction> &, const State &) -> void
 {
-    _weights.assign(propagators.number_of_constraints(), 1.0);
+    auto r = 1.0 / static_cast<double>(_number_of_conflicts - _conflict_of[constraint_index] + 1);
+    _weights[constraint_index] = (1.0 - _alpha) * _weights[constraint_index] + _alpha * r;
+    ++_number_of_conflicts;
+    _conflict_of[constraint_index] = _number_of_conflicts;
+    _alpha = max(chs_alpha_minimum, _alpha - chs_alpha_decay);
+}
+
+auto ConflictHistorySearch::contribution_of(int constraint_index) const -> double
+{
+    return _weights[constraint_index] + chs_delta;
+}
+
+auto ConflictHistorySearch::on_restart() -> void
+{
+    // Smooth scores towards 0 by their staleness, and reset alpha. Inert until
+    // restarts exist (nothing calls this yet).
     for (size_t c = 0; c < _weights.size(); ++c)
-        if (auto weight = state.optional_weight_of(propagators.constraint_id_for_index(static_cast<int>(c))))
-            _weights[c] = *weight;
+        _weights[c] *= pow(chs_smoothing_base, static_cast<double>(_number_of_conflicts - _conflict_of[c]));
+    _alpha = chs_alpha_initial;
+}
+
+auto ConflictHistorySearch::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    DenseConstraintWeighting::load(state, propagators);
+    _conflict_of.assign(propagators.number_of_constraints(), 0);
+    _number_of_conflicts = 0;
+    _alpha = chs_alpha_initial;
 }

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -227,8 +227,8 @@ namespace gcs
      */
     enum class WeightingScheme
     {
-        Classic, ///< ClassicDomWDeg
-        Chs      ///< ConflictHistorySearch
+        Classic,              ///< ClassicDomWDeg
+        ConflictHistorySearch ///< ConflictHistorySearch (recency-weighted)
     };
 }
 

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -123,40 +123,112 @@ namespace gcs
     };
 
     /**
+     * \brief Common storage for weighting schemes that keep one weight per
+     * constraint, indexed densely by constraint index.
+     *
+     * Provides the dense vector and the read / snapshot / load machinery;
+     * concrete schemes supply note_conflict (the update) and on_restart, and may
+     * override contribution_of to map a stored weight to a variable's weighted
+     * degree (the default is the weight itself).
+     *
+     * \ingroup SearchHeuristics
+     */
+    class DenseConstraintWeighting : public VariableWeighting
+    {
+    public:
+        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+
+        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
+
+        auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
+
+    protected:
+        /**
+         * One weight per constraint, each initialised to (and reset by load to)
+         * default_weight.
+         */
+        DenseConstraintWeighting(const innards::Propagators & propagators, double default_weight);
+
+        /**
+         * What constraint_index contributes to a variable's weighted degree.
+         * Default is its stored weight; a scheme can override (for example to add
+         * an offset).
+         */
+        [[nodiscard]] virtual auto contribution_of(int constraint_index) const -> double;
+
+        std::vector<double> _weights;
+        double _default_weight;
+    };
+
+    /**
      * \brief Classic dom/wdeg (Boussemart, Hemery, Lecoutre, Sais, ECAI 2004):
      * one weight per constraint, initialised to 1, bumped by 1 on every domain
      * wipeout.
      *
      * weighted_degree_of(x) sums w(c) over the constraints on x with at least two
      * unassigned variables, so at the root --- every weight 1, every variable
-     * unassigned --- it equals the variable's degree, and the heuristic starts
-     * out like dom_then_deg and specialises as conflicts accumulate.
+     * unassigned --- it equals the variable's degree, and the heuristic
+     * specialises as conflicts accumulate.
      *
      * \ingroup SearchHeuristics
      */
-    class ClassicDomWDeg final : public VariableWeighting
+    class ClassicDomWDeg final : public DenseConstraintWeighting
     {
     public:
-        /**
-         * One weight per constraint (Propagators::number_of_constraints), each
-         * initialised to 1.
-         */
         explicit ClassicDomWDeg(const innards::Propagators & propagators);
 
         auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
             const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
 
-        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
-            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+        auto on_restart() -> void override;
+    };
+
+    /**
+     * \brief Conflict-History Search (Habet & Terrioux, SAC 2019 / J. Heuristics
+     * 2021): a recency-weighted per-constraint score.
+     *
+     * Each constraint has a score q(c), initialised to 0. On a conflict wiping a
+     * variable of c, q(c) moves towards r(c) = 1 / (#Conflicts - Conflict(c) + 1)
+     * by an exponential recency-weighted average q(c) <- (1 - alpha) q(c) + alpha
+     * r(c), where alpha starts at 0.4 and decays towards 0.06 over conflicts.
+     * weighted_degree_of(x) sums q(c) + delta over x's constraints with at least
+     * two unassigned variables, so early on (all q(c) = 0) it orders by degree.
+     * on_restart resets alpha and smooths the scores; it is inert until restarts
+     * land.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class ConflictHistorySearch final : public DenseConstraintWeighting
+    {
+    public:
+        explicit ConflictHistorySearch(const innards::Propagators & propagators);
+
+        auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
 
         auto on_restart() -> void override;
 
-        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
-
         auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
 
+    protected:
+        [[nodiscard]] auto contribution_of(int constraint_index) const -> double override;
+
     private:
-        std::vector<double> _weights;
+        std::vector<long long> _conflict_of; // Conflict(c): #Conflicts when c last conflicted
+        long long _number_of_conflicts = 0;
+        double _alpha;
+    };
+
+    /**
+     * \brief Selects which weighting scheme gcs::variable_order::dom_wdeg uses.
+     *
+     * \ingroup SearchHeuristics
+     */
+    enum class WeightingScheme
+    {
+        Classic, ///< ClassicDomWDeg
+        Chs      ///< ConflictHistorySearch
     };
 }
 

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -5,6 +5,7 @@
 #include <gcs/variable_id.hh>
 #include <gcs/variable_weighting.hh>
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <optional>
@@ -13,6 +14,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using Catch::Approx;
 using std::nullopt;
 using std::vector;
 
@@ -173,4 +175,56 @@ TEST_CASE("WeightingState merge policies")
         CHECK(m.weight_of(NumberedConstraint{2}) == 3.0); // (5 + 1) / 2
         CHECK(m.weight_of(NumberedConstraint{3}) == 3.5); // (0 + 7) / 2
     }
+}
+
+TEST_CASE("ConflictHistorySearch builds a recency-weighted score")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto b = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+
+    ConflictHistorySearch weighting{propagators};
+    auto current = state.current();
+
+    // Before any conflict every q(c) = 0, so weighted_degree_of is just delta per
+    // constraint (CHS orders by degree early on).
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(1.0e-4));
+
+    // One conflict on _1: q(_1) = (1 - alpha) * 0 + alpha * r, with alpha = 0.4 and
+    // r = 1 / (0 - 0 + 1) = 1, so q(_1) = 0.4. _2 is untouched.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(0.4 + 1.0e-4));
+    CHECK(weighting.weighted_degree_of(current, propagators, b) == Approx(1.0e-4));
+
+    // A second conflict, now on _2, after one earlier conflict: its recency factor
+    // r = 1 / (#Conflicts - Conflict(_2) + 1) = 1 / (1 - 0 + 1) = 0.5 is smaller,
+    // so _2 ends up below _1.
+    weighting.note_conflict(1, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, b) < weighting.weighted_degree_of(current, propagators, a));
+}
+
+TEST_CASE("ConflictHistorySearch snapshot and load round-trip the scores")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+
+    ConflictHistorySearch weighting{propagators};
+    auto current = state.current();
+    weighting.note_conflict(0, {}, nullopt, state); // q(_1) = 0.4
+
+    auto snap = weighting.snapshot(propagators);
+    CHECK(snap.weight_of(NumberedConstraint{1}) == Approx(0.4));
+
+    ConflictHistorySearch reloaded{propagators};
+    reloaded.load(snap, propagators);
+    CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(weighting.weighted_degree_of(current, propagators, a)));
 }


### PR DESCRIPTION
## What

**Stage 2, part 1** of dom/wdeg (issue #315): the **Conflict-History Search (CHS)** scheme and a
**`WeightingScheme` selector** on `dom_wdeg`, behind a shared dense-weighting base. CHS is one of
the RFC's "two to beat".

> Stacked on #323 → #322 → #321 → #318 → `main`.

## Changes (two commits)

1. **`DenseConstraintWeighting` base + `ConflictHistorySearch`.**
   - Factor the dense per-constraint storage common to global schemes into a
     `DenseConstraintWeighting` base — the weight vector, the `|fut|>1` `weighted_degree_of` loop,
     and `snapshot`/`load` — with a virtual `contribution_of` hook for how a stored weight maps to a
     variable's weighted degree. `ClassicDomWDeg` becomes a thin derived class (init 1, `+1` on
     conflict).
   - `ConflictHistorySearch` (Habet & Terrioux): a recency-weighted per-constraint score `q(c)`,
     updated by an exponential recency-weighted average on each conflict (`alpha` from 0.4 decaying
     to 0.06), contributing `q(c)+delta` to weighted degree. `on_restart` smooths the scores and
     resets `alpha` — **wired but inert** until restarts land. The CHS tunables are isolated
     constants, to be auto-tuned rather than chosen by design.
   - Unit tests: the ERWA update, recency ordering, snapshot/load.
2. **Scheme selector.** `variable_order::dom_wdeg` gains a `WeightingScheme` parameter (default
   `Classic`) that picks the live weighting at setup. So the scheme is a knob behind a default,
   not hard-coded. The end-to-end test runs under both schemes and still enumerates every solution.

```cpp
branch_with(variable_order::dom_wdeg(problem, WeightingScheme::Chs), value_order::smallest_first())
```

## Behaviour / scope

`ClassicDomWDeg` is unchanged behaviourally (the refactor is mechanical; its tests are untouched and
pass). `dom_wdeg`'s default stays `Classic`. No proof impact.

**Next (Stage 2, part 2):** `ca.cd` (`RefinedWeighting`), which is *local* (per-`(constraint,
variable)`) and needs the `(ConstraintID, var)` weight extension deferred from Stage 1; it becomes
`dom_wdeg`'s default once it lands. The RefinedWeighting `ia/ca/id/cd` ablation variants and the
benchmark `--branch dom-wdeg:variant` hook follow.

## Verification

Built under **GCC 15.2 and clang 21**; the new unit tests and full `ctest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)