### PR TITLE
Audit constraints for degenerate (empty / all-constant) argument cases (#254)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -320,7 +320,7 @@ if(GCS_BUILD_TESTS)
     foreach(mode lex_gt lex_ge lex_lt lex_le
                  lex_gt_fixed lex_ge_fixed lex_lt_fixed lex_le_fixed
                  am1_eq am1_in_set al1_eq al1_in_set
-                 mixed_same_var stacked_unary wide_constants)
+                 mixed_same_var stacked_unary wide_constants degenerate)
         add_test(NAME smart_table_constraint_${mode}
             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:smart_table_test> ${mode})
     endforeach()

--- a/gcs/constraints/abs_test.cc
+++ b/gcs/constraints/abs_test.cc
@@ -135,7 +135,23 @@ auto main(int argc, char * argv[]) -> int
         {pair{-1, 6}, pair{-2, 5}},
         {pair{1, 3}, pair{-1, 3}},
         {pair{-1, 5}, pair{-6, 8}},
-        {pair{-1, 1}, pair{-2, 4}}};
+        {pair{-1, 1}, pair{-2, 4}},
+        // All-constant arguments (issue #254): both operands are
+        // ConstantIntegerVariableIDs, so the constraint reduces to a
+        // true/false check on abs(c1) == c2. Both directions are covered.
+        {2, 2},     // abs(2) == 2: tautology
+        {2, 3},     // abs(2) != 3: contradiction
+        {-4, 4},    // abs(-4) == 4: tautology
+        {-4, 5},    // abs(-4) != 5: contradiction
+        {0, 0},     // abs(0) == 0: tautology
+        {-7, 6},    // abs(-7) != 6: contradiction
+        // Singleton-domain variables (genuine variables, domain size 1):
+        // exercises the propagation path rather than constant folding.
+        {pair{-4, -4}, pair{4, 4}}, // tautology
+        {pair{-4, -4}, pair{5, 5}}, // contradiction
+        // Mixed: one genuine constant, one real singleton-domain variable.
+        {-6, pair{6, 6}},           // tautology
+        {pair{-6, -6}, 7}};         // contradiction
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/all_different/all_different_except_test.cc
+++ b/gcs/constraints/all_different/all_different_except_test.cc
@@ -149,6 +149,11 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
     run_alldiffexcept_test(proofs, view_cfg, {{0, 2}, {1, 2}, {1, 2}}, {0});
     run_alldiffexcept_test(proofs, view_cfg, {{0, 1}, {0, 1}, {0, 2}, {0, 2}}, {0});
 
+    // Degenerate all-fixed (issue #254), both directions.
+    run_alldiffexcept_test(proofs, view_cfg, {{2, 2}, {2, 2}}, {2});    // dup of excluded value: allowed (tautology)
+    run_alldiffexcept_test(proofs, view_cfg, {{1, 1}, {2, 2}}, {0});    // distinct constants (tautology)
+    run_alldiffexcept_test(proofs, view_cfg, {{3, 3}, {3, 3}}, {});     // dup, empty excluded set (contradiction)
+
     if (run_dup) {
         // Same variable in two positions: forces it into the excluded set.
         run_alldiffexcept_dup_test(proofs, {{0, 3}}, {0, 0}, {0});

--- a/gcs/constraints/all_different/symmetric_all_different_test.cc
+++ b/gcs/constraints/all_different/symmetric_all_different_test.cc
@@ -156,6 +156,11 @@ namespace
         // Out-of-range value gets bound-trimmed by Inverse before propagation.
         run_symalldiff_test(proofs, true, {{0, 1, 5}, {0, 1}}, 0);
 
+        // Fully all-fixed (issue #254), both directions.
+        run_symalldiff_test(proofs, true, {{0}, {1}}, 0); // identity: valid involution (tautology)
+        run_symalldiff_test(proofs, true, {{1}, {0}}, 0); // swap: valid involution (tautology)
+        run_symalldiff_test(proofs, true, {{1}, {1}}, 0); // both map to 1: not an involution (contradiction)
+
         // Cases where AllDifferent-GAC + Inverse-channeling is strictly
         // weaker than the symmetric-alldifferent GAC of Régin (1999).
         // GAC for the latter requires non-bipartite matching on the

--- a/gcs/constraints/all_different_test.cc
+++ b/gcs/constraints/all_different_test.cc
@@ -116,6 +116,39 @@ auto run_alldiff_dup_test(bool proofs, const vector<vector<int>> & unique_domain
     check_results(proof_name, expected, actual);
 }
 
+// issue #254: AllDifferent over a degenerate collection — the empty array and
+// the single-element array (both trivially satisfiable), plus tiny all-constant
+// arrays in both the distinct (SAT) and duplicate (UNSAT) directions. Guards
+// against UB on empty containers and proof steps referencing absent variables.
+auto run_alldiff_collection_test(bool proofs, const string & label,
+    const vector<variant<int, pair<int, int>>> & specs) -> void
+{
+    print(cerr, "all_different_collection [{}] {}{}", label, specs, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    auto is_satisfying = [](const vector<int> & vs) {
+        for (std::size_t i = 0; i < vs.size(); ++i)
+            for (std::size_t j = i + 1; j < vs.size(); ++j)
+                if (vs[i] == vs[j])
+                    return false;
+        return true;
+    };
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, is_satisfying, specs);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> vars;
+    for (const auto & s : specs)
+        vars.push_back(visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, s));
+    p.post(AllDifferent{vars});
+
+    auto proof_name = proofs ? make_optional("all_different_test_collection") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{vars});
+    check_results(proof_name, expected, actual);
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -137,7 +170,12 @@ auto main(int argc, char * argv[]) -> int
             // issue #108: constants in hall set crash prove_matching_is_too_small
             {pair{-2, 3}, 5, pair{3, 5}, pair{3, 6}, 3, pair{3, 5}},
             // issue #108: constants in hall set crash prove_deletion_using_sccs
-            {pair{1, 2}, pair{1, 2}, 3, pair{3, 4}, pair{4, 5}, pair{5, 6}}};
+            {pair{1, 2}, pair{1, 2}, 3, pair{3, 4}, pair{4, 5}, pair{5, 6}},
+            // issue #254: fully all-constant arguments (genuine
+            // ConstantIntegerVariableIDs), both directions.
+            {1, 2, 3, 4, 5, 6}, // all distinct constants (tautology)
+            {1, 1, 3, 4, 5, 6}, // two equal constants (contradiction)
+            {7, 7, 7, 7, 7, 7}}; // all equal constants (contradiction)
 
     random_device rand_dev;
     mt19937 rand(rand_dev());
@@ -173,6 +211,13 @@ auto main(int argc, char * argv[]) -> int
                 run_alldiff_dup_test<GACAllDifferent>(proofs, unique_domains, positions, "gac");
                 run_alldiff_dup_test<VCAllDifferent>(proofs, unique_domains, positions, "vc");
             }
+
+            // Degenerate collections (issue #254).
+            run_alldiff_collection_test(proofs, "empty", {});
+            run_alldiff_collection_test(proofs, "single_var", {pair{0, 2}});
+            run_alldiff_collection_test(proofs, "single_const", {5});
+            run_alldiff_collection_test(proofs, "const_distinct", {1, 2, 3});
+            run_alldiff_collection_test(proofs, "const_dup", {1, 2, 1});
         }
     }
 

--- a/gcs/constraints/all_equal_test.cc
+++ b/gcs/constraints/all_equal_test.cc
@@ -30,8 +30,11 @@ using std::nullopt;
 using std::pair;
 using std::random_device;
 using std::set;
+using std::string;
 using std::tuple;
+using std::variant;
 using std::vector;
