### PR TITLE
Refined triggers (B2): PB watched-set laziness for mini-linear

### DIFF
--- a/gcs/constraints/mini_linear_test.cc
+++ b/gcs/constraints/mini_linear_test.cc
@@ -1,17 +1,22 @@
-/* Test vehicle for the refined per-literal trigger mechanism (issue #335, stage
- * B1). MiniLinearGreaterEqual is a deliberately small `sum c_i x_i >= K`
- * bounds-consistency propagator (all c_i > 0, all x_i >= 0) that drives itself
- * ENTIRELY from refined watches: it has no coarse Triggers, arms one upper-bound
- * watch per variable at install, and re-arms a variable's watch when it fires.
+/* Test vehicle for the refined per-literal trigger mechanism (issue #335, stages
+ * B1 and B2). MiniLinearGreaterEqual is a deliberately small `sum c_i x_i >= K`
+ * bounds-consistency propagator (all c_i > 0, all x_i >= 0). It runs in three
+ * trigger modes with an identical propagation body, so they can be compared
+ * directly: coarse on_bounds; a refined upper-bound watch on every variable,
+ * re-armed on fire (B1); and the PB watched-set that keeps armed only enough
+ * upper-bound watches to cover K + W, so variables outside the set are never
+ * watched (B2).
  *
  * It exists only to exercise the refined-watch engine (the index, the fired-watch
- * inbox, consume-on-fire, re-arm, and restore-on-backtrack); it is not a public
- * constraint and is expected to be retired once refined triggers fold into the
- * real Linear (stage E). Correctness is checked the same way the real Linear is:
- * a brute-force solution oracle (catches over-pruning and any missed leaf check)
- * plus per-node bounds-consistency checking (catches under-pruning, including a
- * watch that was not restored after backtrack, since the check runs at
- * post-backtrack nodes too).
+ * inbox, consume-on-fire, re-arm, restore-on-backtrack, and is_watching); it is
+ * not a public constraint and is expected to be retired once refined triggers fold
+ * into the real Linear (stage E). Correctness is checked the way the real Linear
+ * is: a brute-force solution oracle (catches over-pruning and any missed leaf
+ * check), a raw solution-count check (catches duplicate solutions that a solution
+ * SET would hide), and per-node bounds-consistency checking (catches under-pruning,
+ * including a watch not restored after backtrack, since it runs at post-backtrack
+ * nodes too). A laziness comparison asserts watched-set <= refined-all <= coarse
+ * wakes, and strictly fewer on dominant instances.
  */
 
 #include <gcs/constraint.hh>
@@ -25,11 +30,13 @@
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 #include <gcs/stats.hh>
 
 #include <util/enumerate.hh>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
