### PR TITLE
Refined triggers (C-1): Nogoods via refined per-literal watches

### DIFF
--- a/gcs/constraints/nogoods.cc
+++ b/gcs/constraints/nogoods.cc
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -37,8 +38,10 @@ using std::shared_ptr;
 using std::size_t;
 using std::string;
 using std::stringstream;
+using std::unique;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -69,8 +72,9 @@ auto NogoodStore::size() const -> size_t
     return _nogoods->size();
 }
 
-Nogoods::Nogoods(vector<Nogood> nogoods) :
-    _store(make_shared<NogoodStore>())
+Nogoods::Nogoods(vector<Nogood> nogoods, bool refined) :
+    _store(make_shared<NogoodStore>()),
+    _refined(refined)
 {
     for (auto & nogood : nogoods) {
         for (const auto & lit : nogood)
@@ -79,16 +83,17 @@ Nogoods::Nogoods(vector<Nogood> nogoods) :
     }
 }
 
-Nogoods::Nogoods(shared_ptr<NogoodStore> store, vector<IntegerVariableID> trigger_vars) :
+Nogoods::Nogoods(shared_ptr<NogoodStore> store, vector<IntegerVariableID> trigger_vars, bool refined) :
     _store(move(store)),
-    _trigger_vars(move(trigger_vars))
+    _trigger_vars(move(trigger_vars)),
+    _refined(refined)
 {
 }
 
 auto Nogoods::clone() const -> unique_ptr<Constraint>
 {
-    // Share the live store; copy the trigger list.
-    return make_unique<Nogoods>(_store, _trigger_vars);
+    // Share the live store; copy the trigger list; preserve the trigger mode.
+    return make_unique<Nogoods>(_store, _trigger_vars, _refined);
 }
 
 auto Nogoods::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
@@ -153,93 +158,207 @@ namespace
         else
             watches.emplace_back(*w1, *w2);
     }
