### PR TITLE
ProofModel: emit a trivial `>= 0` for tautological clauses, drop the optional

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -373,6 +373,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(reification_test PRIVATE glasgow_constraint_solver)
     add_test(NAME reification_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:reification_test>)
 
+    add_executable(proof_model_tautology_test innards/proofs/proof_model_tautology_test.cc)
+    target_link_libraries(proof_model_tautology_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME proof_model_tautology_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:proof_model_tautology_test>)
+
     add_executable(invar_test innards/proofs/invar_test.cc)
     target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
     add_test(NAME invar_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -195,7 +195,7 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
             WPBSum{} == Integer{n - 1},
             HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
 
-        pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line.value(), geq_line.value()});
+        pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
 
         for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
             pos_var_data.emplace(idx,
@@ -210,20 +210,20 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
             tie(leq_line, geq_line) = model->add_constraint(
                 WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i,
                 HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
-            pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line.value(), geq_line.value()});
+            pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line, geq_line});
 
             // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
             tie(leq_line, geq_line) = model->add_constraint(
                 WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
                 HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
-            pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line.value(), geq_line.value()});
+            pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
 
             // (succ[i] = j) -> pos[j] = pos[i] + 1
             for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
                 tie(leq_line, geq_line) = model->add_constraint(
                     WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
                     HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
-                pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line.value(), geq_line.value()});
+                pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});
             }
         }
     }

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -133,9 +133,7 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
             "Disjunctive", "first task finishes before second starts",
             WPBSum{} + 1_i * _starts[i] + -1_i * _starts[j] <= -_lengths[i],
             flag);
-        if (! fwd || ! rev)
-            throw UnexpectedException{"Disjunctive: pairwise reification half missing"};
-        return BeforeFlagData{flag, *fwd, *rev};
+        return BeforeFlagData{flag, fwd, rev};
     };
     for (size_t a = 0; a < _active_tasks.size(); ++a) {
         auto i = _active_tasks[a];
@@ -145,11 +143,9 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
             auto data_ji = emit_before(j, i);
             auto clause = model.add_constraint("Disjunctive", "one task must finish first",
                 WPBSum{} + 1_i * data_ij.flag + 1_i * data_ji.flag >= 1_i);
-            if (! clause)
-                throw UnexpectedException{"Disjunctive: pairwise clause missing"};
             _before_flags.emplace(std::make_pair(i, j), data_ij);
             _before_flags.emplace(std::make_pair(j, i), data_ji);
-            _clause_lines.emplace(std::make_pair(i, j), *clause);
+            _clause_lines.emplace(std::make_pair(i, j), clause);
         }
     }
 }

--- a/gcs/constraints/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d.cc
@@ -213,9 +213,7 @@ auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
             : (WPBSum{} + 1_i * pos_i + 1_i * size_i + -1_i * pos_j <= 0_i);
         auto [fwd, rev] = model.add_two_way_reified_constraint(
             "Disjunctive2D", "first rectangle precedes second on this axis", ineq, flag);
-        if (! fwd || ! rev)
-            throw UnexpectedException{"Disjunctive2D: pairwise reification half missing"};
-        return BeforeFlagData{flag, *fwd, *rev};
+        return BeforeFlagData{flag, fwd, rev};
     };
 
     // For each rectangle with a variable size on an axis, a proof-only
@@ -276,13 +274,11 @@ auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
             }
             auto clause = model.add_constraint("Disjunctive2D", "rectangles must be separated on some axis",
                 move(clause_sum) >= 1_i);
-            if (! clause)
-                throw UnexpectedException{"Disjunctive2D: separation clause missing"};
             _before_x.emplace(make_pair(i, j), bx_ij);
             _before_x.emplace(make_pair(j, i), bx_ji);
             _before_y.emplace(make_pair(i, j), by_ij);
             _before_y.emplace(make_pair(j, i), by_ji);
-            _clause_lines.emplace(make_pair(i, j), *clause);
+            _clause_lines.emplace(make_pair(i, j), clause);
         }
     }
 }

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -641,7 +641,7 @@ auto Knapsack::define_proof_model(ProofModel & model) -> void
         for (const auto & [idx, v] : enumerate(_vars))
             sum_eq += cc.at(idx) * v;
         auto [eq1, eq2] = model.add_constraint(sum_eq == 1_i * _totals.at(cc_idx));
