### PR TITLE
Add the Nogoods constraint (propagation core)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(glasgow_constraint_solver
         constraints/minus.cc
         constraints/mult_bc.cc
         constraints/n_value.cc
+        constraints/nogoods.cc
         constraints/parity.cc
         constraints/plus.cc
         constraints/regular/regular.cc
@@ -166,6 +167,7 @@ if(GCS_BUILD_TESTS)
     add_executable(min_max_test constraints/min_max_test.cc)
     add_executable(mult_bc_test constraints/mult_bc_test.cc)
     add_executable(n_value_test constraints/n_value_test.cc)
+    add_executable(nogoods_test constraints/nogoods_test.cc)
     add_executable(parity_test constraints/parity_test.cc)
     add_executable(plus_minus_test constraints/plus_minus_test.cc)
     add_executable(regular_test constraints/regular/regular_test.cc)
@@ -184,7 +186,7 @@ if(GCS_BUILD_TESTS)
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test arithmetic_test at_most_one_test comparison_test
             count_test cumulative_test disjunctive_test disjunctive_2d_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test lex_test linear_test linear_constant_test
-            logical_test min_max_test mult_bc_test n_value_test parity_test
+            logical_test min_max_test mult_bc_test n_value_test nogoods_test parity_test
             plus_minus_test regular_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test value_precede_test)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
@@ -315,6 +317,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME min_max_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:min_max_test>)
     add_test(NAME mult_bc_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:mult_bc_test>)
     add_test(NAME n_value_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:n_value_test>)
+    add_test(NAME nogoods_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:nogoods_test>)
     add_test(NAME parity_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_test>)
     add_test(NAME plus_minus_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:plus_minus_test>)
     add_test(NAME regular_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:regular_test>)

