### PR TITLE
Benchmark CLI flags: --branch, --restarts, --timeout

### DIFF
--- a/examples/benchmark_cli.hh
+++ b/examples/benchmark_cli.hh
@@ -1,0 +1,72 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_EXAMPLES_BENCHMARK_CLI_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_EXAMPLES_BENCHMARK_CLI_HH
+
+// Shared helpers for the benchmark / example command-line programs: a dom-wdeg
+// weighting-scheme name parser (for a `--branch` flag) and a graceful
+// `--timeout` wrapper around solve_with. Header-only; included by the benchmark
+// binaries, not part of the library API.
+
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+#include <gcs/stats.hh>
+#include <gcs/variable_weighting.hh>
+
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <stop_token>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace gcs::bench
+{
+    // Map a dom-wdeg variant string to a weighting scheme, matching the langford
+    // example's spelling (used by the `--branch dom-wdeg[:VARIANT]` flag).
+    [[nodiscard]] inline auto scheme_from_string(const std::string & name) -> std::optional<WeightingScheme>
+    {
+        using enum WeightingScheme;
+        if (name == "classic")
+            return Classic;
+        if (name == "ia")
+            return InitialArity;
+        if (name == "ca")
+            return CurrentArity;
+        if (name == "id")
+            return InitialDomain;
+        if (name == "cd")
+            return CurrentDomain;
+        if (name == "ca.cd" || name == "cacd")
+            return CurrentArityCurrentDomain;
+        if (name == "chs")
+            return ConflictHistorySearch;
+        return std::nullopt;
+    }
+
+    // Run solve_with, aborting the solve gracefully after `timeout_seconds`
+    // (<= 0 means no limit) so that a capped run still returns the statistics it
+    // had reached. A background timer sets the solver's abort flag at the
+    // deadline; it is asked to stop as soon as the solve returns.
+    [[nodiscard]] inline auto solve_with_timeout(double timeout_seconds, Problem & problem,
+        SolveCallbacks callbacks, const std::optional<ProofOptions> & proof = std::nullopt) -> Stats
+    {
+        if (timeout_seconds <= 0.0)
+            return solve_with(problem, std::move(callbacks), proof);
+
+        std::atomic<bool> abort_flag{false};
+        std::jthread timer([&abort_flag, timeout_seconds](std::stop_token stop) {
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::duration<double>(timeout_seconds);
+            while (! stop.stop_requested() && std::chrono::steady_clock::now() < deadline)
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            if (! stop.stop_requested())
+                abort_flag.store(true);
+        });
+
+        auto stats = solve_with(problem, std::move(callbacks), proof, &abort_flag);
+        timer.request_stop();
+        return stats;
+    }
+}
+
+#endif

--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -5,6 +5,8 @@
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
+#include <examples/benchmark_cli.hh>
+
 #include <cstdlib>
 #include <iostream>
 #include <optional>
@@ -100,6 +102,8 @@ auto main(int argc, char * argv[]) -> int
                 cxxopts::value<string>()->default_value("dom-then-deg"))             //
             ("restarts", "Restart on a Luby schedule with the given conflict scale", //
                 cxxopts::value<unsigned long long>()->implicit_value("100"))         //
+            ("timeout", "Abort the solve after this many seconds (0 = no limit)",    //
+                cxxopts::value<double>()->default_value("0"))                        //
             ;
 
         options.add_options()                                                                   //
@@ -152,8 +156,8 @@ auto main(int argc, char * argv[]) -> int
         ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
         : nullopt;
 