+using std::visit;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -69,6 +72,37 @@ auto run_test(bool proofs, const ViewWrapConfig & view_cfg, const vector<pair<in
 
     auto proof_name = proofs ? make_optional("all_equal_test_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
+    check_results(proof_name, expected, actual);
+}
+
+// issue #254: AllEqual over a degenerate collection — empty / single-element
+// (both vacuously satisfiable, no propagator) and tiny all-genuine-constant
+// arrays (ConstantIntegerVariableID) in both the equal (SAT) and unequal
+// (UNSAT) directions, plus a mixed const+variable case.
+auto run_all_equal_collection_test(bool proofs, const string & label,
+    const vector<variant<int, pair<int, int>>> & specs) -> void
+{
+    print(cerr, "all_equal_collection [{}] {}{}", label, specs, proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    set<tuple<vector<int>>> expected, actual;
+    build_expected(expected, [](const vector<int> & vs) {
+        for (std::size_t i = 1; i < vs.size(); ++i)
+            if (vs[i] != vs[0])
+                return false;
+        return true;
+    },
+        specs);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem p;
+    vector<IntegerVariableID> vars;
+    for (const auto & s : specs)
+        vars.push_back(visit([&](auto b) { return create_integer_variable_or_constant(p, b); }, s));
+    p.post(AllEqual{vars});
+
+    auto proof_name = proofs ? make_optional("all_equal_test_collection") : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{vars});
     check_results(proof_name, expected, actual);
 }
 
@@ -180,6 +214,10 @@ auto main(int argc, char * argv[]) -> int
         {{1, 5}, {2, 6}, {3, 7}},
         {{2, 4}, {2, 4}, {2, 4}},
         {{1, 6}, {2, 5}, {3, 4}, {4, 7}},
+        // issue #254: all-fixed (singleton-domain) collections, both directions.
+        {{3, 3}, {3, 3}},          // equal constants (tautology)
+        {{2, 2}, {5, 5}},          // unequal constants (contradiction)
+        {{4, 4}, {4, 4}, {4, 4}},  // three equal constants (tautology)
     };
 
     random_device rand_dev;
@@ -207,6 +245,15 @@ auto main(int argc, char * argv[]) -> int
             run_test(proofs, view_cfg, doms);
         if (run_holes)
             run_holes_test(proofs);
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            // Degenerate collections with genuine constants (issue #254).
+            run_all_equal_collection_test(proofs, "empty", {});
+            run_all_equal_collection_test(proofs, "single_var", {pair{0, 2}});
+            run_all_equal_collection_test(proofs, "single_const", {5});
+            run_all_equal_collection_test(proofs, "const_equal", {3, 3, 3});
+            run_all_equal_collection_test(proofs, "const_unequal", {3, 4});
+            run_all_equal_collection_test(proofs, "mixed", {3, pair{1, 5}, 3});
+        }
         if (run_dup) {
             // {x, x} — tautology, every value of x.
             run_dup_all_equal_test(proofs, {{1, 5}}, {0, 0});

--- a/gcs/constraints/among_test.cc
+++ b/gcs/constraints/among_test.cc
@@ -176,7 +176,18 @@ auto main(int argc, char * argv[]) -> int
             {pair{1, 1}, vector{1, 2, 3}, {pair{1, 5}, pair{1, 5}, pair{1, 5}}},
             {pair{3, 5}, vector{1, 3}, {pair{1, 2}, pair{1, 2}, pair{1, 5}}},
             {pair{0, 5}, vector{1, 3}, {pair{1, 2}, pair{1, 2}, pair{1, 5}}},
-            {pair{1, 5}, vector{2, 3, 2, 3, 3}, {pair{1, 5}, pair{1, 5}, pair{1, 5}}}};
+            {pair{1, 5}, vector{2, 3, 2, 3, 3}, {pair{1, 5}, pair{1, 5}, pair{1, 5}}},
+            // Degenerate cases (issue #254): empty array, empty value set,
+            // single element, all-constant. Result is a genuine constant.
+            {0, vector{2, 3}, {}},                    // empty array: 0 in set (tautology)
+            {1, vector{2, 3}, {}},                    // empty array: can't be 1 (contradiction)
+            {0, vector<int>{}, {5, 5, 5}},            // empty value set: nothing matches (tautology)
+            {1, vector<int>{}, {5, 5, 5}},            // empty value set: can't be 1 (contradiction)
+            {1, vector{5}, {5}},                      // single element matches (tautology)
+            {1, vector{5}, {6}},                      // single element, no match (contradiction)
+            {2, vector{5, 6}, {5, 6, 7}},             // all-constant array: 2 match (tautology)
+            {3, vector{5, 6}, {5, 6, 7}},             // all-constant array: only 2 match (contradiction)
+            {pair{0, 2}, vector{5}, {5, pair{1, 10}}}}; // mixed: one constant match + one variable
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/arithmetic_test.cc
+++ b/gcs/constraints/arithmetic_test.cc
@@ -263,10 +263,25 @@ auto main(int, char *[]) -> int
         {{1, 3}, {1, 3}, {0, 10}},
         {{1, 3}, {1, 3}, {1, 3}},
         {{1, 5}, {6, 8}, {-10, 10}},
-        {{1, 1}, {2, 4}, {-5, 5}}};
+        {{1, 1}, {2, 4}, {-5, 5}},
+        // issue #254: all-fixed (singleton-domain) operands. Each row runs for
+        // Plus/Minus/Times/Div/Mod; build_expected gives the per-operation
+        // truth, so each tautology direction is hit by exactly one operation
+        // and the others act as the contradiction direction.
+        {{2, 2}, {3, 3}, {5, 5}},   // Plus: 2+3==5
+        {{5, 5}, {2, 2}, {3, 3}},   // Minus: 5-2==3
+        {{2, 2}, {3, 3}, {6, 6}},   // Times: 2*3==6
+        {{6, 6}, {3, 3}, {2, 2}},   // Div: 6/3==2
+        {{7, 7}, {3, 3}, {1, 1}},   // Mod: 7%3==1
+        {{5, 5}, {0, 0}, {3, 3}},   // Div/Mod by fixed zero: no solution
+        {{5, 5}, {2, 2}, {99, 99}}}; // all operations contradicted
 
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> power_data = {
         {{0, 3}, {0, 5}, {-1, 250}},
+        // issue #254: all-fixed operands for Power, both directions.
+        {{2, 2}, {3, 3}, {8, 8}}, // 2^3 == 8 (tautology)
+        {{2, 2}, {3, 3}, {9, 9}}, // 2^3 != 9 (contradiction)
+        {{2, 2}, {0, 0}, {1, 1}}, // 2^0 == 1 (tautology)
         {{2, 4}, {0, 4}, {0, 260}},
         {{-3, 3}, {0, 4}, {-30, 90}},
         {{1, 1}, {-3, 3}, {-2, 2}},

--- a/gcs/constraints/at_most_one_test.cc
+++ b/gcs/constraints/at_most_one_test.cc
@@ -150,6 +150,12 @@ auto run_all_tests(Variant variant, bool proofs, const ViewWrapConfig & view_cfg
     // Unsatisfiable: two vars forced to equal a fixed val
     run_at_most_one_test(variant, proofs, view_cfg, {{2, 2}, {2, 2}, {1, 3}}, {2, 2});
 
+    // Fully all-fixed (issue #254), both directions: every var and the value
+    // are singletons, so the constraint reduces to a count check.
+    run_at_most_one_test(variant, proofs, view_cfg, {{5, 5}, {5, 5}}, {5, 5}); // two equal val: contradiction
+    run_at_most_one_test(variant, proofs, view_cfg, {{5, 5}, {6, 6}}, {5, 5}); // exactly one equals val: tautology
+    run_at_most_one_test(variant, proofs, view_cfg, {{6, 6}, {7, 7}}, {5, 5}); // none equals val: tautology
+
     // 4-variable tests
     run_at_most_one_test(variant, proofs, view_cfg, {{1, 3}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});
     run_at_most_one_test(variant, proofs, view_cfg, {{2, 2}, {1, 3}, {1, 3}, {1, 3}}, {2, 2});

--- a/gcs/constraints/circuit/circuit_test.cc
+++ b/gcs/constraints/circuit/circuit_test.cc
@@ -98,6 +98,14 @@ auto main(int argc, char * argv[]) -> int
             continue;
         for (int n : {3, 4, 5})
             run_circuit_test(proofs, view_cfg, n);
+        // Degenerate minimal circuits (issue #254): n=1 is a single self-loop
+        // (the canonical minimal circuit), n=2 the unique 2-cycle. Run only in
+        // the bare configuration; the view sweep targets the larger instances
+        // and its positions can exceed these tiny n.
+        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+            run_circuit_test(proofs, view_cfg, 1);
+            run_circuit_test(proofs, view_cfg, 2);
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/comparison_test.cc
+++ b/gcs/constraints/comparison_test.cc
@@ -255,7 +255,14 @@ auto main(int argc, char * argv[]) -> int
         {pair{1, 1}, pair{2, 2}},
         {pair{2, 2}, pair{1, 1}},
         {pair{1, 1}, pair{1, 1}},
-        {pair{-2, -2}, pair{-2, -1}}};
+        {pair{-2, -2}, pair{-2, -1}},
+        // issue #254: genuine all-constant operands (ConstantIntegerVariableID).
+        // Each comparison mode gets both directions via build_expected, e.g.
+        // 3<5 holds but 5<3 does not; 4 and 4 are (not) equal as appropriate.
+        {3, 5},
+        {5, 3},
+        {4, 4},
+        {-2, -2}};
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/count_test.cc
+++ b/gcs/constraints/count_test.cc
@@ -174,7 +174,16 @@ auto main(int argc, char * argv[]) -> int
         {pair{2, 2}, pair{3, 6}, {pair{5, 9}, pair{-5, 3}, pair{2, 6}}},
         // Constant array entries: voi seen N times where some array slots are fixed.
         {pair{0, 3}, pair{0, 3}, {1, 2, pair{1, 3}}},
