### PR TITLE
dom_wdeg: score each candidate once per node, not per comparison

### DIFF
--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -237,23 +237,45 @@ auto gcs::variable_order::dom_wdeg(vector<IntegerVariableID> vars, WeightingSche
             weighting->load(*initial, propagators);
         propagators.set_conflict_observer(weighting.get());
 
-        return in_order_of_selector(vars,
-            [weighting](const CurrentState & state, const innards::Propagators & p,
-                const IntegerVariableID & a, const IntegerVariableID & b) -> bool {
-                // Minimise dom(x)/W(x), cross-multiplied to avoid division: a
-                // variable with W(x)=0 (in no constraint with two or more
-                // unassigned variables) then sorts last for free. Tie-break on
-                // highest degree, matching dom_then_deg.
-                auto dom_a = static_cast<double>(state.domain_size(a).raw_value);
-                auto dom_b = static_cast<double>(state.domain_size(b).raw_value);
-                auto w_a = weighting->weighted_degree_of(state, p, a);
-                auto w_b = weighting->weighted_degree_of(state, p, b);
-                auto lhs = dom_a * w_b;
-                auto rhs = dom_b * w_a;
-                if (lhs != rhs)
-                    return lhs < rhs;
-                return p.degree_of(a) > p.degree_of(b);
-            });
+        // Select the argmin of dom(x)/W(x). This is the same selection an
+        // in_order_of_selector min-scan would make, but we compute each
+        // candidate's weighted degree exactly once per node and carry the
+        // incumbent's cached score, rather than recomputing weighted_degree_of
+        // for *both* arguments of every comparison. weighted_degree_of walks
+        // every constraint in a variable's scope, so on wide constraints (e.g.
+        // count / cardinality) the redundant per-comparison recompute of the
+        // incumbent's score dominates the entire solve.
+        return [vars, weighting](const CurrentState & state,
+                   const innards::Propagators & p) -> optional<IntegerVariableID> {
+            optional<IntegerVariableID> result;
+            double dom_result = 0.0, w_result = 0.0;
+            for (const auto & v : vars) {
+                auto size = state.domain_size(v);
+                if (size < 2_i)
+                    continue;
+                auto dom_v = static_cast<double>(size.raw_value);
+                auto w_v = weighting->weighted_degree_of(state, p, v);
+                if (! result) {
+                    result = v;
+                    dom_result = dom_v;
+                    w_result = w_v;
+                    continue;
+                }
+                // Cross-multiplied dom(x)/W(x) to avoid division: a variable
+                // with W(x)=0 (in no constraint with two or more unassigned
+                // variables) sorts last for free. Tie-break on highest degree,
+                // matching dom_then_deg.
+                auto lhs = dom_v * w_result;
+                auto rhs = dom_result * w_v;
+                bool v_better = (lhs != rhs) ? (lhs < rhs) : (p.degree_of(v) > p.degree_of(*result));
+                if (v_better) {
+                    result = v;
+                    dom_result = dom_v;
+                    w_result = w_v;
+                }
+            }
+            return result;
+        };
     };
 }
 


### PR DESCRIPTION
A performance fix to the `dom_wdeg` variable selector, found while benchmarking
the restarts + nogoods work (#315).

### The problem

The selector picked the argmin of `dom(x)/W(x)` with a generic
`in_order_of_selector` min-scan whose comparator called `weighted_degree_of` on
**both** of its arguments. `weighted_degree_of` walks every constraint in a
variable's scope, and the *incumbent* argument was re-scored on every comparison
— so the incumbent's score was recomputed O(n) times per node. On problems with
a wide constraint (count / cardinality) the incumbent is the most expensive
variable to score, so this redundant recompute dominated the entire solve:
`magic_series 300` under dom-wdeg managed only ~2 search nodes/second, essentially
all of it in `weighted_degree_of`.

### The fix

Replace the generic min-scan in the `dom_wdeg` path with a selector that computes
each candidate's weighted degree exactly once and carries the incumbent's cached
score. The selection is **identical** — same cross-multiplied `dom/W` comparison,
same `W=0`-sorts-last, same degree tie-break — so the search tree is unchanged;
only the per-node cost drops.

### Validation

- Re-ran every benchmark that completes under `dom-wdeg:chs` (langford-11, qap-12,
  ortho_latin-6, magic_square-5, n_queens-88): **recursions, solutions, restarts
  and learned-nogood counts are byte-identical** before and after, while wall time
  falls.
- `search_heuristics_test` and `variable_weighting_test` pass on GCC and clang.

### Effect

~40–48× per node on the wide-constraint case (magic_series), 19% on qap-12, 45%
on n_queens-88, ~0 where selection was never the bottleneck (tsp, n_queens-14).
`weighted_degree_of` remains the dominant symbol (it is intrinsic to dom_wdeg on
wide constraints) — the fix removes the O(n) incumbent *multiplier*, not the
per-call cost. A deeper follow-up (maintain per-constraint unassigned-counts
incrementally, removing the `has_single_value` scan) is left as future work.

Based on #344, but touches only `gcs/search_heuristics.cc` and is independent of
the triggers stack — can be rebased earlier if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)