+
+    // The coarse path: wake on every change to any nogood variable and re-scan the
+    // whole store. Correct but does O(store) work per wake; kept for the growable
+    // restart-learning store until that is converted to refined watches (C-2).
+    auto install_scan_nogoods(Propagators & propagators, const ConstraintID & id,
+        shared_ptr<vector<Nogood>> nogoods, shared_ptr<vector<vector<IntegerVariableID>>> nogood_vars,
+        const vector<IntegerVariableID> & trigger_vars) -> void
+    {
+        Triggers triggers;
+        for (auto & v : trigger_vars)
+            triggers.on_change.emplace_back(v);
+
+        // The watches are this propagator's own, non-backtrackable, and grown lazily
+        // to keep pace with the nogoods.
+        auto watches = make_shared<vector<pair<size_t, size_t>>>();
+
+        // Init: set up watches for the nogoods present up front (none, for a store
+        // that the restart loop will grow during search).
+        propagators.install_initialiser(
+            [nogoods, nogood_vars, watches](const State & state, auto & inference, ProofLogger * const logger) -> void {
+                watches->reserve(nogoods->size());
+                for (size_t ni = 0; ni < nogoods->size(); ++ni)
+                    init_watches_for(ni, *nogoods, *nogood_vars, *watches, state, inference, logger);
+            });
+
+        propagators.install(
+            id,
+            [nogoods, nogood_vars, watches](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                // Catch up: initialise watches for any nogoods learned since the last
+                // fire. (A unit/contradiction is propagated here, on first sight.)
+                for (size_t ni = watches->size(); ni < nogoods->size(); ++ni)
+                    init_watches_for(ni, *nogoods, *nogood_vars, *watches, state, inference, logger);
+
+                auto is_broken = [&](const Nogood & nogood, size_t p) -> bool {
+                    return state.test_literal(nogood[p]) == LiteralIs::DefinitelyTrue;
+                };
+
+                auto find_unbroken = [&](const Nogood & nogood, size_t skip1, size_t skip2) -> optional<size_t> {
+                    for (size_t p = 0; p < nogood.size(); ++p) {
+                        if (p == skip1 || p == skip2)
+                            continue;
+                        if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue)
+                            return p;
+                    }
+                    return nullopt;
+                };
+
+                for (size_t ni = 0; ni < nogoods->size(); ++ni) {
+                    auto & w = (*watches)[ni];
+                    const auto & nogood = (*nogoods)[ni];
+                    const auto & vars = (*nogood_vars)[ni];
+
+                    bool b1 = is_broken(nogood, w.first);
+                    bool b2 = is_broken(nogood, w.second);
+
+                    if (! b1 && ! b2)
+                        continue;
+
+                    if (b1 && b2) {
+                        auto new1 = find_unbroken(nogood, no_watch, no_watch);
+                        if (! new1)
+                            inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, vars));
+                        auto new2 = find_unbroken(nogood, *new1, no_watch);
+                        if (! new2)
+                            inference.infer(logger, ! nogood[*new1], JustifyUsingRUP{}, generic_reason(state, vars));
+                        else {
+                            w.first = *new1;
+                            w.second = *new2;
+                        }
+                    }
+                    else if (b1) {
+                        auto new1 = find_unbroken(nogood, w.second, no_watch);
+                        if (! new1)
+                            inference.infer(logger, ! nogood[w.second], JustifyUsingRUP{}, generic_reason(state, vars));
+                        else
+                            w.first = *new1;
+                    }
+                    else {
+                        auto new2 = find_unbroken(nogood, w.first, no_watch);
+                        if (! new2)
+                            inference.infer(logger, ! nogood[w.first], JustifyUsingRUP{}, generic_reason(state, vars));
+                        else
+                            w.second = *new2;
+                    }
+                }
+                return PropagatorState::Enable;
+            },
+            triggers);
+    }
+
+    // The refined path: no coarse triggers. Instead, watch *every* literal of every
+    // nogood, restore-on-backtrack. A literal's watch is consumed when the literal
+    // becomes entailed and restored when it un-entails on backtrack, so the armed
+    // set is always exactly the clause's non-entailed literals. The propagator
+    // therefore wakes precisely when a clause loses a non-entailed literal, and
+    // visits only the clauses that fired -- never the whole store.
+    //
+    // Watching all literals (rather than a two-watched-literal scheme) keeps this
+    // stateless: there is no per-clause "which two positions are watched"
+    // bookkeeping to hold consistent with backtracking, so it reuses the existing
+    // restore-on-backtrack mechanism directly. Restoring a consumed watch on
+    // backtrack (rather than leaving it removed) is essential here: a watch can fire
+    // and be consumed in a propagate() that a *sibling* clause's contradiction ends
+    // before this propagator runs, and restore puts that abandoned consume back
+    // rather than losing the watch for good and later missing a unit/contradiction.
+    // (A true two-watched-literal scheme would arm fewer watches, but in this
+    // consume-on-fire engine it needs an extra primitive to keep its watched-pair
+    // bookkeeping backtrack-consistent; left to stage C-2 if measurement shows the
+    // extra wakes matter.)
+    auto install_refined_nogoods(Propagators & propagators, const ConstraintID & id,
+        shared_ptr<vector<Nogood>> nogoods, shared_ptr<vector<vector<IntegerVariableID>>> nogood_vars) -> void
+    {
+        // Arm a refined watch on every literal of every nogood at install (the
+        // permanent base set; the firing consume is what is trailed and undone on
+        // backtrack). payload = the nogood index, so a fire says which clause to
+        // revisit.
+        Triggers triggers;
+        for (size_t ni = 0; ni < nogoods->size(); ++ni)
+            for (const auto & lit : (*nogoods)[ni])
+                triggers.refined.emplace_back(lit, static_cast<std::uint32_t>(ni));
+
+        // Detect any nogood already unit or violated against the initial domains in
+        // initialise(), exactly as the coarse path does, so a root-level
+        // contradiction is found before search starts (identical search tree). The
+        // bookkeeping it records is discarded.
+        auto initial_scratch = make_shared<vector<pair<size_t, size_t>>>();
+        propagators.install_initialiser(
+            [nogoods, nogood_vars, initial_scratch](const State & state, auto & inference, ProofLogger * const logger) -> void {
+                initial_scratch->reserve(nogoods->size());
+                for (size_t ni = 0; ni < nogoods->size(); ++ni)
+                    init_watches_for(ni, *nogoods, *nogood_vars, *initial_scratch, state, inference, logger);
+            });
+
+        // On the first run, scan every clause once. initialise() can entail literals
+        // (e.g. one nogood's unit inference, or another constraint's initialiser),
+        // but it does not fire refined watches -- only propagate()'s requeue does --
+        // so a clause made unit by an initialise-time entailment would otherwise be
+        // missed. This mirrors the coarse path's root re-scan; thereafter every
+        // entailment goes through requeue and fires a watch, so fired-only suffices.
+        // NOTE: this flag is not backtrackable; restarts (stage C-2) must re-scan at
+        // each root, or rely on root facts persisting.
+        auto did_root_scan = make_shared<bool>(false);
+
+        propagators.install(
+            id,
+            [nogoods, nogood_vars, did_root_scan](const State & state, auto & inference, ProofLogger * const logger,
+                const RefinedWatchContext & ctx) -> PropagatorState {
+                // Visit each clause that lost a watched (non-entailed) literal this
+                // wake, once -- or every clause on the first (root) run.
+                vector<size_t> fired;
+                if (! *did_root_scan) {
+                    *did_root_scan = true;
+                    for (size_t ni = 0; ni < nogoods->size(); ++ni)
+                        fired.push_back(ni);
+                }
+                else {
+                    for (auto payload : ctx.fired_payloads())
+                        fired.push_back(payload);
+                    sort(fired);
+                    fired.erase(unique(fired.begin(), fired.end()), fired.end());
+                }
+
+                for (size_t ni : fired) {
+                    const auto & nogood = (*nogoods)[ni];
+                    const auto & vars = (*nogood_vars)[ni];
+
+                    // Find up to two non-entailed literals. Two or more: the clause
+                    // cannot be unit yet (and the surviving watches will fire later).
+                    // Exactly one: unit, force its negation. None: contradiction.
+                    optional<size_t> only;
+                    bool two_or_more = false;
+                    for (size_t p = 0; p < nogood.size(); ++p)
+                        if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue) {
+                            if (! only)
+                                only = p;
+                            else {
+                                two_or_more = true;
+                                break;
+                            }
+                        }
+
+                    if (two_or_more)
+                        continue;
+                    if (! only)
+                        inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, vars));
+                    else
+                        inference.infer(logger, ! nogood[*only], JustifyUsingRUP{}, generic_reason(state, vars));
+                }
+                return PropagatorState::Enable;
+            },
+            triggers);
+    }
 }
 
 auto Nogoods::install_propagators(Propagators & propagators) -> void
 {
-    Triggers triggers;
-    for (auto & v : _trigger_vars)
-        triggers.on_change.emplace_back(v);
-
-    // The nogood data is shared with the store (so additions are visible here);
-    // the watches are this propagator's own, non-backtrackable, and grown lazily
-    // to keep pace with the nogoods.
-    auto nogoods = _store->_nogoods;
-    auto nogood_vars = _store->_vars;
-    auto watches = make_shared<vector<pair<size_t, size_t>>>();
-
-    // Init: set up watches for the nogoods present up front (none, for a store
-    // that the restart loop will grow during search).
-    propagators.install_initialiser(
-        [nogoods, nogood_vars, watches](const State & state, auto & inference, ProofLogger * const logger) -> void {
-            watches->reserve(nogoods->size());
-            for (size_t ni = 0; ni < nogoods->size(); ++ni)
-                init_watches_for(ni, *nogoods, *nogood_vars, *watches, state, inference, logger);
-        });
-
-    propagators.install(
-        constraint_id(),
-        [nogoods, nogood_vars, watches](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            // Catch up: initialise watches for any nogoods learned since the last
-            // fire. (A unit/contradiction is propagated here, on first sight.)
-            for (size_t ni = watches->size(); ni < nogoods->size(); ++ni)
-                init_watches_for(ni, *nogoods, *nogood_vars, *watches, state, inference, logger);
-
-            auto is_broken = [&](const Nogood & nogood, size_t p) -> bool {
-                return state.test_literal(nogood[p]) == LiteralIs::DefinitelyTrue;
-            };
-
-            auto find_unbroken = [&](const Nogood & nogood, size_t skip1, size_t skip2) -> optional<size_t> {
-                for (size_t p = 0; p < nogood.size(); ++p) {
-                    if (p == skip1 || p == skip2)
-                        continue;
-                    if (state.test_literal(nogood[p]) != LiteralIs::DefinitelyTrue)
-                        return p;
-                }
-                return nullopt;
-            };
-
-            for (size_t ni = 0; ni < nogoods->size(); ++ni) {
-                auto & w = (*watches)[ni];
-                const auto & nogood = (*nogoods)[ni];
-                const auto & vars = (*nogood_vars)[ni];
-
-                bool b1 = is_broken(nogood, w.first);
-                bool b2 = is_broken(nogood, w.second);
-
-                if (! b1 && ! b2)
-                    continue;
-
-                if (b1 && b2) {
-                    auto new1 = find_unbroken(nogood, no_watch, no_watch);
-                    if (! new1)
-                        inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, vars));
-                    auto new2 = find_unbroken(nogood, *new1, no_watch);
-                    if (! new2)
-                        inference.infer(logger, ! nogood[*new1], JustifyUsingRUP{}, generic_reason(state, vars));
-                    else {
-                        w.first = *new1;
-                        w.second = *new2;
-                    }
-                }
-                else if (b1) {
-                    auto new1 = find_unbroken(nogood, w.second, no_watch);
-                    if (! new1)
-                        inference.infer(logger, ! nogood[w.second], JustifyUsingRUP{}, generic_reason(state, vars));
-                    else
-                        w.first = *new1;
-                }
-                else {
-                    auto new2 = find_unbroken(nogood, w.first, no_watch);
-                    if (! new2)
-                        inference.infer(logger, ! nogood[w.first], JustifyUsingRUP{}, generic_reason(state, vars));
-                    else
-                        w.second = *new2;
-                }
-            }
-            return PropagatorState::Enable;
-        },
-        triggers);
+    // The nogood data is shared with the store, so additions are visible here.
+    if (_refined)
+        install_refined_nogoods(propagators, constraint_id(), _store->_nogoods, _store->_vars);
+    else
+        install_scan_nogoods(propagators, constraint_id(), _store->_nogoods, _store->_vars, _trigger_vars);
 }
 
 auto Nogoods::s_exprify(const innards::ProofModel * const model) const -> string

