### PR TITLE
Stage 2 (part 3): --branch hook to benchmark the dom/wdeg schemes (#315)

### DIFF
--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -2,10 +2,12 @@
 #include <gcs/constraints/arithmetic.hh>
 #include <gcs/constraints/element.hh>
 #include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 #include <vector>
 
 #include <cxxopts.hpp>
@@ -38,18 +40,64 @@ using fmt::print;
 using fmt::println;
 #endif
 
+using std::optional;
+
+namespace
+{
+    // Map a dom-wdeg variant string to a weighting scheme, for the --branch flag.
+    auto scheme_from_string(const string & name) -> optional<WeightingScheme>
+    {
+        using enum WeightingScheme;
+        if (name == "classic")
+            return Classic;
+        if (name == "ia")
+            return Ia;
+        if (name == "ca")
+            return Ca;
+        if (name == "id")
+            return Id;
+        if (name == "cd")
+            return Cd;
+        if (name == "ca.cd" || name == "cacd")
+            return CaCd;
+        if (name == "chs")
+            return Chs;
+        return std::nullopt;
+    }
+
+    // Build the brancher named by --branch: "dom-then-deg", or "dom-wdeg"
+    // optionally suffixed with a scheme, e.g. "dom-wdeg:chs" (default ca.cd).
+    auto brancher_from_string(const string & spec, const Problem & problem) -> optional<BranchHeuristic>
+    {
+        if (spec == "dom-then-deg")
+            return branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
+        if (spec == "dom-wdeg" || spec.starts_with("dom-wdeg:")) {
+            auto colon = spec.find(':');
+            auto variant = (colon == string::npos) ? string{"ca.cd"} : spec.substr(colon + 1);
+            auto scheme = scheme_from_string(variant);
+            if (! scheme)
+                return std::nullopt;
+            return branch_with(variable_order::dom_wdeg(problem, *scheme), value_order::smallest_first());
+        }
+        return std::nullopt;
+    }
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     cxxopts::Options options("Knapsack");
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options()                                                //
-            ("help", "Display help information")                             //
-            ("prove", "Create a proof")                                      //
-            ("proof-files-basename", "Basename for the .opb and .pbp files", //
-                cxxopts::value<string>()->default_value("langford"))         //
-            ("stats", "Print solve statistics")                              //
+        options.add_options()                                                      //
+            ("help", "Display help information")                                   //
+            ("prove", "Create a proof")                                            //
+            ("proof-files-basename", "Basename for the .opb and .pbp files",       //
+                cxxopts::value<string>()->default_value("langford"))               //
+            ("stats", "Print solve statistics")                                    //
+            ("branch", "Branching heuristic: dom-then-deg, or dom-wdeg[:VARIANT] " //
+                       "(VARIANT = classic / ia / ca / id / cd / ca.cd / chs)",    //
+                cxxopts::value<string>()->default_value("dom-then-deg"))           //
             ;
 
         options.add_options()                                                                   //
@@ -92,14 +140,23 @@ auto main(int argc, char * argv[]) -> int
         p.post(PlusGAC{position[i + k], constant_variable(Integer{i + 2}), position[i]});
     }
 
-    auto stats = solve(
-        p, [&](const CurrentState & s) -> bool {
-            println("solution: {}", solution | std::ranges::views::transform(cref(s)));
-            println("position: {}", position | std::ranges::views::transform(cref(s)));
-            println("");
+    auto brancher = brancher_from_string(options_vars["branch"].as<string>(), p);
+    if (! brancher) {
+        println(cerr, "Error: unknown --branch value {}", options_vars["branch"].as<string>());
+        return EXIT_FAILURE;
+    }
 
-            return true;
-        },
+    auto stats = solve_with(
+        p,
+        SolveCallbacks{
+            .solution = [&](const CurrentState & s) -> bool {
+                println("solution: {}", solution | std::ranges::views::transform(cref(s)));
+                println("position: {}", position | std::ranges::views::transform(cref(s)));
+                println("");
+
+                return true;
+            },
+            .branch = *brancher},
         options_vars.contains("prove")
             ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>())
             : nullopt);

--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -51,17 +51,17 @@ namespace
         if (name == "classic")
             return Classic;
         if (name == "ia")
-            return Ia;
+            return InitialArity;
         if (name == "ca")
-            return Ca;
+            return CurrentArity;
         if (name == "id")
-            return Id;
+            return InitialDomain;
         if (name == "cd")
-            return Cd;
+            return CurrentDomain;
         if (name == "ca.cd" || name == "cacd")
-            return CaCd;
+            return CurrentArityCurrentDomain;
         if (name == "chs")
-            return Chs;
+            return ConflictHistorySearch;
         return std::nullopt;
     }
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -401,6 +401,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(conflict_observer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME conflict_observer_test COMMAND $<TARGET_FILE:conflict_observer_test>)
 
+    add_executable(variable_weighting_test variable_weighting_test.cc)
+    target_link_libraries(variable_weighting_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME variable_weighting_test COMMAND $<TARGET_FILE:variable_weighting_test>)
+
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -405,6 +405,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(variable_weighting_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME variable_weighting_test COMMAND $<TARGET_FILE:variable_weighting_test>)
 
+    add_executable(search_heuristics_test search_heuristics_test.cc)
+    target_link_libraries(search_heuristics_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME search_heuristics_test COMMAND $<TARGET_FILE:search_heuristics_test>)
+
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(glasgow_constraint_solver
         stats.cc
         variable_condition.cc
         variable_id.cc
+        variable_weighting.cc
         constraints/abs.cc
         constraints/abs/justify.cc
         constraints/all_different/all_different_except.cc

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -396,6 +396,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(state_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME state_test COMMAND $<TARGET_FILE:state_test>)
 
+    add_executable(conflict_observer_test innards/conflict_observer_test.cc)
+    target_link_libraries(conflict_observer_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME conflict_observer_test COMMAND $<TARGET_FILE:conflict_observer_test>)
+
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -6,6 +6,7 @@
 #include <gcs/innards/s_expr-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <variant>
@@ -166,5 +167,17 @@ struct fmt::formatter<gcs::ConstraintID> : fmt::formatter<std::string>
     }
 };
 #endif
+
+// Lets ConstraintID be used as a key in unordered containers (the weighting
+// state map, the dense-index map in Propagators). Equality on the variant is
+// structural; hashing its string form agrees with that.
+template <>
+struct std::hash<gcs::ConstraintID>
+{
+    [[nodiscard]] auto operator()(const gcs::ConstraintID & constraint_id) const -> std::size_t
+    {
+        return std::hash<std::string>{}(gcs::as_string(constraint_id));
+    }
+};
 
 #endif

--- a/gcs/innards/conflict_observer.hh
+++ b/gcs/innards/conflict_observer.hh
@@ -1,0 +1,55 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_CONFLICT_OBSERVER_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_CONFLICT_OBSERVER_HH
+
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state-fwd.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Watches propagation for conflicts (domain wipeouts) as they
+     * happen, so that a search heuristic can attribute each wipeout to the
+     * constraint --- and, later, the specific Reason --- that caused it.
+     *
+     * A borrowed observer is attached to the Propagators for the duration of a
+     * search (Propagators::set_conflict_observer). Whenever a propagator raises
+     * a contradiction, Propagators::propagate notifies the observer exactly once
+     * with the failing constraint and its scope. This is the write side of the
+     * dom/wdeg weighting seam (issue #315, Stage 0): the weighting value object
+     * will implement this interface. It is deliberately minimal and carries no
+     * query API of its own --- the brancher reads back weights by another path.
+     *
+     * \ingroup Innards
+     */
+    class ConflictObserver
+    {
+    public:
+        virtual ~ConflictObserver() = default;
+
+        /**
+         * \brief Called when a propagator wipes out a domain.
+         *
+         * \param constraint_index the dense constraint index of the failing
+         *   propagator, as from Propagators::constraint_index_of_propagator.
+         * \param scope the failing propagator's scope, as from
+         *   Propagators::scope_of_propagator: its variables, with views
+         *   resolved to the underlying simple variable and duplicates removed.
+         * \param reason the reason carried by the contradiction. The optional
+         *   is engaged whenever a contradiction occurred, but the ReasonFunction
+         *   it holds may itself be empty when the propagator supplied no reason;
+         *   it is evaluated lazily, only if the observer chooses to call it.
+         * \param state the current state, for querying variable domains.
+         */
+        virtual auto note_conflict(
+            int constraint_index,
+            const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<ReasonFunction> & reason,
+            const State & state) -> void = 0;
+    };
+}
+
+#endif

--- a/gcs/innards/conflict_observer_test.cc
+++ b/gcs/innards/conflict_observer_test.cc
@@ -1,0 +1,177 @@
+#include <gcs/constraint.hh>
+#include <gcs/innards/conflict_observer.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/variable_id.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::nullopt;
+using std::optional;
+using std::vector;
+
+namespace
+{
+    // Records every conflict it is told about, so a test can check which
+    // constraint (and scope) a wipeout was attributed to.
+    struct RecordingObserver final : ConflictObserver
+    {
+        struct Call
+        {
+            int constraint_index;
+            vector<SimpleIntegerVariableID> scope;
+            bool reason_present;
+            bool reason_non_empty;
+        };
+
+        vector<Call> calls;
+
+        auto note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> & scope,
+            const optional<ReasonFunction> & reason, const State &) -> void override
+        {
+            calls.push_back(Call{constraint_index, scope, reason.has_value(),
+                reason.has_value() && static_cast<bool>(*reason)});
+        }
+    };
+
+    // A do-nothing propagator, written as a fresh lambda at each install site
+    // (the PropagationFunction constructor wants the closure by value), used as
+    // an innocent bystander constraint that must not be blamed for a wipeout.
+    auto a_propagator_that_does_nothing()
+    {
+        return [](const State &, auto &, ProofLogger * const) -> PropagatorState { return PropagatorState::Enable; };
+    }
+}
+
+TEST_CASE("Conflict observer attributes a wipeout to the failing constraint, not a bystander")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 1_i);
+
+    Propagators propagators;
+    // Constraint _1: innocent, triggers on x only. Dense constraint index 0.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x}});
+    // Constraint _2: explicitly contradicts, with a non-empty reason. It is
+    // registered second, so its propagator (id 1) runs after the bystander and
+    // it gets dense constraint index 1. Its scope triggers on x and y, plus a
+    // view of x (x + 1) that must resolve back to x and deduplicate away.
+    propagators.install(
+        NumberedConstraint{2},
+        [x, y](const State & inner_state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.contradiction(logger, JustifyUsingRUP{},
+                generic_reason(inner_state, vector<IntegerVariableID>{x, y}));
+        },
+        Triggers{.on_change = {x, y}, .on_bounds = {x + 1_i}});
+
+    RecordingObserver observer;
+    propagators.set_conflict_observer(&observer);
+
+    auto no_contradiction = propagators.propagate(nullopt, state, nullptr);
+
+    CHECK_FALSE(no_contradiction);
+    REQUIRE(observer.calls.size() == 1);
+
+    const auto & call = observer.calls.front();
+    // The blame falls on _2 (dense index 1), never on the bystander _1.
+    CHECK(call.constraint_index == 1);
+    CHECK(propagators.constraint_id_for_index(call.constraint_index) == ConstraintID{NumberedConstraint{2}});
+    // Scope is the failing propagator's scope: x and y, with the x + 1 view
+    // resolved and deduplicated.
+    CHECK(call.scope == vector<SimpleIntegerVariableID>{x, y});
+    // The reason was carried through, engaged and non-empty.
+    CHECK(call.reason_present);
+    CHECK(call.reason_non_empty);
+}
+
+TEST_CASE("Conflict observer fires for an inference-driven wipeout")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
+
+    Propagators propagators;
+    // The contradiction here comes not from an explicit contradiction() call but
+    // from an inference that empties x's domain (the Contradiction case inside
+    // the tracker), exercising the other reason-stash path.
+    propagators.install(
+        NumberedConstraint{7},
+        [x](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.infer_greater_than_or_equal(logger, x, 5_i, JustifyUsingRUP{}, ReasonFunction{});
+            return PropagatorState::Enable;
+        },
+        Triggers{.on_bounds = {x}});
+
+    RecordingObserver observer;
+    propagators.set_conflict_observer(&observer);
+
+    auto no_contradiction = propagators.propagate(nullopt, state, nullptr);
+
+    CHECK_FALSE(no_contradiction);
+    REQUIRE(observer.calls.size() == 1);
+
+    const auto & call = observer.calls.front();
+    CHECK(call.constraint_index == 0);
+    CHECK(propagators.constraint_id_for_index(call.constraint_index) == ConstraintID{NumberedConstraint{7}});
+    CHECK(call.scope == vector<SimpleIntegerVariableID>{x});
+    // An empty ReasonFunction was supplied: the optional is engaged, but the
+    // function it holds is empty.
+    CHECK(call.reason_present);
+    CHECK_FALSE(call.reason_non_empty);
+}
+
+TEST_CASE("Propagation without a conflict observer still detects the wipeout")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
+
+    Propagators propagators;
+    propagators.install(
+        NumberedConstraint{1},
+        [](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{});
+        },
+        Triggers{.on_change = {x}});
+
+    // No observer attached: the propagate() notification is guarded and must not
+    // be reached, but the contradiction is still reported.
+    CHECK(propagators.conflict_observer() == nullptr);
+    CHECK_FALSE(propagators.propagate(nullopt, state, nullptr));
+}
+
+TEST_CASE("Propagator scope and variable-to-constraint adjacency")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    // Constraint index 0, propagator 0: over x and y (with a duplicate and a
+    // view of y to check deduplication / view resolution).
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(),
+        Triggers{.on_change = {x, y}, .on_bounds = {y, -y}});
+    // Constraint index 1, propagator 1: over y and z.
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(),
+        Triggers{.on_change = {y, z}});
+
+    CHECK(propagators.scope_of_propagator(0) == vector<SimpleIntegerVariableID>{x, y});
+    CHECK(propagators.scope_of_propagator(1) == vector<SimpleIntegerVariableID>{y, z});
+
+    // x is only in constraint 0; y is in both; z is only in constraint 1.
+    CHECK(propagators.constraint_indices_of_variable(x) == vector<int>{0});
+    CHECK(propagators.constraint_indices_of_variable(y) == vector<int>{0, 1});
+    CHECK(propagators.constraint_indices_of_variable(z) == vector<int>{1});
+
+    // A variable no propagator triggers on has no constraints.
+    auto unused = state.allocate_integer_variable_with_state(0_i, 0_i);
+    CHECK(propagators.constraint_indices_of_variable(unused).empty());
+}

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <version>
@@ -34,6 +35,13 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
 
+        // The reason supplied with the contradiction that ended this tracker's
+        // life, stashed before the throw so it is reachable at the catch site
+        // (a conflict observer may want to know which literals were implicated).
+        // Engaged whenever a contradiction has been raised; the ReasonFunction
+        // it holds may itself be empty if the caller supplied no reason.
+        std::optional<ReasonFunction> _last_contradiction_reason;
+
         auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
         {
             return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason);
