### PR TITLE
Default the dom/wdeg weighting scheme to CHS

### DIFF
--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -66,15 +66,16 @@ namespace
     }
 
     // Build the brancher named by --branch: "dom-then-deg", or "dom-wdeg"
-    // optionally suffixed with a scheme, e.g. "dom-wdeg:chs" (default ca.cd).
+    // (the library default scheme) optionally suffixed with a scheme,
+    // e.g. "dom-wdeg:classic".
     auto brancher_from_string(const string & spec, const Problem & problem) -> optional<BranchHeuristic>
     {
         if (spec == "dom-then-deg")
             return branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
-        if (spec == "dom-wdeg" || spec.starts_with("dom-wdeg:")) {
-            auto colon = spec.find(':');
-            auto variant = (colon == string::npos) ? string{"ca.cd"} : spec.substr(colon + 1);
-            auto scheme = scheme_from_string(variant);
+        if (spec == "dom-wdeg")
+            return branch_with(variable_order::dom_wdeg(problem), value_order::smallest_first());
+        if (spec.starts_with("dom-wdeg:")) {
+            auto scheme = scheme_from_string(spec.substr(spec.find(':') + 1));
             if (! scheme)
                 return std::nullopt;
             return branch_with(variable_order::dom_wdeg(problem, *scheme), value_order::smallest_first());

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -155,18 +155,18 @@ namespace gcs
          * are broken on highest constraint degree, and a variable with W(x)=0 (in
          * no constraint with two or more unassigned variables) is least preferred.
          *
-         * \p scheme selects the weighting (default WeightingScheme::CurrentArityCurrentDomain, the
-         * strongest in Wattez et al.). An optional initial WeightingState seeds
-         * the weights --- for carrying weights across searches or injecting
-         * proof-mined weights. Value ordering is chosen separately, as usual via
-         * gcs::branch_with().
+         * \p scheme selects the weighting (default WeightingScheme::ConflictHistorySearch,
+         * the most robust in our experiments --- see issue #315). An optional initial
+         * WeightingState seeds the weights --- for carrying weights across searches or
+         * injecting proof-mined weights. Value ordering is chosen separately, as usual
+         * via gcs::branch_with().
          *
          * \ingroup SearchHeuristics
          * \sa WeightingState
          * \sa WeightingScheme
          */
         [[nodiscard]] auto dom_wdeg(const Problem &,
-            WeightingScheme scheme = WeightingScheme::CurrentArityCurrentDomain,
+            WeightingScheme scheme = WeightingScheme::ConflictHistorySearch,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**
@@ -176,7 +176,7 @@ namespace gcs
          * \sa gcs::variable_order::dom_wdeg(const Problem &, WeightingScheme, std::optional<WeightingState>)
          */
         [[nodiscard]] auto dom_wdeg(std::vector<IntegerVariableID>,
-            WeightingScheme scheme = WeightingScheme::CurrentArityCurrentDomain,
+            WeightingScheme scheme = WeightingScheme::ConflictHistorySearch,
             std::optional<WeightingState> initial = std::nullopt) -> BranchVariableHeuristic;
 
         /**

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -50,15 +50,17 @@ TEST_CASE("dom_wdeg orders by dom/W, with a zero-weight variable last")
     propagators.install(NumberedConstraint{5}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
     propagators.install(NumberedConstraint{6}, a_propagator_that_does_nothing(), Triggers{.on_change = {c, x}});
 
-    // dom/W: a=4/1=4, b=4/2=2, c=4/3 -> c is smallest.
-    auto selector = variable_order::dom_wdeg({a, b, c})(dummy, state, propagators);
+    // dom/W: a=4/1=4, b=4/2=2, c=4/3 -> c is smallest. Use Classic explicitly:
+    // it has uniform weights at the root, so this exercises the dom/W ratio
+    // rather than the default scheme's particular starting point.
+    auto selector = variable_order::dom_wdeg({a, b, c}, WeightingScheme::Classic)(dummy, state, propagators);
     auto picked = selector(state.current(), propagators);
     REQUIRE(picked.has_value());
     CHECK(*picked == IntegerVariableID{c});
 
     // d has weighted degree 0, so dom/W is infinite: it is least preferred and a
     // (finite ratio) wins.
-    auto with_isolated = variable_order::dom_wdeg({d, a})(dummy, state, propagators);
+    auto with_isolated = variable_order::dom_wdeg({d, a}, WeightingScheme::Classic)(dummy, state, propagators);
     auto picked_isolated = with_isolated(state.current(), propagators);
     REQUIRE(picked_isolated.has_value());
     CHECK(*picked_isolated == IntegerVariableID{a});
@@ -108,7 +110,9 @@ TEST_CASE("dom_wdeg tie-breaks on degree")
 
     REQUIRE(propagators.degree_of(a) > propagators.degree_of(b));
 
-    auto selector = variable_order::dom_wdeg({a, b})(dummy, state, propagators);
+    // Classic gives both the same weight, so the dom/W ratio ties and the
+    // degree tie-break decides --- which is what this test checks.
+    auto selector = variable_order::dom_wdeg({a, b}, WeightingScheme::Classic)(dummy, state, propagators);
     auto picked = selector(state.current(), propagators);
     REQUIRE(picked.has_value());
     CHECK(*picked == IntegerVariableID{a});


### PR DESCRIPTION
Part of the dom/wdeg work (issue #315), stacked on #330 (`restart-nogood-learning`).

Changes the default weighting scheme for `variable_order::dom_wdeg` from `ca.cd` (CurrentArityCurrentDomain) to `chs` (ConflictHistorySearch).

The search-gain validation ([#315 comment](https://github.com/ciaranm/glasgow-constraint-solver/issues/315#issuecomment-4700060234)) found `ca.cd` to be **fragile**: on a fair (randomly-relabelled) backdoor k-colourability instance it fails to solve even with restarts (574k nodes / 738 restarts in 45 s), whereas `classic` and `chs` solve it in ~14k nodes and the full stack (`+ restarts`) in 412. `chs` was the most robust scheme everywhere measured — also the strongest on uniform random instances in decision mode (3.2× fewer nodes than `dom_then_deg`). So `chs` is a much better out-of-the-box default. This also fixes what MiniZinc `dom_w_deg` inherits (via #331).

The three selector unit tests that exercised the dom/W ratio + degree tie-break used the default scheme implicitly; they're now pinned to `WeightingScheme::Classic`, whose uniform root weights are what those tests actually describe — so they test the comparator, not whichever scheme is the default.

Other tunables (broadening, decay, scale) remain SMAC questions; this is just the scheme default.

## Testing

- GCC 15 + clang 21 build clean; full ctest 331/331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)