--- a/gcs/constraints/nogoods.hh
+++ b/gcs/constraints/nogoods.hh
@@ -72,6 +72,12 @@ namespace gcs
     private:
         std::shared_ptr<NogoodStore> _store;
         std::vector<IntegerVariableID> _trigger_vars;
+        // Whether to use refined per-literal watches (true) or the coarse
+        // wake-on-every-trigger-var-and-scan-the-whole-store path (false). The
+        // fixed-nogoods constructor defaults to refined; the growable-store
+        // constructor (used by the restart loop) stays coarse until the
+        // growable catch-up is converted (issue #335, stage C-2).
+        bool _refined;
 
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
@@ -80,15 +86,22 @@ namespace gcs
         /**
          * \brief A fixed set of nogoods; the propagator wakes on the variables
          * they mention.
+         *
+         * \param refined use refined per-literal watches (the default); pass
+         * false to force the coarse whole-store-scan path (used to compare the
+         * two in tests).
          */
-        explicit Nogoods(std::vector<Nogood> nogoods);
+        explicit Nogoods(std::vector<Nogood> nogoods, bool refined = true);
 
         /**
          * \brief An externally owned store, grown during search, with the
          * variables to wake on (the restart loop passes every problem variable,
          * since a later-learned nogood may mention any of them).
+         *
+         * \param refined use refined per-literal watches; defaults to false
+         * because the growable catch-up is not yet converted (stage C-2).
          */
