### PR TITLE
Stage 2 (part 2): ca.cd (RefinedWeighting) with local weights (#315)

### DIFF
--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -205,12 +205,27 @@ auto gcs::variable_order::dom_wdeg(const Problem & problem, WeightingScheme sche
 auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingScheme scheme, optional<WeightingState> initial) -> BranchVariableHeuristic
 {
     return [vars = move(vars), scheme, initial = move(initial)](
-               const Problem &, innards::State &, innards::Propagators & propagators) -> BranchVariableSelector {
+               const Problem &, innards::State & state, innards::Propagators & propagators) -> BranchVariableSelector {
         shared_ptr<VariableWeighting> weighting;
         switch (scheme) {
             using enum WeightingScheme;
         case Classic:
             weighting = make_shared<ClassicDomWDeg>(propagators);
+            break;
+        case Ia:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ia);
+            break;
+        case Ca:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ca);
+            break;
+        case Id:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Id);
+            break;
+        case Cd:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Cd);
+            break;
+        case CaCd:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CaCd);
             break;
         case ConflictHistorySearch:
             // Qualified: the WeightingScheme::ConflictHistorySearch enumerator

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -212,20 +212,20 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingSche
         case Classic:
             weighting = make_shared<ClassicDomWDeg>(propagators);
             break;
-        case Ia:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ia);
+        case InitialArity:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::InitialArity);
             break;
-        case Ca:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ca);
+        case CurrentArity:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CurrentArity);
             break;
-        case Id:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Id);
+        case InitialDomain:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::InitialDomain);
             break;
-        case Cd:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Cd);
+        case CurrentDomain:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CurrentDomain);
             break;
-        case CaCd:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CaCd);
+        case CurrentArityCurrentDomain:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CurrentArityCurrentDomain);
             break;
         case ConflictHistorySearch:
             // Qualified: the WeightingScheme::ConflictHistorySearch enumerator

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -155,7 +155,7 @@ namespace gcs
          * are broken on highest constraint degree, and a variable with W(x)=0 (in
          * no constraint with two or more unassigned variables) is least preferred.
          *
