### PR TITLE
Disjunctive: non-strict variable durations (#384)

### DIFF
--- a/gcs/constraints/disjunctive.cc
+++ b/gcs/constraints/disjunctive.cc
@@ -122,23 +122,19 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
         else {
             if (initial_state.lower_bound(_lengths[i]) < 0_i)
                 throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
-            // Variable durations in non-strict mode need the zero-length escape
-            // machinery; that lands in a later PR of the #384 stack.
-            if (! _strict)
-                throw InvalidProblemDefinitionException{
-                    "Disjunctive: variable durations are not yet supported in non-strict mode"};
             _length_ub[i] = initial_state.upper_bound(_lengths[i]);
         }
     }
 
-    // In non-strict mode, zero-length tasks are dropped: they cannot constrain
-    // any other task. In strict mode, every task participates (a zero-length
-    // task at time t is forbidden from sitting strictly inside any other
-    // task's active interval). With constant durations the distinction is
-    // fully resolved here.
+    // In non-strict mode, a task that is definitely zero-length cannot constrain
+    // any other task, so drop it. A constant zero is dropped here; a variable
+    // duration that *can* be zero stays active and gets a zero-length escape
+    // flag (it might still take a positive value during search). In strict mode
+    // every task participates (a zero-length task may not sit strictly inside
+    // another's active interval).
     _active_tasks.reserve(n);
     for (size_t i = 0; i < n; ++i) {
-        if (! _strict && _length_vals[i] == 0_i)
+        if (! _strict && is_constant_variable(_lengths[i]) && _length_vals[i] == 0_i)
             continue;
         _active_tasks.push_back(i);
     }
@@ -157,6 +153,17 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
         _per_task_t_lo[i] = s_lo;
         _per_task_t_hi[i] = s_hi + _length_ub[i] - 1_i;
     }
+
+    // Non-strict mode: note which active tasks' durations can be 0, so
+    // define_proof_model can add a zero-length escape to the separation clause.
+    // The propagator already ignores zero-mandatory tasks via lb(l).
+    _can_be_zero.assign(n, 0);
+    if (! _strict)
+        for (auto i : _active_tasks)
+            _can_be_zero[i] = (! is_constant_variable(_lengths[i]) &&
+                                  initial_state.lower_bound(_lengths[i]) == 0_i)
+                ? 1
+                : 0;
 
     return true;
 }
@@ -197,6 +204,16 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
         _end[i] = end;
     }
 
+    // Non-strict mode: a "duration <= 0" escape flag per can-be-zero task, added
+    // as a disjunct to the separation clause below (a zero-length task does not
+    // constrain). nullopt otherwise.
+    _zero.assign(_starts.size(), nullopt);
+    for (auto i : _active_tasks)
+        if (_can_be_zero[i])
+            _zero[i] = model.create_proof_flag_fully_reifying(
+                "disjzero", "Disjunctive", "task has zero duration",
+                WPBSum{} + 1_i * _lengths[i] <= 0_i);
+
     // before_{i,j} <-> s_i + l_i <= s_j. For a constant duration this folds to
     // s_i - s_j <= -l (byte-identical to the constant-only implementation); for
     // a variable duration the length term stays on the left.
@@ -215,8 +232,13 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
             auto j = _active_tasks[b];
             auto data_ij = emit_before(i, j);
             auto data_ji = emit_before(j, i);
+            // A zero-length task escapes the separation clause (non-strict).
+            auto clause_sum = WPBSum{} + 1_i * data_ij.flag + 1_i * data_ji.flag;
+            for (auto r : {i, j})
+                if (_zero[r])
+                    clause_sum += 1_i * *_zero[r];
             auto clause = model.add_constraint("Disjunctive", "one task must finish first",
-                WPBSum{} + 1_i * data_ij.flag + 1_i * data_ji.flag >= 1_i);
+                move(clause_sum) >= 1_i);
             _before_flags.emplace(std::make_pair(i, j), data_ij);
             _before_flags.emplace(std::make_pair(j, i), data_ji);
             _clause_lines.emplace(std::make_pair(i, j), clause);
