### PR TITLE
Parity: conform to cake's parity (Xs) Y and add to the workflow-2 chain (#354)

### DIFF
--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -141,11 +141,14 @@ auto ParityOdd::s_exprify(const innards::ProofModel * const model) const -> stri
 {
     stringstream s;
 
-    print(s, "{} xor (", _constraint_id);
+    // cake_pb_cp encodes parity as `parity (X1 ... Xn) Y` meaning Y = XOR(Xi).
+    // ParityOdd is the bare odd-parity assertion XOR(Xi) = 1, so we write the
+    // constant Y = 1 (1 = XOR(Xi) <-> XOR(Xi) = 1). The scp_reader requires Y = 1.
+    print(s, "{} parity (", _constraint_id);
     for (const auto & lit : _lits) {
         print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
     }
-    print(s, ")");
+    print(s, " ) 1");
 
     return s.str();
 }

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -11,6 +11,7 @@
 #include <gcs/constraints/logical.hh>
 #include <gcs/constraints/minus.hh>
 #include <gcs/constraints/n_value.hh>
+#include <gcs/constraints/parity.hh>
 #include <gcs/constraints/plus.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/s_expr.hh>
@@ -364,6 +365,18 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
             post_constraint(problem,
                 Or{resolve_variable_list(variables, terms[2], "the or variable list"),
                     resolve_variable(variables, terms[3])},
+                label);
+        }
+        else if (op == "parity") {
+            // (label parity (X1 ... Xn) Y): cake encodes Y = XOR(Xi). The solver
+            // only has the bare odd-parity constraint (ParityOdd, XOR(Xi) = 1),
+            // which it writes with the constant Y = 1, so require that here.
+            if (terms.size() != 4)
+                throw ScpReadError{"parity takes (label parity (vars...) 1)"};
+            if (as_integer(terms[3]) != Integer{1})
+                throw ScpReadError{"parity Y must be the constant 1 (only bare odd parity is supported)"};
+            post_constraint(problem,
+                ParityOdd{resolve_variable_list(variables, terms[2], "the parity variable list")},
                 label);
         }
         else if (op == "plus") {

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -171,6 +171,19 @@ add_scp_chain_test(binary_equals_unsat    none)
 add_scp_chain_test(and_sat      none)
 add_scp_chain_test(or_sat       none)
 
+# none (chain-only): parity (ParityOdd). cake's `parity (Xs) Y` encodes Y = XOR(Xs);
+# the solver's bare odd-parity XOR(Xs)=1 is written as `parity (Xs) 1`. cake builds
+# the same chain of arc-consistent XOR gadgets the solver does (seed + 4 clauses per
+# input + final pin), and the propagator's RUP inferences verify against it directly
+# (no pol scaffolding) -- it only fires with <=1 input free, so unit propagation
+# threads through the chain. Inputs are {0,1}, so it diverges from cake only on the
+# binary lb/ub boundary lines (the #358 subcase, as for and/or) -> none, not strict.
+# parity_unsat forces the conflict over *free* vars (parity gives A!=B, equals gives
+# A=B) rather than fixed domains, which would drag in the ge0 ladder for the pinned
+# variable (also #358). SAT enumeration + UNSAT.
+add_scp_chain_test(parity_sat    none)
+add_scp_chain_test(parity_unsat  none)
+
 # none (chain-only): inverse channeling chain-verifies; it references the
 # variables' own eq/ge literals, so it trips the same lazy-vs-eager variable-
 # encoding gap as element (#358) (cake's full ge0 ladder + eq0 <=> ge0 & ~ge1),

--- a/verified_encodings/scp_cases/parity_sat.scp
+++ b/verified_encodings/scp_cases/parity_sat.scp
@@ -1,0 +1,1 @@
+( ( (A 0 1) (B 0 1) (C 0 1) ) ( (_1 parity ( A B C ) 1) ) (enumerate) )

--- a/verified_encodings/scp_cases/parity_unsat.scp
+++ b/verified_encodings/scp_cases/parity_unsat.scp
@@ -1,0 +1,1 @@
+( ( (A 0 1) (B 0 1) ) ( (_1 parity ( A B ) 1) (_2 equals A B) ) )


### PR DESCRIPTION
Brings `ParityOdd` into the verified-encoding (workflow-2) chain.

## Mapping
cake_pb_cp encodes `parity (X1..Xn) Y` as `Y = XOR(Xi)`. The solver's `ParityOdd` is the bare odd-parity assertion `XOR(Xi) = 1`, which is exactly `parity (Xi) 1` (`1 = XOR(Xi) ⟺ XOR(Xi) = 1`). So:
- `s_exprify` now writes `parity ( Xi ) 1` (was `xor`, which cake rejects as `unsupported constraint`);
- `scp_reader` parses `parity (vars) 1` → `ParityOdd` (`Y` must be the constant `1` — the only form the solver emits).

`define_proof_model` and the propagator are **unchanged**.

## Why RUP still suffices (no `pol` scaffolding)
cake builds the same chain of arc-consistent 4-clause XOR gadgets the solver does (seed + 4 clauses per input + final pin). The propagator only fires with ≤1 input free, so unit propagation threads through the chain. I verified against cake's OPB that inferring **any** single free input — including cake's *seed* `Y`, which needs backward propagation through the whole chain — and the all-set contradiction are all RUP-derivable, and that a bogus inference is correctly rejected. So the existing `JustifyUsingRUP` carries over directly.

## `none` (chain-verify), not strict
Parity's inputs are `{0,1}`, so the encoding diverges from cake only on the binary lb/ub boundary lines (the same `#358` subcase as `and`/`or`) — not on parity itself. `parity_unsat` forces its conflict over *free* vars (`parity` ⟹ `A≠B`, `equals` ⟹ `A=B`) rather than fixed domains, which would otherwise drag in the `ge0` ladder for a pinned variable (also `#358`).

## Verified
360/360 ctest, 49/49 scp_chain (`parity_sat` enumerates 4 solutions; `parity_unsat` refutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)