-        {pair{0, 3}, 2, {pair{1, 4}, 2, pair{1, 4}, 2}}};
+        {pair{0, 3}, 2, {pair{1, 4}, 2, pair{1, 4}, 2}},
+        // Degenerate cases (issue #254): empty array, single element, all-constant.
+        // Genuine ConstantIntegerVariableIDs for how_many / voi / array entries.
+        {0, 5, {}},                         // empty array: count of 5 is 0 (tautology)
+        {1, 5, {}},                         // empty array: count can't be 1 (contradiction)
+        {1, 3, {3}},                        // single constant element == voi (tautology)
+        {2, 3, {3}},                        // single element: count can't be 2 (contradiction)
+        {2, 4, {4, 4, 7}},                  // all-constant array: 4 occurs twice (tautology)
+        {1, 4, {4, 4, 7}},                  // all-constant array: count is 2, not 1 (contradiction)
+        {pair{0, 2}, 5, {5, pair{1, 10}}}}; // mixed: one constant match + one variable
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/cumulative_test.cc
+++ b/gcs/constraints/cumulative_test.cc
@@ -504,6 +504,16 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 4}}, {1}, {3}, 2},
         // Two tasks of differing lengths, cap 1: gaps matter.
         {{{0, 3}, {0, 3}}, {1, 2}, {1, 1}, 1},
+        // Degenerate cases (issue #254).
+        // Empty active-task list: the only task has zero length and zero height,
+        // so no propagator is installed and every start is feasible.
+        {{{0, 2}}, {0}, {0}, 1},
+        // All-fixed start (singleton): load fits under capacity (tautology).
+        {{{5, 5}}, {3}, {2}, 5},
+        // All-fixed start: a single task overloads capacity (contradiction).
+        {{{0, 0}}, {2}, {10}, 5},
+        // All-fixed starts: two tasks overlap at time 0, exceeding capacity.
+        {{{0, 0}, {0, 0}}, {1, 1}, {3, 3}, 5},
     };
 
     // Random instances for breadth. Kept small because search is exhaustive

--- a/gcs/constraints/disjunctive_2d_test.cc
+++ b/gcs/constraints/disjunctive_2d_test.cc
@@ -295,6 +295,15 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {0, 2}, {2, 2}},
         // Wider value ranges so we don't hit small-value coincidences.
         {{{0, 4}, {0, 4}}, {{0, 4}, {0, 4}}, {3, 2}, {2, 3}},
+        // Degenerate cases (issue #254).
+        // Empty rectangle list: vacuously satisfiable.
+        {{}, {}, {}, {}},
+        // Single rectangle: nothing to overlap with (vacuously satisfiable).
+        {{{1, 2}}, {{1, 2}}, {1}, {1}},
+        // All-fixed positions, separated along x: (0,0) and (2,0), both 1x1.
+        {{{0, 0}, {2, 2}}, {{0, 0}, {0, 0}}, {1, 1}, {1, 1}},
+        // All-fixed positions overlapping at the origin (contradiction).
+        {{{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {1, 1}, {1, 1}},
     };
 
     random_device rand_dev;

--- a/gcs/constraints/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive_test.cc
@@ -198,6 +198,13 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 2}, {0, 2}}, {0, 2}},
         // Two zero-length tasks.
         {{{0, 2}, {0, 2}}, {0, 0}},
+        // Degenerate cases (issue #254).
+        // Empty task list: vacuously satisfiable (no propagator installed).
+        {{}, {}},
+        // All-fixed starts, abutting but not overlapping: [0,1) then [1,2).
+        {{{0, 0}, {1, 1}}, {1, 1}},
+        // All-fixed starts that overlap: both span [0,2) (contradiction).
+        {{{0, 0}, {1, 1}}, {2, 2}},
     };
 
     // Random instances for breadth.

--- a/gcs/constraints/element_test.cc
+++ b/gcs/constraints/element_test.cc
@@ -256,23 +256,45 @@ auto main(int argc, char * argv[]) -> int
         {{-1, 3}, {0, 2}, {{-1, 2}, {1, 3}, {4, 5}}},
         {{1, 4}, {0, 4}, {{1, 4}, {2, 3}, {0, 5}, {-2, 0}, {5, 7}}},
         {{-5, 5}, {-3, 2}, {{-8, 0}, {4, 4}, {10, 10}, {2, 11}, {4, 10}}},
-        {{7, 10}, {0, 9}, {{8, 18}, {9, 19}, {-1, 0}, {-6, 0}}}};
+        {{7, 10}, {0, 9}, {{8, 18}, {9, 19}, {-1, 0}, {-6, 0}}},
+        // Degenerate cases (issue #254): empty array (no valid index), and
+        // all-fixed index/var/array in both directions including out-of-range.
+        {{1, 2}, {0, 1}, {}},        // empty array: no valid index (unsat)
+        {{1, 1}, {0, 0}, {{1, 1}}},  // all fixed, array[0]==1==var (tautology)
+        {{2, 2}, {0, 0}, {{1, 1}}},  // all fixed, array[0]==1 != var 2 (contradiction)
+        {{1, 1}, {1, 1}, {{1, 1}}}}; // all fixed, index 1 out of range (contradiction)
 
     vector<tuple<pair<int, int>, pair<int, int>, vector<int>>> const_data = {
         {{1, 2}, {1, 2}, {1, 2}},
         {{1, 2}, {0, 1}, {1, 2}},
         {{1, 2}, {0, 2}, {1, 2, 2}},
         {{1, 2}, {0, 2}, {1, 2, 5}},
-        {{-4, 6}, {-3, 3}, {-7, 2, -4, -10}}};
+        {{-4, 6}, {-3, 3}, {-7, 2, -4, -10}},
+        // Degenerate cases (issue #254): empty constant array + all-fixed.
+        {{1, 2}, {0, 1}, {}},   // empty constant array: no valid index (unsat)
+        {{4, 4}, {0, 0}, {4}},  // all fixed, array[0]==4==var (tautology)
+        {{3, 3}, {0, 0}, {4}},  // all fixed, array[0]==4 != var 3 (contradiction)
+        {{1, 1}, {1, 1}, {4}},  // all fixed, index 1 out of range (contradiction)
+        {{3, 5}, {0, 0}, {4}}}; // var in 3..5 forced to array[0]==4 (single solution)
 
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>, vector<vector<int>>>> const2d_data = {
         {{1, 2}, {1, 2}, {1, 2}, {{1, 2}, {1, 2}}},
         {{1, 2}, {0, 1}, {1, 2}, {{1, 2}, {1, 2}}},
-        {{1, 8}, {0, 3}, {0, 3}, {{1, 5}, {7, 9}, {3, 6}}}};
+        {{1, 8}, {0, 3}, {0, 3}, {{1, 5}, {7, 9}, {3, 6}}},
+        // Degenerate (issue #254): empty 2D array (no rows) — no valid index.
+        {{1, 2}, {0, 1}, {0, 1}, {}},
+        // All-fixed 2D, both directions.
+        {{5, 5}, {0, 0}, {0, 0}, {{5}}},  // a[0][0]==5==var (tautology)
+        {{4, 4}, {0, 0}, {0, 0}, {{5}}}}; // a[0][0]==5 != var 4 (contradiction)
 
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>, vector<vector<pair<int, int>>>>> var2d_data = {
         {{1, 2}, {1, 2}, {1, 2}, {{{1, 2}, {2, 3}}, {{1, 2}, {2, 3}}}},
-        {{2, 6}, {0, 2}, {0, 1}, {{{2, 4}, {0, 1}}, {{-2, -2}, {1, 3}}, {{-2, 1}, {-3, 0}}}}};
+        {{2, 6}, {0, 2}, {0, 1}, {{{2, 4}, {0, 1}}, {{-2, -2}, {1, 3}}, {{-2, 1}, {-3, 0}}}},
+        // Degenerate (issue #254): empty 2D array (no rows) — no valid index.
+        {{1, 2}, {0, 1}, {0, 1}, {}},
+        // All-fixed 2D.
+        {{5, 5}, {0, 0}, {0, 0}, {{{5, 5}}}},   // a[0][0]==5==var (tautology)
+        {{4, 4}, {0, 0}, {0, 0}, {{{5, 5}}}}};  // a[0][0]==5 != var 4 (contradiction)
     random_device rand_dev;
     mt19937 rand(rand_dev());
 