-         * \p scheme selects the weighting (default WeightingScheme::CaCd, the
+         * \p scheme selects the weighting (default WeightingScheme::CurrentArityCurrentDomain, the
          * strongest in Wattez et al.). An optional initial WeightingState seeds
          * the weights --- for carrying weights across searches or injecting
          * proof-mined weights. Value ordering is chosen separately, as usual via
@@ -166,7 +166,7 @@ namespace gcs
          * \sa WeightingScheme
          */
         [[nodiscard]] auto dom_wdeg(const Problem &,
-            WeightingScheme scheme = WeightingScheme::CaCd,
+            WeightingScheme scheme = WeightingScheme::CurrentArityCurrentDomain,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
@@ -176,7 +176,7 @@ namespace gcs
          * \sa gcs::variable_order::dom_wdeg(const Problem &, WeightingScheme, std::optional<WeightingState>)
          */
         [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
-            WeightingScheme scheme = WeightingScheme::CaCd,
+            WeightingScheme scheme = WeightingScheme::CurrentArityCurrentDomain,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -155,10 +155,10 @@ namespace gcs
          * are broken on highest constraint degree, and a variable with W(x)=0 (in
          * no constraint with two or more unassigned variables) is least preferred.
          *
-         * \p scheme selects the weighting (default WeightingScheme::Classic, the
-         * original dom/wdeg). An optional initial WeightingState seeds the weights
-         * --- for carrying weights across searches or injecting proof-mined
-         * weights. Value ordering is chosen separately, as usual via
+         * \p scheme selects the weighting (default WeightingScheme::CaCd, the
+         * strongest in Wattez et al.). An optional initial WeightingState seeds
+         * the weights --- for carrying weights across searches or injecting
+         * proof-mined weights. Value ordering is chosen separately, as usual via
          * gcs::branch_with().
          *
          * \ingroup SearchHeuristics
@@ -166,7 +166,7 @@ namespace gcs
          * \sa WeightingScheme
          */
         [[nodiscard]] auto dom_wdeg(const Problem &,
-            WeightingScheme scheme = WeightingScheme::Classic,
+            WeightingScheme scheme = WeightingScheme::CaCd,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
@@ -176,7 +176,7 @@ namespace gcs
          * \sa gcs::variable_order::dom_wdeg(const Problem &, WeightingScheme, std::optional<WeightingState>)
          */
         [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
-            WeightingScheme scheme = WeightingScheme::Classic,
+            WeightingScheme scheme = WeightingScheme::CaCd,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -121,7 +121,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
-    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::CaCd, WeightingScheme::ConflictHistorySearch);
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::CurrentArityCurrentDomain, WeightingScheme::ConflictHistorySearch);
 
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -121,7 +121,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
-    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::ConflictHistorySearch);
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::CaCd, WeightingScheme::ConflictHistorySearch);
 
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -216,7 +216,7 @@ RefinedWeighting::RefinedWeighting(const Propagators & propagators, const State 
     _local_weights(propagators.number_of_constraints())
 {
     // Capture the initial domain size of every variable in a constraint scope,
-    // for the Id variant.
+    // for the InitialDomain variant.
     for (size_t c = 0; c < propagators.number_of_constraints(); ++c)
         for (const auto & v : propagators.scope_of_constraint(static_cast<int>(c)))
             _initial_domain.try_emplace(v.index, state.domain_size(v).raw_value);
@@ -239,19 +239,19 @@ auto RefinedWeighting::note_conflict(int constraint_index, const vector<SimpleIn
         double increment = 0.0;
         switch (_variant) {
             using enum Variant;
-        case Ia:
+        case InitialArity:
             increment = 1.0 / static_cast<double>(scope.size());
             break;
-        case Ca:
+        case CurrentArity:
             increment = 1.0 / static_cast<double>(futures);
             break;
-        case Id:
+        case InitialDomain:
             increment = 1.0 / static_cast<double>(_initial_domain.at(x.index));
             break;
-        case Cd:
+        case CurrentDomain:
             increment = 1.0 / (1.0 + static_cast<double>(state.domain_size(x).raw_value));
             break;
-        case CaCd:
+        case CurrentArityCurrentDomain:
             increment = 1.0 / (static_cast<double>(futures) * (1.0 + static_cast<double>(state.domain_size(x).raw_value)));
             break;
         }

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -7,14 +7,18 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <map>
 #include <optional>
+#include <utility>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::map;
 using std::max;
 using std::nullopt;
 using std::optional;
+using std::pair;
 using std::pow;
 using std::size_t;
 using std::unordered_map;
@@ -52,26 +56,48 @@ auto WeightingState::set_weight(const ConstraintID & constraint_id, double weigh
 
 auto WeightingState::merge(const WeightingState & other, MergePolicy policy) -> void
 {
-    for (const auto & [constraint_id, their_weight] : other._constraint_weights) {
-        auto & my_weight = _constraint_weights[constraint_id];
+    auto combine = [policy](double & mine, double theirs) {
         switch (policy) {
             using enum MergePolicy;
         case Sum:
-            my_weight += their_weight;
+            mine += theirs;
             break;
         case Max:
-            my_weight = max(my_weight, their_weight);
+            mine = max(mine, theirs);
             break;
         case Average:
-            my_weight = (my_weight + their_weight) / 2.0;
+            mine = (mine + theirs) / 2.0;
             break;
         }
-    }
+    };
+
+    for (const auto & [constraint_id, their_weight] : other._constraint_weights)
+        combine(_constraint_weights[constraint_id], their_weight);
+    for (const auto & [key, their_weight] : other._local_weights)
+        combine(_local_weights[key], their_weight);
 }
 
 auto WeightingState::constraint_weights() const -> const unordered_map<ConstraintID, double> &
 {
     return _constraint_weights;
+}
+
+auto WeightingState::local_weight_of(const ConstraintID & constraint_id, SimpleIntegerVariableID var) const -> optional<double>
+{
+    auto it = _local_weights.find(pair{constraint_id, var});
+    if (it == _local_weights.end())
+        return nullopt;
+    return it->second;
+}
+
+auto WeightingState::set_local_weight(const ConstraintID & constraint_id, SimpleIntegerVariableID var, double weight) -> void
+{
+    _local_weights[pair{constraint_id, var}] = weight;
+}
+
+auto WeightingState::local_weights() const -> const map<pair<ConstraintID, SimpleIntegerVariableID>, double> &
+{
+    return _local_weights;
 }
 
 DenseConstraintWeighting::DenseConstraintWeighting(const Propagators & propagators, double default_weight) :
@@ -183,4 +209,108 @@ auto ConflictHistorySearch::load(const WeightingState & state, const Propagators
     _conflict_of.assign(propagators.number_of_constraints(), 0);
     _number_of_conflicts = 0;
     _alpha = chs_alpha_initial;
+}
+
+RefinedWeighting::RefinedWeighting(const Propagators & propagators, const State & state, Variant variant) :
+    _variant(variant),
+    _local_weights(propagators.number_of_constraints())
+{
+    // Capture the initial domain size of every variable in a constraint scope,
+    // for the Id variant.
+    for (size_t c = 0; c < propagators.number_of_constraints(); ++c)
+        for (const auto & v : propagators.scope_of_constraint(static_cast<int>(c)))
+            _initial_domain.try_emplace(v.index, state.domain_size(v).raw_value);
+}
+
+auto RefinedWeighting::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> & scope,
+    const optional<ReasonFunction> &, const State & state) -> void
+{
+    long long futures = 0;
+    for (const auto & v : scope)
+        if (! state.has_single_value(v))
+            ++futures;
+    if (futures == 0)
+        return;
+
+    auto & weights = _local_weights[constraint_index];
+    for (const auto & x : scope) {
+        if (state.has_single_value(x))
+            continue;
+        double increment = 0.0;
+        switch (_variant) {
+            using enum Variant;
+        case Ia:
+            increment = 1.0 / static_cast<double>(scope.size());
+            break;
+        case Ca:
+            increment = 1.0 / static_cast<double>(futures);
+            break;
+        case Id:
+            increment = 1.0 / static_cast<double>(_initial_domain.at(x.index));
+            break;
+        case Cd:
+            increment = 1.0 / (1.0 + static_cast<double>(state.domain_size(x).raw_value));
+            break;
+        case CaCd:
+            increment = 1.0 / (static_cast<double>(futures) * (1.0 + static_cast<double>(state.domain_size(x).raw_value)));
+            break;
+        }
+        auto [it, inserted] = weights.try_emplace(x.index, 1.0);
+        it->second += increment;
+    }
+}
+
+auto RefinedWeighting::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
+    IntegerVariableID var) const -> double
+{
+    auto simple = overloaded{
+        [](const SimpleIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v; },
+        [](const ViewOfIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v.actual_variable; },
+        [](const ConstantIntegerVariableID &) -> optional<SimpleIntegerVariableID> { return nullopt; }}
+                      .visit(var);
+
+    if (! simple)
+        return 0.0;
+
+    double total = 0.0;
+    for (const auto & constraint_index : propagators.constraint_indices_of_variable(*simple)) {
+        int futures = 0;
+        for (const auto & v : propagators.scope_of_constraint(constraint_index)) {
+            if (! state.has_single_value(v))
+                if (++futures >= 2)
+                    break;
+        }
+        if (futures >= 2) {
+            const auto & weights = _local_weights[constraint_index];
+            auto it = weights.find(simple->index);
+            total += (it != weights.end() ? it->second : 1.0);
+        }
+    }
+    return total;
+}
+
+auto RefinedWeighting::on_restart() -> void
+{
+    // The refined increments keep their weights across restarts.
+}
+
+auto RefinedWeighting::snapshot(const Propagators & propagators) const -> WeightingState
+{
+    WeightingState result;
+    for (size_t c = 0; c < _local_weights.size(); ++c)
+        for (const auto & [var_index, weight] : _local_weights[c])
+            result.set_local_weight(propagators.constraint_id_for_index(static_cast<int>(c)),
+                SimpleIntegerVariableID{var_index}, weight);
+    return result;
+}
+
+auto RefinedWeighting::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    for (size_t c = 0; c < _local_weights.size(); ++c) {
+        _local_weights[c].clear();
+        auto constraint_id = propagators.constraint_id_for_index(static_cast<int>(c));
+        for (const auto & v : propagators.scope_of_constraint(static_cast<int>(c)))
+            if (auto weight = state.local_weight_of(constraint_id, v))
+                _local_weights[c][v.index] = *weight;
+    }
 }

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -6,8 +6,10 @@
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/variable_id.hh>
 
+#include <map>
 #include <optional>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -25,8 +27,10 @@ namespace gcs
      * search/thread and entering another: the basis for share-nothing parallel
      * sync and for seeding a search with proof-mined weights.
      *
-     * v1 holds only global per-constraint weights; a per-(constraint, variable)
-     * map for AbsCon-local schemes is a later additive extension.
+     * It holds a global per-constraint weight map (for whole-constraint schemes)
+     * and a per-(constraint, variable) local weight map (for schemes that weight
+     * variables within a constraint, such as ca.cd); a scheme uses whichever it
+     * needs.
      *
      * \ingroup SearchHeuristics
      */
@@ -59,10 +63,22 @@ namespace gcs
         auto set_weight(const ConstraintID &, double) -> void;
 
         /**
-         * Combine another WeightingState into this one. For every constraint in
-         * \p other, this one's weight (taken as 0 if absent) is combined with
+         * The local weight recorded for a (constraint, variable) pair, or nullopt
+         * if it has none.
+         */
+        [[nodiscard]] auto local_weight_of(const ConstraintID &, SimpleIntegerVariableID) const -> std::optional<double>;
+
+        /**
+         * Set (or overwrite) the local weight for a (constraint, variable) pair.
+         */
+        auto set_local_weight(const ConstraintID &, SimpleIntegerVariableID, double) -> void;
+
+        /**
+         * Combine another WeightingState into this one, entry by entry across both
+         * the per-constraint and per-(constraint, variable) maps. For every entry
+         * in \p other, this one's value (taken as 0 if absent) is combined with
          * other's under \p policy: Sum adds, Max keeps the larger, Average takes
-         * the mean. Constraints present only in this one are left unchanged.
+         * the mean. Entries present only in this one are left unchanged.
          */
         auto merge(const WeightingState & other, MergePolicy policy) -> void;
 
@@ -71,8 +87,15 @@ namespace gcs
          */
         [[nodiscard]] auto constraint_weights() const -> const std::unordered_map<ConstraintID, double> &;
 
+        /**
+         * The full (ConstraintID, variable) -> weight map, for iteration /
+         * serialisation.
+         */
+        [[nodiscard]] auto local_weights() const -> const std::map<std::pair<ConstraintID, SimpleIntegerVariableID>, double> &;
+
     private:
         std::unordered_map<ConstraintID, double> _constraint_weights;
+        std::map<std::pair<ConstraintID, SimpleIntegerVariableID>, double> _local_weights;
     };
 
     /**
@@ -221,13 +244,75 @@ namespace gcs
     };
 
     /**
+     * \brief Refined dom/wdeg increments (Wattez, Lecoutre, Paparrizou, Tabary,
+     * ICTAI 2019): a per-(constraint, variable) local weight whose increment on a
+     * conflict reflects the constraint's arity and the variables' domains.
+     *
+     * On a conflict of constraint c, for each still-unassigned variable x of c the
+     * local weight w(c)[x] (initialised to 1) is incremented by a Variant-chosen
+     * amount:
+     *   - Ia (initial arity):  1 / |scp(c)|
+     *   - Ca (current arity):  1 / |fut(c)|
+     *   - Id (initial domain): 1 / |dom_init(x)|
+     *   - Cd (current domain): 1 / (1 + |dom(x)|)
+     *   - CaCd (the default, the strongest in their study):
+     *         1 / (|fut(c)| * (1 + |dom(x)|))
+     * weighted_degree_of(x) sums w(c)[x] over x's constraints with at least two
+     * unassigned variables, so at the root (all weights 1) it equals the degree.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class RefinedWeighting final : public VariableWeighting
+    {
+    public:
+        /**
+         * \brief Which of the ia / ca / id / cd / ca.cd increments to use.
+         */
+        enum class Variant
+        {
+            Ia,
+            Ca,
+            Id,
+            Cd,
+            CaCd
+        };
+
+        RefinedWeighting(const innards::Propagators & propagators, const innards::State & state, Variant variant);
+
+        auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
+
+        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+
+        auto on_restart() -> void override;
+
+        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
+
+        auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
+
+    private:
+        Variant _variant;
+        // Local weights by constraint index, then variable index; an absent entry
+        // means the default weight of 1. Initial domain sizes by variable index,
+        // for the Id variant.
+        std::vector<std::unordered_map<unsigned long long, double>> _local_weights;
+        std::unordered_map<unsigned long long, long long> _initial_domain;
+    };
+
+    /**
      * \brief Selects which weighting scheme gcs::variable_order::dom_wdeg uses.
      *
      * \ingroup SearchHeuristics
      */
     enum class WeightingScheme
     {
-        Classic,              ///< ClassicDomWDeg
+        Classic, ///< ClassicDomWDeg
+        Ia,      ///< RefinedWeighting, initial-arity increment
+        Ca,      ///< RefinedWeighting, current-arity increment
+        Id,      ///< RefinedWeighting, initial-domain increment
+        Cd,      ///< RefinedWeighting, current-domain increment
+        CaCd,    ///< RefinedWeighting, ca.cd increment
         ConflictHistorySearch ///< ConflictHistorySearch (recency-weighted)
     };
 }

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -251,11 +251,11 @@ namespace gcs
      * On a conflict of constraint c, for each still-unassigned variable x of c the
      * local weight w(c)[x] (initialised to 1) is incremented by a Variant-chosen
      * amount:
