### PR TITLE
Allow several conflict observers; wire MiniZinc dom_w_deg to real dom/wdeg

### DIFF
--- a/gcs/innards/conflict_observer.hh
+++ b/gcs/innards/conflict_observer.hh
@@ -15,13 +15,14 @@ namespace gcs::innards
      * happen, so that a search heuristic can attribute each wipeout to the
      * constraint --- and, later, the specific Reason --- that caused it.
      *
-     * A borrowed observer is attached to the Propagators for the duration of a
-     * search (Propagators::set_conflict_observer). Whenever a propagator raises
-     * a contradiction, Propagators::propagate notifies the observer exactly once
-     * with the failing constraint and its scope. This is the write side of the
-     * dom/wdeg weighting seam (issue #315, Stage 0): the weighting value object
-     * will implement this interface. It is deliberately minimal and carries no
-     * query API of its own --- the brancher reads back weights by another path.
+     * Borrowed observers are attached to the Propagators for the duration of a
+     * search (Propagators::add_conflict_observer). Whenever a propagator raises
+     * a contradiction, Propagators::propagate notifies each attached observer
+     * exactly once with the failing constraint and its scope. This is the write
+     * side of the dom/wdeg weighting seam (issue #315, Stage 0): the weighting
+     * value object implements this interface. It is deliberately minimal and
+     * carries no query API of its own --- the brancher reads back weights by
+     * another path.
      *
      * \ingroup Innards
      */

--- a/gcs/innards/conflict_observer_test.cc
+++ b/gcs/innards/conflict_observer_test.cc
@@ -74,7 +74,7 @@ TEST_CASE("Conflict observer attributes a wipeout to the failing constraint, not
         Triggers{.on_change = {x, y}, .on_bounds = {x + 1_i}});
 
     RecordingObserver observer;
-    propagators.set_conflict_observer(&observer);
+    propagators.add_conflict_observer(&observer);
 
     auto no_contradiction = propagators.propagate(nullopt, state, nullptr);
 
@@ -111,7 +111,7 @@ TEST_CASE("Conflict observer fires for an inference-driven wipeout")
         Triggers{.on_bounds = {x}});
 
     RecordingObserver observer;
-    propagators.set_conflict_observer(&observer);
+    propagators.add_conflict_observer(&observer);
 
     auto no_contradiction = propagators.propagate(nullopt, state, nullptr);
 
@@ -143,8 +143,36 @@ TEST_CASE("Propagation without a conflict observer still detects the wipeout")
 
     // No observer attached: the propagate() notification is guarded and must not
     // be reached, but the contradiction is still reported.
-    CHECK(propagators.conflict_observer() == nullptr);
+    CHECK(propagators.conflict_observers().empty());
     CHECK_FALSE(propagators.propagate(nullopt, state, nullptr));
+}
+
+TEST_CASE("Every attached conflict observer is notified of a wipeout")
+{
+    State state;
+    auto x = state.allocate_integer_variable_with_state(0_i, 1_i);
+
+    Propagators propagators;
+    propagators.install(
+        NumberedConstraint{3},
+        [x](const State & inner_state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            inference.contradiction(logger, JustifyUsingRUP{},
+                generic_reason(inner_state, vector<IntegerVariableID>{x}));
+        },
+        Triggers{.on_change = {x}});
+
+    // A seq_search can chain several stateful branchers, each with its own
+    // weighting; every one must see every conflict.
+    RecordingObserver first, second;
+    propagators.add_conflict_observer(&first);
+    propagators.add_conflict_observer(&second);
+
+    CHECK_FALSE(propagators.propagate(nullopt, state, nullptr));
+
+    REQUIRE(first.calls.size() == 1);
+    REQUIRE(second.calls.size() == 1);
+    CHECK(first.calls.front().constraint_index == 0);
+    CHECK(second.calls.front().constraint_index == 0);
 }
 
 TEST_CASE("Propagator scope and variable-to-constraint adjacency")

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -77,10 +77,12 @@ struct Propagators::Imp
     vector<vector<int>> var_constraint_indices;
     vector<vector<SimpleIntegerVariableID>> constraint_scope;
 
