### PR TITLE
verified_encodings: find cake_pb_cp on PATH, not a hardcoded path (#368)

### DIFF
--- a/dev_docs/workflow2_testing.md
+++ b/dev_docs/workflow2_testing.md
@@ -31,7 +31,10 @@ One ctest per case. **Where `cake_pb_cp` is absent** (e.g. GitHub CI, where
 building CakeML is awkward) the runner degrades to a workflow-1 self-verify
 (`veripb` on the solver's *own* OPB/pbp) rather than skipping, so the case is
 still exercised; it skips (`SKIP_RETURN_CODE 77`) only when `veripb` itself is
-absent. The `(enumerate)` `.scp` element (so cake emits `preserved:`) means
+absent. To run the full chain locally rather than the fallback, put `cake_pb_cp`
+on `PATH` (alongside `veripb`/`opbdiff`, e.g. symlinked into `~/.cargo/bin`) or
+point `CAKE_PB_CP` at the built binary. The `(enumerate)` `.scp` element (so cake
+emits `preserved:`) means
 **SAT cases verify by complete enumeration** — not just UNSAT — so the table can
 exercise the naturally-satisfiable forms too.
 

--- a/verified_encodings/run_cake_pb_cp.bash
+++ b/verified_encodings/run_cake_pb_cp.bash
@@ -25,13 +25,14 @@ shift || true
 
 export PATH=$HOME/.cargo/bin:$PATH
 
-# The prebuilt cake_pb_cp is not generally installed; allow an override.
-CAKE_PB_CP=${CAKE_PB_CP:-$HOME/claude/CakePB-dev/cp/cake_pb_cp}
+# cake_pb_cp is found on PATH, like veripb and opbdiff; the prebuilt binary is not
+# generally installed, so set CAKE_PB_CP to an explicit path to override.
+CAKE_PB_CP=${CAKE_PB_CP:-cake_pb_cp}
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
-if [[ ! -x "$CAKE_PB_CP" ]]; then
-    echo "SKIP: cake_pb_cp not found at '$CAKE_PB_CP' (set CAKE_PB_CP to override)"
+if ! have "$CAKE_PB_CP"; then
+    echo "SKIP: cake_pb_cp not on PATH (set CAKE_PB_CP=/path/to/cake_pb_cp to override)"
     exit 77
 fi
 if ! have veripb; then

--- a/verified_encodings/run_scp_chain.bash
+++ b/verified_encodings/run_scp_chain.bash
@@ -31,7 +31,10 @@ scp=$2
 opbdiff_mode=${3:-strict}
 
 export PATH=$HOME/.cargo/bin:$PATH
-CAKE_PB_CP=${CAKE_PB_CP:-$HOME/claude/CakePB-dev/cp/cake_pb_cp}
+# cake_pb_cp is found on PATH, like veripb and opbdiff; set CAKE_PB_CP to an
+# explicit path to override. When it is absent the chain degrades to a workflow-1
+# self-verify below, so machines without a CakeML build (CI, contributors) pass.
+CAKE_PB_CP=${CAKE_PB_CP:-cake_pb_cp}
 
 have() { command -v "$1" >/dev/null 2>&1; }
 verified() { grep -qE '^s VERIFIED' <<< "$1"; }
@@ -46,10 +49,10 @@ set -e
 echo "[1] $(basename "$solver") --all --prove $(basename "$scp")"
 "$solver" --all --prove --proof-files-basename "$base" "$scp" > /dev/null
 
-if [[ ! -x "$CAKE_PB_CP" ]]; then
+if ! have "$CAKE_PB_CP"; then
     # cake_pb_cp unavailable -- fall back to a workflow-1 self-verify so the case
     # still gets checked (the solver's proof is valid against its own OPB).
-    echo "[fallback] cake_pb_cp not found at '$CAKE_PB_CP'; workflow-1 self-verify only"
+    echo "[fallback] cake_pb_cp not on PATH (set CAKE_PB_CP to override); workflow-1 self-verify only"
     out=$(veripb "${base}.opb" "${base}.pbp" 2>&1)
     if ! verified "$out"; then echo "FAIL: self-verify"; tail -5 <<< "$out"; exit 1; fi
     grep -E '^s VERIFIED' <<< "$out"


### PR DESCRIPTION
Closes #368 (thanks @mmcilree).

## Problem
Both workflow-2 test runners defaulted `CAKE_PB_CP` to `$HOME/claude/CakePB-dev/cp/cake_pb_cp` — a machine-specific path baked into checked-in scripts. (As Matthew noted on the issue, the tests don't actually *fail* without it — `run_scp_chain.bash` already degrades to a workflow-1 self-verify — but the hardcoded path is wrong regardless.)

## Change
Discover `cake_pb_cp` on `PATH` via the existing `have` helper, exactly as `veripb` and `opbdiff` already are. `CAKE_PB_CP` still overrides with an explicit path.

- `run_scp_chain.bash` — unchanged fallback: absent `cake_pb_cp` ⇒ workflow-1 self-verify (CI / no-CakeML contributors pass).
- `run_cake_pb_cp.bash` — unchanged skip: absent `cake_pb_cp` ⇒ `SKIP_RETURN_CODE 77`.
- `dev_docs/workflow2_testing.md` — documents how to enable the full chain locally (put `cake_pb_cp` on `PATH`, e.g. symlinked into `~/.cargo/bin`, or set `CAKE_PB_CP`).

## Verified
- Full chain via PATH discovery (no env set): passes.
- Genuine fallback (bogus absolute override *and* bare not-on-PATH name): both exit 0 via workflow-1 self-verify.
- `run_cake_pb_cp.bash` with absent cake: skips (77).
- `ctest -R 'scp_chain|verified|cake'`: 50/50 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)