### PR TITLE
Add a restart loop around the depth-first search

### DIFF
--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -98,6 +98,9 @@ auto main(int argc, char * argv[]) -> int
             ("branch", "Branching heuristic: dom-then-deg, or dom-wdeg[:VARIANT] " //
                        "(VARIANT = classic / ia / ca / id / cd / ca.cd / chs)",    //
                 cxxopts::value<string>()->default_value("dom-then-deg"))           //
+            ("restart", "Restart on a Luby schedule with the given conflict scale " //
+                        "(finds one solution only, since restarts cannot enumerate)", //
+                cxxopts::value<unsigned long long>()->implicit_value("100"))       //
             ;
 
         options.add_options()                                                                   //
@@ -146,6 +149,13 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_FAILURE;
     }
 
+    // Restarts re-explore, so without nogoods they can only find one solution;
+    // when restarting we stop at the first, otherwise we enumerate as before.
+    auto restarts = options_vars.contains("restart")
+        ? make_optional(RestartSchedule::luby(options_vars["restart"].as<unsigned long long>()))
+        : nullopt;
+    auto keep_searching_after_solution = ! restarts.has_value();
+
     auto stats = solve_with(
         p,
         SolveCallbacks{
@@ -154,9 +164,10 @@ auto main(int argc, char * argv[]) -> int
                 println("position: {}", position | std::ranges::views::transform(cref(s)));
                 println("");
 
-                return true;
+                return keep_searching_after_solution;
             },
-            .branch = *brancher},
+            .branch = *brancher,
+            .restarts = restarts},
         options_vars.contains("prove")
             ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>())
             : nullopt);

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(glasgow_constraint_solver
         presolver.cc
         problem.cc
         proof.cc
+        restarts.cc
         scp_reader.cc
         search_heuristics.cc
         solve.cc
@@ -438,6 +439,10 @@ if(GCS_BUILD_TESTS)
     add_executable(variable_weighting_test variable_weighting_test.cc)
     target_link_libraries(variable_weighting_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME variable_weighting_test COMMAND $<TARGET_FILE:variable_weighting_test>)
+
+    add_executable(restarts_test restarts_test.cc)
+    target_link_libraries(restarts_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME restarts_test COMMAND $<TARGET_FILE:restarts_test>)
 
     add_executable(search_heuristics_test search_heuristics_test.cc)
     target_link_libraries(search_heuristics_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/innards/conflict_observer.hh
+++ b/gcs/innards/conflict_observer.hh
@@ -49,6 +49,19 @@ namespace gcs::innards
             const std::vector<SimpleIntegerVariableID> & scope,
             const std::optional<ReasonFunction> & reason,
             const State & state) -> void = 0;
+
+        /**
+         * \brief Called by the search at each restart boundary, so a weighting
+         * scheme can decay or smooth its scores.
+         *
+         * This is how solve_with() reaches the live weighting (which it does not
+         * own) to signal a restart: the weighting is attached here as the
+         * conflict observer, so the restart hook rides the same seam. The default
+         * does nothing; VariableWeighting forwards to its scheme.
+         */
+        virtual auto on_restart() -> void
+        {
+        }
     };
 }
 

--- a/gcs/restarts.cc
+++ b/gcs/restarts.cc
@@ -1,0 +1,44 @@
+#include <gcs/restarts.hh>
+
+using namespace gcs;
+
+namespace
+{
+    // The i-th term (i >= 1) of the Luby sequence 1, 1, 2, 1, 1, 2, 4, ...,
+    // via Knuth's reluctant doubling.
+    auto luby_term(unsigned long long i) -> unsigned long long
+    {
+        for (unsigned long long k = 1;;) {
+            auto block = (1ULL << k) - 1;
+            if (i == block)
+                return 1ULL << (k - 1);
+            if (i < block) {
+                i = i - ((1ULL << (k - 1)) - 1);
+                k = 1;
+            }
+            else
+                ++k;
+        }
+    }
+}
+
+RestartSchedule::RestartSchedule(unsigned long long scale) :
+    _scale(scale),
+    _index(1)
+{
+}
+
+auto RestartSchedule::luby(unsigned long long scale) -> RestartSchedule
+{
+    return RestartSchedule{scale};
+}
+
+auto RestartSchedule::current_cutoff() const -> unsigned long long
+{
+    return luby_term(_index) * _scale;
+}
+
+auto RestartSchedule::advance() -> void
+{
+    ++_index;
+}