--- a/gcs/constraints/equals_test.cc
+++ b/gcs/constraints/equals_test.cc
@@ -195,7 +195,13 @@ auto main(int argc, char * argv[]) -> int
         {pair{1, 3}, pair{5, 8}},
         {pair{4, 13}, pair{3, 16}},
         {pair{-2, 4}, pair{-8, 7}},
-        {pair{-7, 3}, pair{-10, 5}}};
+        {pair{-7, 3}, pair{-10, 5}},
+        // issue #254: genuine all-constant operands (ConstantIntegerVariableID),
+        // both directions. Each Equals/NotEquals (and reified) mode is computed
+        // from build_expected: 4==4 holds, 4==5 does not.
+        {4, 4},
+        {4, 5},
+        {-3, -3}};
 
     random_device rand_dev;
     mt19937 rand(get_seed().value_or(rand_dev()));

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
@@ -122,6 +122,17 @@ auto main(int, char *[]) -> int
         {{pair{1, 3}, pair{1, 3}, pair{2, 3}}, {1, 2, 3}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
         // Bounded form, value absent from a domain.
         {{pair{1, 3}, pair{1, 3}, pair{1, 3}}, {1, 2}, {pair{1, 3}, pair{0, 1}}, false},
+        // Degenerate cases (issue #254): empty vars, empty value set, single
+        // value, and all-constant vars/counts in both directions.
+        {{}, {1}, {0}, false},                              // empty vars, open: count of 1 is 0 (tautology)
+        {{}, {1}, {1}, false},                              // empty vars, open: count can't be 1 (contradiction)
+        {{}, {1}, {0}, true},                               // empty vars, closed: vacuously satisfied
+        {{5}, {5}, {1}, false},                             // single all-const var matches value (tautology)
+        {{5}, {3}, {1}, false},                             // count of absent value can't be 1 (contradiction)
+        {{1, 1, 2}, {1, 2}, {2, 1}, false},                 // all-const vars + counts, correct (tautology)
+        {{1, 1, 2}, {1, 2}, {1, 1}, false},                 // all-const vars + counts, wrong count (contradiction)
+        {{pair{1, 2}, pair{1, 2}}, {1}, {pair{0, 2}}, false}, // single cover value
+        {{pair{1, 2}}, {}, {}, false},                      // empty value set, open: any assignment allowed
     };
 
     random_device rand_dev;

--- a/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
@@ -111,6 +111,17 @@ auto main(int, char *[]) -> int
         {{pair{1, 3}, pair{1, 3}, pair{2, 3}}, {1, 2, 3}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
         // A GAC-only pruning: AllDifferent-style Hall set (each value once).
         {{pair{1, 2}, pair{1, 2}, pair{1, 3}}, {1, 2, 3}, {pair{0, 1}, pair{0, 1}, pair{0, 1}}, false},
+        // Degenerate cases (issue #254): empty vars, empty value set, single
+        // value, and all-constant vars/counts in both directions.
+        {{}, {1}, {0}, false},                              // empty vars, open: count of 1 is 0 (tautology)
+        {{}, {1}, {1}, false},                              // empty vars, open: count can't be 1 (contradiction)
+        {{}, {1}, {0}, true},                               // empty vars, closed: vacuously satisfied
+        {{5}, {5}, {1}, false},                             // single all-const var matches value (tautology)
+        {{5}, {3}, {1}, false},                             // count of absent value can't be 1 (contradiction)
+        {{1, 1, 2}, {1, 2}, {2, 1}, false},                 // all-const vars + counts, correct (tautology)
+        {{1, 1, 2}, {1, 2}, {1, 1}, false},                 // all-const vars + counts, wrong count (contradiction)
+        {{pair{1, 2}, pair{1, 2}}, {1}, {pair{0, 2}}, false}, // single cover value
+        {{pair{1, 2}}, {}, {}, false},                      // empty value set, open: any assignment allowed
     };
 
     random_device rand_dev;

--- a/gcs/constraints/in_test.cc
+++ b/gcs/constraints/in_test.cc
@@ -236,6 +236,21 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
     // Self-reference: trivially satisfied
     run_in_self_reference_test(proofs, view_cfg, {1, 5});
     run_in_self_reference_test(proofs, view_cfg, {-2, 2});
+
+    // Degenerate collections (issue #254): an In with no supporting values at
+    // all is unsatisfiable and must be handled cleanly (no UB on the empty
+    // value/var lists), across every overload.
+    run_in_integer_vals_test(proofs, view_cfg, {1, 5}, {});           // empty value list: unsat
+    run_in_const_vars_test(proofs, view_cfg, {1, 5}, {});             // empty const-var list: unsat
+    run_in_var_list_test(proofs, view_cfg, {1, 5}, {});              // empty supporter list: unsat
+    run_in_var_list_mixed_test(proofs, view_cfg, {1, 5}, {}, {});    // both empty: unsat
+
+    // Fixed (singleton-domain) variable against a constant value set, both
+    // directions: the value is present (tautology) or absent (contradiction).
+    run_in_integer_vals_test(proofs, view_cfg, {3, 3}, {1, 3, 5});    // 3 in set: tautology
+    run_in_integer_vals_test(proofs, view_cfg, {2, 2}, {1, 3, 5});    // 2 not in set: contradiction
+    run_in_const_vars_test(proofs, view_cfg, {4, 4}, {4, 5, 6});      // 4 in const-var set: tautology
+    run_in_const_vars_test(proofs, view_cfg, {7, 7}, {4, 5, 6});      // 7 not in set: contradiction
 }
 
 auto run_random_tests(bool proofs, const ViewWrapConfig & view_cfg, mt19937 & rand) -> void

--- a/gcs/constraints/increasing_test.cc
+++ b/gcs/constraints/increasing_test.cc
@@ -144,6 +144,18 @@ auto run_all_for_variant(bool proofs, const ViewWrapConfig & view_cfg) -> void
     // Constant entries pinning the chain at a fixed value.
     run_inc_test<V>(proofs, view_cfg, {pair{0, 5}, 3, pair{0, 5}});
     run_inc_test<V>(proofs, view_cfg, {2, pair{0, 5}, 4});
