### PR TITLE
Disjunctive: variable durations in strict mode (#384)

### DIFF
--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -14,6 +14,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -36,6 +37,8 @@ using std::map;
 using std::max;
 using std::min;
 using std::move;
+using std::nullopt;
+using std::optional;
 using std::pair;
 using std::shared_ptr;
 using std::size_t;
@@ -67,25 +70,28 @@ namespace
     }
 }
 
-Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengths, bool strict) :
+Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths, bool strict) :
     _starts(move(starts)),
-    _lengths(as_constant_var_ids(lengths)),
+    _lengths(move(lengths)),
     _strict(strict)
 {
     if (_starts.size() != _lengths.size())
         throw InvalidProblemDefinitionException{"Disjunctive: starts and lengths must have the same size"};
-    for (const auto & l : lengths)
-        if (l < 0_i)
+    // Constant durations are checked here; variable durations are checked
+    // against their root lower bound in prepare().
+    for (const auto & l : _lengths)
+        if (is_constant_variable(l) && const_value_of(l) < 0_i)
             throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
+}
+
+Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengths, bool strict) :
+    Disjunctive(move(starts), as_constant_var_ids(lengths), strict)
+{
 }
 
 auto Disjunctive::clone() const -> unique_ptr<Constraint>
 {
-    vector<Integer> lengths;
-    lengths.reserve(_lengths.size());
-    for (const auto & l : _lengths)
-        lengths.push_back(const_value_of(l));
-    return make_unique<Disjunctive>(_starts, move(lengths), _strict);
+    return make_unique<Disjunctive>(_starts, _lengths, _strict);
 }
 
 auto Disjunctive::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
@@ -104,7 +110,7 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
     auto n = _starts.size();
 
     // Resolve length snapshots. _length_vals is the constant value (0
-    // placeholder for a variable, unused until variable durations land);
+    // placeholder for a variable, where _lengths[i] is read from the state);
     // _length_ub is the initial upper bound used to size the window.
     _length_vals.assign(n, 0_i);
     _length_ub.assign(n, 0_i);
@@ -113,8 +119,16 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
             _length_vals[i] = const_value_of(_lengths[i]);
             _length_ub[i] = const_value_of(_lengths[i]);
         }
-        else
+        else {
+            if (initial_state.lower_bound(_lengths[i]) < 0_i)
+                throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
+            // Variable durations in non-strict mode need the zero-length escape
+            // machinery; that lands in a later PR of the #384 stack.
+            if (! _strict)
+                throw InvalidProblemDefinitionException{
+                    "Disjunctive: variable durations are not yet supported in non-strict mode"};
             _length_ub[i] = initial_state.upper_bound(_lengths[i]);
+        }
     }
 
     // In non-strict mode, zero-length tasks are dropped: they cannot constrain
@@ -164,12 +178,35 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
     // Line numbers of both reification halves of each before flag, and of
     // each pairwise clause, are stored so the propagator can pol them into
     // bridge-derived at-most-one lemmas during justifications.