-        _eqns_lines.emplace_back(eq1.value(), eq2.value());
+        _eqns_lines.emplace_back(eq1, eq2);
     }
 }
 

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -99,20 +99,20 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
 
     overloaded{
         [&](const reif::MustHold &) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional less than", terms <= _value, nullopt), nullopt};
+            _proof_lines = pair{model.add_constraint("ReifiedLinearInequality", "unconditional less than", terms <= _value, nullopt), nullopt};
         },
         [&](const reif::MustNotHold &) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "unconditional greater than", terms >= _value + 1_i, nullopt), nullopt};
+            _proof_lines = pair{model.add_constraint("ReifiedLinearInequality", "unconditional greater than", terms >= _value + 1_i, nullopt), nullopt};
         },
         [&](const reif::If & cond) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines = pair{model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         },
         [&](const reif::NotIf & cond) {
-            _proof_lines = pair{*model.add_constraint("ReifiedLinearInequality", "greater than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines = pair{model.add_constraint("ReifiedLinearInequality", "greater than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         },
         [&](const reif::Iff & cond) {
             _proof_lines = pair{
-                *model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
+                model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
                 model.add_constraint("ReifiedLinearInequality", "greater than option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
         }}
         .visit(_reif_cond);

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -1179,7 +1179,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
                 auto neg_le = optional_model->add_constraint(
                     bit_sum_without_neg + (1_i * v_magnitude) <= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
 
-                channelling_constraints.insert({v, ChannellingData{*pos_ge, *pos_le, *neg_ge, *neg_le}});
+                channelling_constraints.insert({v, ChannellingData{pos_ge, pos_le, neg_ge, neg_le}});
 
                 mag_var.insert({v, v_magnitude});
 
@@ -1210,7 +1210,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
                     WPBSum{} + -1_i * ProofBitVariable{v1_mag, i, true} + -1_i * ProofBitVariable{v2_mag, j, true} >= -1_i,
                     HalfReifyOnConjunctionOf{! flag});
 
-                bit_products[i.as_index()].emplace_back(BitProductData{flag, *forwards, *backwards, nullopt, nullopt});
+                bit_products[i.as_index()].emplace_back(BitProductData{flag, forwards, backwards, nullopt, nullopt});
                 bit_product_sum += power2(i + j) * flag;
             }
         }
@@ -1218,29 +1218,29 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
         visit(
             [&](auto v3_mag) {
                 auto s = optional_model->add_constraint(bit_product_sum + (-1_i * v3_mag) == 0_i);
-                v3_eq_product_lines = make_pair(*s.first, *s.second);
+                v3_eq_product_lines = make_pair(s.first, s.second);
             },
             v3_mag);
 
         auto xyss = optional_model->create_proof_flag("xy[s][s]");
-        sign_lines.emplace_back(*optional_model->add_constraint(
+        sign_lines.emplace_back(optional_model->add_constraint(
             WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, ! v2_sign}));
 
         if (mag_var.contains(_v1))
-            sign_lines.emplace_back(*optional_model->add_constraint(
+            sign_lines.emplace_back(optional_model->add_constraint(
                 WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, ! v2_sign}));
         if (mag_var.contains(_v2))
-            sign_lines.emplace_back(*optional_model->add_constraint(
+            sign_lines.emplace_back(optional_model->add_constraint(
                 WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, v2_sign}));
         if (mag_var.contains(_v1) && mag_var.contains(_v2))
-            sign_lines.emplace_back(*optional_model->add_constraint(
+            sign_lines.emplace_back(optional_model->add_constraint(
                 WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, v2_sign}));
 
-        sign_lines.emplace_back(*optional_model->add_constraint(
+        sign_lines.emplace_back(optional_model->add_constraint(
             WPBSum{} + 1_i * xyss + 1_i * (_v1 != 0_i) + 1_i * (_v2 != 0_i) >= 3_i,
             HalfReifyOnConjunctionOf{v3_sign}));
 
-        sign_lines.emplace_back(*optional_model->add_constraint(
+        sign_lines.emplace_back(optional_model->add_constraint(
             WPBSum{} + 1_i * ! xyss + 1_i * (_v1 == 0_i) + 1_i * (_v2 == 0_i) >= 1_i,
             HalfReifyOnConjunctionOf{! v3_sign}));
     }

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -123,8 +123,8 @@ auto gcs::innards::define_sortedness_proof_model(ProofModel & model,
             auto [fwd, rev] = model.add_two_way_reified_constraint("Sort", "stable before",
                 WPBSum{} + 1_i * x[ip] + -1_i * x[i] <= bound, flag);
             w.before[ip][i] = flag;
-            w.before_fwd[ip][i] = fwd.value();
-            w.before_rev[ip][i] = rev.value();
+            w.before_fwd[ip][i] = fwd;
+            w.before_rev[ip][i] = rev;
         }
 
     // pos[i] is the stable rank of x[i]: the number of elements before it.
@@ -144,8 +144,8 @@ auto gcs::innards::define_sortedness_proof_model(ProofModel & model,
             if (ip != i)
                 rank += -1_i * w.before[ip][i];
         auto [le, ge] = model.add_constraint("Sort", "pos is stable rank", move(rank) == 0_i);
-        w.rank_ge.push_back(ge.value());
-        w.rank_le.push_back(le.value());
+        w.rank_ge.push_back(ge);
+        w.rank_le.push_back(le);
     }
 
     // Channel: x[i] is placed at position pos[i] of y.

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -527,8 +527,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         }
         else {
             visit([&](const auto & id) {
-                forwards_line = *_imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
-                reverse_line = *_imp->model->add_constraint(WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
+                forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
+                reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
             },
                 id);
             ++_imp->model_variables;
@@ -546,8 +546,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         }
         else {
             visit([&](const auto & id) {
-                forwards_line = *_imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
-                reverse_line = *_imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
+                forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
+                reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
             },
                 id);
             ++_imp->model_variables;
@@ -566,8 +566,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
                 id);
         else {
             visit([&](const auto & id) {
-                forwards_line = *_imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
-                reverse_line = *_imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
+                forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
+                reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
             },
                 id);
             ++_imp->model_variables;
@@ -670,12 +670,12 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         _imp->gevars_that_exist[id].emplace(v, visit([&](const auto & vid) -> pair<ProofLine, ProofLine> {
             if (can_label)
                 return pair{
-                    _imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}).value(),
-                    _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}}).value()};
+                    _imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
+                    _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
             else
                 return pair{
-                    _imp->model->add_constraint(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}).value(),
-                    _imp->model->add_constraint(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}}).value()};
+                    _imp->model->add_constraint(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
+                    _imp->model->add_constraint(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
         },
                                                    id));
         ++_imp->model_variables;
@@ -1085,7 +1085,7 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
 
     _imp->view_proof_only_vars.emplace(view, v_id);
     _imp->view_proof_only_to_view.emplace(v_id, view);
-    _imp->view_link_ids.emplace(v_id, pair{link_le.value(), link_ge.value()});
+    _imp->view_link_ids.emplace(v_id, pair{link_le, link_ge});
     _imp->views_of_variable[view.actual_variable].push_back(v_id);
 
     // Backfill: if X atoms already exist when this view is registered,

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -104,20 +104,24 @@ auto ProofModel::emit_constraint_label(const string & constraint_id, const strin
     return ProofLineLabel{"c[" + constraint_id + "]" + (role.empty() ? "" : "[" + role + "]")};
 }
 
-auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> std::optional<ProofLine>
+auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> ProofLine
 {
     WPBSum sum;
 
+    // A clause containing a statically-true literal is a tautology. It
+    // constrains nothing, but we still emit it as a trivially-true `sum >= 0`
+    // rather than omitting it, so there is always a line to return and the
+    // constraint counter stays in step. This is why no add_constraint overload
+    // returns optional any more (issue #264); a tautology was the only source.
+    bool tautological = false;
     for (auto & lit : lits) {
-        if (overloaded{
-                [&](const TrueLiteral &) { return true; },
-                [&](const FalseLiteral &) { return false; },
-                [&]<typename T_>(const VariableConditionFrom<T_> & cond) -> bool {
-                    sum += 1_i * cond;
-                    return false;
-                }}
-                .visit(simplify_literal(names_and_ids_tracker(), lit)))
-            return nullopt;
+        overloaded{
+            [&](const TrueLiteral &) { tautological = true; },
+            [&](const FalseLiteral &) {},
+            [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
+                sum += 1_i * cond;
+            }}
+            .visit(simplify_literal(names_and_ids_tracker(), lit));
     }
 
     // put these in some kind of order
@@ -126,16 +130,16 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     // remove duplicates
     sum.terms.erase(unique(sum.terms).begin(), sum.terms.end());
 
-    return add_constraint(constraint_name, rule, move(sum) >= 1_i, nullopt);
+    return add_constraint(constraint_name, rule, move(sum) >= (tautological ? 0_i : 1_i), nullopt);
 }
 
-auto ProofModel::add_constraint(const Literals & lits) -> std::optional<ProofLine>
+auto ProofModel::add_constraint(const Literals & lits) -> ProofLine
 {
     return add_constraint("?", "?", lits);
 }
 
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule,
-    const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
+    const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
 {
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     if (half_reif)
@@ -150,14 +154,14 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     return line;
 }
 
-auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
+auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
 {
     return add_constraint("?", "?", ineq, half_reif);
 }
 
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule,
     const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
-    -> pair<optional<ProofLine>, optional<ProofLine>>
+    -> pair<ProofLine, ProofLine>
 {
     names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
     if (half_reif)
@@ -185,7 +189,7 @@ auto ProofModel::add_labelled_constraint(
     const string & constraint_id, const string & role_le, const string & role_ge,
     const StringLiteral & constraint_name, const StringLiteral & rule,
     const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
-    -> pair<optional<ProofLine>, optional<ProofLine>>
+    -> pair<ProofLine, ProofLine>
 {
     names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
     if (half_reif)
@@ -213,7 +217,7 @@ auto ProofModel::add_labelled_constraint(
 }
 
 auto ProofModel::add_labelled_constraint(const string & label, const WPBSumLE & ineq,
-    const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
+    const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
 {
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     if (half_reif)
@@ -229,7 +233,7 @@ auto ProofModel::add_labelled_constraint(const string & label, const WPBSumLE & 
 
 auto ProofModel::add_labelled_constraint(const string & constraint_id, const string & role,
     const StringLiteral & constraint_name, const StringLiteral & rule,
-    const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> optional<ProofLine>
+    const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
 {
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     if (half_reif)
@@ -247,13 +251,13 @@ auto ProofModel::add_labelled_constraint(const string & constraint_id, const str
 }
 
 auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
-    -> pair<optional<ProofLine>, optional<ProofLine>>
+    -> pair<ProofLine, ProofLine>
 {
     return add_constraint("?", "?", eq, half_reif);
 }
 
 auto ProofModel::add_two_way_reified_constraint(const StringLiteral & constraint_name, const StringLiteral & rule,
-    const WPBSumLE & ineq, const ProofFlag & flag) -> pair<optional<ProofLine>, optional<ProofLine>>
+    const WPBSumLE & ineq, const ProofFlag & flag) -> pair<ProofLine, ProofLine>
 {
     auto forward = add_constraint(constraint_name, rule, ineq, HalfReifyOnConjunctionOf{{flag}});
     auto reverse = add_constraint(constraint_name, rule, negate_inequality(ineq), HalfReifyOnConjunctionOf{{! flag}});

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -68,7 +68,7 @@ namespace gcs::innards
          */
         auto add_constraint(
             const WPBSumLE & ineq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::optional<ProofLine>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
 
         /**
          * Add a pair of pseudo-Boolean constraints representing an equality to a Proof model.
@@ -81,13 +81,13 @@ namespace gcs::innards
          */
         auto add_constraint(
             const WPBSumEq & eq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
 
         /**
          * Add a CNF definition to a Proof model.
          */
         auto add_constraint(
-            const Literals & lits) -> std::optional<ProofLine>;
+            const Literals & lits) -> ProofLine;
 
         /**
          * Add a pseudo-Boolean constraint to a Proof model.
@@ -96,7 +96,7 @@ namespace gcs::innards
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
             const WPBSumLE & ineq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::optional<ProofLine>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
 
         /**
          * Add a pair of pseudo-Boolean constraints representing an equality to a Proof model.
@@ -108,7 +108,7 @@ namespace gcs::innards
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
             const WPBSumEq & eq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
 
         /**
          * \brief Like add_constraint for an equality, but emits an @label on each
@@ -127,7 +127,7 @@ namespace gcs::innards
             const std::string & role_le, const std::string & role_ge,
             const StringLiteral & constraint_name, const StringLiteral & rule,
             const WPBSumEq & eq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
 
         /**
          * \brief Add a single inequality under a caller-supplied @label, returning
@@ -137,7 +137,7 @@ namespace gcs::innards
          */
         auto add_labelled_constraint(
             const std::string & label, const WPBSumLE & ineq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::optional<ProofLine>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
 
         /**
          * \brief Like add_constraint for a single inequality, but emits @c[id][role]
@@ -148,7 +148,7 @@ namespace gcs::innards
             const std::string & constraint_id, const std::string & role,
             const StringLiteral & constraint_name, const StringLiteral & rule,
             const WPBSumLE & ineq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::optional<ProofLine>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
 
         /**
          * Add a CNF definition to a Proof model.
@@ -156,7 +156,7 @@ namespace gcs::innards
         auto add_constraint(
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
-            const Literals & lits) -> std::optional<ProofLine>;
+            const Literals & lits) -> ProofLine;
 
         /**
          * \brief Encode `flag ⇔ ineq` in OPB by emitting both halves of the equivalence:
@@ -171,7 +171,7 @@ namespace gcs::innards
             const StringLiteral & constraint_name,
             const StringLiteral & rule,
             const WPBSumLE & ineq,
-            const ProofFlag & flag) -> std::pair<std::optional<ProofLine>, std::optional<ProofLine>>;
+            const ProofFlag & flag) -> std::pair<ProofLine, ProofLine>;
 
         /**
          * \brief Create a fresh proof flag and fully reify it against `ineq` in one

--- a/gcs/innards/proofs/proof_model_tautology_test.cc
+++ b/gcs/innards/proofs/proof_model_tautology_test.cc
@@ -1,0 +1,51 @@
+#include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <sstream>
+
+using std::ostringstream;
+
+using namespace gcs;
+using namespace gcs::innards;
+
+// Issue #264: a clause whose only content is a statically-true literal is a
+// tautology with an empty left-hand side. add_constraint must still emit a
+// trivially-true `>= 0` constraint and return a usable line for it, rather than
+// returning nothing -- which is why no add_constraint overload is optional any
+// more. The emitted constraint must parse in the OPB and stay referenceable from
+// a later proof step, so here we reference its line in a pol step; VeriPB rejects
+// the proof if the line is missing or the empty constraint is malformed.
+auto main() -> int
+{
+    ProofOptions proof_options{"proof_model_tautology_test"};
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+
+    // A variable so the model is not degenerate; the tautology stands on its own
+    // and does not mention it.
+    [[maybe_unused]] auto x = model.create_proof_only_integer_variable(
+        0_i, 10_i, "x", IntegerVariableProofRepresentation::Bits);
+
+    auto tautology_line = model.add_constraint(Literals{TrueLiteral{}});
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    // The tautology's line must be referenceable: re-deriving it by pol succeeds
+    // only if it was emitted and is well-formed.
+    ostringstream ref;
+    ref << tautology_line;
+    logger.emit_proof_line("pol " + ref.str() + " ;", ProofLevel::Current);
+
+    logger.conclude_none();
+    tracker.finalise();
+
+    return 0;
+}


### PR DESCRIPTION
Closes #264.

## What

`ProofModel::add_constraint` and friends returned `std::optional<ProofLine>` (and `pair<optional, optional>` for the equality/two-way variants) **solely** because the CNF/clause overload returned `nullopt` for a tautological clause — one whose literals include a statically-true literal after `simplify_literal`. The `WPBSum`/reified overloads never returned `nullopt`; their `optional` was vestigial, and ~19 call sites already dereferenced the result with `*` / `.value()`.

This makes the clause overload emit a **trivially-true constraint** instead of omitting it, so no overload can return `nullopt`, and then drops the `optional` across the whole family.

## How

- **Tautology → `>= 0`.** As the issue noted, `emit_inequality_to` already folds a `TrueLiteral` term into the rhs, so a clause `sum >= 1` containing one lowers to `(remaining terms) >= 0`. A pure single-literal tautology gives an empty-LHS `>= 0`, which VeriPB 3.0.2 accepts and which remains referenceable by line number.
- **Return types narrowed** to `ProofLine` / `pair<ProofLine, ProofLine>` on every `add_constraint` / `add_labelled_constraint` / `add_two_way_reified_constraint` overload.
- **Call sites simplified:** removed the now-redundant `*` / `.value()` derefs and the `if (! line) throw …` emptiness checks (circuit, disjunctive, disjunctive_2d, knapsack, linear_inequality, mult_bc, sort, names_and_ids_tracker). Non-tautological clauses emit byte-identical OPB; the only output change is that a previously-omitted tautological clause now emits one trivial line (no stored golden proofs to update).

## Tests

- New `proof_model_tautology_test`: emits an empty-LHS tautology and references its line in a later `pol` step, so VeriPB fails if the line is missing or malformed. Verifies (`s VERIFIED`).
- Full suite **335/335** green with veripb (GCC).
- Builds clean under both GCC 15 and clang 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)