### PR TITLE
s_expr: wrap all_equal / increasing variable lists in a sublist (#379)

### DIFF
--- a/gcs/constraints/all_equal.cc
+++ b/gcs/constraints/all_equal.cc
@@ -151,8 +151,9 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
 auto AllEqual::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
-    std::vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom("all_equal")};
+    std::vector<SExpr> vars;
     for (const auto & v : _vars)
-        terms.push_back(tracker.s_expr_term_of(v));
-    return SExpr::list(std::move(terms));
+        vars.push_back(tracker.s_expr_term_of(v));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("all_equal"),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/constraints/increasing.cc
+++ b/gcs/constraints/increasing.cc
@@ -141,8 +141,9 @@ auto IncreasingChain::s_expr(const ProofModel * const model) const -> SExpr
         ? (_descending ? "strictly_decreasing" : "strictly_increasing")
         : (_descending ? "decreasing" : "increasing");
 
-    std::vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(keyword)};
+    std::vector<SExpr> vars;
     for (const auto & v : _vars)
-        terms.push_back(tracker.s_expr_term_of(v));
-    return SExpr::list(std::move(terms));
+        vars.push_back(tracker.s_expr_term_of(v));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(keyword),
+        SExpr::list(std::move(vars))});
 }

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -1,10 +1,12 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/all_equal.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/count.hh>
 #include <gcs/constraints/element.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/in.hh>
+#include <gcs/constraints/increasing.hh>
 #include <gcs/constraints/inverse.hh>
 #include <gcs/constraints/linear/linear_equality.hh>
 #include <gcs/constraints/linear/linear_inequality.hh>
@@ -293,6 +295,21 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
             if (terms.size() != 3)
                 throw ScpReadError{"all_different takes one list: (label all_different (vars...))"};
             post_constraint(problem, AllDifferent{resolve_variable_list(variables, terms[2], "the all_different variable list")}, label);
+        }
+        else if (op == "all_equal") {
+            if (terms.size() != 3)
+                throw ScpReadError{"all_equal takes one list: (label all_equal (vars...))"};
+            post_constraint(problem, AllEqual{resolve_variable_list(variables, terms[2], "the all_equal variable list")}, label);
+        }
+        else if (op == "increasing" || op == "strictly_increasing" || op == "decreasing" || op == "strictly_decreasing") {
+            // The keyword carries the strict / descending flags that IncreasingChain
+            // takes directly (the inverse of how the writer derives the keyword).
+            if (terms.size() != 3)
+                throw ScpReadError{"the increasing family takes one list: (label " + op + " (vars...))"};
+            post_constraint(problem,
+                IncreasingChain{resolve_variable_list(variables, terms[2], "the increasing variable list"),
+                    op.starts_with("strictly_"), op.ends_with("decreasing")},
+                label);
         }
         else if (op == "in") {
             if (terms.size() != 4)

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -1,10 +1,12 @@
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/all_equal.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/count.hh>
 #include <gcs/constraints/element.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/in.hh>
+#include <gcs/constraints/increasing.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/current_state.hh>
 #include <gcs/expression.hh>
@@ -92,6 +94,29 @@ TEST_CASE("read_scp: all_different enumerates correctly")
         ))");
 
     CHECK(solutions == set<map<string, long long>>{{{"A", 0}, {"B", 1}}, {{"A", 1}, {"B", 0}}});
+}
+
+TEST_CASE("read_scp: all_equal enumerates correctly")
+{
+    auto solutions = enumerate(R"(
+        (
+            ( (A 0 2) (B 0 2) (C 0 2) )
+            ( (_1 all_equal (A B C)) )
+        ))");
+
+    CHECK(solutions == set<map<string, long long>>{{{"A", 0}, {"B", 0}, {"C", 0}}, {{"A", 1}, {"B", 1}, {"C", 1}}, {{"A", 2}, {"B", 2}, {"C", 2}}});
+}
+
+TEST_CASE("read_scp: the increasing family enumerates correctly")
+{
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (Z 0 2) ) ( (_1 increasing (X Y Z)) ) )"))
+        CHECK((s.at("X") <= s.at("Y") && s.at("Y") <= s.at("Z")));
+    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) (Z 0 3) ) ( (_1 strictly_increasing (X Y Z)) ) )"))
+        CHECK((s.at("X") < s.at("Y") && s.at("Y") < s.at("Z")));
+    for (const auto & s : enumerate("( ( (X 0 2) (Y 0 2) (Z 0 2) ) ( (_1 decreasing (X Y Z)) ) )"))
+        CHECK((s.at("X") >= s.at("Y") && s.at("Y") >= s.at("Z")));
+    for (const auto & s : enumerate("( ( (X 0 3) (Y 0 3) (Z 0 3) ) ( (_1 strictly_decreasing (X Y Z)) ) )"))
+        CHECK((s.at("X") > s.at("Y") && s.at("Y") > s.at("Z")));
 }
 
 TEST_CASE("read_scp: in with a mix of integer and variable values")