-     *   - Ia (initial arity):  1 / |scp(c)|
-     *   - Ca (current arity):  1 / |fut(c)|
-     *   - Id (initial domain): 1 / |dom_init(x)|
-     *   - Cd (current domain): 1 / (1 + |dom(x)|)
-     *   - CaCd (the default, the strongest in their study):
+     *   - InitialArity:  1 / |scp(c)|
+     *   - CurrentArity:  1 / |fut(c)|
+     *   - InitialDomain: 1 / |dom_init(x)|
+     *   - CurrentDomain: 1 / (1 + |dom(x)|)
+     *   - CurrentArityCurrentDomain (the default, the strongest in their study):
      *         1 / (|fut(c)| * (1 + |dom(x)|))
      * weighted_degree_of(x) sums w(c)[x] over x's constraints with at least two
      * unassigned variables, so at the root (all weights 1) it equals the degree.
@@ -270,11 +270,11 @@ namespace gcs
          */
         enum class Variant
         {
-            Ia,
-            Ca,
-            Id,
-            Cd,
-            CaCd
+            InitialArity,
+            CurrentArity,
+            InitialDomain,
+            CurrentDomain,
+            CurrentArityCurrentDomain
         };
 
         RefinedWeighting(const innards::Propagators & propagators, const innards::State & state, Variant variant);