@@ -58,6 +66,7 @@ namespace gcs::innards
 
         [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason) -> void
         {
+            _last_contradiction_reason = reason;
             if (logger)
                 logger->infer(FalseLiteral{}, why, reason);
             throw TrackedPropagationFailed{};
@@ -125,8 +134,18 @@ namespace gcs::innards
         auto reset() -> void
         {
             _inferences.clear();
+            _last_contradiction_reason.reset();
             _did_anything_since_last_call_inside_propagator = false;
             _did_anything_since_last_call_by_propagation_queue = false;
+        }
+
+        // The reason of the contradiction that ended this tracker's life, valid
+        // at the catch site after propagate() unwinds a TrackedPropagationFailed.
+        // Has no value if no contradiction was raised; the held ReasonFunction
+        // may be empty if the caller supplied none.
+        [[nodiscard]] auto last_contradiction_reason() const -> const std::optional<ReasonFunction> &
+        {
+            return _last_contradiction_reason;
         }
 
         auto did_anything_since_last_call_by_propagation_queue() -> bool
@@ -145,7 +164,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &) -> void
+        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction & reason) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -175,6 +194,7 @@ namespace gcs::innards
                 break;
 
             [[unlikely]] case Inference::Contradiction:
+                _last_contradiction_reason = reason;
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
                 throw TrackedPropagationFailed{};
@@ -220,6 +240,7 @@ namespace gcs::innards
                 break;
 
             [[unlikely]] case Inference::Contradiction:
+                _last_contradiction_reason = reason;
                 if (logger)
                     logger->infer(lit, just, reason);
                 _did_anything_since_last_call_by_propagation_queue = true;

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -31,7 +31,7 @@ using std::swap;
 using std::to_underlying;
 using std::vector;
 using std::visit;
-using std::ranges::find;
+using std::ranges::contains;
 
 namespace
 {
@@ -135,14 +135,15 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
     // Record this propagator's scope (its trigger variables, views resolved and
     // deduplicated) and add it to each variable's constraint adjacency.
     auto & scope = _imp->propagator_scope.emplace_back();
+    scope.reserve(triggers.on_change.size() + triggers.on_bounds.size() + triggers.on_instantiated.size());
     auto add_to_scope = [&](IntegerVariableID var) {
         overloaded{
             [&](const SimpleIntegerVariableID & v) {
-                if (find(scope, v) == scope.end())
+                if (! contains(scope, v))
                     scope.push_back(v);
             },
             [&](const ViewOfIntegerVariableID & v) {
-                if (find(scope, v.actual_variable) == scope.end())
+                if (! contains(scope, v.actual_variable))
                     scope.push_back(v.actual_variable);
             },
             [&](const ConstantIntegerVariableID &) {
@@ -160,7 +161,7 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         if (_imp->var_constraint_indices.size() <= v.index)
             _imp->var_constraint_indices.resize(v.index + 1);
         auto & indices = _imp->var_constraint_indices[v.index];
-        if (find(indices, constraint_index) == indices.end())
+        if (! contains(indices, constraint_index))
             indices.push_back(constraint_index);
     }
 
@@ -168,7 +169,7 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         _imp->constraint_scope.resize(constraint_index + 1);
     auto & cscope = _imp->constraint_scope[constraint_index];
     for (const auto & v : scope)
-        if (find(cscope, v) == cscope.end())
+        if (! contains(cscope, v))
             cscope.push_back(v);
 
     for (const auto & v : triggers.on_change) {

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -1,4 +1,5 @@
 #include <gcs/exception.hh>
+#include <gcs/innards/conflict_observer.hh>
 #include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -84,6 +85,11 @@ struct Propagators::Imp
     // install(), used by a conflict observer / weighted-degree heuristic.
     vector<vector<SimpleIntegerVariableID>> propagator_scope;
     vector<vector<int>> var_constraint_indices;
+
+    // A borrowed conflict observer, notified when a propagator wipes out a
+    // domain (see propagate). Set once at search start via set_conflict_observer;
+    // the caller owns it. nullptr when there is no observer.
+    ConflictObserver * conflict_observer = nullptr;
 };
 
 Propagators::Propagators() :
@@ -307,6 +313,13 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         catch (const TrackedPropagationFailed &) {
             contradiction = true;
             ++_imp->contradicting_propagations;
+            // Exactly one propagator contradiction ends each propagate(), so this
+            // fires at most once per call. Non-propagator contradiction paths
+            // (initialisers, the objective bound) never reach here, so they are
+            // not attributed to any constraint.
+            if (_imp->conflict_observer)
+                _imp->conflict_observer->note_conflict(_imp->propagator_constraint_index[propagator_id],
+                    _imp->propagator_scope[propagator_id], tracker.last_contradiction_reason(), state);
         }
 
         if (contradiction || (optional_abort_flag && optional_abort_flag->load()))
@@ -439,4 +452,14 @@ auto Propagators::constraint_indices_of_variable(SimpleIntegerVariableID var) co
         return none;
     }
     return _imp->var_constraint_indices[var.index];
+}
+
+auto Propagators::set_conflict_observer(ConflictObserver * observer) -> void
+{
+    _imp->conflict_observer = observer;
+}
+
+auto Propagators::conflict_observer() const -> ConflictObserver *
+{
+    return _imp->conflict_observer;
 }

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -39,18 +39,6 @@ namespace
     {
         vector<pair<int, int>> ids_and_masks;
     };
-
-    // ConstraintID structural equality (CurrentlyUnnamedConstraint,
-    // NumberedConstraint, NamedConstraint all compare) backs the dense-index
-    // map below; hashing its string form is enough, since equality is checked
-    // structurally on the variant.
-    struct ConstraintIDHash
-    {
-        auto operator()(const ConstraintID & id) const -> std::size_t
-        {
-            return std::hash<std::string>{}(as_string(id));
-        }
-    };
 }
 
 struct Propagators::Imp
@@ -75,16 +63,19 @@ struct Propagators::Imp
     // a fresh dense index on first sight of each ConstraintID.
     vector<int> propagator_constraint_index;
     vector<ConstraintID> constraint_ids;
-    std::unordered_map<ConstraintID, int, ConstraintIDHash> constraint_index_of_id;
+    std::unordered_map<ConstraintID, int> constraint_index_of_id;
 
     // The scope of each propagator (indexed by propagator id): its trigger
     // variables with views resolved to the underlying simple variable and
     // duplicates removed. var_constraint_indices is the transpose aggregated by
     // constraint: indexed by variable index, the deduplicated dense constraint
-    // indices that variable participates in. Built alongside the triggers in
-    // install(), used by a conflict observer / weighted-degree heuristic.
+    // indices that variable participates in. constraint_scope is the union of a
+    // constraint's propagators' scopes (indexed by dense constraint index), used
+    // for the |fut|>1 weighted-degree filter. All built alongside the triggers
+    // in install().
     vector<vector<SimpleIntegerVariableID>> propagator_scope;
     vector<vector<int>> var_constraint_indices;
+    vector<vector<SimpleIntegerVariableID>> constraint_scope;
 
     // A borrowed conflict observer, notified when a propagator wipes out a
     // domain (see propagate). Set once at search start via set_conflict_observer;
@@ -172,6 +163,13 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         if (find(indices, constraint_index) == indices.end())
             indices.push_back(constraint_index);
     }
+
+    if (_imp->constraint_scope.size() <= static_cast<std::size_t>(constraint_index))
+        _imp->constraint_scope.resize(constraint_index + 1);
+    auto & cscope = _imp->constraint_scope[constraint_index];
+    for (const auto & v : scope)
+        if (find(cscope, v) == cscope.end())
+            cscope.push_back(v);
 
     for (const auto & v : triggers.on_change) {
         trigger_on_change(v, id);
@@ -452,6 +450,11 @@ auto Propagators::constraint_indices_of_variable(SimpleIntegerVariableID var) co
         return none;
     }
     return _imp->var_constraint_indices[var.index];
+}
+
+auto Propagators::scope_of_constraint(int constraint_index) const -> const vector<SimpleIntegerVariableID> &
+{
+    return _imp->constraint_scope[constraint_index];
 }
 
 auto Propagators::set_conflict_observer(ConflictObserver * observer) -> void

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -30,6 +30,7 @@ using std::swap;
 using std::to_underlying;
 using std::vector;
 using std::visit;
+using std::ranges::find;
 
 namespace
 {
@@ -74,6 +75,15 @@ struct Propagators::Imp
     vector<int> propagator_constraint_index;
     vector<ConstraintID> constraint_ids;
     std::unordered_map<ConstraintID, int, ConstraintIDHash> constraint_index_of_id;
+
+    // The scope of each propagator (indexed by propagator id): its trigger
+    // variables with views resolved to the underlying simple variable and
+    // duplicates removed. var_constraint_indices is the transpose aggregated by
+    // constraint: indexed by variable index, the deduplicated dense constraint
+    // indices that variable participates in. Built alongside the triggers in
+    // install(), used by a conflict observer / weighted-degree heuristic.
+    vector<vector<SimpleIntegerVariableID>> propagator_scope;
+    vector<vector<int>> var_constraint_indices;
 };
 
 Propagators::Propagators() :
@@ -122,7 +132,40 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
     auto [it, inserted] = _imp->constraint_index_of_id.try_emplace(constraint_id, static_cast<int>(_imp->constraint_ids.size()));
     if (inserted)
         _imp->constraint_ids.push_back(constraint_id);
-    _imp->propagator_constraint_index.push_back(it->second);
+    int constraint_index = it->second;
+    _imp->propagator_constraint_index.push_back(constraint_index);
+
+    // Record this propagator's scope (its trigger variables, views resolved and
+    // deduplicated) and add it to each variable's constraint adjacency.
+    auto & scope = _imp->propagator_scope.emplace_back();
+    auto add_to_scope = [&](IntegerVariableID var) {
+        overloaded{
+            [&](const SimpleIntegerVariableID & v) {
+                if (find(scope, v) == scope.end())
+                    scope.push_back(v);
+            },
+            [&](const ViewOfIntegerVariableID & v) {
+                if (find(scope, v.actual_variable) == scope.end())
+                    scope.push_back(v.actual_variable);
+            },
+            [&](const ConstantIntegerVariableID &) {
+            }}
+            .visit(var);
+    };
+    for (const auto & v : triggers.on_change)
+        add_to_scope(v);
+    for (const auto & v : triggers.on_bounds)
+        add_to_scope(v);
+    for (const auto & v : triggers.on_instantiated)
+        add_to_scope(v);
+
+    for (const auto & v : scope) {
+        if (_imp->var_constraint_indices.size() <= v.index)
+            _imp->var_constraint_indices.resize(v.index + 1);
+        auto & indices = _imp->var_constraint_indices[v.index];
+        if (find(indices, constraint_index) == indices.end())
+            indices.push_back(constraint_index);
+    }
 
     for (const auto & v : triggers.on_change) {
         trigger_on_change(v, id);
@@ -382,4 +425,18 @@ auto Propagators::constraint_index_of_propagator(int propagator_id) const -> int
 auto Propagators::constraint_id_for_index(int constraint_index) const -> const ConstraintID &
 {
     return _imp->constraint_ids[constraint_index];
+}
+
+auto Propagators::scope_of_propagator(int propagator_id) const -> const vector<SimpleIntegerVariableID> &
+{
+    return _imp->propagator_scope[propagator_id];
+}
+
+auto Propagators::constraint_indices_of_variable(SimpleIntegerVariableID var) const -> const vector<int> &
+{
+    if (var.index >= _imp->var_constraint_indices.size()) {
+        static const vector<int> none;
+        return none;
+    }
+    return _imp->var_constraint_indices[var.index];
 }

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -336,6 +336,14 @@ namespace gcs::innards
          */
         [[nodiscard]] auto constraint_indices_of_variable(SimpleIntegerVariableID) const -> const std::vector<int> &;
 
+        /**
+         * The scope of the constraint with the given dense index: the union of
+         * its propagators' scopes (views resolved, deduplicated). Used to count
+         * how many of a constraint's variables are still unassigned (the
+         * |fut|>1 filter in a weighted-degree heuristic).
+         */
+        [[nodiscard]] auto scope_of_constraint(int constraint_index) const -> const std::vector<SimpleIntegerVariableID> &;
+
         ///@}
 
         /**

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -20,6 +20,8 @@
 
 namespace gcs::innards
 {
+    class ConflictObserver;
+
     class PropagationFunctionImplBase
     {
     public:
@@ -333,6 +335,33 @@ namespace gcs::innards
          * constraint — the adjacency a weighted-degree heuristic sums over.
          */
         [[nodiscard]] auto constraint_indices_of_variable(SimpleIntegerVariableID) const -> const std::vector<int> &;
+
+        ///@}
+
+        /**
+         * \name Conflict observation
+         */
+        ///@{
+
+        /**
+         * Attach a borrowed conflict observer, notified by propagate() whenever
+         * a propagator wipes out a domain. The observer is borrowed: the caller
+         * owns it and must keep it alive for the duration of the search. Pass
+         * nullptr to detach. A conflict is a Propagators event (it carries the
+         * failing constraint's index, scope, and reason, all from here), so the
+         * observer lives with the rest of the conflict-observation machinery
+         * rather than on State.
+         *
+         * \sa ConflictObserver
+         */
+        auto set_conflict_observer(ConflictObserver * observer) -> void;
+
+        /**
+         * The conflict observer currently attached, or nullptr if none.
+         *
+         * \sa Propagators::set_conflict_observer()
+         */
+        [[nodiscard]] auto conflict_observer() const -> ConflictObserver *;
 
         ///@}
     };

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -318,6 +318,22 @@ namespace gcs::innards
          */
         [[nodiscard]] auto constraint_id_for_index(int constraint_index) const -> const ConstraintID &;
 
+        /**
+         * The scope of the propagator with the given id: its trigger variables
+         * (across all trigger kinds) with views resolved to their underlying
+         * simple variable and duplicates removed. Indexed by propagator id.
+         */
+        [[nodiscard]] auto scope_of_propagator(int propagator_id) const -> const std::vector<SimpleIntegerVariableID> &;
+
+        /**
+         * The dense constraint indices of every constraint the given variable
+         * participates in (it appears in the scope of one of that constraint's
+         * propagators), deduplicated. Empty for a variable that no propagator
+         * triggers on. This is scope_of_propagator transposed and aggregated by
+         * constraint — the adjacency a weighted-degree heuristic sums over.
+         */
+        [[nodiscard]] auto constraint_indices_of_variable(SimpleIntegerVariableID) const -> const std::vector<int> &;
+
         ///@}
     };
 }

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -31,13 +31,14 @@ namespace
 {
     auto solve_subproblem(unsigned depth, SimpleTuples & tuples, const vector<IntegerVariableID> & vars,
         Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
+        const BranchCallback & branch_callback,
         ProofLogger * const logger, SimpleIntegerVariableID selector_var_id) -> void
     {
         if (logger)
             logger->enter_proof_level(depth + 1);
 
         if (propagators.propagate(this_branch_guess, state, logger)) {
-            auto brancher = branch_with(variable_order::dom_then_deg(vars), value_order::smallest_first())(state.current(), propagators);
+            auto brancher = branch_callback(state.current(), propagators);
             auto branch_iter = brancher.begin();
             if (branch_iter == brancher.end()) {
                 vector<Integer> tuple;
@@ -73,7 +74,7 @@ namespace
                     auto timestamp = state.new_epoch();
                     auto branch = *branch_iter;
                     state.guess(branch);
-                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch, logger, selector_var_id);
+                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch, branch_callback, logger, selector_var_id);
                     state.backtrack(timestamp);
                 }
             }