+
+    // All-constant chains (issue #254): genuine ConstantIntegerVariableIDs,
+    // so each variant reduces to a true/false check. build_expected computes
+    // the per-variant truth, covering both directions: e.g. {1,2,3} satisfies
+    // (Strictly)Increasing but not the Decreasing variants; {2,2,3} satisfies
+    // Increasing but not StrictlyIncreasing; {3,2,1} the mirror image.
+    run_inc_test<V>(proofs, view_cfg, {1, 2, 3});
+    run_inc_test<V>(proofs, view_cfg, {2, 2, 3});
+    run_inc_test<V>(proofs, view_cfg, {3, 2, 1});
+    run_inc_test<V>(proofs, view_cfg, {2, 2, 2});
+    // Mixed: a genuine constant plus a singleton-domain variable.
+    run_inc_test<V>(proofs, view_cfg, {1, pair{2, 2}, 3});
 }
 
 // Dup-variable test: Increasing/Decreasing variants with the same

--- a/gcs/constraints/inverse_test.cc
+++ b/gcs/constraints/inverse_test.cc
@@ -140,7 +140,11 @@ auto main(int argc, char * argv[]) -> int
         // `0 ≥ 1` contradiction, which downstream pol expressions sum into a
         // valid contradiction proof.
         {{3, 2, 3, pair{0, 3}}, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}},
-        {{pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, {1, pair{0, 3}, 1, pair{0, 3}}}};
+        {{pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, {1, pair{0, 3}, 1, pair{0, 3}}},
+        // issue #254: fully all-constant arguments, both directions.
+        {{0, 1}, {0, 1}},  // identity permutation, consistent (tautology)
+        {{1, 0}, {1, 0}},  // swap: x[0]=1<->y[1]=0, x[1]=0<->y[0]=1, consistent (tautology)
+        {{1, 0}, {0, 1}}}; // x swapped but y identity: inconsistent (contradiction)
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/knapsack_test.cc
+++ b/gcs/constraints/knapsack_test.cc
@@ -187,7 +187,19 @@ auto main(int, char *[]) -> int
         {{0, 1}, {{8, 7, 4, 8}, {4, 3, 4, 4}}, {{0, 18}, {10, 1000}}},
         {{0, 1}, {{7, 4, 4, 7}, {1, 2, 1, 0}}, {{18, 19}, {3, 8}}},
         {{2, 4}, {{4, 1, 2, 3}, {4, 6, 3, 8}, {5, 3, 1, 6}}, {{0, 64}, {0, 48}, {0, 41}}},
-        {{1, 4}, {{1, 8, 3, 1}}, {{3, 42}}}};
+        {{1, 4}, {{1, 8, 3, 1}}, {{3, 42}}},
+        // Degenerate cases (issue #254).
+        // Empty item list (zero columns): every weighted sum is 0, so the
+        // totals must admit 0.
+        {{0, 0}, {{}}, {{0, 0}}},          // empty items, total admits 0 (tautology)
+        {{0, 0}, {{}}, {{5, 5}}},          // empty items, total can't be 0 (contradiction)
+        // Single item.
+        {{0, 1}, {{5}}, {{0, 5}}},         // one item, two takings
+        // All-fixed taken variables (valrange is a singleton), both directions.
+        {{0, 0}, {{2, 3}}, {{0, 0}}},      // all taken 0: sum 0 == total (tautology)
+        {{0, 0}, {{2, 3}}, {{5, 5}}},      // all taken 0: sum 0 != total 5 (contradiction)
+        {{1, 1}, {{2, 3}}, {{5, 5}}},      // all taken 1: sum 5 == total (tautology)
+        {{1, 1}, {{2, 3}}, {{4, 4}}}};     // all taken 1: sum 5 != total 4 (contradiction)
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/lex.cc
+++ b/gcs/constraints/lex.cc
@@ -478,8 +478,19 @@ namespace
         WPBSum at_least_one;
         for (auto & da : *d.decision_at)
             at_least_one += 1_i * da;
-        if (equal_prefix_satisfies)
+        if (equal_prefix_satisfies) {
+            if (n == 0) {
+                // The common prefix is empty, and an empty prefix is trivially
+                // equal (prefix_equal[0] is the nullopt placeholder for that
+                // always-TRUE flag). With equal_prefix_satisfies, the
+                // at-least-one disjunction is therefore satisfied
+                // unconditionally and needs no constraint. Dereferencing
+                // prefix_equal->at(0) here would be a nullopt access (issue
+                // #254: lex with one empty operand).
+                return d;
+            }
             at_least_one += 1_i * *d.prefix_equal->at(n);
+        }
         model.add_constraint(move(at_least_one) >= 1_i, cond_half_reify);
 
         return d;

--- a/gcs/constraints/lex_test.cc
+++ b/gcs/constraints/lex_test.cc
@@ -472,6 +472,17 @@ auto run_variant_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
     // element" case.
     run_lex_test_unequal<V>(proofs, view_cfg, {{1, 3}}, {{1, 3}, {1, 3}, {1, 3}});
     run_lex_test_unequal<V>(proofs, view_cfg, {{1, 3}, {1, 3}, {1, 3}}, {{1, 3}});
+
+    // Degenerate (issue #254): empty operands and all-fixed operands.
+    // Empty-vs-empty: equal, so the non-strict variants hold and the strict
+    // ones do not. Empty-vs-nonempty: the empty side is a strict prefix.
+    run_lex_test_unequal<V>(proofs, view_cfg, {}, {});               // equal-length empty: depends on or_equal
+    run_lex_test_unequal<V>(proofs, view_cfg, {}, {{1, 3}});         // empty < [x]
+    run_lex_test_unequal<V>(proofs, view_cfg, {{1, 3}}, {});         // [x] > empty
+    // All-fixed (singleton) operands, both directions.
+    run_lex_test_unequal<V>(proofs, view_cfg, {{1, 1}}, {{2, 2}});             // [1] < [2]
+    run_lex_test_unequal<V>(proofs, view_cfg, {{1, 1}, {2, 2}}, {{1, 1}, {2, 2}}); // equal
+    run_lex_test_unequal<V>(proofs, view_cfg, {{1, 1}, {3, 3}}, {{1, 1}, {2, 2}}); // [1,3] > [1,2]
 }
 
 // Dup-variable test: Lex with the same handle appearing across the two

--- a/gcs/constraints/logical_test.cc
+++ b/gcs/constraints/logical_test.cc
@@ -181,7 +181,17 @@ auto main(int argc, char * argv[]) -> int
         {{{2, 5}, {-2, -1}, {1, 3}, {2, 5}}, {0, 2}},
         {{{2, 5}, {2, 5}}, {0, 0}},
         {{{-2, 1}, {2, 5}, {-2, 1}, {2, 5}}, {-1, 1}},
-        {{{}}, {0, 1}}};
+        {{{}}, {0, 1}},
+        // Degenerate cases (issue #254). Genuinely empty operand array: And() is
+        // true, Or() is false, so the reif is pinned accordingly.
+        {{}, {0, 1}},
+        // All-constant operands, both reif directions. Each row runs for both
+        // And and Or; build_expected computes the per-connective truth.
+        {{{1, 1}, {1, 1}}, {0, 1}}, // all true: And true, Or true
+        {{{1, 1}, {0, 0}}, {0, 1}}, // one false: And false, Or true
+        {{{0, 0}, {0, 0}}, {0, 1}}, // all false: And false, Or false
+        {{{1, 1}, {1, 1}}, {0, 0}}, // all true but reif pinned false (contradiction for Or; And too)
+        {{{0, 0}, {0, 0}}, {1, 1}}}; // all false but reif pinned true (contradiction)
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/min_max_test.cc
+++ b/gcs/constraints/min_max_test.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/constraints/min_max.hh>
+#include <gcs/exception.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 #include <util/enumerate.hh>
@@ -162,7 +163,16 @@ auto main(int argc, char * argv[]) -> int
         {pair{-3, 2}, {pair{-1, 7}, pair{-2, 6}, pair{1, 8}, pair{4, 11}}},
         // Constant array entries: forced winner / fixed pivot.
         {pair{-5, 10}, {3, pair{0, 7}, 5}},