@@ -269,6 +294,28 @@ TEST_CASE("read_scp: element and count survive write -> read -> write unchanged"
     Problem rebuilt;
     read_scp(rebuilt, scp_a);
     auto scp_b = prove_to_scp(rebuilt, "scp_reader_elemcount_b");
+
+    CHECK(scp_a == scp_b);
+    CHECK_FALSE(scp_a.empty());
+}
+
+TEST_CASE("read_scp: all_equal and the increasing family survive write -> read -> write unchanged")
+{
+    Problem original;
+    auto a = original.create_integer_variable(0_i, 3_i, "A");
+    auto b = original.create_integer_variable(0_i, 3_i, "B");
+    auto c = original.create_integer_variable(0_i, 3_i, "C");
+    auto d = original.create_integer_variable(0_i, 3_i, "D");
+    original.post(AllEqual{std::vector<IntegerVariableID>{a, b}});
+    original.post(Increasing{std::vector<IntegerVariableID>{b, c}});
+    original.post(StrictlyIncreasing{std::vector<IntegerVariableID>{c, d}});
+    original.post(Decreasing{std::vector<IntegerVariableID>{d, c}});         // exercises the descending keyword
+    original.post(StrictlyDecreasing{std::vector<IntegerVariableID>{d, c}}); // ... and its strict variant
+    auto scp_a = prove_to_scp(original, "scp_reader_aeqinc_a");
+
+    Problem rebuilt;
+    read_scp(rebuilt, scp_a);
+    auto scp_b = prove_to_scp(rebuilt, "scp_reader_aeqinc_b");
 
     CHECK(scp_a == scp_b);
     CHECK_FALSE(scp_a.empty());


### PR DESCRIPTION
Closes #379.

## What

The `.scp` s-expression writers were inconsistent in how they serialise a variadic variable list. Every other variadic single-list constraint **wraps** the list in a sublist (`(c all_different (A B C))`), but `all_equal` and the `increasing` family **spread** the variables straight into the top-level term (`(c all_equal A B C)`). That forces any `.scp` reader to special-case those two ops instead of applying one uniform invariant ("a variadic variable list is always a sublist"), and it's fragile — spreading only stays unambiguous while the op has no trailing argument.

## Changes

- **Writers** — `AllEqual::s_expr` and `IncreasingChain::s_expr` now wrap their variable list, mirroring `all_different` (`gac_all_different.cc`):
  - `(_1 all_equal (A B C))` (was `(_1 all_equal A B C)`)
  - `(_1 strictly_increasing (A B C))` (was `(_1 strictly_increasing A B C)`)
- **Reader** — added `all_equal` and `increasing` / `decreasing` / `strictly_increasing` / `strictly_decreasing` cases to `gcs/scp_reader.cc`, which had neither before. The keyword carries the strict/descending flags straight into `IncreasingChain` (the exact inverse of how the writer derives the keyword).
- **Tests** — `scp_reader_test.cc` gains enumerate tests for `all_equal` and all four `increasing`-family keywords, plus a write → read → write round-trip identity test.

No committed `.scp` fixtures reference these ops, so none needed updating. The change is `.scp`-format-only — it does not touch OPB/proof output, so existing proofs are unaffected.

## Testing

- `scp_reader_test` — all 23 cases pass (264 assertions).
- `all_equal_test` and `increasing_test` re-run under `run_test_and_verify.bash`: VeriPB reports `VERIFIED COMPLETE ENUMERATION` / `VERIFIED UNSATISFIABLE`.
- Emitted format confirmed wrapped, e.g. `(_1 all_equal (_1 _2 _1))`.
- clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)