@@ -90,9 +91,13 @@ namespace
     }
 }
 
-auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
+auto AutoTable::run(Problem & problem, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
 {
     SimpleTuples tuples;
+
+    // dom_then_deg is stateless, so its setup is a no-op; build the per-node
+    // callback once and reuse it down the subproblem recursion.
+    auto branch_callback = branch_with(variable_order::dom_then_deg(_vars), value_order::smallest_first())(problem, initial_state, propagators);
 
     auto timestamp = initial_state.new_epoch(true);
     initial_state.guess(TrueLiteral{});
@@ -100,7 +105,7 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
     auto selector_var_id = initial_state.what_variable_id_will_be_created_next();
     if (logger)
         logger->emit_proof_comment("starting autotabulation");
-    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, logger, selector_var_id);
+    solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, branch_callback, logger, selector_var_id);
 
     if (logger)
         logger->emit_proof_comment("creating autotable with " + to_string(tuples.size()) + " entries");

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -205,12 +205,27 @@ auto gcs::variable_order::dom_wdeg(const Problem & problem, WeightingScheme sche
 auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingScheme scheme, optional<WeightingState> initial) -> BranchVariableHeuristic
 {
     return [vars = move(vars), scheme, initial = move(initial)](
-               const Problem &, innards::State &, innards::Propagators & propagators) -> BranchVariableSelector {
+               const Problem &, innards::State & state, innards::Propagators & propagators) -> BranchVariableSelector {
         shared_ptr<VariableWeighting> weighting;
         switch (scheme) {
             using enum WeightingScheme;
         case Classic:
             weighting = make_shared<ClassicDomWDeg>(propagators);
+            break;
+        case Ia:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ia);
+            break;
+        case Ca:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ca);
+            break;
+        case Id:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Id);
+            break;
+        case Cd:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Cd);
+            break;
+        case CaCd:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CaCd);
             break;
         case ConflictHistorySearch:
             // Qualified: the WeightingScheme::ConflictHistorySearch enumerator

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -212,20 +212,20 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingSche
         case Classic:
             weighting = make_shared<ClassicDomWDeg>(propagators);
             break;
-        case Ia:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ia);
+        case InitialArity:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::InitialArity);
             break;
-        case Ca:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Ca);
+        case CurrentArity:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CurrentArity);
             break;
-        case Id:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Id);
+        case InitialDomain:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::InitialDomain);
             break;
-        case Cd:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::Cd);
+        case CurrentDomain:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CurrentDomain);
             break;
-        case CaCd:
-            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CaCd);
+        case CurrentArityCurrentDomain:
+            weighting = make_shared<RefinedWeighting>(propagators, state, RefinedWeighting::Variant::CurrentArityCurrentDomain);
             break;
         case ConflictHistorySearch:
             // Qualified: the WeightingScheme::ConflictHistorySearch enumerator

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -197,16 +197,25 @@ auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> Branch
     });
 }
 
-auto gcs::variable_order::dom_wdeg(const Problem & problem, optional<WeightingState> initial) -> BranchVariableHeuristic
+auto gcs::variable_order::dom_wdeg(const Problem & problem, WeightingScheme scheme, optional<WeightingState> initial) -> BranchVariableHeuristic
 {
-    return dom_wdeg(problem.all_normal_variables(), move(initial));
+    return dom_wdeg(problem.all_normal_variables(), scheme, move(initial));
 }
 
-auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<WeightingState> initial) -> BranchVariableHeuristic
+auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingScheme scheme, optional<WeightingState> initial) -> BranchVariableHeuristic
 {
-    return [vars = move(vars), initial = move(initial)](
+    return [vars = move(vars), scheme, initial = move(initial)](
                const Problem &, innards::State &, innards::Propagators & propagators) -> BranchVariableSelector {
-        auto weighting = make_shared<ClassicDomWDeg>(propagators);
+        shared_ptr<VariableWeighting> weighting;
+        switch (scheme) {
+            using enum WeightingScheme;
+        case Classic:
+            weighting = make_shared<ClassicDomWDeg>(propagators);
+            break;
+        case Chs:
+            weighting = make_shared<ConflictHistorySearch>(propagators);
+            break;
+        }
         if (initial)
             weighting->load(*initial, propagators);
         propagators.set_conflict_observer(weighting.get());

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -173,6 +173,40 @@ auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> Branch
     });
 }
 
+auto gcs::variable_order::dom_wdeg(const Problem & problem, optional<WeightingState> initial) -> BranchVariableHeuristic
+{
+    return dom_wdeg(problem.all_normal_variables(), move(initial));
+}
+
+auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<WeightingState> initial) -> BranchVariableHeuristic
+{
+    return [vars = move(vars), initial = move(initial)](
+               const Problem &, innards::State &, innards::Propagators & propagators) -> BranchVariableSelector {
+        auto weighting = make_shared<ClassicDomWDeg>(propagators);
+        if (initial)
+            weighting->load(*initial, propagators);
+        propagators.set_conflict_observer(weighting.get());
+
+        return variable_order::in_order_of(vars,
+            [weighting](const CurrentState & state, const innards::Propagators & p,
+                const IntegerVariableID & a, const IntegerVariableID & b) -> bool {
+                // Minimise dom(x)/W(x), cross-multiplied to avoid division: a
+                // variable with W(x)=0 (in no constraint with two or more
+                // unassigned variables) then sorts last for free. Tie-break on
+                // highest degree, matching dom_then_deg.
+                auto dom_a = static_cast<double>(state.domain_size(a).raw_value);
+                auto dom_b = static_cast<double>(state.domain_size(b).raw_value);
+                auto w_a = weighting->weighted_degree_of(state, p, a);
+                auto w_b = weighting->weighted_degree_of(state, p, b);
+                auto lhs = dom_a * w_b;
+                auto rhs = dom_b * w_a;
+                if (lhs != rhs)
+                    return lhs < rhs;
+                return p.degree_of(a) > p.degree_of(b);
+            });
+    };
+}
+
 auto gcs::variable_order::with_smallest_value(const Problem & problem) -> BranchVariableSelector
 {
     return with_smallest_value(problem.all_normal_variables());

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -40,37 +40,46 @@ namespace
 
 using namespace gcs;
 
-auto gcs::branch_with(BranchVariableSelector var, BranchValueGenerator val) -> BranchCallback
+auto gcs::branch_with(BranchVariableHeuristic var, BranchValueGenerator val) -> BranchHeuristic
 {
-    return [var = move(var), val = move(val)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, const innards::Propagators & p,
-                   BranchVariableSelector select_var, BranchValueGenerator make_val_gen) -> generator<IntegerVariableCondition> {
-            auto branch_var = select_var(s, p);
-            if (branch_var)
-                return make_val_gen(s, p, *branch_var);
-            else
-                return []() -> generator<IntegerVariableCondition> { co_return; }();
-        }(s, p, move(var), move(val));
+    return [var = move(var), val = move(val)](const Problem & problem, innards::State & state, innards::Propagators & propagators) -> BranchCallback {
+        // Run the variable heuristic's per-search setup once, then reuse the
+        // resulting selector at every node.
+        auto select_var = var(problem, state, propagators);
+        return [select_var = move(select_var), val = val](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
+            return [](const CurrentState & s, const innards::Propagators & p,
+                       BranchVariableSelector select_var, BranchValueGenerator make_val_gen) -> generator<IntegerVariableCondition> {
+                auto branch_var = select_var(s, p);
+                if (branch_var)
+                    return make_val_gen(s, p, *branch_var);
+                else
+                    return []() -> generator<IntegerVariableCondition> { co_return; }();
+            }(s, p, select_var, val);
+        };
     };
 }
 
-auto gcs::branch_sequence(BranchCallback a, BranchCallback b) -> BranchCallback
+auto gcs::branch_sequence(BranchHeuristic a, BranchHeuristic b) -> BranchHeuristic
 {
-    return [a = move(a), b = move(b)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a, BranchCallback b) -> generator<IntegerVariableCondition> {
-            auto gen_a = a(s, p);
-            auto iter_a = gen_a.begin();
-            if (iter_a != gen_a.end()) {
-                for (; iter_a != gen_a.end(); ++iter_a)
-                    co_yield *iter_a;
-            }
-            else {
-                auto gen_b = b(s, p);
-                auto iter_b = gen_b.begin();
-                for (; iter_b != gen_b.end(); ++iter_b)
-                    co_yield *iter_b;
-            }
-        }(s, p, move(a), move(b));
+    return [a = move(a), b = move(b)](const Problem & problem, innards::State & state, innards::Propagators & propagators) -> BranchCallback {
+        auto callback_a = a(problem, state, propagators);
+        auto callback_b = b(problem, state, propagators);
+        return [callback_a = move(callback_a), callback_b = move(callback_b)](const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
+            return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a, BranchCallback b) -> generator<IntegerVariableCondition> {
+                auto gen_a = a(s, p);
+                auto iter_a = gen_a.begin();
+                if (iter_a != gen_a.end()) {
+                    for (; iter_a != gen_a.end(); ++iter_a)
+                        co_yield *iter_a;
+                }
+                else {
+                    auto gen_b = b(s, p);
+                    auto iter_b = gen_b.begin();
+                    for (; iter_b != gen_b.end(); ++iter_b)
+                        co_yield *iter_b;
+                }
+            }(s, p, callback_a, callback_b);
+        };
     };
 }
 
@@ -92,53 +101,68 @@ namespace
             }
         };
     }
+
+    auto in_order_of_selector(vector<IntegerVariableID> vars, variable_order::VariableComparator comp) -> BranchVariableSelector
+    {
+        return [vars = move(vars), comp = move(comp)](
+                   const CurrentState & state, const innards::Propagators & propagators) -> optional<IntegerVariableID> {
+            optional<IntegerVariableID> result;
+            for (auto & v : vars) {
+                auto size = state.domain_size(v);
+                if (size < 2_i)
+                    continue;
+                if ((! result) || comp(state, propagators, v, *result))
+                    result = v;
+            }
+            return result;
+        };
+    }
+
+    // Wrap a stateless selector (one needing no per-search setup) as a
+    // BranchVariableHeuristic: the setup ignores its arguments and just returns
+    // the selector.
+    auto as_heuristic(BranchVariableSelector selector) -> BranchVariableHeuristic
+    {
+        return [selector = move(selector)](const Problem &, innards::State &, innards::Propagators &) -> BranchVariableSelector {
+            return selector;
+        };
+    }
 }
 
