### PR TITLE
Render negative proof values as -N, matching cake (#354)

### DIFF
--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1284,13 +1284,12 @@ auto NamesAndIDsTracker::create_proof_flag_values(const ConstraintID & id, const
     for (size_t k = 0; k < values.size(); ++k) {
         if (k != 0)
             name += "_";
-        // Negatives are spelled `minusN`, matching the solver's value-naming
-        // everywhere else (e.g. the eq literals i[X][eqminusN]). cake instead
-        // renders them `-N` (format_int_list), so negative-domain cases diverge
-        // from cake on value spelling -- the same naming gap as the eq literals
-        // (cake's eq-N vs the solver's eqminusN), part of the #358 family. For a
-        // non-negative domain (the common nvalue case) the two coincide.
-        name += values[k] < 0 ? "minus" + to_string(-values[k]) : to_string(values[k]);
+        // Negative values are rendered `-N`, matching cake's format_int_list and
+        // the solver's eq/ge literals (i[X][eq-N]). VeriPB allows '-' in both
+        // variable names and @labels (VeriPB-dev #191), so this is legal in the
+        // labelled flag definitions too and byte-matches cake over negative
+        // domains.
+        name += to_string(values[k]);
     }
     name += "]";
     if (annotation)
@@ -1373,11 +1372,9 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
-        string value_name;
-        if (value < 0_i)
-            value_name = "minus" + abs(value).to_string();
-        else
-            value_name = value.to_string();
+        // Negative values render as `-N` (matching cake); '-' is legal in both
+        // VeriPB variable names and @labels (VeriPB-dev #191).
+        string value_name = value.to_string();
 
         overloaded{
             [&](const SimpleIntegerVariableID & id) -> void {
@@ -1428,8 +1425,10 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
+        // Negative values render as `-N` (matching cake); '-' is legal in both
+        // VeriPB variable names and @labels (VeriPB-dev #191).
         auto value_name = [](Integer v) {
-            return v < 0_i ? "minus" + abs(v).to_string() : v.to_string();
+            return v.to_string();
         };
 
         overloaded{

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -446,9 +446,9 @@ namespace gcs::innards
          * `create_proof_flag_values(id, {v})` -> `v[id][v]`. A distinct name (not
          * an overload of create_proof_flag) because the value-list signature
          * would otherwise be indistinguishable from the `x[...]` one. Negative
-         * values are spelled `minusN` (the solver's convention, e.g. eq literals
-         * `eqminusN`); cake uses `-N`, so negative domains diverge on value
-         * spelling -- see #354 / #358. See #354.
+         * values render as `-N`, matching cake (and the solver's eq/ge literals,
+         * e.g. `i[X][eq-N]`); '-' is legal in both VeriPB variable names and
+         * @labels (VeriPB-dev #191). See #354.
          */
         [[nodiscard]] auto create_proof_flag_values(const ConstraintID & id, const std::vector<long long> & values,
             const std::optional<std::string> & annotation = std::nullopt) -> ProofFlag;

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -106,17 +106,17 @@ add_scp_chain_test(element_unsat  none)
 add_scp_chain_test(nvalue_sat    none)
 add_scp_chain_test(nvalue_unsat  none)
 
-# DISABLED (temporarily omitted, cake-blocked): negative-domain nvalue. cake_pb_cp
-# renders negative values in its labels verbatim (@v[id][-N], @i[X][eq-N]/[ge-N]),
-# but VeriPB 3.0's label grammar (@[a-zA-Z0-9_^\[\]\{\}]+) forbids '-' -- it is
-# allowed in *variable* names ([a-zA-Z_][_a-zA-Z0-9\-...]+) but not labels -- so
-# veripb rejects cake's OPB at the elaboration step. The solver side is fine (it
-# spells negatives "minus", a legal label). This is a cake-side issue (reported
-# upstream); re-enable once cake renders negative values dash-free in labels. Every
-# other family routes negatives through bit-encoding / non-value labels and chain-
-# verifies (equals/not_equals/less_than/all_different/count even byte-match strict).
+# none (chain-only): negative-domain nvalue. cake_pb_cp renders negative values
+# in its labels verbatim (@v[id][-N], @i[X][eq-N]/[ge-N]); VeriPB-dev #191 settled
+# that '-' is legal in @labels (it was already legal in variable names), so veripb
+# now parses cake's OPB. The solver previously spelled negatives "minus", which
+# made its proof reference i[X][eqminusN] while cake's OPB defined i[X][eq-N] -- a
+# different variable to veripb, so the elaboration failed. The solver now renders
+# negatives `-N` everywhere (eq/ge literals and v[...] flags), so its proof and
+# cake's OPB agree on the variables and the chain verifies. Stays `none` because
+# byte-match is still gated by the lazy-vs-eager variable encoding (#358), as for
+# the positive nvalue cases above.
 add_scp_chain_test(nvalue_neg_sat none)
-set_tests_properties(scp_chain_nvalue_neg_sat PROPERTIES DISABLED TRUE)
 
 # none (chain-only): reified equality, all four modes of ReifiedEquals -- the b[...]
 # family's reified consumer (#354). cake's encode_equal (-iff) splits the equality


### PR DESCRIPTION
Now that VeriPB allows `-` in `@labels` (VeriPB-dev #191; it was already legal in variable names), the solver no longer needs the `minusN` workaround for negative values in proof names.

## Problem
The solver derived constraint labels from variable names, so to stay within the old label grammar it spelled negative values `minusN` (e.g. the eq literal `i[X][eqminus1]`, the value flag `v[id][minus1]`). cake_pb_cp renders the same values `-N`. In workflow 2 (solver proof elaborated against cake's re-derived OPB) this meant the proof referenced `i[X][eqminus1]` while cake's OPB defined `i[X][eq-1]` — distinct variables to VeriPB — so negative-domain `nvalue` failed to elaborate and its test was `DISABLED`.

## Change
Render negatives as `-N` everywhere the solver emits a value into a proof name:
- `allocate_xliteral_meaning` — eq/ge literals (`i[X][eq-1]`, `i[X][ge-1]`) and interval literals (`i[X][in-2_-1]`);
- `create_proof_flag_values` — the value-indexed `v[...]` flags (`v[id][-1]`).

Non-negative values are unchanged, so the only proofs affected are those that put a negative value into a name. The naming function writes both the OPB definitions and the proof references, so workflow-1 self-verification stays internally consistent.

## Result
- Re-enables `scp_chain_nvalue_neg_sat` (was `DISABLED`): negative-domain nvalue now chain-verifies against cake — `s VERIFIED COMPLETE ENUMERATION OF 9 SOLUTIONS`. It stays `none` (chain-only) because byte-match is still gated by the lazy-vs-eager variable encoding (#358).
- Full suite green: 357/357 ctest, 46/46 scp_chain (the strict negative-domain cases `lin_equals_neg_coeff_sat` / `greater_equal_neg_unsat` are unaffected — their negatives ride the bit encoding, not value labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)