### PR TITLE
xcsp: --branch / --restarts flags for benchmarking dom/wdeg

### DIFF
--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -1618,6 +1618,45 @@ namespace
             return result;
         }
     };
+
+    // Map a dom-wdeg variant string to a weighting scheme, for the --branch flag.
+    auto scheme_from_string(const string & name) -> optional<WeightingScheme>
+    {
+        using enum WeightingScheme;
+        if (name == "classic")
+            return Classic;
+        if (name == "ia")
+            return InitialArity;
+        if (name == "ca")
+            return CurrentArity;
+        if (name == "id")
+            return InitialDomain;
+        if (name == "cd")
+            return CurrentDomain;
+        if (name == "ca.cd" || name == "cacd")
+            return CurrentArityCurrentDomain;
+        if (name == "chs")
+            return ConflictHistorySearch;
+        return nullopt;
+    }
+
+    // Build the brancher named by --branch: "dom-then-deg" (the default, over
+    // all variables, as solve_with would otherwise pick), or "dom-wdeg"
+    // optionally suffixed with a scheme, e.g. "dom-wdeg:chs" (default ca.cd).
+    auto brancher_from_string(const string & spec, const Problem & problem) -> optional<BranchHeuristic>
+    {
+        if (spec == "dom-then-deg")
+            return branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
+        if (spec == "dom-wdeg" || spec.starts_with("dom-wdeg:")) {
+            auto colon = spec.find(':');
+            auto variant = (colon == string::npos) ? string{"ca.cd"} : spec.substr(colon + 1);
+            auto scheme = scheme_from_string(variant);
+            if (! scheme)
+                return nullopt;
+            return branch_with(variable_order::dom_wdeg(problem, *scheme), value_order::smallest_first());
+        }
+        return nullopt;
+    }
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -1625,10 +1664,15 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::Options options("XCSP Glasgow Constraint Solver", "Get started by using option --help");
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
-            ("all", "Find all solutions")        //
+        options.add_options("Program Options")                                       //
+            ("help", "Display help information")                                     //
+            ("prove", "Create a proof")                                              //
+            ("all", "Find all solutions")                                            //
+            ("branch", "Branching heuristic: dom-then-deg, or dom-wdeg[:VARIANT] "   //
+                       "(VARIANT one of classic, ia, ca, id, cd, ca.cd, chs)",       //
+                cxxopts::value<string>()->default_value("dom-then-deg"))             //
+            ("restarts", "Restart on a Luby schedule with the given conflict scale", //
+                cxxopts::value<unsigned long long>()->implicit_value("100"))         //
             ("timeout", "Timeout in seconds", cxxopts::value<int>());
 
         options.add_options()("file", "Input file in XCSP format", cxxopts::value<string>());
@@ -1705,6 +1749,16 @@ auto main(int argc, char * argv[]) -> int
         });
     }
 
+    auto brancher = brancher_from_string(options_vars["branch"].as<string>(), problem);
+    if (! brancher) {
+        cerr << "Error: unknown --branch value " << options_vars["branch"].as<string>() << endl;
+        return EXIT_FAILURE;
+    }
+
+    auto restarts = options_vars.contains("restarts")
+        ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
+        : nullopt;
+
     auto stats = solve_with(problem,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
@@ -1730,7 +1784,9 @@ auto main(int argc, char * argv[]) -> int
                     saved_solution.emplace(s.clone());
                     return false;
                 }
-            }},
+            },
+            .branch = *brancher,
+            .restarts = restarts},
         options_vars.contains("prove") ? make_optional<ProofOptions>("xcsp") : nullopt,
         &abort_flag);
 
@@ -1775,6 +1831,9 @@ auto main(int argc, char * argv[]) -> int
         cout << "v </instantiation>" << endl;
     }
 
+    cout << "d RECURSIONS " << stats.recursions << endl;
+    cout << "d RESTARTS " << stats.restarts << endl;
+    cout << "d LEARNED NOGOODS " << stats.learned_nogoods << endl;
     cout << "d WRONG DECISIONS " << stats.failures << endl;
     cout << "d PROPAGATIONS " << stats.propagations << endl;
     cout << "d EFFECTFUL PROPAGATIONS " << stats.effectful_propagations << endl;

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -1641,16 +1641,17 @@ namespace
     }
 
     // Build the brancher named by --branch: "dom-then-deg" (the default, over
-    // all variables, as solve_with would otherwise pick), or "dom-wdeg"
-    // optionally suffixed with a scheme, e.g. "dom-wdeg:chs" (default ca.cd).
+    // all variables, as solve_with would otherwise pick), or "dom-wdeg" (the
+    // library default scheme) optionally suffixed with a scheme, e.g.
+    // "dom-wdeg:classic".
     auto brancher_from_string(const string & spec, const Problem & problem) -> optional<BranchHeuristic>
     {
         if (spec == "dom-then-deg")
             return branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
-        if (spec == "dom-wdeg" || spec.starts_with("dom-wdeg:")) {
-            auto colon = spec.find(':');
-            auto variant = (colon == string::npos) ? string{"ca.cd"} : spec.substr(colon + 1);
-            auto scheme = scheme_from_string(variant);
+        if (spec == "dom-wdeg")
+            return branch_with(variable_order::dom_wdeg(problem), value_order::smallest_first());
+        if (spec.starts_with("dom-wdeg:")) {
+            auto scheme = scheme_from_string(spec.substr(spec.find(':') + 1));
             if (! scheme)
                 return nullopt;
             return branch_with(variable_order::dom_wdeg(problem, *scheme), value_order::smallest_first());


### PR DESCRIPTION
Part of the dom/wdeg work (issue #315), stacked on #330 (`restart-nogood-learning`).

The XCSP frontend had no way to choose a search heuristic — it always used `solve_with`'s default (`dom_then_deg` over all variables) — so dom/wdeg couldn't be benchmarked on XCSP instances at all. This adds, mirroring the langford (#326) and colour (#332) example hooks:

- `--branch dom-then-deg | dom-wdeg[:VARIANT]` (VARIANT one of `classic`, `ia`, `ca`, `id`, `cd`, `ca.cd`, `chs`), branching over all variables as the default brancher does;
- `--restarts[=SCALE]` (Luby) — so the full restart + nogood-learning stack is reachable from the XCSP frontend;
- three extra stat lines: `d RECURSIONS`, `d RESTARTS`, `d LEARNED NOGOODS` (the frontend already printed wrong-decisions / propagations / solve-time, but not the node count).

Default behaviour (no flags) is unchanged: `--branch` defaults to `dom-then-deg`, which is exactly the brancher `solve_with` picks when none is given.

This is what made the suite-style search-gain validation in the #315 comment possible on real XCSP instances (k-colourability decision) — including the finding that the default weighting scheme `ca.cd` is fragile where `classic`/`chs` win.

## Testing

- GCC 15 + clang 21 build clean; existing XCSP behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)