-        Nogoods(std::shared_ptr<NogoodStore> store, std::vector<IntegerVariableID> trigger_vars);
+        Nogoods(std::shared_ptr<NogoodStore> store, std::vector<IntegerVariableID> trigger_vars, bool refined = false);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/nogoods_test.cc
+++ b/gcs/constraints/nogoods_test.cc
@@ -3,13 +3,16 @@
 #include <gcs/current_state.hh>
 #include <gcs/exception.hh>
 #include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
+#include <gcs/stats.hh>
 #include <gcs/variable_condition.hh>
 
 #include <cstddef>
 #include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <random>
 #include <set>
 #include <tuple>
 #include <utility>
@@ -29,11 +32,14 @@ using namespace gcs::test_innards;
 using std::cerr;
 using std::flush;
 using std::make_optional;
+using std::mt19937;
 using std::nullopt;
 using std::pair;
+using std::random_device;
 using std::set;
 using std::size_t;
 using std::tuple;
+using std::uniform_int_distribution;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -113,9 +119,9 @@ namespace
         return Holds::Undecided;
     }
 
-    auto run_nogoods_test(bool proofs, const vector<pair<int, int>> & domains, const vector<TestNogood> & nogoods) -> void
+    auto run_nogoods_test(bool refined, bool proofs, const vector<pair<int, int>> & domains, const vector<TestNogood> & nogoods) -> void
     {
-        print(cerr, "nogoods {} vars, {} nogoods{}", domains.size(), nogoods.size(), proofs ? " with proofs:" : ":");
+        print(cerr, "nogoods [{}] {} vars, {} nogoods{}", refined ? "refined" : "scan", domains.size(), nogoods.size(), proofs ? " with proofs:" : ":");
         cerr << flush;
 
         // Oracle: an assignment is a solution iff no nogood is fully satisfied.
@@ -149,7 +155,7 @@ namespace
                 n.push_back(make_condition(vars, l));
             posted.push_back(std::move(n));
         }