@@ -305,9 +327,9 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
     propagators.install(
         constraint_id(),
         [starts = move(_starts), lengths = move(_length_vals), length_vars = move(_lengths),
-            end_ge = move(_end_ge), end_le = move(_end_le), active_tasks = move(_active_tasks),
-            before_flags = move(_before_flags), clause_lines = move(_clause_lines),
-            bridge](
+            end_ge = move(_end_ge), end_le = move(_end_le), zero = move(_zero), strict = _strict,
+            active_tasks = move(_active_tasks), before_flags = move(_before_flags),
+            clause_lines = move(_clause_lines), bridge](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
             // for a constant duration both are the value; for a variable
@@ -336,6 +358,19 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 pb.add_for_literal(logger->names_and_ids_tracker(),
                     length_vars[i] >= state.lower_bound(length_vars[i]));
                 pb.emit(*logger, ProofLevel::Temporary);
+            };
+
+            // Non-strict mode: every task involved in a contradiction / push has
+            // a positive guaranteed duration (it contributes a mandatory part or
+            // footprint), so its zero-length escape flag is false. Pin those
+            // flags false (RUP under reason) and add them to a clause pol so the
+            // separation clause reduces to its before-flag disjunction. No-op in
+            // strict mode / for always-positive durations.
+            auto add_escape_pins = [&](PolBuilder & pol, const ReasonFunction & reason, size_t i, size_t j) {
+                for (auto r : {i, j})
+                    if (zero[r])
+                        pol.add(logger->emit_rup_proof_line_under_reason(reason,
+                            WPBSum{} + 1_i * *zero[r] <= 0_i, ProofLevel::Temporary));
             };
 
             // Time-table consistency, specialised to heights = 1 and
@@ -481,14 +516,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 // active flags' AND-gate forward reifs, and
                                 // the clause supplies the E_ij + E_ji >= 1
                                 // that closes the case split.
-                                return PolBuilder{}
-                                    .add(L1)
-                                    .add(L2)
-                                    .add(clause_line)
-                                    .add(bfi.active_fwd)
-                                    .add(bfj.active_fwd)
-                                    .saturate()
-                                    .emit(*logger, ProofLevel::Temporary);
+                                PolBuilder am1;
+                                am1.add(L1).add(L2).add(clause_line).add(bfi.active_fwd).add(bfj.active_fwd);
+                                add_escape_pins(am1, reason, ti, tj);
+                                return am1.saturate().emit(*logger, ProofLevel::Temporary);
                             };
 
                             auto atmost1_line = innards::recover_am1<ProofFlag>(
@@ -609,14 +640,10 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         auto L1 = Lpol(e_ij.forward_line, bfi, bfj, end_le[ti]);
                         auto L2 = Lpol(e_ji.forward_line, bfj, bfi, end_le[tj]);
 
-                        return PolBuilder{}
-                            .add(L1)
-                            .add(L2)
-                            .add(clause_line)
-                            .add(bfi.active_fwd)
-                            .add(bfj.active_fwd)
-                            .saturate()
-                            .emit(*logger, ProofLevel::Temporary);
+                        PolBuilder am1;
+                        am1.add(L1).add(L2).add(clause_line).add(bfi.active_fwd).add(bfj.active_fwd);
+                        add_escape_pins(am1, reason, ti, tj);
+                        return am1.saturate().emit(*logger, ProofLevel::Temporary);
                     };
                     auto atmost1_line = innards::recover_am1<ProofFlag>(
                         *logger, ProofLevel::Top,
@@ -778,9 +805,8 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // (constant 0, or a variable duration currently fixed to 0) with a
             // fixed start sits strictly inside another task's open active
             // interval, where that task has a fixed start and a fixed positive
-            // duration. (Non-strict mode never sees constant zero-length tasks
-            // in active_tasks — dropped at prepare() time — and does not yet
-            // admit variable durations.)
+            // duration. Non-strict mode skips this entirely: a zero-length task
+            // floats freely (and the separation clause's zero escape allows it).
             //
             // The proof is JustifyUsingRUP: at this all-fixed leaf the
             // declarative pairwise encoding alone is enough. With s_z, s_k (and
@@ -789,6 +815,8 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // before_{k,z} = (vk + l_k <= vz) UPs to 0, contradicting the
             // encoded clause before_{z,k} + before_{k,z} >= 1.
             for (auto z : active_tasks) {
+                if (! strict)
+                    break;
                 if (max_len(z) > 0_i)
                     continue;
                 if (! state.has_single_value(starts[z]))

--- a/gcs/constraints/disjunctive.hh
+++ b/gcs/constraints/disjunctive.hh
@@ -8,6 +8,7 @@
 #include <gcs/variable_id.hh>
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <optional>
 #include <utility>
@@ -93,6 +94,13 @@ namespace gcs
         std::vector<std::optional<innards::ProofOnlySimpleIntegerVariableID>> _end;
         std::vector<std::optional<innards::ProofLine>> _end_ge;
         std::vector<std::optional<innards::ProofLine>> _end_le;
+
+        // Non-strict mode: whether each task's duration can be 0 (std::uint8_t
+        // rather than the vector<bool> bitset specialisation), and, for those
+        // tasks, a reified "duration <= 0" flag that escapes the separation
+        // clause (a zero-length task does not constrain in non-strict mode).
+        std::vector<std::uint8_t> _can_be_zero;
+        std::vector<std::optional<innards::ProofFlag>> _zero;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive_test.cc
@@ -153,7 +153,7 @@ namespace
     // spec {lo, hi}; lo == hi is a constant duration, lo < hi a variable one.
     // Enumerated variables appear in every solution vector as: starts (task
     // order), then the variable durations (task order).
-    auto run_var_disjunctive_test(bool proofs, const string & mode,
+    auto run_var_disjunctive_test(bool proofs, const string & mode, bool strict,
         const vector<pair<int, int>> & start_ranges,
         const vector<pair<int, int>> & length_specs) -> void
     {
@@ -162,8 +162,8 @@ namespace
         for (size_t i = 0; i < n; ++i)
             lvar[i] = length_specs[i].first != length_specs[i].second;
 
-        print(cerr, "disjunctive_strict var starts={} lspecs={}{}", start_ranges,
-            length_specs, proofs ? " with proofs:" : ":");
+        print(cerr, "disjunctive{} var starts={} lspecs={}{}", strict ? "_strict" : "",
+            start_ranges, length_specs, proofs ? " with proofs:" : ":");
         cerr << flush;
 
         auto is_satisfying = [&](const vector<int> & vals) {
@@ -173,6 +173,9 @@ namespace
                 l[i] = lvar[i] ? vals.at(k++) : length_specs[i].first;
             for (size_t i = 0; i < n; ++i)
                 for (size_t j = i + 1; j < n; ++j) {
+                    // Non-strict: a pair involving a zero-length task floats.
+                    if (! strict && (l[i] == 0 || l[j] == 0))
+                        continue;
                     bool i_before_j = vals[i] + l[i] <= vals[j];
                     bool j_before_i = vals[j] + l[j] <= vals[i];
                     if (! i_before_j && ! j_before_i)
@@ -208,7 +211,7 @@ namespace
                 lengths_v.push_back(constant_variable(Integer{length_specs[i].first}));
         }
 
-        p.post(Disjunctive{starts, lengths_v, true});
+        p.post(Disjunctive{starts, lengths_v, strict});
 
         auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_var") : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{all_vars});
@@ -220,7 +223,7 @@ namespace
     // constant-start branch of the end-proxy materialisation (a constant start
     // contributes no order-literal to the pol — it is folded into end_ge). Only
     // the variable durations are enumerated; the fixed starts feed the checker.
-    auto run_const_start_var_len_test(bool proofs, const string & mode,
+    auto run_const_start_var_len_test(bool proofs, const string & mode, bool strict,
         const vector<int> & const_starts, const vector<pair<int, int>> & length_specs) -> void
     {
         auto n = const_starts.size();
@@ -228,8 +231,8 @@ namespace
         for (size_t i = 0; i < n; ++i)
             lvar[i] = length_specs[i].first != length_specs[i].second;
 
-        print(cerr, "disjunctive_strict const-start starts={} lspecs={}{}", const_starts,
-            length_specs, proofs ? " with proofs:" : ":");
+        print(cerr, "disjunctive{} const-start starts={} lspecs={}{}", strict ? "_strict" : "",
+            const_starts, length_specs, proofs ? " with proofs:" : ":");
         cerr << flush;
 
         auto is_satisfying = [&](const vector<int> & vals) {
@@ -239,6 +242,9 @@ namespace
                 l[i] = lvar[i] ? vals.at(k++) : length_specs[i].first;
             for (size_t i = 0; i < n; ++i)
                 for (size_t j = i + 1; j < n; ++j) {
+                    // Non-strict: a pair involving a zero-length task floats.
+                    if (! strict && (l[i] == 0 || l[j] == 0))
+                        continue;
                     bool i_before_j = const_starts[i] + l[i] <= const_starts[j];
                     bool j_before_i = const_starts[j] + l[j] <= const_starts[i];
                     if (! i_before_j && ! j_before_i)
@@ -271,7 +277,7 @@ namespace
                 lengths_v.push_back(constant_variable(Integer{length_specs[i].first}));
         }
 
-        p.post(Disjunctive{starts, lengths_v, true});
+        p.post(Disjunctive{starts, lengths_v, strict});
 
         auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_cstart") : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{all_vars});
@@ -367,10 +373,9 @@ auto main(int argc, char * argv[]) -> int
         data.emplace_back(random_instance(n_dist(rand), 4, 3));
     }
 
-    // Variable-duration instances (strict only; non-strict variable durations
-    // are rejected in prepare). Each entry: { start_ranges, length_specs },
-    // where a length spec {lo, hi} is constant when lo == hi, variable when
-    // lo < hi.
+    // Variable-duration instances, run in both strict and non-strict mode. Each
+    // entry: { start_ranges, length_specs }, where a length spec {lo, hi} is
+    // constant when lo == hi, variable when lo < hi.
     vector<pair<vector<pair<int, int>>, vector<pair<int, int>>>> var_data = {
         // Two tasks, both variable durations.
         {{{0, 3}, {0, 3}}, {{1, 2}, {1, 2}}},
@@ -378,8 +383,8 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 3}, {0, 3}}, {{1, 3}, {2, 2}}},
         // Three tasks, variable durations, tight horizon.
         {{{0, 3}, {0, 3}, {0, 3}}, {{1, 2}, {1, 2}, {1, 2}}},
-        // A duration that can be zero (strict: a zero-length task is still
-        // forbidden strictly inside another's interval).
+        // A duration that can be zero: strict forbids it strictly inside
+        // another's interval; non-strict lets the zero-length task float.
         {{{0, 2}, {0, 2}}, {{0, 2}, {1, 1}}},
         // Forced overlap at the root: starts pinned, minimum durations collide.
         {{{0, 1}, {0, 1}}, {{2, 3}, {2, 3}}},
@@ -407,8 +412,8 @@ auto main(int argc, char * argv[]) -> int
         var_data.emplace_back(random_var_instance(n_dist(rand)));
     }
 
-    // Constant-start variable-duration instances (strict only). Each entry:
-    // { const_start_values, length_specs }.
+    // Constant-start variable-duration instances, run in both modes. Each
+    // entry: { const_start_values, length_specs }.
     vector<pair<vector<int>, vector<pair<int, int>>>> cstart_data = {
         // Two constant-start tasks, variable durations; the gap forces shortness.
         {{0, 1}, {{1, 2}, {1, 2}}},
@@ -428,14 +433,14 @@ auto main(int argc, char * argv[]) -> int
         for (auto & [sr, lens] : data)
             run_disjunctive_test(proofs, mode, strict, view_cfg, sr, lens);
 
-        // Variable-duration cases run in strict mode only (non-strict variable
-        // durations are rejected in prepare) and only when not view-wrapping,
-        // to avoid duplicating coverage under every wrap.
-        if (strict && run_dup) {
+        // Variable-duration cases run in both modes, only when not view-wrapping
+        // (these runners create bare variables), to avoid duplicating coverage
+        // under every wrap.
+        if (run_dup) {
             for (auto & [sr, ls] : var_data)
-                run_var_disjunctive_test(proofs, mode, sr, ls);
+                run_var_disjunctive_test(proofs, mode, strict, sr, ls);
             for (auto & [cs, ls] : cstart_data)
-                run_const_start_var_len_test(proofs, mode, cs, ls);
+                run_const_start_var_len_test(proofs, mode, strict, cs, ls);
         }
 
         // Dup tests use bare variables (the harness duplicates a handle into


### PR DESCRIPTION
Fourth PR of the variable-durations stack for 1D `Disjunctive` (#384).
Stacked on #388 — review/merge that first.

## What

Variable durations are now supported in **non-strict** mode too, implemented
natively (no routing to `Cumulative`), lifting the guard PR2 left in place.

- `prepare()`: only a **constant** zero-length task is dropped; a variable
  duration that *can* be 0 stays active (it may still take a positive value
  during search) and is noted in `_can_be_zero`. The non-strict + variable guard
  is removed.
- `define_proof_model()`: each can-be-zero task gets a fully-reified `l <= 0`
  escape flag (`_zero`), added as a disjunct to its pairwise separation clauses
  (mirroring `Disjunctive2D`) so a zero-length task does not constrain.
- The propagator pins those escape flags false — every task that appears in a
  contradiction / push has a positive guaranteed duration — and folds them into
  the clause pol via a shared `add_escape_pins` helper, so the separation clause
  reduces to its before-flag disjunction. The strict zero-inside check is skipped
  entirely in non-strict mode.

## Verification

- A non-strict probe (three tasks, durations [0,2]) drives the zero escape:
  VeriPB `COMPLETE ENUMERATION OF 2063 SOLUTIONS`, with the `disjzero` escape
  flags confirmed present.
- The variable-duration and constant-start test runners are parameterised by
  `strict` and now run in both modes; non-strict cases (including durations that
  can be zero) all VeriPB-verified, complete enumeration with caps off.
- **Both the strict and non-strict constant-duration proofs are byte-identical
  to main** (OPB and PBP, via deterministic fixed-instance probes).
- Builds clean under both GCC and clang.

With this PR the propagator matches `Cumulative` / `Disjunctive2D`: durations may
be variables or constants in both modes. Only the frontends (MiniZinc / XCSP)
remain, in the final PR of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