--- a/gcs/constraints/nogoods.cc
+++ b/gcs/constraints/nogoods.cc
@@ -1,0 +1,235 @@
+#include <gcs/constraints/nogoods.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_shared;
+using std::make_unique;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::size_t;
+using std::string;
+using std::stringstream;
+using std::unique_ptr;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+#else
+using fmt::print;
+#endif
+
+Nogoods::Nogoods(vector<Nogood> nogoods) :
+    _nogoods(move(nogoods))
+{
+}
+
+auto Nogoods::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<Nogoods>(_nogoods);
+}
+
+auto Nogoods::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto Nogoods::define_proof_model(ProofModel & model) -> void
+{
+    // A nogood forbids a conjunction of literals, so its definition is the clause
+    // of their negations: at least one negated literal must hold.
+    for (const auto & nogood : _nogoods) {
+        Literals lits;
+        for (const auto & lit : nogood)
+            lits.emplace_back(! lit);
+        model.add_constraint("Nogoods", "nogood", move(lits));
+    }
+}
+
+namespace
+{
+    constexpr size_t no_watch = std::numeric_limits<size_t>::max();
+}
+
+auto Nogoods::install_propagators(Propagators & propagators) -> void
+{
+    // The distinct variables each nogood mentions (for its reason), and their
+    // union (what to wake on). Nogoods are short, so a linear dedup is fine.
+    auto nogood_vars = make_shared<vector<vector<IntegerVariableID>>>();
+    nogood_vars->reserve(_nogoods.size());
+    vector<IntegerVariableID> all_vars;
+    auto add_distinct = [](vector<IntegerVariableID> & vs, const IntegerVariableID & v) {
+        if (std::find(vs.begin(), vs.end(), v) == vs.end())
+            vs.push_back(v);
+    };
+    for (const auto & nogood : _nogoods) {
+        vector<IntegerVariableID> vs;
+        for (const auto & lit : nogood) {
+            add_distinct(vs, lit.var);
+            add_distinct(all_vars, lit.var);
+        }
+        nogood_vars->push_back(move(vs));
+    }
+
+    Triggers triggers;
+    for (auto & v : all_vars)
+        triggers.on_change.emplace_back(v);
+
+    // Watches are non-backtrackable: when a watch moves during search, leaving it
+    // moved after backtrack is sound (its literal can only become "more not-held"
+    // as the state relaxes) and avoids restoration overhead. The shared_ptr lets
+    // the initialiser and the main propagator share one watch store and one copy
+    // of the (moved-out) nogood data.
+    auto watches = make_shared<vector<pair<size_t, size_t>>>();
+    auto nogoods = make_shared<const vector<Nogood>>(move(_nogoods));
+
+    // Init: find two watch positions per nogood, propagating units and raising
+    // contradictions. A position is unusable as a watch iff its literal is
+    // currently DefinitelyTrue (entailed) --- then it cannot be the disjunct that
+    // saves the clause.
+    propagators.install_initialiser(
+        [nogoods, nogood_vars, watches](const State & state, auto & inference, ProofLogger * const logger) -> void {
+            watches->reserve(nogoods->size());
+
+            for (size_t ni = 0; ni < nogoods->size(); ++ni) {
+                const auto & nogood = (*nogoods)[ni];
+                const auto & vars = (*nogood_vars)[ni];
+
+                auto find_unbroken = [&](size_t skip) -> optional<size_t> {
+                    for (size_t p = 0; p < nogood.size(); ++p) {
+                        if (p == skip)
+                            continue;
+                        if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue)
+                            return p;
+                    }
+                    return nullopt;
+                };
+
+                auto w1 = find_unbroken(no_watch);
+                if (! w1)
+                    inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, vars));
+
+                auto w2 = find_unbroken(*w1);
+                if (! w2) {
+                    // Unit clause: the only not-yet-held literal must be falsified.
+                    inference.infer(logger, ! nogood[*w1], JustifyUsingRUP{}, generic_reason(state, vars));
+                    // Mark as handled: both watches at one position read as broken
+                    // on every later fire, and any rescue finds the unit redundant.
+                    watches->emplace_back(*w1, *w1);
+                }
+                else
+                    watches->emplace_back(*w1, *w2);
+            }
+        });
+
+    propagators.install(
+        constraint_id(),
+        [nogoods, nogood_vars, watches](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            auto is_broken = [&](const Nogood & nogood, size_t p) -> bool {
+                return state.test_literal(nogood[p]) == LiteralIs::DefinitelyTrue;
+            };
+
+            auto find_unbroken = [&](const Nogood & nogood, size_t skip1, size_t skip2) -> optional<size_t> {
+                for (size_t p = 0; p < nogood.size(); ++p) {
+                    if (p == skip1 || p == skip2)
+                        continue;
+                    if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue)
+                        return p;
+                }
+                return nullopt;
+            };
+
+            for (size_t ni = 0; ni < nogoods->size(); ++ni) {
+                auto & w = (*watches)[ni];
+                const auto & nogood = (*nogoods)[ni];
+                const auto & vars = (*nogood_vars)[ni];
+
+                bool b1 = is_broken(nogood, w.first);
+                bool b2 = is_broken(nogood, w.second);
+
+                if (! b1 && ! b2)
+                    continue;
+
+                if (b1 && b2) {
+                    auto new1 = find_unbroken(nogood, no_watch, no_watch);
+                    if (! new1)
+                        inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, vars));
+                    auto new2 = find_unbroken(nogood, *new1, no_watch);
+                    if (! new2)
+                        inference.infer(logger, ! nogood[*new1], JustifyUsingRUP{}, generic_reason(state, vars));
+                    else {
+                        w.first = *new1;
+                        w.second = *new2;
+                    }
+                }
+                else if (b1) {
+                    auto new1 = find_unbroken(nogood, w.second, no_watch);
+                    if (! new1)
+                        inference.infer(logger, ! nogood[w.second], JustifyUsingRUP{}, generic_reason(state, vars));
+                    else
+                        w.first = *new1;
+                }
+                else {
+                    auto new2 = find_unbroken(nogood, w.first, no_watch);
+                    if (! new2)
+                        inference.infer(logger, ! nogood[w.first], JustifyUsingRUP{}, generic_reason(state, vars));
+                    else
+                        w.second = *new2;
+                }
+            }
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto Nogoods::s_exprify(const innards::ProofModel * const model) const -> string
+{
+    // Each nogood is a list of (variable op value) condition terms. This is not
+    // part of the CakePB workflow (which has no `nogoods` rule), but s_exprify is
+    // still invoked whenever a .scp is written, so it must produce valid output.
+    stringstream s;
+    print(s, "{} nogoods (", _constraint_id);
+    for (const auto & nogood : _nogoods) {
+        print(s, " (");
+        for (const auto & lit : nogood)
+            print(s, " ({} {} {})",
+                model->names_and_ids_tracker().s_expr_name_of(lit.var),
+                model->names_and_ids_tracker().s_expr_name_of(lit.op),
+                lit.value.to_string());
+        print(s, " )");
+    }
+    print(s, " )");
+    return s.str();
+}