@@ -54,6 +61,7 @@ using std::tuple;
 using std::uniform_int_distribution;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -79,19 +87,30 @@ namespace
     // obligation of its own, and the real Linear already certifies the logic.
     class MiniLinearGreaterEqual : public Constraint
     {
+    public:
+        // How the propagator is triggered; the propagation body is identical in all
+        // three. Coarse = ordinary on_bounds triggers. RefinedAll = a refined upper-
+        // bound watch on every variable, re-armed on fire (the B1 scheme; lazier than
+        // coarse only by skipping lower-bound-change and self-retrigger wakes).
+        // WatchedSet = the PB watched-set: keep armed only enough upper-bound watches
+        // to cover K + W, so variables outside the set are never watched (B2).
+        enum class Mode
+        {
+            Coarse,
+            RefinedAll,
+            WatchedSet
+        };
+
     private:
         WeightedSum _coeff_vars;
         Integer _value;
-        bool _refined;
+        Mode _mode;
 
     public:
-        // refined = true drives the propagator from refined upper-bound watches;
-        // false falls back to coarse on_bounds triggers with the identical
-        // propagation body, so the two can be compared directly.
-        explicit MiniLinearGreaterEqual(WeightedSum coeff_vars, Integer value, bool refined = true) :
+        explicit MiniLinearGreaterEqual(WeightedSum coeff_vars, Integer value, Mode mode = Mode::RefinedAll) :
             _coeff_vars(move(coeff_vars)),
             _value(value),
-            _refined(refined)
+            _mode(mode)
         {
         }
 
@@ -101,21 +120,23 @@ namespace
             for (const auto & [coeff, var] : _coeff_vars.terms)
                 terms.emplace_back(coeff, var);
 
-            // Arm one upper-bound watch per variable: x_i < ub(x_i) becomes entailed
-            // exactly when x_i's upper bound next drops. Payload = the variable's
-            // index into terms, so the propagator knows which watch to re-arm.
+            // Coarse triggers on every variable's bounds. Both refined modes arm an
+            // upper-bound watch (x_i < ub(x_i), entailed exactly when x_i's upper
+            // bound drops) on every variable at install -- so scope and degree match
+            // coarse (identical search tree), and WatchedSet then sheds the watches it
+            // does not need. Payload = the variable's index into terms.
             Triggers triggers;
-            if (_refined)
+            if (_mode == Mode::Coarse)
+                for (const auto & term : terms)
+                    triggers.on_bounds.push_back(term.second);
+            else
                 for (const auto & [idx, term] : enumerate(terms))
                     triggers.refined.emplace_back(term.second < initial_state.upper_bound(term.second),
                         static_cast<std::uint32_t>(idx));
-            else
-                for (const auto & term : terms)
-                    triggers.on_bounds.push_back(term.second);
 
             propagators.install(
                 constraint_id(),
-                [terms = move(terms), value = _value](
+                [terms = move(terms), value = _value, mode = _mode](
                     const State & state, auto & inference, ProofLogger * const logger,
                     const RefinedWatchContext & watches) -> PropagatorState {
                     Integer max_sum{0_i};
@@ -131,11 +152,45 @@ namespace
                             if (new_lower > state.lower_bound(var))
                                 inference.infer_greater_than_or_equal(logger, var, new_lower, JustifyUsingRUP{}, ReasonFunction{});
                         }
-                        // A watch is consumed when it fires; re-arm each fired
-                        // variable's upper-bound watch at its now-lower bound.
-                        for (auto payload : watches.fired_payloads()) {
-                            auto var = terms[payload].second;
-                            watches.watch(var < state.upper_bound(var), payload);
+
+                        if (mode == Mode::RefinedAll) {
+                            // A watch is consumed when it fires; re-arm each fired
+                            // variable's upper-bound watch at its now-lower bound.
+                            for (auto payload : watches.fired_payloads())
+                                watches.watch(terms[payload].second < state.upper_bound(terms[payload].second), payload);
+                        }
+                        else if (mode == Mode::WatchedSet) {
+                            // Keep enough upper-bound watches armed that the watched
+                            // set alone covers K + W (W = max c_i*(ub_i - lb_i) on the
+                            // post-prune bounds). Because max_sum >= the sum over the
+                            // watched set, that certifies global dormancy and the
+                            // unwatched variables need no watch. A fired variable not
+                            // needed for coverage is simply not re-armed (it sheds).
+                            Integer w{0_i};
+                            for (const auto & [coeff, var] : terms) {
+                                auto span = coeff * (state.upper_bound(var) - state.lower_bound(var));
+                                if (span > w)
+                                    w = span;
+                            }
+                            auto needed = value + w;
+                            Integer covered{0_i};
+                            for (const auto & [coeff, var] : terms)
+                                if (watches.is_watching(var))
+                                    covered += coeff * state.upper_bound(var);
+                            if (covered < needed) {
+                                vector<pair<Integer, std::uint32_t>> candidates;
+                                for (const auto & [idx, term] : enumerate(terms))
+                                    if (! watches.is_watching(term.second))
+                                        candidates.emplace_back(term.first * state.upper_bound(term.second),
+                                            static_cast<std::uint32_t>(idx));
+                                sort(candidates, [](const auto & a, const auto & b) { return a.first > b.first; });
+                                for (const auto & [contrib, idx] : candidates) {
+                                    if (covered >= needed)
+                                        break;
+                                    watches.watch(terms[idx].second < state.upper_bound(terms[idx].second), idx);
+                                    covered += contrib;
+                                }
+                            }
                         }
                     }
                     return PropagatorState::Enable;
@@ -145,7 +200,7 @@ namespace
 
         auto clone() const -> unique_ptr<Constraint> override
         {
-            return make_unique<MiniLinearGreaterEqual>(_coeff_vars, _value, _refined);
+            return make_unique<MiniLinearGreaterEqual>(_coeff_vars, _value, _mode);
         }
 
         auto s_exprify(const ProofModel * const) const -> string override
@@ -154,13 +209,24 @@ namespace
         }
     };
 
-    // One `sum c_i x_i >= K` over three non-negative variables: enumerate every
-    // solution and check it against the brute-force oracle, with per-node
-    // bounds-consistency checking on every variable.
-    auto run_mini_linear_ge_test(pair<int, int> v1_range, pair<int, int> v2_range, pair<int, int> v3_range,
-        vector<int> coeffs, int value) -> void
+    auto mode_name(MiniLinearGreaterEqual::Mode mode) -> const char *
     {
-        print(cerr, "mini_linear ge {} {} {} coeffs={} >= {}:", v1_range, v2_range, v3_range, coeffs, value);
+        switch (mode) {
+            using enum MiniLinearGreaterEqual::Mode;
+        case Coarse: return "coarse";
+        case RefinedAll: return "refined-all";
+        case WatchedSet: return "watched-set";
+        }
+        return "?";
+    }
+
+    // One `sum c_i x_i >= K` over three non-negative variables, propagated in the
+    // given trigger mode: enumerate every solution and check it against the brute-
+    // force oracle, with per-node bounds-consistency checking on every variable.
+    auto run_mini_linear_ge_test(MiniLinearGreaterEqual::Mode mode, pair<int, int> v1_range, pair<int, int> v2_range,
+        pair<int, int> v3_range, vector<int> coeffs, int value) -> void
+    {
+        print(cerr, "mini_linear ge [{}] {} {} {} coeffs={} >= {}:", mode_name(mode), v1_range, v2_range, v3_range, coeffs, value);
         cerr << flush;
 
         auto is_satisfying = [&](int a, int b, int c) {
@@ -180,7 +246,7 @@ namespace
         WeightedSum c;
         for (const auto & [idx, coeff] : enumerate(coeffs))
             c += Integer{coeff} * vs[idx];
-        p.post(MiniLinearGreaterEqual{c, Integer{value}});
+        p.post(MiniLinearGreaterEqual{c, Integer{value}, mode});
 
         solve_for_tests_checking_consistency(p, nullopt, expected, actual,
             tuple{pair{v1, CheckConsistency::BC}, pair{v2, CheckConsistency::BC}, pair{v3, CheckConsistency::BC}});
@@ -198,23 +264,24 @@ namespace
         WeightedSum cc;
         for (const auto & [idx, coeff] : enumerate(coeffs))
             cc += Integer{coeff} * cvs[idx];
-        pc.post(MiniLinearGreaterEqual{cc, Integer{value}});
+        pc.post(MiniLinearGreaterEqual{cc, Integer{value}, mode});
         auto stats = solve(pc, [](const CurrentState &) { return true; });
         if (stats.solutions != expected.size())
             throw UnexpectedException{"mini_linear produced the wrong number of solutions (duplicates or missing)"};
     }
 
-    // Positive-laziness / same-tree check: solve the same instance with refined
-    // watches and with coarse on_bounds (identical propagation body). Both must
-    // explore the same search tree (equal recursions: same bounds-consistent
-    // fixpoint, same brancher), and the refined version must never wake more often
-    // -- it skips the lower-bound-change and self-retrigger wakes coarse on_bounds
-    // incurs. The printed counts show the reduction; the mutation tests separately
-    // confirm the refined path is load-bearing rather than a silent fallback.
-    auto measure_laziness(pair<int, int> v1_range, pair<int, int> v2_range, pair<int, int> v3_range,
-        vector<int> coeffs, int value) -> void
+    // Positive-laziness / same-tree check: solve the same instance in all three
+    // trigger modes (identical propagation body). All must explore the same search
+    // tree (equal recursions: same bounds-consistent fixpoint, same brancher) and
+    // find the same solutions; and the watched-set must wake no more than
+    // refined-all, which wakes no more than coarse. The printed counts show the
+    // reduction; the mutation tests separately confirm each mechanism is load-bearing
+    // rather than a silent fallback.
+    auto measure_laziness(bool strict_watched_set_win, pair<int, int> v1_range, pair<int, int> v2_range,
+        pair<int, int> v3_range, vector<int> coeffs, int value) -> void
     {
-        auto run = [&](bool refined) -> Stats {
+        using enum MiniLinearGreaterEqual::Mode;
+        auto run = [&](MiniLinearGreaterEqual::Mode mode) -> Stats {
             Problem p;
             auto v1 = p.create_integer_variable(Integer(v1_range.first), Integer(v1_range.second));
             auto v2 = p.create_integer_variable(Integer(v2_range.first), Integer(v2_range.second));
@@ -223,46 +290,64 @@ namespace
             WeightedSum c;
             for (const auto & [idx, coeff] : enumerate(coeffs))
                 c += Integer{coeff} * vs[idx];
-            p.post(MiniLinearGreaterEqual{c, Integer{value}, refined});
-            return solve(p, [](const CurrentState &) { return true; });
+            p.post(MiniLinearGreaterEqual{c, Integer{value}, mode});
+            // Bounds-splitting branching (x <= mid, then x > mid) drops upper bounds
+            // gradually, so a shed variable's later drops no longer wake the watched-
+            // set propagator -- which is where its advantage over refined-all shows
+            // (instantiation branching drops each ub once, at the moment it sheds).
+            return solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) { return true; }, .branch = branch_with(variable_order::dom_then_deg(p), value_order::split_smallest_first())});
         };
 
-        auto refined = run(true), coarse = run(false);
-        println(cerr, "mini_linear laziness {} {} {} coeffs={} >= {}: recursions={} solutions={} propagations refined={} coarse={}",
-            v1_range, v2_range, v3_range, coeffs, value, coarse.recursions, coarse.solutions, refined.propagations, coarse.propagations);
-        if (refined.recursions != coarse.recursions || refined.solutions != coarse.solutions)
-            throw UnexpectedException{"refined and coarse triggers diverged: different search tree or solution count"};
-        if (refined.propagations > coarse.propagations)
-            throw UnexpectedException{"refined triggers woke more often than coarse on_bounds"};
+        auto coarse = run(Coarse), refined_all = run(RefinedAll), watched = run(WatchedSet);
+        println(cerr, "mini_linear laziness {} {} {} coeffs={} >= {}: recursions={} solutions={} propagations coarse={} refined-all={} watched-set={}",
+            v1_range, v2_range, v3_range, coeffs, value, coarse.recursions, coarse.solutions,
+            coarse.propagations, refined_all.propagations, watched.propagations);
+        if (refined_all.recursions != coarse.recursions || watched.recursions != coarse.recursions ||
+            refined_all.solutions != coarse.solutions || watched.solutions != coarse.solutions)
+            throw UnexpectedException{"mini_linear trigger modes diverged: different search tree or solution count"};
+        if (refined_all.propagations > coarse.propagations || watched.propagations > refined_all.propagations)
+            throw UnexpectedException{"expected watched-set <= refined-all <= coarse propagations"};
+        // On a strongly dominant instance the watched set is just the big variable,
+        // so it must wake STRICTLY less than refined-all (which re-arms every
+        // variable). This guards is_watching: if it stopped reporting armed watches,
+        // the grow step would re-watch everything and the win would vanish.
+        if (strict_watched_set_win && watched.propagations >= refined_all.propagations)
+            throw UnexpectedException{"watched-set did not wake strictly less than refined-all on a dominant instance"};
     }
 }
 
 auto main(int, char *[]) -> int
 {
-    // Hand-picked cases: a slack constraint, tight ones that force lower-bound
-    // raises (and so watch firing + re-arming as the search drives bounds down),
-    // and a trivially-true / trivially-false pair.
-    run_mini_linear_ge_test({0, 4}, {0, 4}, {0, 4}, {1, 1, 1}, 6);
-    run_mini_linear_ge_test({0, 5}, {0, 5}, {0, 5}, {1, 2, 3}, 12);
-    run_mini_linear_ge_test({0, 6}, {0, 3}, {0, 3}, {100, 5, 2}, 350);
-    run_mini_linear_ge_test({0, 3}, {0, 3}, {0, 3}, {2, 3, 5}, 0);
-    run_mini_linear_ge_test({0, 2}, {0, 2}, {0, 2}, {1, 1, 1}, 7);
-    run_mini_linear_ge_test({1, 4}, {2, 5}, {0, 6}, {3, 1, 4}, 20);
+    using enum MiniLinearGreaterEqual::Mode;
 
-    measure_laziness({0, 6}, {0, 3}, {0, 3}, {100, 5, 2}, 350);
-    measure_laziness({0, 5}, {0, 5}, {0, 5}, {1, 2, 3}, 12);
-    measure_laziness({1, 4}, {2, 5}, {0, 6}, {3, 1, 4}, 20);
+    // Run the refined-all (B1) and watched-set (B2) modes through identical
+    // correctness checks: hand-picked cases (a slack constraint, tight ones that
+    // force lower-bound raises, a trivially-true and a trivially-false) plus random
+    // instances. Coarse is exercised by the laziness comparison below.
+    for (auto mode : {RefinedAll, WatchedSet}) {
+        run_mini_linear_ge_test(mode, {0, 4}, {0, 4}, {0, 4}, {1, 1, 1}, 6);
+        run_mini_linear_ge_test(mode, {0, 5}, {0, 5}, {0, 5}, {1, 2, 3}, 12);
+        run_mini_linear_ge_test(mode, {0, 6}, {0, 3}, {0, 3}, {100, 5, 2}, 350);
+        run_mini_linear_ge_test(mode, {0, 3}, {0, 3}, {0, 3}, {2, 3, 5}, 0);
+        run_mini_linear_ge_test(mode, {0, 2}, {0, 2}, {0, 2}, {1, 1, 1}, 7);
+        run_mini_linear_ge_test(mode, {1, 4}, {2, 5}, {0, 6}, {3, 1, 4}, 20);
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
-    uniform_int_distribution coeff_dist(1, 8);
-    uniform_int_distribution hi_dist(2, 7);
-    uniform_int_distribution val_dist(0, 60);
-    for (int x = 0; x < 200; ++x) {
-        auto hi = [&]() { return pair{0, hi_dist(rand)}; };
-        run_mini_linear_ge_test(hi(), hi(), hi(),
-            {coeff_dist(rand), coeff_dist(rand), coeff_dist(rand)}, val_dist(rand));
+        random_device rand_dev;
+        mt19937 rand(rand_dev());
+        uniform_int_distribution coeff_dist(1, 8);
+        uniform_int_distribution hi_dist(2, 7);
+        uniform_int_distribution val_dist(0, 60);
+        for (int x = 0; x < 200; ++x) {
+            auto hi = [&]() { return pair{0, hi_dist(rand)}; };
+            run_mini_linear_ge_test(mode, hi(), hi(), hi(),
+                {coeff_dist(rand), coeff_dist(rand), coeff_dist(rand)}, val_dist(rand));
+        }
     }
+
+    measure_laziness(true, {0, 15}, {0, 15}, {0, 15}, {100, 1, 1}, 100);
+    measure_laziness(true, {0, 6}, {0, 3}, {0, 3}, {100, 5, 2}, 350);
+    measure_laziness(false, {0, 5}, {0, 5}, {0, 5}, {1, 2, 3}, 12);
+    measure_laziness(false, {1, 4}, {2, 5}, {0, 6}, {3, 1, 4}, 20);
 
     return EXIT_SUCCESS;
 }

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -69,18 +69,23 @@ namespace
         RefinedWatch watch;
     };
 