-        {pair{-5, 10}, {pair{0, 4}, 7, pair{1, 6}, pair{2, 9}}}};
+        {pair{-5, 10}, {pair{0, 4}, 7, pair{1, 6}, pair{2, 9}}},
+        // Degenerate cases (issue #254): all-constant arrays + genuine constant
+        // result. Each row is run for both Min and Max; build_expected computes
+        // the per-direction truth. (Empty array is rejected at construction by
+        // ArrayMin/ArrayMax::prepare and so is covered separately, not here.)
+        {4, {4, 4, 4}},        // all equal: min == max == 4, result 4 (tautology both)
+        {4, {3, 5, 4}},        // min 3 / max 5: result 4 wrong for both (contradiction both)
+        {4, {4}},              // single constant element (tautology both)
+        {3, {4}},              // single constant element: result 3 wrong (contradiction both)
+        {pair{0, 9}, {3, 5, pair{0, 9}}}}; // mixed: two constants plus a variable
 
     random_device rand_dev;
     mt19937 rand(rand_dev());
@@ -198,6 +208,35 @@ auto main(int argc, char * argv[]) -> int
                 // {x, y, z} with result = y — forces y == min/max(x,y,z).
                 run_dup_min_max_test(proofs, m, "xyz_resy", {{1, 4}, {1, 4}, {1, 4}}, {0, 1, 2}, 1, {0, 5});
             }
+        }
+    }
+
+    // Degenerate (issue #254): min/max over an empty array has no well-defined
+    // value, and must be rejected with a clean exception rather than asserting
+    // or reading past the end of the (empty) container.
+    {
+        bool empty_min_throws = false, empty_max_throws = false;
+        try {
+            Problem p;
+            auto result = p.create_integer_variable(0_i, 5_i);
+            p.post(ArrayMin{vector<IntegerVariableID>{}, result});
+            solve(p, [](const CurrentState &) { return true; });
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            empty_min_throws = true;
+        }
+        try {
+            Problem p;
+            auto result = p.create_integer_variable(0_i, 5_i);
+            p.post(ArrayMax{vector<IntegerVariableID>{}, result});
+            solve(p, [](const CurrentState &) { return true; });
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            empty_max_throws = true;
+        }
+        if (! empty_min_throws || ! empty_max_throws) {
+            println(cerr, "min/max over empty array: expected InvalidProblemDefinitionException");
+            return EXIT_FAILURE;
         }
     }
 

--- a/gcs/constraints/mult_bc_test.cc
+++ b/gcs/constraints/mult_bc_test.cc
@@ -99,7 +99,15 @@ auto main(int, char *[]) -> int
         {{-10, 2}, {-5, 3}, {4, 9}},
         {{9, 23}, {-5, 9}, {9, 14}},
         {{-4, 8}, {-8, 7}, {-2, 9}},
-        {{-34, -27}, {-10, 2}, {29, 179}}};
+        {{-34, -27}, {-10, 2}, {29, 179}},
+        // issue #254: all-fixed (singleton-domain) operands, both directions —
+        // the product is fully determined, so the constraint reduces to a
+        // true/false check.
+        {{2, 2}, {3, 3}, {6, 6}},     // 2*3 == 6 (tautology)
+        {{2, 2}, {3, 3}, {7, 7}},     // 2*3 != 7 (contradiction)
+        {{0, 0}, {5, 5}, {0, 0}},     // 0*5 == 0 (tautology)
+        {{-2, -2}, {3, 3}, {-6, -6}}, // -2*3 == -6 (tautology)
+        {{-2, -2}, {3, 3}, {6, 6}}};  // -2*3 != 6 (contradiction)
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/n_value_test.cc
+++ b/gcs/constraints/n_value_test.cc
@@ -133,7 +133,14 @@ auto main(int argc, char * argv[]) -> int
         {pair{-5, 5}, {pair{-8, 0}, pair{4, 4}, pair{10, 10}, pair{2, 11}, pair{4, 10}}},
         // Constant array entries: pinned values count toward distinct.
         {pair{0, 5}, {3, pair{1, 4}, 3}},
-        {pair{0, 5}, {1, 2, 3, pair{0, 5}}}};
+        {pair{0, 5}, {1, 2, 3, pair{0, 5}}},
+        // Degenerate cases (issue #254): all-constant arrays + genuine constant result.
+        {1, {5, 5, 5}},        // all same constant: 1 distinct value (tautology)
+        {2, {5, 6, 5}},        // all-constant: 2 distinct values (tautology)
+        {1, {5, 6}},           // all-constant: 2 distinct, result can't be 1 (contradiction)
+        {1, {7}},              // single constant element: 1 distinct (tautology)
+        {2, {7}},              // single constant element: result can't be 2 (contradiction)
+        {2, {5, pair{5, 6}, 6}}}; // mixed: two constants plus a variable
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/parity_test.cc
+++ b/gcs/constraints/parity_test.cc
@@ -148,7 +148,13 @@ auto main(int argc, char * argv[]) -> int
         // All-constant infeasible (count = 2, even).
         {1, 1, 0},
         // All-constant feasible (count = 1, odd).
-        {1, 0, 0}};
+        {1, 0, 0},
+        // Single genuine constant (issue #254): one nonzero is odd (tautology).
+        {5},
+        // Two genuine nonzero constants: count = 2, even (contradiction).
+        {2, 3},
+        // Longer all-constant: count = 3, odd (tautology).
+        {1, 2, 0, -1}};
 
     random_device rand_dev;
     mt19937 rand(rand_dev());

--- a/gcs/constraints/plus_minus_test.cc
+++ b/gcs/constraints/plus_minus_test.cc
@@ -187,7 +187,14 @@ auto main(int argc, char * argv[]) -> int
         // Constant-result regression: x + y == 6 over [1,5] × [1,5].
         {pair{1, 5}, pair{1, 5}, 6},
         // Constant-operand: x + 2 == z over [1,5] × [3,8].
-        {pair{1, 5}, 2, pair{3, 8}}};
+        {pair{1, 5}, 2, pair{3, 8}},
+        // issue #254: fully all-constant operands (ConstantIntegerVariableID).
+        // Each row runs for both Plus and Minus; build_expected gives the
+        // per-operation truth, e.g. {2,3,5}: 2+3==5 (Plus SAT) but 2-3!=5
+        // (Minus UNSAT); {4,1,3}: 4+1!=3 (Plus UNSAT) but 4-1==3 (Minus SAT).
+        {2, 3, 5},
+        {4, 1, 3},
+        {0, 0, 0}};
 
     // The random sweep mixes constants and bounds-pairs across all three slots
     // via random_bounds_or_constant. v1/v2's variant is wider than the helper's

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -287,6 +287,25 @@ namespace
         auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
         auto gen_reason = generic_reason(state, vars);
 
+        // Degenerate empty sequence (issue #254): with no variables there is
+        // nothing to propagate over, but the empty word is accepted only if the
+        // initial state (0) is itself a final state. The per-position loops
+        // below are all empty when vars.empty(), so detect the infeasible case
+        // explicitly. The proof model pins state_at_pos[0] to state 0 and
+        // requires it to be final (with an exactly-one over the states), so the
+        // contradiction is reverse-unit-propagatable.
+        if (vars.empty()) {
+            bool initial_is_final = false;
+            for (auto f : final_states)
+                if (f == 0L) {
+                    initial_is_final = true;
+                    break;
+                }
+            if (! initial_is_final)
+                inference.contradiction(logger, JustifyUsingRUP{}, gen_reason);
+            return;
+        }
+
         ReasonFunction reason;
         ProofLine reason_definition_1, reason_definition_2;
 

--- a/gcs/constraints/regular/regular_test.cc
+++ b/gcs/constraints/regular/regular_test.cc
@@ -252,6 +252,46 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
         {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}},
         {1});
 