-        p.post(Nogoods{std::move(posted)});
+        p.post(Nogoods{std::move(posted), refined});
 
         auto proof_name = proofs ? make_optional<std::string>("nogoods_test") : nullopt;
 
@@ -182,52 +188,156 @@ namespace
         check_results(proof_name, expected, actual);
     }
 
-    auto run_all_tests(bool proofs) -> void
+    using Instance = pair<vector<pair<int, int>>, vector<TestNogood>>;
+
+    // The hand-picked instances, shared by the per-mode oracle/UP/proof tests and
+    // the scan-vs-refined differential.
+    auto hand_picked_instances() -> vector<Instance>
     {
         using enum VariableConditionOperator;
+        return {
+            // Pure equality nogoods (a NegativeTable in disguise).
+            {{{1, 3}, {1, 3}}, {{{0, Equal, 1}, {1, Equal, 1}}}},
+            // Exclude the diagonal.
+            {{{1, 3}, {1, 3}}, {{{0, Equal, 1}, {1, Equal, 1}}, {{0, Equal, 2}, {1, Equal, 2}}, {{0, Equal, 3}, {1, Equal, 3}}}},
+            // Cascade: (x=1, y=*) all forbidden forces x != 1.
+            {{{1, 3}, {1, 3}}, {{{0, Equal, 1}, {1, Equal, 1}}, {{0, Equal, 1}, {1, Equal, 2}}, {{0, Equal, 1}, {1, Equal, 3}}}},
+            // A unit nogood over an order literal: forbids x >= 4, i.e. forces x < 4.
+            {{{0, 6}}, {{{0, GreaterEqual, 4}}}},
+            // Order literals: forbid (x >= 3 and y < 3).
+            {{{0, 5}, {0, 5}}, {{{0, GreaterEqual, 3}, {1, Less, 3}}}},
+            // Entailment watching: x is in [11, 13] so x >= 10 always holds; the
+            // nogood (x >= 10 and y = 5) must therefore force y != 5. The oracle's
+            // bound-based entailment fires on the >= 11 bound, so a propagator that
+            // matched x >= 10 only exactly would be caught.
+            {{{11, 13}, {4, 6}}, {{{0, GreaterEqual, 10}, {1, Equal, 5}}}},
+            // Mixed literal kinds in one nogood.
+            {{{0, 3}, {0, 3}, {0, 3}}, {{{0, Equal, 1}, {1, GreaterEqual, 2}, {2, NotEqual, 2}}}},
+            // A not-equal literal: forbid (x != 2 and y != 2) over small domains.
+            {{{1, 3}, {1, 3}}, {{{0, NotEqual, 2}, {1, NotEqual, 2}}}},
+            // Unsatisfiable at the root: forbid both x <= 2 and x >= 3 over [0, 5].
+            {{{0, 5}}, {{{0, Less, 3}}, {{0, GreaterEqual, 3}}}},
+            // Several order nogoods that interact over three variables.
+            {{{0, 4}, {0, 4}, {0, 4}}, {{{0, GreaterEqual, 3}, {1, GreaterEqual, 3}}, {{1, Less, 2}, {2, Less, 2}}, {{0, Equal, 0}, {2, GreaterEqual, 4}}}},
+        };
+    }
 