+    // For a task with a variable duration, the "after" bridge flag reifies on a
+    // proof-only end = s + l (a single variable keeps the pin RUP-friendly).
+    // Capture both definition directions: _end_ge materialises end's bound and
+    // _end_le cancels end back to s + l in the before-flag pol.
+    _end.assign(_starts.size(), nullopt);
+    _end_ge.assign(_starts.size(), nullopt);
+    _end_le.assign(_starts.size(), nullopt);
+    for (auto i : _active_tasks) {
+        if (is_constant_variable(_lengths[i]))
+            continue;
+        auto end = model.create_proof_only_integer_variable(
+            0_i, _per_task_t_hi[i] + 1_i, "disjend", IntegerVariableProofRepresentation::Bits);
+        _end_ge[i] = model.add_constraint("Disjunctive", "end >= s + l",
+            WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
+        _end_le[i] = model.add_constraint("Disjunctive", "end <= s + l",
+            WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] <= 0_i);
+        _end[i] = end;
+    }
+
+    // before_{i,j} <-> s_i + l_i <= s_j. For a constant duration this folds to
+    // s_i - s_j <= -l (byte-identical to the constant-only implementation); for
+    // a variable duration the length term stays on the left.
     auto emit_before = [&](size_t i, size_t j) -> BeforeFlagData {
         auto flag = model.create_proof_flag("disjbefore");
+        auto ineq = is_constant_variable(_lengths[i])
+            ? (WPBSum{} + 1_i * _starts[i] + -1_i * _starts[j] <= -_length_vals[i])
+            : (WPBSum{} + 1_i * _starts[i] + 1_i * _lengths[i] + -1_i * _starts[j] <= 0_i);
         auto [fwd, rev] = model.add_two_way_reified_constraint(
-            "Disjunctive", "first task finishes before second starts",
-            WPBSum{} + 1_i * _starts[i] + -1_i * _starts[j] <= -_length_vals[i],
-            flag);
+            "Disjunctive", "first task finishes before second starts", ineq, flag);
         return BeforeFlagData{flag, fwd, rev};
     };
     for (size_t a = 0; a < _active_tasks.size(); ++a) {
@@ -199,7 +236,7 @@ namespace
         ProofFlag before; // before_{i,t} <-> starts[i] <= t
         ProofLine before_fwd;
         ProofLine before_rev;
-        ProofFlag after; // after_{i,t} <-> starts[i] >= t - lengths[i] + 1
+        ProofFlag after; // after_{i,t} <-> starts[i] + lengths[i] >= t + 1
         ProofLine after_fwd;
         ProofLine after_rev;
         ProofFlag active; // active_{i,t} <-> before_{i,t} ^ after_{i,t}
@@ -227,21 +264,26 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
     auto bridge = make_shared<BridgeMap>();
 
     propagators.install_initialiser(
-        [starts = _starts, lengths = _length_vals, active_tasks = _active_tasks,
-            per_task_t_lo = _per_task_t_lo, per_task_t_hi = _per_task_t_hi,
-            bridge](State &, auto &, ProofLogger * const logger) -> void {
+        [starts = _starts, lengths = _length_vals, length_ub = _length_ub, ends = _end,
+            active_tasks = _active_tasks, per_task_t_lo = _per_task_t_lo,
+            per_task_t_hi = _per_task_t_hi, bridge](State &, auto &, ProofLogger * const logger) -> void {
             if (! logger)
                 return;
             for (auto i : active_tasks) {
-                if (lengths[i] == 0_i)
+                if (length_ub[i] == 0_i)
                     continue;
                 for (Integer t = per_task_t_lo[i]; t <= per_task_t_hi[i]; ++t) {
                     auto [B, B_fwd, B_rev] = logger->create_proof_flag_reifying(
                         WPBSum{} + 1_i * starts[i] <= t,
                         "djbef", ProofLevel::Top);
-                    auto [F, F_fwd, F_rev] = logger->create_proof_flag_reifying(
-                        WPBSum{} + 1_i * starts[i] >= t - lengths[i] + 1_i,
-                        "djaft", ProofLevel::Top);
+                    // after_{i,t} <-> s_i + l_i >= t+1. Constant duration: the
+                    // single-variable s_i >= t-l+1. Variable duration: the
+                    // single-variable end_i >= t+1 (end_i = s_i + l_i).
+                    auto [F, F_fwd, F_rev] = ends[i].has_value()
+                        ? logger->create_proof_flag_reifying(
+                              WPBSum{} + 1_i * *ends[i] >= t + 1_i, "djaft", ProofLevel::Top)
+                        : logger->create_proof_flag_reifying(
+                              WPBSum{} + 1_i * starts[i] >= t - lengths[i] + 1_i, "djaft", ProofLevel::Top);
                     auto [A, A_fwd, A_rev] = logger->create_proof_flag_reifying(
                         WPBSum{} + 1_i * B + 1_i * F >= 2_i,
                         "djact", ProofLevel::Top);
@@ -252,16 +294,31 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         });
 
     Triggers triggers;
-    for (auto i : _active_tasks)
+    for (auto i : _active_tasks) {
         triggers.on_bounds.emplace_back(_starts[i]);
+        // A rise in a task's minimum duration extends its mandatory part, so
+        // re-fire on variable-duration bound changes too.
+        if (! is_constant_variable(_lengths[i]))
+            triggers.on_bounds.emplace_back(_lengths[i]);
+    }
 
     propagators.install(
         constraint_id(),
-        [starts = move(_starts), lengths = move(_length_vals),
-            active_tasks = move(_active_tasks),
+        [starts = move(_starts), lengths = move(_length_vals), length_vars = move(_lengths),
+            end_ge = move(_end_ge), end_le = move(_end_le), active_tasks = move(_active_tasks),
             before_flags = move(_before_flags), clause_lines = move(_clause_lines),
             bridge](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            // Current guaranteed (min) and possible (max) duration of task i:
+            // for a constant duration both are the value; for a variable
+            // duration they are the live lower / upper bounds.
+            auto is_var_len = [&](size_t i) -> bool { return ! is_constant_variable(length_vars[i]); };
+            auto min_len = [&](size_t i) -> Integer {
+                return is_var_len(i) ? state.lower_bound(length_vars[i]) : lengths[i];
+            };
+            auto max_len = [&](size_t i) -> Integer {
+                return is_var_len(i) ? state.upper_bound(length_vars[i]) : lengths[i];
+            };
             // Time-table consistency, specialised to heights = 1 and
             // capacity = 1. Mandatory part of task i is [lst_i, eet_i)
             // where lst_i = ub(s_i) and eet_i = lb(s_i) + l_i: the slice it
@@ -282,10 +339,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             bool any = false;
             Integer t_lo = 0_i, t_hi = -1_i;
             for (auto i : active_tasks) {
-                if (lengths[i] == 0_i)
+                if (max_len(i) == 0_i)
                     continue;
                 auto [s_lo, s_hi] = state.bounds(starts[i]);
-                auto lo = s_lo, hi = s_hi + lengths[i] - 1_i;
+                auto lo = s_lo, hi = s_hi + max_len(i) - 1_i;
                 if (! any || lo < t_lo) t_lo = lo;
                 if (! any || hi > t_hi) t_hi = hi;
                 any = true;
@@ -296,10 +353,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 vector<int> mand_load(range, 0);
 
                 for (auto i : active_tasks) {
-                    if (lengths[i] == 0_i)
+                    if (min_len(i) == 0_i)
                         continue;
                     auto lst = state.upper_bound(starts[i]);
-                    auto eet = state.lower_bound(starts[i]) + lengths[i];
+                    auto eet = state.lower_bound(starts[i]) + min_len(i);
                     if (lst < eet)
                         for (Integer t = lst; t < eet; ++t)
                             ++mand_load[(t - t_lo).raw_value];
@@ -315,10 +372,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         size_t pi = 0, pj = 0;
                         bool got_first = false, got_second = false;
                         for (auto i : active_tasks) {
-                            if (lengths[i] == 0_i)
+                            if (min_len(i) == 0_i)
                                 continue;
                             auto lst = state.upper_bound(starts[i]);
-                            auto eet = state.lower_bound(starts[i]) + lengths[i];
+                            auto eet = state.lower_bound(starts[i]) + min_len(i);
                             if (lst < eet && violating_t >= lst && violating_t < eet) {
                                 if (! got_first) {
                                     pi = i;
@@ -335,28 +392,42 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             throw UnexpectedException{
                                 "Disjunctive: mand_load > 1 without two contributing tasks"};
 
-                        auto justify = [logger, &before_flags, &clause_lines, &bridge,
-                                           violating_t, pi, pj](const ReasonFunction & reason) -> void {
+                        auto justify = [&, violating_t, pi, pj](const ReasonFunction & reason) -> void {
                             auto & bf_i = bridge->at(make_pair(pi, violating_t));
                             auto & bf_j = bridge->at(make_pair(pj, violating_t));
 
-                            // Pin active_{*,vt} = 1 for both contributing tasks
-                            // under the bounds reason. Cumulative-style chain:
-                            // before, then after, then active — VeriPB UP can't
-                            // chase through the AND-gate of active's reverse
-                            // half in a single step.
-                            logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * bf_i.before >= 1_i, ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * bf_i.after >= 1_i, ProofLevel::Temporary);
-                            auto A_i_line = logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * bf_i.active >= 1_i, ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * bf_j.before >= 1_i, ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * bf_j.after >= 1_i, ProofLevel::Temporary);
-                            auto A_j_line = logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * bf_j.active >= 1_i, ProofLevel::Temporary);
+                            // Pin active_{r,vt} = 1 under the bounds reason.
+                            // Cumulative-style chain: before, then after, then
+                            // active — VeriPB UP can't chase the AND-gate of
+                            // active's reverse half in one step. For a variable
+                            // duration the after flag reifies on end = s + l, so
+                            // materialise end >= lb(s) + lb(l) first (the
+                            // end-proxy technique) so the after RUP closes
+                            // single-variable in end.
+                            auto pin = [&](const BridgeFlags & bf, size_t r) -> ProofLine {
+                                logger->emit_rup_proof_line_under_reason(reason,
+                                    WPBSum{} + 1_i * bf.before >= 1_i, ProofLevel::Temporary);
+                                if (is_var_len(r)) {
+                                    // Materialise end >= lb(s) + lb(l). A constant
+                                    // start is already folded into end_ge's RHS, so
+                                    // only a variable start contributes a literal
+                                    // (a constant has no pol-defining literal).
+                                    PolBuilder pb;
+                                    pb.add(*end_ge[r]);
+                                    if (! is_constant_variable(starts[r]))
+                                        pb.add_for_literal(logger->names_and_ids_tracker(),
+                                            starts[r] >= state.lower_bound(starts[r]));
+                                    pb.add_for_literal(logger->names_and_ids_tracker(),
+                                        length_vars[r] >= state.lower_bound(length_vars[r]));
+                                    pb.emit(*logger, ProofLevel::Temporary);
+                                }
+                                logger->emit_rup_proof_line_under_reason(reason,
+                                    WPBSum{} + 1_i * bf.after >= 1_i, ProofLevel::Temporary);
+                                return logger->emit_rup_proof_line_under_reason(reason,
+                                    WPBSum{} + 1_i * bf.active >= 1_i, ProofLevel::Temporary);
+                            };
+                            auto A_i_line = pin(bf_i, pi);
+                            auto A_j_line = pin(bf_j, pj);
 
                             // Pairwise atmost-one over {A_i, A_j} via
                             // recover_am1. The pair_ne callback derives one
@@ -372,9 +443,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             flag_to_task.emplace(bf_i.active, pi);
                             flag_to_task.emplace(bf_j.active, pj);
 
-                            auto pair_ne = [logger, &before_flags, &clause_lines, &bridge,
-                                               violating_t, &flag_to_task](
-                                               const ProofFlag & a, const ProofFlag & b) -> ProofLine {
+                            auto pair_ne = [&](const ProofFlag & a, const ProofFlag & b) -> ProofLine {
                                 auto ti = flag_to_task.at(a);
                                 auto tj = flag_to_task.at(b);
                                 auto & bfi = bridge->at(make_pair(ti, violating_t));
@@ -384,23 +453,21 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 auto clause_line = clause_lines.at(
                                     make_pair(min(ti, tj), max(ti, tj)));
 
-                                // L1: E_ij_fwd + F_i_fwd + B_j_fwd + saturate.
-                                // (s_j - s_i) + s_i + (-s_j) = 0, RHS = 1.
-                                // Result: ¬E_ij + ¬F_i + ¬B_j >= 1.
-                                auto L1 = PolBuilder{}
-                                              .add(e_ij.forward_line)
-                                              .add(bfi.after_fwd)
-                                              .add(bfj.before_fwd)
-                                              .saturate()
-                                              .emit(*logger, ProofLevel::Temporary);
-
-                                // L2: symmetric, swapping roles of i and j.
-                                auto L2 = PolBuilder{}
-                                              .add(e_ji.forward_line)
-                                              .add(bfj.after_fwd)
-                                              .add(bfi.before_fwd)
-                                              .saturate()
-                                              .emit(*logger, ProofLevel::Temporary);
+                                // L1: E_ij_fwd + F_i_fwd + B_j_fwd, plus end_le[i]
+                                // for a variable duration (cancels end back to
+                                // s_i + l_i), then saturate. The integer terms
+                                // cancel to 0, RHS = 1, giving ¬E_ij + ¬F_i +
+                                // ¬B_j >= 1. L2 is symmetric, swapping i and j.
+                                auto Lpol = [&](ProofLine before_line, const BridgeFlags & aft,
+                                                const BridgeFlags & bef, const optional<ProofLine> & aft_end_le) -> ProofLine {
+                                    PolBuilder pol;
+                                    pol.add(before_line).add(aft.after_fwd).add(bef.before_fwd);
+                                    if (aft_end_le)
+                                        pol.add(*aft_end_le);
+                                    return pol.saturate().emit(*logger, ProofLevel::Temporary);
+                                };
+                                auto L1 = Lpol(e_ij.forward_line, bfi, bfj, end_le[ti]);
+                                auto L2 = Lpol(e_ji.forward_line, bfj, bfi, end_le[tj]);
 
                                 // AM1: L1 + L2 + clause + A_i_fwd + A_j_fwd +
                                 // saturate. The B/F terms cancel against the
@@ -433,10 +500,29 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 .emit(*logger, ProofLevel::Temporary);
                         };
 
+                        // The end-proxy pins use lb(l) for variable-length
+                        // tasks, so those durations must be part of the reason.
+                        auto reason_vars = starts;
+                        if (is_var_len(pi))
+                            reason_vars.push_back(length_vars[pi]);
+                        if (is_var_len(pj))
+                            reason_vars.push_back(length_vars[pj]);
                         inference.contradiction(logger,
                             JustifyExplicitlyThenRUP{justify},
-                            generic_reason(state, starts));
+                            generic_reason(state, reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
+                    }
+
+                // Bound-push proofs (emit_chain_step) don't yet thread the
+                // end-proxy through their pair_ne pol, so for now pushes only
+                // run when every active task has a constant duration. Variable
+                // durations still get full contradiction proofs above; their
+                // pushes land in a later PR of the #384 stack.
+                bool any_var_len = false;
+                for (auto i : active_tasks)
+                    if (is_var_len(i)) {
+                        any_var_len = true;
+                        break;
                     }
 
                 // One step of an lb/ub-push chain: a blocked time t and the
@@ -562,6 +648,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 };
 
                 for (auto j : active_tasks) {
+                    // See any_var_len above: skip pushes entirely when any
+                    // duration is variable (PR3 of #384 lifts this).
+                    if (any_var_len)
+                        break;
                     if (lengths[j] == 0_i)
                         continue;
                     auto [cur_lb, cur_ub] = state.bounds(starts[j]);
@@ -682,32 +772,41 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 }
             }
 
-            // Strict-mode zero-length tasks: check that no fixed zero-length
-            // task sits strictly inside a fixed positive-length task's open
-            // active interval. (Non-strict mode never sees zero-length tasks
-            // in active_tasks — they were dropped at prepare() time.)
+            // Strict-mode zero-length tasks: check that no zero-length task
+            // (constant 0, or a variable duration currently fixed to 0) with a
+            // fixed start sits strictly inside another task's open active
+            // interval, where that task has a fixed start and a fixed positive
+            // duration. (Non-strict mode never sees constant zero-length tasks
+            // in active_tasks — dropped at prepare() time — and does not yet
+            // admit variable durations.)
             //
-            // The proof is JustifyUsingRUP: at the all-fixed leaf, the
-            // declarative pairwise encoding alone is enough. With s_z and
-            // s_k fixed at vz, vk satisfying vk < vz < vk + l_k,
-            // before_{z,k} = (vz <= vk) UPs to 0 and before_{k,z} =
-            // (vk + l_k <= vz) UPs to 0, contradicting the encoded clause
-            // before_{z,k} + before_{k,z} >= 1.
+            // The proof is JustifyUsingRUP: at this all-fixed leaf the
+            // declarative pairwise encoding alone is enough. With s_z, s_k (and
+            // any variable durations) fixed at vz, vk, l_k satisfying
+            // vk < vz < vk + l_k, before_{z,k} = (vz <= vk) UPs to 0 and
+            // before_{k,z} = (vk + l_k <= vz) UPs to 0, contradicting the
+            // encoded clause before_{z,k} + before_{k,z} >= 1.
             for (auto z : active_tasks) {
-                if (lengths[z] > 0_i)
+                if (max_len(z) > 0_i)
                     continue;
                 if (! state.has_single_value(starts[z]))
                     continue;
                 auto vz = state.lower_bound(starts[z]);
                 for (auto k : active_tasks) {
-                    if (k == z || lengths[k] == 0_i)
+                    // k must have a fixed, positive duration.
+                    if (k == z || min_len(k) != max_len(k) || min_len(k) == 0_i)
                         continue;
                     if (! state.has_single_value(starts[k]))
                         continue;
                     auto vk = state.lower_bound(starts[k]);
-                    if (vk < vz && vz < vk + lengths[k]) {
+                    if (vk < vz && vz < vk + min_len(k)) {
+                        auto reason_vars = starts;
+                        if (is_var_len(z))
+                            reason_vars.push_back(length_vars[z]);
+                        if (is_var_len(k))
+                            reason_vars.push_back(length_vars[k]);
                         inference.contradiction(logger, JustifyUsingRUP{},
-                            generic_reason(state, starts));
+                            generic_reason(state, reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }
@@ -725,7 +824,9 @@ auto Disjunctive::s_expr(const ProofModel * const model) const -> SExpr
     for (const auto & v : _starts)
         starts.push_back(tracker.s_expr_term_of(v));
     for (const auto & l : _lengths)
-        lengths.push_back(SExpr::atom(const_value_of(l).to_string()));
+        lengths.push_back(is_constant_variable(l)
+                ? SExpr::atom(const_value_of(l).to_string())
+                : tracker.s_expr_term_of(l));
     return SExpr::list({SExpr::atom(as_string(_constraint_id)),
         SExpr::atom(_strict ? "disjunctive_strict" : "disjunctive"),
         SExpr::list(std::move(starts)),

--- a/gcs/constraints/disjunctive.hh
+++ b/gcs/constraints/disjunctive.hh
@@ -3,20 +3,24 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_only_variables-fwd.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
 #include <cstddef>
 #include <map>
+#include <optional>
 #include <utility>
 #include <vector>
 
 namespace gcs
 {
     /**
-     * \brief Disjunctive (1D non-overlap) constraint, basic case: tasks with
-     * variable origins and constant durations. No two tasks may occupy the
-     * same time point.
+     * \brief Disjunctive (1D non-overlap) constraint: tasks with variable
+     * origins; the durations may each be variables or constants (constants pass
+     * through as ConstantIntegerVariableID). No two tasks may occupy the same
+     * time point. In non-strict mode, durations must currently be constant
+     * (variable non-strict durations are future work).
      *
      * A task <em>i</em> is active at time <em>t</em> iff
      * <em>starts[i] &le; t &lt; starts[i] + lengths[i]</em>. For every pair of
@@ -31,8 +35,9 @@ namespace gcs
      * and CPMpy's <code>NoOverlap</code>. In non-strict mode, zero-length
      * tasks are dropped at install time and place no constraint on the other
      * tasks &mdash; equivalent to MiniZinc's <code>disjunctive</code> and
-     * XCSP3's <code>zeroIgnored = true</code>. Because lengths are constant,
-     * the distinction is fully resolved at construction.
+     * XCSP3's <code>zeroIgnored = true</code>. With constant durations the
+     * distinction is fully resolved at construction; with variable durations a
+     * task may become zero-length during search.
      *
      * Propagation is time-table consistent at heights = 1, capacity = 1:
      * mandatory parts of distinct tasks may not overlap, and each task's
@@ -52,8 +57,8 @@ namespace gcs
 
         // Length snapshots resolved in prepare(). _length_vals holds the
         // constant value for a constant duration (0 placeholder for a variable
-        // one, unused until variable durations land); _length_ub holds the
-        // initial upper bound, used to size the possible-active window.
+        // one, where _lengths[i] is read from the state instead); _length_ub
+        // holds the initial upper bound, used to size the possible-active window.
         std::vector<Integer> _length_vals;
         std::vector<Integer> _length_ub;
 
@@ -79,11 +84,33 @@ namespace gcs
         std::map<std::pair<std::size_t, std::size_t>, BeforeFlagData> _before_flags;
         std::map<std::pair<std::size_t, std::size_t>, innards::ProofLine> _clause_lines;
 
+        // For a task whose duration varies, a proof-only end = s + l on which
+        // that task's "after" bridge flag is reified (a single variable keeps
+        // the after pin RUP-friendly). Both definition directions are captured:
+        // _end_ge is end >= s+l (materialises end's bound), _end_le is end <= s+l
+        // (cancels end back to s+l in the before-flag pol). nullopt for a task
+        // whose duration is constant (those reify after on s directly).
+        std::vector<std::optional<innards::ProofOnlySimpleIntegerVariableID>> _end;
+        std::vector<std::optional<innards::ProofLine>> _end_ge;
+        std::vector<std::optional<innards::ProofLine>> _end_le;
+
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
+        /**
+         * \brief General form: durations may be variables or constants
+         * (constants pass through as ConstantIntegerVariableID).
+         */
+        explicit Disjunctive(std::vector<IntegerVariableID> starts,
+            std::vector<IntegerVariableID> lengths,
+            bool strict = true);
+
+        /**
+         * \brief Convenience form for constant durations. Delegates to the
+         * general constructor.
+         */
         explicit Disjunctive(std::vector<IntegerVariableID> starts,
             std::vector<Integer> lengths,
             bool strict = true);

--- a/gcs/constraints/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive_test.cc
@@ -147,6 +147,136 @@ namespace
 
         check_results(proof_name, expected, actual);
     }
+
+    // Variable-duration test (strict only — non-strict variable durations are
+    // rejected in prepare for now). Each task has a start range and a duration
+    // spec {lo, hi}; lo == hi is a constant duration, lo < hi a variable one.
+    // Enumerated variables appear in every solution vector as: starts (task
+    // order), then the variable durations (task order).
+    auto run_var_disjunctive_test(bool proofs, const string & mode,
+        const vector<pair<int, int>> & start_ranges,
+        const vector<pair<int, int>> & length_specs) -> void
+    {
+        auto n = start_ranges.size();
+        vector<bool> lvar(n);
+        for (size_t i = 0; i < n; ++i)
+            lvar[i] = length_specs[i].first != length_specs[i].second;
+
+        print(cerr, "disjunctive_strict var starts={} lspecs={}{}", start_ranges,
+            length_specs, proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        auto is_satisfying = [&](const vector<int> & vals) {
+            vector<int> l(n);
+            size_t k = n;
+            for (size_t i = 0; i < n; ++i)
+                l[i] = lvar[i] ? vals.at(k++) : length_specs[i].first;
+            for (size_t i = 0; i < n; ++i)
+                for (size_t j = i + 1; j < n; ++j) {
+                    bool i_before_j = vals[i] + l[i] <= vals[j];
+                    bool j_before_i = vals[j] + l[j] <= vals[i];
+                    if (! i_before_j && ! j_before_i)
+                        return false;
+                }
+            return true;
+        };
+
+        vector<pair<int, int>> all_ranges = start_ranges;
+        for (size_t i = 0; i < n; ++i)
+            if (lvar[i])
+                all_ranges.push_back(length_specs[i]);
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, is_satisfying, all_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        vector<IntegerVariableID> starts, lengths_v, all_vars;
+        for (auto & [lo, hi] : start_ranges) {
+            auto v = p.create_integer_variable(Integer{lo}, Integer{hi});
+            starts.push_back(v);
+            all_vars.push_back(v);
+        }
+        for (size_t i = 0; i < n; ++i) {
+            if (lvar[i]) {
+                auto lv = p.create_integer_variable(
+                    Integer{length_specs[i].first}, Integer{length_specs[i].second});
+                lengths_v.push_back(lv);
+                all_vars.push_back(lv);
+            }
+            else
+                lengths_v.push_back(constant_variable(Integer{length_specs[i].first}));
+        }
+
+        p.post(Disjunctive{starts, lengths_v, true});
+
+        auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_var") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{all_vars});
+        check_results(proof_name, expected, actual);
+    }
+
+    // Constant-start variable-duration test: every start is a true
+    // ConstantIntegerVariableID (not a singleton variable), exercising the
+    // constant-start branch of the end-proxy materialisation (a constant start
+    // contributes no order-literal to the pol — it is folded into end_ge). Only
+    // the variable durations are enumerated; the fixed starts feed the checker.
+    auto run_const_start_var_len_test(bool proofs, const string & mode,
+        const vector<int> & const_starts, const vector<pair<int, int>> & length_specs) -> void
+    {
+        auto n = const_starts.size();
+        vector<bool> lvar(n);
+        for (size_t i = 0; i < n; ++i)
+            lvar[i] = length_specs[i].first != length_specs[i].second;
+
+        print(cerr, "disjunctive_strict const-start starts={} lspecs={}{}", const_starts,
+            length_specs, proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        auto is_satisfying = [&](const vector<int> & vals) {
+            vector<int> l(n);
+            size_t k = 0;
+            for (size_t i = 0; i < n; ++i)
+                l[i] = lvar[i] ? vals.at(k++) : length_specs[i].first;
+            for (size_t i = 0; i < n; ++i)
+                for (size_t j = i + 1; j < n; ++j) {
+                    bool i_before_j = const_starts[i] + l[i] <= const_starts[j];
+                    bool j_before_i = const_starts[j] + l[j] <= const_starts[i];
+                    if (! i_before_j && ! j_before_i)
+                        return false;
+                }
+            return true;
+        };
+
+        vector<pair<int, int>> all_ranges;
+        for (size_t i = 0; i < n; ++i)
+            if (lvar[i])
+                all_ranges.push_back(length_specs[i]);
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, is_satisfying, all_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        vector<IntegerVariableID> starts, lengths_v, all_vars;
+        for (size_t i = 0; i < n; ++i)
+            starts.push_back(constant_variable(Integer{const_starts[i]}));
+        for (size_t i = 0; i < n; ++i) {
+            if (lvar[i]) {
+                auto lv = p.create_integer_variable(
+                    Integer{length_specs[i].first}, Integer{length_specs[i].second});
+                lengths_v.push_back(lv);
+                all_vars.push_back(lv);
+            }
+            else
+                lengths_v.push_back(constant_variable(Integer{length_specs[i].first}));
+        }
+
+        p.post(Disjunctive{starts, lengths_v, true});
+
+        auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_cstart") : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{all_vars});
+        check_results(proof_name, expected, actual);
+    }
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -237,11 +367,72 @@ auto main(int argc, char * argv[]) -> int
         data.emplace_back(random_instance(n_dist(rand), 4, 3));
     }
 
+    // Variable-duration instances (strict only; non-strict variable durations
+    // are rejected in prepare). Each entry: { start_ranges, length_specs },
+    // where a length spec {lo, hi} is constant when lo == hi, variable when
+    // lo < hi.
+    vector<pair<vector<pair<int, int>>, vector<pair<int, int>>>> var_data = {
+        // Two tasks, both variable durations.
+        {{{0, 3}, {0, 3}}, {{1, 2}, {1, 2}}},
+        // Mixed: one variable, one constant duration.
+        {{{0, 3}, {0, 3}}, {{1, 3}, {2, 2}}},
+        // Three tasks, variable durations, tight horizon.
+        {{{0, 3}, {0, 3}, {0, 3}}, {{1, 2}, {1, 2}, {1, 2}}},
+        // A duration that can be zero (strict: a zero-length task is still
+        // forbidden strictly inside another's interval).
+        {{{0, 2}, {0, 2}}, {{0, 2}, {1, 1}}},
+        // Forced overlap at the root: starts pinned, minimum durations collide.
+        {{{0, 1}, {0, 1}}, {{2, 3}, {2, 3}}},
+    };
+
+    // Variable-duration random cases (n=2 or 3, narrow horizons, durations 0-2).
+    auto random_var_instance = [&](int nn)
+        -> pair<vector<pair<int, int>>, vector<pair<int, int>>> {
+        uniform_int_distribution<> lo_dist(0, 3), span_dist(0, 3), llo_dist(0, 2), lspan_dist(0, 2);
+        vector<pair<int, int>> sr, ls;
+        for (int i = 0; i < nn; ++i) {
+            auto lo = lo_dist(rand), span = span_dist(rand);
+            sr.emplace_back(lo, min(lo + span, 3));
+            auto llo = llo_dist(rand), lspan = lspan_dist(rand);
+            ls.emplace_back(llo, min(llo + lspan, 2));
+        }
+        return {sr, ls};
+    };
+    for (int k = 0; k < 20; ++k) {
+        uniform_int_distribution<> n_dist(2, 3);
+        var_data.emplace_back(random_var_instance(n_dist(rand)));
+    }
+
+    // Constant-start variable-duration instances (strict only). Each entry:
+    // { const_start_values, length_specs }.
+    vector<pair<vector<int>, vector<pair<int, int>>>> cstart_data = {
+        // Two constant-start tasks, variable durations; the gap forces shortness.
+        {{0, 1}, {{1, 2}, {1, 2}}},
+        // Mixed: variable + constant duration on constant starts.
+        {{0, 2}, {{1, 3}, {2, 2}}},
+        // Three constant starts, variable durations.
+        {{0, 2, 4}, {{1, 2}, {1, 2}, {1, 2}}},
+        // Forced overlap: pinned starts, minimum durations collide.
+        {{0, 1}, {{2, 3}, {2, 3}}},
+        // A duration that can be zero on a constant start (strict zero-inside).
+        {{1, 0}, {{0, 2}, {2, 2}}},
+    };
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
         for (auto & [sr, lens] : data)
             run_disjunctive_test(proofs, mode, strict, view_cfg, sr, lens);
+
+        // Variable-duration cases run in strict mode only (non-strict variable
+        // durations are rejected in prepare) and only when not view-wrapping,
+        // to avoid duplicating coverage under every wrap.
+        if (strict && run_dup) {
+            for (auto & [sr, ls] : var_data)
+                run_var_disjunctive_test(proofs, mode, sr, ls);
+            for (auto & [cs, ls] : cstart_data)
+                run_const_start_var_len_test(proofs, mode, cs, ls);
+        }
 
         // Dup tests use bare variables (the harness duplicates a handle into
         // several task positions); only run them when no wrapping is in


### PR DESCRIPTION
Second PR of the variable-durations stack for 1D `Disjunctive` (#384).
Stacked on #386 — review/merge that first.

## What

Strict-mode support for **variable task durations**. The contradiction
(mandatory-overlap) proof now handles variable durations; bound pushes remain
constant-only for now (PR3 of the stack).

- General `vector<IntegerVariableID>` constructor; the `vector<Integer>` form
  delegates to it; `clone()` uses the general form.
- `prepare()` guards: variable durations must have a non-negative lower bound,
  and are rejected in non-strict mode (the zero-length escape machinery lands
  in PR4).
- OPB before-flag carries the duration term on the left for a variable length;
  a proof-only `end = s + l` proxy (both `end >= s+l` and `end <= s+l` captured)
  lets the bridge `after` flag reify on the single variable `end`.
- The contradiction proof pins `active` via the end proxy (materialising
  `end >= lb(s)+lb(l)`) and threads `end_le` through the `pair_ne` pol so the
  duration term cancels — the `Disjunctive2D` `Lpol` technique, one dimension
  down. Reasons include the variable durations they depend on.
- Mandatory parts use the live `lb`/`ub` of variable durations; length-bound
  triggers re-fire the propagator. The strict zero-inside check is generalised
  to durations currently fixed to 0.
- Bound pushes are skipped whenever any duration is variable (`emit_chain_step`
  does not yet thread the end proxy); lifted in PR3.

## Verification

- The `end_le` cancellation was de-risked first with a standalone probe:
  three variable-duration tasks → VeriPB `COMPLETE ENUMERATION OF 228 SOLUTIONS`,
  with `disjend` proxies and `pol`-based contradictions confirmed present.
- Strict variable-duration cases (mixed const/var, can-be-zero, forced overlap,
  20 random) added to `disjunctive_test.cc`; all VeriPB-verified, complete
  enumeration with caps off.
- **Constant-duration proofs are byte-identical to main** (OPB and PBP, via a
  deterministic fixed-instance probe — the data-driven test uses randomized
  branching and is not itself a byte oracle).
- Non-strict + variable durations correctly rejected.
- Builds clean under both GCC and clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