+    // Degenerate cases (issue #254). The even-zeros DFA: state 0 (initial) is
+    // the "even count of 0s" state; 0 toggles state, 1 keeps it.
+    // Empty sequence with the initial state accepting -> the empty word is
+    // accepted (zero 0s is even).
+    run_regular_test(proofs, view_cfg, "empty seq accepted",
+        {},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0});
+    // Empty sequence with only the non-initial state accepting -> the empty
+    // word is rejected.
+    run_regular_test(proofs, view_cfg, "empty seq rejected",
+        {},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {1});
+    // Single fixed symbol, both directions.
+    run_regular_test(proofs, view_cfg, "single fixed accepted",
+        {{1, 1}},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0}); // [1] has zero 0s: accepted
+    run_regular_test(proofs, view_cfg, "single fixed rejected",
+        {{0, 0}},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0}); // [0] has one 0 (odd): rejected
+    // Fully fixed multi-symbol accepted word.
+    run_regular_test(proofs, view_cfg, "all fixed accepted",
+        {{1, 1}, {0, 0}, {0, 0}},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0}); // two 0s (even): accepted
+    // Mixed fixed + variable: only the middle symbol can make the count even.
+    run_regular_test(proofs, view_cfg, "mixed fixed and variable",
+        {{0, 0}, {0, 1}, {0, 0}},
+        2,
+        {{{0_i, 1}, {1_i, 0}}, {{0_i, 0}, {1_i, 1}}},
+        {0}); // accepted only when the middle symbol is 1
+
     // Regex-string and dup tests use bare variables; only run them when no
     // wrapping is in effect, to avoid duplicating the bare coverage under
     // every wrap.

--- a/gcs/constraints/seq_precede_chain_test.cc
+++ b/gcs/constraints/seq_precede_chain_test.cc
@@ -158,6 +158,13 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
     run_test(proofs, view_cfg, {pair{1, 4}, 1, pair{1, 4}, 2});
     // Constant zero / negative entries are unconstrained by the chain.
     run_test(proofs, view_cfg, {0, pair{1, 3}, -1, pair{1, 3}});
+
+    // Degenerate (issue #254): single-element and fully all-constant arrays,
+    // both directions (a value v>=2 needs v-1 to appear earlier).
+    run_test(proofs, view_cfg, {1});       // single constant, value < 2 (tautology)
+    run_test(proofs, view_cfg, {2});       // single constant, value 2 with no preceding 1 (contradiction)
+    run_test(proofs, view_cfg, {1, 2, 3}); // all-const, properly chained (tautology)
+    run_test(proofs, view_cfg, {3, 1, 2}); // all-const, 3 before its prerequisite 2 (contradiction)
 }
 
 // Dup-variable test: SeqPrecedeChain with the same handle in several

--- a/gcs/constraints/smart_table_test.cc
+++ b/gcs/constraints/smart_table_test.cc
@@ -359,6 +359,69 @@ auto run_wide_constants_test(bool proofs, const string & mode) -> void
     }
 }
 