-        // Pure equality nogoods (a NegativeTable in disguise).
-        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
-            {{{0, Equal, 1}, {1, Equal, 1}}});
-        // Exclude the diagonal.
-        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
-            {{{0, Equal, 1}, {1, Equal, 1}}, {{0, Equal, 2}, {1, Equal, 2}}, {{0, Equal, 3}, {1, Equal, 3}}});
-        // Cascade: (x=1, y=*) all forbidden forces x != 1.
-        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
-            {{{0, Equal, 1}, {1, Equal, 1}}, {{0, Equal, 1}, {1, Equal, 2}}, {{0, Equal, 1}, {1, Equal, 3}}});
+    auto run_all_tests(bool refined, bool proofs) -> void
+    {
+        for (const auto & [domains, nogoods] : hand_picked_instances())
+            run_nogoods_test(refined, proofs, domains, nogoods);
+    }
 
-        // A unit nogood over an order literal: forbids x >= 4, i.e. forces x < 4.
-        run_nogoods_test(proofs, {{0, 6}},
-            {{{0, GreaterEqual, 4}}});
+    // Solve one instance in the chosen trigger mode with a deterministic,
+    // degree-independent brancher (in_order), returning the search statistics.
+    // Because in_order ignores degree, the scan path (which adds an on_change
+    // trigger per variable) and the refined path (which adds none) branch
+    // identically, so any difference in recursions or solutions is a difference
+    // in *propagation* -- a missed inference under-propagates and explores more
+    // nodes; an unsound inference prunes a real solution.
+    template <typename ValueGen_>
+    auto solve_for_differential(bool refined, const vector<pair<int, int>> & domains,
+        const vector<TestNogood> & nogoods, ValueGen_ value_gen) -> Stats
+    {
+        Problem p;
+        vector<IntegerVariableID> vars;
+        for (const auto & d : domains)
+            vars.push_back(p.create_integer_variable(Integer{d.first}, Integer{d.second}));
 
-        // Order literals: forbid (x >= 3 and y < 3).
-        run_nogoods_test(proofs, {{0, 5}, {0, 5}},
-            {{{0, GreaterEqual, 3}, {1, Less, 3}}});
+        vector<Nogood> posted;
+        for (const auto & nogood : nogoods) {
+            Nogood n;
+            for (const auto & l : nogood)
+                n.push_back(make_condition(vars, l));
+            posted.push_back(std::move(n));
+        }
+        p.post(Nogoods{std::move(posted), refined});
 
-        // Entailment watching: x is in [11, 13] so x >= 10 always holds; the
-        // nogood (x >= 10 and y = 5) must therefore force y != 5. The oracle's
-        // bound-based entailment fires on the >= 11 bound, so a propagator that
-        // matched x >= 10 only exactly would be caught.
-        run_nogoods_test(proofs, {{11, 13}, {4, 6}},
-            {{{0, GreaterEqual, 10}, {1, Equal, 5}}});
+        return solve_with(p,
+            SolveCallbacks{
+                .solution = [](const CurrentState &) { return true; },
+                .branch = branch_with(variable_order::in_order(vars), value_gen)});
+    }
 