+    // The underlying simple-variable index of a variable id, or nullopt for a
+    // constant (no variable change can fire on it).
+    auto underlying_var_index(const IntegerVariableID & var) -> std::optional<std::size_t>
+    {
+        return overloaded{
+            [](const SimpleIntegerVariableID & v) -> std::optional<std::size_t> { return v.index; },
+            [](const ViewOfIntegerVariableID & v) -> std::optional<std::size_t> { return v.actual_variable.index; },
+            [](const ConstantIntegerVariableID &) -> std::optional<std::size_t> { return std::nullopt; }}
+            .visit(var);
+    }
+
     // The underlying simple-variable index a literal's truth depends on, or nullopt
     // for a constant/true/false literal that no variable change can fire.
     auto underlying_var_index(const Literal & literal) -> std::optional<std::size_t>
     {
         return overloaded{
-            [](const IntegerVariableCondition & cond) -> std::optional<std::size_t> {
-                return overloaded{
-                    [](const SimpleIntegerVariableID & v) -> std::optional<std::size_t> { return v.index; },
-                    [](const ViewOfIntegerVariableID & v) -> std::optional<std::size_t> { return v.actual_variable.index; },
-                    [](const ConstantIntegerVariableID &) -> std::optional<std::size_t> { return std::nullopt; }}
-                    .visit(cond.var);
-            },
+            [](const IntegerVariableCondition & cond) -> std::optional<std::size_t> { return underlying_var_index(cond.var); },
             [](const TrueLiteral &) -> std::optional<std::size_t> { return std::nullopt; },
             [](const FalseLiteral &) -> std::optional<std::size_t> { return std::nullopt; }}
             .visit(literal);
@@ -160,6 +165,17 @@ struct Propagators::Imp : RefinedWatchSink
     auto add_refined_watch(int owner_propagator, const Literal & literal, std::uint32_t payload) -> void override
     {
         register_refined_watch(owner_propagator, literal, payload, true);
+    }
+
+    [[nodiscard]] auto is_watching(int owner_propagator, const IntegerVariableID & var) const -> bool override
+    {
+        auto var_index = underlying_var_index(var);
+        if (! var_index || refined_watches_by_var.size() <= *var_index)
+            return false;
+        for (const auto & w : refined_watches_by_var[*var_index])
+            if (w.owner == owner_propagator)
+                return true;
+        return false;
     }
 };
 

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -46,6 +46,14 @@ namespace gcs::innards
          * wake it. Watches armed while propagating are restored on backtrack.
          */
         virtual auto add_refined_watch(int owner_propagator, const Literal & literal, std::uint32_t payload) -> void = 0;
