### PR TITLE
Refined triggers (Stage A): inert RefinedWatchContext seam

### DIFF
--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -295,7 +295,10 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         int propagator_id = _imp->queue[--_imp->enqueued_end];
         try {
             ++_imp->total_propagations;
-            auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
+            // No refined watches are registered yet, so every propagator sees an
+            // empty fired-payload set (see RefinedWatchContext); this is inert.
+            RefinedWatchContext watches{};
+            auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger, watches);
             if (tracker.did_anything_since_last_call_by_propagation_queue())
                 ++_imp->effectful_propagations;
             switch (propagator_state) {

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -14,13 +14,56 @@
 #include <gcs/problem.hh>
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
+#include <span>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace gcs::innards
 {
     class ConflictObserver;
+
+    /**
+     * \brief The refined-watch context handed to a propagator each time it runs.
+     *
+     * A propagator that registers refined per-literal watches (rather than, or in
+     * addition to, the coarse \ref Triggers) is told which of its watches fired
+     * since it last ran, via the opaque payloads it chose at registration time, so
+     * it can do work proportional to what changed instead of rescanning its state.
+     *
+     * This is the seam for that mechanism. Today no propagator registers refined
+     * watches, so fired_payloads() is always empty and propagators ignore the
+     * context; the watch index that populates it, and the registration and
+     * watch-editing API, land in later stages. The context is forwarded only to
+     * propagators whose function accepts it (see PropagationFunctionImpl), so
+     * existing propagators are unaffected.
+     *
+     * \ingroup Innards
+     */
+    class RefinedWatchContext
+    {
+    private:
+        std::span<const std::uint32_t> _fired_payloads;
+
+    public:
+        explicit RefinedWatchContext(std::span<const std::uint32_t> fired_payloads = {}) :
+            _fired_payloads(fired_payloads)
+        {
+        }
+
+        /**
+         * \brief The payloads of this propagator's refined watches that fired
+         * since it last ran, in no particular order.
+         *
+         * Empty for a propagator that uses only coarse triggers.
+         */
+        [[nodiscard]] auto fired_payloads() const -> std::span<const std::uint32_t>
+        {
+            return _fired_payloads;
+        }
+    };
 
     class PropagationFunctionImplBase
     {
@@ -34,8 +77,8 @@ namespace gcs::innards
         auto operator=(const PropagationFunctionImplBase &) -> PropagationFunctionImplBase & = delete;
         auto operator=(PropagationFunctionImplBase &&) -> PropagationFunctionImplBase & = default;
 
-        [[nodiscard]] virtual auto operator()(const State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger) -> PropagatorState = 0;
-        [[nodiscard]] virtual auto operator()(const State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger) -> PropagatorState = 0;
+        [[nodiscard]] virtual auto operator()(const State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger, const RefinedWatchContext & watches) -> PropagatorState = 0;
+        [[nodiscard]] virtual auto operator()(const State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger, const RefinedWatchContext & watches) -> PropagatorState = 0;
     };
 
     template <typename Func_>
@@ -50,14 +93,20 @@ namespace gcs::innards
         {
         }
 
-        [[nodiscard]] virtual auto operator()(const State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger) -> PropagatorState override
+        [[nodiscard]] virtual auto operator()(const State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger, [[maybe_unused]] const RefinedWatchContext & watches) -> PropagatorState override
         {
-            return _f(state, tracker, logger);
+            if constexpr (std::is_invocable_v<Func_ &, const State &, SimpleInferenceTracker &, ProofLogger * const, const RefinedWatchContext &>)
+                return _f(state, tracker, logger, watches);
+            else
+                return _f(state, tracker, logger);
         }
 
-        [[nodiscard]] virtual auto operator()(const State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger) -> PropagatorState override
+        [[nodiscard]] virtual auto operator()(const State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger, [[maybe_unused]] const RefinedWatchContext & watches) -> PropagatorState override
         {
-            return _f(state, tracker, logger);
+            if constexpr (std::is_invocable_v<Func_ &, const State &, EagerProofLoggingInferenceTracker &, ProofLogger * const, const RefinedWatchContext &>)
+                return _f(state, tracker, logger, watches);
+            else
+                return _f(state, tracker, logger);
         }
     };
 
@@ -73,14 +122,14 @@ namespace gcs::innards
         {
         }
 
-        [[nodiscard]] auto operator()(const State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger) -> PropagatorState
+        [[nodiscard]] auto operator()(const State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger, const RefinedWatchContext & watches) -> PropagatorState
         {
-            return _impl->operator()(state, tracker, logger);
+            return _impl->operator()(state, tracker, logger, watches);
         }
 
-        [[nodiscard]] auto operator()(const State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger) -> PropagatorState
+        [[nodiscard]] auto operator()(const State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger, const RefinedWatchContext & watches) -> PropagatorState
         {
-            return _impl->operator()(state, tracker, logger);
+            return _impl->operator()(state, tracker, logger, watches);
         }
     };
 


### PR DESCRIPTION
First step of the refined per-literal trigger mechanism (#335). This lands **only the calling-convention seam**, inert and behaviour-preserving — directly analogous to the conflict-observation seam (#318).

## What this does

- Adds `RefinedWatchContext` (`gcs/innards/propagators.hh`): the per-call object a propagator will use to learn which of its refined watches fired since it last ran, via the opaque payloads it chose at registration time. Today it exposes only `fired_payloads()`, which is always empty.
- Threads the context through the `PropagationFunction` wrapper layer. Crucially, `PropagationFunctionImpl` forwards it to the wrapped function **only `if constexpr`** that function is invocable with it; otherwise it calls the old 3-argument form. So **all 47 existing propagators are untouched** — they neither see nor mention the context.
- `Propagators::propagate()` constructs an empty context and passes it at the single call site.

## Why a separate seam PR

The watch index that populates the context, the registration / watch-editing API, and the first client (a bounds-consistent mini-linear) land in later stages (#335, Stages B1 onward). Isolating the wrapper-layer signature change here keeps it tiny and behaviour-preserving, and in particular isolates the one piece that is sensitive to the compiler — the `if constexpr` / `std::is_invocable_v` forwarding — so it gets its own clean check under both GCC and clang.

## Validation

Inert by construction: no refined watches exist, so every propagator receives an empty payload set and ignores it. Gate is byte-identical behaviour.

- GCC 15: `ctest` 331/331.
- clang 21: `ctest` 331/331.
- clang-format clean.

No proof impact (no inference is added, removed, or reordered).