@@ -295,7 +295,7 @@ namespace gcs
         Variant _variant;
         // Local weights by constraint index, then variable index; an absent entry
         // means the default weight of 1. Initial domain sizes by variable index,
-        // for the Id variant.
+        // for the InitialDomain variant.
         std::vector<std::unordered_map<unsigned long long, double>> _local_weights;
         std::unordered_map<unsigned long long, long long> _initial_domain;
     };
@@ -307,13 +307,13 @@ namespace gcs
      */
     enum class WeightingScheme
     {
-        Classic, ///< ClassicDomWDeg
-        Ia,      ///< RefinedWeighting, initial-arity increment
-        Ca,      ///< RefinedWeighting, current-arity increment
-        Id,      ///< RefinedWeighting, initial-domain increment
-        Cd,      ///< RefinedWeighting, current-domain increment
-        CaCd,    ///< RefinedWeighting, ca.cd increment
-        ConflictHistorySearch ///< ConflictHistorySearch (recency-weighted)
+        Classic,                   ///< ClassicDomWDeg
+        InitialArity,              ///< RefinedWeighting, initial-arity increment
+        CurrentArity,              ///< RefinedWeighting, current-arity increment
+        InitialDomain,             ///< RefinedWeighting, initial-domain increment
+        CurrentDomain,             ///< RefinedWeighting, current-domain increment
+        CurrentArityCurrentDomain, ///< RefinedWeighting, ca.cd increment
+        ConflictHistorySearch      ///< ConflictHistorySearch (recency-weighted)
     };
 }
 

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -238,7 +238,7 @@ TEST_CASE("RefinedWeighting ca.cd increments by 1 / (fut * (1 + dom))")
     Propagators propagators;
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
 