-    auto stats = solve_with(
-        p,
+    auto stats = bench::solve_with_timeout(
+        options_vars["timeout"].as<double>(), p,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
                 println("solution: {}", solution | std::ranges::views::transform(cref(s)));

--- a/examples/ortho_latin/ortho_latin.cc
+++ b/examples/ortho_latin/ortho_latin.cc
@@ -2,7 +2,10 @@
 #include <gcs/constraints/arithmetic.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
+
+#include <examples/benchmark_cli.hh>
 
 #include <cstdlib>
 #include <cxxopts.hpp>
@@ -43,12 +46,19 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")                                                       //
-            ("help", "Display help information")                                                     //
-            ("prove", "Create a proof")                                                              //
-            ("proof-files-basename", "Basename for the .opb and .pbp files",                         //
-                cxxopts::value<string>()->default_value("ortho_latin"))                              //
-            ("stats", "Print solve statistics")                                                      //
+        options.add_options("Program Options")                                       //
+            ("help", "Display help information")                                     //
+            ("prove", "Create a proof")                                              //
+            ("proof-files-basename", "Basename for the .opb and .pbp files",         //
+                cxxopts::value<string>()->default_value("ortho_latin"))              //
+            ("stats", "Print solve statistics")                                      //
+            ("branch", "Branching heuristic: default, or dom-wdeg[:VARIANT] "        //
+                       "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",      //
+                cxxopts::value<string>()->default_value("default"))                  //
+            ("timeout", "Abort the solve after this many seconds (0 = no limit)",    //
+                cxxopts::value<double>()->default_value("0"))                        //
+            ("restarts", "Restart on a Luby schedule with the given conflict scale", //
+                cxxopts::value<unsigned long long>()->implicit_value("100"))         //
             ;
 
         options.add_options()                                                                    //
@@ -122,17 +132,42 @@ auto main(int argc, char * argv[]) -> int
         p.post(Equals{g1[x][0], constant_variable(Integer{x})});
     }
 
-    auto stats = solve(
-        p, [&](const CurrentState & s) -> bool {
-            for (int x = 0; x < size; ++x) {
-                for (int y = 0; y < size; ++y)
-                    print("{},{} ", s(g1[x][y]), s(g2[x][y]));
-                println("");
-            }
-            println("");
+    auto restarts = options_vars.contains("restarts")
+        ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
+        : nullopt;
 
-            return true;
-        },
+    auto branch_spec = options_vars["branch"].as<string>();
+    BranchHeuristic brancher;
+    if (branch_spec == "default")
+        brancher = branch_with(variable_order::dom_then_deg(p), value_order::smallest_first());
+    else if (branch_spec == "dom-wdeg" || branch_spec.starts_with("dom-wdeg:")) {
+        auto colon = branch_spec.find(':');
+        auto scheme = bench::scheme_from_string(colon == string::npos ? "chs" : branch_spec.substr(colon + 1));
+        if (! scheme) {
+            println(cerr, "Error: unknown --branch scheme in {}", branch_spec);
+            return EXIT_FAILURE;
+        }
+        brancher = branch_with(variable_order::dom_wdeg(p, *scheme), value_order::smallest_first());
+    }
+    else {
+        println(cerr, "Error: unknown --branch value {}", branch_spec);
+        return EXIT_FAILURE;
+    }
+
+    auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), p,
+        SolveCallbacks{
+            .solution = [&](const CurrentState & s) -> bool {
+                for (int x = 0; x < size; ++x) {
+                    for (int y = 0; y < size; ++y)
+                        print("{},{} ", s(g1[x][y]), s(g2[x][y]));
+                    println("");
+                }
+                println("");
+
+                return true;
+            },
+            .branch = brancher,
+            .restarts = restarts},
         options_vars.contains("prove")
             ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>())
             : nullopt);

--- a/minicp_benchmarks/magic_series/magic_series.cc
+++ b/minicp_benchmarks/magic_series/magic_series.cc
@@ -4,6 +4,8 @@
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
+#include <examples/benchmark_cli.hh>
+
 #include <cstdlib>
 #include <cxxopts.hpp>
 #include <iostream>
@@ -26,9 +28,16 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
+        options.add_options("Program Options")                                       //
+            ("help", "Display help information")                                     //
+            ("prove", "Create a proof")                                              //
+            ("branch", "Branching heuristic: default, or dom-wdeg[:VARIANT] "        //
+                       "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",      //
+                cxxopts::value<std::string>()->default_value("default"))             //
+            ("timeout", "Abort the solve after this many seconds (0 = no limit)",    //
+                cxxopts::value<double>()->default_value("0"))                        //
+            ("restarts", "Restart on a Luby schedule with the given conflict scale", //
+                cxxopts::value<unsigned long long>()->implicit_value("100"))         //
             ("extra-constraints", "Use extra constraints described in the MiniCP paper");
 
         options.add_options() //
@@ -88,7 +97,29 @@ auto main(int argc, char * argv[]) -> int
         p.post(move(sum_mul_s) == Integer{size});
     }
 
