### PR TITLE
Refined triggers (B1): per-literal watch index + mini-linear client

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -165,6 +165,7 @@ if(GCS_BUILD_TESTS)
     add_executable(linear_constant_test constraints/linear/linear_constant_test.cc)
     add_executable(logical_test constraints/logical_test.cc)
     add_executable(min_max_test constraints/min_max_test.cc)
+    add_executable(mini_linear_test constraints/mini_linear_test.cc)
     add_executable(mult_bc_test constraints/mult_bc_test.cc)
     add_executable(n_value_test constraints/n_value_test.cc)
     add_executable(nogoods_test constraints/nogoods_test.cc)
@@ -186,7 +187,7 @@ if(GCS_BUILD_TESTS)
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test arithmetic_test at_most_one_test comparison_test
             count_test cumulative_test disjunctive_test disjunctive_2d_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test lex_test linear_test linear_constant_test
-            logical_test min_max_test mult_bc_test n_value_test nogoods_test parity_test
+            logical_test min_max_test mini_linear_test mult_bc_test n_value_test nogoods_test parity_test
             plus_minus_test regular_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test value_precede_test)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
@@ -220,6 +221,7 @@ if(GCS_BUILD_TESTS)
             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:element_test> ${mode})
     endforeach()
     add_test(NAME equals_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:equals_test>)
+    add_test(NAME mini_linear_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:mini_linear_test>)
     add_test(NAME linear_constant_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_constant_test>)
     add_test(NAME sort_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:sort_test>)
     add_test(NAME arg_sort_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:arg_sort_test>)