-auto gcs::variable_order::random(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::random(const Problem & problem) -> BranchVariableHeuristic
 {
     return variable_order::random(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::random(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::random(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
-    return random_variable_selector(move(vars), make_shared_rng());
+    return as_heuristic(random_variable_selector(move(vars), make_shared_rng()));
 }
 
-auto gcs::variable_order::random(const Problem & problem, uint_fast32_t seed) -> BranchVariableSelector
+auto gcs::variable_order::random(const Problem & problem, uint_fast32_t seed) -> BranchVariableHeuristic
 {
     return variable_order::random(problem.all_normal_variables(), seed);
 }
 
-auto gcs::variable_order::random(vector<IntegerVariableID> vars, uint_fast32_t seed) -> BranchVariableSelector
+auto gcs::variable_order::random(vector<IntegerVariableID> vars, uint_fast32_t seed) -> BranchVariableHeuristic
 {
-    return random_variable_selector(move(vars), make_shared_rng(seed));
+    return as_heuristic(random_variable_selector(move(vars), make_shared_rng(seed)));
 }
 
-auto gcs::variable_order::in_order_of(const Problem & problem, VariableComparator comp) -> BranchVariableSelector
+auto gcs::variable_order::in_order_of(const Problem & problem, VariableComparator comp) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(problem.all_normal_variables(), move(comp));
 }
 
-auto gcs::variable_order::in_order_of(vector<IntegerVariableID> vars, VariableComparator comp) -> BranchVariableSelector
+auto gcs::variable_order::in_order_of(vector<IntegerVariableID> vars, VariableComparator comp) -> BranchVariableHeuristic
 {
-    return [vars = move(vars), comp = move(comp)](
-               const CurrentState & state, const innards::Propagators & propagators) -> optional<IntegerVariableID> {
-        optional<IntegerVariableID> result;
-        for (auto & v : vars) {
-            auto size = state.domain_size(v);
-            if (size < 2_i)
-                continue;
-            if ((! result) || comp(state, propagators, v, *result))
-                result = v;
-        }
-        return result;
-    };
+    return as_heuristic(in_order_of_selector(move(vars), move(comp)));
 }
 
-auto gcs::variable_order::in_order(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::in_order(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
-    return [vars = move(vars)](
-               const CurrentState & state, const innards::Propagators &) -> optional<IntegerVariableID> {
+    return as_heuristic([vars = move(vars)](
+                            const CurrentState & state, const innards::Propagators &) -> optional<IntegerVariableID> {
         for (auto & v : vars) {
             auto size = state.domain_size(v);
             if (size < 2_i)
@@ -146,27 +170,27 @@ auto gcs::variable_order::in_order(vector<IntegerVariableID> vars) -> BranchVari
             return v;
         }
         return nullopt;
-    };
+    });
 }
 
-auto gcs::variable_order::dom(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::dom(const Problem & problem) -> BranchVariableHeuristic
 {
     return dom(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::dom(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::dom(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(vars, [](const CurrentState & state, const innards::Propagators &, const IntegerVariableID & a, const IntegerVariableID & b) {
         return state.domain_size(a) < state.domain_size(b);
     });
 }
 
-auto gcs::variable_order::dom_then_deg(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::dom_then_deg(const Problem & problem) -> BranchVariableHeuristic
 {
     return dom_then_deg(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::dom_then_deg(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(vars, [](const CurrentState & state, const innards::Propagators & p, const IntegerVariableID & a, const IntegerVariableID & b) {
         return tuple{state.domain_size(a), -p.degree_of(a)} < tuple{state.domain_size(b), -p.degree_of(b)};
@@ -187,7 +211,7 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<Weig
             weighting->load(*initial, propagators);
         propagators.set_conflict_observer(weighting.get());
 
-        return variable_order::in_order_of(vars,
+        return in_order_of_selector(vars,
             [weighting](const CurrentState & state, const innards::Propagators & p,
                 const IntegerVariableID & a, const IntegerVariableID & b) -> bool {
                 // Minimise dom(x)/W(x), cross-multiplied to avoid division: a
@@ -207,12 +231,12 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, optional<Weig
     };
 }
 
-auto gcs::variable_order::with_smallest_value(const Problem & problem) -> BranchVariableSelector
+auto gcs::variable_order::with_smallest_value(const Problem & problem) -> BranchVariableHeuristic
 {
     return with_smallest_value(problem.all_normal_variables());
 }
 
-auto gcs::variable_order::with_smallest_value(vector<IntegerVariableID> vars) -> BranchVariableSelector
+auto gcs::variable_order::with_smallest_value(vector<IntegerVariableID> vars) -> BranchVariableHeuristic
 {
     return variable_order::in_order_of(vars, [](const CurrentState & state, const innards::Propagators &, const IntegerVariableID & a, const IntegerVariableID & b) {
         return state.lower_bound(a) < state.lower_bound(b);

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -212,8 +212,10 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingSche
         case Classic:
             weighting = make_shared<ClassicDomWDeg>(propagators);
             break;
-        case Chs:
-            weighting = make_shared<ConflictHistorySearch>(propagators);
+        case ConflictHistorySearch:
+            // Qualified: the WeightingScheme::ConflictHistorySearch enumerator
+            // (via using enum) otherwise shadows the class of the same name.
+            weighting = make_shared<gcs::ConflictHistorySearch>(propagators);
             break;
         }
         if (initial)

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -147,35 +147,36 @@ namespace gcs
         /**
          * \brief dom/wdeg: branch on the non-assigned variable minimising
          * dom(x)/W(x), where W(x) is the weighted degree from a dynamic
-         * constraint weighting (classic dom/wdeg: Boussemart, Hemery, Lecoutre,
-         * Sais, ECAI 2004).
+         * constraint weighting.
          *
          * Returns a BranchVariableHeuristic, not a bare selector: at search start
-         * it constructs a ClassicDomWDeg weighting (one weight per constraint,
-         * initialised to 1, bumped on each domain wipeout), attaches it as the
-         * Propagators' conflict observer, and returns the selector. Weights start
-         * uniform, so at the root the heuristic orders by dom(x)/degree(x) and it
-         * specialises towards hard constraints as conflicts accumulate. Ties are
-         * broken on highest constraint degree, and a variable with W(x)=0 (in no
-         * constraint with two or more unassigned variables) is least preferred.
+         * it constructs the weighting for the chosen WeightingScheme, attaches it
+         * as the Propagators' conflict observer, and returns the selector. Ties
+         * are broken on highest constraint degree, and a variable with W(x)=0 (in
+         * no constraint with two or more unassigned variables) is least preferred.
          *
-         * An optional initial WeightingState seeds the weights --- for carrying
-         * weights across searches or injecting proof-mined weights. Value
-         * ordering is chosen separately, as usual via gcs::branch_with().
+         * \p scheme selects the weighting (default WeightingScheme::Classic, the
+         * original dom/wdeg). An optional initial WeightingState seeds the weights
+         * --- for carrying weights across searches or injecting proof-mined
+         * weights. Value ordering is chosen separately, as usual via
+         * gcs::branch_with().
          *
          * \ingroup SearchHeuristics
          * \sa WeightingState
+         * \sa WeightingScheme
          */
         [[nodiscard]] auto dom_wdeg(const Problem &,
+            WeightingScheme scheme = WeightingScheme::Classic,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
          * \brief dom/wdeg over an explicit list of variables.
          *
          * \ingroup SearchHeuristics
-         * \sa gcs::variable_order::dom_wdeg(const Problem &, std::optional<WeightingState>)
+         * \sa gcs::variable_order::dom_wdeg(const Problem &, WeightingScheme, std::optional<WeightingState>)
          */
         [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
+            WeightingScheme scheme = WeightingScheme::Classic,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -1,11 +1,15 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SEARCH_HEURISTICS_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SEARCH_HEURISTICS_HH
 
+#include <gcs/innards/state-fwd.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
+#include <gcs/variable_weighting.hh>
 
 #include <cstdint>
 #include <functional>
+#include <optional>
+#include <vector>
 
 namespace gcs
 {
@@ -27,6 +31,25 @@ namespace gcs
      */
     using BranchVariableSelector = std::function<std::optional<IntegerVariableID>(
         const CurrentState &, const innards::Propagators &)>;
+
+    /**
+     * A variable-ordering heuristic that needs per-search setup before it can
+     * select: given a search's Problem, State, and Propagators, it does any
+     * one-time setup (for example a stateful heuristic constructing its weights
+     * and attaching itself as a conflict observer) and returns the
+     * BranchVariableSelector to branch with. Called once per search; in a
+     * parallel search, once per thread with that thread's own State and
+     * Propagators. A stateless ordering simply ignores the arguments and returns
+     * its selector.
+     *
+     * Currently only gcs::variable_order::dom_wdeg() returns one of these; the
+     * other gcs::variable_order:: orderings still return a BranchVariableSelector
+     * directly, pending a later migration to this shape.
+     *
+     * \ingroup SearchHeuristics
+     */
+    using BranchVariableHeuristic = std::function<BranchVariableSelector(
+        const Problem &, innards::State &, innards::Propagators &)>;
 
     /**
      * Given a branch variable, how do we branch on it? Usually this will be used via the gcs::branch_with()
@@ -123,6 +146,40 @@ namespace gcs
          * \sa gcs::branch_with()
          */
         [[nodiscard]] auto dom_then_deg(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+
+        /**
+         * \brief dom/wdeg: branch on the non-assigned variable minimising
+         * dom(x)/W(x), where W(x) is the weighted degree from a dynamic
+         * constraint weighting (classic dom/wdeg: Boussemart, Hemery, Lecoutre,
+         * Sais, ECAI 2004).
+         *
+         * Returns a BranchVariableHeuristic, not a bare selector: at search start
+         * it constructs a ClassicDomWDeg weighting (one weight per constraint,
+         * initialised to 1, bumped on each domain wipeout), attaches it as the
+         * Propagators' conflict observer, and returns the selector. Weights start
+         * uniform, so at the root the heuristic orders by dom(x)/degree(x) and it
+         * specialises towards hard constraints as conflicts accumulate. Ties are
+         * broken on highest constraint degree, and a variable with W(x)=0 (in no
+         * constraint with two or more unassigned variables) is least preferred.
+         *
+         * An optional initial WeightingState seeds the weights --- for carrying
+         * weights across searches or injecting proof-mined weights. Value
+         * ordering is chosen separately, as usual via gcs::branch_with().
+         *
+         * \ingroup SearchHeuristics
+         * \sa WeightingState
+         */
+        [[nodiscard]] auto dom_wdeg(const Problem &,
+            std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
+
+        /**
+         * \brief dom/wdeg over an explicit list of variables.
+         *
+         * \ingroup SearchHeuristics
+         * \sa gcs::variable_order::dom_wdeg(const Problem &, std::optional<WeightingState>)
+         */
+        [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
+            std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
          * Branch on non-assigned variables in this order.

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -155,7 +155,7 @@ namespace gcs
          * are broken on highest constraint degree, and a variable with W(x)=0 (in
          * no constraint with two or more unassigned variables) is least preferred.
          *
-         * \p scheme selects the weighting (default WeightingScheme::CaCd, the
+         * \p scheme selects the weighting (default WeightingScheme::CurrentArityCurrentDomain, the
          * strongest in Wattez et al.). An optional initial WeightingState seeds
          * the weights --- for carrying weights across searches or injecting
          * proof-mined weights. Value ordering is chosen separately, as usual via
@@ -166,7 +166,7 @@ namespace gcs
          * \sa WeightingScheme
          */
         [[nodiscard]] auto dom_wdeg(const Problem &,
-            WeightingScheme scheme = WeightingScheme::CaCd,
+            WeightingScheme scheme = WeightingScheme::CurrentArityCurrentDomain,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
@@ -176,7 +176,7 @@ namespace gcs
          * \sa gcs::variable_order::dom_wdeg(const Problem &, WeightingScheme, std::optional<WeightingState>)
          */
         [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
-            WeightingScheme scheme = WeightingScheme::CaCd,
+            WeightingScheme scheme = WeightingScheme::CurrentArityCurrentDomain,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -155,10 +155,10 @@ namespace gcs
          * are broken on highest constraint degree, and a variable with W(x)=0 (in
          * no constraint with two or more unassigned variables) is least preferred.
          *
-         * \p scheme selects the weighting (default WeightingScheme::Classic, the
-         * original dom/wdeg). An optional initial WeightingState seeds the weights
-         * --- for carrying weights across searches or injecting proof-mined
-         * weights. Value ordering is chosen separately, as usual via
+         * \p scheme selects the weighting (default WeightingScheme::CaCd, the
+         * strongest in Wattez et al.). An optional initial WeightingState seeds
+         * the weights --- for carrying weights across searches or injecting
+         * proof-mined weights. Value ordering is chosen separately, as usual via
          * gcs::branch_with().
          *
          * \ingroup SearchHeuristics
@@ -166,7 +166,7 @@ namespace gcs
          * \sa WeightingScheme
          */
         [[nodiscard]] auto dom_wdeg(const Problem &,
-            WeightingScheme scheme = WeightingScheme::Classic,
+            WeightingScheme scheme = WeightingScheme::CaCd,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
@@ -176,7 +176,7 @@ namespace gcs
          * \sa gcs::variable_order::dom_wdeg(const Problem &, WeightingScheme, std::optional<WeightingState>)
          */
         [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
-            WeightingScheme scheme = WeightingScheme::Classic,
+            WeightingScheme scheme = WeightingScheme::CaCd,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -40,11 +40,8 @@ namespace gcs
      * BranchVariableSelector to branch with. Called once per search; in a
      * parallel search, once per thread with that thread's own State and
      * Propagators. A stateless ordering simply ignores the arguments and returns
-     * its selector.
-     *
-     * Currently only gcs::variable_order::dom_wdeg() returns one of these; the
-     * other gcs::variable_order:: orderings still return a BranchVariableSelector
-     * directly, pending a later migration to this shape.
+     * its selector; a stateful one (gcs::variable_order::dom_wdeg) uses them.
+     * Every gcs::variable_order:: ordering returns one of these.
      *
      * \ingroup SearchHeuristics
      */
@@ -65,20 +62,20 @@ namespace gcs
         const CurrentState &, const innards::Propagators &, const IntegerVariableID &)>;
 
     /**
-     * Combine a BranchVariableSelector from gcs::variable_order:: with a BranchValueGenerator
-     * from gcs::value_order:: to produce a BranchCallback for SolveCallbacks.
+     * Combine a BranchVariableHeuristic from gcs::variable_order:: with a BranchValueGenerator
+     * from gcs::value_order:: to produce a BranchHeuristic for SolveCallbacks.
      *
      * \ingroup SearchHeuristics
      */
-    [[nodiscard]] auto branch_with(BranchVariableSelector, BranchValueGenerator) -> BranchCallback;
+    [[nodiscard]] auto branch_with(BranchVariableHeuristic, BranchValueGenerator) -> BranchHeuristic;
 
     /**
-     * Combine two BranchCallback instances, first trying the first instance, and if it returns
-     * nullopt, instead trying the second instance.
+     * Combine two BranchHeuristic instances, first trying the first instance, and if it returns
+     * nullopt, instead trying the second instance. (Both are set up once per search.)
      *
      * \ingroup SearchHeuristics
      */
-    [[nodiscard]] auto branch_sequence(BranchCallback, BranchCallback) -> BranchCallback;
+    [[nodiscard]] auto branch_sequence(BranchHeuristic, BranchHeuristic) -> BranchHeuristic;
 
     /**
      * Variable ordering heuristics.
@@ -103,7 +100,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto in_order_of(const Problem &, VariableComparator) -> BranchVariableSelector;
+        [[nodiscard]] auto in_order_of(const Problem &, VariableComparator) -> BranchVariableHeuristic;
 
         /**
          * Branch on the smallest non-assigned variable wrt this comparator.
@@ -111,7 +108,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto in_order_of(std::vector<IntegerVariableID>, VariableComparator) -> BranchVariableSelector;
+        [[nodiscard]] auto in_order_of(std::vector<IntegerVariableID>, VariableComparator) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain.
@@ -119,7 +116,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto dom(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain.
@@ -127,7 +124,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto dom(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain, tie-breaking on highest
@@ -136,7 +133,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom_then_deg(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto dom_then_deg(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with smallest domain, tie-breaking on highest
@@ -145,7 +142,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto dom_then_deg(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto dom_then_deg(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * \brief dom/wdeg: branch on the non-assigned variable minimising
@@ -187,7 +184,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto in_order(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto in_order(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the smallest value in its domain.
@@ -195,7 +192,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_smallest_value(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto with_smallest_value(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the smallest value in its domain.
@@ -203,7 +200,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_smallest_value(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto with_smallest_value(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the largest value in its domain.
@@ -211,7 +208,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_largest_value(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto with_largest_value(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on the non-assigned variable with the largest value in its domain.
@@ -219,7 +216,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto with_largest_value(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto with_largest_value(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, seeded non-deterministically.
@@ -227,7 +224,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(const Problem &) -> BranchVariableSelector;
+        [[nodiscard]] auto random(const Problem &) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, seeded non-deterministically.
@@ -235,7 +232,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(std::vector<IntegerVariableID>) -> BranchVariableSelector;
+        [[nodiscard]] auto random(std::vector<IntegerVariableID>) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, with an explicit seed for
@@ -244,7 +241,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(const Problem &, std::uint_fast32_t seed) -> BranchVariableSelector;
+        [[nodiscard]] auto random(const Problem &, std::uint_fast32_t seed) -> BranchVariableHeuristic;
 
         /**
          * Branch on a random non-assigned variable, with an explicit seed for
@@ -253,7 +250,7 @@ namespace gcs
          * \ingroup SearchHeuristics
          * \sa gcs::branch_with()
          */
-        [[nodiscard]] auto random(std::vector<IntegerVariableID>, std::uint_fast32_t seed) -> BranchVariableSelector;
+        [[nodiscard]] auto random(std::vector<IntegerVariableID>, std::uint_fast32_t seed) -> BranchVariableHeuristic;
     }
 
     /**

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -121,7 +121,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
-    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::Chs);
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::ConflictHistorySearch);
 
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -1,0 +1,112 @@
+#include <gcs/constraint.hh>
+#include <gcs/current_state.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/variable_id.hh>
+#include <gcs/variable_weighting.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+namespace
+{
+    auto a_propagator_that_does_nothing()
+    {
+        return [](const State &, auto &, ProofLogger * const) -> PropagatorState { return PropagatorState::Enable; };
+    }
+}
+
+// dom_wdeg's setup only uses the Propagators (it ignores the Problem and State),
+// so these tests drive it with a hand-built State + Propagators and an empty
+// dummy Problem for the unused argument, which gives full control over domains,
+// scopes, and weights.
+
+TEST_CASE("dom_wdeg orders by dom/W, with a zero-weight variable last")
+{
+    Problem dummy;
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4
+    auto b = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4
+    auto c = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4
+    auto d = state.allocate_integer_variable_with_state(0_i, 3_i); // dom 4, in no constraint
+    auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
+
+    Propagators propagators;
+    // a is in one constraint, b in two, c in three (each paired with x); weights
+    // are uniform at the root, so W(a)=1, W(b)=2, W(c)=3 and W(d)=0.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{4}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{5}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{6}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+
+    // dom/W: a=4/1=4, b=4/2=2, c=4/3 -> c is smallest.
+    auto selector = variable_order::dom_wdeg({a, b, c})(dummy, state, propagators);
+    auto picked = selector(state.current(), propagators);
+    REQUIRE(picked.has_value());
+    CHECK(*picked == IntegerVariableID{c});
+
+    // d has weighted degree 0, so dom/W is infinite: it is least preferred and a
+    // (finite ratio) wins.
+    auto with_isolated = variable_order::dom_wdeg({d, a})(dummy, state, propagators);
+    auto picked_isolated = with_isolated(state.current(), propagators);
+    REQUIRE(picked_isolated.has_value());
+    CHECK(*picked_isolated == IntegerVariableID{a});
+}
+
+TEST_CASE("dom_wdeg seeded weights change the choice")
+{
+    Problem dummy;
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto b = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto c = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+    propagators.install(NumberedConstraint{4}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{5}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+    propagators.install(NumberedConstraint{6}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
+
+    // Without a seed, c wins (as above). Seeding a's only constraint heavily
+    // makes W(a)=10, so dom/W a=0.4 is now the smallest and a wins instead.
+    WeightingState seed;
+    seed.set_weight(NumberedConstraint{1}, 10.0);
+
+    auto selector = variable_order::dom_wdeg({a, b, c}, seed)(dummy, state, propagators);
+    auto picked = selector(state.current(), propagators);
+    REQUIRE(picked.has_value());
+    CHECK(*picked == IntegerVariableID{a});
+}
+
+TEST_CASE("dom_wdeg tie-breaks on degree")
+{
+    Problem dummy;
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 3_i);
+    auto b = state.allocate_integer_variable_with_state(0_i, 3_i);
+
+    Propagators propagators;
+    // Both share the single constraint, so W(a)=W(b)=1 and dom/W ties. But a is
+    // registered on an extra trigger, giving it the higher degree, so the
+    // tie-break prefers it.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(),
+        Triggers{.on_change = {a, b}, .on_bounds = {a}});
+
+    REQUIRE(propagators.degree_of(a) > propagators.degree_of(b));
+
+    auto selector = variable_order::dom_wdeg({a, b})(dummy, state, propagators);
+    auto picked = selector(state.current(), propagators);
+    REQUIRE(picked.has_value());
+    CHECK(*picked == IntegerVariableID{a});
+}

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -1,9 +1,11 @@
 #include <gcs/constraint.hh>
+#include <gcs/constraints/equals.hh>
 #include <gcs/current_state.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
 #include <gcs/variable_id.hh>
 #include <gcs/variable_weighting.hh>
 
@@ -109,4 +111,28 @@ TEST_CASE("dom_wdeg tie-breaks on degree")
     auto picked = selector(state.current(), propagators);
     REQUIRE(picked.has_value());
     CHECK(*picked == IntegerVariableID{a});
+}
+
+TEST_CASE("dom_wdeg wired into solve_with finds every solution")
+{
+    // An all-different triangle over {1,2,3}: the six permutations. dom/wdeg only
+    // changes branch order, so a complete search must still enumerate them all --
+    // this exercises the whole wiring: selection via callbacks.branch, the
+    // once-per-search setup in solve_with, and the conflict observer driving the
+    // weights during search.
+    Problem problem;
+    auto a = problem.create_integer_variable(1_i, 3_i);
+    auto b = problem.create_integer_variable(1_i, 3_i);
+    auto c = problem.create_integer_variable(1_i, 3_i);
+    problem.post(NotEquals{a, b});
+    problem.post(NotEquals{b, c});
+    problem.post(NotEquals{a, c});
+
+    int solutions = 0;
+    solve_with(problem,
+        SolveCallbacks{
+            .solution = [&](const CurrentState &) -> bool { ++solutions; return true; },
+            .branch = branch_with(variable_order::dom_wdeg(problem), value_order::smallest_first())});
+
+    CHECK(solutions == 6);
 }

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -10,6 +10,7 @@
 #include <gcs/variable_weighting.hh>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <optional>
 
@@ -85,7 +86,7 @@ TEST_CASE("dom_wdeg seeded weights change the choice")
     WeightingState seed;
     seed.set_weight(NumberedConstraint{1}, 10.0);
 
-    auto selector = variable_order::dom_wdeg({a, b, c}, seed)(dummy, state, propagators);
+    auto selector = variable_order::dom_wdeg({a, b, c}, WeightingScheme::Classic, seed)(dummy, state, propagators);
     auto picked = selector(state.current(), propagators);
     REQUIRE(picked.has_value());
     CHECK(*picked == IntegerVariableID{a});
@@ -120,6 +121,8 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::Chs);
+
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);
     auto b = problem.create_integer_variable(1_i, 3_i);
@@ -132,7 +135,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     solve_with(problem,
         SolveCallbacks{
             .solution = [&](const CurrentState &) -> bool { ++solutions; return true; },
-            .branch = branch_with(variable_order::dom_wdeg(problem), value_order::smallest_first())});
+            .branch = branch_with(variable_order::dom_wdeg(problem, scheme), value_order::smallest_first())});
 
     CHECK(solutions == 6);
 }

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -121,7 +121,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
-    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::CaCd, WeightingScheme::ConflictHistorySearch);
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::CurrentArityCurrentDomain, WeightingScheme::ConflictHistorySearch);
 
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -121,7 +121,7 @@ TEST_CASE("dom_wdeg wired into solve_with finds every solution")
     // this exercises the whole wiring: selection via callbacks.branch, the
     // once-per-search setup in solve_with, and the conflict observer driving the
     // weights during search.
-    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::ConflictHistorySearch);
+    auto scheme = GENERATE(WeightingScheme::Classic, WeightingScheme::CaCd, WeightingScheme::ConflictHistorySearch);
 
     Problem problem;
     auto a = problem.create_integer_variable(1_i, 3_i);

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -32,6 +32,7 @@ namespace
     auto solve_with_state(unsigned long long depth, Stats & stats, Problem & problem,
         Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
         SolveCallbacks & callbacks,
+        const BranchCallback & branch_callback,
         ProofLogger * const logger,
         bool & this_subtree_contains_solution,
         Integer & number_of_solutions,
@@ -54,10 +55,7 @@ namespace
             if (optional_abort_flag && optional_abort_flag->load())
                 return false;
 
-            auto create_branch_generator = callbacks.branch
-                ? callbacks.branch
-                : branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
-            auto branch_generator = create_branch_generator(state.current(), propagators);
+            auto branch_generator = branch_callback(state.current(), propagators);
             auto branch_iter = branch_generator.begin();
 
             if (branch_iter == branch_generator.end()) {
@@ -93,7 +91,7 @@ namespace
                     state.guess(guess);
                     bool child_contains_solution = false;
                     if (! solve_with_state(depth + 1, stats, problem, propagators, state, guess,
-                            callbacks, logger, child_contains_solution, number_of_solutions, objective_value, optional_abort_flag))
+                            callbacks, branch_callback, logger, child_contains_solution, number_of_solutions, objective_value, optional_abort_flag))
                         result = false;
 
                     if (child_contains_solution)
@@ -179,7 +177,18 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
         bool child_contains_solution = false;
         Integer number_of_solutions = 0_i;
         optional<Integer> objective_value = nullopt;
-        if (solve_with_state(0, stats, problem, propagators, state, nullopt, callbacks, optional_proof ? optional_proof->logger() : nullptr,
+
+        // Run the branching heuristic's per-search setup once, now that
+        // propagators (and any presolver-added constraints) are final, so a
+        // stateful heuristic sizes and attaches itself correctly; the resulting
+        // per-node BranchCallback is reused throughout the search.
+        auto branch_heuristic = callbacks.branch
+            ? callbacks.branch
+            : branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
+        auto branch_callback = branch_heuristic(problem, state, propagators);
+
+        if (solve_with_state(0, stats, problem, propagators, state, nullopt, callbacks, branch_callback,
+                optional_proof ? optional_proof->logger() : nullptr,
                 child_contains_solution, number_of_solutions, objective_value, optional_abort_flag)) {
             if (optional_proof) {
                 if (problem.optional_minimise_variable()) {

--- a/gcs/solve.hh
+++ b/gcs/solve.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_SOLVE_HH
 
 #include <gcs/current_state.hh>
+#include <gcs/innards/state-fwd.hh>
 #include <gcs/problem.hh>
 #include <gcs/proof.hh>
 #include <gcs/stats.hh>
@@ -52,6 +53,24 @@ namespace gcs
     using BranchCallback = std::function<std::generator<IntegerVariableCondition>(const CurrentState &, const innards::Propagators &)>;
 
     /**
+     * \brief The branching heuristic for gcs::solve_with(): given a search's
+     * Problem, State, and Propagators, it does any one-time per-search setup and
+     * returns the per-node BranchCallback to branch with.
+     *
+     * solve_with() calls it exactly once, after propagators are built, so a
+     * stateful heuristic (for example dom/wdeg) can construct its state and
+     * attach itself as a conflict observer before search begins; the returned
+     * BranchCallback is then reused at every node. A stateless heuristic ignores
+     * the arguments and returns its callback. gcs::branch_with() produces one of
+     * these from a gcs::variable_order:: heuristic and a gcs::value_order::
+     * generator.
+     *
+     * \ingroup SolveCallbacks
+     * \sa SearchHeuristics
+     */
+    using BranchHeuristic = std::function<BranchCallback(const Problem &, innards::State &, innards::Propagators &)>;
+
+    /**
      * \brief Called by gcs::solve_with() after the proof has been started.
      *
      * \ingroup SolveCallbacks
@@ -77,7 +96,7 @@ namespace gcs
     {
         SolutionCallback solution = SolutionCallback{};
         TraceCallback trace = TraceCallback{};
-        BranchCallback branch = BranchCallback{};
+        BranchHeuristic branch = BranchHeuristic{};
         AfterProofStartedCallback after_proof_started = AfterProofStartedCallback{};
         CompletedCallback completed = CompletedCallback{};
     };

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -1,0 +1,123 @@
+#include <gcs/current_state.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/variable_weighting.hh>
+
+#include <util/overloaded.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <optional>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::max;
+using std::nullopt;
+using std::optional;
+using std::size_t;
+using std::unordered_map;
+using std::vector;
+
+auto WeightingState::weight_of(const ConstraintID & constraint_id) const -> double
+{
+    auto it = _constraint_weights.find(constraint_id);
+    return it == _constraint_weights.end() ? 0.0 : it->second;
+}
+
+auto WeightingState::optional_weight_of(const ConstraintID & constraint_id) const -> optional<double>
+{
+    auto it = _constraint_weights.find(constraint_id);
+    if (it == _constraint_weights.end())
+        return nullopt;
+    return it->second;
+}
+
+auto WeightingState::set_weight(const ConstraintID & constraint_id, double weight) -> void
+{
+    _constraint_weights[constraint_id] = weight;
+}
+
+auto WeightingState::merge(const WeightingState & other, MergePolicy policy) -> void
+{
+    for (const auto & [constraint_id, their_weight] : other._constraint_weights) {
+        auto & my_weight = _constraint_weights[constraint_id];
+        switch (policy) {
+            using enum MergePolicy;
+        case Sum:
+            my_weight += their_weight;
+            break;
+        case Max:
+            my_weight = max(my_weight, their_weight);
+            break;
+        case Average:
+            my_weight = (my_weight + their_weight) / 2.0;
+            break;
+        }
+    }
+}
+
+auto WeightingState::constraint_weights() const -> const unordered_map<ConstraintID, double> &
+{
+    return _constraint_weights;
+}
+
+ClassicDomWDeg::ClassicDomWDeg(const Propagators & propagators) :
+    _weights(propagators.number_of_constraints(), 1.0)
+{
+}
+
+auto ClassicDomWDeg::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
+    const optional<ReasonFunction> &, const State &) -> void
+{
+    _weights[constraint_index] += 1.0;
+}
+
+auto ClassicDomWDeg::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
+    IntegerVariableID var) const -> double
+{
+    auto simple = overloaded{
+        [](const SimpleIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v; },
+        [](const ViewOfIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v.actual_variable; },
+        [](const ConstantIntegerVariableID &) -> optional<SimpleIntegerVariableID> { return nullopt; }}
+                      .visit(var);
+
+    if (! simple)
+        return 0.0;
+
+    double total = 0.0;
+    for (const auto & constraint_index : propagators.constraint_indices_of_variable(*simple)) {
+        // Only constraints with at least two unassigned variables count; we just
+        // need to know whether that threshold is met, so stop counting at two.
+        int futures = 0;
+        for (const auto & v : propagators.scope_of_constraint(constraint_index)) {
+            if (! state.has_single_value(v))
+                if (++futures >= 2)
+                    break;
+        }
+        if (futures >= 2)
+            total += _weights[constraint_index];
+    }
+    return total;
+}
+
+auto ClassicDomWDeg::on_restart() -> void
+{
+    // Classic dom/wdeg keeps its weights across restarts; CHS-style smoothing is
+    // a different scheme. Nothing to do.
+}
+
+auto ClassicDomWDeg::snapshot(const Propagators & propagators) const -> WeightingState
+{
+    WeightingState result;
+    for (size_t c = 0; c < _weights.size(); ++c)
+        result.set_weight(propagators.constraint_id_for_index(static_cast<int>(c)), _weights[c]);
+    return result;
+}
+
+auto ClassicDomWDeg::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    _weights.assign(propagators.number_of_constraints(), 1.0);
+    for (size_t c = 0; c < _weights.size(); ++c)
+        if (auto weight = state.optional_weight_of(propagators.constraint_id_for_index(static_cast<int>(c))))
+            _weights[c] = *weight;
+}

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -5,6 +5,7 @@
 #include <util/overloaded.hh>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <optional>
 
@@ -14,9 +15,21 @@ using namespace gcs::innards;
 using std::max;
 using std::nullopt;
 using std::optional;
+using std::pow;
 using std::size_t;
 using std::unordered_map;
 using std::vector;
+
+namespace
+{
+    // Conflict-History Search tunables (Habet & Terrioux). These are defaults to
+    // be auto-tuned, not design choices.
+    constexpr double chs_alpha_initial = 0.4;
+    constexpr double chs_alpha_minimum = 0.06;
+    constexpr double chs_alpha_decay = 1.0e-6;
+    constexpr double chs_delta = 1.0e-4;
+    constexpr double chs_smoothing_base = 0.995;
+}
 
 auto WeightingState::weight_of(const ConstraintID & constraint_id) const -> double
 {
@@ -61,18 +74,18 @@ auto WeightingState::constraint_weights() const -> const unordered_map<Constrain
     return _constraint_weights;
 }
 
-ClassicDomWDeg::ClassicDomWDeg(const Propagators & propagators) :
-    _weights(propagators.number_of_constraints(), 1.0)
+DenseConstraintWeighting::DenseConstraintWeighting(const Propagators & propagators, double default_weight) :
+    _weights(propagators.number_of_constraints(), default_weight),
+    _default_weight(default_weight)
 {
 }
 
-auto ClassicDomWDeg::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
-    const optional<ReasonFunction> &, const State &) -> void
+auto DenseConstraintWeighting::contribution_of(int constraint_index) const -> double
 {
-    _weights[constraint_index] += 1.0;
+    return _weights[constraint_index];
 }
 
-auto ClassicDomWDeg::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
+auto DenseConstraintWeighting::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
     IntegerVariableID var) const -> double
 {
     auto simple = overloaded{
@@ -95,9 +108,36 @@ auto ClassicDomWDeg::weighted_degree_of(const CurrentState & state, const Propag
                     break;
         }
         if (futures >= 2)
-            total += _weights[constraint_index];
+            total += contribution_of(constraint_index);
     }
     return total;
+}
+
+auto DenseConstraintWeighting::snapshot(const Propagators & propagators) const -> WeightingState
+{
+    WeightingState result;
+    for (size_t c = 0; c < _weights.size(); ++c)
+        result.set_weight(propagators.constraint_id_for_index(static_cast<int>(c)), _weights[c]);
+    return result;
+}
+
+auto DenseConstraintWeighting::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    _weights.assign(propagators.number_of_constraints(), _default_weight);
+    for (size_t c = 0; c < _weights.size(); ++c)
+        if (auto weight = state.optional_weight_of(propagators.constraint_id_for_index(static_cast<int>(c))))
+            _weights[c] = *weight;
+}
+
+ClassicDomWDeg::ClassicDomWDeg(const Propagators & propagators) :
+    DenseConstraintWeighting(propagators, 1.0)
+{
+}
+
+auto ClassicDomWDeg::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
+    const optional<ReasonFunction> &, const State &) -> void
+{
+    _weights[constraint_index] += 1.0;
 }
 
 auto ClassicDomWDeg::on_restart() -> void
@@ -106,18 +146,41 @@ auto ClassicDomWDeg::on_restart() -> void
     // a different scheme. Nothing to do.
 }
 
-auto ClassicDomWDeg::snapshot(const Propagators & propagators) const -> WeightingState
+ConflictHistorySearch::ConflictHistorySearch(const Propagators & propagators) :
+    DenseConstraintWeighting(propagators, 0.0),
+    _conflict_of(propagators.number_of_constraints(), 0),
+    _alpha(chs_alpha_initial)
 {
-    WeightingState result;
-    for (size_t c = 0; c < _weights.size(); ++c)
-        result.set_weight(propagators.constraint_id_for_index(static_cast<int>(c)), _weights[c]);
-    return result;
 }
 
-auto ClassicDomWDeg::load(const WeightingState & state, const Propagators & propagators) -> void
+auto ConflictHistorySearch::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> &,
+    const optional<ReasonFunction> &, const State &) -> void
 {
-    _weights.assign(propagators.number_of_constraints(), 1.0);
+    auto r = 1.0 / static_cast<double>(_number_of_conflicts - _conflict_of[constraint_index] + 1);
+    _weights[constraint_index] = (1.0 - _alpha) * _weights[constraint_index] + _alpha * r;
+    ++_number_of_conflicts;
+    _conflict_of[constraint_index] = _number_of_conflicts;
+    _alpha = max(chs_alpha_minimum, _alpha - chs_alpha_decay);
+}
+
+auto ConflictHistorySearch::contribution_of(int constraint_index) const -> double
+{
+    return _weights[constraint_index] + chs_delta;
+}
+
+auto ConflictHistorySearch::on_restart() -> void
+{
+    // Smooth scores towards 0 by their staleness, and reset alpha. Inert until
+    // restarts exist (nothing calls this yet).
     for (size_t c = 0; c < _weights.size(); ++c)
-        if (auto weight = state.optional_weight_of(propagators.constraint_id_for_index(static_cast<int>(c))))
-            _weights[c] = *weight;
+        _weights[c] *= pow(chs_smoothing_base, static_cast<double>(_number_of_conflicts - _conflict_of[c]));
+    _alpha = chs_alpha_initial;
+}
+
+auto ConflictHistorySearch::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    DenseConstraintWeighting::load(state, propagators);
+    _conflict_of.assign(propagators.number_of_constraints(), 0);
+    _number_of_conflicts = 0;
+    _alpha = chs_alpha_initial;
 }

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -216,7 +216,7 @@ RefinedWeighting::RefinedWeighting(const Propagators & propagators, const State 
     _local_weights(propagators.number_of_constraints())
 {
     // Capture the initial domain size of every variable in a constraint scope,
-    // for the Id variant.
+    // for the InitialDomain variant.
     for (size_t c = 0; c < propagators.number_of_constraints(); ++c)
         for (const auto & v : propagators.scope_of_constraint(static_cast<int>(c)))
             _initial_domain.try_emplace(v.index, state.domain_size(v).raw_value);
@@ -239,19 +239,19 @@ auto RefinedWeighting::note_conflict(int constraint_index, const vector<SimpleIn
         double increment = 0.0;
         switch (_variant) {
             using enum Variant;
-        case Ia:
+        case InitialArity:
             increment = 1.0 / static_cast<double>(scope.size());
             break;
-        case Ca:
+        case CurrentArity:
             increment = 1.0 / static_cast<double>(futures);
             break;
-        case Id:
+        case InitialDomain:
             increment = 1.0 / static_cast<double>(_initial_domain.at(x.index));
             break;
-        case Cd:
+        case CurrentDomain:
             increment = 1.0 / (1.0 + static_cast<double>(state.domain_size(x).raw_value));
             break;
-        case CaCd:
+        case CurrentArityCurrentDomain:
             increment = 1.0 / (static_cast<double>(futures) * (1.0 + static_cast<double>(state.domain_size(x).raw_value)));
             break;
         }

--- a/gcs/variable_weighting.cc
+++ b/gcs/variable_weighting.cc
@@ -7,14 +7,18 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <map>
 #include <optional>
+#include <utility>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::map;
 using std::max;
 using std::nullopt;
 using std::optional;
+using std::pair;
 using std::pow;
 using std::size_t;
 using std::unordered_map;
@@ -52,26 +56,48 @@ auto WeightingState::set_weight(const ConstraintID & constraint_id, double weigh
 
 auto WeightingState::merge(const WeightingState & other, MergePolicy policy) -> void
 {
-    for (const auto & [constraint_id, their_weight] : other._constraint_weights) {
-        auto & my_weight = _constraint_weights[constraint_id];
+    auto combine = [policy](double & mine, double theirs) {
         switch (policy) {
             using enum MergePolicy;
         case Sum:
-            my_weight += their_weight;
+            mine += theirs;
             break;
         case Max:
-            my_weight = max(my_weight, their_weight);
+            mine = max(mine, theirs);
             break;
         case Average:
-            my_weight = (my_weight + their_weight) / 2.0;
+            mine = (mine + theirs) / 2.0;
             break;
         }
-    }
+    };
+
+    for (const auto & [constraint_id, their_weight] : other._constraint_weights)
+        combine(_constraint_weights[constraint_id], their_weight);
+    for (const auto & [key, their_weight] : other._local_weights)
+        combine(_local_weights[key], their_weight);
 }
 
 auto WeightingState::constraint_weights() const -> const unordered_map<ConstraintID, double> &
 {
     return _constraint_weights;
+}
+
+auto WeightingState::local_weight_of(const ConstraintID & constraint_id, SimpleIntegerVariableID var) const -> optional<double>
+{
+    auto it = _local_weights.find(pair{constraint_id, var});
+    if (it == _local_weights.end())
+        return nullopt;
+    return it->second;
+}
+
+auto WeightingState::set_local_weight(const ConstraintID & constraint_id, SimpleIntegerVariableID var, double weight) -> void
+{
+    _local_weights[pair{constraint_id, var}] = weight;
+}
+
+auto WeightingState::local_weights() const -> const map<pair<ConstraintID, SimpleIntegerVariableID>, double> &
+{
+    return _local_weights;
 }
 
 DenseConstraintWeighting::DenseConstraintWeighting(const Propagators & propagators, double default_weight) :
@@ -183,4 +209,108 @@ auto ConflictHistorySearch::load(const WeightingState & state, const Propagators
     _conflict_of.assign(propagators.number_of_constraints(), 0);
     _number_of_conflicts = 0;
     _alpha = chs_alpha_initial;
+}
+
+RefinedWeighting::RefinedWeighting(const Propagators & propagators, const State & state, Variant variant) :
+    _variant(variant),
+    _local_weights(propagators.number_of_constraints())
+{
+    // Capture the initial domain size of every variable in a constraint scope,
+    // for the Id variant.
+    for (size_t c = 0; c < propagators.number_of_constraints(); ++c)
+        for (const auto & v : propagators.scope_of_constraint(static_cast<int>(c)))
+            _initial_domain.try_emplace(v.index, state.domain_size(v).raw_value);
+}
+
+auto RefinedWeighting::note_conflict(int constraint_index, const vector<SimpleIntegerVariableID> & scope,
+    const optional<ReasonFunction> &, const State & state) -> void
+{
+    long long futures = 0;
+    for (const auto & v : scope)
+        if (! state.has_single_value(v))
+            ++futures;
+    if (futures == 0)
+        return;
+
+    auto & weights = _local_weights[constraint_index];
+    for (const auto & x : scope) {
+        if (state.has_single_value(x))
+            continue;
+        double increment = 0.0;
+        switch (_variant) {
+            using enum Variant;
+        case Ia:
+            increment = 1.0 / static_cast<double>(scope.size());
+            break;
+        case Ca:
+            increment = 1.0 / static_cast<double>(futures);
+            break;
+        case Id:
+            increment = 1.0 / static_cast<double>(_initial_domain.at(x.index));
+            break;
+        case Cd:
+            increment = 1.0 / (1.0 + static_cast<double>(state.domain_size(x).raw_value));
+            break;
+        case CaCd:
+            increment = 1.0 / (static_cast<double>(futures) * (1.0 + static_cast<double>(state.domain_size(x).raw_value)));
+            break;
+        }
+        auto [it, inserted] = weights.try_emplace(x.index, 1.0);
+        it->second += increment;
+    }
+}
+
+auto RefinedWeighting::weighted_degree_of(const CurrentState & state, const Propagators & propagators,
+    IntegerVariableID var) const -> double
+{
+    auto simple = overloaded{
+        [](const SimpleIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v; },
+        [](const ViewOfIntegerVariableID & v) -> optional<SimpleIntegerVariableID> { return v.actual_variable; },
+        [](const ConstantIntegerVariableID &) -> optional<SimpleIntegerVariableID> { return nullopt; }}
+                      .visit(var);
+
+    if (! simple)
+        return 0.0;
+
+    double total = 0.0;
+    for (const auto & constraint_index : propagators.constraint_indices_of_variable(*simple)) {
+        int futures = 0;
+        for (const auto & v : propagators.scope_of_constraint(constraint_index)) {
+            if (! state.has_single_value(v))
+                if (++futures >= 2)
+                    break;
+        }
+        if (futures >= 2) {
+            const auto & weights = _local_weights[constraint_index];
+            auto it = weights.find(simple->index);
+            total += (it != weights.end() ? it->second : 1.0);
+        }
+    }
+    return total;
+}
+
+auto RefinedWeighting::on_restart() -> void
+{
+    // The refined increments keep their weights across restarts.
+}
+
+auto RefinedWeighting::snapshot(const Propagators & propagators) const -> WeightingState
+{
+    WeightingState result;
+    for (size_t c = 0; c < _local_weights.size(); ++c)
+        for (const auto & [var_index, weight] : _local_weights[c])
+            result.set_local_weight(propagators.constraint_id_for_index(static_cast<int>(c)),
+                SimpleIntegerVariableID{var_index}, weight);
+    return result;
+}
+
+auto RefinedWeighting::load(const WeightingState & state, const Propagators & propagators) -> void
+{
+    for (size_t c = 0; c < _local_weights.size(); ++c) {
+        _local_weights[c].clear();
+        auto constraint_id = propagators.constraint_id_for_index(static_cast<int>(c));
+        for (const auto & v : propagators.scope_of_constraint(static_cast<int>(c)))
+            if (auto weight = state.local_weight_of(constraint_id, v))
+                _local_weights[c][v.index] = *weight;
+    }
 }

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -1,0 +1,163 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_VARIABLE_WEIGHTING_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_VARIABLE_WEIGHTING_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/innards/conflict_observer.hh>
+#include <gcs/innards/propagators-fwd.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace gcs
+{
+    class CurrentState;
+
+    /**
+     * \brief A portable, copyable snapshot of per-constraint weights, keyed by
+     * ConstraintID.
+     *
+     * This is the value-object seam of the dom/wdeg design: a VariableWeighting
+     * can be snapshotted out to one of these, a fresh one loaded from it, and two
+     * merged. Being keyed by the stable ConstraintID --- the identity a proof log
+     * also names --- rather than a live dense index, it survives leaving one
+     * search/thread and entering another: the basis for share-nothing parallel
+     * sync and for seeding a search with proof-mined weights.
+     *
+     * v1 holds only global per-constraint weights; a per-(constraint, variable)
+     * map for AbsCon-local schemes is a later additive extension.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class WeightingState
+    {
+    public:
+        /**
+         * \brief How two WeightingStates combine, for parallel/merge sync.
+         */
+        enum class MergePolicy
+        {
+            Sum,
+            Max,
+            Average
+        };
+
+        /**
+         * The weight recorded for a constraint, or 0.0 if it has none.
+         */
+        [[nodiscard]] auto weight_of(const ConstraintID &) const -> double;
+
+        /**
+         * The weight recorded for a constraint, or nullopt if it has none.
+         */
+        [[nodiscard]] auto optional_weight_of(const ConstraintID &) const -> std::optional<double>;
+
+        /**
+         * Set (or overwrite) the weight for a constraint.
+         */
+        auto set_weight(const ConstraintID &, double) -> void;
+
+        /**
+         * Combine another WeightingState into this one. For every constraint in
+         * \p other, this one's weight (taken as 0 if absent) is combined with
+         * other's under \p policy: Sum adds, Max keeps the larger, Average takes
+         * the mean. Constraints present only in this one are left unchanged.
+         */
+        auto merge(const WeightingState & other, MergePolicy policy) -> void;
+
+        /**
+         * The full ConstraintID -> weight map, for iteration / serialisation.
+         */
+        [[nodiscard]] auto constraint_weights() const -> const std::unordered_map<ConstraintID, double> &;
+
+    private:
+        std::unordered_map<ConstraintID, double> _constraint_weights;
+    };
+
+    /**
+     * \brief Live, per-search variable weighting: what a dom/wdeg-style brancher
+     * reads, and what propagation notifies on a conflict.
+     *
+     * Implements innards::ConflictObserver (the write side, fired by
+     * Propagators::propagate on a domain wipeout) and adds weighted_degree_of
+     * (the read side, summed by the brancher). A VariableWeighting is owned by
+     * the search driver (solve_with, or a parallel orchestrator), borrowed by
+     * State for the write side and captured by the brancher for the read side.
+     * Implementations store weights densely by constraint index for speed;
+     * snapshot()/load() bridge that to the portable, ConstraintID-keyed
+     * WeightingState.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class VariableWeighting : public innards::ConflictObserver
+    {
+    public:
+        ~VariableWeighting() override = default;
+
+        /**
+         * The weighted degree W(x) of a variable, to be combined with dom(x) by
+         * the brancher. Sums the live weight over the constraints the variable
+         * is in that still have at least two unassigned variables (the |fut|>1
+         * filter).
+         */
+        [[nodiscard]] virtual auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double = 0;
+
+        /**
+         * Called at each restart boundary (for smoothing / decay schemes).
+         * Inert until restarts land.
+         */
+        virtual auto on_restart() -> void = 0;
+
+        /**
+         * Read the live weights out into a portable WeightingState.
+         */
+        [[nodiscard]] virtual auto snapshot(const innards::Propagators & propagators) const -> WeightingState = 0;
+
+        /**
+         * Replace the live weights with those from a WeightingState (constraints
+         * absent from it revert to the scheme's default).
+         */
+        virtual auto load(const WeightingState & state, const innards::Propagators & propagators) -> void = 0;
+    };
+
+    /**
+     * \brief Classic dom/wdeg (Boussemart, Hemery, Lecoutre, Sais, ECAI 2004):
+     * one weight per constraint, initialised to 1, bumped by 1 on every domain
+     * wipeout.
+     *
+     * weighted_degree_of(x) sums w(c) over the constraints on x with at least two
+     * unassigned variables, so at the root --- every weight 1, every variable
+     * unassigned --- it equals the variable's degree, and the heuristic starts
+     * out like dom_then_deg and specialises as conflicts accumulate.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class ClassicDomWDeg final : public VariableWeighting
+    {
+    public:
+        /**
+         * One weight per constraint (Propagators::number_of_constraints), each
+         * initialised to 1.
+         */
+        explicit ClassicDomWDeg(const innards::Propagators & propagators);
+
+        auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
+
+        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+
+        auto on_restart() -> void override;
+
+        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
+
+        auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
+
+    private:
+        std::vector<double> _weights;
+    };
+}
+
+#endif

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -6,8 +6,10 @@
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/variable_id.hh>
 
+#include <map>
 #include <optional>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace gcs
@@ -25,8 +27,10 @@ namespace gcs
      * search/thread and entering another: the basis for share-nothing parallel
      * sync and for seeding a search with proof-mined weights.
      *
-     * v1 holds only global per-constraint weights; a per-(constraint, variable)
-     * map for AbsCon-local schemes is a later additive extension.
+     * It holds a global per-constraint weight map (for whole-constraint schemes)
+     * and a per-(constraint, variable) local weight map (for schemes that weight
+     * variables within a constraint, such as ca.cd); a scheme uses whichever it
+     * needs.
      *
      * \ingroup SearchHeuristics
      */
@@ -59,10 +63,22 @@ namespace gcs
         auto set_weight(const ConstraintID &, double) -> void;
 
         /**
-         * Combine another WeightingState into this one. For every constraint in
-         * \p other, this one's weight (taken as 0 if absent) is combined with
+         * The local weight recorded for a (constraint, variable) pair, or nullopt
+         * if it has none.
+         */
+        [[nodiscard]] auto local_weight_of(const ConstraintID &, SimpleIntegerVariableID) const -> std::optional<double>;
+
+        /**
+         * Set (or overwrite) the local weight for a (constraint, variable) pair.
+         */
+        auto set_local_weight(const ConstraintID &, SimpleIntegerVariableID, double) -> void;
+
+        /**
+         * Combine another WeightingState into this one, entry by entry across both
+         * the per-constraint and per-(constraint, variable) maps. For every entry
+         * in \p other, this one's value (taken as 0 if absent) is combined with
          * other's under \p policy: Sum adds, Max keeps the larger, Average takes
-         * the mean. Constraints present only in this one are left unchanged.
+         * the mean. Entries present only in this one are left unchanged.
          */
         auto merge(const WeightingState & other, MergePolicy policy) -> void;
 
@@ -71,8 +87,15 @@ namespace gcs
          */
         [[nodiscard]] auto constraint_weights() const -> const std::unordered_map<ConstraintID, double> &;
 
+        /**
+         * The full (ConstraintID, variable) -> weight map, for iteration /
+         * serialisation.
+         */
+        [[nodiscard]] auto local_weights() const -> const std::map<std::pair<ConstraintID, SimpleIntegerVariableID>, double> &;
+
     private:
         std::unordered_map<ConstraintID, double> _constraint_weights;
+        std::map<std::pair<ConstraintID, SimpleIntegerVariableID>, double> _local_weights;
     };
 
     /**
@@ -221,13 +244,75 @@ namespace gcs
     };
 
     /**
+     * \brief Refined dom/wdeg increments (Wattez, Lecoutre, Paparrizou, Tabary,
+     * ICTAI 2019): a per-(constraint, variable) local weight whose increment on a
+     * conflict reflects the constraint's arity and the variables' domains.
+     *
+     * On a conflict of constraint c, for each still-unassigned variable x of c the
+     * local weight w(c)[x] (initialised to 1) is incremented by a Variant-chosen
+     * amount:
+     *   - Ia (initial arity):  1 / |scp(c)|
+     *   - Ca (current arity):  1 / |fut(c)|
+     *   - Id (initial domain): 1 / |dom_init(x)|
+     *   - Cd (current domain): 1 / (1 + |dom(x)|)
+     *   - CaCd (the default, the strongest in their study):
+     *         1 / (|fut(c)| * (1 + |dom(x)|))
+     * weighted_degree_of(x) sums w(c)[x] over x's constraints with at least two
+     * unassigned variables, so at the root (all weights 1) it equals the degree.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class RefinedWeighting final : public VariableWeighting
+    {
+    public:
+        /**
+         * \brief Which of the ia / ca / id / cd / ca.cd increments to use.
+         */
+        enum class Variant
+        {
+            Ia,
+            Ca,
+            Id,
+            Cd,
+            CaCd
+        };
+
+        RefinedWeighting(const innards::Propagators & propagators, const innards::State & state, Variant variant);
+
+        auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
+
+        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+
+        auto on_restart() -> void override;
+
+        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
+
+        auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
+
+    private:
+        Variant _variant;
+        // Local weights by constraint index, then variable index; an absent entry
+        // means the default weight of 1. Initial domain sizes by variable index,
+        // for the Id variant.
+        std::vector<std::unordered_map<unsigned long long, double>> _local_weights;
+        std::unordered_map<unsigned long long, long long> _initial_domain;
+    };
+
+    /**
      * \brief Selects which weighting scheme gcs::variable_order::dom_wdeg uses.
      *
      * \ingroup SearchHeuristics
      */
     enum class WeightingScheme
     {
-        Classic,              ///< ClassicDomWDeg
+        Classic, ///< ClassicDomWDeg
+        Ia,      ///< RefinedWeighting, initial-arity increment
+        Ca,      ///< RefinedWeighting, current-arity increment
+        Id,      ///< RefinedWeighting, initial-domain increment
+        Cd,      ///< RefinedWeighting, current-domain increment
+        CaCd,    ///< RefinedWeighting, ca.cd increment
         ConflictHistorySearch ///< ConflictHistorySearch (recency-weighted)
     };
 }

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -227,8 +227,8 @@ namespace gcs
      */
     enum class WeightingScheme
     {
-        Classic, ///< ClassicDomWDeg
-        Chs      ///< ConflictHistorySearch
+        Classic,              ///< ClassicDomWDeg
+        ConflictHistorySearch ///< ConflictHistorySearch (recency-weighted)
     };
 }
 

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -251,11 +251,11 @@ namespace gcs
      * On a conflict of constraint c, for each still-unassigned variable x of c the
      * local weight w(c)[x] (initialised to 1) is incremented by a Variant-chosen
      * amount:
-     *   - Ia (initial arity):  1 / |scp(c)|
-     *   - Ca (current arity):  1 / |fut(c)|
-     *   - Id (initial domain): 1 / |dom_init(x)|
-     *   - Cd (current domain): 1 / (1 + |dom(x)|)
-     *   - CaCd (the default, the strongest in their study):
+     *   - InitialArity:  1 / |scp(c)|
+     *   - CurrentArity:  1 / |fut(c)|
+     *   - InitialDomain: 1 / |dom_init(x)|
+     *   - CurrentDomain: 1 / (1 + |dom(x)|)
+     *   - CurrentArityCurrentDomain (the default, the strongest in their study):
      *         1 / (|fut(c)| * (1 + |dom(x)|))
      * weighted_degree_of(x) sums w(c)[x] over x's constraints with at least two
      * unassigned variables, so at the root (all weights 1) it equals the degree.
@@ -270,11 +270,11 @@ namespace gcs
          */
         enum class Variant
         {
-            Ia,
-            Ca,
-            Id,
-            Cd,
-            CaCd
+            InitialArity,
+            CurrentArity,
+            InitialDomain,
+            CurrentDomain,
+            CurrentArityCurrentDomain
         };
 
         RefinedWeighting(const innards::Propagators & propagators, const innards::State & state, Variant variant);
@@ -295,7 +295,7 @@ namespace gcs
         Variant _variant;
         // Local weights by constraint index, then variable index; an absent entry
         // means the default weight of 1. Initial domain sizes by variable index,
-        // for the Id variant.
+        // for the InitialDomain variant.
         std::vector<std::unordered_map<unsigned long long, double>> _local_weights;
         std::unordered_map<unsigned long long, long long> _initial_domain;
     };
@@ -307,13 +307,13 @@ namespace gcs
      */
     enum class WeightingScheme
     {
-        Classic, ///< ClassicDomWDeg
-        Ia,      ///< RefinedWeighting, initial-arity increment
-        Ca,      ///< RefinedWeighting, current-arity increment
-        Id,      ///< RefinedWeighting, initial-domain increment
-        Cd,      ///< RefinedWeighting, current-domain increment
-        CaCd,    ///< RefinedWeighting, ca.cd increment
-        ConflictHistorySearch ///< ConflictHistorySearch (recency-weighted)
+        Classic,                   ///< ClassicDomWDeg
+        InitialArity,              ///< RefinedWeighting, initial-arity increment
+        CurrentArity,              ///< RefinedWeighting, current-arity increment
+        InitialDomain,             ///< RefinedWeighting, initial-domain increment
+        CurrentDomain,             ///< RefinedWeighting, current-domain increment
+        CurrentArityCurrentDomain, ///< RefinedWeighting, ca.cd increment
+        ConflictHistorySearch      ///< ConflictHistorySearch (recency-weighted)
     };
 }
 

--- a/gcs/variable_weighting.hh
+++ b/gcs/variable_weighting.hh
@@ -123,40 +123,112 @@ namespace gcs
     };
 
     /**
+     * \brief Common storage for weighting schemes that keep one weight per
+     * constraint, indexed densely by constraint index.
+     *
+     * Provides the dense vector and the read / snapshot / load machinery;
+     * concrete schemes supply note_conflict (the update) and on_restart, and may
+     * override contribution_of to map a stored weight to a variable's weighted
+     * degree (the default is the weight itself).
+     *
+     * \ingroup SearchHeuristics
+     */
+    class DenseConstraintWeighting : public VariableWeighting
+    {
+    public:
+        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
+            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+
+        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
+
+        auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
+
+    protected:
+        /**
+         * One weight per constraint, each initialised to (and reset by load to)
+         * default_weight.
+         */
+        DenseConstraintWeighting(const innards::Propagators & propagators, double default_weight);
+
+        /**
+         * What constraint_index contributes to a variable's weighted degree.
+         * Default is its stored weight; a scheme can override (for example to add
+         * an offset).
+         */
+        [[nodiscard]] virtual auto contribution_of(int constraint_index) const -> double;
+
+        std::vector<double> _weights;
+        double _default_weight;
+    };
+
+    /**
      * \brief Classic dom/wdeg (Boussemart, Hemery, Lecoutre, Sais, ECAI 2004):
      * one weight per constraint, initialised to 1, bumped by 1 on every domain
      * wipeout.
      *
      * weighted_degree_of(x) sums w(c) over the constraints on x with at least two
      * unassigned variables, so at the root --- every weight 1, every variable
-     * unassigned --- it equals the variable's degree, and the heuristic starts
-     * out like dom_then_deg and specialises as conflicts accumulate.
+     * unassigned --- it equals the variable's degree, and the heuristic
+     * specialises as conflicts accumulate.
      *
      * \ingroup SearchHeuristics
      */
-    class ClassicDomWDeg final : public VariableWeighting
+    class ClassicDomWDeg final : public DenseConstraintWeighting
     {
     public:
-        /**
-         * One weight per constraint (Propagators::number_of_constraints), each
-         * initialised to 1.
-         */
         explicit ClassicDomWDeg(const innards::Propagators & propagators);
 
         auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
             const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
 
-        [[nodiscard]] auto weighted_degree_of(const CurrentState & state,
-            const innards::Propagators & propagators, IntegerVariableID var) const -> double override;
+        auto on_restart() -> void override;
+    };
+
+    /**
+     * \brief Conflict-History Search (Habet & Terrioux, SAC 2019 / J. Heuristics
+     * 2021): a recency-weighted per-constraint score.
+     *
+     * Each constraint has a score q(c), initialised to 0. On a conflict wiping a
+     * variable of c, q(c) moves towards r(c) = 1 / (#Conflicts - Conflict(c) + 1)
+     * by an exponential recency-weighted average q(c) <- (1 - alpha) q(c) + alpha
+     * r(c), where alpha starts at 0.4 and decays towards 0.06 over conflicts.
+     * weighted_degree_of(x) sums q(c) + delta over x's constraints with at least
+     * two unassigned variables, so early on (all q(c) = 0) it orders by degree.
+     * on_restart resets alpha and smooths the scores; it is inert until restarts
+     * land.
+     *
+     * \ingroup SearchHeuristics
+     */
+    class ConflictHistorySearch final : public DenseConstraintWeighting
+    {
+    public:
+        explicit ConflictHistorySearch(const innards::Propagators & propagators);
+
+        auto note_conflict(int constraint_index, const std::vector<SimpleIntegerVariableID> & scope,
+            const std::optional<innards::ReasonFunction> & reason, const innards::State & state) -> void override;
 
         auto on_restart() -> void override;
 
-        [[nodiscard]] auto snapshot(const innards::Propagators & propagators) const -> WeightingState override;
-
         auto load(const WeightingState & state, const innards::Propagators & propagators) -> void override;
 
+    protected:
+        [[nodiscard]] auto contribution_of(int constraint_index) const -> double override;
+
     private:
-        std::vector<double> _weights;
+        std::vector<long long> _conflict_of; // Conflict(c): #Conflicts when c last conflicted
+        long long _number_of_conflicts = 0;
+        double _alpha;
+    };
+
+    /**
+     * \brief Selects which weighting scheme gcs::variable_order::dom_wdeg uses.
+     *
+     * \ingroup SearchHeuristics
+     */
+    enum class WeightingScheme
+    {
+        Classic, ///< ClassicDomWDeg
+        Chs      ///< ConflictHistorySearch
     };
 }
 

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -5,6 +5,7 @@
 #include <gcs/variable_id.hh>
 #include <gcs/variable_weighting.hh>
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <optional>
@@ -13,6 +14,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using Catch::Approx;
 using std::nullopt;
 using std::vector;
 
@@ -173,4 +175,56 @@ TEST_CASE("WeightingState merge policies")
         CHECK(m.weight_of(NumberedConstraint{2}) == 3.0); // (5 + 1) / 2
         CHECK(m.weight_of(NumberedConstraint{3}) == 3.5); // (0 + 7) / 2
     }
+}
+
+TEST_CASE("ConflictHistorySearch builds a recency-weighted score")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto b = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {b, x}});
+
+    ConflictHistorySearch weighting{propagators};
+    auto current = state.current();
+
+    // Before any conflict every q(c) = 0, so weighted_degree_of is just delta per
+    // constraint (CHS orders by degree early on).
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(1.0e-4));
+
+    // One conflict on _1: q(_1) = (1 - alpha) * 0 + alpha * r, with alpha = 0.4 and
+    // r = 1 / (0 - 0 + 1) = 1, so q(_1) = 0.4. _2 is untouched.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(0.4 + 1.0e-4));
+    CHECK(weighting.weighted_degree_of(current, propagators, b) == Approx(1.0e-4));
+
+    // A second conflict, now on _2, after one earlier conflict: its recency factor
+    // r = 1 / (#Conflicts - Conflict(_2) + 1) = 1 / (1 - 0 + 1) = 0.5 is smaller,
+    // so _2 ends up below _1.
+    weighting.note_conflict(1, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, b) < weighting.weighted_degree_of(current, propagators, a));
+}
+
+TEST_CASE("ConflictHistorySearch snapshot and load round-trip the scores")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, x}});
+
+    ConflictHistorySearch weighting{propagators};
+    auto current = state.current();
+    weighting.note_conflict(0, {}, nullopt, state); // q(_1) = 0.4
+
+    auto snap = weighting.snapshot(propagators);
+    CHECK(snap.weight_of(NumberedConstraint{1}) == Approx(0.4));
+
+    ConflictHistorySearch reloaded{propagators};
+    reloaded.load(snap, propagators);
+    CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(weighting.weighted_degree_of(current, propagators, a)));
 }

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -238,7 +238,7 @@ TEST_CASE("RefinedWeighting ca.cd increments by 1 / (fut * (1 + dom))")
     Propagators propagators;
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
 
-    RefinedWeighting weighting{propagators, state, RefinedWeighting::Variant::CaCd};
+    RefinedWeighting weighting{propagators, state, RefinedWeighting::Variant::CurrentArityCurrentDomain};
     auto current = state.current();
 
     // Every local weight starts at 1, so the root weighted degree is the degree.
@@ -260,8 +260,8 @@ TEST_CASE("RefinedWeighting variants increment differently and round-trip")
     Propagators propagators;
     propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
 
-    // The Ca variant increments by 1 / fut = 1 / 2 = 0.5, not the ca.cd 0.125.
-    RefinedWeighting ca{propagators, state, RefinedWeighting::Variant::Ca};
+    // The CurrentArity variant increments by 1 / fut = 1 / 2 = 0.5, not the ca.cd 0.125.
+    RefinedWeighting ca{propagators, state, RefinedWeighting::Variant::CurrentArity};
     auto current = state.current();
     ca.note_conflict(0, {a, b}, nullopt, state);
     CHECK(ca.weighted_degree_of(current, propagators, a) == Approx(1.5));
@@ -270,7 +270,7 @@ TEST_CASE("RefinedWeighting variants increment differently and round-trip")
     auto snap = ca.snapshot(propagators);
     REQUIRE(snap.local_weight_of(NumberedConstraint{1}, a).has_value());
     CHECK(snap.local_weight_of(NumberedConstraint{1}, a).value() == Approx(1.5));
-    RefinedWeighting reloaded{propagators, state, RefinedWeighting::Variant::Ca};
+    RefinedWeighting reloaded{propagators, state, RefinedWeighting::Variant::CurrentArity};
     reloaded.load(snap, propagators);
     CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(1.5));
 }

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -1,0 +1,176 @@
+#include <gcs/constraint.hh>
+#include <gcs/current_state.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/variable_id.hh>
+#include <gcs/variable_weighting.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::nullopt;
+using std::vector;
+
+namespace
+{
+    // A do-nothing propagator, written fresh at each install site (the
+    // PropagationFunction constructor wants the closure by value), to give a
+    // constraint a scope without any real propagation behaviour.
+    auto a_propagator_that_does_nothing()
+    {
+        return [](const State &, auto &, ProofLogger * const) -> PropagatorState { return PropagatorState::Enable; };
+    }
+}
+
+TEST_CASE("ClassicDomWDeg starts at the variable's degree")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+
+    // Every weight is 1 and every variable is unassigned, so weighted_degree_of
+    // is just the number of constraints each variable is in.
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 2.0);
+    CHECK(weighting.weighted_degree_of(current, propagators, y) == 2.0);
+    CHECK(weighting.weighted_degree_of(current, propagators, z) == 2.0);
+
+    // A view resolves to its underlying variable; a constant is in no constraints.
+    CHECK(weighting.weighted_degree_of(current, propagators, x + 1_i) == 2.0);
+    CHECK(weighting.weighted_degree_of(current, propagators, constant_variable(4_i)) == 0.0);
+}
+
+TEST_CASE("ClassicDomWDeg bumps the failing constraint's weight")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+
+    // Conflict on constraint _1 (dense index 0): w(_1) goes 1 -> 2.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 3.0); // w(_1)=2 + w(_3)=1
+    CHECK(weighting.weighted_degree_of(current, propagators, y) == 3.0); // w(_1)=2 + w(_2)=1
+    CHECK(weighting.weighted_degree_of(current, propagators, z) == 2.0); // w(_2)=1 + w(_3)=1, unchanged
+
+    // Weights accumulate and are not tied to search state (no backtrack resets
+    // them): a second conflict on _1 takes it to 3.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 4.0); // w(_1)=3 + w(_3)=1
+}
+
+TEST_CASE("ClassicDomWDeg counts only constraints with at least two unassigned variables")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(5_i, 5_i); // already fixed
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    // _1 over {x, y}: y is fixed, so only one unassigned variable -> excluded.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    // _2 over {x, z}: two unassigned -> counted.
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 1.0);
+
+    // Even bumping the excluded constraint's weight does not change x's score,
+    // because the |fut|>1 filter drops it.
+    weighting.note_conflict(0, {}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, x) == 1.0);
+}
+
+TEST_CASE("ClassicDomWDeg snapshot and load round-trip")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto z = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, y}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {y, z}});
+    propagators.install(NumberedConstraint{3}, a_propagator_that_does_nothing(), Triggers{.on_change = {x, z}});
+
+    ClassicDomWDeg weighting{propagators};
+    auto current = state.current();
+    weighting.note_conflict(0, {}, nullopt, state); // w(_1)=2
+    weighting.note_conflict(2, {}, nullopt, state); // w(_3)=2
+
+    auto snap = weighting.snapshot(propagators);
+    CHECK(snap.weight_of(NumberedConstraint{1}) == 2.0);
+    CHECK(snap.weight_of(NumberedConstraint{2}) == 1.0);
+    CHECK(snap.weight_of(NumberedConstraint{3}) == 2.0);
+    // An identity not in the model has no weight.
+    CHECK(snap.optional_weight_of(NamedConstraint{"absent"}) == nullopt);
+    CHECK(snap.weight_of(NamedConstraint{"absent"}) == 0.0);
+
+    // Loading the snapshot into a fresh weighting reproduces the scores.
+    ClassicDomWDeg reloaded{propagators};
+    reloaded.load(snap, propagators);
+    CHECK(reloaded.weighted_degree_of(current, propagators, x) == weighting.weighted_degree_of(current, propagators, x));
+    CHECK(reloaded.weighted_degree_of(current, propagators, y) == weighting.weighted_degree_of(current, propagators, y));
+    CHECK(reloaded.weighted_degree_of(current, propagators, z) == weighting.weighted_degree_of(current, propagators, z));
+}
+
+TEST_CASE("WeightingState merge policies")
+{
+    WeightingState a;
+    a.set_weight(NumberedConstraint{1}, 3.0);
+    a.set_weight(NumberedConstraint{2}, 5.0);
+
+    WeightingState b;
+    b.set_weight(NumberedConstraint{2}, 1.0);
+    b.set_weight(NumberedConstraint{3}, 7.0);
+
+    SECTION("sum")
+    {
+        auto m = a;
+        m.merge(b, WeightingState::MergePolicy::Sum);
+        CHECK(m.weight_of(NumberedConstraint{1}) == 3.0); // only in a, unchanged
+        CHECK(m.weight_of(NumberedConstraint{2}) == 6.0); // 5 + 1
+        CHECK(m.weight_of(NumberedConstraint{3}) == 7.0); // 0 + 7
+    }
+
+    SECTION("max")
+    {
+        auto m = a;
+        m.merge(b, WeightingState::MergePolicy::Max);
+        CHECK(m.weight_of(NumberedConstraint{1}) == 3.0);
+        CHECK(m.weight_of(NumberedConstraint{2}) == 5.0); // max(5, 1)
+        CHECK(m.weight_of(NumberedConstraint{3}) == 7.0); // max(0, 7)
+    }
+
+    SECTION("average")
+    {
+        auto m = a;
+        m.merge(b, WeightingState::MergePolicy::Average);
+        CHECK(m.weight_of(NumberedConstraint{1}) == 3.0); // only in a, unchanged
+        CHECK(m.weight_of(NumberedConstraint{2}) == 3.0); // (5 + 1) / 2
+        CHECK(m.weight_of(NumberedConstraint{3}) == 3.5); // (0 + 7) / 2
+    }
+}