--- a/gcs/restarts.hh
+++ b/gcs/restarts.hh
@@ -1,0 +1,58 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_RESTARTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_RESTARTS_HH
+
+namespace gcs
+{
+    /**
+     * \brief A restart schedule: a growing sequence of conflict cutoffs for
+     * gcs::solve_with().
+     *
+     * When a SolveCallbacks carries one, search runs as a loop of restarts ---
+     * each restart explores until it has seen the current cutoff's worth of
+     * conflicts (domain wipeouts), then abandons the tree and begins again from
+     * the root, with the cutoff advanced to the next term of the sequence and any
+     * weighting decay applied. Weights (and, in optimisation, the incumbent
+     * bound) persist across restarts, so a later run searches differently.
+     *
+     * The only policy provided is Luby (Knuth's reluctant doubling: the sequence
+     * 1, 1, 2, 1, 1, 2, 4, ... times a scale), whose growing-but-occasionally-
+     * small cutoffs eventually exceed any tree's size, so a final run completes
+     * and the search terminates. The scale is a tunable isolated behind a default
+     * (see issue #315), not a design input.
+     *
+     * \warning Without recorded nogoods a restart re-explores --- and so
+     * re-finds --- solutions, so a restart schedule is only sound for finding one
+     * solution or for optimising. Combining it with all-solution enumeration is
+     * rejected at runtime (gcs::solve_with throws UnimplementedException).
+     *
+     * \ingroup Core
+     * \sa gcs::SolveCallbacks
+     */
+    class RestartSchedule final
+    {
+    private:
+        explicit RestartSchedule(unsigned long long scale);
+
+        unsigned long long _scale;
+        unsigned long long _index; // 1-based position in the Luby sequence
+
+    public:
+        /**
+         * \brief A Luby schedule: cutoff i is luby(i) * \p scale conflicts.
+         */
+        [[nodiscard]] static auto luby(unsigned long long scale = 100ULL) -> RestartSchedule;
+
+        /**
+         * \brief The current cutoff, in conflicts since the last restart.
+         */
+        [[nodiscard]] auto current_cutoff() const -> unsigned long long;
+
+        /**
+         * \brief Advance to the next cutoff in the sequence; call once at each
+         * restart boundary.
+         */
+        auto advance() -> void;
+    };
+}
+
+#endif

--- a/gcs/restarts_test.cc
+++ b/gcs/restarts_test.cc
@@ -1,0 +1,51 @@
+#include <gcs/restarts.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+using namespace gcs;
+
+using std::vector;
+
+namespace
+{
+    // The cutoffs a schedule produces over its first n terms, starting from its
+    // initial cutoff and advancing between each.
+    auto first_cutoffs(RestartSchedule schedule, unsigned n) -> vector<unsigned long long>
+    {
+        vector<unsigned long long> cutoffs;
+        for (unsigned i = 0; i < n; ++i) {
+            cutoffs.push_back(schedule.current_cutoff());
+            schedule.advance();
+        }
+        return cutoffs;
+    }
+}
+
+TEST_CASE("Luby schedule follows the Luby sequence")
+{
+    // 1, 1, 2, 1, 1, 2, 4, 1, 1, 2, 1, 1, 2, 4, 8, ...
+    CHECK(first_cutoffs(RestartSchedule::luby(1), 15) ==
+        vector<unsigned long long>{1, 1, 2, 1, 1, 2, 4, 1, 1, 2, 1, 1, 2, 4, 8});
+}
+
+TEST_CASE("Luby schedule scales every cutoff")
+{
+    CHECK(first_cutoffs(RestartSchedule::luby(100), 7) ==
+        vector<unsigned long long>{100, 100, 200, 100, 100, 200, 400});
+}
+
+TEST_CASE("Luby schedule keeps returning to small cutoffs")
+{
+    // The reluctant-doubling property we rely on for testability: even far out,
+    // a 1*scale cutoff keeps recurring (so short and long runs interleave).
+    auto schedule = RestartSchedule::luby(1);
+    bool saw_one_after_the_first_block = false;
+    for (unsigned i = 0; i < 64; ++i) {
+        if (i >= 7 && schedule.current_cutoff() == 1)
+            saw_one_after_the_first_block = true;
+        schedule.advance();
+    }
+    CHECK(saw_one_after_the_first_block);
+}

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -1,4 +1,5 @@
 #include <gcs/exception.hh>