--- a/gcs/constraints/mini_linear_test.cc
+++ b/gcs/constraints/mini_linear_test.cc
@@ -1,0 +1,268 @@
+/* Test vehicle for the refined per-literal trigger mechanism (issue #335, stage
+ * B1). MiniLinearGreaterEqual is a deliberately small `sum c_i x_i >= K`
+ * bounds-consistency propagator (all c_i > 0, all x_i >= 0) that drives itself
+ * ENTIRELY from refined watches: it has no coarse Triggers, arms one upper-bound
+ * watch per variable at install, and re-arms a variable's watch when it fires.
+ *
+ * It exists only to exercise the refined-watch engine (the index, the fired-watch
+ * inbox, consume-on-fire, re-arm, and restore-on-backtrack); it is not a public
+ * constraint and is expected to be retired once refined triggers fold into the
+ * real Linear (stage E). Correctness is checked the same way the real Linear is:
+ * a brute-force solution oracle (catches over-pruning and any missed leaf check)
+ * plus per-node bounds-consistency checking (catches under-pruning, including a
+ * watch that was not restored after backtrack, since the check runs at
+ * post-backtrack nodes too).
+ */
+
+#include <gcs/constraint.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/current_state.hh>
+#include <gcs/exception.hh>
+#include <gcs/expression.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+#include <gcs/stats.hh>
+
+#include <util/enumerate.hh>
+
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <set>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+using std::make_optional;
+using std::make_unique;
+using std::move;
+using std::mt19937;
+using std::nullopt;
+using std::pair;
+using std::random_device;
+using std::set;
+using std::string;
+using std::tuple;
+using std::uniform_int_distribution;
+using std::unique_ptr;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using std::cerr;
+using std::flush;
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // A minimal certified-free `sum c_i x_i >= K` propagator (positive
+    // coefficients, non-negative variables) that triggers only through refined
+    // watches. No proof is emitted, so its tests run without --prove; the trigger
+    // mechanism it exercises is semantics-preserving and carries no proof
+    // obligation of its own, and the real Linear already certifies the logic.
+    class MiniLinearGreaterEqual : public Constraint
+    {
+    private:
+        WeightedSum _coeff_vars;
+        Integer _value;
+        bool _refined;
+
+    public:
+        // refined = true drives the propagator from refined upper-bound watches;
+        // false falls back to coarse on_bounds triggers with the identical
+        // propagation body, so the two can be compared directly.
+        explicit MiniLinearGreaterEqual(WeightedSum coeff_vars, Integer value, bool refined = true) :
+            _coeff_vars(move(coeff_vars)),
+            _value(value),
+            _refined(refined)
+        {
+        }
+
+        auto install(Propagators & propagators, State & initial_state, ProofModel * const) && -> void override
+        {
+            vector<pair<Integer, IntegerVariableID>> terms;
+            for (const auto & [coeff, var] : _coeff_vars.terms)
+                terms.emplace_back(coeff, var);
+
+            // Arm one upper-bound watch per variable: x_i < ub(x_i) becomes entailed
+            // exactly when x_i's upper bound next drops. Payload = the variable's
+            // index into terms, so the propagator knows which watch to re-arm.
+            Triggers triggers;
+            if (_refined)
+                for (const auto & [idx, term] : enumerate(terms))
+                    triggers.refined.emplace_back(term.second < initial_state.upper_bound(term.second),
+                        static_cast<std::uint32_t>(idx));
+            else
+                for (const auto & term : terms)
+                    triggers.on_bounds.push_back(term.second);
+
+            propagators.install(
+                constraint_id(),
+                [terms = move(terms), value = _value](
+                    const State & state, auto & inference, ProofLogger * const logger,
+                    const RefinedWatchContext & watches) -> PropagatorState {
+                    Integer max_sum{0_i};
+                    for (const auto & [coeff, var] : terms)
+                        max_sum += coeff * state.upper_bound(var);
+
+                    if (max_sum < value)
+                        inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{});
+                    else {
+                        auto slack = max_sum - value;
+                        for (const auto & [coeff, var] : terms) {
+                            auto new_lower = state.upper_bound(var) - (slack / coeff);
+                            if (new_lower > state.lower_bound(var))
+                                inference.infer_greater_than_or_equal(logger, var, new_lower, JustifyUsingRUP{}, ReasonFunction{});
+                        }
+                        // A watch is consumed when it fires; re-arm each fired
+                        // variable's upper-bound watch at its now-lower bound.
+                        for (auto payload : watches.fired_payloads()) {
+                            auto var = terms[payload].second;
+                            watches.watch(var < state.upper_bound(var), payload);
+                        }
+                    }
+                    return PropagatorState::Enable;
+                },
+                triggers);
+        }
+
+        auto clone() const -> unique_ptr<Constraint> override
+        {
+            return make_unique<MiniLinearGreaterEqual>(_coeff_vars, _value, _refined);
+        }
+
+        auto s_exprify(const ProofModel * const) const -> string override
+        {
+            return "mini_linear_greater_equal";
+        }
+    };
+
+    // One `sum c_i x_i >= K` over three non-negative variables: enumerate every
+    // solution and check it against the brute-force oracle, with per-node
+    // bounds-consistency checking on every variable.
+    auto run_mini_linear_ge_test(pair<int, int> v1_range, pair<int, int> v2_range, pair<int, int> v3_range,
+        vector<int> coeffs, int value) -> void
+    {
+        print(cerr, "mini_linear ge {} {} {} coeffs={} >= {}:", v1_range, v2_range, v3_range, coeffs, value);
+        cerr << flush;
+
+        auto is_satisfying = [&](int a, int b, int c) {
+            return coeffs[0] * a + coeffs[1] * b + coeffs[2] * c >= value;
+        };
+
+        set<tuple<int, int, int>> expected, actual;
+        build_expected(expected, is_satisfying, v1_range, v2_range, v3_range);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto v1 = p.create_integer_variable(Integer(v1_range.first), Integer(v1_range.second));
+        auto v2 = p.create_integer_variable(Integer(v2_range.first), Integer(v2_range.second));
+        auto v3 = p.create_integer_variable(Integer(v3_range.first), Integer(v3_range.second));
+        auto vs = vector<IntegerVariableID>{v1, v2, v3};
+
+        WeightedSum c;
+        for (const auto & [idx, coeff] : enumerate(coeffs))
+            c += Integer{coeff} * vs[idx];
+        p.post(MiniLinearGreaterEqual{c, Integer{value}});
+
+        solve_for_tests_checking_consistency(p, nullopt, expected, actual,
+            tuple{pair{v1, CheckConsistency::BC}, pair{v2, CheckConsistency::BC}, pair{v3, CheckConsistency::BC}});
+
+        check_results(nullopt, expected, actual);
+
+        // check_results compares solution SETS, which hides a solution reported more
+        // than once (a backtrack/watch bug can re-explore a subtree). Assert the raw
+        // count from a plain enumeration matches the oracle too.
+        Problem pc;
+        auto c1 = pc.create_integer_variable(Integer(v1_range.first), Integer(v1_range.second));
+        auto c2 = pc.create_integer_variable(Integer(v2_range.first), Integer(v2_range.second));
+        auto c3 = pc.create_integer_variable(Integer(v3_range.first), Integer(v3_range.second));
+        auto cvs = vector<IntegerVariableID>{c1, c2, c3};
+        WeightedSum cc;
+        for (const auto & [idx, coeff] : enumerate(coeffs))
+            cc += Integer{coeff} * cvs[idx];
+        pc.post(MiniLinearGreaterEqual{cc, Integer{value}});
+        auto stats = solve(pc, [](const CurrentState &) { return true; });
+        if (stats.solutions != expected.size())
+            throw UnexpectedException{"mini_linear produced the wrong number of solutions (duplicates or missing)"};
+    }
+
+    // Positive-laziness / same-tree check: solve the same instance with refined
+    // watches and with coarse on_bounds (identical propagation body). Both must
+    // explore the same search tree (equal recursions: same bounds-consistent
+    // fixpoint, same brancher), and the refined version must never wake more often
+    // -- it skips the lower-bound-change and self-retrigger wakes coarse on_bounds
+    // incurs. The printed counts show the reduction; the mutation tests separately
+    // confirm the refined path is load-bearing rather than a silent fallback.
+    auto measure_laziness(pair<int, int> v1_range, pair<int, int> v2_range, pair<int, int> v3_range,
+        vector<int> coeffs, int value) -> void
+    {
+        auto run = [&](bool refined) -> Stats {
+            Problem p;
+            auto v1 = p.create_integer_variable(Integer(v1_range.first), Integer(v1_range.second));
+            auto v2 = p.create_integer_variable(Integer(v2_range.first), Integer(v2_range.second));
+            auto v3 = p.create_integer_variable(Integer(v3_range.first), Integer(v3_range.second));
+            auto vs = vector<IntegerVariableID>{v1, v2, v3};
+            WeightedSum c;
+            for (const auto & [idx, coeff] : enumerate(coeffs))
+                c += Integer{coeff} * vs[idx];
+            p.post(MiniLinearGreaterEqual{c, Integer{value}, refined});
+            return solve(p, [](const CurrentState &) { return true; });
+        };
+
+        auto refined = run(true), coarse = run(false);
+        println(cerr, "mini_linear laziness {} {} {} coeffs={} >= {}: recursions={} solutions={} propagations refined={} coarse={}",
+            v1_range, v2_range, v3_range, coeffs, value, coarse.recursions, coarse.solutions, refined.propagations, coarse.propagations);
+        if (refined.recursions != coarse.recursions || refined.solutions != coarse.solutions)
+            throw UnexpectedException{"refined and coarse triggers diverged: different search tree or solution count"};
+        if (refined.propagations > coarse.propagations)
+            throw UnexpectedException{"refined triggers woke more often than coarse on_bounds"};
+    }
+}
+
+auto main(int, char *[]) -> int
+{
+    // Hand-picked cases: a slack constraint, tight ones that force lower-bound
+    // raises (and so watch firing + re-arming as the search drives bounds down),
+    // and a trivially-true / trivially-false pair.
+    run_mini_linear_ge_test({0, 4}, {0, 4}, {0, 4}, {1, 1, 1}, 6);
+    run_mini_linear_ge_test({0, 5}, {0, 5}, {0, 5}, {1, 2, 3}, 12);
+    run_mini_linear_ge_test({0, 6}, {0, 3}, {0, 3}, {100, 5, 2}, 350);
+    run_mini_linear_ge_test({0, 3}, {0, 3}, {0, 3}, {2, 3, 5}, 0);
+    run_mini_linear_ge_test({0, 2}, {0, 2}, {0, 2}, {1, 1, 1}, 7);
+    run_mini_linear_ge_test({1, 4}, {2, 5}, {0, 6}, {3, 1, 4}, 20);
+
+    measure_laziness({0, 6}, {0, 3}, {0, 3}, {100, 5, 2}, 350);
+    measure_laziness({0, 5}, {0, 5}, {0, 5}, {1, 2, 3}, 12);
+    measure_laziness({1, 4}, {2, 5}, {0, 6}, {3, 1, 4}, 20);
+
+    random_device rand_dev;
+    mt19937 rand(rand_dev());
+    uniform_int_distribution coeff_dist(1, 8);
+    uniform_int_distribution hi_dist(2, 7);
+    uniform_int_distribution val_dist(0, 60);
+    for (int x = 0; x < 200; ++x) {
+        auto hi = [&]() { return pair{0, hi_dist(rand)}; };
+        run_mini_linear_ge_test(hi(), hi(), hi(),
+            {coeff_dist(rand), coeff_dist(rand), coeff_dist(rand)}, val_dist(rand));
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -13,7 +13,10 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <optional>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -39,9 +42,52 @@ namespace
     {
         vector<pair<int, int>> ids_and_masks;
     };
+
+    // A refined per-literal watch armed on a variable: when `literal` becomes
+    // entailed, `payload` is delivered to propagator `owner`. `id` is a stable
+    // identity used to find and undo the watch on backtrack.
+    struct RefinedWatch
+    {
+        Literal literal;
+        std::uint32_t payload;
+        int owner;
+        std::uint64_t id;
+    };
+
+    enum class WatchEditOp
+    {
+        Added,
+        Removed
+    };
+
+    // One entry on the refined-watch backtrack trail: an Added/Removed edit to the
+    // watches armed on var_index, replayed in reverse to restore on backtrack.
+    struct RefinedWatchEdit
+    {
+        WatchEditOp op;
+        std::size_t var_index;
+        RefinedWatch watch;
+    };
+
+    // The underlying simple-variable index a literal's truth depends on, or nullopt
+    // for a constant/true/false literal that no variable change can fire.
+    auto underlying_var_index(const Literal & literal) -> std::optional<std::size_t>
+    {
+        return overloaded{
+            [](const IntegerVariableCondition & cond) -> std::optional<std::size_t> {
+                return overloaded{
+                    [](const SimpleIntegerVariableID & v) -> std::optional<std::size_t> { return v.index; },
+                    [](const ViewOfIntegerVariableID & v) -> std::optional<std::size_t> { return v.actual_variable.index; },
+                    [](const ConstantIntegerVariableID &) -> std::optional<std::size_t> { return std::nullopt; }}
+                    .visit(cond.var);
+            },
+            [](const TrueLiteral &) -> std::optional<std::size_t> { return std::nullopt; },
+            [](const FalseLiteral &) -> std::optional<std::size_t> { return std::nullopt; }}
+            .visit(literal);
+    }
 }
 
-struct Propagators::Imp
+struct Propagators::Imp : RefinedWatchSink
 {
     vector<PropagationFunction> propagation_functions;
     std::array<vector<InitialisationFunction>, number_of_initialiser_priorities> initialisation_functions_by_priority;
@@ -81,6 +127,40 @@ struct Propagators::Imp
     // domain (see propagate). Set once at search start via set_conflict_observer;
     // the caller owns it. nullptr when there is no observer.
     ConflictObserver * conflict_observer = nullptr;
+
+    // Refined per-literal watches, parallel to (and leaving untouched) iv_triggers.
+    // refined_watches_by_var[v] are the watches currently armed on variable v; on a
+    // change to v each is tested and, if its literal is now entailed, its payload is
+    // appended to inbox_by_propagator[owner], the owner is woken, and the watch is
+    // consumed. Edits made while propagating go on refined_watch_edit_trail and are
+    // undone on backtrack (one truncate callback per propagate(), replayed in
+    // reverse); install-time base watches are not trailed. inbox_by_propagator is
+    // transient within a propagate(): cleared after each propagator runs, with
+    // pending_inbox_owners cleaning up any left non-empty by a contradiction.
+    // next_refined_watch_id hands out a stable identity per watch for trail undo.
+    vector<vector<RefinedWatch>> refined_watches_by_var;
+    vector<vector<std::uint32_t>> inbox_by_propagator;
+    vector<int> pending_inbox_owners;
+    vector<RefinedWatchEdit> refined_watch_edit_trail;
+    std::uint64_t next_refined_watch_id = 0;
+
+    auto register_refined_watch(int owner, const Literal & literal, std::uint32_t payload, bool trailed) -> void
+    {
+        auto var_index = underlying_var_index(literal);
+        if (! var_index)
+            return;
+        if (refined_watches_by_var.size() <= *var_index)
+            refined_watches_by_var.resize(*var_index + 1);
+        RefinedWatch w{literal, payload, owner, next_refined_watch_id++};
+        refined_watches_by_var[*var_index].push_back(w);
+        if (trailed)
+            refined_watch_edit_trail.push_back({WatchEditOp::Added, *var_index, w});
+    }
+
+    auto add_refined_watch(int owner_propagator, const Literal & literal, std::uint32_t payload) -> void override
+    {
+        register_refined_watch(owner_propagator, literal, payload, true);
+    }
 };
 
 Propagators::Propagators() :
@@ -156,6 +236,9 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         add_to_scope(v);
     for (const auto & v : triggers.on_instantiated)
         add_to_scope(v);
+    for (const auto & refined : triggers.refined)
+        if (auto cond = std::get_if<IntegerVariableCondition>(&refined.first))
+            add_to_scope(cond->var);
 
     for (const auto & v : scope) {
         if (_imp->var_constraint_indices.size() <= v.index)
@@ -185,6 +268,12 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
     for (const auto & v : triggers.on_instantiated) {
         trigger_on_instantiated(v, id);
         increase_degree(v);
+    }
+
+    for (const auto & [literal, payload] : triggers.refined) {
+        if (auto cond = std::get_if<IntegerVariableCondition>(&literal))
+            increase_degree(cond->var);
+        _imp->register_refined_watch(id, literal, payload, false);
     }
 }
 
@@ -221,21 +310,72 @@ auto Propagators::initialise(State & state, ProofLogger * const logger) const ->
 
 auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofLogger * const logger, atomic<bool> * optional_abort_flag) const -> bool
 {
-    auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) {
-        if (v.index < _imp->iv_triggers.size()) {
-            auto & triggers = _imp->iv_triggers[v.index];
-
-            for (auto & [p, mask] : triggers.ids_and_masks)
-                if (mask & (1 << to_underlying(inf))) {
-                    if (_imp->lookup[p] >= _imp->enqueued_end && _imp->lookup[p] < _imp->idle_end) {
-                        auto being_swapped_item = _imp->queue[_imp->enqueued_end];
-                        swap(_imp->queue[_imp->lookup[p]], _imp->queue[_imp->enqueued_end]);
-                        swap(_imp->lookup[p], _imp->lookup[being_swapped_item]);
-                        ++_imp->enqueued_end;
-                    }
-                }
+    auto enqueue_propagator = [&](int p) {
+        if (_imp->lookup[p] >= _imp->enqueued_end && _imp->lookup[p] < _imp->idle_end) {
+            auto being_swapped_item = _imp->queue[_imp->enqueued_end];
+            swap(_imp->queue[_imp->lookup[p]], _imp->queue[_imp->enqueued_end]);
+            swap(_imp->lookup[p], _imp->lookup[being_swapped_item]);
+            ++_imp->enqueued_end;
         }
     };
+
+    auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) {
+        if (v.index < _imp->iv_triggers.size())
+            for (auto & [p, mask] : _imp->iv_triggers[v.index].ids_and_masks)
+                if (mask & (1 << to_underlying(inf)))
+                    enqueue_propagator(p);
+
+        // Refined watches: fire any whose literal is now entailed, delivering the
+        // payload to its owner and consuming the watch. We test every watch armed on
+        // v on any change to v (correct, since test_literal reads current bounds); a
+        // later stage can narrow this to only the literals a given bound move crosses.
+        if (v.index < _imp->refined_watches_by_var.size()) {
+            auto & watches = _imp->refined_watches_by_var[v.index];
+            for (std::size_t i = 0; i < watches.size();) {
+                if (state.test_literal(watches[i].literal) == LiteralIs::DefinitelyTrue) {
+                    const auto fired = watches[i];
+                    if (_imp->inbox_by_propagator[fired.owner].empty())
+                        _imp->pending_inbox_owners.push_back(fired.owner);
+                    _imp->inbox_by_propagator[fired.owner].push_back(fired.payload);
+                    enqueue_propagator(fired.owner);
+                    _imp->refined_watch_edit_trail.push_back({WatchEditOp::Removed, v.index, fired});
+                    watches[i] = watches.back();
+                    watches.pop_back();
+                }
+                else
+                    ++i;
+            }
+        }
+    };
+
+    _imp->inbox_by_propagator.resize(_imp->propagation_functions.size());
+
+    // Snapshot the refined-watch edit trail BEFORE any firing this call. The guess
+    // first pass below can already fire and consume watches, so the snapshot must
+    // precede it; otherwise those consumes fall below the snapshot and are never
+    // undone, corrupting the watch state across sibling branches. On backtrack we
+    // replay our own trail in reverse here (State runs an epoch's callbacks in
+    // registration order, which would compose per-edit undos incorrectly), undoing
+    // exactly the edits made during this propagate(). Install-time base watches are
+    // registered before search and so sit below every snapshot and persist.
+    auto refined_trail_start = _imp->refined_watch_edit_trail.size();
+    state.on_backtrack([&, refined_trail_start]() {
+        while (_imp->refined_watch_edit_trail.size() > refined_trail_start) {
+            const auto & e = _imp->refined_watch_edit_trail.back();
+            auto & watches = _imp->refined_watches_by_var[e.var_index];
+            if (e.op == WatchEditOp::Added) {
+                for (std::size_t i = 0; i < watches.size(); ++i)
+                    if (watches[i].id == e.watch.id) {
+                        watches[i] = watches.back();
+                        watches.pop_back();
+                        break;
+                    }
+            }
+            else
+                watches.push_back(e.watch);
+            _imp->refined_watch_edit_trail.pop_back();
+        }
+    });
 
     if (! lit) {
         // On the first pass, walk propagators in registration order. Our queue runs
@@ -295,10 +435,12 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         int propagator_id = _imp->queue[--_imp->enqueued_end];
         try {
             ++_imp->total_propagations;
-            // No refined watches are registered yet, so every propagator sees an
-            // empty fired-payload set (see RefinedWatchContext); this is inert.
-            RefinedWatchContext watches{};
+            RefinedWatchContext watches{*_imp, propagator_id, _imp->inbox_by_propagator[propagator_id]};
             auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger, watches);
+            // The fired set has now been delivered; clear it so that, if this
+            // propagator is woken again later in this fixpoint, it sees only the
+            // payloads that fired since.
+            _imp->inbox_by_propagator[propagator_id].clear();
             if (tracker.did_anything_since_last_call_by_propagation_queue())
                 ++_imp->effectful_propagations;
             switch (propagator_state) {
@@ -327,6 +469,13 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         if (contradiction || (optional_abort_flag && optional_abort_flag->load()))
             break;
     }
+
+    // Drop any fired payloads left undelivered (e.g. a propagator was woken but a
+    // contradiction ended the loop before it ran); they must not leak into the next
+    // propagate(). In the normal case each propagator already cleared its own.
+    for (auto owner : _imp->pending_inbox_owners)
+        _imp->inbox_by_propagator[owner].clear();
+    _imp->pending_inbox_owners.clear();
 
     return ! contradiction;
 }

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -26,29 +26,57 @@ namespace gcs::innards
     class ConflictObserver;
 
     /**
+     * \brief Back-channel through which a RefinedWatchContext registers refined
+     * watches with the engine.
+     *
+     * Implemented by the Propagators internals. It exists so that
+     * RefinedWatchContext — which appears in propagator function signatures, above
+     * the Propagators class — can edit the watch index without depending on it.
+     *
+     * \ingroup Innards
+     */
+    class RefinedWatchSink
+    {
+    public:
+        virtual ~RefinedWatchSink() = default;
+
+        /**
+         * \brief Arm a refined watch owned by the given propagator: when `literal`
+         * next becomes entailed, append `payload` to that propagator's fired set and
+         * wake it. Watches armed while propagating are restored on backtrack.
+         */
+        virtual auto add_refined_watch(int owner_propagator, const Literal & literal, std::uint32_t payload) -> void = 0;
+    };
+
+    /**
      * \brief The refined-watch context handed to a propagator each time it runs.
      *
      * A propagator that registers refined per-literal watches (rather than, or in
      * addition to, the coarse \ref Triggers) is told which of its watches fired
      * since it last ran, via the opaque payloads it chose at registration time, so
      * it can do work proportional to what changed instead of rescanning its state.
+     * A watch is consumed when it fires; the propagator re-arms a replacement via
+     * watch() if it still wants to hear about that literal.
      *
-     * This is the seam for that mechanism. Today no propagator registers refined
-     * watches, so fired_payloads() is always empty and propagators ignore the
-     * context; the watch index that populates it, and the registration and
-     * watch-editing API, land in later stages. The context is forwarded only to
-     * propagators whose function accepts it (see PropagationFunctionImpl), so
-     * existing propagators are unaffected.
+     * The context is forwarded only to propagators whose function accepts it (see
+     * PropagationFunctionImpl), so propagators that use only the coarse \ref
+     * Triggers are unaffected and see no overhead.
      *
      * \ingroup Innards
      */
     class RefinedWatchContext
     {
     private:
+        RefinedWatchSink * _sink = nullptr;
+        int _owner = -1;
         std::span<const std::uint32_t> _fired_payloads;
 
     public:
-        explicit RefinedWatchContext(std::span<const std::uint32_t> fired_payloads = {}) :
+        RefinedWatchContext() = default;
+
+        RefinedWatchContext(RefinedWatchSink & sink, int owner_propagator, std::span<const std::uint32_t> fired_payloads) :
+            _sink(&sink),
+            _owner(owner_propagator),
             _fired_payloads(fired_payloads)
         {
         }
@@ -62,6 +90,17 @@ namespace gcs::innards
         [[nodiscard]] auto fired_payloads() const -> std::span<const std::uint32_t>
         {
             return _fired_payloads;
+        }
+
+        /**
+         * \brief Arm a refined watch: when `literal` next becomes entailed
+         * (test_literal == DefinitelyTrue), this propagator is woken and handed
+         * `payload` among its fired_payloads(). A watch registered while
+         * propagating is restored on backtrack.
+         */
+        auto watch(const Literal & literal, std::uint32_t payload) const -> void
+        {
+            _sink->add_refined_watch(_owner, literal, payload);
         }
     };
 
@@ -184,6 +223,16 @@ namespace gcs::innards
         std::vector<IntegerVariableID> on_change = {};
         std::vector<IntegerVariableID> on_bounds = {};
         std::vector<IntegerVariableID> on_instantiated = {};
+
+        /**
+         * \brief Refined per-literal watches to arm when the constraint is
+         * installed: each (literal, payload) wakes this propagator, handing it
+         * payload, when literal first becomes entailed. These install-time watches
+         * are the persistent baseline (not undone on backtrack); watches the
+         * propagator arms later via RefinedWatchContext::watch are restored on
+         * backtrack. \sa RefinedWatchContext
+         */
+        std::vector<std::pair<Literal, std::uint32_t>> refined = {};
     };
 
     /**


### PR DESCRIPTION
Stage B1 of the refined per-literal trigger mechanism (#335), on top of the Stage-A seam (#336). This is the first stage with real semantics: it builds the watch engine and exercises it end-to-end with a small client.

## Engine (`gcs/innards/propagators`)

- **Refined per-literal watch index**, parallel to `iv_triggers` (which is untouched — coarse-triggered propagators see no change). A watch is `(literal, payload, owner)`; when the literal becomes entailed (`test_literal == DefinitelyTrue`) it appends `payload` to the owner's fired-watch inbox, wakes it, and is **consumed**.
- Propagators arm watches two ways: at install via `Triggers::refined` (a persistent baseline) or dynamically via `RefinedWatchContext::watch` while propagating.
- **Restore-on-backtrack** via a per-`propagate()` edit trail replayed in reverse by a single `on_backtrack` callback. This is necessary because `State` runs an epoch's callbacks in *registration order*, so naive per-edit undo closures would compose incorrectly (e.g. an add-then-consume of the same watch). The trail snapshot is taken **before** the guess first pass, which can itself fire and consume watches.
- The fired-watch inbox is transient within a `propagate()`: cleared after a propagator runs, with anything left undelivered by a contradiction cleared at exit.

## Client + validation (`gcs/constraints/mini_linear_test.cc`)

`MiniLinearGreaterEqual` is a test-only `sum c_i x_i ≥ K` (positive coefficients, non-negative variables) bounds-consistency propagator with **no coarse triggers** — it arms one upper-bound watch per variable and re-arms on fire. It's a deliberately small vehicle to exercise the engine, and is expected to be retired when refined triggers fold into the real `Linear` (stage E).

Validated three independent ways over hand-picked + 200 random instances:
1. **Per-node BC consistency** (`solve_for_tests_checking_consistency`) — catches under-propagation, including at post-backtrack nodes (so it tests restore-on-backtrack directly).
2. **Solution-count vs a brute-force oracle** — catches duplicate solutions, which a solution-*set* comparison silently hides.
3. **Refined-vs-coarse** (same propagation body, two trigger modes) — asserts an identical search tree (equal recursions) and solution count, with refined never waking more. Measured ~1.3–1.5× fewer wakes, from skipping the lower-bound-change and self-retrigger wakes coarse `on_bounds` incurs.

Every machinery point was **mutation-tested** — disabling firing, re-arm, restore-on-backtrack, trailing the consume, or correct snapshot ordering each makes a check fail, confirming the path is load-bearing and the checks are non-vacuous.

## A bug the methodology caught

During development the trail snapshot was taken *after* the guess first pass, so that pass's consumes were never undone on backtrack — producing **duplicate solutions**. This **passed the set-based consistency check** (a set dedups) and was caught only by the count check added for the laziness measurement — exactly the "differential testing is sampling / green ≠ no-op" gap from the design discussion, caught in practice. The snapshot was moved before the first pass, and the count check now guards the regression.

## Gate

- GCC 15 and clang 21: `ctest` **332/332**.
- clang-format clean.
- No proof impact: the trigger change is semantics-preserving, and mini-linear runs without proof (the real `Linear` certifies the bounds logic).