--- a/gcs/variable_weighting_test.cc
+++ b/gcs/variable_weighting_test.cc
@@ -228,3 +228,49 @@ TEST_CASE("ConflictHistorySearch snapshot and load round-trip the scores")
     reloaded.load(snap, propagators);
     CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(weighting.weighted_degree_of(current, propagators, a)));
 }
+
+TEST_CASE("RefinedWeighting ca.cd increments by 1 / (fut * (1 + dom))")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
+    auto b = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
+
+    RefinedWeighting weighting{propagators, state, RefinedWeighting::Variant::CaCd};
+    auto current = state.current();
+
+    // Every local weight starts at 1, so the root weighted degree is the degree.
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(1.0));
+
+    // One conflict on _1: both future variables (a, b) get
+    // w(_1)[x] += 1 / (fut * (1 + dom)) = 1 / (2 * (1 + 3)) = 0.125.
+    weighting.note_conflict(0, {a, b}, nullopt, state);
+    CHECK(weighting.weighted_degree_of(current, propagators, a) == Approx(1.125));
+    CHECK(weighting.weighted_degree_of(current, propagators, b) == Approx(1.125));
+}
+
+TEST_CASE("RefinedWeighting variants increment differently and round-trip")
+{
+    State state;
+    auto a = state.allocate_integer_variable_with_state(0_i, 2_i); // dom 3
+    auto b = state.allocate_integer_variable_with_state(0_i, 2_i);
+
+    Propagators propagators;
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
+
+    // The Ca variant increments by 1 / fut = 1 / 2 = 0.5, not the ca.cd 0.125.
+    RefinedWeighting ca{propagators, state, RefinedWeighting::Variant::Ca};
+    auto current = state.current();
+    ca.note_conflict(0, {a, b}, nullopt, state);
+    CHECK(ca.weighted_degree_of(current, propagators, a) == Approx(1.5));
+
+    // snapshot / load round-trips the local weights.
+    auto snap = ca.snapshot(propagators);
+    REQUIRE(snap.local_weight_of(NumberedConstraint{1}, a).has_value());
+    CHECK(snap.local_weight_of(NumberedConstraint{1}, a).value() == Approx(1.5));
+    RefinedWeighting reloaded{propagators, state, RefinedWeighting::Variant::Ca};
+    reloaded.load(snap, propagators);
+    CHECK(reloaded.weighted_degree_of(current, propagators, a) == Approx(1.5));
+}

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -841,13 +841,13 @@ auto main(int argc, char * argv[]) -> int
         else
             throw FlatZincInterfaceError{format("Unknown solve method {} in {}", string{solve_method}, fznname)};
 
