### PR TITLE
Finish the s_exprify -> s_expr migration; remove the legacy string writer

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -97,16 +97,17 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(
-            const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(
+            const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 ```
 
 `install` is rvalue-qualified (`&&`) — it consumes the Constraint
 object. `clone` produces a fresh independent copy (used by some search
-strategies). `s_exprify` produces a textual dump of the constraint for
-debugging.
+strategies). `s_expr` returns the constraint's `.scp` entry as a structured
+s-expression term `(name op args...)` (built with `innards::SExpr::list`/`atom`
+and `NamesAndIDsTracker::s_expr_term_of`); `innards::write_scp` serialises it.
 
 ## install: the entry point
 
@@ -638,7 +639,7 @@ correctness work wants the full enumeration check.
 1. Header file with class declaration, Doxygen comments, the standard
    trio of virtual methods.
 2. `.cc` file with constructor, `install` method (OPB block + propagator
-   registration), `clone`, `s_exprify`.
+   registration), `clone`, `s_expr`.
 3. Test file with the standard `for (bool proofs : {false, true})`
    loop and a `can_run_veripb()` gate on the proofs leg. Split into
    multiple ctest entries via an argv mode if the test gets slow.

--- a/dev_docs/scp_s_expr_migration.md
+++ b/dev_docs/scp_s_expr_migration.md
@@ -1,78 +1,51 @@
-# Migrating `s_exprify` → `s_expr` (structured `.scp` terms)
+# `s_exprify` → `s_expr` (structured `.scp` terms) — complete
 
-## Where we are
+## What this was
 
-A constraint's `.scp` entry used to be produced by `Constraint::s_exprify()`,
-which returned a hand-built string (the body of the `(name op args...)` list,
-without the enclosing parentheses; `solve()` added those). Every constraint did
-its own string formatting, which gave inconsistent spacing and nothing for a
-`.scp` *reader* to share.
+A constraint's `.scp` entry used to be produced by `Constraint::s_exprify()`, a
+hand-built string (the body of the `(name op args...)` list, without the
+enclosing parentheses; `write_scp` added them). Every constraint did its own
+string formatting, which gave inconsistent spacing and nothing for a `.scp`
+*reader* to share.
 
-We are moving to `Constraint::s_expr()`, which returns the term as a structured
-`innards::SExpr` (the full `(name op args...)` list). The stringification then
-happens once, centrally, in `innards::write_scp` (`gcs/innards/proofs/scp_writer.cc`),
-which is the sole `.scp` serialiser — `solve()` just calls it. The structured
-term is also what a future `.scp` reader will produce, so writer and reader share
-one representation and can be compared directly (`parse_s_expr(line) == c.s_expr()`).
+It now comes from `Constraint::s_expr()`, which returns the term as a structured
+`innards::SExpr` (the full `(name op args...)` list). Stringification happens
+once, centrally, in `innards::write_scp` (`gcs/innards/proofs/scp_writer.cc`),
+the sole `.scp` serialiser. The structured term is also what the `.scp` reader
+produces, so writer and reader share one representation and compare directly
+(`parse_s_expr(line) == c.s_expr()`). Output is canonical (single line,
+single-space) regardless of how a term is built.
 
-### Transitional bridge (current state)
+## Status: complete
 
-`Constraint` declares both methods, each with a default that derives it from the
-other (`gcs/constraint.cc`):
+`Constraint::s_expr()` is now **pure virtual** — every constraint overrides it —
+and the legacy `s_exprify()` method plus the transitional bridge (which derived
+each form from the other) have been removed (`gcs/constraint.hh`,
+`gcs/constraint.cc`). `write_scp` was already off `s_exprify()`, so nothing
+changed there.
 
-- `s_expr()` default: `parse_s_expr("(" + s_exprify() + ")")`
-- `s_exprify()` default: `to_string(s_expr().as_list())` (body, no outer parens)
+To build a term, use `innards::SExpr::list({...})` and `SExpr::atom(...)`, with
+`NamesAndIDsTracker::s_expr_term_of(...)` for operands — it has overloads for an
+`IntegerVariableID`, a `Literal` (the and/or/parity inputs), and a
+`ReificationCondition` (returns `nullopt` when unconditional). Integer atoms are
+`SExpr::atom(value.to_string())`. See `abs.cc` (simple) and `in.cc` (sub-lists)
+for the canonical shape.
 
-So a constraint overrides **exactly one**. Un-migrated constraints keep their
-`s_exprify()` string override and get `s_expr()` via the bridge; migrated ones
-override `s_expr()` and get `s_exprify()` for free. Overriding *neither* recurses
-— don't (a constraint must define its `.scp` form somehow).
+### Suspect forms resolved (not enshrined)
 
-Because `write_scp` goes through `s_expr()`, **every** constraint's output now
-passes through the parser, so it must be balanced, parseable s-expression text.
-Output is also canonicalised (single line, single-space) regardless of how the
-legacy string was formatted.
-
-Migrated so far: `abs`, the reified comparisons, GAC/VC `all_different`, `in`.
-
-## What's left
-
-Migrate the remaining 37 `s_exprify` overrides to `s_expr()` (build an `SExpr`
-instead of a string), then finish the cutover:
-
-1. Migrate each remaining constraint (list below) to override `s_expr()`.
-2. Resolve the **suspect forms** as they are migrated (don't enshrine them):
-   - **`GACArithmetic` double parentheses** — its `s_exprify()` already returns
-     `(name op ...)` *with* outer parens, so the writer double-wraps it to
-     `((name op ...))`. The bridge preserves this faithfully today; fix it when
-     migrating arithmetic (return the body, or a single list).
-   - **`element`** — the old comma-joined `elem,idx` atoms (and `(var,offset)`
-     index) were wrong: `cake_pb_cp` wants a bare varc list `(X0 ... Xn-1)` and a
-     space-separated `(var offset)` index. `s_exprify()` now emits that form (and
-     `element_2d` for the 2-D case); carry it over when migrating to `s_expr()`.
-   - **Multi-line tabular constraints** (`table`, `smart_table`, `regular`,
-     `knapsack`, …) currently emit pretty multi-line strings; via the bridge
-     these are already canonicalised to one line. Confirm that's acceptable when
-     migrating them.
-3. Once **all** constraints override `s_expr()`:
-   - Make `s_expr()` pure virtual.
-   - Delete the bridge defaults and the `s_exprify()` method entirely (or keep a
-     single non-virtual `to_string(s_expr())` convenience if any caller wants the
-     string body).
-   - `write_scp` is already off `s_exprify()`, so no change there.
+- **`GACArithmetic` double parentheses** — the old `s_exprify()` returned
+  `(name op ...)` *with* its own outer parens, so `write_scp` double-wrapped it to
+  `((name op ...))`. `s_expr()` returns the single proper list, fixing it.
+- **`element`** — keeps the corrected form `s_exprify()` had reached: a bare varc
+  list `(X0 ... Xn-1)` (and `((row) (row) ...)` for `element_2d`) plus a
+  space-separated `(var offset)` index, then the result.
+- **Multi-line tabular constraints** (`table`, `negative_table`, `smart_table`,
+  `regular`, `knapsack`, `sort`, `arg_sort`) — built as nested `SExpr` lists;
+  `write_scp` renders them on one canonical line (as the bridge already did).
 
 ## Bugs surfaced by routing the writer through the parser
 
 - **`inverse`, `arg_sort`** emitted a stray trailing `)` (they hand-wrote the
-  closing paren that `solve()` also adds), leaving the `.scp` unbalanced —
-  harmless only because nothing parsed it. Fixed in this change.
-
-## Remaining constraints (override still on `s_exprify`)
-
-all_different_except, symmetric_all_different, all_equal, among, arithmetic
-(Plus/Minus/Times/Div/Mod/Power — note double-paren above), at_most_one, circuit,
-count, cumulative, disjunctive, disjunctive_2d, element, equals,
-bounds/gac global_cardinality, increasing, inverse, knapsack, lex,
-lex_smart_table, linear_equality, linear_inequality, logical, min_max, minus,
-mult_bc, n_value, parity, plus, regular, seq_precede_chain, smart_table,
-arg_sort, sort, negative_table, table, value_precede.
+  closing paren that `write_scp` also adds), leaving the `.scp` unbalanced —
+  harmless only because nothing parsed it. Fixed during the bridge work; the
+  structured form is balanced by construction.

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -1,34 +1,9 @@
 #include <gcs/constraint.hh>
 #include <gcs/exception.hh>
-#include <gcs/innards/s_expr.hh>
-
-using std::string;
-using std::variant;
 
 using namespace gcs;
-using namespace gcs::innards;
-
-#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-using std::format;
-#else
-using fmt::format;
-#endif
 
 Constraint::~Constraint() = default;
-
-// Bridge between the structured s_expr() and the legacy string s_exprify(). A
-// constraint overrides exactly one; the other is derived here. s_expr() is the
-// full `(name op args...)` list, s_exprify() is its body without the enclosing
-// parentheses (the `#` alternate form), so they wrap/unwrap one level.
-auto Constraint::s_expr(const innards::ProofModel * const model) const -> SExpr
-{
-    return parse_s_expr("(" + s_exprify(model) + ")");
-}
-
-auto Constraint::s_exprify(const innards::ProofModel * const model) const -> string
-{
-    return format("{:#}", s_expr(model));
-}
 
 auto gcs::as_string(const ConstraintID & constraint_id) -> std::string
 {

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -87,21 +87,11 @@ namespace gcs
          * stringification happens once, centrally, and the structured term can
          * be compared against a parsed `.scp` line directly.
          *
-         * A constraint must override **exactly one** of s_expr() (preferred) or
-         * the legacy s_exprify(): by default s_expr() parses s_exprify()'s
-         * string and s_exprify() prints s_expr(), so overriding neither would
-         * recurse. New constraints should override s_expr(); the remaining
-         * legacy s_exprify() overrides are being migrated across (see
-         * dev_docs/scp_s_expr_migration.md), after which s_exprify() goes away.
+         * Every constraint overrides this. (It used to be derivable from a legacy
+         * string form, s_exprify(); that bridge has been removed now that all
+         * constraints build the structured term directly.)
          */
-        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr;
-
-        /**
-         * Legacy string form: the body of s_expr() *without* the enclosing
-         * parentheses (the historical `Constraint::s_exprify` contract). \see
-         * s_expr.
-         */
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr = 0;
     };
 }
 

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -193,17 +194,16 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto AllDifferentExcept::s_exprify(const ProofModel * const model) const -> string
+auto AllDifferentExcept::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} all_different_except (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars, excluded;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") (");
+        vars.push_back(tracker.s_expr_term_of(var));
     for (const auto & v : _excluded)