-    auto stats = solve_with(p,
+    auto restarts = options_vars.contains("restarts")
+        ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
+        : nullopt;
+
+    auto branch_spec = options_vars["branch"].as<std::string>();
+    BranchHeuristic brancher;
+    if (branch_spec == "default")
+        brancher = branch_with(variable_order::dom(series), value_order::smallest_in());
+    else if (branch_spec == "dom-wdeg" || branch_spec.starts_with("dom-wdeg:")) {
+        auto colon = branch_spec.find(':');
+        auto scheme = bench::scheme_from_string(colon == std::string::npos ? "chs" : branch_spec.substr(colon + 1));
+        if (! scheme) {
+            cerr << "Error: unknown --branch scheme in " << branch_spec << endl;
+            return EXIT_FAILURE;
+        }
+        brancher = branch_with(variable_order::dom_wdeg(p, *scheme), value_order::smallest_in());
+    }
+    else {
+        cerr << "Error: unknown --branch value " << branch_spec << endl;
+        return EXIT_FAILURE;
+    }
+
+    auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), p,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
                 cout << "solution:";
@@ -98,7 +129,8 @@ auto main(int argc, char * argv[]) -> int
 
                 return true;
             },
-            .branch = branch_with(variable_order::dom(series), value_order::smallest_in())},
+            .branch = brancher,
+            .restarts = restarts},
         options_vars.contains("prove") ? make_optional<ProofOptions>("magic_series") : nullopt);
 
     cout << stats;

--- a/minicp_benchmarks/magic_square/magic_square.cc
+++ b/minicp_benchmarks/magic_square/magic_square.cc
@@ -7,6 +7,8 @@
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
+#include <examples/benchmark_cli.hh>
+
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -30,9 +32,16 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
+        options.add_options("Program Options")                                       //
+            ("help", "Display help information")                                     //
+            ("prove", "Create a proof")                                              //
+            ("branch", "Branching heuristic: default, or dom-wdeg[:VARIANT] "        //
+                       "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",      //
+                cxxopts::value<std::string>()->default_value("default"))             //
+            ("timeout", "Abort the solve after this many seconds (0 = no limit)",    //
+                cxxopts::value<double>()->default_value("0"))                        //
+            ("restarts", "Restart on a Luby schedule with the given conflict scale", //
+                cxxopts::value<unsigned long long>()->implicit_value("100"))         //
             ("all-different", "Use AllDifferent rather than inequalities");
 
         options.add_options()("size", "Size of the problem to solve", cxxopts::value<int>()->default_value("5"));
@@ -113,13 +122,36 @@ auto main(int argc, char * argv[]) -> int
     p.post(LessThan{grid[0][0], grid[size - 1][size - 1]});
     p.post(LessThan{grid[0][0], grid[size - 1][0]});
 
+    auto restarts = options_vars.contains("restarts")
+        ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
+        : nullopt;
+
+    auto branch_spec = options_vars["branch"].as<std::string>();
+    BranchHeuristic brancher;
+    if (branch_spec == "default")
+        brancher = branch_with(variable_order::dom(grid_flat), value_order::smallest_in());
+    else if (branch_spec == "dom-wdeg" || branch_spec.starts_with("dom-wdeg:")) {
+        auto colon = branch_spec.find(':');
+        auto scheme = bench::scheme_from_string(colon == std::string::npos ? "chs" : branch_spec.substr(colon + 1));
+        if (! scheme) {
+            cerr << "Error: unknown --branch scheme in " << branch_spec << endl;
+            return EXIT_FAILURE;
+        }
+        brancher = branch_with(variable_order::dom_wdeg(p, *scheme), value_order::smallest_in());
+    }
+    else {
+        cerr << "Error: unknown --branch value " << branch_spec << endl;
+        return EXIT_FAILURE;
+    }
+
     unsigned long long n_solutions = 0;
-    auto stats = solve_with(p,
+    auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), p,
         SolveCallbacks{
             .solution = [&](const CurrentState &) -> bool {
                 return ++n_solutions < 10000;
             },
-            .branch = branch_with(variable_order::dom(grid_flat), value_order::smallest_in())},
+            .branch = brancher,
+            .restarts = restarts},
         options_vars.contains("prove") ? make_optional<ProofOptions>("magic_square") : nullopt);
 
     cout << stats;

--- a/minicp_benchmarks/n_queens/n_queens.cc
+++ b/minicp_benchmarks/n_queens/n_queens.cc
@@ -4,6 +4,8 @@
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
+#include <examples/benchmark_cli.hh>
+
 #include <cstdlib>
 #include <iostream>
 #include <optional>