-        BranchCallback brancher = branch_sequence(
+        BranchHeuristic brancher = branch_sequence(
             branch_with(variable_order::dom_then_deg(data.branch_variables), value_order::smallest_first()),
             branch_with(variable_order::dom_then_deg(data.all_variables), value_order::smallest_first()));
 
         if ((! free_search) && fzn["solve"].contains("ann")) {
-            function<optional<BranchCallback>(const nlohmann::json &)> parse_search;
-            parse_search = [&data, &parse_search, &random_seed](const nlohmann::json & ann) -> optional<BranchCallback> {
+            function<optional<BranchHeuristic>(const nlohmann::json &)> parse_search;
+            parse_search = [&data, &parse_search, &random_seed](const nlohmann::json & ann) -> optional<BranchHeuristic> {
                 if (ann["id"] == "bool_search" || ann["id"] == "int_search") {
                     auto args = ann["args"];
                     vector<IntegerVariableID> vars = arg_as_array_of_var(data, args, 0);
@@ -855,7 +855,7 @@ auto main(int argc, char * argv[]) -> int
                     string val_heuristic = args[2];
                     string method = args[3];
 
-                    BranchVariableSelector var;
+                    BranchVariableHeuristic var;
                     if (var_heuristic == "first_fail")
                         var = variable_order::dom(vars);
                     else if (var_heuristic == "input_order")
@@ -902,7 +902,7 @@ auto main(int argc, char * argv[]) -> int
                     return branch_with(var, val);
                 }
                 else if (ann["id"] == "seq_search") {
-                    optional<BranchCallback> branch_seq;
+                    optional<BranchHeuristic> branch_seq;
                     for (const auto & sub_ann : ann["args"][0]) {
                         auto subsearch = parse_search(sub_ann);
                         if (subsearch) {


### PR DESCRIPTION
## What

**Stage 2, part 3** of dom/wdeg (issue #315) — and the last of Stage 2: a `--branch` hook on an
example so the weighting schemes can actually be **measured**. With this, "the three schemes are
selectable and benchmarkable" (the Stage 2 done-criterion) is met.

> Stacked on #325 → #324 → #323 → #322 → #321 → #318 → `main`.

## Change

The `langford` example (one of the RFC's named benchmark families) gains a `--branch` flag and
switches from `solve()` to `solve_with()` so it can use it:

- `--branch dom-then-deg` (default — identical to the previous behaviour), or
- `--branch dom-wdeg[:VARIANT]` with `VARIANT` ∈ `classic` / `ia` / `ca` / `id` / `cd` / `ca.cd` /
  `chs` (bare `dom-wdeg` means `ca.cd`).

The existing `--stats` flag already prints the `Stats` (recursions, failures, propagations, …), so
the search shape per scheme is reported without further change. Example:

```
$ langford 5 --stats --branch dom-then-deg     # recursions: 25, failures: 24
$ langford 5 --stats --branch dom-wdeg:ca.cd    # recursions: 41
$ langford 5 --stats --branch dom-wdeg:chs      # recursions: 28
```

(langford 5 is unsatisfiable, so this is a clean full-tree comparison — and a reminder that dom/wdeg
isn't a free win on small instances, especially before restarts, which is the sort of thing the hook
now lets you check.)

## Notes

- Default behaviour is unchanged: `--branch dom-then-deg` is exactly the brancher `solve()` used.
- The same `brancher_from_string` pattern copies trivially to other examples; one is enough to make
  the schemes benchmarkable, so this keeps the change to a single example.

This closes out **Stage 2** (all three schemes built, selectable, and benchmarkable). **Stage 3** —
the restart loop — is the next phase per the #315 checklist; `on_restart` is already wired (inert)
in the weighting schemes, waiting for it.

## Verification

Built under **GCC 15.2 and clang 21**; full `ctest` passes; the flag exercised across schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)