-        print(s, " {}", v);
-    print(s, ")");
-
-    return s.str();
+        excluded.push_back(SExpr::atom(v.to_string()));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("all_different_except"),
+        SExpr::list(std::move(vars)),
+        SExpr::list(std::move(excluded))});
 }

--- a/gcs/constraints/all_different/all_different_except.hh
+++ b/gcs/constraints/all_different/all_different_except.hh
@@ -48,7 +48,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     /**

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -178,14 +179,14 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
         triggers);
 }
 
-auto SymmetricAllDifferent::s_exprify(const ProofModel * const model) const -> string
+auto SymmetricAllDifferent::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} symmetric_all_different (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") {}", _start);
-
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("symmetric_all_different"),
+        SExpr::list(std::move(vars)),
+        SExpr::atom(_start.to_string())});
 }

--- a/gcs/constraints/all_different/symmetric_all_different.hh
+++ b/gcs/constraints/all_different/symmetric_all_different.hh
@@ -48,7 +48,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <memory>
@@ -147,11 +148,11 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
         return PropagatorState::Enable; }, triggers);
 }
 
-auto AllEqual::s_exprify(const ProofModel * const model) const -> string
+auto AllEqual::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-    print(s, "{} all_equal", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom("all_equal")};
     for (const auto & v : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    return s.str();
+        terms.push_back(tracker.s_expr_term_of(v));
+    return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/all_equal.hh
+++ b/gcs/constraints/all_equal.hh
@@ -35,7 +35,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/among.cc
+++ b/gcs/constraints/among.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -307,19 +308,17 @@ auto Among::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Among::s_exprify(const ProofModel * const model) const -> std::string
+auto Among::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} among (", _constraint_id);
-    for (const auto & var : _vars) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    }
-    print(s, ") (");
-    for (const auto & val : _values_of_interest) {
-        print(s, " {}", val);
-    }
-    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_how_many));
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> vars;
+    for (const auto & var : _vars)
+        vars.push_back(tracker.s_expr_term_of(var));
+    std::vector<SExpr> vals;
+    for (const auto & val : _values_of_interest)
+        vals.push_back(SExpr::atom(val.to_string()));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("among"),
+        SExpr::list(std::move(vars)),
+        SExpr::list(std::move(vals)),
+        tracker.s_expr_term_of(_how_many)});
 }

--- a/gcs/constraints/among.hh
+++ b/gcs/constraints/among.hh
@@ -34,7 +34,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/arithmetic.cc
+++ b/gcs/constraints/arithmetic.cc
@@ -3,6 +3,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -110,9 +111,8 @@ namespace gcs::innards
 }
 
 template <ArithmeticOperator op_>
-auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) const -> std::string
+auto GACArithmetic<op_>::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    // (name op v1 v2 result)
     string op_str;
     switch (op_) {
     case ArithmeticOperator::Plus: op_str = "plus"; break;
@@ -122,10 +122,10 @@ auto GACArithmetic<op_>::s_exprify(const innards::ProofModel * const model) cons
     case ArithmeticOperator::Mod: op_str = "mod"; break;
     case ArithmeticOperator::Power: op_str = "power"; break;
     }
-    stringstream s;
-    print(s, "({} {} {} {} {})", _constraint_id, op_str,
-        model->names_and_ids_tracker().s_expr_name_of(_v1),
-        model->names_and_ids_tracker().s_expr_name_of(_v2),
-        model->names_and_ids_tracker().s_expr_name_of(_result));
-    return s.str();
+    // The single (name op v1 v2 result) list. The old s_exprify built this *with*
+    // its own outer parens, which write_scp then double-wrapped to ((name ...));
+    // returning a structured term wraps exactly once.
+    auto & tracker = model->names_and_ids_tracker();
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(op_str),
+        tracker.s_expr_term_of(_v1), tracker.s_expr_term_of(_v2), tracker.s_expr_term_of(_result)});
 }

--- a/gcs/constraints/arithmetic.hh
+++ b/gcs/constraints/arithmetic.hh
@@ -53,7 +53,7 @@ namespace gcs
 
             virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
             virtual auto clone() const -> std::unique_ptr<Constraint> override;
-            [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+            [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         };
     }
 

--- a/gcs/constraints/at_most_one.cc
+++ b/gcs/constraints/at_most_one.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
@@ -146,14 +147,16 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto AtMostOne::s_exprify(const ProofModel * const model) const -> string
+auto AtMostOne::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-    print(s, "{} at_most_one (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("at_most_one"),
+        SExpr::list(std::move(vars)),
+        tracker.s_expr_term_of(_val)});
 }
 
 // ----- AtMostOneSmartTable (kept for benchmarking) --------------------------
@@ -196,12 +199,14 @@ auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_sta
     move(smt_table).install(propagators, initial_state, optional_model);
 }
 
-auto AtMostOneSmartTable::s_exprify(const ProofModel * const model) const -> string
+auto AtMostOneSmartTable::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-    print(s, "{} at_most_one_smart_table (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_val));
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("at_most_one_smart_table"),
+        SExpr::list(std::move(vars)),
+        tracker.s_expr_term_of(_val)});
 }

--- a/gcs/constraints/at_most_one.hh
+++ b/gcs/constraints/at_most_one.hh
@@ -45,7 +45,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     /**
@@ -69,7 +69,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 
 #include <list>
 #include <map>
@@ -240,16 +241,15 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
     return pos_var_data;
 }
 
-auto CircuitBase::s_exprify(const innards::ProofModel * const model) const -> string
+auto CircuitBase::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} circuit (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
     for (const auto & var : _succ)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")");
-
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("circuit"),
+        SExpr::list(std::move(vars))});
 }
 
 template auto gcs::innards::circuit::prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const PosVarDataMap & pos_var_data,

--- a/gcs/constraints/circuit/circuit_base.hh
+++ b/gcs/constraints/circuit/circuit_base.hh
@@ -81,7 +81,7 @@ namespace gcs::innards::circuit
     public:
         explicit CircuitBase(std::vector<IntegerVariableID> var, bool gac_all_different = false);
         [[nodiscard]] auto clone() const -> std::unique_ptr<Constraint> override = 0;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/count.cc
+++ b/gcs/constraints/count.cc
@@ -4,6 +4,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -239,17 +240,14 @@ auto Count::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Count::s_exprify(const ProofModel * const model) const -> std::string
+auto Count::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} count (", _constraint_id);
-    for (const auto & v : _vars) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    }
-    print(s, ") {} {}",
-        model->names_and_ids_tracker().s_expr_name_of(_value_of_interest),
-        model->names_and_ids_tracker().s_expr_name_of(_how_many));
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> vars;
+    for (const auto & v : _vars)
+        vars.push_back(tracker.s_expr_term_of(v));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("count"),
+        SExpr::list(std::move(vars)),
+        tracker.s_expr_term_of(_value_of_interest),
+        tracker.s_expr_term_of(_how_many)});
 }

--- a/gcs/constraints/count.hh
+++ b/gcs/constraints/count.hh
@@ -32,7 +32,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/cumulative.cc
+++ b/gcs/constraints/cumulative.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <optional>
@@ -643,18 +644,20 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Cumulative::s_exprify(const ProofModel * const model) const -> string
+auto Cumulative::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-    print(s, "{} cumulative (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> starts, lengths, heights;
     for (const auto & v : _starts)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, " ) ( ");
+        starts.push_back(tracker.s_expr_term_of(v));
     for (const auto & l : _lengths)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(l));
-    print(s, " ) ( ");
+        lengths.push_back(tracker.s_expr_term_of(l));
     for (const auto & h : _heights)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(h));
-    print(s, " ) {}", model->names_and_ids_tracker().s_expr_name_of(_capacity));
-    return s.str();
+        heights.push_back(tracker.s_expr_term_of(h));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("cumulative"),
+        SExpr::list(std::move(starts)),
+        SExpr::list(std::move(lengths)),
+        SExpr::list(std::move(heights)),
+        tracker.s_expr_term_of(_capacity)});
 }

--- a/gcs/constraints/cumulative.hh
+++ b/gcs/constraints/cumulative.hh
@@ -100,7 +100,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
@@ -681,15 +682,16 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Disjunctive::s_exprify(const ProofModel * const model) const -> string
+auto Disjunctive::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-    print(s, "{} disjunctive{} (", _constraint_id, _strict ? "_strict" : "");
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> starts, lengths;
     for (const auto & v : _starts)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, " ) ( ");
+        starts.push_back(tracker.s_expr_term_of(v));
     for (const auto & l : _lengths)
-        print(s, " {}", l);
-    print(s, " )");
-    return s.str();
+        lengths.push_back(SExpr::atom(l.to_string()));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom(_strict ? "disjunctive_strict" : "disjunctive"),
+        SExpr::list(std::move(starts)),
+        SExpr::list(std::move(lengths))});
 }

--- a/gcs/constraints/disjunctive.hh
+++ b/gcs/constraints/disjunctive.hh
@@ -84,7 +84,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <algorithm>
@@ -788,21 +789,22 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Disjunctive2D::s_exprify(const ProofModel * const model) const -> string
+auto Disjunctive2D::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-    print(s, "{} disjunctive2d{} (", _constraint_id, _strict ? "_strict" : "");
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> xs, ys, widths, heights;
     for (const auto & v : _xs)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, " ) ( ");
+        xs.push_back(tracker.s_expr_term_of(v));
     for (const auto & v : _ys)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, " ) ( ");
+        ys.push_back(tracker.s_expr_term_of(v));
     for (const auto & w : _widths)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(w));
-    print(s, " ) ( ");
+        widths.push_back(tracker.s_expr_term_of(w));
     for (const auto & h : _heights)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(h));
-    print(s, " )");
-    return s.str();
+        heights.push_back(tracker.s_expr_term_of(h));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom(_strict ? "disjunctive2d_strict" : "disjunctive2d"),
+        SExpr::list(std::move(xs)),
+        SExpr::list(std::move(ys)),
+        SExpr::list(std::move(widths)),
+        SExpr::list(std::move(heights))});
 }

--- a/gcs/constraints/disjunctive_2d.hh
+++ b/gcs/constraints/disjunctive_2d.hh
@@ -130,7 +130,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/element.cc
+++ b/gcs/constraints/element.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
 
@@ -554,62 +555,57 @@ auto NDimensionalElement<EntryType_, dimensions_>::clone() const -> unique_ptr<C
 }
 
 template <typename EntryType_, unsigned dimensions_>
-auto NDimensionalElement<EntryType_, dimensions_>::s_exprify(const ProofModel * const model) const -> std::string
+auto NDimensionalElement<EntryType_, dimensions_>::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     // cake_pb_cp reads the array as a bare varc list -- position is implicit, so
-    // no per-entry index -- and each index as a space-separated (variable offset)
-    // pair, then the result: "(X0 ... Xn-1) (Y0 off0) ... Z". The offset matches
-    // our _index_starts (both subtract it: the chosen entry is Xs[val(Y) - off]).
-    auto print_elem = [&](auto & s, const auto & elem) {
-        if constexpr (std::is_same_v<EntryType_, IntegerVariableID>) {
-            print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(elem));
-        }
-        else {
-            print(s, " {}", elem);
-        }
+    // no per-entry index -- and each index as a (variable offset) pair, then the
+    // result: "(X0 ... Xn-1) (Y0 off0) ... Z". The offset matches our
+    // _index_starts (both subtract it: the chosen entry is Xs[val(Y) - off]).
+    auto entry_term = [&](const auto & elem) -> SExpr {
+        if constexpr (std::is_same_v<EntryType_, IntegerVariableID>)
+            return tracker.s_expr_term_of(elem);
+        else
+            return SExpr::atom(elem.to_string());
     };
 
-    auto print_array = [&](auto & s, const auto & arr, auto self_ref) -> void {
+    // Build the array's children: the innermost rows (a vector of EntryType_) in
+    // traversal order; in a multi-dimensional array each row is its own sub-list
+    // (cake reads element_2d's array as ((row1) (row2) ...)), in 1-D they are flat.
+    vector<SExpr> array_children;
+    auto build_array = [&](auto & self, const auto & arr) -> void {
         using ArrayType = std::decay_t<decltype(arr)>;
-
-        // Innermost level (a vector of EntryType_): emit the entries; in a
-        // multi-dimensional array each such row is wrapped in its own parens
-        // (cake reads element_2d's array as ((row1) (row2) ...)).
         if constexpr (std::is_same_v<typename ArrayType::value_type, EntryType_>) {
             if (dimensions_ > 1) {
-                print(s, " (");
+                vector<SExpr> row;
+                for (const auto & e : arr)
+                    row.push_back(entry_term(e));
+                array_children.push_back(SExpr::list(move(row)));
             }
-            for (const auto & e : arr) {
-                print_elem(s, e);
-            }
-            if (dimensions_ > 1) {
-                print(s, ")");
+            else {
+                for (const auto & e : arr)
+                    array_children.push_back(entry_term(e));
             }
         }
         else {
-            // Recursive case: dig deeper
-            for (const auto & sub_arr : arr) {
-                self_ref(s, sub_arr, self_ref);
-            }
+            for (const auto & sub_arr : arr)
+                self(self, sub_arr);
         }
     };
+    build_array(build_array, *_array);
 
-    print(s, "{} {} (", _constraint_id, dimensions_ == 1 ? "element" : "element_2d");
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom(dimensions_ == 1 ? "element" : "element_2d"),
+        SExpr::list(move(array_children))};
 
-    print_array(s, *_array, print_array);
+    for (size_t i = 0; i < _index_vars.size(); ++i)
+        terms.push_back(SExpr::list({tracker.s_expr_term_of(_index_vars[i]),
+            SExpr::atom(_index_starts[i].to_string())}));
 
-    print(s, ")");
+    terms.push_back(tracker.s_expr_term_of(_result_var));
 
-    for (size_t i = 0; i < _index_vars.size(); ++i) {
-        print(s, " ({} {})",
-            model->names_and_ids_tracker().s_expr_name_of(_index_vars[i]),
-            _index_starts[i]);
-    }
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result_var));
-
-    return s.str();
+    return SExpr::list(move(terms));
 }
 
 namespace gcs

--- a/gcs/constraints/element.hh
+++ b/gcs/constraints/element.hh
@@ -60,7 +60,7 @@ namespace gcs
     public:
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     class Element : public NDimensionalElement<IntegerVariableID, 1>

--- a/gcs/constraints/equals.cc
+++ b/gcs/constraints/equals.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 
 #include <util/overloaded.hh>
 
@@ -355,9 +356,9 @@ NotEqualsIff::NotEqualsIff(const IntegerVariableID v1, const IntegerVariableID v
 {
 }
 
-auto ReifiedEquals::s_exprify(const innards::ProofModel * const model) const -> string
+auto ReifiedEquals::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     string constraint_type = overloaded{
         [](const reif::MustHold &) -> string { return "equals"; },
@@ -368,12 +369,13 @@ auto ReifiedEquals::s_exprify(const innards::ProofModel * const model) const -> 
             return _neq ? "not_equals_iff" : "equals_iff";
         }}.visit(_cond);
 
-    print(s, "{} {}", _constraint_id, constraint_type);
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_cond));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type)};
+    if (auto cond = tracker.s_expr_term_of(_cond))
+        terms.push_back(std::move(*cond));
+    terms.push_back(tracker.s_expr_term_of(_v1));
+    terms.push_back(tracker.s_expr_term_of(_v2));
 
-    return s.str();
+    return SExpr::list(std::move(terms));
 }
 
 template auto gcs::innards::enforce_equality(ProofLogger * const logger, const IntegerVariableID & v1, const IntegerVariableID & v2, const State & state,

--- a/gcs/constraints/equals.hh
+++ b/gcs/constraints/equals.hh
@@ -2,10 +2,10 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_EQUALS_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/reason.hh>
-#include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
@@ -41,7 +41,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     /**

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -8,6 +8,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -412,20 +413,19 @@ auto BoundsGlobalCardinality::prepare(Propagators &, State &, ProofModel * const
     return true;
 }
 
-auto BoundsGlobalCardinality::s_exprify(const ProofModel * const model) const -> string
+auto BoundsGlobalCardinality::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} boundsglobalcardinality{} (", _constraint_id, _closed ? "closed" : "");
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars, values, counts;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") (");
+        vars.push_back(tracker.s_expr_term_of(var));
     for (const auto & val : _values)
-        print(s, " {}", val);
-    print(s, ") (");
+        values.push_back(SExpr::atom(val.to_string()));
     for (const auto & c : _counts)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(c));
-    print(s, ")");
-
-    return s.str();
+        counts.push_back(tracker.s_expr_term_of(c));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom(_closed ? "boundsglobalcardinalityclosed" : "boundsglobalcardinality"),
+        SExpr::list(std::move(vars)),
+        SExpr::list(std::move(values)),
+        SExpr::list(std::move(counts))});
 }

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
@@ -57,7 +57,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -629,20 +630,19 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
         triggers);
 }
 
-auto GACGlobalCardinality::s_exprify(const ProofModel * const model) const -> string
+auto GACGlobalCardinality::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} gacglobalcardinality{} (", _constraint_id, _closed ? "closed" : "");
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars, values, counts;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") (");
+        vars.push_back(tracker.s_expr_term_of(var));
     for (const auto & val : _values)
-        print(s, " {}", val);
-    print(s, ") (");
+        values.push_back(SExpr::atom(val.to_string()));
     for (const auto & c : _counts)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(c));
-    print(s, ")");
-
-    return s.str();
+        counts.push_back(tracker.s_expr_term_of(c));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom(_closed ? "gacglobalcardinalityclosed" : "gacglobalcardinality"),
+        SExpr::list(std::move(vars)),
+        SExpr::list(std::move(values)),
+        SExpr::list(std::move(counts))});
 }

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.hh
@@ -53,7 +53,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/increasing.cc
+++ b/gcs/constraints/increasing.cc
@@ -4,6 +4,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -132,17 +133,16 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
         return entailed ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable; }, triggers);
 }
 
-auto IncreasingChain::s_exprify(const ProofModel * const model) const -> string
+auto IncreasingChain::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     const char * keyword = _strict
         ? (_descending ? "strictly_decreasing" : "strictly_increasing")
         : (_descending ? "decreasing" : "increasing");
 
-    print(s, "{} {}", _constraint_id, keyword);
+    std::vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(keyword)};
     for (const auto & v : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-
-    return s.str();
+        terms.push_back(tracker.s_expr_term_of(v));
+    return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/increasing.hh
+++ b/gcs/constraints/increasing.hh
@@ -42,7 +42,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     /**

--- a/gcs/constraints/inverse.cc
+++ b/gcs/constraints/inverse.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
 
@@ -182,22 +183,20 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
         return PropagatorState::Enable; }, triggers);
 }
 
-auto Inverse::s_exprify(const innards::ProofModel * const model) const -> std::string
+auto Inverse::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     // cake_pb_cp wants each side grouped with its offset: a (list offset) pair,
-    // i.e. `inverse ((X...) offx) ((Y...) offy)`. The outer pair of parentheses
-    // around the whole body is added by solve()/write_scp.
-    print(s, "{} inverse ( (", _constraint_id);
-    for (const auto & x : _x) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(x));
-    }
-    print(s, " ) {} ) ( (", _x_start);
-    for (const auto & y : _y) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(y));
-    }
-    print(s, " ) {} )", _y_start);
-
-    return s.str();
+    // i.e. `inverse ((X...) offx) ((Y...) offy)`. The outer list wrapping the
+    // whole term is the SExpr::list returned here.
+    std::vector<SExpr> xs;
+    for (const auto & x : _x)
+        xs.push_back(tracker.s_expr_term_of(x));
+    std::vector<SExpr> ys;
+    for (const auto & y : _y)
+        ys.push_back(tracker.s_expr_term_of(y));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("inverse"),
+        SExpr::list({SExpr::list(std::move(xs)), SExpr::atom(_x_start.to_string())}),
+        SExpr::list({SExpr::list(std::move(ys)), SExpr::atom(_y_start.to_string())})});
 }

--- a/gcs/constraints/inverse.hh
+++ b/gcs/constraints/inverse.hh
@@ -36,7 +36,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/knapsack.cc
+++ b/gcs/constraints/knapsack.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -660,24 +661,29 @@ auto Knapsack::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Knapsack::s_exprify(const innards::ProofModel * const model) const -> string
+auto Knapsack::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
-    print(s, "{} knapsack\n            (", _constraint_id);
+    vector<SExpr> coeff_rows;
     for (const auto & cs : _coeffs) {
-        print(s, "\n                (");
+        vector<SExpr> row;
         for (const auto & c : cs)
-            print(s, " {}", c);
-        print(s, ")");
+            row.push_back(SExpr::atom(c.to_string()));
+        coeff_rows.push_back(SExpr::list(move(row)));
     }
-    print(s, "\n            )\n            (");
-    for (const auto & v : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, ")\n            (");
-    for (const auto & t : _totals)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(t));
-    print(s, ")\n        ");
 
-    return s.str();
+    vector<SExpr> vars;
+    for (const auto & v : _vars)
+        vars.push_back(tracker.s_expr_term_of(v));
+
+    vector<SExpr> totals;
+    for (const auto & t : _totals)
+        totals.push_back(tracker.s_expr_term_of(t));
+
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("knapsack"),
+        SExpr::list(move(coeff_rows)),
+        SExpr::list(move(vars)),
+        SExpr::list(move(totals))});
 }

--- a/gcs/constraints/knapsack.hh
+++ b/gcs/constraints/knapsack.hh
@@ -38,7 +38,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/lex.cc
+++ b/gcs/constraints/lex.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/overloaded.hh>
@@ -621,9 +622,9 @@ auto LexCompareGreaterThanOrMaybeEqual::install_propagators(Propagators & propag
         std::move(infer_cond_when_undecided));
 }
 
-auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const innards::ProofModel * const model) const -> std::string
+auto LexCompareGreaterThanOrMaybeEqual::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     string reif_suffix = overloaded{
         [](const reif::MustHold &) -> string { return ""; },
@@ -638,8 +639,6 @@ auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const innards::ProofModel * co
         _or_equal ? "_equal" : "",
         reif_suffix);
 
-    print(s, "{} {}", _constraint_id, cmp);
-
     auto cond_lit = overloaded{
         [](const reif::MustHold &) -> optional<IntegerVariableCondition> { return nullopt; },
         [](const reif::MustNotHold &) -> optional<IntegerVariableCondition> { return nullopt; },
@@ -648,18 +647,19 @@ auto LexCompareGreaterThanOrMaybeEqual::s_exprify(const innards::ProofModel * co
         [](const reif::Iff & r) -> optional<IntegerVariableCondition> { return r.cond; }}
                         .visit(_reif_cond);
 
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(cmp)};
     if (cond_lit)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(*cond_lit));
+        terms.push_back(tracker.s_expr_term_of(*cond_lit));
 
-    print(s, " (");
     auto & first = _vars_swapped ? _vars_2 : _vars_1;
     auto & second = _vars_swapped ? _vars_1 : _vars_2;
+    vector<SExpr> a, b;
     for (const auto & var : first)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") (");
+        a.push_back(tracker.s_expr_term_of(var));
     for (const auto & var : second)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")");
+        b.push_back(tracker.s_expr_term_of(var));
+    terms.push_back(SExpr::list(std::move(a)));
+    terms.push_back(SExpr::list(std::move(b)));
 
-    return s.str();
+    return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/lex.hh
+++ b/gcs/constraints/lex.hh
@@ -21,7 +21,7 @@ namespace gcs
      *
      * Internally enforces vars_1 (>|>=)_lex vars_2 — strict or non-strict
      * depending on the `or_equal` flag — under a `ReificationCondition`. The
-     * `vars_swapped` flag is a hint to s_exprify about whether the
+     * `vars_swapped` flag is a hint to s_expr about whether the
      * user-facing direction was less-than (less-than variants swap their
      * arguments at construction so the propagator always sees a "greater"
      * problem).
@@ -100,7 +100,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     /**

--- a/gcs/constraints/lex_smart_table.cc
+++ b/gcs/constraints/lex_smart_table.cc
@@ -3,6 +3,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 
 #include <algorithm>
 #include <sstream>
@@ -65,17 +66,14 @@ auto LexSmartTable::install(Propagators & propagators, State & initial_state, Pr
     move(smt_table).install(propagators, initial_state, optional_model);
 }
 
-auto LexSmartTable::s_exprify(const innards::ProofModel * const model) const -> std::string
+auto LexSmartTable::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} lex (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> a, b;
     for (const auto & var : _vars_1)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") (");
+        a.push_back(tracker.s_expr_term_of(var));
     for (const auto & var : _vars_2)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")");
-
-    return s.str();
+        b.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("lex"),
+        SExpr::list(std::move(a)), SExpr::list(std::move(b))});
 }

--- a/gcs/constraints/lex_smart_table.hh
+++ b/gcs/constraints/lex_smart_table.hh
@@ -31,7 +31,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -10,6 +10,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 
 #include <util/enumerate.hh>
 #include <util/overloaded.hh>
@@ -394,9 +395,9 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
     }
 }
 
-auto ReifiedLinearEquality::s_exprify(const ProofModel * const model) const -> std::string
+auto ReifiedLinearEquality::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     auto [rei, cons] = overloaded{
         [&](const reif::MustHold &) { return make_pair(false, "lin_equals"); },
@@ -406,17 +407,19 @@ auto ReifiedLinearEquality::s_exprify(const ProofModel * const model) const -> s
         [&](const reif::NotIf &) { return make_pair(true, "lin_not_equals_if"); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", _constraint_id, cons);
-    if (rei) {
-        print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
-    }
-    print(s, " (");
-    for (const auto & [c, v] : _coeff_vars.terms) {
-        print(s, " {} {}", c, model->names_and_ids_tracker().s_expr_name_of(v));
-    }
-    print(s, ") {}", _value);
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(cons)};
+    if (rei)
+        terms.push_back(*tracker.s_expr_term_of(_reif_cond));
 
-    return s.str();
+    vector<SExpr> coeff_vars;
+    for (const auto & [c, v] : _coeff_vars.terms) {
+        coeff_vars.push_back(SExpr::atom(c.to_string()));
+        coeff_vars.push_back(tracker.s_expr_term_of(v));
+    }
+    terms.push_back(SExpr::list(std::move(coeff_vars)));
+    terms.push_back(SExpr::atom(_value.to_string()));
+
+    return SExpr::list(std::move(terms));
 }
 
 auto ReifiedLinearEquality::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -2,10 +2,10 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LINEAR_LINEAR_EQUALITY_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
-#include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/reification.hh>
 
 #include <optional>
@@ -48,7 +48,7 @@ namespace gcs
             innards::ProofModel * const) && -> void override;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     class LinearEquality : public ReifiedLinearEquality

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -199,27 +200,29 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
         sanitised_cv, sanitised_neg_cv);
 }
 
-auto ReifiedLinearInequality::s_exprify(const ProofModel * const model) const -> std::string
+auto ReifiedLinearInequality::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     // cake_pb_cp's name for the <= form is lin_less_equal (not lin_less_than_equal).
     auto [rei, cons] = overloaded{
         [&](const reif::MustHold &) { return make_pair(false, "lin_less_equal"); },
         [&](const reif::If &) { return make_pair(true, "lin_less_equal_if"); },
         [&](const reif::Iff &) { return make_pair(true, "lin_less_equal_iff"); },
-        [&](const auto &) { throw UnexpectedException{"Unexpected reification type in s_exprify"}; return make_pair(false, ""); }}
+        [&](const auto &) { throw UnexpectedException{"Unexpected reification type in s_expr"}; return make_pair(false, ""); }}
                            .visit(_reif_cond);
 
-    print(s, "{} {}", _constraint_id, cons);
-    if (rei) {
-        print(s, " {} ", model->names_and_ids_tracker().s_expr_name_of(_reif_cond));
-    }
-    print(s, "(");
-    for (const auto & [c, v] : _coeff_vars.terms) {
-        print(s, " {} {}", c, model->names_and_ids_tracker().s_expr_name_of(v));
-    }
-    print(s, ") {}", _value);
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(cons)};
+    if (rei)
+        terms.push_back(*tracker.s_expr_term_of(_reif_cond));
 
-    return s.str();
+    vector<SExpr> coeff_vars;
+    for (const auto & [c, v] : _coeff_vars.terms) {
+        coeff_vars.push_back(SExpr::atom(c.to_string()));
+        coeff_vars.push_back(tracker.s_expr_term_of(v));
+    }
+    terms.push_back(SExpr::list(std::move(coeff_vars)));
+    terms.push_back(SExpr::atom(_value.to_string()));
+
+    return SExpr::list(std::move(terms));
 }

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -2,11 +2,11 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LINEAR_LINEAR_INEQUALITY_HH 1
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/propagators-fwd.hh>
-#include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/reification.hh>
 
 #include <memory>
@@ -43,7 +43,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/logical.cc
+++ b/gcs/constraints/logical.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/overloaded.hh>
@@ -252,17 +253,15 @@ auto And::install_propagators(Propagators & propagators) -> void
     install_propagators_logical(propagators, constraint_id(), _lits, _full_reif, _reif_state);
 }
 
-auto And::s_exprify(const innards::ProofModel * const model) const -> string
+auto And::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} and (", _constraint_id);
-    for (const auto & lit : _lits) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
-    }
-    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_full_reif));
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> lits;
+    for (const auto & lit : _lits)
+        lits.push_back(tracker.s_expr_term_of(lit));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("and"),
+        SExpr::list(std::move(lits)),
+        tracker.s_expr_term_of(_full_reif)});
 }
 
 Or::Or(const vector<IntegerVariableID> & vars, const IntegerVariableID & full_reif) :
@@ -319,15 +318,13 @@ auto Or::install_propagators(Propagators & propagators) -> void
     install_propagators_logical(propagators, constraint_id(), move(lits), ! _full_reif, _reif_state);
 }
 
-auto Or::s_exprify(const innards::ProofModel * const model) const -> string
+auto Or::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} or (", _constraint_id);
-    for (const auto & lit : _lits) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
-    }
-    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_full_reif));
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> lits;
+    for (const auto & lit : _lits)
+        lits.push_back(tracker.s_expr_term_of(lit));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("or"),
+        SExpr::list(std::move(lits)),
+        tracker.s_expr_term_of(_full_reif)});
 }

--- a/gcs/constraints/logical.hh
+++ b/gcs/constraints/logical.hh
@@ -39,7 +39,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 
     /**
@@ -70,7 +70,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/min_max.cc
+++ b/gcs/constraints/min_max.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 
 #include <util/enumerate.hh>
 
@@ -198,17 +199,15 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
         return PropagatorState::Enable; }, triggers);
 }
 
-auto ArrayMinMax::s_exprify(const innards::ProofModel * const model) const -> string
+auto ArrayMinMax::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} {} (", _constraint_id, _min ? "min" : "max");
-    for (const auto & v : _vars) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    }
-    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_result));
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> vars;
+    for (const auto & v : _vars)
+        vars.push_back(tracker.s_expr_term_of(v));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(_min ? "min" : "max"),
+        SExpr::list(std::move(vars)),
+        tracker.s_expr_term_of(_result)});
 }
 
 Min::Min(const IntegerVariableID v1, const IntegerVariableID v2, const IntegerVariableID result) :

--- a/gcs/constraints/min_max.hh
+++ b/gcs/constraints/min_max.hh
@@ -39,7 +39,7 @@ namespace gcs
 
             virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
             virtual auto clone() const -> std::unique_ptr<Constraint> override;
-            [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+            [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         };
     }
 

--- a/gcs/constraints/minus.cc
+++ b/gcs/constraints/minus.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <sstream>
@@ -174,15 +175,13 @@ auto Minus::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Minus::s_exprify(const innards::ProofModel * const model) const -> string
+auto Minus::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     // Three flat args (`minus X Y Z`) to match cake_pb_cp's binary prim parse.
-    print(s, "{} minus", _constraint_id);
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));
-
-    return s.str();
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("minus"),
+        tracker.s_expr_term_of(_a),
+        tracker.s_expr_term_of(_b),
+        tracker.s_expr_term_of(_result)});
 }

--- a/gcs/constraints/minus.hh
+++ b/gcs/constraints/minus.hh
@@ -30,7 +30,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/mult_bc.cc
+++ b/gcs/constraints/mult_bc.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/presolvers/auto_table.hh>
 #include <iostream>
 #include <sstream>
@@ -1282,15 +1283,11 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
         return PropagatorState::Enable; }, triggers);
 }
 
-auto MultBC::s_exprify(const innards::ProofModel * const model) const -> string
+auto MultBC::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} multiply (", _constraint_id);
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v1));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v2));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_v3));
-    print(s, ")");
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("multiply"),
+        SExpr::list({tracker.s_expr_term_of(_v1),
+            tracker.s_expr_term_of(_v2),
+            tracker.s_expr_term_of(_v3)})});
 }

--- a/gcs/constraints/mult_bc.hh
+++ b/gcs/constraints/mult_bc.hh
@@ -25,7 +25,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators & propagators, innards::State &, innards::ProofModel *) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/n_value.cc
+++ b/gcs/constraints/n_value.cc
@@ -4,6 +4,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <list>
@@ -124,15 +125,13 @@ auto NValue::install_propagators(Propagators & propagators) -> void
         return PropagatorState::Enable; }, triggers);
 }
 
-auto NValue::s_exprify(const innards::ProofModel * const model) const -> string
+auto NValue::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} nvalue (", _constraint_id);
-    for (const auto & var : _vars) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    }
-    print(s, ") {}", model->names_and_ids_tracker().s_expr_name_of(_n_values));
-
-    return s.str();
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> vars;
+    for (const auto & var : _vars)
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("nvalue"),
+        SExpr::list(std::move(vars)),
+        tracker.s_expr_term_of(_n_values)});
 }

--- a/gcs/constraints/n_value.hh
+++ b/gcs/constraints/n_value.hh
@@ -33,7 +33,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/parity.cc
+++ b/gcs/constraints/parity.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <optional>
@@ -137,18 +138,17 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
             }
         } }, triggers);
 }
-auto ParityOdd::s_exprify(const innards::ProofModel * const model) const -> string
+auto ParityOdd::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     // cake_pb_cp encodes parity as `parity (X1 ... Xn) Y` meaning Y = XOR(Xi).
     // ParityOdd is the bare odd-parity assertion XOR(Xi) = 1, so we write the
     // constant Y = 1 (1 = XOR(Xi) <-> XOR(Xi) = 1). The scp_reader requires Y = 1.
-    print(s, "{} parity (", _constraint_id);
-    for (const auto & lit : _lits) {
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(lit));
-    }
-    print(s, " ) 1");
-
-    return s.str();
+    std::vector<SExpr> lits;
+    for (const auto & lit : _lits)
+        lits.push_back(tracker.s_expr_term_of(lit));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("parity"),
+        SExpr::list(std::move(lits)),
+        SExpr::atom("1")});
 }

--- a/gcs/constraints/parity.hh
+++ b/gcs/constraints/parity.hh
@@ -31,7 +31,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/plus.cc
+++ b/gcs/constraints/plus.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <sstream>
@@ -161,16 +162,14 @@ auto Plus::install_propagators(Propagators & propagators) -> void
         triggers);
 }
 
-auto Plus::s_exprify(const innards::ProofModel * const model) const -> string
+auto Plus::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
     // cake_pb_cp's binary prim parse wants three flat args (`plus X Y Z`), not a
     // bracketed list, so X op Y = Z reads as rest = [X; Y; Z].
-    print(s, "{} plus", _constraint_id);
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_a));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_b));
-    print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(_result));
-
-    return s.str();
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("plus"),
+        tracker.s_expr_term_of(_a),
+        tracker.s_expr_term_of(_b),
+        tracker.s_expr_term_of(_result)});
 }

--- a/gcs/constraints/plus.hh
+++ b/gcs/constraints/plus.hh
@@ -31,7 +31,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 
 #include <version>
 
@@ -363,7 +364,7 @@ namespace
 
 namespace
 {
-    // Records the alphabet (sorted transition keys) for proof logging and s_exprify.
+    // Records the alphabet (sorted transition keys) for proof logging and s_expr.
     auto symbols_of(const vector<unordered_map<Integer, set<long>>> & transitions) -> vector<Integer>
     {
         set<Integer> sym_set;
@@ -542,29 +543,42 @@ auto Regular::install_propagators(Propagators & propagators) -> void
         return PropagatorState::Enable; }, triggers);
 }
 
-auto Regular::s_exprify(const ProofModel * const model) const -> string
+auto Regular::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
-    print(s, "{} regular (", _constraint_id);
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ") {}\n       (", _num_states);
+        vars.push_back(tracker.s_expr_term_of(var));
+
+    vector<SExpr> syms;
     for (const auto & sym : symbols())
-        print(s, " {}", sym);
-    print(s, ")\n       ((");
+        syms.push_back(SExpr::atom(sym.to_string()));
+
+    // The old textual form wrapped the per-state list inside one extra pair of
+    // parentheses (the `((` ... `))` around the loop), so the transitions term
+    // is an outer list containing a single inner list of per-state edge lists.
+    vector<SExpr> states;
     for (size_t i = 0; i < _transitions.size(); i++) {
-        print(s, "(");
+        vector<SExpr> edges;
         for (const auto & tran : _transitions[i]) {
             for (const auto & target : tran.second)
-                print(s, " ({} {})", tran.first, target);
+                edges.push_back(SExpr::list({SExpr::atom(tran.first.to_string()),
+                    SExpr::atom(std::to_string(target))}));
         }
-        print(s, ")\n        ");
+        states.push_back(SExpr::list(move(edges)));
     }
-    print(s, "))\n       (");
-    for (const auto & f : _final_states)
-        print(s, " {}", f);
-    print(s, ")");
+    auto transitions_term = SExpr::list({SExpr::list(move(states))});
 
-    return s.str();
+    vector<SExpr> finals;
+    for (const auto & f : _final_states)
+        finals.push_back(SExpr::atom(std::to_string(f)));
+
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("regular"),
+        SExpr::list(move(vars)),
+        SExpr::atom(std::to_string(_num_states)),
+        SExpr::list(move(syms)),
+        std::move(transitions_term),
+        SExpr::list(move(finals))});
 }

--- a/gcs/constraints/regular/regular.hh
+++ b/gcs/constraints/regular/regular.hh
@@ -75,7 +75,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/seq_precede_chain.cc
+++ b/gcs/constraints/seq_precede_chain.cc
@@ -3,6 +3,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -83,12 +84,13 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
     ValuePrecede{move(chain), move(_vars)}.install(propagators, initial_state, optional_model);
 }
 
-auto SeqPrecedeChain::s_exprify(const ProofModel * const model) const -> string
+auto SeqPrecedeChain::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-    print(s, "{} seq_precede_chain (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")");
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("seq_precede_chain"),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/seq_precede_chain.hh
+++ b/gcs/constraints/seq_precede_chain.hh
@@ -45,7 +45,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/smart_table.cc
+++ b/gcs/constraints/smart_table.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 
 #include <algorithm>
 #include <map>
@@ -949,7 +950,7 @@ auto SmartTable::install(Propagators & propagators, State & initial_state, Proof
         triggers);
 }
 
-auto SmartTable::s_exprify(const ProofModel * const model) const -> string
+auto SmartTable::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto to_op = [](SmartEntryConstraint c) {
         switch (c) {
@@ -965,41 +966,40 @@ auto SmartTable::s_exprify(const ProofModel * const model) const -> string
         throw NonExhaustiveSwitch{};
     };
 
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
-    print(s, "{} smart_table (\n        (", _constraint_id);
-
+    vector<SExpr> entries;
     for (const auto & tuple : _tuples) {
         for (const auto & entry : tuple) {
             overloaded{
                 [&](const BinaryEntry & binary_entry) {
-                    print(s, " ({} {} {})",
-                        model->names_and_ids_tracker().s_expr_name_of(binary_entry.var_1),
-                        to_op(binary_entry.constraint_type),
-                        model->names_and_ids_tracker().s_expr_name_of(binary_entry.var_2));
+                    entries.push_back(SExpr::list({tracker.s_expr_term_of(binary_entry.var_1),
+                        SExpr::atom(to_op(binary_entry.constraint_type)),
+                        tracker.s_expr_term_of(binary_entry.var_2)}));
                 },
                 [&](const UnaryValueEntry & unary_val_entry) {
-                    print(s, " ({} {} {})",
-                        model->names_and_ids_tracker().s_expr_name_of(unary_val_entry.var),
-                        to_op(unary_val_entry.constraint_type),
-                        unary_val_entry.value);
+                    entries.push_back(SExpr::list({tracker.s_expr_term_of(unary_val_entry.var),
+                        SExpr::atom(to_op(unary_val_entry.constraint_type)),
+                        SExpr::atom(unary_val_entry.value.to_string())}));
                 },
                 [&](const UnarySetEntry & unary_set_entry) {
-                    print(s, " ({} {} (",
-                        model->names_and_ids_tracker().s_expr_name_of(unary_set_entry.var),
-                        to_op(unary_set_entry.constraint_type));
+                    vector<SExpr> values;
                     for (const auto & value : unary_set_entry.values)
-                        print(s, " {}", value);
-                    print(s, "))");
+                        values.push_back(SExpr::atom(value.to_string()));
+                    entries.push_back(SExpr::list({tracker.s_expr_term_of(unary_set_entry.var),
+                        SExpr::atom(to_op(unary_set_entry.constraint_type)),
+                        SExpr::list(move(values))}));
                 }}
                 .visit(entry);
         }
     }
-    print(s, ")\n        (");
 
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")\n        )");
+        vars.push_back(tracker.s_expr_term_of(var));
 
-    return s.str();
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("smart_table"),
+        SExpr::list(move(entries)),
+        SExpr::list(move(vars))});
 }

--- a/gcs/constraints/smart_table.hh
+++ b/gcs/constraints/smart_table.hh
@@ -141,7 +141,7 @@ namespace gcs
         {
             return innards::UnarySetEntry{a, move(b), innards::SmartEntryConstraint::NotIn};
         }
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -10,6 +10,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -446,20 +447,23 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     // (full enumeration + BC consistency + VeriPB all unchanged when removed).
 }
 
-auto ArgSort::s_exprify(const ProofModel * const model) const -> string
+auto ArgSort::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
-    print(s, "{} arg_sort\n          (", _constraint_id);
+    vector<SExpr> xs;
     for (const auto & v : _x)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, ")\n          (");
-    for (const auto & v : _p)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    // Note: no trailing ')' here -- solve()/write_scp wraps the whole body in
-    // one pair of parentheses. The stray ')' this used to emit left the .scp
-    // unbalanced (harmless only because nothing parsed it).
-    print(s, ")\n          {}", _offset);
+        xs.push_back(tracker.s_expr_term_of(v));
 
-    return s.str();
+    vector<SExpr> ps;
+    for (const auto & v : _p)
+        ps.push_back(tracker.s_expr_term_of(v));
+
+    // The offset is a trailing bare atom (not wrapped in its own list), matching
+    // the old textual form.
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("arg_sort"),
+        SExpr::list(move(xs)),
+        SExpr::list(move(ps)),
+        SExpr::atom(_offset.to_string())});
 }

--- a/gcs/constraints/sort/arg_sort.hh
+++ b/gcs/constraints/sort/arg_sort.hh
@@ -49,7 +49,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -1099,17 +1100,20 @@ auto Sort::install_propagators(Propagators & propagators) -> void
     install_sortedness_propagator(propagators, constraint_id(), _x, _y, _witness);
 }
 
-auto Sort::s_exprify(const ProofModel * const model) const -> string
+auto Sort::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
+    auto & tracker = model->names_and_ids_tracker();
 
-    print(s, "{} sort\n          (", _constraint_id);
+    vector<SExpr> xs;
     for (const auto & v : _x)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, ")\n          (");
-    for (const auto & v : _y)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(v));
-    print(s, ")");
+        xs.push_back(tracker.s_expr_term_of(v));
 
-    return s.str();
+    vector<SExpr> ys;
+    for (const auto & v : _y)
+        ys.push_back(tracker.s_expr_term_of(v));
+
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("sort"),
+        SExpr::list(move(xs)),
+        SExpr::list(move(ys))});
 }

--- a/gcs/constraints/sort/sort.hh
+++ b/gcs/constraints/sort/sort.hh
@@ -39,7 +39,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -298,32 +299,24 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
         _tuples);
 }
 
-auto NegativeTable::s_exprify(const innards::ProofModel * const model) const -> std::string
+auto NegativeTable::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} negative_table", _constraint_id);
-    println(s, "(");
-
-    println(s, "    (");
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> tuple_terms;
     visit([&](const auto & tuples) {
         for (const auto & t : depointinate(tuples)) {
-            println(s, "        (");
-            for (const auto & v : t) {
-                println(s, "            {}", tuple_entry_as_string(v));
-            }
-            println(s, "        )");
+            vector<SExpr> row;
+            for (const auto & v : t)
+                row.push_back(SExpr::atom(tuple_entry_as_string(v)));
+            tuple_terms.push_back(SExpr::list(std::move(row)));
         }
     },
         _tuples);
-    println(s, "    )");
-
-    println(s, "    (");
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        println(s, "        {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    println(s, "    )");
-
-    println(s, ")");
-
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("negative_table"),
+        SExpr::list(std::move(tuple_terms)),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/table/negative_table.hh
+++ b/gcs/constraints/table/negative_table.hh
@@ -31,7 +31,7 @@ namespace gcs
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <util/enumerate.hh>
@@ -195,32 +196,24 @@ auto Table::install_propagators(Propagators & propagators) -> void
         move(_tuples));
 }
 
-auto Table::s_exprify(const innards::ProofModel * const model) const -> std::string
+auto Table::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} table", _constraint_id);
-    println(s, "(");
-
-    println(s, "    (");
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> tuple_terms;
     visit([&](const auto & tuples) {
         for (const auto & t : depointinate(tuples)) {
-            println(s, "        (");
-            for (const auto & v : t) {
-                println(s, "            {}", tuple_entry_as_string(v));
-            }
-            println(s, "        )");
+            vector<SExpr> row;
+            for (const auto & v : t)
+                row.push_back(SExpr::atom(tuple_entry_as_string(v)));
+            tuple_terms.push_back(SExpr::list(std::move(row)));
         }
     },
         _tuples);
-    println(s, "    )");
-
-    println(s, "    (");
+    vector<SExpr> vars;
     for (const auto & var : _vars)
-        println(s, "        {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    println(s, "    )");
-
-    println(s, ")");
-
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)),
+        SExpr::atom("table"),
+        SExpr::list(std::move(tuple_terms)),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -33,7 +33,7 @@ namespace gcs
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
 
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/constraints/value_precede.cc
+++ b/gcs/constraints/value_precede.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <version>
@@ -206,17 +207,16 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
     }
 }
 
-auto ValuePrecede::s_exprify(const ProofModel * const model) const -> string
+auto ValuePrecede::s_expr(const ProofModel * const model) const -> SExpr
 {
-    stringstream s;
-
-    print(s, "{} value_precede (", _constraint_id);
+    auto & tracker = model->names_and_ids_tracker();
+    std::vector<SExpr> chain;
     for (const auto & val : _chain)
-        print(s, " {}", val);
-    print(s, ") (");
+        chain.push_back(SExpr::atom(val.to_string()));
+    std::vector<SExpr> vars;
     for (const auto & var : _vars)
-        print(s, " {}", model->names_and_ids_tracker().s_expr_name_of(var));
-    print(s, ")");
-
-    return s.str();
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("value_precede"),
+        SExpr::list(std::move(chain)),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/value_precede.hh
+++ b/gcs/constraints/value_precede.hh
@@ -69,7 +69,7 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &,
             innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_exprify(const innards::ProofModel * const) const -> std::string override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };
 }
 

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1698,6 +1698,13 @@ auto NamesAndIDsTracker::s_expr_term_of(IntegerVariableID id) const -> SExpr
     return parse_s_expr(s_expr_name_of(id));
 }
 
+auto NamesAndIDsTracker::s_expr_term_of(Literal lit) const -> SExpr
+{
+    // As for the variable overload: s_expr_name_of(Literal) is always a single,
+    // non-empty term (a bare atom for a condition/True/False, or a view list).
+    return parse_s_expr(s_expr_name_of(lit));
+}
+
 auto NamesAndIDsTracker::s_expr_term_of(ReificationCondition cond) const -> optional<SExpr>
 {
     // s_expr_name_of(ReificationCondition) returns "" for the unconditional

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -529,6 +529,14 @@ namespace gcs::innards
         [[nodiscard]] auto s_expr_term_of(IntegerVariableID id) const -> SExpr;
 
         /**
+         * Get the s-expr *term* for a literal: s_expr_name_of() parsed into an
+         * SExpr (a bare atom like `_1` or `1`, or a list for a view literal).
+         * The literal-list constraints (and / or / parity) write their inputs
+         * with this. Prefer it over `parse_s_expr(s_expr_name_of(...))`.
+         */
+        [[nodiscard]] auto s_expr_term_of(Literal lit) const -> SExpr;
+
+        /**
          * Get the s-expr term for a reification condition, or nullopt when the
          * condition is unconditional (MustHold / MustNotHold). Keeps the
          * "no condition" case explicit rather than leaking the empty string that

--- a/gcs/innards/s_expr_test.cc
+++ b/gcs/innards/s_expr_test.cc
@@ -42,7 +42,7 @@ TEST_CASE("SExpr: incidental whitespace is normalised away")
 {
     // Leading/trailing/inner spacing, tabs and newlines all collapse to the
     // single canonical form: this is exactly the messy hand-formatting the
-    // old string-built s_exprify produced (e.g. "( 0 3)").
+    // old string-built constraint writers produced (e.g. "( 0 3)").
     CHECK(format("{}", parse_s_expr("(   0    3 )")) == "(0 3)");
     CHECK(format("{}", parse_s_expr("  (_1   all_different ( _1 _1 _2 _2))  ")) ==
         "(_1 all_different (_1 _1 _2 _2))");
@@ -130,7 +130,8 @@ TEST_CASE("SExpr: a sequence of top-level terms")
 
 TEST_CASE("SExpr: the '#' alternate form drops a list's enclosing parentheses")
 {
-    // This is the shape Constraint::s_exprify returns; solve() wraps it in ().
+    // The `#` form yields a list's body without its outer parens (the s-expr
+    // body of a constraint's term).
     auto body = SExpr::list({SExpr::atom("_1"),
         SExpr::atom("abs"),
         parse_s_expr("_2"),


### PR DESCRIPTION
Completes the `.scp`-writer migration started in `dev_docs/scp_s_expr_migration.md`: the remaining 37 constraints move from the legacy string `s_exprify()` to the structured `s_expr() -> innards::SExpr`, and the transitional bridge is removed.

## Change
- **37 constraints migrated** to override `s_expr()` (building `SExpr::list`/`SExpr::atom` with `NamesAndIDsTracker::s_expr_term_of(...)`), joining the 5 already done (`abs`, reified comparisons, GAC/VC `all_different`, `in`).
- **Cutover**: `Constraint::s_expr()` is now **pure virtual**; the `s_exprify()` method and the bridge defaults are deleted (`gcs/constraint.{hh,cc}`). `write_scp` was already off `s_exprify()`.
- **New helper**: `s_expr_term_of(Literal)` (mirrors the `IntegerVariableID` overload) for the `and`/`or`/`parity` literal inputs.

## Faithfulness / safety
The bridge already round-tripped every constraint's `s_exprify()` output through `parse_s_expr`, so the migrated `s_expr()` is **byte-identical to the old canonical `.scp` output**. The chain-consumed constraints (`abs`, comparisons, linear, `all_different`, `count`, `element`, `nvalue`, reified-equality, `inverse`, `and`/`or`, `plus`, `minus`, `parity`) are regression-checked by the workflow-2 **scp_chain** suite. The cutover itself is a completeness proof: a missed migration (leftover `s_exprify` override) or an un-overridden `s_expr` fails to compile.

## Suspect forms resolved (not copied)
- **`GACArithmetic`** returned `(name op …)` *with* its own outer parens → `write_scp` double-wrapped to `((name op …))`. Now returns the single proper list (bug fixed).
- **`element`** keeps the corrected bare-varc-list `(X0 … Xn-1)` + `(var offset)` index form.
- **Tabular** (`table`/`negative_table`/`smart_table`/`regular`/`knapsack`/`sort`/`arg_sort`) build nested `SExpr` lists, one-lined by `write_scp` (as the bridge already did).

## Verified
- `360/360` ctest, `49/49` scp_chain.
- Cutover compiles cleanly (no leftover `s_exprify`, no abstract constraint).
- Docs updated: migration doc marked complete; `dev_docs/constraints.md` authoring guide now points at `s_expr`.

(Most of the mechanical translations were done by parallel subagents over partitioned, non-overlapping file sets; the `arithmetic`/`element` suspect forms and the cutover were done directly, and every function was reviewed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)