-    RefinedWeighting weighting{propagators, state, RefinedWeighting::Variant::CaCd};
+    RefinedWeighting weighting{propagators, state, RefinedWeighting::Variant::CurrentArityCurrentDomain};
     auto current = state.current();
 
     // Every local weight starts at 1, so the root weighted degree is the degree.
@@ -260,8 +260,8 @@ TEST_CASE("RefinedWeighting variants increment differently and round-trip")
     Propagators propagators;
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
 
-    // The Ca variant increments by 1 / fut = 1 / 2 = 0.5, not the ca.cd 0.125.
-    RefinedWeighting ca{propagators, state, RefinedWeighting::Variant::Ca};
+    // The CurrentArity variant increments by 1 / fut = 1 / 2 = 0.5, not the ca.cd 0.125.
+    RefinedWeighting ca{propagators, state, RefinedWeighting::Variant::CurrentArity};
     auto current = state.current();
     ca.note_conflict(0, {a, b}, nullopt, state);
     CHECK(ca.weighted_degree_of(current, propagators, a) == Approx(1.5));
@@ -270,7 +270,7 @@ TEST_CASE("RefinedWeighting variants increment differently and round-trip")
     auto snap = ca.snapshot(propagators);
     REQUIRE(snap.local_weight_of(NumberedConstraint{1}, a).has_value());
     CHECK(snap.local_weight_of(NumberedConstraint{1}, a).value() == Approx(1.5));