+#include <gcs/innards/conflict_observer.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -12,6 +13,7 @@
 
 #include <util/enumerate.hh>
 
+#include <limits>
 #include <string>
 
 using namespace gcs;
@@ -19,6 +21,7 @@ using namespace gcs::innards;
 
 using std::atomic;
 using std::max;
+using std::numeric_limits;
 using std::nullopt;
 using std::optional;
 using std::pair;
@@ -45,6 +48,19 @@ namespace
         RestartCutoffHit
     };
 
+    /**
+     * The restart budget threaded through the recursion: how many conflicts
+     * (dead-end nodes) the current run has seen, and the cutoff at which it
+     * should abandon the tree and restart. When restarts are disabled the cutoff
+     * is "infinite", so the check never fires and search is a single pass.
+     */
+    struct RestartState
+    {
+        unsigned long long conflicts_since_restart;
+        unsigned long long cutoff;
+        bool enabled;
+    };
+
     auto solve_with_state(unsigned long long depth, Stats & stats, Problem & problem,
         Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
         SolveCallbacks & callbacks,
@@ -53,6 +69,7 @@ namespace
         bool & this_subtree_contains_solution,
         Integer & number_of_solutions,
         optional<Integer> & objective_value,
+        RestartState & restart,
         atomic<bool> * optional_abort_flag) -> SearchResult
     {
         stats.max_depth = max(stats.max_depth, depth);
@@ -61,80 +78,127 @@ namespace
         if (logger)
             logger->enter_proof_level(depth + 1);
 
-        bool objective_failure = false;
-        if (problem.optional_minimise_variable() && objective_value) {
-            if (state.infer(*problem.optional_minimise_variable() < *objective_value) == Inference::Contradiction)
-                objective_failure = true;
+        auto result = SearchResult::Complete;
+
+        if (restart.conflicts_since_restart >= restart.cutoff) {
+            // This run has spent its conflict budget: abandon the tree and unwind
+            // to the root for a restart. Unlike Stop we fall through to the tail
+            // backtrack/forget logging below, at this and every ancestor frame, so
+            // the proof stays balanced and the restart can continue it.
+            result = SearchResult::RestartCutoffHit;
         }
-
-        if ((! objective_failure) && propagators.propagate(this_branch_guess, state, logger, optional_abort_flag)) {
-            if (optional_abort_flag && optional_abort_flag->load())
-                return SearchResult::Stop;
-
-            auto branch_generator = branch_callback(state.current(), propagators);
-            auto branch_iter = branch_generator.begin();
-
-            if (branch_iter == branch_generator.end()) {
-                if (logger) {
-                    vector<pair<IntegerVariableID, Integer>> vars_and_values;
-                    for (const auto & v : problem.all_normal_variables())
-                        vars_and_values.emplace_back(v, state(v));
-                    logger->solution(vars_and_values, problem.optional_minimise_variable() ? make_optional(pair{*problem.optional_minimise_variable(), state(*problem.optional_minimise_variable())}) : nullopt);
-                }
-
-                if (problem.optional_minimise_variable())
-                    objective_value = state(*problem.optional_minimise_variable());
-
-                ++stats.solutions;
-                ++number_of_solutions;
-                this_subtree_contains_solution = true;
-                if (callbacks.solution && ! callbacks.solution(state.current()))
-                    return SearchResult::Stop;
+        else {
+            bool objective_failure = false;
+            if (problem.optional_minimise_variable() && objective_value) {
+                if (state.infer(*problem.optional_minimise_variable() < *objective_value) == Inference::Contradiction)
+                    objective_failure = true;
             }
-            else {
-                if (callbacks.trace && ! callbacks.trace(state.current()))
-                    return SearchResult::Stop;
 
+            if ((! objective_failure) && propagators.propagate(this_branch_guess, state, logger, optional_abort_flag)) {
                 if (optional_abort_flag && optional_abort_flag->load())
                     return SearchResult::Stop;
 
-                auto recurse = [&](const Literal & guess) -> SearchResult {
+                auto branch_generator = branch_callback(state.current(), propagators);
+                auto branch_iter = branch_generator.begin();
+
+                if (branch_iter == branch_generator.end()) {
+                    if (logger) {
+                        vector<pair<IntegerVariableID, Integer>> vars_and_values;
+                        for (const auto & v : problem.all_normal_variables())
+                            vars_and_values.emplace_back(v, state(v));
+                        logger->solution(vars_and_values, problem.optional_minimise_variable() ? make_optional(pair{*problem.optional_minimise_variable(), state(*problem.optional_minimise_variable())}) : nullopt);
+                    }
+
+                    if (problem.optional_minimise_variable())
+                        objective_value = state(*problem.optional_minimise_variable());
+
+                    ++stats.solutions;
+                    ++number_of_solutions;
+                    this_subtree_contains_solution = true;
+                    if (callbacks.solution && ! callbacks.solution(state.current()))
+                        return SearchResult::Stop;
+
+                    // We found a solution and were asked to keep searching. Without
+                    // recorded nogoods a restart re-explores the tree and so would
+                    // re-find (and re-count) this solution, so a restart schedule is
+                    // only sound for finding one solution or for optimising. Reject
+                    // the unsound combination rather than silently miscounting.
+                    if (restart.enabled && ! problem.optional_minimise_variable())
+                        throw UnimplementedException{"restarts without nogoods cannot enumerate all "
+                                                     "solutions; use a restart schedule only to find one "
+                                                     "solution or to optimise"};
+                }
+                else {
+                    if (callbacks.trace && ! callbacks.trace(state.current()))
+                        return SearchResult::Stop;
+
                     if (optional_abort_flag && optional_abort_flag->load())
                         return SearchResult::Stop;
 
-                    auto timestamp = state.new_epoch();
-                    state.guess(guess);
-                    bool child_contains_solution = false;
-                    auto result = solve_with_state(depth + 1, stats, problem, propagators, state, guess,
-                        callbacks, branch_callback, logger, child_contains_solution, number_of_solutions, objective_value, optional_abort_flag);
+                    auto recurse = [&](const Literal & guess) -> SearchResult {
+                        if (optional_abort_flag && optional_abort_flag->load())
+                            return SearchResult::Stop;
 
-                    if (child_contains_solution)
-                        this_subtree_contains_solution = true;
-                    else
-                        ++stats.failures;
+                        auto timestamp = state.new_epoch();
+                        state.guess(guess);
+                        bool child_contains_solution = false;
+                        auto child_result = solve_with_state(depth + 1, stats, problem, propagators, state, guess,
+                            callbacks, branch_callback, logger, child_contains_solution, number_of_solutions, objective_value, restart, optional_abort_flag);
 
-                    state.backtrack(timestamp);
-                    return result;
-                };
+                        if (child_contains_solution)
+                            this_subtree_contains_solution = true;
+                        else
+                            ++stats.failures;
 
-                for (; branch_iter != branch_generator.end(); ++branch_iter) {
-                    auto guess = *branch_iter;
-                    if (auto result = recurse(guess); result != SearchResult::Complete)
-                        return result;
+                        state.backtrack(timestamp);
+                        return child_result;
+                    };
+
+                    for (; branch_iter != branch_generator.end(); ++branch_iter) {
+                        auto child_result = recurse(*branch_iter);
+                        if (child_result == SearchResult::Stop)
+                            return SearchResult::Stop;
+                        if (child_result == SearchResult::RestartCutoffHit) {
+                            result = SearchResult::RestartCutoffHit;
+                            break;
+                        }
+                    }
                 }
+            }
+            else {
+                // A dead end: either the objective bound or a propagator wiped out
+                // a domain. That is one conflict spent against the restart budget.
+                ++restart.conflicts_since_restart;
             }
         }
 
         if (logger) {
             logger->enter_proof_level(depth);
-            vector<Literal> guesses;
-            for (const auto & g : state.guesses())
-                guesses.push_back(g);
-            logger->backtrack(guesses);
-            logger->forget_proof_level(depth + 1);
+            if (result == SearchResult::RestartCutoffHit) {
+                // A restart abandons this subtree *unrefuted*, so it asserts no
+                // backtrack lemma --- it only deletes what this pass derived below,
+                // which is always sound. But we must NOT delete the root node's
+                // own guess-independent propagation (proof level 1): the next pass
+                // starts from the same root fixpoint, so propagate() re-emits
+                // nothing there, and that reasoning has to survive for the next
+                // pass's backtracks to remain RUP. So at the root (depth 0) we keep
+                // level 1; deeper guess-dependent levels are re-derived next pass.
+                if (depth > 0)
+                    logger->forget_proof_level(depth + 1);
+            }
+            else {
+                // A normal backtrack: the subtree under these guesses was refuted,
+                // so we may assert the negation of the guess set (RUP from the
+                // refutation that the forget below then discards).
+                vector<Literal> guesses;
+                for (const auto & g : state.guesses())
+                    guesses.push_back(g);
+                logger->backtrack(guesses);
+                logger->forget_proof_level(depth + 1);
+            }
         }
 
-        return SearchResult::Complete;
+        return result;
     }
 }
 
@@ -201,9 +265,34 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
             : branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
         auto branch_callback = branch_heuristic(problem, state, propagators);
 
-        auto search_result = solve_with_state(0, stats, problem, propagators, state, nullopt, callbacks, branch_callback,
-            optional_proof ? optional_proof->logger() : nullptr,
-            child_contains_solution, number_of_solutions, objective_value, optional_abort_flag);
+        // A restart loop around the depth-first search: each pass explores until
+        // it has spent its conflict cutoff, then unwinds to the root (proof
+        // balanced) and the schedule grows the cutoff for the next pass. Weights
+        // and the incumbent objective bound persist across passes, so a later pass
+        // searches differently; the growing Luby cutoff eventually exceeds the
+        // whole tree, so a final pass completes. Without a schedule the cutoff is
+        // infinite and this is a single, exhaustive pass.
+        auto restart_schedule = callbacks.restarts;
+        RestartState restart{
+            .conflicts_since_restart = 0,
+            .cutoff = restart_schedule ? restart_schedule->current_cutoff() : numeric_limits<unsigned long long>::max(),
+            .enabled = restart_schedule.has_value()};
+
+        SearchResult search_result;
+        do {
+            restart.conflicts_since_restart = 0;
+            search_result = solve_with_state(0, stats, problem, propagators, state, nullopt, callbacks, branch_callback,
+                optional_proof ? optional_proof->logger() : nullptr,
+                child_contains_solution, number_of_solutions, objective_value, restart, optional_abort_flag);
+
+            if (search_result == SearchResult::RestartCutoffHit) {
+                ++stats.restarts;
+                if (auto observer = propagators.conflict_observer())
+                    observer->on_restart();
+                restart_schedule->advance();
+                restart.cutoff = restart_schedule->current_cutoff();
+            }
+        } while (search_result == SearchResult::RestartCutoffHit);
 
         if (search_result == SearchResult::Complete) {
             if (optional_proof) {

--- a/gcs/solve.hh
+++ b/gcs/solve.hh
@@ -5,8 +5,11 @@
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/problem.hh>
 #include <gcs/proof.hh>
+#include <gcs/restarts.hh>
 #include <gcs/stats.hh>
 #include <gcs/variable_condition.hh>
+
+#include <optional>
 
 #include <atomic>
 #include <functional>
@@ -101,6 +104,16 @@ namespace gcs
         BranchHeuristic branch = BranchHeuristic{};
         AfterProofStartedCallback after_proof_started = AfterProofStartedCallback{};
         CompletedCallback completed = CompletedCallback{};
+
+        /**
+         * \brief If set, search restarts on a growing sequence of conflict
+         * cutoffs instead of running a single depth-first pass.
+         *
+         * Default (unset) reproduces a single, exhaustive depth-first search.
+         * \warning Sound only for finding one solution or for optimising; see
+         * gcs::RestartSchedule.
+         */
+        std::optional<RestartSchedule> restarts = std::nullopt;
     };
 
     /**

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -1,4 +1,8 @@
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/arithmetic.hh>
 #include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/element.hh>
+#include <gcs/constraints/equals.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/expression.hh>
 #include <gcs/presolvers/auto_table.hh>
@@ -8,12 +12,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdlib>
+#include <optional>
 #include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 using namespace gcs::test_innards;
 
+using std::nullopt;
+using std::optional;
 using std::vector;
 
 TEST_CASE("Solve unsat")
@@ -50,6 +57,119 @@ TEST_CASE("Solve unsat by model optimisation")
         ProofOptions{"solve_test"});
 
     CHECK(! found_solution);
+    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+}
+
+// Four variables over three values, pairwise different: unsatisfiable, and
+// posted as weak pairwise NotEquals (no Hall pruning) so search must branch and
+// hit conflicts rather than wiping out at the root. A luby(1) schedule then
+// restarts after almost every conflict, so the search only terminates because
+// the growing cutoff eventually exceeds the whole tree --- exercising the
+// restart loop and that the proof stays balanced across many restarts.
+TEST_CASE("Solve unsat with restarts")
+{
+    Problem p;
+    vector<IntegerVariableID> xs;
+    for (int i = 0; i < 4; ++i)
+        xs.push_back(p.create_integer_variable(0_i, 2_i));
+    for (unsigned i = 0; i < xs.size(); ++i)
+        for (unsigned j = i + 1; j < xs.size(); ++j)
+            p.post(NotEquals{xs[i], xs[j]});
+
+    bool found_solution = false;
+    auto stats = solve_with(
+        p,
+        SolveCallbacks{
+            .solution = [&](const CurrentState &) -> bool { found_solution = true; return false; },
+            .restarts = RestartSchedule::luby(1)},
+        ProofOptions{"solve_test"});
+
+    CHECK(! found_solution);
+    CHECK(stats.restarts > 0);
+    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+}
+
+// Optimisation with restarts: the incumbent bound persists across restarts, so
+// each pass only finds strictly better solutions and the final pass proves
+// optimality. Objective-bound dead-ends count as conflicts, so a luby(1)
+// schedule restarts here too.
+TEST_CASE("Optimise with restarts")
+{
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 2_i);
+    auto y = p.create_integer_variable(0_i, 2_i);
+    auto z = p.create_integer_variable(0_i, 2_i);
+    p.post(NotEquals{x, y});
+    p.post(NotEquals{x, z});
+    p.post(NotEquals{y, z});
+    p.maximise(x);
+
+    optional<Integer> best = nullopt;
+    auto stats = solve_with(
+        p,
+        SolveCallbacks{
+            .solution = [&](const CurrentState & s) -> bool { best = s(x); return true; },
+            .restarts = RestartSchedule::luby(1)},
+        ProofOptions{"solve_test"});
+
+    CHECK(best == optional<Integer>{2_i});
+    CHECK(stats.restarts > 0);
+    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+}
+
+// Without nogoods, restarts cannot soundly enumerate: a callback that keeps
+// going after a solution, with no objective, is the one unsupported combination,
+// and is rejected rather than allowed to miscount.
+TEST_CASE("Restarts refuse to enumerate all solutions")
+{
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 2_i);
+    auto y = p.create_integer_variable(0_i, 2_i);
+    p.post(NotEquals{x, y});
+
+    CHECK_THROWS_AS(
+        solve_with(
+            p,
+            SolveCallbacks{
+                .solution = [](const CurrentState &) -> bool { return true; },
+                .restarts = RestartSchedule::luby(1)}),
+        UnimplementedException);
+}
+
+// An unsatisfiable Langford-pairing instance (size 5): rich enough that
+// AllDifferent and Element prune at the root, so the root node emits
+// guess-independent propagation that later restart passes do not re-derive.
+// This guards the fix that keeps that root reasoning (proof level 1) across
+// restarts; the NotEquals cases above have too little root propagation to
+// exercise it. The luby scale is chosen so a couple of restarts fire before the
+// growing cutoff exhausts the tree.
+TEST_CASE("Solve unsat with restarts and root propagation")
+{
+    Problem p;
+    const int k = 5;
+    vector<IntegerVariableID> position, solution;
+    for (int i = 0; i < 2 * k; ++i) {
+        position.emplace_back(p.create_integer_variable(0_i, Integer{2 * k - 1}));
+        solution.emplace_back(p.create_integer_variable(1_i, Integer{k}));
+    }
+    p.post(AllDifferent{position});
+    for (int i = 0; i < k; ++i) {
+        auto i_var = p.create_integer_variable(Integer{i + 1}, Integer{i + 1});
+        p.post(Element{i_var, position[i], &solution});
+        p.post(Element{i_var, position[i + k], &solution});
+        p.post(PlusGAC{position[i + k], constant_variable(Integer{i + 2}), position[i]});
+    }
+
+    bool found_solution = false;
+    auto stats = solve_with(
+        p,
+        SolveCallbacks{
+            .solution = [&](const CurrentState &) -> bool { found_solution = true; return false; },
+            .restarts = RestartSchedule::luby(10)},
+        ProofOptions{"solve_test"});
+
+    CHECK(! found_solution);
+    CHECK(stats.restarts > 0);
     CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
 }
 

--- a/gcs/stats.cc
+++ b/gcs/stats.cc
@@ -14,6 +14,7 @@ auto gcs::operator<<(ostream & o, const Stats & s) -> ostream &
     o << "failures: " << s.failures << '\n';
     o << "propagations: " << s.propagations << " " << s.effectful_propagations << " " << s.contradicting_propagations << '\n';
     o << "max depth:  " << s.max_depth << '\n';
+    o << "restarts: " << s.restarts << '\n';
     o << "solutions: " << s.solutions << '\n';
     o << "solve time: " << (s.solve_time.count() / 1'000'000.0) << "s" << '\n';
     return o;

--- a/gcs/stats.hh
+++ b/gcs/stats.hh
@@ -30,6 +30,7 @@ namespace gcs
         unsigned long long contradicting_propagations = 0;
         unsigned long long solutions = 0;
         unsigned long long max_depth = 0;
+        unsigned long long restarts = 0;
 
         unsigned long long n_propagators = 0;
 


### PR DESCRIPTION
Stage 3 of #315: a restart loop around the depth-first search — the foundation dom/wdeg needs, since weights persist across restarts so a later pass searches differently. Stacked on #327 (the `SearchResult` refactor).

**Opt-in, default-identical.** Restarts are enabled by a new `RestartSchedule` field on `SolveCallbacks` (Luby only, scale isolated behind a default per [the tunables guidance]). With none set the cutoff is infinite and search is a single exhaustive pass — byte-for-byte today's behaviour, and the full suite confirms it.

**Control flow** (mirrors the GSS searcher, as suggested): `solve_with_state` produces `SearchResult::RestartCutoffHit` once a run has spent its conflict cutoff; unlike `Stop` it unwinds through the normal backtrack/forget logging so the proof stays balanced. The driver loops while the result is `RestartCutoffHit`, calls `on_restart()` on the weighting (reached via the `ConflictObserver` already on the propagators), and advances the schedule. One recursive function still serves decision / enumeration / optimisation — no duplication. `stats` gains a `restarts` counter.

**Proofs** (the subtle part, and the bit @ciaranm's one-level hint cracked):
- A restart abandons a subtree *unrefuted*, so it asserts **no** backtrack lemma (the negation-of-guesses isn't RUP-derivable) — it only deletes what the pass derived, which is always sound.
- But the **root node's guess-independent propagation lives at proof level 1**, and the next pass starts from the same root fixpoint so `propagate()` re-emits nothing there. Deleting it would leave the next pass's backtracks non-RUP. So the root (depth 0) **keeps level 1**; deeper guess-dependent levels are re-derived each pass.

**Soundness guard.** Without nogoods a restart re-explores and so re-finds solutions, so a schedule is only sound for finding one solution or optimising. Continuing past a solution with restarts on and no objective now throws `UnimplementedException` rather than miscounting; Stage 4 (nogoods) lifts this.

**Testing.** `solve_test` covers unsat, optimisation, the enumeration guard, and an unsatisfiable Langford instance whose AllDifferent/Element root propagation exercises the level-1 fix (it fails without it). `langford` gains a `--restart` hook to benchmark restarts on a real instance (e.g. langford-5 unsat: a couple of restarts, then the growing cutoff exhausts and proves unsat — proof verifies). Full `ctest` 330/330; proofs verify under GCC 15 and clang 21.

Next: Stage 4, the `Nogoods` constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)