+// issue #254: degenerate SmartTable instances — an empty tuple list (no
+// allowed tuple, so unsatisfiable), all-fixed (singleton-domain) variables in
+// both the matching and non-matching directions, and a single-variable table.
+auto run_degenerate_test(bool proofs, const string & mode) -> void
+{
+    auto basename = "smart_table_test_" + mode;
+
+    // Empty tuple list: unsatisfiable.
+    {
+        print(cerr, "smart table {} empty-tuples{}", mode, proofs ? " with proofs:" : ":");
+        cerr << flush;
+        Problem p;
+        auto x = p.create_integer_variable(1_i, 2_i);
+        auto y = p.create_integer_variable(1_i, 2_i);
+        p.post(SmartTable{{x, y}, SmartTuples{}});
+        set<tuple<int, int>> expected, actual; // empty: unsatisfiable
+        auto proof_name = proofs ? make_optional(basename + "_empty") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{x, y});
+        check_results(proof_name, expected, actual);
+    }
+
+    // All-fixed variables that satisfy the (single) tuple.
+    {
+        print(cerr, "smart table {} fixed-match{}", mode, proofs ? " with proofs:" : ":");
+        cerr << flush;
+        Problem p;
+        auto x = p.create_integer_variable(1_i, 1_i);
+        auto y = p.create_integer_variable(2_i, 2_i);
+        p.post(SmartTable{{x, y}, SmartTuples{{SmartTable::equals(x, 1_i), SmartTable::equals(y, 2_i)}}});
+        set<tuple<int, int>> expected{{1, 2}}, actual;
+        auto proof_name = proofs ? make_optional(basename + "_match") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{x, y});
+        check_results(proof_name, expected, actual);
+    }
+
+    // All-fixed variables that violate the tuple: unsatisfiable.
+    {
+        print(cerr, "smart table {} fixed-nomatch{}", mode, proofs ? " with proofs:" : ":");
+        cerr << flush;
+        Problem p;
+        auto x = p.create_integer_variable(1_i, 1_i);
+        auto y = p.create_integer_variable(3_i, 3_i);
+        p.post(SmartTable{{x, y}, SmartTuples{{SmartTable::equals(x, 1_i), SmartTable::equals(y, 2_i)}}});
+        set<tuple<int, int>> expected, actual; // empty: y is fixed to 3, tuple needs y == 2
+        auto proof_name = proofs ? make_optional(basename + "_nomatch") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{x, y});
+        check_results(proof_name, expected, actual);
+    }
+
+    // Single variable, single unary tuple selecting a subset of the domain.
+    {
+        print(cerr, "smart table {} single-var{}", mode, proofs ? " with proofs:" : ":");
+        cerr << flush;
+        Problem p;
+        auto x = p.create_integer_variable(1_i, 3_i);
+        p.post(SmartTable{{x}, SmartTuples{{SmartTable::equals(x, 2_i)}}});
+        set<tuple<int>> expected{{2}}, actual;
+        auto proof_name = proofs ? make_optional(basename + "_single") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{x});
+        check_results(proof_name, expected, actual);
+    }
+}
+
 auto main(int argc, char * argv[]) -> int
 {
     if (argc != 2)
@@ -377,7 +440,7 @@ auto main(int argc, char * argv[]) -> int
 
     // These modes carry their own instances rather than using the
     // length/ranges table below.
-    if (mode == "mixed_same_var" || mode == "stacked_unary" || mode == "wide_constants") {
+    if (mode == "mixed_same_var" || mode == "stacked_unary" || mode == "wide_constants" || mode == "degenerate") {
         for (bool proofs : {false, true}) {
             if (proofs && ! can_run_veripb())
                 continue;
@@ -385,8 +448,10 @@ auto main(int argc, char * argv[]) -> int
                 run_mixed_same_var_test(proofs, mode);
             else if (mode == "stacked_unary")
                 run_stacked_unary_test(proofs, mode);
-            else
+            else if (mode == "wide_constants")
                 run_wide_constants_test(proofs, mode);
+            else
+                run_degenerate_test(proofs, mode);
         }
         return EXIT_SUCCESS;
     }

--- a/gcs/constraints/sort/arg_sort_test.cc
+++ b/gcs/constraints/sort/arg_sort_test.cc
@@ -121,6 +121,14 @@ auto main(int argc, char * argv[]) -> int
         // Single element: p[0] pinned to offset.
         run_arg_sort_test(proofs, 0, {{0, 5}});
 
+        // Degenerate (issue #254): empty input (vacuously satisfied) and
+        // all-fixed inputs (the permutation is uniquely determined), 0- and
+        // 1-based.
+        run_arg_sort_test(proofs, 0, {});                          // empty input
+        run_arg_sort_test(proofs, 0, {{5, 5}});                    // single fixed: p[0]==offset
+        run_arg_sort_test(proofs, 0, {{3, 3}, {1, 1}, {2, 2}});    // all fixed distinct, 0-based
+        run_arg_sort_test(proofs, 1, {{3, 3}, {1, 1}, {2, 2}});    // all fixed distinct, 1-based
+
         // Negative values.
         run_arg_sort_test(proofs, 0, {{-2, 0}, {-2, 0}});
 

--- a/gcs/constraints/sort/sort_test.cc
+++ b/gcs/constraints/sort/sort_test.cc
@@ -146,6 +146,14 @@ auto main(int argc, char * argv[]) -> int
         // Single element (y[0] == x[0]).
         run_sort_test(proofs, {{0, 3}}, {{0, 3}});
 
+        // Degenerate (issue #254): empty arrays (vacuously satisfied) and
+        // all-fixed inputs/outputs in both directions.
+        run_sort_test(proofs, {}, {});                                            // empty: vacuous
+        run_sort_test(proofs, {{5, 5}}, {{5, 5}});                                // single fixed: y[0]==x[0] (tautology)
+        run_sort_test(proofs, {{3, 3}}, {{2, 2}});                                // single fixed: y[0]!=x[0] (contradiction)
+        run_sort_test(proofs, {{2, 2}, {1, 1}, {2, 2}}, {{1, 1}, {2, 2}, {2, 2}}); // all fixed, correctly sorted (tautology)
+        run_sort_test(proofs, {{1, 1}, {2, 2}}, {{2, 2}, {1, 1}});                // all fixed, y not sorted (contradiction)
+
         // n = 4, exercises the matching/SCC on a larger instance.
         run_sort_test(proofs, {{0, 3}, {0, 3}, {0, 3}, {0, 3}}, {{0, 3}, {0, 3}, {0, 3}, {0, 3}});
 

--- a/gcs/constraints/table/negative_table_test.cc
+++ b/gcs/constraints/table/negative_table_test.cc
@@ -182,6 +182,14 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
         {{4_i, 4_i}, {1_i, 1_i}}); // first tuple already infeasible (4 not in dom): satisfied automatically
     run_negative_table_test_2(proofs, view_cfg, {1, 3}, {1, 3},
         {{1_i, 1_i}, {1_i, 1_i}, {2_i, 2_i}}); // duplicates in forbidden list
+    // Degenerate (issue #254): empty forbidden list (all allowed) and all-fixed
+    // variables in both directions.
+    run_negative_table_test_2(proofs, view_cfg, {1, 3}, {1, 3},
+        {}); // empty forbidden list: every assignment allowed
+    run_negative_table_test_2(proofs, view_cfg, {1, 1}, {2, 2},
+        {{2_i, 1_i}, {3_i, 3_i}}); // fixed (1,2) not forbidden (tautology)
+    run_negative_table_test_2(proofs, view_cfg, {1, 1}, {2, 2},
+        {{1_i, 2_i}}); // fixed (1,2) is forbidden (contradiction)
 
     // Three-variable cases.
     run_negative_table_test_3(proofs, view_cfg, {1, 3}, {1, 3}, {1, 3},

--- a/gcs/constraints/table_test.cc
+++ b/gcs/constraints/table_test.cc
@@ -180,6 +180,14 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
         {});  // empty table: unsatisfiable
     run_table_test_2(proofs, view_cfg, {-2, 2}, {-2, 2},
         {{-2_i, 2_i}, {0_i, 0_i}, {2_i, -2_i}});
+    // Degenerate (issue #254): all-fixed variables, both directions, and a
+    // mixed fixed+variable case. (Empty tuple list → UNSAT is covered above.)
+    run_table_test_2(proofs, view_cfg, {1, 1}, {1, 1},
+        {{1_i, 1_i}});  // fixed (1,1) is an allowed tuple (tautology)
+    run_table_test_2(proofs, view_cfg, {2, 2}, {3, 3},
+        {{1_i, 1_i}});  // fixed (2,3) is not in the table (contradiction)
+    run_table_test_2(proofs, view_cfg, {1, 1}, {1, 3},
+        {{1_i, 1_i}, {1_i, 2_i}});  // mixed: v1 fixed, v2 variable
 
     // Table, 3 variables
     run_table_test_3(proofs, view_cfg, {1, 3}, {1, 3}, {1, 3},

--- a/gcs/constraints/value_precede_test.cc
+++ b/gcs/constraints/value_precede_test.cc
@@ -146,6 +146,15 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
     run_value_precede_test(proofs, view_cfg, {1, 2}, {1, pair{1, 3}, pair{1, 3}});
     run_value_precede_test(proofs, view_cfg, {1, 2}, {pair{1, 3}, 2, pair{1, 3}});  // unsat: forces 2 in pos 1 with no preceding 1
     run_value_precede_test(proofs, view_cfg, {1, 2, 3}, {1, pair{1, 3}, 2, pair{1, 3}});
+
+    // Degenerate collections (issue #254): empty / single-element vars, and
+    // all-constant vars in both directions.
+    run_value_precede_test(proofs, view_cfg, {1, 2}, {});       // empty vars: vacuously true
+    run_value_precede_test(proofs, view_cfg, {1, 2}, {1});      // single const: 1 with no 2 (tautology)
+    run_value_precede_test(proofs, view_cfg, {1, 2}, {2});      // single const: 2 before any 1 (contradiction)
+    run_value_precede_test(proofs, view_cfg, {1, 2}, {5});      // single const: neither chain value (tautology)
+    run_value_precede_test(proofs, view_cfg, {1, 2, 3}, {1, 2, 3}); // all-const, in order (tautology)
+    run_value_precede_test(proofs, view_cfg, {1, 2, 3}, {3, 2, 1}); // all-const, reversed (contradiction)
 }
 
 // Dup-variable test: ValuePrecede with the same handle in several array


### PR DESCRIPTION
Closes #254.

Audits **every** constraint family in `gcs/constraints/` for the two degenerate
argument shapes called out in #254 — **all-constant arguments** and **empty /
single-element collections** (plus mixed const+var) — and adds test coverage,
run with proofs on so VeriPB validates each case in both the tautology and
contradiction directions.

## Bugs found and fixed

Two genuine bugs surfaced, each fixed with its regression test in the same commit:

1. **Lex with an empty operand** — `build_lex_direction_encoding` formed the
   at-least-one disjunction with `1*(*prefix_equal->at(n))`. When
   `n = min(|vars_1|,|vars_2|) == 0` (one operand empty) and the empty prefix
   satisfies the constraint, `prefix_equal->at(0)` is the deliberately-`nullopt`
   placeholder for the trivially-TRUE empty-prefix flag, so dereferencing it was
   UB and registered a garbage proof flag — aborting with `ProofError: can't
   find literals for flag`. Latent until `--prove`. Fixed by skipping the
   (unconditionally-satisfied) constraint when `n == 0`.

2. **Regular over an empty sequence** — `propagate_regular` does all its work in
   loops over the per-position arrays (length = number of variables), so with an
   empty variable list it never checked that the empty word is accepted only
   when the initial state is final. `Regular([], …, final_states)` reported the
   empty assignment as a solution even when `0 ∉ final_states` — a **wrong-SAT
   soundness bug**, present with and without proofs. Fixed by inferring a RUP
   contradiction for the empty-sequence case when the initial state isn't final
   (the proof model already pins state 0 and requires a final state).

## Coverage

All families now exercise the degenerate shapes: abs, all_different (+ except,
symmetric), all_equal, among, arithmetic, at_most_one, circuit, comparison,
count, cumulative, disjunctive (+ 2d), element, equals, global_cardinality
(bounds + GAC), in, increasing, inverse, knapsack, lex, logical, min/max,
mult_bc, n_value, parity, plus/minus, regular, seq_precede_chain, smart_table,
sort/arg_sort, table/negative_table, value_precede.

Where the existing data-driven harness accepts a `variant<int,…>` spec, genuine
`ConstantIntegerVariableID`s are used (the #248-class path). Where it only takes
`pair<int,int>`, or the constraint rejects constants by design (SmartTable),
singleton-domain variables and/or focused tests cover the all-fixed path. A few
constraints needed small focused additions (AllDifferent / AllEqual collection
tests, a SmartTable `degenerate` mode, a Min/Max empty-array exception check,
Circuit n=1/n=2). Notable well-defined rejections kept as tested behaviour:
min/max of an empty array throws `InvalidProblemDefinitionException` (not UB).

## Testing

Full suite green: **361/361 ctest tests pass** (GCC release, VeriPB 3.0.2),
including all proof verification. One commit per constraint family so any
regression stays bisectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)