### PR TITLE
Keystone: position-indexed aux-naming overload; all_different byte-matches cake (#354)

### DIFF
--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINT_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINT_HH
 
+#include <gcs/constraint_id.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/s_expr-fwd.hh>
@@ -11,53 +12,11 @@
 #include <variant>
 #include <version>
 
-#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-#include <format>
-#else
-#include <fmt/core.h>
-#endif
-
 namespace gcs
 {
     /**
      * \defgroup Constraints Constraints
      */
-
-    struct CurrentlyUnnamedConstraint final
-    {
-        [[nodiscard]] auto operator<=>(const CurrentlyUnnamedConstraint &) const = default;
-        [[nodiscard]] auto as_string() const -> std::string
-        {
-            return "unnamed";
-        }
-    };
-
-    struct NumberedConstraint final
-    {
-        unsigned long long number;
-        [[nodiscard]] auto operator<=>(const NumberedConstraint &) const = default;
-        [[nodiscard]] auto as_string() const -> std::string
-        {
-            return "_" + std::to_string(number);
-        }
-    };
-
-    struct NamedConstraint final
-    {
-        std::string name;
-        [[nodiscard]] auto operator<=>(const NamedConstraint &) const = default;
-        [[nodiscard]] auto as_string() const -> std::string
-        {
-            return name;
-        }
-    };
-
-    // The *identity* of a constraint (`_1`, `_2`, or a caller-given name) -- not
-    // its type (`abs`, `all_different`, ...). Kept distinct from "name" because
-    // both readings of that word kept getting confused.
-    using ConstraintID = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
-
-    [[nodiscard]] auto as_string(const ConstraintID &) -> std::string;
 
     /**
      * \brief Subclasses of Constraint give a high level way of defining
@@ -145,26 +104,5 @@ namespace gcs
         [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string;
     };
 }
-
-// The following is needed to allow ConstraintID to be used in format strings.
-#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-template <>
-struct std::formatter<gcs::ConstraintID> : std::formatter<std::string>
-{
-    auto format(const gcs::ConstraintID & constraint_id, std::format_context & ctx) const
-    {
-        return std::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
-    }
-};
-#else
-template <>
-struct fmt::formatter<gcs::ConstraintID> : fmt::formatter<std::string>
-{
-    auto format(const gcs::ConstraintID & constraint_id, fmt::format_context & ctx) const
-    {
-        return fmt::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
-    }
-};
-#endif
 
 #endif

--- a/gcs/constraint_id.hh
+++ b/gcs/constraint_id.hh
@@ -1,0 +1,74 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINT_ID_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINT_ID_HH
+
+#include <string>
+#include <variant>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+#else
+#include <fmt/core.h>
+#endif
+
+namespace gcs
+{
+    struct CurrentlyUnnamedConstraint final
+    {
+        [[nodiscard]] auto operator<=>(const CurrentlyUnnamedConstraint &) const = default;
+        [[nodiscard]] auto as_string() const -> std::string
+        {
+            return "unnamed";
+        }
+    };
+
+    struct NumberedConstraint final
+    {
+        unsigned long long number;
+        [[nodiscard]] auto operator<=>(const NumberedConstraint &) const = default;
+        [[nodiscard]] auto as_string() const -> std::string
+        {
+            return "_" + std::to_string(number);
+        }
+    };
+
+    struct NamedConstraint final
+    {
+        std::string name;
+        [[nodiscard]] auto operator<=>(const NamedConstraint &) const = default;
+        [[nodiscard]] auto as_string() const -> std::string
+        {
+            return name;
+        }
+    };
+
+    // The *identity* of a constraint (`_1`, `_2`, or a caller-given name) -- not
+    // its type (`abs`, `all_different`, ...). Kept distinct from "name" because
+    // both readings of that word kept getting confused.
+    using ConstraintID = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
+
+    [[nodiscard]] auto as_string(const ConstraintID &) -> std::string;
+}
+
+// The following is needed to allow ConstraintID to be used in format strings.
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+template <>
+struct std::formatter<gcs::ConstraintID> : std::formatter<std::string>
+{
+    auto format(const gcs::ConstraintID & constraint_id, std::format_context & ctx) const
+    {
+        return std::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
+    }
+};
+#else
+template <>
+struct fmt::formatter<gcs::ConstraintID> : fmt::formatter<std::string>
+{
+    auto format(const gcs::ConstraintID & constraint_id, fmt::format_context & ctx) const
+    {
+        return fmt::formatter<std::string>::format(gcs::as_string(constraint_id), ctx);
+    }
+};
+#endif
+
+#endif

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -12,18 +12,27 @@ using std::vector;
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const string & constraint_id, const vector<gcs::IntegerVariableID> & vars) -> void
+auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const ConstraintID & constraint_id, const vector<gcs::IntegerVariableID> & vars) -> void
 {
+    auto id_label = as_string(constraint_id);
 
     for (unsigned i = 0; i < vars.size(); ++i)
         for (unsigned j = i + 1; j < vars.size(); ++j) {
-            auto selector = model.create_proof_flag("notequals");
-            // cake_pb_cp labels the pair (i, j): @c[id][<i>lt<j>] is vars[i] < vars[j]
-            // (the "lower" half), @c[id][<i>gt<j>] is vars[i] > vars[j] ("higher").
-            model.add_labelled_constraint(constraint_id, to_string(i) + "lt" + to_string(j),
-                "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
-            model.add_labelled_constraint(constraint_id, to_string(i) + "gt" + to_string(j),
-                "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
+            // Conform to cake_pb_cp's naming so workflow-2 byte-matches (#354):
+            // the pair selector is the position-indexed x[id][i_j] (cake's
+            // Indices [i;j] flag), TRUE meaning vars[i] > vars[j] (the "higher"
+            // half), with the "lower" half reified on its negation. cake labels
+            // the pair the same way: @c[id][<i>lt<j>] is the lower half
+            // (vars[i] < vars[j]), @c[id][<i>gt<j>] the higher. The proof never
+            // references these selectors by name (the propagator's justifications
+            // RUP over the variable literals), so the name/polarity are free to
+            // match cake without touching any proof step.
+            auto selector = model.create_proof_flag(constraint_id,
+                {static_cast<long long>(i), static_cast<long long>(j)});
+            model.add_labelled_constraint(id_label, to_string(i) + "lt" + to_string(j),
+                "AllDifferent", "not equals because lower", WPBSum{} + 1_i * vars[i] + -1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{! selector});
+            model.add_labelled_constraint(id_label, to_string(i) + "gt" + to_string(j),
+                "AllDifferent", "not equals because higher", WPBSum{} + -1_i * vars[i] + 1_i * vars[j] <= -1_i, HalfReifyOnConjunctionOf{selector});
         }
 }
 

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -22,7 +22,7 @@ namespace gcs
         // appears more than once in `vars`, the resulting pair-of-half-reified
         // constraints is jointly inconsistent — both polarities of the
         // selector are forced false.
-        auto define_clique_not_equals_encoding(ProofModel & model, const std::string & constraint_id,
+        auto define_clique_not_equals_encoding(ProofModel & model, const ConstraintID & constraint_id,
             const std::vector<IntegerVariableID> & vars) -> void;
 
         // Emits the AllDifferentExcept clique encoding. Where the same variable

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -626,7 +626,7 @@ auto GACAllDifferent::prepare(Propagators &, State & initial_state, ProofModel *
 
 auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
+    define_clique_not_equals_encoding(model, _constraint_id, _sanitised_vars);
 }
 
 auto GACAllDifferent::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -113,7 +113,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
                 WPBSum{} + 1_i * (_vars[j] != Integer(i) + _start) + 1_i * (_vars[i] == Integer(j) + _start) >= 1_i);
         }
 
-    define_clique_not_equals_encoding(model, as_string(_constraint_id), _vars);
+    define_clique_not_equals_encoding(model, _constraint_id, _vars);
 
     // Per-value am1s for the alldiff hall-set / SCC justifications,
     // built once at the root.

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -143,7 +143,7 @@ auto VCAllDifferent::prepare(Propagators &, State & initial_state, ProofModel * 
 
 auto VCAllDifferent::define_proof_model(ProofModel & model) -> void
 {
-    define_clique_not_equals_encoding(model, as_string(_constraint_id), _sanitised_vars);
+    define_clique_not_equals_encoding(model, _constraint_id, _sanitised_vars);
 }
 
 auto VCAllDifferent::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -176,7 +176,7 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
     else {
         // Still need to define the all different encoding.
         if (model)
-            define_clique_not_equals_encoding(*model, as_string(_constraint_id), _succ);
+            define_clique_not_equals_encoding(*model, _constraint_id, _succ);
     }
 
     // Define encoding to eliminate sub-cycles

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1236,6 +1236,37 @@ auto NamesAndIDsTracker::create_proof_flag(const string & name) -> ProofFlag
     return result;
 }
 
+auto NamesAndIDsTracker::create_proof_flag(const ConstraintID & id, const vector<long long> & indices,
+    const optional<string> & annotation) -> ProofFlag
+{
+    // Mirror cake_pb_cp's Indices flag rendering (cp_to_ilpScript.sml format_flag):
+    // x[id][i1_i2..][annotation?] -- the index list joined by '_', the optional
+    // annotation in its own brackets.
+    string name = "x[" + as_string(id) + "][";
+    for (size_t k = 0; k < indices.size(); ++k) {
+        if (k != 0)
+            name += "_";
+        name += to_string(indices[k]);
+    }
+    name += "]";
+    if (annotation)
+        name += "[" + *annotation + "]";
+    return make_proof_flag_named(name);
+}
+
+auto NamesAndIDsTracker::make_proof_flag_named(const string & full_name) -> ProofFlag
+{
+    // The supplied name is used verbatim as the PB-file variable name (rather
+    // than wrapped in `f[index][...]`), so the same string is both the tracked
+    // name and the verbose rendering. See the header for why.
+    ProofFlag result{allocate_flag_index(), true};
+    track_variable_name(result, full_name);
+    auto flagvar = allocate_flag_xliteral(result, full_name);
+    _imp->flags.emplace(result, flagvar);
+    _imp->flags.emplace(! result, ! flagvar);
+    return result;
+}
+
 auto NamesAndIDsTracker::pb_file_string_for(const XLiteral & lit) const -> string
 {
     if (_imp->verbose_names) {
@@ -1401,14 +1432,13 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
     return result;
 }
 
-auto NamesAndIDsTracker::allocate_xliteral_meaning(ProofFlag flag) -> XLiteral
+auto NamesAndIDsTracker::allocate_flag_xliteral(ProofFlag flag, const string & verbose_name) -> XLiteral
 {
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
-        string name = format("f[{}][{}]", flag.index, name_of(flag));
-        _imp->xlits_to_verbose_names.emplace(result, name);
-        _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
+        _imp->xlits_to_verbose_names.emplace(result, verbose_name);
+        _imp->xlits_to_verbose_names.emplace(! result, "~" + verbose_name);
     }
 
     if (_imp->variables_map_file) {
@@ -1425,6 +1455,11 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(ProofFlag flag) -> XLiteral
     }
 
     return result;
+}
+
+auto NamesAndIDsTracker::allocate_xliteral_meaning(ProofFlag flag) -> XLiteral
+{
+    return allocate_flag_xliteral(flag, format("f[{}][{}]", flag.index, name_of(flag)));
 }
 
 auto NamesAndIDsTracker::allocate_xliteral_meaning_negative_bit_of(SimpleOrProofOnlyIntegerVariableID id, Integer power) -> XLiteral

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_VARIABLE_CONSTRAINTS_TRACKER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_VARIABLE_CONSTRAINTS_TRACKER_HH
 
+#include <gcs/constraint_id.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
@@ -19,6 +20,7 @@
 #include <string>
 #include <utility>
 #include <variant>
+#include <vector>
 #include <version>
 
 #ifdef __cpp_lib_generator
@@ -70,6 +72,17 @@ namespace gcs::innards
         std::unique_ptr<Imp> _imp;
 
         [[nodiscard]] auto allocate_flag_index() -> unsigned long long;
+
+        // Allocate the XLiteral backing a flag, registering `verbose_name` (and
+        // its negation) as the PB-file rendering. Shared by create_proof_flag
+        // (which passes the `f[index][stem]` form) and make_proof_flag_named
+        // (which passes a fully-formed two-level name verbatim).
+        [[nodiscard]] auto allocate_flag_xliteral(ProofFlag flag, const std::string & verbose_name) -> XLiteral;
+
+        // Create a flag whose PB-file variable name is `full_name` verbatim
+        // (rather than wrapped in `f[index][...]`). The cake-conforming
+        // create_proof_flag overloads build cake's `x[...]` (etc.) names and call this.
+        [[nodiscard]] auto make_proof_flag_named(const std::string & full_name) -> ProofFlag;
 
         auto emit_proof_line_now_or_at_start(const std::function<auto(ProofLogger * const)->void> &) -> void;
 
@@ -386,9 +399,32 @@ namespace gcs::innards
         auto track_bounds(const SimpleOrProofOnlyIntegerVariableID & id, Integer, Integer) -> void;
 
         /**
-         * Create a proof flag with a new identifier.
+         * Create a proof flag with a new identifier, named `f[index][stem]`.
          */
-        [[nodiscard]] auto create_proof_flag(const std::string &) -> ProofFlag;
+        [[nodiscard]] auto create_proof_flag(const std::string & stem) -> ProofFlag;
+
+        /**
+         * Create a position-indexed flag named `x[id][i1_i2..][annotation?]`,
+         * conforming to cake_pb_cp's naming for verified encodings (workflow 2)
+         * rather than the solver's default `f[index][stem]`.
+         *
+         * This mirrors cake's `Indices (num list) (annotation option)` flag
+         * constructor (cp_to_ilpScript.sml `format_flag`): the indices are the
+         * array positions the auxiliary ranges over, joined by `_`, and the
+         * optional annotation is appended in its own brackets. So an
+         * all_different pair selector is `create_proof_flag(id, {i, j})` ->
+         * `x[id][i_j]`, and a count per-position flag is
+         * `create_proof_flag(id, {i}, "eq")` -> `x[id][i][eq]`.
+         *
+         * cake's prefix encodes what the auxiliary is indexed by, not whether it
+         * is reified: `x` = array positions (this method), `b` = a scalar flag
+         * with only an annotation (`Flag`), `v` = values (`Values`). The `b` / `v`
+         * families get their own entry points when their first consumers land.
+         * Because VeriPB binds variables by name, a flag the solver's proof shares
+         * with cake's re-derived OPB must be defined under cake's name. See #354.
+         */
+        [[nodiscard]] auto create_proof_flag(const ConstraintID & id, const std::vector<long long> & indices,
+            const std::optional<std::string> & annotation = std::nullopt) -> ProofFlag;
 
         /**
          * Reify a PB constraint on a conjunction of ProofFlags or ProofLiterals

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -446,6 +446,12 @@ auto ProofModel::create_proof_flag(const string & name) -> ProofFlag
     return names_and_ids_tracker().create_proof_flag(name);
 }
 
+auto ProofModel::create_proof_flag(const ConstraintID & id, const vector<long long> & indices,
+    const optional<string> & annotation) -> ProofFlag
+{
+    return names_and_ids_tracker().create_proof_flag(id, indices, annotation);
+}
+
 auto ProofModel::finalise() -> void
 {
     _imp->finalised = true;

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_MODEL_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_MODEL_HH
 
+#include <gcs/constraint_id.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
@@ -199,7 +200,15 @@ namespace gcs::innards
         [[nodiscard]] auto create_proof_only_integer_variable(Integer, Integer, const std::string &,
             const IntegerVariableProofRepresentation enc) -> ProofOnlySimpleIntegerVariableID;
 
-        [[nodiscard]] auto create_proof_flag(const std::string &) -> ProofFlag;
+        [[nodiscard]] auto create_proof_flag(const std::string & stem) -> ProofFlag;
+
+        /**
+         * Create a position-indexed flag named `x[id][i1_i2..][annotation?]`,
+         * conforming to cake_pb_cp's naming for verified encodings. See
+         * NamesAndIDsTracker::create_proof_flag(const ConstraintID &, const std::vector<long long> &, ...).
+         */
+        [[nodiscard]] auto create_proof_flag(const ConstraintID & id, const std::vector<long long> & indices,
+            const std::optional<std::string> & annotation = std::nullopt) -> ProofFlag;
 
         /**
          * Set up proof logging for an integer variable with the specified bounds,

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -49,12 +49,13 @@ add_scp_chain_test(multi_mixed_unsat        strict)  # comparison + linear toget
 add_scp_chain_test(not_equals_sat       aux)
 add_scp_chain_test(lin_not_equals_sat   aux)
 
-# none (chain-only): all_different's per-pair selector has the *opposite* polarity
-# to cake's (the deferred conform-the-solver item), and multiple identical-looking
-# selectors defeat aux-name matching anyway -- so the chain (which verifies
-# regardless: the flag is existential) is the oracle here, not opbdiff.
-add_scp_chain_test(all_different_unsat  none)
-add_scp_chain_test(all_different_sat    none)
+# strict: all_different's per-pair selector is now named x[id][i_j] with cake's
+# polarity (selector TRUE = "higher"), via create_proof_flag_with_verbose_name --
+# the first consumer of the two-level aux-naming primitive (#354). The proof never
+# references the selectors by name, so this is purely an OPB-definition conform and
+# the encoding now byte-matches cake's.
+add_scp_chain_test(all_different_unsat  strict)
+add_scp_chain_test(all_different_sat    strict)
 
 # none (chain-only): a {0,1} model variable is encoded as a single tautological
 # line on i[v][b0], where cake emits two bound lines (lb + ub) on the same i[v][b0]


### PR DESCRIPTION
Closes the keystone pilot of #354 (part of #353).

## The problem

The verified-encoding chain (workflow 2) has `cake_pb_cp` re-derive the OPB, then VeriPB elaborates the solver's proof against *cake's* OPB. cake names auxiliaries by **what they are indexed over** (`cp_to_ilpScript.sml` `format_flag`): `x[id][i1_i2..][annot?]` for array-position-indexed flags (`Indices`), `v[…]` for value-indexed (`Values`), `b[id][ann]` for a scalar flag (`Flag`). The solver instead names every proof flag `f[index][stem]`. Because VeriPB binds variables by name, a flag the solver's proof shares with cake's OPB is a hard mismatch — the single biggest blocker for the counting / extensional family.

After #351 made *count* differences tolerable, this is purely a **naming** problem.

## The API

A `create_proof_flag` **overload taking `(ConstraintID, index list, optional annotation)`** that names the flag `x[id][i1_i2..][annot?]`, mirroring cake's `Indices` constructor — on `NamesAndIDsTracker`, mirrored on `ProofModel`. Call sites pass the owning constraint's identity and the array positions the auxiliary ranges over, not a hand-formatted string: an all_different pair selector is `create_proof_flag(id, {i, j})`. The existing `create_proof_flag(stem)` (→ `f[index][stem]`) is unchanged. The `b` (scalar `Flag`) and `v` (`Values`) families get their own entry points when their first consumers land.

Internally the overload builds the name and feeds a private `make_proof_flag_named()`; `allocate_xliteral_meaning(ProofFlag)` is refactored onto a shared `allocate_flag_xliteral()` helper.

So the proof layer can name a flag by its owning constraint's **identity** without depending on `Constraint` itself, the `ConstraintID` variant (+ parts, `as_string`, formatter) move from `constraint.hh` to a new lightweight **`gcs/constraint_id.hh`**, parallel to `gcs/variable_id.hh`. `constraint.hh` re-includes it, so existing users are unaffected.

## Pilot consumer: all_different

`define_clique_not_equals_encoding`'s pair selector is now `x[id][i_j]` (`Indices [i;j]`) with cake's polarity (selector **TRUE = the "higher" half**), where it was `f[N][notequals]` with the *opposite* polarity. Both the name and the polarity flip are required for the canonical forms to match (opbdiff rewrites `~x = 1 − x`). The propagator's justifications RUP over the variable literals and **never reference the selectors by name**, so this is purely an OPB-definition conform — no proof step changes. `define_clique_not_equals_encoding` now takes a `ConstraintID` (was a pre-stringified label), threaded from its four callers (gac / vc / symmetric all_different, circuit).

## Result

`all_different_unsat` and `all_different_sat` now chain-verify in **strict** (byte-match) opbdiff mode. Full suite green (**344/344**), including the large Hall-set/SCC `all_different_constraint`, the view-mixed variants, and circuit (shares the clique encoding).

## Follow-ups

count is the next consumer (#356, stacked) and confirmed the API generalises. The `b`/`v` families slot in at the comparison/not_equals and value-indexed consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)