@@ -30,6 +32,11 @@ auto main(int argc, char * argv[]) -> int
         options.add_options("Program Options")                                       //
             ("help", "Display help information")                                     //
             ("prove", "Create a proof")                                              //
+            ("branch", "Branching heuristic: default, or dom-wdeg[:VARIANT] "        //
+                       "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",      //
+                cxxopts::value<string>()->default_value("default"))                  //
+            ("timeout", "Abort the solve after this many seconds (0 = no limit)",    //
+                cxxopts::value<double>()->default_value("0"))                        //
             ("restarts", "Restart on a Luby schedule with the given conflict scale", //
                 cxxopts::value<unsigned long long>()->implicit_value("100"));
 
@@ -77,7 +84,25 @@ auto main(int argc, char * argv[]) -> int
         ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
         : nullopt;
 
-    auto stats = solve_with(p,
+    auto branch_spec = options_vars["branch"].as<string>();
+    BranchHeuristic brancher;
+    if (branch_spec == "default")
+        brancher = branch_with(variable_order::dom(queens), value_order::smallest_in());
+    else if (branch_spec == "dom-wdeg" || branch_spec.starts_with("dom-wdeg:")) {
+        auto colon = branch_spec.find(':');
+        auto scheme = bench::scheme_from_string(colon == string::npos ? "chs" : branch_spec.substr(colon + 1));
+        if (! scheme) {
+            cerr << "Error: unknown --branch scheme in " << branch_spec << endl;
+            return EXIT_FAILURE;
+        }
+        brancher = branch_with(variable_order::dom_wdeg(p, *scheme), value_order::smallest_in());
+    }
+    else {
+        cerr << "Error: unknown --branch value " << branch_spec << endl;
+        return EXIT_FAILURE;
+    }
+
+    auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), p,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
                 cout << "solution:";
@@ -87,7 +112,7 @@ auto main(int argc, char * argv[]) -> int
 
                 return options_vars.contains("all");
             },
-            .branch = branch_with(variable_order::dom(queens), value_order::smallest_in()),
+            .branch = brancher,
             .restarts = restarts},
         options_vars.contains("prove") ? make_optional<ProofOptions>("n_queens") : nullopt);
 

--- a/minicp_benchmarks/qap/qap.cc
+++ b/minicp_benchmarks/qap/qap.cc
@@ -5,6 +5,8 @@
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
+#include <examples/benchmark_cli.hh>
+
 #include <array>
 #include <cstdlib>
 #include <fstream>
@@ -34,6 +36,11 @@ auto main(int argc, char * argv[]) -> int
         options.add_options("Program Options")                                       //
             ("help", "Display help information")                                     //
             ("prove", "Create a proof")                                              //
+            ("branch", "Branching heuristic: default, or dom-wdeg[:VARIANT] "        //
+                       "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",      //
+                cxxopts::value<std::string>()->default_value("default"))             //
+            ("timeout", "Abort the solve after this many seconds (0 = no limit)",    //
+                cxxopts::value<double>()->default_value("0"))                        //
             ("restarts", "Restart on a Luby schedule with the given conflict scale", //
                 cxxopts::value<unsigned long long>()->implicit_value("100"));
 
@@ -143,13 +150,31 @@ auto main(int argc, char * argv[]) -> int
         ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
         : nullopt;
 
-    auto stats = solve_with(p,
+    auto branch_spec = options_vars["branch"].as<std::string>();
+    BranchHeuristic brancher;
+    if (branch_spec == "default")
+        brancher = branch_with(variable_order::dom(xs), value_order::smallest_in());
+    else if (branch_spec == "dom-wdeg" || branch_spec.starts_with("dom-wdeg:")) {
+        auto colon = branch_spec.find(':');
+        auto scheme = bench::scheme_from_string(colon == std::string::npos ? "chs" : branch_spec.substr(colon + 1));
+        if (! scheme) {
+            cerr << "Error: unknown --branch scheme in " << branch_spec << endl;
+            return EXIT_FAILURE;
+        }
+        brancher = branch_with(variable_order::dom_wdeg(p, *scheme), value_order::smallest_in());
+    }
+    else {
+        cerr << "Error: unknown --branch value " << branch_spec << endl;
+        return EXIT_FAILURE;
+    }
+
+    auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), p,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
                 cout << "cost: " << s(cost) << endl;
                 return true;
             },