-    // A borrowed conflict observer, notified when a propagator wipes out a
-    // domain (see propagate). Set once at search start via set_conflict_observer;
-    // the caller owns it. nullptr when there is no observer.
-    ConflictObserver * conflict_observer = nullptr;
+    // Borrowed conflict observers, each notified when a propagator wipes out a
+    // domain (see propagate). Attached at search start via add_conflict_observer;
+    // the caller owns them. There can be several: a seq_search may chain several
+    // stateful branchers, each carrying its own weighting, and every one needs
+    // to see every conflict. Empty when there are no observers.
+    vector<ConflictObserver *> conflict_observers;
 };
 
 Propagators::Propagators() :
@@ -316,8 +318,8 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
             // fires at most once per call. Non-propagator contradiction paths
             // (initialisers, the objective bound) never reach here, so they are
             // not attributed to any constraint.
-            if (_imp->conflict_observer)
-                _imp->conflict_observer->note_conflict(_imp->propagator_constraint_index[propagator_id],
+            for (auto & observer : _imp->conflict_observers)
+                observer->note_conflict(_imp->propagator_constraint_index[propagator_id],
                     _imp->propagator_scope[propagator_id], tracker.last_contradiction_reason(), state);
         }
 
@@ -458,12 +460,12 @@ auto Propagators::scope_of_constraint(int constraint_index) const -> const vecto
     return _imp->constraint_scope[constraint_index];
 }
 
-auto Propagators::set_conflict_observer(ConflictObserver * observer) -> void
+auto Propagators::add_conflict_observer(ConflictObserver * observer) -> void
 {
-    _imp->conflict_observer = observer;
+    _imp->conflict_observers.push_back(observer);
 }
 
-auto Propagators::conflict_observer() const -> ConflictObserver *
+auto Propagators::conflict_observers() const -> const vector<ConflictObserver *> &
 {
-    return _imp->conflict_observer;
+    return _imp->conflict_observers;
 }

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -354,22 +354,26 @@ namespace gcs::innards
         /**
          * Attach a borrowed conflict observer, notified by propagate() whenever
          * a propagator wipes out a domain. The observer is borrowed: the caller
-         * owns it and must keep it alive for the duration of the search. Pass
-         * nullptr to detach. A conflict is a Propagators event (it carries the
-         * failing constraint's index, scope, and reason, all from here), so the
-         * observer lives with the rest of the conflict-observation machinery
-         * rather than on State.
+         * owns it and must keep it alive for the duration of the search. A
+         * conflict is a Propagators event (it carries the failing constraint's
+         * index, scope, and reason, all from here), so the observer lives with
+         * the rest of the conflict-observation machinery rather than on State.
+         *
+         * Several observers may be attached: a seq_search can chain several
+         * stateful branchers, each carrying its own weighting, and every one
+         * must see every conflict. Each is notified, in the order attached.
          *
          * \sa ConflictObserver
          */
-        auto set_conflict_observer(ConflictObserver * observer) -> void;
+        auto add_conflict_observer(ConflictObserver * observer) -> void;
 
         /**
-         * The conflict observer currently attached, or nullptr if none.
+         * The conflict observers currently attached, in the order they were
+         * added; empty if there are none.
          *
-         * \sa Propagators::set_conflict_observer()
+         * \sa Propagators::add_conflict_observer()
          */
-        [[nodiscard]] auto conflict_observer() const -> ConflictObserver *;
+        [[nodiscard]] auto conflict_observers() const -> const std::vector<ConflictObserver *> &;
 
         ///@}
     };

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -235,7 +235,7 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingSche
         }
         if (initial)
             weighting->load(*initial, propagators);