-    RefinedWeighting reloaded{propagators, state, RefinedWeighting::Variant::Ca};
+    RefinedWeighting reloaded{propagators, state, RefinedWeighting::Variant::CurrentArity};
     reloaded.load(snap, propagators);
     CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(1.5));
 }

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -228,3 +228,49 @@ TEST_CASE("ConflictHistorySearch snapshot and load round-trip the scores")
     reloaded.load(snap, propagators);
     CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(weighting.weighted_degree_of(current, propagators, a)));
 }
+
+TEST_CASE("RefinedWeighting ca.cd increments by 1 / (fut * (1 + dom))")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
+    auto b = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
+
+    RefinedWeighting weighting{propagators, state, RefinedWeighting::Variant::CaCd};
+    auto current = state.current();
+
+    // Every local weight starts at 1, so the root weighted degree is the degree.
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(1.0));
+
+    // One conflict on _1: both future variables (a, b) get
+    // w(_1)[x] += 1 / (fut * (1 + dom)) = 1 / (2 * (1 + 3)) = 0.125.
+    weighting.note_conflict(0, {a, b}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(1.125));
+    CHECK(weighting.weighted_degree_of(current, propagators, b) == Approx(1.125));
+}
+
+TEST_CASE("RefinedWeighting variants increment differently and round-trip")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
+    auto b = state.allocate_integer_variable_with_state(0_i, 2_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
+
+    // The Ca variant increments by 1 / fut = 1 / 2 = 0.5, not the ca.cd 0.125.
+    RefinedWeighting ca{propagators, state, RefinedWeighting::Variant::Ca};
+    auto current = state.current();
+    ca.note_conflict(0, {a, b}, nullopt, state);
+    CHECK(ca.weighted_degree_of(current, propagators, a) == Approx(1.5));
+
+    // snapshot / load round-trips the local weights.
+    auto snap = ca.snapshot(propagators);
+    REQUIRE(snap.local_weight_of(NumberedConstraint{1}, a).has_value());
+    CHECK(snap.local_weight_of(NumberedConstraint{1}, a).value() == Approx(1.5));
+    RefinedWeighting reloaded{propagators, state, RefinedWeighting::Variant::Ca};
+    reloaded.load(snap, propagators);
+    CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(1.5));
+}


