### PR TITLE
Refined triggers (C-2): refined watches for the learned-nogood store

### DIFF
--- a/gcs/constraints/nogoods.cc
+++ b/gcs/constraints/nogoods.cc
@@ -265,24 +265,24 @@ namespace
     // rather than losing the watch for good and later missing a unit/contradiction.
     // (A true two-watched-literal scheme would arm fewer watches, but in this
     // consume-on-fire engine it needs an extra primitive to keep its watched-pair
-    // bookkeeping backtrack-consistent; left to stage C-2 if measurement shows the
-    // extra wakes matter.)
+    // bookkeeping backtrack-consistent; deferred as a later optimisation if
+    // measurement shows the extra wakes matter.)
     auto install_refined_nogoods(Propagators & propagators, const ConstraintID & id,
         shared_ptr<vector<Nogood>> nogoods, shared_ptr<vector<vector<IntegerVariableID>>> nogood_vars) -> void
     {
-        // Arm a refined watch on every literal of every nogood at install (the
-        // permanent base set; the firing consume is what is trailed and undone on
-        // backtrack). payload = the nogood index, so a fire says which clause to
-        // revisit.
+        // Arm a refined watch on every literal of each nogood present at install
+        // (the permanent base set, via Triggers; the firing consume is what is
+        // trailed and undone on backtrack). payload = the nogood index, so a fire
+        // says which clause to revisit. A growable store (the restart loop's learned
+        // nogoods) is empty here and arms nothing now -- those are caught up below.
         Triggers triggers;
         for (size_t ni = 0; ni < nogoods->size(); ++ni)
             for (const auto & lit : (*nogoods)[ni])
                 triggers.refined.emplace_back(lit, static_cast<std::uint32_t>(ni));
 
         // Detect any nogood already unit or violated against the initial domains in
-        // initialise(), exactly as the coarse path does, so a root-level
-        // contradiction is found before search starts (identical search tree). The
-        // bookkeeping it records is discarded.
+        // initialise(), as the coarse path does, so a root-level contradiction is
+        // found before search starts (identical search tree). Discards its bookkeeping.
         auto initial_scratch = make_shared<vector<pair<size_t, size_t>>>();
         propagators.install_initialiser(
             [nogoods, nogood_vars, initial_scratch](const State & state, auto & inference, ProofLogger * const logger) -> void {
@@ -291,25 +291,37 @@ namespace
                     init_watches_for(ni, *nogoods, *nogood_vars, *initial_scratch, state, inference, logger);
             });
 
-        // On the first run, scan every clause once. initialise() can entail literals
-        // (e.g. one nogood's unit inference, or another constraint's initialiser),
-        // but it does not fire refined watches -- only propagate()'s requeue does --
-        // so a clause made unit by an initialise-time entailment would otherwise be
-        // missed. This mirrors the coarse path's root re-scan; thereafter every
-        // entailment goes through requeue and fires a watch, so fired-only suffices.
-        // NOTE: this flag is not backtrackable; restarts (stage C-2) must re-scan at
-        // each root, or rely on root facts persisting.
-        auto did_root_scan = make_shared<bool>(false);
+        // High-water mark of nogoods whose watches are armed; the install-time base
+        // set above covers [0, armed). Non-backtrackable, which is sound because the
+        // catch-up below arms only at a root re-propagation, and those edits live in
+        // the persistent root epoch (never backtracked between restart passes), so
+        // the count stays in step with the armed watches.
+        auto armed = make_shared<size_t>(nogoods->size());
 
         propagators.install(
             id,
-            [nogoods, nogood_vars, did_root_scan](const State & state, auto & inference, ProofLogger * const logger,
+            [nogoods, nogood_vars, armed](const State & state, auto & inference, ProofLogger * const logger,
                 const RefinedWatchContext & ctx) -> PropagatorState {
-                // Visit each clause that lost a watched (non-entailed) literal this
-                // wake, once -- or every clause on the first (root) run.
                 vector<size_t> fired;
-                if (! *did_root_scan) {
-                    *did_root_scan = true;
+                if (ctx.fired_payloads().empty()) {
+                    // A root re-propagation: this propagator is enqueued un-fired only
+                    // at propagate(nullopt) -- depth 0 -- which the restart loop
+                    // re-enters once per pass. Two jobs here (both also needed at the
+                    // very first root):
+                    //  (1) Catch up newly-learned nogoods (the restart loop grows the
+                    //      store between passes): arm a watch on every literal of each
+                    //      clause not yet armed.
+                    //  (2) Scan every clause for a unit/contradiction. initialise()
+                    //      and root propagation can entail literals without firing
+                    //      refined watches (only requeue fires them), and a just-armed
+                    //      clause may already be unit, so fired-only would miss these.
+                    // Away from the root every entailment goes through requeue and
+                    // fires a watch, so fired-only suffices there (the laziness win).
+                    for (size_t ni = *armed; ni < nogoods->size(); ++ni)
+                        for (const auto & lit : (*nogoods)[ni])
+                            ctx.watch(lit, static_cast<std::uint32_t>(ni));
+                    *armed = nogoods->size();
+
                     for (size_t ni = 0; ni < nogoods->size(); ++ni)
                         fired.push_back(ni);
                 }

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -14,6 +14,7 @@
 
 #include <util/enumerate.hh>
 
+#include <cstdlib>
 #include <limits>
 #include <string>
 #include <variant>
@@ -286,7 +287,14 @@ auto gcs::solve_with(Problem & problem, SolveCallbacks callbacks,
     shared_ptr<NogoodStore> nogood_store;
     if (callbacks.restarts) {
         nogood_store = make_shared<NogoodStore>();
-        auto nogoods_constraint = Nogoods{nogood_store, problem.all_normal_variables()};
+        // Use refined per-literal watches for the learned-nogood store (issue #335,
+        // stage C-2): the propagator wakes only when a learned clause loses a
+        // non-entailed literal and visits only the clauses that fired, rather than
+        // the coarse wake-on-every-variable-and-scan-the-whole-store path that was
+        // the ~13.1M-wasted-propagation cost. Setting GCS_LEARNED_NOGOODS_SCAN picks
+        // the legacy scan path, for the scan-vs-refined differential and perf check.
+        bool refined_nogoods = (std::getenv("GCS_LEARNED_NOGOODS_SCAN") == nullptr);
+        auto nogoods_constraint = Nogoods{nogood_store, problem.all_normal_variables(), refined_nogoods};
         nogoods_constraint.set_constraint_id(NamedConstraint{"learned_nogoods"});
         std::move(nogoods_constraint).install(propagators, state, optional_proof ? optional_proof->model() : nullptr);
     }

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -183,6 +183,54 @@ TEST_CASE("Optimise with restarts")
     CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
 }
 
+// Scan-vs-refined differential for the engine-owned learned-nogood store (issue
+// #335, stage C-2). The refined per-literal-watch path (the default) must explore
+// the identical search and learn the identical nogoods as the legacy whole-store-
+// scan path (selected by GCS_LEARNED_NOGOODS_SCAN), since the conversion is
+// semantics-preserving. We drive a pigeonhole UNSAT (6 values into 5) with a
+// luby(1) schedule -- many restarts, a growing nogood store, and the growable
+// catch-up exercised at every restart root -- under deterministic, domain-based
+// (degree-independent) branching, and require byte-identical search statistics.
+// A missed or spurious inference on the refined path would change the tree.
+TEST_CASE("Learned nogoods: refined matches scan under restarts")
+{
+    auto run = [](bool scan) -> Stats {
+        if (scan)
+            setenv("GCS_LEARNED_NOGOODS_SCAN", "1", 1);
+        else
+            unsetenv("GCS_LEARNED_NOGOODS_SCAN");
+
+        Problem p;
+        vector<IntegerVariableID> xs;
+        for (int i = 0; i < 6; ++i)
+            xs.push_back(p.create_integer_variable(0_i, 4_i));
+        for (unsigned i = 0; i < xs.size(); ++i)
+            for (unsigned j = i + 1; j < xs.size(); ++j)
+                p.post(NotEquals{xs[i], xs[j]});
+
+        return solve_with(
+            p,
+            SolveCallbacks{
+                .branch = branch_with(variable_order::dom(p), value_order::smallest_in()),
+                .restarts = RestartSchedule::luby(1)},
+            nullopt);
+    };
+
+    auto refined = run(false);
+    auto scan = run(true);
+    unsetenv("GCS_LEARNED_NOGOODS_SCAN");
+
+    // The instance must actually restart and learn, or the differential is vacuous.
+    CHECK(refined.restarts > 0);
+    CHECK(refined.learned_nogoods > 0);
+
+    CHECK(refined.recursions == scan.recursions);
+    CHECK(refined.failures == scan.failures);
+    CHECK(refined.restarts == scan.restarts);
+    CHECK(refined.learned_nogoods == scan.learned_nogoods);
+    CHECK(refined.solutions == scan.solutions);
+}
+
 // An unsatisfiable Langford-pairing instance (size 5): rich enough that
 // AllDifferent and Element prune at the root, so the root node emits
 // guess-independent propagation that later restart passes do not re-derive.


### PR DESCRIPTION
Stage C-2 of the refined per-literal trigger mechanism (#335), on top of C-1 (#339). This is the actual payoff: the restart loop's engine-owned **learned-nogood store** moves off the coarse wake-on-every-variable-and-scan-the-whole-store path onto refined per-literal watches — the ~13.1M-wasted-propagation cost measured in #315.

## Growable catch-up

C-1 handled a fixed nogood set (all known at install, armed via `Triggers`). The learned-nogood store is empty at install and grows during search, so its watches can't be armed up front. The key observation from `solve.cc`: the refined propagator runs *un-fired* only at a root re-propagation (`propagate(nullopt)`, depth 0), which the restart loop re-enters once per pass, and the root epoch persists across passes (only child epochs are backtracked between passes). So a non-backtrackable "armed high-water" stays in step with the watches armed there.

On each root re-propagation the propagator now:

- **catches up** newly-learned nogoods — arms a watch on every literal of each clause learned since the last pass; and
- **re-scans** every clause for a unit/contradiction (`initialise()` and root propagation can entail literals without firing refined watches, and a just-armed clause may already be unit).

Away from the root, every entailment goes through `requeue` and fires a watch, so fired-only processing suffices — the laziness win. This replaces C-1's one-time `did_root_scan` flag with a per-restart-root re-scan keyed off `fired_payloads().empty()`.

`solve.cc` selects the refined path by default; `GCS_LEARNED_NOGOODS_SCAN` selects the legacy scan path (for the differential and the perf comparison below). The scan path stays in the tree as the differential oracle.

## Validation

- **Scan-vs-refined differential** (`solve_test`): a pigeonhole UNSAT (6 into 5) under `luby(1)` — many restarts, a growing store, the catch-up exercised at every restart root — under deterministic, domain-based (degree-independent) branching. Asserts byte-identical recursions, failures, restarts, learned-nogood count and solutions between the two paths. Two mutations confirm it is load-bearing: skipping the catch-up arming diverges (194 vs 62 recursions), as does skipping the per-root re-scan (105 vs 62).
- All existing restart tests pass on the refined path (now the default) and **VeriPB** verifies their proofs.
- **Semantics-preserving and faster**, measured scan vs refined (identical search each time):
  - langford-8 `luby(10)`: identical tree, fewer propagations;
  - qap-12 `luby(1000)` (471 learned nogoods): 7.50s → **6.83s**;
  - qap-12 `luby(100)` (1896 learned nogoods): 10.02s → **7.69s**.

  The win grows with the nogood-store size — it is the whole-store-per-wake scan being removed.

A true two-watched-literal scheme would arm fewer watches still, but in this consume-on-fire engine it needs an extra primitive to keep its watched-pair bookkeeping backtrack-consistent; left as a later optimisation if the per-literal wake count shows up in profiling.

GCC 15 + clang 21: `ctest` **332/332**, clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)