-        // Mixed literal kinds in one nogood.
-        run_nogoods_test(proofs, {{0, 3}, {0, 3}, {0, 3}},
-            {{{0, Equal, 1}, {1, GreaterEqual, 2}, {2, NotEqual, 2}}});
+    auto run_differential(const vector<pair<int, int>> & domains, const vector<TestNogood> & nogoods) -> void
+    {
+        auto check = [&](auto make_value_gen, const char * label) {
+            auto scan = solve_for_differential(false, domains, nogoods, make_value_gen());
+            auto refined = solve_for_differential(true, domains, nogoods, make_value_gen());
+            println(cerr, "nogoods differential [{}] {} vars {} nogoods: scan rec={} sol={} | refined rec={} sol={}",
+                label, domains.size(), nogoods.size(), scan.recursions, scan.solutions, refined.recursions, refined.solutions);
+            if (scan.recursions != refined.recursions || scan.solutions != refined.solutions) {
+                println(cerr, "DIVERGED. instance:");
+                for (size_t vi = 0; vi < domains.size(); ++vi)
+                    println(cerr, "  var {}: [{}, {}]", vi, domains[vi].first, domains[vi].second);
+                for (const auto & ng : nogoods) {
+                    print(cerr, "  nogood:");
+                    for (const auto & l : ng)
+                        print(cerr, " (v{} op{} {})", l.var, static_cast<int>(l.op), l.value);
+                    println(cerr, "");
+                }
+                throw UnexpectedException{"refined nogoods diverged from scan: different search tree or solution count"};
+            }
+        };
+        // Instantiation branching (each upper-/single-value decision) and bounds-
+        // splitting (gradual order-literal entailment, more backtracking): both
+        // must give scan and refined the identical tree.
+        check([] { return value_order::smallest_in(); }, "smallest");
+        check([] { return value_order::split_smallest_first(); }, "split");
+    }
 
-        // A not-equal literal: forbid (x != 2 and y != 2) over small domains.
-        run_nogoods_test(proofs, {{1, 3}, {1, 3}},
-            {{{0, NotEqual, 2}, {1, NotEqual, 2}}});
+    // Random, often backtrack-heavy instances for the differential: small domains,
+    // a handful of nogoods of mixed literal kinds, so clauses go unit and conflict
+    // and watches move and are restored across many backtracks.
+    auto run_random_differentials() -> void
+    {
+        using enum VariableConditionOperator;
+        mt19937 rng;
+        if (auto seed = get_seed())
+            rng.seed(*seed);
+        else
+            rng.seed(random_device{}());
 
-        // Unsatisfiable at the root: forbid both x <= 2 and x >= 3 over [0, 5].
-        run_nogoods_test(proofs, {{0, 5}},
-            {{{0, Less, 3}}, {{0, GreaterEqual, 3}}});
+        auto pick_op = [&]() {
+            switch (uniform_int_distribution{0, 3}(rng)) {
+            case 0: return Equal;
+            case 1: return NotEqual;
+            case 2: return GreaterEqual;
+            default: return Less;
+            }
+        };
 
-        // Several order nogoods that interact over three variables.
-        run_nogoods_test(proofs, {{0, 4}, {0, 4}, {0, 4}},
-            {{{0, GreaterEqual, 3}, {1, GreaterEqual, 3}},
-                {{1, Less, 2}, {2, Less, 2}},
-                {{0, Equal, 0}, {2, GreaterEqual, 4}}});
+        for (int iter = 0; iter < 300; ++iter) {
+            int nvars = uniform_int_distribution{2, 4}(rng);
+            vector<pair<int, int>> domains;
+            for (int v = 0; v < nvars; ++v) {
+                int lo = uniform_int_distribution{0, 3}(rng);
+                domains.emplace_back(lo, lo + uniform_int_distribution{0, 4}(rng));
+            }
+
+            int nng = uniform_int_distribution{1, 6}(rng);
+            vector<TestNogood> nogoods;
+            for (int n = 0; n < nng; ++n) {
+                TestNogood ng;
+                int len = uniform_int_distribution{1, 4}(rng);
+                for (int l = 0; l < len; ++l) {
+                    auto var = static_cast<size_t>(uniform_int_distribution{0, nvars - 1}(rng));
+                    // A value spanning just outside the domain, so literals are a
+                    // mix of always-/never-/sometimes-true.
+                    int value = uniform_int_distribution{domains[var].first - 1, domains[var].second + 1}(rng);
+                    ng.push_back(TestLit{var, pick_op(), value});
+                }
+                nogoods.push_back(std::move(ng));
+            }
+            run_differential(domains, nogoods);
+        }
+    }
+
+    auto run_all_differentials() -> void
+    {
+        for (const auto & [domains, nogoods] : hand_picked_instances())
+            run_differential(domains, nogoods);
+        run_random_differentials();
     }
 }
 