--- a/gcs/constraints/nogoods.hh
+++ b/gcs/constraints/nogoods.hh
@@ -1,0 +1,53 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_NOGOODS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_NOGOODS_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/variable_condition.hh>
+
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief A single nogood: a conjunction of decision literals that together
+     * lead to failure, and so must not all hold.
+     */
+    using Nogood = std::vector<IntegerVariableCondition>;
+
+    /**
+     * \brief Forbid each of a set of nogoods --- for every nogood, at least one
+     * of its literals must be false.
+     *
+     * Each nogood is a conjunction of `=` / `≠` / `≥` / `≤` literals (the
+     * decisions on a refuted branch); the constraint asserts the negation of each
+     * conjunction, i.e. the clause of the negated literals. Propagation is
+     * per-clause unit propagation by two watched literals with *entailment-based*
+     * watching: a literal `x ≥ 10` counts as held once `lower(x) ≥ 10`, so an
+     * `x ≥ 12` bound makes it hold too. The maintained consistency is unit
+     * propagation on each clause individually, **not** GAC over the conjunction
+     * of clauses (which would be co-NP-hard).
+     *
+     * This is the engine half of the restart-nogood machinery (issue #315). For
+     * now it takes a fixed set of nogoods at construction; feeding it nogoods
+     * extracted at restart boundaries is a later step.
+     *
+     * \ingroup Constraints
+     */
+    class Nogoods : public Constraint
+    {
+    private:
+        std::vector<Nogood> _nogoods;
+
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit Nogoods(std::vector<Nogood> nogoods);
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/nogoods_test.cc
+++ b/gcs/constraints/nogoods_test.cc
@@ -1,0 +1,245 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/nogoods.hh>
+#include <gcs/current_state.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+#include <gcs/variable_condition.hh>
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <set>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::nullopt;
+using std::pair;
+using std::set;
+using std::size_t;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+namespace
+{
+    // A literal of a test nogood, by variable index so the same nogood drives
+    // both the posted constraint and the independent oracle.
+    struct TestLit
+    {
+        size_t var;
+        VariableConditionOperator op;
+        int value;
+    };
+    using TestNogood = vector<TestLit>;
+
+    auto literal_true_on(const TestLit & l, const vector<int> & assignment) -> bool
+    {
+        using enum VariableConditionOperator;
+        switch (l.op) {
+        case Equal: return assignment[l.var] == l.value;
+        case NotEqual: return assignment[l.var] != l.value;
+        case GreaterEqual: return assignment[l.var] >= l.value;
+        case Less: return assignment[l.var] < l.value;
+        }
+        return false;
+    }
+
+    auto make_condition(const vector<IntegerVariableID> & vars, const TestLit & l) -> IntegerVariableCondition
+    {
+        return VariableConditionFrom<IntegerVariableID>{vars[l.var], l.op, Integer{l.value}};
+    }
+
+    enum class Holds
+    {
+        True,
+        False,
+        Undecided
+    };
+
+    // The oracle's own bound-based entailment, independent of the propagator's.
+    // For >= / < it is genuinely bound-based (x >= 10 holds once lower >= 10), so
+    // it catches a propagator that only matched literals exactly.
+    auto literal_holds(const CurrentState & s, const vector<IntegerVariableID> & vars, const TestLit & l) -> Holds
+    {
+        using enum VariableConditionOperator;
+        auto v = vars[l.var];
+        Integer val{l.value};
+        switch (l.op) {
+        case Equal:
+            if (! s.in_domain(v, val))
+                return Holds::False;
+            return s.has_single_value(v) ? Holds::True : Holds::Undecided;
+        case NotEqual:
+            if (! s.in_domain(v, val))
+                return Holds::True;
+            return s.has_single_value(v) ? Holds::False : Holds::Undecided;
+        case GreaterEqual:
+            if (s.lower_bound(v) >= val)
+                return Holds::True;
+            if (s.upper_bound(v) < val)
+                return Holds::False;
+            return Holds::Undecided;
+        case Less:
+            if (s.upper_bound(v) < val)
+                return Holds::True;
+            if (s.lower_bound(v) >= val)
+                return Holds::False;
+            return Holds::Undecided;
+        }
+        return Holds::Undecided;
+    }
+
+    auto run_nogoods_test(bool proofs, const vector<pair<int, int>> & domains, const vector<TestNogood> & nogoods) -> void
+    {
+        print(cerr, "nogoods {} vars, {} nogoods{}", domains.size(), nogoods.size(), proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        // Oracle: an assignment is a solution iff no nogood is fully satisfied.
+        set<tuple<vector<int>>> expected, actual;
+        build_expected(
+            expected, [&](const vector<int> & a) -> bool {
+                for (const auto & nogood : nogoods) {
+                    bool all_true = true;
+                    for (const auto & l : nogood)
+                        if (! literal_true_on(l, a)) {
+                            all_true = false;
+                            break;
+                        }
+                    if (all_true)
+                        return false;
+                }
+                return true;
+            },
+            domains);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        vector<IntegerVariableID> vars;
+        for (const auto & d : domains)
+            vars.push_back(p.create_integer_variable(Integer{d.first}, Integer{d.second}));
+
+        vector<Nogood> posted;
+        for (const auto & nogood : nogoods) {
+            Nogood n;
+            for (const auto & l : nogood)
+                n.push_back(make_condition(vars, l));
+            posted.push_back(std::move(n));
+        }
+        p.post(Nogoods{std::move(posted)});
+
+        auto proof_name = proofs ? make_optional<std::string>("nogoods_test") : nullopt;
+
+        solve_for_tests_with_callbacks(
+            p, proof_name,
+            [&](const CurrentState & s) -> bool {
+                actual.emplace(extract_from_state(s, vars));
+                return true;
+            },
+            [&](const CurrentState & s) -> bool {
+                // Per-clause unit-propagation reference. At every node, for each
+                // nogood: if no literal is falsified then the clause is not yet
+                // satisfied, so at least two literals must still be non-entailed
+                // (the two watches). One or zero ⇒ the propagator missed a unit
+                // inference or a contradiction.
+                for (const auto & nogood : nogoods) {
+                    int entailed = 0, falsified = 0;
+                    for (const auto & l : nogood)
+                        switch (literal_holds(s, vars, l)) {
+                        case Holds::True: ++entailed; break;
+                        case Holds::False: ++falsified; break;
+                        case Holds::Undecided: break;
+                        }
+                    if (falsified == 0 && entailed > static_cast<int>(nogood.size()) - 2)
+                        throw UnexpectedException{"nogood under-propagated: a clause was unit or violated but not enforced"};
+                }
+                return true;
+            });
+
+        check_results(proof_name, expected, actual);
+    }
+
+    auto run_all_tests(bool proofs) -> void
+    {
+        using enum VariableConditionOperator;
+
+        // Pure equality nogoods (a NegativeTable in disguise).
+        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
+            {{{0, Equal, 1}, {1, Equal, 1}}});
+        // Exclude the diagonal.
+        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
+            {{{0, Equal, 1}, {1, Equal, 1}}, {{0, Equal, 2}, {1, Equal, 2}}, {{0, Equal, 3}, {1, Equal, 3}}});
+        // Cascade: (x=1, y=*) all forbidden forces x != 1.
+        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
+            {{{0, Equal, 1}, {1, Equal, 1}}, {{0, Equal, 1}, {1, Equal, 2}}, {{0, Equal, 1}, {1, Equal, 3}}});
+
+        // A unit nogood over an order literal: forbids x >= 4, i.e. forces x < 4.
+        run_nogoods_test(proofs, {{0, 6}},
+            {{{0, GreaterEqual, 4}}});
+
+        // Order literals: forbid (x >= 3 and y < 3).
+        run_nogoods_test(proofs, {{0, 5}, {0, 5}},
+            {{{0, GreaterEqual, 3}, {1, Less, 3}}});
+
+        // Entailment watching: x is in [11, 13] so x >= 10 always holds; the
+        // nogood (x >= 10 and y = 5) must therefore force y != 5. The oracle's
+        // bound-based entailment fires on the >= 11 bound, so a propagator that
+        // matched x >= 10 only exactly would be caught.
+        run_nogoods_test(proofs, {{11, 13}, {4, 6}},
+            {{{0, GreaterEqual, 10}, {1, Equal, 5}}});
+
+        // Mixed literal kinds in one nogood.
+        run_nogoods_test(proofs, {{0, 3}, {0, 3}, {0, 3}},
+            {{{0, Equal, 1}, {1, GreaterEqual, 2}, {2, NotEqual, 2}}});
+
+        // A not-equal literal: forbid (x != 2 and y != 2) over small domains.
+        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
+            {{{0, NotEqual, 2}, {1, NotEqual, 2}}});
+
+        // Unsatisfiable at the root: forbid both x <= 2 and x >= 3 over [0, 5].
+        run_nogoods_test(proofs, {{0, 5}},
+            {{{0, Less, 3}}, {{0, GreaterEqual, 3}}});
+
+        // Several order nogoods that interact over three variables.
+        run_nogoods_test(proofs, {{0, 4}, {0, 4}, {0, 4}},
+            {{{0, GreaterEqual, 3}, {1, GreaterEqual, 3}},
+                {{1, Less, 2}, {2, Less, 2}},
+                {{0, Equal, 0}, {2, GreaterEqual, 4}}});
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    set_seed_from_argv(argc, argv);
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        run_all_tests(proofs);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/gcs.hh
+++ b/gcs/gcs.hh
@@ -42,6 +42,7 @@
 #include <gcs/constraints/minus.hh>
 #include <gcs/constraints/mult_bc.hh>
 #include <gcs/constraints/n_value.hh>