### PR DESCRIPTION
## What

**Stage 2, part 2** of dom/wdeg (issue #315): the **`ca.cd` scheme (`RefinedWeighting`)** — the
RFC's default-to-be and the other of the "two to beat" — built on a per-`(constraint, variable)`
**local weight** extension to `WeightingState`.

> Stacked on #324 → #323 → #322 → #321 → #318 → `main`.

## Changes (two commits)

1. **`WeightingState` local weights + `RefinedWeighting`.**
   - `WeightingState` gains a per-`(constraint, variable)` local weight map alongside the global
     one (`merge` and the accessors handle both) — the portable form of the local weights a scheme
     like `ca.cd` needs.
   - `RefinedWeighting` (Wattez, Lecoutre, Paparrizou, Tabary, ICTAI 2019): a local weight
     `w(c)[x]` per constraint variable, initialised to 1, incremented on a conflict over the
     still-unassigned variables of the failing constraint by a `Variant`-chosen amount —
     `ia` (`1/|scp|`), `ca` (`1/|fut|`), `id` (`1/dom_init`), `cd` (`1/(1+dom)`), and the default
     **`ca.cd` (`1/(|fut|*(1+dom))`)**. `weighted_degree_of` sums `w(c)[x]` over `x`'s constraints
     with `|fut|>1`, so at the root (all weights 1) it equals the degree — same starting point as
     the global schemes. Initial domain sizes are captured at construction for the `id` variant.
   - Unit tests: the `ca.cd` increment, a variant difference, and the local snapshot/load round-trip.
2. **Scheme selection.** `WeightingScheme` gains `Ia`/`Ca`/`Id`/`Cd`/`CaCd`, and **`CaCd` becomes the
   `dom_wdeg` default** (the RFC's intended default). `dom_wdeg` dispatches each scheme at setup. The
   end-to-end test runs under `Classic`, `CaCd`, and `Chs` and still enumerates every solution.

## Notes

- **Default change:** `dom_wdeg(problem)` now uses `ca.cd` rather than classic. Since at the root
  every local weight is 1, the root ordering is still degree-based (identical to classic at the
  root), so the existing selector tests are unaffected; the schemes diverge only as conflicts
  accumulate. `dom_wdeg` remains opt-in (the default brancher is still `dom_then_deg`).
- `note_conflict`'s `|fut|`/arity for the increment use the *failing propagator's* scope (what the
  observer is handed); `weighted_degree_of`'s `|fut|>1` filter uses the full constraint scope. They
  coincide for single-propagator constraints.

## Verification

Built under **GCC 15.2 and clang 21**; the new unit tests and full `ctest` pass.

**Next (Stage 2, part 3):** the example/benchmark `--branch dom-wdeg:variant` hook with `--stats`
search-shape columns, so the schemes (incl. the `ia/ca/id/cd` ablations) are benchmarkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)