@@ -235,11 +345,19 @@ auto main(int argc, char * argv[]) -> int
 {
     set_seed_from_argv(argc, argv);
 
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
-            continue;
-        run_all_tests(proofs);
-    }
+    // Scan vs refined must explore the identical tree and find the identical
+    // solutions on every instance: a pure same-tree differential (no proof needed).
+    run_all_differentials();
+
+    // Each mode independently checked against the brute-force oracle and the
+    // per-node unit-propagation reference, with its proof verified when veripb is
+    // available.
+    for (bool refined : {false, true})
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            run_all_tests(refined, proofs);
+        }
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Stage C-1 of the refined per-literal trigger mechanism (#335), on top of B2 (#338). This is the first *real* client of the refined-watch engine: the `Nogoods` constraint's fixed-nogoods path moves off the coarse "wake on every nogood variable and re-scan the whole store" scheme onto refined watches, so it wakes only when a clause loses a non-entailed literal and visits only the clauses that fired. That whole-store scan is the source of the ~13.1M wasted propagations measured in #315. The growable restart-learning store stays coarse for now (stage C-2).

## Scheme: watch every literal, restore-on-backtrack

Each nogood arms a refined watch on **every** literal (payload = the clause index). A literal's watch is consumed when it becomes entailed and restored when it un-entails on backtrack, so the armed set is always exactly the clause's non-entailed literals; the propagator visits a fired clause and does the unit/contradiction check (0 non-entailed → contradiction, 1 → force its negation, ≥2 → nothing). This reuses the B1/B2 restore mechanism directly and is **stateless** — there is no per-clause "which positions are watched" bookkeeping to hold consistent with backtracking.

I started on the two-watched-literal scheme we'd planned (no-change-on-backtrack) and the differential below shot it down, for two reasons worth recording:

- **Restore, not leave-in-place, is essential.** A watch can fire and be consumed inside a `propagate()` that a *sibling* clause's contradiction ends *before this propagator runs* to process the fire. Restore puts that abandoned consume back on backtrack; leaving it removed (classic non-backtrackable watches) loses the watch for good and the clause later misses a unit/contradiction. Classic SAT 2WL never hits this because it doesn't consume-then-abandon a watch — it's specific to this engine's consume-on-fire. A true 2WL scheme (fewer watches) would need an extra engine primitive to keep its watched-pair bookkeeping backtrack-consistent; deferred to C-2 if measurement shows the extra wakes matter.

- **`initialise()` does not fire refined watches** (only `propagate()`'s requeue does), so a clause made unit by an initialise-time entailment would be missed. The propagator does a one-time full scan on its first (root) run to cover this, mirroring the coarse path's root re-scan; thereafter fired-only suffices. (Non-backtrackable flag — restarts, in C-2, will need to re-scan at each root.)

`Nogoods` gains a `refined` flag: the fixed-nogoods constructor defaults to refined, the growable-store constructor stays coarse, so `solve.cc`'s learned-nogood path is unchanged. Proof model and inferences are untouched (`JustifyUsingRUP` + `generic_reason`), so the conversion is semantics-preserving and proofs verify.

## Validation

`gcs/constraints/nogoods_test.cc` gains a **scan-vs-refined differential**: solve each instance both ways with a deterministic, degree-independent brancher (`in_order` — degree-independent matters, since the coarse path adds an `on_change` trigger per variable and the refined path adds none, so `dom_then_deg` would diverge for non-propagation reasons) and assert **identical recursions and solution count**. A missed inference under-propagates (more recursions); an unsound one prunes a real solution (fewer). Run over the hand-picked instances and 300 random backtrack-heavy ones. The differential is what caught both subtleties above during development.

Each mode is also run through the existing brute-force oracle, the per-node unit-propagation reference, and VeriPB proof verification. Three mutation tests confirm the checks are load-bearing: disabling the first-run scan is caught via recursions (same solutions, more nodes); disabling restore brings the abandoned-fire bug back; skipping the unit inference is caught.

GCC 15 + clang 21: `ctest` **332/332**, clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)