+#include <gcs/constraints/nogoods.hh>
 #include <gcs/constraints/parity.hh>
 #include <gcs/constraints/plus.hh>
 #include <gcs/constraints/regular.hh>


### PR DESCRIPTION
Stage 4 of #315: the **propagation core** of the `Nogoods` constraint, fed a *fixed* set (extraction at restart boundaries is Stage 5; restart wiring is Stage 6). Stacked on #328.

A `Nogoods` constraint stores a set of nogoods — each a conjunction of decision literals (`=`/`≠`/`≥`/`≤`) that must not all hold — and enforces **per-clause unit propagation**, *not* GAC over the conjunction (which is co-NP-hard).

**Mechanism.** It generalises `NegativeTable`'s two-watched-literal scheme from `var==value` tuples to arbitrary order/equality literals. Watching is **entailment-based**, riding `State::test_literal`: a literal `x ≥ 10` counts as held once `lower(x) ≥ 10`, so an `x ≥ 12` bound makes it hold too. Watches are non-backtrackable (a moved watch stays sound as the state relaxes). `define_proof_model` emits each nogood as a CNF clause of negated literals; inferences are `JustifyUsingRUP` — the order-encoding axioms already in the model let RUP bridge literal strengths, so the order-literal units verify with no explicit steps.

**Testing — the two-sided net** (companion plan §6): the solution set is checked against an independent oracle and `--prove` catches over-pruning; a **per-node unit-propagation reference**, run at every search node via the trace callback (deliberately *not* `solve_for_tests_checking_gac`, which would wrongly flag a correct UP propagator), catches *under*-pruning and mis-computed entailment. The reference asserts the 2WL invariant — every unsatisfied clause has ≥2 non-entailed literals — using its *own* bound-based entailment, so it fires if the propagator fails to see `x≥12 ⊨ x≥10`. I confirmed it's non-vacuous by weakening the propagator to skip unit inferences and watching the reference catch them while the solution-set check passed. Cases cover equality / order / not-equal / mixed literals, cascades, a unit nogood, the entailment case, and root unsat.

Full `ctest` 331/331; proofs verify under GCC 15 and clang 21.

Next: Stage 5 — reduced-nld extraction on restart unroll + the log-on-unroll / delete-on-purge proof lifecycle, feeding this constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)