+
+        /**
+         * \brief Whether the given propagator currently has any refined watch armed
+         * on the given variable. Reads the (backtrack-consistent) watch index, so a
+         * propagator can use it to recompute its watched set without keeping its own
+         * state. \sa RefinedWatchContext::is_watching
+         */
+        [[nodiscard]] virtual auto is_watching(int owner_propagator, const IntegerVariableID & var) const -> bool = 0;
     };
 
     /**
@@ -101,6 +109,17 @@ namespace gcs::innards
         auto watch(const Literal & literal, std::uint32_t payload) const -> void
         {
             _sink->add_refined_watch(_owner, literal, payload);
+        }
+
+        /**
+         * \brief Whether this propagator currently has any refined watch armed on
+         * `var`. Lets a propagator recompute which variables it should watch each
+         * time it runs, without tracking that set itself (which would have to be
+         * kept consistent with backtracking); the watch index already is.
+         */
+        [[nodiscard]] auto is_watching(const IntegerVariableID & var) const -> bool
+        {
+            return _sink->is_watching(_owner, var);
         }
     };
 


### PR DESCRIPTION
Stage B2 of the refined per-literal trigger mechanism (#335), on top of B1 (#337). This is the **real laziness**: mini-linear now watches only a subset of its variables, so variables that don't matter never wake it.

## Engine (`gcs/innards/propagators`)

One small addition: `ctx.is_watching(var)` — a query over the (already backtrack-consistent) watch index telling a propagator whether it currently watches a variable. That lets a propagator recompute its watched set on each run **without keeping its own state**, which would otherwise have to be kept consistent with backtracking. No new storage, no new trail — it reads what B1 already maintains.

## The PB watched-set (`gcs/constraints/mini_linear_test.cc`)

`MiniLinearGreaterEqual` now has three trigger modes sharing one propagation body — `Coarse` (on_bounds), `RefinedAll` (B1: a refined watch on every variable), and `WatchedSet` (B2). The watched-set keeps armed only enough upper-bound watches to cover `K + W` (`W = maxⱼ cⱼ·(ubⱼ−lbⱼ)`). Since `max_sum ≥ Σ over the watched set`, that certifies global dormancy, so **variables outside the set are never watched**. Correctness rests on two monotonicity facts:

- `W` only ever *decreases* under tightening, so a stale `W` is conservative — never a missed wake.
- After BC pruning, `slack ≥ W`, so arming all variables always achieves coverage (the grow loop terminates).

It arms all variables at install (so scope/degree — and hence the search tree — match the other modes), **sheds** a fired variable by not re-arming it when it's not needed for coverage, and **grows** (largest contribution first) when coverage drops. Shedding needs no explicit watch removal: a shed variable is just one whose consumed watch wasn't re-armed, and backtrack-restore (B1) handles the rest.

## Validation

- Correctness over hand-picked + 200 random instances in **both** refined modes: per-node BC consistency (under-pruning, incl. post-backtrack) and a raw solution-count check vs a brute-force oracle.
- A three-way laziness comparison asserts an **identical search tree** (recursions) and solution count across coarse / refined-all / watched-set, with `watched-set ≤ refined-all ≤ coarse` wakes and **strictly fewer** for watched-set on dominant instances. Measured, `x,y,z ∈ [0,15]`, `100x+y+z ≥ 100`: **7680 / 3840 / 1112** propagations (watched-set is 3.5× fewer than refined-all, 7× fewer than coarse) — same tree, same 3840 solutions.
- **Mutation-tested**: breaking the grow step (under-coverage) is caught by the BC/count checks; degenerating the watched-set to watch-all is caught by the strict-win check. Honest note: breaking `is_watching` only produces duplicate watches on the already-covering variables — benign bloat, with no correctness or headline-laziness effect — so no behavioural check flags it, correctly.

## Gate

GCC 15 and clang 21: `ctest` **332/332**. clang-format clean. No proof impact (semantics-preserving; mini-linear runs without proof).
