### PR TITLE
Proof names: render negative values with '-', not "minus"

### DIFF
--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1338,11 +1338,11 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
-        string value_name;
-        if (value < 0_i)
-            value_name = "minus" + abs(value).to_string();
-        else
-            value_name = value.to_string();
+        // Negative values render with a leading '-' (e.g. i[X][eq-1]). The VeriPB
+        // 3.0 grammar permits '-' anywhere except the first character of a name
+        // (which the surrounding i[...] / p[...] always supplies), so this is a
+        // legal name and matches cake_pb_cp's rendering directly.
+        auto value_name = value.to_string();
 
         overloaded{
             [&](const SimpleIntegerVariableID & id) -> void {
@@ -1393,9 +1393,9 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
-        auto value_name = [](Integer v) {
-            return v < 0_i ? "minus" + abs(v).to_string() : v.to_string();
-        };
+        // Negatives render with a leading '-' (legal mid-name in VeriPB 3.0; see
+        // the eq/ge case above), matching cake_pb_cp.
+        auto value_name = [](Integer v) { return v.to_string(); };
 
         overloaded{
             [&](const SimpleIntegerVariableID & id) -> void {


### PR DESCRIPTION
## What

The verbose-names variable encoder spelled negative values as `minusN`
(`i[X][eqminus1]`, `i[X][inminus2_0]`) on the belief that a raw `-` is
invalid in a VeriPB variable name. **That belief is wrong.** The VeriPB
3.0 grammar's variable token (from `veripb-parser`) is:

```
[a-zA-Z_][_a-zA-Z0-9\-\^\[\]\{\}]+
```

so `-` is legal **anywhere except the first character** — and the
surrounding `i[...]` / `p[...]` prefix always supplies a leading letter.
This drops the `minus` workaround in both `allocate_xliteral_meaning`
overloads (eq/ge order literals and `in[lo_hi]` interval literals);
`Integer::to_string()` already renders the sign.

## Why

cake_pb_cp renders negatives with `-` (`int_to_string #"-"`), so the old
`minus` spelling diverged from cake on *every* negative value name — a
self-inflicted gap in the workflow-2 `opbdiff` byte-match oracle. With
this change negative-domain encodings byte-match cake directly.

## Verification

- veripb 3.0.2 accepts `-` mid-name (regex + a hand-built `s VERIFIED`
  refutation referencing a dash-named variable).
- 62 negative-value order-literal names (`i[_][eq-N]`/`[ge-N]`) in
  `n_value_test`'s generated proof verify under veripb.
- A negative-domain `count` instance passes the full chain in **strict**
  mode (`opbdiff` byte-match against cake).
- 37/37 `scp_chain` + 111/111 order-encoding constraint tests
  (n_value, element, count, all_different, among, gcc, in, equals,
  linear, abs, table, smart_table, minizinc variants) pass with proof.
- No `minus`/`eqminus`/`geminus` references remain anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)