-        propagators.set_conflict_observer(weighting.get());
+        propagators.add_conflict_observer(weighting.get());
 
         return in_order_of_selector(vars,
             [weighting](const CurrentState & state, const innards::Propagators & p,

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -362,7 +362,7 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
 
             if (search_result == SearchResult::RestartCutoffHit) {
                 ++stats.restarts;
-                if (auto observer = propagators.conflict_observer())
+                for (auto & observer : propagators.conflict_observers())
                     observer->on_restart();
                 restart_schedule->advance();
                 restart.cutoff = restart_schedule->current_cutoff();

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -154,6 +154,9 @@ set_tests_properties(minizinc-nurses PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-seqprecedechain COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ seqprecedechain true true)
 set_tests_properties(minizinc-seqprecedechain PROPERTIES SKIP_RETURN_CODE 66)
 
+add_test(NAME minizinc-seqwdeg COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ seqwdeg true true)
+set_tests_properties(minizinc-seqwdeg PROPERTIES SKIP_RETURN_CODE 66)
+
 add_test(NAME minizinc-setinreif COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ setinreif true true)
 set_tests_properties(minizinc-setinreif PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -860,15 +860,13 @@ auto main(int argc, char * argv[]) -> int
                         var = variable_order::dom(vars);
                     else if (var_heuristic == "input_order")
                         var = variable_order::in_order(vars);
-                    else if (var_heuristic == "dom_w_deg") {
-                        // not technically "w" but it'll do for now
-                        var = variable_order::dom_then_deg(vars);
-                    }
+                    else if (var_heuristic == "dom_w_deg")
+                        var = variable_order::dom_wdeg(vars);
                     else if (var_heuristic == "smallest")
                         var = variable_order::with_smallest_value(vars);
                     else {
                         println(cerr, "Warning: treating unknown int_search variable heuristic {} as dom_w_deg instead", var_heuristic);
-                        var = variable_order::dom_then_deg(vars);
+                        var = variable_order::dom_wdeg(vars);
                     }
 
                     BranchValueGenerator val;

--- a/minizinc/tests/seqwdeg.mzn
+++ b/minizinc/tests/seqwdeg.mzn
@@ -1,0 +1,20 @@
+include "alldifferent.mzn";
+
+% Two coupled permutation groups, each searched with its own dom_w_deg. This
+% exercises a seq_search of two stateful weightings: each carries its own
+% conflict-driven weighting, so the engine must let several conflict observers
+% coexist (issue #315). The solution set is differentially checked against the
+% reference solver.
+array[1..4] of var 1..4: x;
+array[1..4] of var 1..4: y;
+
+constraint alldifferent(x);
+constraint alldifferent(y);
+constraint forall(i in 1..4) (x[i] != y[i]);
+
+solve :: seq_search([
+    int_search(x, dom_w_deg, indomain_min),
+    int_search(y, dom_w_deg, indomain_min)
+]) satisfy;
+
+output ["ENUMSOL: x=\(x) y=\(y)\n"];


### PR DESCRIPTION
Part of the dom/wdeg work (issue #315), stacked on #330 (`restart-nogood-learning`).

## The gap

The conflict-observation seam (#318) put a **single** borrowed `ConflictObserver*` slot on `Propagators`, attached once at search start. That is enough for one stateful brancher, but:

- a `seq_search` can chain several stateful branchers, each wanting its own weighting; and
- MiniZinc's `dom_w_deg` was stubbed to `dom_then_deg` precisely because two `int_search(..., dom_w_deg, ...)` annotations would each call `set_conflict_observer` and the second would **silently clobber** the first, freezing the earlier brancher's weights at their initial values.

## The fix (commit 1)

Hold a `vector<ConflictObserver*>` instead of one slot: `add_conflict_observer()` appends, `conflict_observers()` returns them all, `propagate()` notifies each exactly once on a wipeout, and the restart hook fans out to every one. Attribution is unchanged (constraint index, scope, reason); every observer simply gets told.

**Design note (flagging for your call).** I took the *fan-out* option — each brancher owns its own weighting and all observers see all conflicts — because it is the minimal change and matches the stated design ("each [brancher] carry their own weighting"). Since weights are per-constraint and global, several same-scheme weightings just track *identical* counts (correct, but redundant); different schemes each keep their own state. The alternative is a single *shared* weighting that multiple selectors read over different variable subsets (less memory, but needs a new injection API and forces one scheme). Happy to switch to shared-weighting if you'd prefer it.

## MiniZinc wiring (commit 2)

`dom_w_deg` (and the unknown-heuristic fallback, whose warning already promised `dom_w_deg`) now maps to `variable_order::dom_wdeg` with the library default scheme. New differential test `seqwdeg`: a `seq_search` of two `dom_w_deg` groups over coupled permutations — full solution set matches the reference solver, and the proof **verifies complete enumeration of 216 solutions**.

This unblocks running real `dom_w_deg` benchmark suites (XCSP / MiniZinc challenge) — which is what proper search-gain validation needs (see the #315 comment).

## Testing

- GCC 15 + clang 21 builds clean.
- Full ctest 332/332 (was 331; +`minizinc-seqwdeg`), including proof verification.
- New unit test: "Every attached conflict observer is notified of a wipeout".

🤖 Generated with [Claude Code](https://claude.com/claude-code)