-            .branch = branch_with(variable_order::dom(xs), value_order::smallest_in()),
+            .branch = brancher,
             .restarts = restarts},
         options_vars.contains("prove") ? make_optional<ProofOptions>("qap") : nullopt);
 

--- a/minicp_benchmarks/tsp/tsp.cc
+++ b/minicp_benchmarks/tsp/tsp.cc
@@ -3,6 +3,8 @@
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
 
+#include <examples/benchmark_cli.hh>
+
 #include <cstdlib>
 #include <iostream>
 #include <optional>
@@ -29,6 +31,11 @@ auto main(int argc, char * argv[]) -> int
         options.add_options()                                                        //
             ("help", "Display help information")                                     //
             ("prove", "Create a proof")                                              //
+            ("branch", "Branching heuristic: default, or dom-wdeg[:VARIANT] "        //
+                       "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",      //
+                cxxopts::value<string>()->default_value("default"))                  //
+            ("timeout", "Abort the solve after this many seconds (0 = no limit)",    //
+                cxxopts::value<double>()->default_value("0"))                        //
             ("restarts", "Restart on a Luby schedule with the given conflict scale", //
                 cxxopts::value<unsigned long long>()->implicit_value("100"));
 
@@ -115,13 +122,31 @@ auto main(int argc, char * argv[]) -> int
         ? make_optional(RestartSchedule::luby(options_vars["restarts"].as<unsigned long long>()))
         : nullopt;
 
-    auto stats = solve_with(p,
+    auto branch_spec = options_vars["branch"].as<string>();
+    BranchHeuristic brancher;
+    if (branch_spec == "default")
+        brancher = branch_with(variable_order::dom(succ), value_order::smallest_in());
+    else if (branch_spec == "dom-wdeg" || branch_spec.starts_with("dom-wdeg:")) {
+        auto colon = branch_spec.find(':');
+        auto scheme = bench::scheme_from_string(colon == string::npos ? "chs" : branch_spec.substr(colon + 1));
+        if (! scheme) {
+            cerr << "Error: unknown --branch scheme in " << branch_spec << endl;
+            return EXIT_FAILURE;
+        }
+        brancher = branch_with(variable_order::dom_wdeg(p, *scheme), value_order::smallest_in());
+    }
+    else {
+        cerr << "Error: unknown --branch value " << branch_spec << endl;
+        return EXIT_FAILURE;
+    }
+
+    auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), p,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
                 cout << "distance: " << s(obj) << endl;
                 return true;
             },
-            .branch = branch_with(variable_order::dom(succ), value_order::smallest_in()),
+            .branch = brancher,
             .restarts = restarts},
         options_vars.contains("prove") ? make_optional<ProofOptions>("tsp") : nullopt);
 


### PR DESCRIPTION
Adds uniform command-line options to the benchmark / example programs so the
restarts + nogoods + heuristic configurations can be measured against a
baseline. This is the benchmarking infrastructure behind the dom/wdeg + restarts
+ nogoods work (#315), and produced the review dataset for the refined-triggers
stack (#336–#344).

### Flags

- `--branch default | dom-wdeg[:VARIANT]` — keeps each program's existing value
  order; the minicp programs' default stays `variable_order::dom` + `smallest_in`
  so the same-search-tree comparison against MiniCP is unaffected.
  (`VARIANT = classic / ia / ca / id / cd / ca.cd / chs`; bare `dom-wdeg` = chs.)
- `--restarts[=SCALE]` — Luby restart schedule (added where missing).
- `--timeout SECONDS` — graceful abort that still prints the statistics reached,
  so a capped run is not lost.

### Shared helper

A header-only `examples/benchmark_cli.hh` holds the shared bits: `scheme_from_string`
for `--branch`, and `solve_with_timeout`, which wraps `solve_with` with an
interruptible timer that sets the solver's abort flag at the deadline.

`langford` already had `--branch` / `--restarts` and only gains `--timeout`;
`ortho_latin` moves from `solve()` to `solve_with` to gain the options.

**No behaviour change with default flags** — baseline invocations are unchanged.

Based on #344. Logically independent of the triggers stack; sits at the top of
it only so it can exercise the whole chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)