### PR TITLE
Reasons/infer rework + annotated assertions + typed per-constraint hints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Not part of the public API. Key components:
 Each constraint in `gcs/constraints/` follows this pattern:
 1. A user-facing struct/class (e.g. `NotEquals`, `AllDifferent`)
 2. An `install` method that registers propagator(s) via `Propagators`
-3. Propagators receive an `InferenceTracker &` and call `infer()` on it with a `Literal`, a `Justification`, and a `ReasonFunction`
+3. Propagators receive an `InferenceTracker &` and call `infer()` on it with a `Literal`, a `Justification`, and a `Reason` (a declarative reason, materialised on demand)
 4. If `Propagators::want_nonpropagating()` is true, the constraint must also define itself in OPB terms for proof logging
 
 ### Justification Types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,8 @@ Each constraint in `gcs/constraints/` follows this pattern:
 
 Every inference must be accompanied by a justification:
 - `NoJustificationNeeded` — assertion without proof
-- `JustifyUsingRUP` — reverse unit propagation suffices
-- `JustifyExplicitly{fn}` — callback that adds explicit VeriPB proof steps
+- `JustifyUsingRUP{}` — reverse unit propagation suffices (optionally `JustifyUsingRUP{hints::Foo{...}}` to carry a typed assertion hint)
+- `JustifyExplicitly{emit, ThenRUP::Yes}` — `emit` is a `(const ReasonLiterals &) -> void` callback (or a named fat-witness struct, for a reification verdict) that writes explicit VeriPB proof steps. `ThenRUP` is mandatory: `Yes` RUPs the inferred literal after the steps, `No` lets the steps conclude it. An optional third argument is a typed assertion hint, shared with `JustifyUsingRUP`.
 
 ### Testing Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Each constraint in `gcs/constraints/` follows this pattern:
 ### Justification Types
 
 Every inference must be accompanied by a justification:
-- `NoJustificationNeeded` — assertion without proof
+- `NoJustificationNeeded` — the inference needs nothing in the proof: it is neither justified nor asserted (the solver simply trusts it)
 - `JustifyUsingRUP{}` — reverse unit propagation suffices (optionally `JustifyUsingRUP{hints::Foo{...}}` to carry a typed assertion hint)
 - `JustifyExplicitly{emit, ThenRUP::Yes}` — `emit` is a `(const ReasonLiterals &) -> void` callback (or a named fat-witness struct, for a reification verdict) that writes explicit VeriPB proof steps. `ThenRUP` is mandatory: `Yes` RUPs the inferred literal after the steps, `No` lets the steps conclude it. An optional third argument is a typed assertion hint, shared with `JustifyUsingRUP`.
 

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -64,6 +64,27 @@ library. For an introduction to *using* the solver, start with the top-level
   distinction that governs which linking clauses are load-bearing — with the
   W1–W5 witness suite as the regression defence against re-simplification.
   Read when touching range/interval reasons, branching, or `infer_not_in_range`.
+- [View proof logging](view-proof-logging.md) — how the proof layer handles
+  views (`ViewOfIntegerVariableID`): the V↔X link constraints that tie a view's
+  proof variable to its underlying variable, and how literals over views are
+  deviewed for emission. Read when touching view handling in proofs.
+- [Proof logging for `Sort` / `ArgSort`](sortedness.md) — the fully-certified
+  Mehlhorn–Thiel sortedness propagator proof: the permutation/root argument and
+  the Hall-band pigeonhole over ranks. A worked companion to `constraints.md`.
+- [Reasons rework (design)](reasons-improvement.md) — the rationale for the
+  declarative `Reason` variant and lazy `materialise()` that replaced the eager
+  `ReasonFunction` thunks. Read alongside `infer-redesign.md`.
+- [Infer rework (implementation notes)](infer-redesign.md) — the as-built
+  justification layer: `JustifyExplicitly` / `JustifyUsingRUP`, the mandatory
+  `ThenRUP` enum, the pay-for-use `SimpleInferenceTracker`, and the typed
+  per-constraint assertion hints (`gcs::innards::hints`).
+- [SCP s-expression migration](scp_s_expr_migration.md) — how constraints expose
+  themselves to the sub-constraint-proof (SCP) writer via `s_expr`, and the
+  status of the per-constraint migration.
+- [Workflow-2 / SCP chain testing](workflow2_testing.md) — the
+  `glasgow_scp_solver` binary and the SCP chain test harness
+  (`run_scp_chain.bash`, `scp_cases/`) for verifying constraint encodings
+  against an external checker.
 
 More documents will be added here as we build up coverage of other parts of
 the codebase.

--- a/dev_docs/benchmarking.md
+++ b/dev_docs/benchmarking.md
@@ -19,12 +19,12 @@ release`; binaries land in `build/`.
 | Benchmark               | Command                                       | Approx wall time |
 |-------------------------|-----------------------------------------------|------------------|
 | `magic_series_300`      | `./build/magic_series --size=300`             | ~6 s             |
-| `magic_square_5`        | `./build/magic_square --size=5`               | ~7 s             |
+| `qap_12`                | `./build/qap --size=12`                       | ~7 s             |
 | `langford_11`           | `./build/langford --size=11 --stats`          | ~12 s            |
 | `n_queens_14_all`       | `./build/n_queens --size=14 --all`            | ~18 s            |
 | `ortho_latin_6_all`     | `./build/ortho_latin --size=6 --all --stats`  | ~20 s            |
-| `qap_12`                | `./build/qap --size=12`                       | ~33 s            |
-| `tsp_default`           | `./build/tsp`                                 | ~60 s            |
+| `magic_square_5`        | `./build/magic_square --size=5`               | ~32 s            |
+| `tsp_default`           | `./build/tsp`                                 | ~50 s            |
 | `n_queens_88`           | `./build/n_queens --size=88`                  | ~5 min           |
 
 The first four cover under-30 s workloads that are quick to iterate on. The
@@ -32,8 +32,10 @@ last four (`ortho_latin` onwards) push out further, with `n_queens_88` being
 the long pole — keep it in the set even though it dominates total runtime,
 because it is the only one that exercises a large search tree at scale.
 
-`magic_series` and `magic_square` are fast but worth keeping: they exercise
-linear-arithmetic-heavy propagation that the others don't.
+`magic_series` and `magic_square` are worth keeping for their
+linear-arithmetic-heavy propagation, which the others don't exercise.
+(`magic_square --size=5` is one of the longer runs in the set — its default
+search explores ~6 M nodes — despite the small board.)
 
 ### Notes on individual benchmarks
 

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -150,7 +150,7 @@ auto Foo::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
     // ... fill in trigger sets ...
-    propagators.install(
+    propagators.install(constraint_id(),
         [/* captures, typically moving in member fields */](
             const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState {
@@ -271,39 +271,59 @@ first.
 
 ### Reasons
 
-Every inference takes a `ReasonFunction` — a thunk that returns the set
-of literals justifying the inference. The two helpers you usually want:
+Every inference carries a `Reason`: a *declarative* description of the
+literals that justify it, materialised on demand — only when proofs are
+on — by `materialise(reason, state) -> ReasonLiterals`. The `Reason`
+variant covers an explicit literal set (`ExplicitReason`), a set of
+variables by full domain or by bounds (`GenericReasonOver` /
+`BothBoundsReasonOver`), a single instantiated value (`ExactSingleValue`),
+and lazily-computed forms (`LazyReasonOver`, `Narrowable*`). The two
+builders you usually want:
 
 ```cpp
-auto reason = generic_reason(state, vars);  // each variable's current bounds
-auto reason = bounds_reason(state, vars);   // bounds + extras
+auto reason = generic_reason(vars);  // each variable's full domain (bounds + holes)
+auto reason = bounds_reason(vars);   // each variable's lower/upper bounds only
 ```
 
-The reason is what goes into the proof's RUP step. Be honest about it:
-list every variable whose state contributed to the inference.
+Both take an optional trailing extra literal; `singleton_reason(lit)`
+builds a one-literal reason. The reason is what goes into the proof's RUP
+step. Be honest about it: list every variable whose state contributed to
+the inference.
 
 ## Justifications
 
 The `justification` parameter tells the proof logger how to back the
-inference. Four kinds:
+inference. The kinds:
 
-| Justification                  | When to use                                                  |
-|--------------------------------|--------------------------------------------------------------|
-| `NoJustificationNeeded{}`      | Trivial axioms (almost never — usually a code smell)         |
-| `JustifyUsingRUP{}`            | Inference is RUP-derivable from the OPB + reason             |
-| `JustifyExplicitlyThenRUP{f}`  | Emit explicit proof lines via `f`, then close with a RUP     |
-| `JustifyExplicitly{f}`         | Emit explicit proof lines via `f`; no RUP closure            |
+| Justification                           | When to use                                                  |
+|-----------------------------------------|--------------------------------------------------------------|
+| `NoJustificationNeeded{}`               | Trivial axioms (almost never — usually a code smell)         |
+| `JustifyUsingRUP{}`                     | Inference is RUP-derivable from the OPB + reason             |
+| `JustifyExplicitly{emit, ThenRUP::Yes}` | Emit explicit proof lines via `emit`, then close with a RUP  |
+| `JustifyExplicitly{emit, ThenRUP::No}`  | Emit explicit proof lines via `emit`; the steps conclude it  |
 
 The vast majority of inferences want `JustifyUsingRUP{}`. Use
-`JustifyExplicitlyThenRUP` when VeriPB can't unit-propagate to the
-inference on its own — typically for chains involving auxiliary flags
-or longer inference paths.
+`JustifyExplicitly{emit, ThenRUP::Yes}` when VeriPB can't unit-propagate
+to the inference on its own — typically for chains involving auxiliary
+flags or longer inference paths. The `ThenRUP` argument is mandatory:
+`Yes` RUPs the inferred literal after the explicit steps, `No` lets the
+steps conclude it themselves.
 
-The callback in `JustifyExplicitlyThenRUP` receives a `ReasonFunction &`
-and can emit proof lines via `logger->emit_rup_proof_line_under_reason`,
-`logger->emit(RUPProofRule{}, ..., ProofLevel::Temporary)`, and
-similar. See `among/among.cc` and `lex/lex.cc` for examples of varying
-complexity.
+The `emit` callback receives a `const ReasonLiterals &` and can emit
+proof lines via `logger->emit_rup_proof_line_under_reason`,
+`logger->emit(RUPProofRule{}, ..., ProofLevel::Temporary)`, and similar.
+See `among/among.cc` and `lex/lex.cc` for examples of varying complexity.
+
+**Assertion hints (optional).** Both `JustifyUsingRUP` and
+`JustifyExplicitly` take an optional trailing *typed assertion hint*, e.g.
+`JustifyUsingRUP{hints::Foo{owner}}` or `JustifyExplicitly{emit,
+ThenRUP::Yes, hints::Foo{owner}}`. The hint structs live per-constraint in
+`gcs/constraints/<foo>/hints.hh` (namespace `gcs::innards::hints`) and only
+annotate the step in *assertion mode* — an alternative proof mode, selected
+by `AssertionLevel`, in which inferences are asserted under their reason for
+an external justifier rather than fully justified. In normal proofs-off mode
+the hint is inert and the output is byte-identical. See `abs/hints.hh` for
+the minimal shape.
 
 **Debug aid only:** `AssertRatherThanJustifying` exists as a "trust me"
 step that bypasses the justification. Use it temporarily during
@@ -668,10 +688,10 @@ correctness work wants the full enumeration check.
     - **Detect and contradict at root** — when an alias makes the
       constraint trivially unsat but the user's intent is still well-
       formed (e.g. `BinaryEntry`-style table rows). The
-      `AllDifferent` family is the precedent: `prepare()` sorts the
-      array, runs `adjacent_find`, and routes to a one-shot
-      contradiction initialiser (see
-      `gac_all_different.cc:602-634` and
+      `AllDifferent` family is the precedent: it sorts the array, runs
+      `adjacent_find`, and routes to a one-shot contradiction initialiser
+      (see the `adjacent_find` site in
+      `all_different/gac_all_different.cc` and
       `install_clique_duplicate_contradiction_initialiser` in
       `all_different/encoding.cc`).
     - **Throw `InvalidProblemDefinitionException`** at construction

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -7,7 +7,7 @@ set of integer variables with constant coefficients (binPacking,
 disjunctive, energetic-time-table extensions).
 
 For the constraint itself — the basic case, the OPB encoding, the
-time-table algorithm — read `gcs/constraints/cumulative.{hh,cc}`. For
+time-table algorithm — read `gcs/constraints/cumulative/cumulative.{hh,cc}`. For
 the broader proof-logging framework (justifications, the OPB scaffold,
 `emit_rup_proof_line_under_reason`), read [`constraints.md`](constraints.md).
 
@@ -69,7 +69,7 @@ can't be satisfied: the mandatory tasks alone already overflow.
 
 ### Proof emission
 
-In the `JustifyExplicitlyThenRUP` callback:
+In the `JustifyExplicitly{…, ThenRUP::Yes}` emit callback:
 
 1. For each task `i` mandatory at `t`, emit three RUPs under the
    bounds reason:

--- a/dev_docs/disjunctive-proof-logging.md
+++ b/dev_docs/disjunctive-proof-logging.md
@@ -12,7 +12,7 @@ bridge between encoding and propagation, and the third reusable
 proof-logging idea that comes out of it.
 
 For the constraint itself — semantics, propagator, the strict / non-strict
-flag — read `gcs/constraints/disjunctive.{hh,cc}`.
+flag — read `gcs/constraints/disjunctive/disjunctive.{hh,cc}`.
 
 ## The declarative OPB encoding
 
@@ -119,8 +119,8 @@ The result line is recorded at `Top`, and the per-call pol expression
 active=1-under-reason lines) is at `Temporary`.
 
 `recover_am1` had to be taught how to isolate its inner workings from
-a `JustifyExplicitlyThenRUP` context to avoid wiping the framework's
-own scope on exit — see the comment in `recover_am1.cc`.
+a `JustifyExplicitly{…, ThenRUP::Yes}` context to avoid wiping the
+framework's own scope on exit — see the comment in `recover_am1.cc`.
 
 ## The three time-table inferences
 
@@ -155,7 +155,8 @@ declarative pairwise encoding alone is RUP-closable. With `s_z` and
 `s_k` fixed at `vz`, `vk` satisfying `vk < vz < vk + l_k`,
 `before_{z,k}` and `before_{k,z}` both UP to 0 from the unit
 assignments and the encoded clause `before_{z,k} + before_{k,z} ≥ 1`
-unit-fails. So this contradiction uses plain `JustifyUsingRUP{}`.
+unit-fails. So this contradiction is pure RUP — `JustifyUsingRUP{hints::Disjunctive{owner}}`
+(the typed hint is inert in proofs-off mode; the justification is still a bare RUP).
 
 ## The third reusable idea
 
@@ -197,7 +198,7 @@ The disjunctive scaffolding adds a third:
 ## 2D non-overlap (`Disjunctive2D` / `diffn`)
 
 The same recipe lifts one dimension up to non-overlapping rectangles
-(`gcs/constraints/disjunctive_2d.{hh,cc}`), with constant sizes. The
+(`gcs/constraints/disjunctive_2d/disjunctive_2d.{hh,cc}`), with constant sizes. The
 declarative OPB is the `diffn` definition: for each pair and axis `d`,
 `before_{i,j,d} ⇔ pos_{i,d} + size_{i,d} ≤ pos_{j,d}`, plus a single
 **4-way separation clause** per pair

--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -31,7 +31,7 @@ equivalent for that frontend's vocabulary).
 
 | Constraint family | gcs propagator | MiniZinc | XCSP3 | CPMpy |
 |---|---|---|---|---|
-| intension (algebraic exprs) | various via tree walk | ✓ | frontend gap (#150) | ? |
+| intension (algebraic exprs) | various via tree walk | ✓ | ✓ (tree walker) | ? |
 | extension (table) | `Table` / `NegativeTable` | ✓ | ✓ | ? |
 | regular | `Regular` | ✓ | ✓ (DFA with named states + transitions) | ? |
 | mdd | solver gap (#149) | ? | solver gap (#149) | ? |
@@ -72,7 +72,7 @@ addressed.
 |---|---|---|---|---|---|
 | half-reified comparisons (`LessThanEqualIf`, …) | partially via `Comparison` + reif | ? | n/a | gap (#61) | |
 | half-reified `And` / `Or` | – | ? | n/a | gap (#61) | |
-| `Among` | `Among` | ? | n/a (use count) | ? | |
+| `Among` | `Among` | ✓ | n/a (use count) | ? | |
 | `SmartTable` | `SmartTable` | ✓ | n/a | ? | Glasgow-specific extension |
 
 ## Solver gaps tracked elsewhere

--- a/dev_docs/infer-redesign.md
+++ b/dev_docs/infer-redesign.md
@@ -1,0 +1,750 @@
+# Redesigning `infer()` (implemented; exploratory design notes retained)
+
+**Scope:** rethink the *whole* inference triple — what is inferred, its reason,
+and its justification — as one declarative, mode-driven mechanism. This subsumes
+the reason-only change in `reasons-improvement.md` and generalises PR #302
+(*Annotated Assertions*) from the justification side into the same model.
+
+The body below is a north-star sketch — intentionally larger than
+`reasons-improvement.md` (the safe first slice). It was largely implemented on the
+`302-then-347` branch: read the **IMPLEMENTED** section next for the authoritative
+as-built picture (it wins over the body wherever they differ), and the body for the
+reasoning and the roads not taken.
+
+## IMPLEMENTED — what was actually built (authoritative)
+
+The reason layer (`reasons-improvement.md`) and this justification layer both
+landed on the `302-then-347` branch (PR #378). The exploratory body below is the
+design we worked from; **where it differs from the code, this section wins.** The
+mechanism evolved past the first cut — the `JustifyByData` of the original note is
+gone (see "Justification dispatch" below) — so this section is kept current with
+HEAD rather than dated.
+
+As built:
+
+- **Reason layer** — the `Reason` variant + `materialise()`, deferred in the
+  inference tracker; the eager `ReasonFunction` and its `LegacyReasonFunction`
+  bridge are gone. One opt-in `LazyReasonFn = std::function` escape hatch remains,
+  used only by genuinely-lazy `LazyReasonOver` reasons (the gcc flow-cut,
+  all_different's Hall justification). (See `reasons-improvement.md`'s implemented
+  note.)
+- **Justification dispatch** — not one `JustifyByData` struct but **two mirrored
+  templated forms** in `gcs/innards/justification.hh`:
+  - `JustifyUsingRUP<Hint_ = NoHint>` — RUP suffices;
+  - `JustifyExplicitly<Emit_, Hint_ = NoHint>{emit, then_rup, hint}` — explicit
+    proof steps.
+
+  They share the `Hint_` axis (a typed assertion hint, below), which is
+  **orthogonal to how the inference is proved**. `then_rup` is a mandatory
+  `enum class ThenRUP { Yes, No }` (was a bare `bool`): `Yes` RUPs the inferred
+  literal after the steps, `No` lets the steps conclude it. The `Justification`
+  variant holds only the plain nameless forms
+  `{JustifyUsingRUP<NoHint>, AssertRatherThanJustifying, NoJustificationNeeded}`;
+  the templated/hinted forms are selected by **overload resolution** in
+  `ProofLogger::infer`, not stored in the variant. Mode dispatch: **Off** runs
+  `emit` then RUPs if `then_rup == Yes` (byte-identical to the old closures),
+  ignoring the hint; **assertion modes** assert the inference under its reason with
+  the resolved annotation and never run `emit`; above `AssertionLevel::Inferences`
+  nothing is emitted. The back end is `gcs/innards/proofs/infer_explicitly.hh`
+  (`infer_explicitly`).
+- **`emit` is a value, not a `std::function`** — `(const ReasonLiterals &) -> void`,
+  built at the call site (a lambda in the common case; a storable struct with
+  `operator()` for backtrack replay). Where a reification *verdict's return type
+  must name the justification* — a lambda type cannot be named — the witness is a
+  named "fat" struct providing an ADL `emit_justification(logger, witness, reason)`
+  instead. `emit_explicit_steps` picks closure-vs-fat-witness by `if constexpr`
+  (compile time). The Simple (proofs-off) tracker never touches `emit` or the hint,
+  so Off mode pays only for constructing the (usually empty) call-site objects.
+- **Typed assertion hints, names decentralised.** Each structured hint is a struct
+  in `namespace gcs::innards::hints` (reopened per constraint) — the enumerable
+  "interface the justifier supports". A witness carries: a
+  `static constexpr std::string_view hint_name` (the coarse model-level name, the
+  2nd annotation field); an optional `static constexpr std::string_view justifier`
+  (the fine per-shape sub-rule keyword, serialised into `hint_fields` — answers
+  #377: one constraint, several inference shapes); an ADL
+  `hint_sexpr(witness, NamesAndIDsTracker&) -> SExpr` (the wire schema, in one
+  place); and an optional ADL `emit_justification(...)` (explicit steps; absent for
+  pure-RUP witnesses). There is **no central `hint_names.hh` and no `hint_name`
+  enum** — the body's "Why the central enum should go" was taken to its conclusion.
+  Coarse names live in three decentralised forms: on the witness (`hint_name`); as a
+  per-file `constexpr std::string_view <name>_hint` where a constraint reuses one
+  across sites (`equals_hint`, `linear_equality_hint`); and as
+  `hints::ModelName{name}` — the minimal name-only tier — at inline-closure sites
+  that want a coarse name without a struct. `hint_annotation` selects
+  NoHint / `ModelName` / structured at compile time; `resolve_annotation` gives
+  3-tier precedence (explicit `hint` → `emit`'s own advertisement → the call site's
+  fallback annotation), reproducing the old witness-carried annotation exactly.
+- **Coverage.** Typed witnesses are in use in ~7 constraints — abs, plus, equals,
+  lex, linear equality, linear inequality, and all_different (GAC). **abs is the
+  canonical reference conversion** (commit `4c85dfe8`): a single
+  `hints::AbsJustification{owner, justifier}` rides *both* `JustifyUsingRUP` (abs's
+  pure-RUP pruning) and `JustifyExplicitly` (its ~10 explicit bounds), carries no
+  operand data (re-derivable), and serialises to one `hint_sexpr` →
+  `((constraint_id _N) (justifier <sub-rule>))`; the eager `emit` closures are
+  untouched. It is the "add a constraint to the Justifier → here is your
+  solver-side change" template.
+
+**The one substantive departure from the body below: there is no logger-side
+per-constraint proof-data store.** The body proposes `logger.constraint_proof_data
+<AllDifferentDef>(owner)` so an `emit` can reach a constraint's mutable proof state
+(all_different's at-most-one line cache) by owner. We built that, then removed it:
+that state is owned by the `Constraint`, which outlives the whole search, so `emit`
+reaches it **directly** — an inline closure *captures* it, or (where the verdict
+must name the justification) a fat witness like `hints::AllDifferentHall` stores
+*pointers* to it (`all_vars`, `value_am1_constraint_numbers`), read only by
+`emit_justification` and never serialised by `hint_sexpr`. Both are valid even for
+backtrack-time replay (G4); the serialised subset stays small. Anywhere the body
+says "reach `def` via the store / owner", read "captured by the emit closure, or
+carried as non-serialised pointers on the fat witness".
+
+Still deferred (consistent with the body's "open questions"):
+- the witness is still built even in plain eager-proof mode, which runs `emit` and
+  never reads the hint — the body's `gather`-deferral (build the witness only in a
+  mode that consumes it) is not done. The proofs-off cost is already nil (the Simple
+  tracker builds neither emit nor hint), and `NoHint` is `[[no_unique_address]]`, so
+  this only bites the typed-hint sites under eager proofs;
+- the coarse `hint_name` is a per-call-site / per-witness literal, not derived from
+  the owner's model type;
+- capability tiers beyond witness-complete are not *formally* modelled, though abs
+  is in practice the "re-derivable, tiny witness" case (empty of operand data);
+- assertion modes above `Definitions` need Matthew's veripb branch — stock VeriPB
+  3.0.2 caps there — so there is **no ctest coverage of assertion-mode output**;
+  behaviour preservation rests on the Off-mode proofs being byte-identical (they
+  are, across the suite);
+- Plan B is rolled out to the ~7 constraints above, not the whole set (per Matthew:
+  fewer hints, expand when the external Justifier needs them).
+
+## The abstraction
+
+Every inference has three layers with a strict one-way dependency:
+
+```
+(1) what is inferred   — the Literal. ALWAYS eager. Never optional, never lazy.
+        │
+(2) reason             — a function of (variable set, state). May be: none / eager / reconstruct-later.
+        │  (a justification needs the reason; never the other way round)
+(3) justification      — = justify(rule_id, reason_literals, witness). May be: none / eager / external-later / internal-later.
+```
+
+The key claim (point 3) is that a justification is **not** an opaque callback —
+it is a *named rule* applied to *explicit inputs*:
+
+```
+justify( rule_id = (ConstraintID, sub-rule),     // ConstraintID already threaded (#317)
+         reason_literals,                          // the materialised reason
+         witness )                                 // "the extra information"
+    -> proof steps
+```
+
+This is exactly the shape of #302's annotation (`hint_name` ≈ `rule_id`,
+`hint_fields` ≈ `witness`), which is evidence the abstraction is right.
+
+## The move that gives you G2: recipe at the call site, strategy by mode
+
+A propagator should **never** branch on whether proofs are on / eager / external.
+It always supplies the same declarative recipe. A *global mode* — a property of
+the InferenceTracker / ProofLogger, exactly where `Simple` vs `Eager` already
+lives — picks the strategy:
+
+| mode | (1) what | (2) reason | (3) justification |
+|---|---|---|---|
+| proofs off | do it | ignored | ignored |
+| eager proofs (today) | do it | materialise now | run `justify(...)` now |
+| external / assertion (#302) | do it | materialise now (it is the reified LHS of the `a` line) | **don't run** — serialise `rule_id → hint_name`, `witness → hint_fields` |
+| internal lazy (G4) | do it | store recipe | store `{rule_id, witness}`; run `justify(...)` later, only on the conflict path |
+
+**The coupling matters:** whenever a justification is realised, the reason must be
+too. So the reason's stance is not fully free:
+
+- external justification ⟹ reason is eager (it is written into the assertion);
+- internal-lazy justification ⟹ reason defers *with* it (re-materialise at
+  conflict time if narrowable, else snapshot);
+- eager justification ⟹ reason eager;
+- reason-without-justification ⟹ the reason's laziness is the only independent case.
+
+## API sketch
+
+```cpp
+// (1) the literal: eager, always. Unchanged.
+
+// (2) the Reason variant, IDENTICAL to reasons-improvement.md
+//     (NoReason / ExplicitReason / {Generic,BothBounds,Lazy}ReasonOver + Narrowable*).
+
+// (3) justification as a typed `Data` witness (one hint_sexpr/emit overload pair
+//     per hint, on #302's SExpr layer). The propagator names the Data type and
+//     hands over the raw args to build it; it no longer *contains* the justifier.
+//     Full mechanism in "Justification dispatch" below.
+```
+
+Call site — the propagator names the witness type and hands over the raw args:
+
+```cpp
+inference.infer(
+    result <= a_hi + b_hi,                                      // (1)
+    BothBoundsReasonOver{operands},                             // (2)
+    justify_with<plus::BoundData>(sum_line, plus::Dir::ResultUB));  // (3) Data built only if proofs on
+```
+
+Mode handling lives in the tracker/logger, not the call site (off / eager /
+assert-external / lazy-internal — see the dispatch section for what each does).
+
+## Justification dispatch: typed `Data` on #302's `SExpr` layer
+
+*(Reconciled with PR #302 as of commit `027780b6`, "Use s-expressions for hint
+fields". An earlier draft of this section argued "tags, not a global enum"; #302
+has since built most of the mechanism, so this is now a much smaller, additive
+proposal on top of what is already there. The change in stance is deliberate —
+see the note at the end of the section.)*
+
+### What #302 already provides (build on it, don't replace it)
+
+As of `027780b6`, #302's hint mechanism is no longer the early enum-plus-flat-
+`vector<hint_field>`. It is:
+
+- `AssertionHintName` — a small, central enum naming the rule/constraint family
+  responsible (`AllDifferent`, `Abs`, `ReifiedEquals`, …) — *the one piece this
+  redesign replaces; see "Why the central enum should go" below*;
+- `hint_fields : std::optional<SExpr>` — the payload, where `SExpr` is the
+  **existing** `.scp` proof-model type (`gcs/innards/s_expr.hh`), so the wire form
+  is codebase-consistent and `format`/`parse_s_expr` round-trips;
+- built by a `hint_sexpr(...)` **overload set** (one overload per leaf type:
+  `AssertionHintIdentifier` keyword, `ProofLineLabel`, `ConstraintID`, `Integer`,
+  `SExpr` pass-through; variables via `names_and_ids_tracker().s_expr_term_of`) and
+  a variadic `hint_list(Ts&&...)` that folds `hint_sexpr` over a typed pack.
+
+This is a good substrate. Two of its properties are exactly what the earlier draft
+was reaching for: a missing `hint_sexpr` overload is a hard **compile error**
+(typed at the leaves, no silent wrong pick), and dispatch is plain overload
+resolution on the argument type. It also settles the "is this too much C++?"
+worry empirically — a variadic template plus an overload set is precisely the
+idiom, and it is already in the branch, written by hand.
+
+### What is still missing: a per-hint *schema*
+
+`hint_list(...)` is free-form. Nothing enforces that an `AllDifferent` hint carries
+`{hall_vars, hall_values, owner}` rather than, say, just a `constraint_id`. The
+*leaves* are typed; the *composition for a given `hint_name`* is by convention,
+checked nowhere. So the external justifier still switches on `hint_name` and must
+know, per name, what shape to expect — a uniform **parse**, but not a uniform
+**interpret**, and no single place documents the contract.
+
+The one addition this redesign makes is to give each structured hint a typed
+`Data` struct and a single `hint_sexpr` overload that owns its schema:
+
+```cpp
+// --- next to all_different ---
+struct HallData {
+    small_vector<IntegerVariableID, 4> hall_vars;
+    small_vector<Integer, 4>           hall_values;
+    ConstraintID                        owner;
+};
+
+// the schema lives in ONE place: this overload. Slots straight into #302's layer.
+auto hint_sexpr(const HallData & d) -> SExpr
+{
+    return hint_list(AssertionHintIdentifier::hall_vars,     d.hall_vars,
+                     AssertionHintIdentifier::hall_values,   d.hall_values,
+                     AssertionHintIdentifier::constraint_id, d.owner);
+}
+```
+
+The call site moves from free-form
+
+```cpp
+.hint_fields = hint_list(AssertionHintIdentifier::constraint_id, constraint_id)   // today
+```
+
+to schema-checked
+
+```cpp
+.hint_fields = hint_sexpr(HallData{hall_vars, hall_values, owner})                // typed
+```
+
+— same wire format, same machinery, one extra overload. The `Data` struct **is**
+the explicit "interface the justifier supports" that #302 wants its hint names to
+define, made compiler-checked and local to the constraint instead of free-form and
+documented only by the Rust decoder. So this is **additive, per-constraint, and
+non-disruptive**: keep the `SExpr` representation; add a `Data` struct wherever a
+hint carries more than one field whose roles matter (the lone `constraint_id` hint
+needs no struct — flat `hint_list` over leaves stays right for genuinely flat
+hints). The wire identifier moves *onto* the `Data` type (`static constexpr
+std::string_view name`), retiring the `hint_name` enum — see "Why the central enum
+should go".
+
+### One `Data`, two consumers — and the G1 deferral
+
+The `Data` struct is the single typed witness; two functions consume it, picked by
+the mode (the tracker/logger property, not the call site):
+
+- **AssertExternal (#302):** `hint_sexpr(const Data &) -> SExpr` — the schema-owning
+  serialiser above. This is the *only* path that crosses to the external Rust
+  justifier, which reimplements the same schema reading the `.scp` s-expression.
+- **Eager / LazyInternal:** `emit_justification(const Data &, ProofLogger &, const
+  ReasonLiterals &) -> void` — emits the real proof steps in C++. For `HallData`
+  this body is the *existing* `justify_all_different_hall_set_or_violator`,
+  unchanged. Eager runs it at inference time; LazyInternal parks the `Data` and
+  runs the same function at backtrack, only on the conflict path.
+
+Crucially, construct `Data` **only in the mode that consumes it**. A hint is built
+wherever its justification path runs — including plain eager proof mode, which
+emits the real justification and never looks at the hint — so building
+`hint_list(...)` eagerly there is wasted, the same eager-build-then-discard
+`reasons-improvement.md` removes on the reason side. The fix mirrors it: pass cheap
+raw args and let a `gather(raw...) -> Data` step defer `Data` + `hint_sexpr` past
+the mode check. For all-different it is nearly free anyway — the Hall set is the
+propagation *result*, and the proof path is already gated — but the principle
+matters for the cheap, ubiquitous infer sites (the bound-pushers).
+
+### Capability tiers — which modes a hint supports
+
+Whether a hint is deferrable is "does it have a `Data` struct plus the two
+overloads?", detected by a concept on the `Data` type rather than a flag:
+
+- **Witness-complete (tier 1):** has `Data`, `hint_sexpr(Data)`,
+  `emit_justification(Data, …)`. All modes. The target and the majority (plus, abs,
+  all-different, GCC, reified-linear).
+- **Re-derivable (tier 2):** `Data` ≈ empty but `emit_justification` re-runs an
+  algorithm from `(def, reason)` (knapsack DP). Lazy/external work *at compute cost*.
+- **Eager-only (tier 3):** no liftable witness; stays an inline `JustifyExplicitly`
+  closure exactly as today. In assert/lazy modes it **falls back to emitting real
+  proof steps** — so the external tool never reimplements it, and lazy analysis
+  just skips it. Graceful, not a blocker; the messy intertwining is allowed to stay
+  precisely where it is necessary.
+
+The `if constexpr (has Data overloads)` branch in the tracker is the only generic
+spot. It parallels the `Deferrable` concept sketched earlier; the only change is
+that the dispatch type is now the `Data` struct itself (which `hint_sexpr` already
+keys on), so there is **no separate empty `Tag` type** — one fewer thing to define
+per rule.
+
+### `derivable_from` and the constraint ID
+
+Two notes specific to #302's current shape:
+
+- It hand-carries `(constraint_id <id>)` *as a hint field* — `027780b6` threads
+  `ConstraintID` through `propagate_gac_all_different` into every caller for exactly
+  this. That is compensating for `infer()` not knowing which constraint owns the
+  inference. Under this redesign `rule_id = (ConstraintID, sub-rule)` is
+  **structural** — part of the inference, not a field the propagator assembles — so
+  the `constraint_id` hint field disappears and the owner is available to `emit` /
+  the assertion for free.
+- `derivable_from` is best a `ConstraintID` (stable across renumbering, portable);
+  for most hints `emit` can reconstruct the specific lines from `(owner + Data)`, so
+  it need not be a stored field. Keep explicit `ProofLineLabel`s only where an
+  assertion leans on a *temporary* lemma line not tied to a definition.
+
+### The one cost this does not remove
+
+The typed `Data` relocates the schema into one compiler-checked place; it does not
+delete the cross-language contract. The external Rust justifier still needs the
+union of hint names, their `Data` schemas (now readable off the `hint_sexpr`
+overloads), and their emit semantics, kept in sync by hand. What the typed layer
+buys is that the C++ side of that contract is *one struct + one overload per hint*,
+self-documenting and checked, rather than free-form `hint_list` calls scattered
+across call sites. Hint names and the `AssertionHintIdentifier` keywords become a
+proof-compatibility surface and want light versioning.
+
+### Where the hint types live: a dedicated namespace
+
+Put every hint `Data` struct **and** its `hint_sexpr`/`emit_justification`
+overloads in one dedicated namespace — say `gcs::innards::hints`. This is logical
+co-location, not physical: reopen `namespace gcs::innards::hints { … }` inside each
+constraint's files, so `HallData` and its `emit` (which calls
+`justify_all_different_hall_set_or_violator` and reaches `def` via the
+`ConstraintID` — all_different-specific logic) still sit next to all_different. A
+reasonable split is to declare the `Data` **structs** in small per-constraint
+headers (the *schema*, i.e. the contract, all in headers under the namespace) and
+keep the `hint_sexpr`/`emit` *definitions* in the `.cc` next to the logic.
+
+This is what makes the cross-language contract above tractable, and it answers the
+enum's one real virtue without the enum:
+
+- **Single discoverable interface surface.** "What does the justifier support?" =
+  "everything in `gcs::innards::hints`." That is the "interface in one place" the
+  enum was wanted for.
+- **Additive, distributed membership.** A new hint adds a struct from a new file;
+  it does *not* edit a shared token. This is the precise difference from the enum —
+  no central edit point, no merge-conflict magnet, no desync. So a namespace
+  matches the enum on discoverability while beating it on locality.
+- **Clean ADL.** All overloads live in the argument type's namespace, so
+  `hint_sexpr(d, …)` / `emit_justification(…, d, …)` resolve with no scatter and no
+  `using` gymnastics.
+- **It enforces canonicality.** A `Data` that wanted a constraint-private type
+  could not sit cleanly in the shared namespace — which is exactly when it would
+  fail to serialise to the Rust side anyway. The namespace pressures `Data` to stay
+  in the serialisable vocabulary (`ConstraintID`, `Integer`, `IntegerVariableID`,
+  vectors) for free.
+
+What this does **not** buy is automatic Rust codegen: without reflection (pre-C++26)
+the cross-language mirror is still hand-maintained. But a namespace is the lightest
+way to make the C++ side of that contract a single enumerable list — a grep or
+doc-gen keyed on `gcs::innards::hints` produces the exhaustive set of `{name, Data
+schema}` to mirror in Rust. (Automatic codegen is judged unlikely to be worth it;
+enumeration-for-a-human is the realistic goal and a namespace delivers it.)
+
+### Why the central enum should go
+
+`AssertionHintName` is prototype convenience — easy to write while bootstrapping —
+not a long-term asset. Once each structured hint has a typed `Data`, the enum
+fails three ways:
+
+1. **It is a redundant second identifier.** The `Data` type (`HallData`) already
+   names the hint kind; the enum value (`AllDifferent`) is a parallel name for the
+   same thing, hand-synced at the call site (`.hint_name = AllDifferent,
+   .hint_fields = hint_sexpr(HallData{…})`) with **nothing checking they agree** —
+   `.hint_name = Abs` over `HallData` compiles. That is exactly the unchecked
+   coupling the typed `Data` removes from the fields, reintroduced on the key.
+2. **It is at the wrong granularity.** It is per-constraint-family, but the
+   justification *shapes* are finer. all_different tags both its Hall-violator
+   contradiction (`gac_all_different.cc:423`, `prove_matching_is_too_small`) and
+   its SCC deletions (`:591`, `prove_deletion_using_sccs`) as one `AllDifferent`;
+   abs tags ~11 distinct inferences `Abs`. So it does not actually discriminate the
+   rule — the real dispatch is in the fields/procedure already.
+3. **It forces a non-local edit** (the enum, its `operator<<`, its `as_string`)
+   distant from the hint logic, for every new kind.
+
+The single thing the enum genuinely provides — a stable, cross-language wire
+identifier — moves onto the `Data`/tag type as `static constexpr std::string_view
+name = "all_different.hall"`. One source of truth: it is the dispatch key *and* the
+wire string, cannot desync from the schema, is at the right (per-shape)
+granularity, and lets us choose the wire spelling explicitly so renaming a C++ type
+does not break old proofs.
+
+This still serves Matthew's real goal — the hint set as a visible "interface the
+justifier supports." The contract that matters is {stable `name`, field schema,
+emit semantics} per shape, and with typed `Data` each is self-documenting and
+correctly granular, and the dedicated `gcs::innards::hints` namespace (above) *is*
+the single enumerable menu — derived from the tags, not a hand-synced parallel list,
+and not the load-bearing dispatch key. The pro-enum cases do not hold up here: we never switch on it in C++
+(dispatch is overload resolution on the `Data` type; lazy-internal uses a per-type
+`emit` function pointer, so no runtime kind-switch), and a closed Rust mirror is
+hand-maintained per new hint either way, so a string with a catch-all arm is no
+worse.
+
+## The witness is the whole ballgame — and the hard cases disagree about it
+
+Two constraints we'd worry about most land in **different** places.
+
+**all-different (GAC) is ~90% there already.** `find_hall_set_or_violator`
+(`gac_all_different.cc:203`) returns `pair<JustifyExplicitlyThenRUP,
+ReasonFunction>`, and the justifier closure is a one-line adapter over an
+*already free function*: `justify_all_different_hall_set_or_violator(logger, vars,
+hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers)`. Decompose:
+- `vars`, `value_am1_constraint_numbers` → **def** (the am1 numbers are proof line
+  refs — serialisable);
+- `hall_variable_ids`, `hall_value_nrs` → **witness** (finite, explicit, serialisable);
+- the *reason* (`gac_all_different.cc:263`) is built from the **same Hall set**
+  plus the `excluded` values.
+
+So this is the poster child: the witness is exactly `HallData`'s `{hall_vars,
+hall_values}`, and it feeds *both* the reason literals (`v != val`) and the
+justifier.
+"Capture the witness once, derive reason + justification" is not aspirational —
+the code already computes them together; the refactor just stops reference-
+capturing `&state`/`&logger` and names the data. Fully serialisable → the external
+Rust justifier reimplements one function reading hall vars/values from `hint_fields`.
+
+**knapsack is the genuine hard case — but not because of hidden state.** Its
+justification (`knapsack.cc:240–453`) is a long sequence of
+`emit_rup_proof_line_under_reason(generic_reason(state, reason_variables), …)` +
+`PolBuilder` lemmas emitted *inline as the DP forward/backward passes walk the
+layer graph*. There is no Hall-set-like witness to lift out. **But** the DP is
+deterministic given the variable domains, and those domains are exactly what the
+reason captures — so the justifier *is* re-derivable from `(def =
+weights/capacities, reason = current domains)` with an essentially empty witness.
+The cost is not hidden state; it is that **the justifier is a whole algorithm**,
+and deferring/porting it means re-running that algorithm (a second C++ pass for
+lazy mode, or a Rust reimplementation for the external tool).
+
+That distinction is the answer to "is the intertwining necessary?". It splits
+into two unrelated problems:
+
+- **(a) Hidden-state capture** — the justifier reference-captures transient data
+  never made explicit. *Mechanical to fix*: make the witness a named struct.
+  all-different shows most constraints are close.
+- **(b) Justifier-is-an-algorithm** — the derivation is interwoven with the
+  propagation algorithm (knapsack DP, perhaps circuit SCC). *Not* about missing
+  data; re-emitting requires re-running the algorithm.
+
+## A capability spectrum, not all-or-nothing
+
+The modes a justifier *supports* become a per-rule property:
+
+1. **Witness-complete** (plus, abs, all-different, GCC, reified-linear): `justify`
+   is a pure fn of `(def, reason, witness)`; the witness records the propagator's
+   non-re-derivable *choices*. Supports **all** modes. The target and the majority.
+2. **Re-derivable** (knapsack): witness ≈ empty, but `justify` re-runs an
+   algorithm from `(def, reason)`. Supports lazy (re-run in C++) and external
+   (re-run in Rust) **at compute cost**; likely default to eager and only port if
+   the trimmer shows it pays.
+3. **Eager-only** (the holdouts): needs live transient state that is neither
+   recorded nor re-derivable; only eager mode. Stays exactly as embedded as today.
+   No flag needed — a tag is eager-only precisely when it does *not* define
+   `gather_justification`, detected by the `Deferrable` concept above, and
+   `realise` auto-degrades it to real proof steps in the defer modes.
+
+The crucial property: **tier 3 is a graceful fallback, not a blocker.** An
+eager-only rule emits real proof steps even in assertion mode (it is never an
+assertion, so the external tool never has to reimplement it) and is simply skipped
+by lazy conflict analysis (it forgoes the trimming benefit). So the messy
+intertwining is allowed to remain *precisely where it is necessary*, and the
+refactor's payoff is incremental and per-constraint: each rule lifted 3→2→1 gains
+trimmability, lazy replay, and Rust-portability, with no big-bang requirement.
+
+## Deep relationship to PR #302
+
+This redesign **is** the generalisation of annotated assertions. #302 already:
+- emits the inference reified under the reason as an `a` line
+  (`emit_under_reason(AssertProofRule{}, …, reason, annotation)`), and
+- attaches `AssertionAnnotation { derivable_from, hint_name, hint_fields }`.
+
+Map directly onto this model (see "Justification dispatch"): the hint identifier is
+the `Data` type's `name` (replacing the `hint_name` enum), `hint_fields` =
+`hint_sexpr(Data)`, `derivable_from` = the `ConstraintID`/line refs `Data` carries.
+The external Rust justifier in the VeriPB trimmer codebase consumes exactly the
+**witness-complete tier**: it reimplements each hint's `emit` reading the `Data`
+back from the `.scp` s-expression. Two big-picture #302 goals fall
+straight out:
+- **(A) proof logging in other solvers**: another solver emits `(inference, reason
+  literals, hint)` and never needs our C++ internals — the portable boundary is
+  the *materialised* forms (`ReasonLiterals` + serialised `Data`), so our
+  in-process `LazyReasonOver`/`emit` functions never cross it.
+- **(B) trim then justify**: emit cheap assertions for everything, trim, then run
+  the justifier only on survivors. Composes with G4 lazy analysis (which avoids
+  *emitting* off-path inferences): trim what G4 emits.
+
+So #302 and this redesign want the same per-inference record — `(reason spec, tag,
+gathered Data)` — designed cheap and storable. Practically, #302 can be the
+justification-side beachhead: land its assertion mode, then this redesign is
+"replace the global hint enum with per-tag `emit`/`gather` and extract every
+justifier into that shape." Adopting the tag mechanism *in #302 itself* is the
+cheapest point to do it — before a flat-field decoder hardens.
+
+## Cost / payoff (honest)
+
+- **Cost:** a large, mostly-mechanical refactor — every embedded justifier becomes
+  an ADL-found `emit`/`gather` pair plus a tag + `Data` struct, done constraint-by-
+  constraint with proof re-verification at each step. Tier-3 holdouts excepted.
+  Plus the per-tag `Data ⇄ flat fields` (de)serialiser, but only for tags that
+  support `AssertExternal`.
+- **Payoff per extracted rule:** trimmable (B), lazily replayable on the conflict
+  path (G4), and reimplementable in Rust (A) — plus the call-site/perf wins from
+  `reasons-improvement.md` come along for free since the reason layer is shared.
+- **Synergy:** for many constraints the reason and the justification draw on the
+  *same data* (all-different's Hall set), so the per-constraint audit table —
+  `{ reason variant, narrowable?, tag name, gathered Data fields }` — is one
+  artifact serving reasons, #302, and this redesign at once.
+
+## Resolved by the tag design
+
+- *Witness typing* — typed per-tag `Data` in C++, lowered to flat fields only on
+  the `AssertExternal` wire; in-memory and lazy paths never flatten.
+- *Sub-rule granularity / a global enum* — gone. Tags group by *argument shape*
+  (Plus's 6 rules → one `BoundTag` with a direction field), each carrying its own
+  local `name`; the external tool dispatches on `name`.
+
+## Open questions
+
+- **Re-derivable rules vs narrowability collide.** A re-derivable justifier
+  (knapsack) re-runs over "the domains" — but lazily, the domains have narrowed.
+  Narrowable ⟹ fine; non-narrowable ⟹ snapshot the domains into reason/`Data`,
+  which for knapsack is potentially large, possibly collapsing tier 2 into tier 3
+  in practice. Probe a real knapsack proof before believing tier 2 is populated.
+- **What does a constraint stash at install time** for its `emit` (the `def` —
+  coefficients, automaton, table, at-most-one line numbers), and how does the
+  external Rust tool obtain the equivalent? Likely the OPB/definition lines it
+  already emits — needs pinning down.
+- **Serialisation mechanism.** Hand-written per tag (no Boost, no reflection
+  before C++26), or a single aggregate-reflection helper? Only bites tags that
+  support `AssertExternal`.
+
+## Relationship to `reasons-improvement.md`
+
+That doc is the reason layer of this one, shippable on its own. This doc adds the
+justification layer and the mode machinery on top. Recommended path: do
+`reasons-improvement.md` first (real perf win, low risk), let #302 land its
+assertion mode, and only then decide whether to pursue this full unification —
+by which point the per-constraint witness work will be far clearer.
+
+## Appendix: worked examples against the real code
+
+Two constraints, deliberately chosen because they sit at opposite ends — `plus`'s
+justifier *reads* the reason and is new-ish code; `all_different`'s *ignores* the
+reason and is already a free function we reuse almost verbatim.
+
+*(Surface note: the `all_different` example below is in the current surface and
+matches `de85b4c9`. The `plus` example still uses the earlier draft's empty `Tag`
+struct with `gather_justification`/`emit_justification` overloads on it; map it onto
+the current surface the same way — there is no separate `Tag`, the `Data` struct is
+the dispatch type and carries the `static constexpr name`; `emit_justification(Data,
+…)` is unchanged (eager/lazy C++ steps); the AssertExternal wire form is
+`hint_sexpr(Data) -> SExpr`. The substance — witness, tiers, what `def` holds — is
+unaffected.)*
+
+### `plus` (today: `plus.cc:55–110`)
+
+Today each of the 6 bound rules calls `inference.infer(logger, lit,
+justify(Conclude::GE|LE), [=]{ return Reason{op1_bound, op2_bound}; })`, and the
+`JustifyExplicitlyThenRUP` lambda captures `[c, sum_line, logger]`, picks
+`sum_line.first`/`.second` by direction, builds a `PolBuilder` from that line plus
+`reason().at(0)`/`.at(1)`, and emits at `ProofLevel::Temporary`.
+
+```cpp
+// --- in the plus namespace ---
+struct BoundTag { static constexpr std::string_view name = "plus.bound"; };
+
+struct BoundData { ProofLine pol_line; };   // the operand bounds come from the reason, positionally
+
+// raw args -> Data. Returns nullopt when the relevant sum_line is unset, which today
+// is the "no explicit step, RUP only" path (the `if (! sum_line_value) return;` guard).
+auto gather_justification(BoundTag,
+        const std::pair<std::optional<ProofLine>, std::optional<ProofLine>> & sum_line,
+        bool conclude_le) -> std::optional<BoundData>
+{
+    auto line = conclude_le ? sum_line.first : sum_line.second;
+    if (! line) return std::nullopt;
+    return BoundData{*line};
+}
+
+// Data + reason -> the explicit lemma. (The trailing RUP under the reason is done by
+// the infer machinery — this is the "ThenRUP" half, factored out.)
+auto emit_justification(BoundTag, ProofLogger & logger, const BoundData & d, const ReasonLiterals & reason) -> void
+{
+    PolBuilder b;
+    b.add(d.pol_line);
+    for (std::size_t i = 0; i < 2; ++i) {   // the two operand bounds, positionally — see note
+        auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason.at(i))));
+        if (holds_alternative<ConstantIntegerVariableID>(lit.var)) continue;
+        b.add_for_literal(logger.names_and_ids_tracker(), lit);
+    }
+    b.emit(logger, ProofLevel::Temporary);
+}
+```
+
+Call site:
+
+```cpp
+inference.infer(result >= a_vals.first + b_vals.first,
+    ExplicitReason{{a >= a_vals.first, b >= b_vals.first}},        // (2) two specific bounds, cheap, known now
+    justify_with(plus::BoundTag{}, sum_line, /*conclude_le=*/true)); // (3)
+```
+
+Notes:
+- **`emit` reads the reason positionally** (`reason.at(0/1)`), so this rule's
+  reason is content- *and order*-coupled → **non-narrowable**, and the reason
+  must be materialised whenever the justification is.
+- The reason is two *specific* picks, not a full domain (bucket D). `ExplicitReason`
+  builds the 2-element vector eagerly; negligible here, but if we wanted it lazy a
+  "picks"-style `LazyReasonOver` is the bucket-D open question from
+  `reasons-improvement.md`.
+- `gather` returning `optional` is the general "sometimes there is no explicit
+  step, just the trailing RUP" pattern (here, an absent `sum_line`).
+
+### `all_different` GAC (today: `gac_all_different.cc`, `all_different/justify.{hh,cc}`; structured hints added in `de85b4c9`)
+
+This is now grounded in real code: as of `de85b4c9`, the GAC propagator emits
+structured hints for **three** distinct inference shapes — all currently sharing
+one coarse `hint_name = AllDifferent`:
+
+| shape | site | inference | hint fields built |
+|---|---|---|---|
+| matching too small | `prove_matching_is_too_small` | `FalseLiteral{}` (contradiction) | `constraint_id`, `hall_vars`, `hall_vals`, `justifier = hall_set_or_violator` |
+| SCC deletion, hall set | `prove_deletion_using_sccs` (hall branch) | value deletions | *identical block to the above* |
+| SCC deletion, trivial | `prove_deletion_using_sccs` (forced-value branch) | one deletion | `constraint_id` only |
+
+Two things to notice in that commit. (1) The first two shapes **hand-build the same
+four-field s-expr block, copy-pasted across the two functions.** (2) `hint_name =
+AllDifferent` does not say which of the three a hint is, so a `justifier =
+hall_set_or_violator` field was added to separate the hall shapes from the trivial
+one — i.e. *the real rule name is being carried as a field because the enum is too
+coarse* (the granularity point from "Why the central enum should go", now live in
+the code).
+
+Both fall straight out of the typed design. The two hall shapes share one witness
+and one `name`; the trivial shape is its own tiny one:
+
+```cpp
+// --- in namespace gcs::innards::hints, reopened in the all_different source ---
+struct HallData {
+    static constexpr std::string_view name = "all_different.hall";   // == de85b4c9's `hall_set_or_violator` justifier
+    small_vector<IntegerVariableID, 4> hall_vars;
+    small_vector<Integer, 4>           hall_values;
+    ConstraintID                        owner;        // handle to this constraint's proof `def`
+};
+
+// schema + wire form in ONE place — replaces BOTH hand-duplicated hint_list blocks in de85b4c9.
+// Variable fields need the names tracker (de85b4c9 renders them with s_expr_term_of), so the
+// serialiser for a Data containing variables takes it — the same dependency, made explicit.
+auto hint_sexpr(const HallData & d, NamesAndIDsTracker & names) -> SExpr
+{
+    std::vector<SExpr> var_terms;
+    for (auto v : d.hall_vars) var_terms.push_back(names.s_expr_term_of(v));
+    return hint_list(hint_list(AssertionHintIdentifier::constraint_id, d.owner),
+                     hint_list(AssertionHintIdentifier::hall_vars,     SExpr::list(std::move(var_terms))),
+                     hint_list(AssertionHintIdentifier::hall_vals,     hint_seq(d.hall_values)));
+}
+
+// eager / lazy C++ steps: reach `def` via the owner, reuse the existing free fn, ignore the reason.
+// NOTE (superseded — see "IMPLEMENTED" at top): the logger-side store was removed,
+// and `HallData` here is, as built, the fat witness `hints::AllDifferentHall`. It
+// DOES define emit_justification, but reaches the constraint's `all_variables` +
+// at-most-one cache through non-serialised POINTERS it carries (`all_vars`,
+// `value_am1_constraint_numbers`) — both owned by the Constraint, which outlives
+// search — and calls justify_all_different_hall_set_or_violator directly. Read
+// `logger.constraint_proof_data<...>(owner)` here as "read off the fat witness's
+// pointers"; `hint_sexpr` serialises only the clean subset (owner + hall set).
+auto emit_justification(ProofLogger & logger, const HallData & d, const ReasonLiterals &) -> void
+{
+    auto & def = logger.constraint_proof_data<AllDifferentDef>(d.owner);     // { all_variables, value_am1_constraint_numbers }
+    justify_all_different_hall_set_or_violator(logger, def.all_variables,
+        {d.hall_vars.begin(), d.hall_vars.end()}, {d.hall_values.begin(), d.hall_values.end()},
+        def.value_am1_constraint_numbers);
+}
+
+// the trivial SCC shape: no hall set, just the owner.
+struct ForcedValueData { static constexpr std::string_view name = "all_different.scc_forced"; ConstraintID owner; };
+auto hint_sexpr(const ForcedValueData & d, NamesAndIDsTracker &) -> SExpr
+{
+    return hint_list(hint_list(AssertionHintIdentifier::constraint_id, d.owner));
+}
+```
+
+`HallData::name` is exactly the `hall_set_or_violator` discriminator `de85b4c9`
+puts in a field; once it lives on the type, the `hint_name` enum entry is the
+redundant coarse duplicate.
+
+Call site (the reason and the justification draw on the **same** computed Hall set;
+build the witness only in a consuming mode — `de85b4c9` already does this with its
+`if (logger.get_assertion_level() != AssertionLevel::Off)` guard):
+
+```cpp
+inference.infer(vars[k] != val,
+    LazyReasonOver{hall_vars, [excluded](const State & st, ReasonLiterals & out) {   // (2) generic over hall_vars + exclusions
+        for (auto v : /*hall_vars*/) for (auto s : excluded) out.push_back(v != s);
+    }},
+    justify_with<all_different::HallData>(hall_vars, hall_values, owner_cid));        // (3) Data built only if consumed
+```
+
+Notes:
+- **One witness serves both hall shapes.** The contradiction
+  (`prove_matching_is_too_small`) and the SCC deletion (hall branch) build the
+  identical `HallData`; the single `hint_sexpr`/`emit` pair replaces the duplicated
+  `hint_list` blocks `de85b4c9` currently carries in both functions.
+- **`emit` ignores the reason** — it derives everything from the Hall set + `def`.
+  Contrast with `plus`. So whether a justifier consumes the reason is genuinely
+  per-rule, and the uniform `emit(…, Data, reason)` signature carries the reason for
+  those that want it and is ignored by those that don't.
+- The body of `emit` is the *existing* `justify_all_different_hall_set_or_violator`,
+  unchanged. The refactor is: stop reference-capturing
+  `&logger`/`&value_am1_constraint_numbers`; carry the Hall set as `HallData`; reach
+  the rest via `owner`.
+- **This pins down the "what does a constraint stash" open question.** `def` here
+  is not pure install-time data — `value_am1_constraint_numbers` is a
+  `map<Integer, ProofLine>` *mutated during proof* (it lazily emits an at-most-one
+  constraint per value and caches its line, `justify.cc:41`). So the logger holds a
+  per-constraint, ConstraintID-keyed proof-data object that may include mutable
+  caches. For the external Rust tool the same at-most-one lines live in the proof,
+  so it rebuilds/looks them up; for in-solver lazy replay the cache persists with
+  the constraint. The witness stays small (the Hall set); `def` is reached by id.
+- Fully serialisable witnesses (`HallData`, `ForcedValueData`) → both are
+  witness-complete (tier-1) rules: all four modes work.

--- a/dev_docs/infer-redesign.md
+++ b/dev_docs/infer-redesign.md
@@ -55,34 +55,41 @@ As built:
   instead. `emit_explicit_steps` picks closure-vs-fat-witness by `if constexpr`
   (compile time). The Simple (proofs-off) tracker never touches `emit` or the hint,
   so Off mode pays only for constructing the (usually empty) call-site objects.
-- **Typed assertion hints, names decentralised.** Each structured hint is a struct
-  in `namespace gcs::innards::hints` (reopened per constraint) — the enumerable
-  "interface the justifier supports". A witness carries: a
-  `static constexpr std::string_view hint_name` (the coarse model-level name, the
-  2nd annotation field); an optional `static constexpr std::string_view justifier`
-  (the fine per-shape sub-rule keyword, serialised into `hint_fields` — answers
-  #377: one constraint, several inference shapes); an ADL
-  `hint_sexpr(witness, NamesAndIDsTracker&) -> SExpr` (the wire schema, in one
-  place); and an optional ADL `emit_justification(...)` (explicit steps; absent for
-  pure-RUP witnesses). There is **no central `hint_names.hh` and no `hint_name`
-  enum** — the body's "Why the central enum should go" was taken to its conclusion.
-  Coarse names live in three decentralised forms: on the witness (`hint_name`); as a
-  per-file `constexpr std::string_view <name>_hint` where a constraint reuses one
-  across sites (`equals_hint`, `linear_equality_hint`); and as
-  `hints::ModelName{name}` — the minimal name-only tier — at inline-closure sites
-  that want a coarse name without a struct. `hint_annotation` selects
-  NoHint / `ModelName` / structured at compile time; `resolve_annotation` gives
-  3-tier precedence (explicit `hint` → `emit`'s own advertisement → the call site's
-  fallback annotation), reproducing the old witness-carried annotation exactly.
-- **Coverage.** Typed witnesses are in use in ~7 constraints — abs, plus, equals,
-  lex, linear equality, linear inequality, and all_different (GAC). **abs is the
-  canonical reference conversion** (commit `4c85dfe8`): a single
-  `hints::AbsJustification{owner, justifier}` rides *both* `JustifyUsingRUP` (abs's
-  pure-RUP pruning) and `JustifyExplicitly` (its ~10 explicit bounds), carries no
-  operand data (re-derivable), and serialises to one `hint_sexpr` →
-  `((constraint_id _N) (justifier <sub-rule>))`; the eager `emit` closures are
-  untouched. It is the "add a constraint to the Justifier → here is your
-  solver-side change" template.
+- **Typed assertion hints, names decentralised.** Each hint is a struct in
+  `namespace gcs::innards::hints` (reopened per constraint), living in
+  `gcs/constraints/<foo>/hints.hh` — the enumerable "interface the justifier
+  supports". The shape is **base + derived by inheritance**: a base struct holds a
+  `ConstraintID originator` and a `static constexpr std::string_view hint_name`
+  (the coarse model-level name, the 2nd annotation field); a derived struct adds a
+  `static constexpr std::string_view subhint_name` (the fine per-shape sub-rule
+  keyword — answers #377: one constraint, several inference shapes) and/or held
+  data. A generic ADL `hint_sexpr(hint, NamesAndIDsTracker&) -> SExpr` gives the
+  default wire form `(constraint_id <originator>)`, plus `(subhint <name>)` when the
+  struct names a `subhint_name`; a constraint opts into serialising more by defining
+  its own `hint_sexpr` next to the struct. An optional ADL
+  `emit_justification(logger, hint, reason)` supplies the explicit steps for a fat
+  witness (absent for pure-RUP hints). There is **no central `hint_names.hh` and no
+  `hint_name` enum** — the body's "Why the central enum should go" was taken to its
+  conclusion; coarse names live only as the struct's `hint_name` member (the
+  framework-level assertions — `initial_bound`, `backtrack`, … — are bare
+  `hint_name`-only structs in `gcs/innards/proofs/hints.hh`). `hint_annotation`
+  (`infer_explicitly.hh`) selects, at compile time, the structured tier (the hint
+  has a `hint_sexpr`), the coarse tier (a non-empty `hint_name` but no `hint_sexpr`),
+  or the call-site fallback; the precedence (explicit `hint` → `emit`'s own
+  advertisement → fallback) is applied inline at the assertion site, reproducing the
+  old witness-carried annotation exactly.
+- **Coverage.** Typed hints are wired **catalogue-wide** — every constraint with
+  its own inferences (~31) has a `gcs/constraints/<foo>/hints.hh`, from a minimal
+  `{originator}` + `hint_name` up to fat witnesses. **abs is the canonical reference
+  conversion** (commit `4c85dfe8`): a single `hints::Abs{originator}` rides *both*
+  `JustifyUsingRUP` (abs's pure-RUP pruning) and `JustifyExplicitly` (its ~10
+  explicit bounds), carries no operand data (re-derivable), and — having no per-shape
+  `subhint_name` and no own `hint_sexpr` — takes the default wire form
+  `((constraint_id _N))`; the eager `emit` closures are untouched. It is the "add a
+  constraint to the Justifier → here is your solver-side change" template.
+  `all_different` shows the base+derived split: `AllDifferent` (the forced-value
+  deletions) plus `AllDifferentHall : AllDifferent` (the GAC Hall shape — a fat
+  witness carrying non-serialised pointers to the at-most-one line cache).
 
 **The one substantive departure from the body below: there is no logger-side
 per-constraint proof-data store.** The body proposes `logger.constraint_proof_data
@@ -111,8 +118,11 @@ Still deferred (consistent with the body's "open questions"):
   3.0.2 caps there — so there is **no ctest coverage of assertion-mode output**;
   behaviour preservation rests on the Off-mode proofs being byte-identical (they
   are, across the suite);
-- Plan B is rolled out to the ~7 constraints above, not the whole set (per Matthew:
-  fewer hints, expand when the external Justifier needs them).
+- `table`'s hint is infrastructure-only: Table propagates through the shared
+  innards helper `propagate_extensional()`, which can't name a constraint-specific
+  hint without an innards→constraints layering inversion; when that util is made
+  hint-aware, Table is ready. (`arithmetic` / `seq_precede_chain` post no inferences
+  of their own and inherit the hints of what they delegate to.)
 
 ## The abstraction
 

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -249,7 +249,7 @@ To be implemented fresh: partition + splits + coverings + root covering in
 interval reason elements (§4), retiring the env gates once §8 is in place.
 
 *Status (2026-06-11, revised same day): all of the above implemented.
-`need_invar` returns `ProofLiteralOrFlag` (the eq atom for width 1) and
+`need_invar` returns `ProofLiteral` (the eq atom for width 1) and
 maintains §3 in full; `need_direct_encoding_for` performs the singleton
 splits; `In` over constants batches initial-domain gaps (§9.3);
 `GCS_RANGE_INFERENCES` is retired and the Equals holes path is interval-based

--- a/dev_docs/reasons-improvement.md
+++ b/dev_docs/reasons-improvement.md
@@ -1,0 +1,266 @@
+# Reasons: incremental improvement (DRAFT for discussion)
+
+**Scope:** improve *only* the reason mechanism. This deliberately does **not**
+touch justifications. The justification side — and a unified rethink of the whole
+`infer()` triple — is explored separately in `infer-redesign.md` and in PR #302
+(*Annotated Assertions*). This doc is the low-risk, near-term slice that delivers
+the performance win on its own and is a strict stepping stone toward the larger
+redesign (the `Reason` type defined here is reused there verbatim).
+
+## IMPLEMENTED (2026-06-19)
+
+This is built on the `302-then-347` branch. As built: the `Reason` variant
+(`NoReason` / `ExplicitReason` / `{Generic,BothBounds,Lazy}ReasonOver` +
+`Narrowable*`) and `materialise()` live in `gcs/innards/reason.hh`; the
+materialise is deferred inside the inference tracker (`snapshot_reason` pins the
+eager-vs-lazy timing so eager reasons snapshot pre-inference into an
+`ExplicitReason` and lazy ones materialise post-inference). The old
+`ReasonFunction` thunk, its `LegacyReasonFunction` bridge, and the `Reason(F&&)`
+ctor are all gone — no `std::function` is built on the reason path. Every step was
+byte-identical to the prior proofs. The justification layer that builds on this is
+implemented too; see the "IMPLEMENTED" note in `infer-redesign.md`.
+
+## Motivation
+
+Today a reason is built like this (`gcs/innards/reason.cc`):
+
+```cpp
+auto generic_reason(const State & state, const std::vector<IntegerVariableID> & vars, ...) -> ReasonFunction
+{
+    Reason reason;
+    for (const auto & var : vars) { /* walk domain, push lits */ }
+    return [=]() { return reason; };          // captures the already-built vector
+}
+```
+
+`ReasonFunction = std::function<auto()->Reason>` *looks* lazy but is not: the
+domain walk, the `small_vector` fill, and a `std::function` allocation all happen
+**eagerly at the call site**, on every `infer()` — and `SimpleInferenceTracker`
+(proofs off) then throws the result away. This eager-build-then-discard is
+measured at ~20% of runtime on some benchmarks.
+
+### Goals (and what this doc delivers)
+
+- **G1 — cheap construction in the easy cases.** Building a reason becomes a
+  handle + a tag, no domain walk, no allocation. ← *delivered here.*
+- **G2 — no diverging call paths.** A propagator writes the same thing whether or
+  not proofs are on. ← *delivered here.*
+- **G3 — more declarative.** Common shapes expressed as data, not lambdas. ←
+  *delivered here for the easy cases.*
+- **G4 — defer-friendly lifetimes.** Reasons become storable specs that *can* be
+  reconstructed later. ← *the reason-side prerequisite is delivered here* (the
+  spec is cheap, copyable, storable); the actual lazy-conflict-analysis machinery
+  needs the justification side too, so it lives in `infer-redesign.md`.
+
+## Core idea
+
+Separate two things that `ReasonFunction` conflates:
+
+1. **`Reason`** — a *declarative description* of a reason. Cheap, copyable,
+   storable. A variant over a handful of shapes.
+2. **`ReasonLiterals`** — the *materialised* literal conjunction the proof log
+   reifies under. This is today's `Reason` type, renamed.
+
+```cpp
+namespace gcs::innards
+{
+    // Was `Reason`. The materialised conjunction of facts.
+    using ReasonLiterals = gch::small_vector<ProofLiteralOrFlag, 2>;
+
+    // Owned / shared / borrowed handle, reusing gcs::ArrayParam (gcs/array_param.hh).
+    // "Borrowed" is the unowned mode: a constraint that always reasons over the
+    // same scope passes `&_vars` and allocates nothing.
+    using ReasonVars = VectorArrayParam<IntegerVariableID>;
+
+    // Escape hatch for the bespoke tail; reads state, appends to `out`.
+    using LazyReasonFn = std::function<void(const State &, ReasonLiterals & out)>;
+
+    struct NoReason {};                                              // explicit "none"
+    struct ExplicitReason            { ReasonLiterals literals; };   // singletons, fixed lists, eager snapshots
+
+    struct GenericReasonOver         { ReasonVars vars; std::optional<Literal> extra; };
+    struct BothBoundsReasonOver      { ReasonVars vars; std::optional<Literal> extra; };
+    struct LazyReasonOver            { ReasonVars vars; LazyReasonFn fn; };
+
+    // Narrowable counterparts: same payload, different tag (see "Narrowable" below).
+    struct NarrowableGenericReasonOver    { ReasonVars vars; std::optional<Literal> extra; };
+    struct NarrowableBothBoundsReasonOver { ReasonVars vars; std::optional<Literal> extra; };
+    struct NarrowableLazyReasonOver       { ReasonVars vars; LazyReasonFn fn; };
+
+    using Reason = std::variant<
+        NoReason, ExplicitReason,
+        GenericReasonOver, BothBoundsReasonOver, LazyReasonOver,
+        NarrowableGenericReasonOver, NarrowableBothBoundsReasonOver, NarrowableLazyReasonOver>;
+
+    // The only place the domain walk happens. Called by a consumer that has
+    // decided it needs the literals (proofs on). Stateless variants ignore `state`.
+    [[nodiscard]] auto materialise(const Reason &, const State &) -> ReasonLiterals;
+}
+```
+
+A call site becomes, e.g.:
+
+```cpp
+inference.infer(logger, result <= a_hi + b_hi, justify(...),
+    GenericReasonOver{some_vars});                 // no walk, no alloc
+
+inference.infer(logger, x != v, JustifyUsingRUP{},
+    ExplicitReason{{cond, y == w}});               // already-known literals
+```
+
+`ReasonFunction` and the three `*_reason()` factory functions go away;
+`generic_reason(state, vars)` is replaced by the value `GenericReasonOver{vars}`
+(note: no `state` at construction — that is the point).
+
+## Where materialisation happens: the InferenceTracker template
+
+The eager-vs-off decision already lives in the `InferenceTracker` template
+(`SimpleInferenceTracker` vs `EagerProofLoggingInferenceTracker`). Reason
+materialisation rides the same axis:
+
+- **`SimpleInferenceTracker`** (proofs off): does nothing with the reason. Cost =
+  building the variant. **This is the G1 win.**
+- **`EagerProofLoggingInferenceTracker`** (proofs on, today's behaviour):
+  `auto lits = materialise(reason, _state);` immediately, then
+  `logger->infer(lit, just, lits, ...)`. State is current, so non-narrowable
+  reasons are correct.
+
+`ProofLogger::infer` / `emit_*_under_reason` take `const ReasonLiterals &`, not a
+callable. The `if (reason)` null-checks disappear: `NoReason{}` materialises to
+empty, which is just an un-reified inequality.
+
+## The "Narrowable" axis (forward-looking, no-op today)
+
+A new per-caller distinction, included now so a future deferred mode needs no
+second sweep of every call site:
+
+- **Non-narrowable** (default, conservative): the reason must reflect the *exact*
+  domain at the moment of inference.
+- **Narrowable**: the constraint is equally happy being handed *tightened*
+  domains, so it can be re-materialised lazily against whatever (narrower) state
+  is current later, with no per-inference bookkeeping ("lazy explanation
+  generation").
+
+In eager proof-logging mode both behave identically (we always materialise now,
+against the current state), so the tag is a no-op until a deferred tracker exists.
+Settling it per constraint needs a dedicated pass with proof-soundness sign-off —
+default everything to non-narrowable.
+
+**Caution.** Known non-narrowable: anything whose *justification reads the reason
+positionally* (`plus.cc:71-76`, `minus.cc`, `mult_bc.cc` — the
+`JustifyExplicitlyThenRUP` callback does `reason().at(i)` and feeds a `PolBuilder`,
+so content *and order* are load-bearing), and the structural propagators (Hall
+sets, GCC flow cuts) whose reason depends on the exact live domain.
+
+## P1 — generator audit summary
+
+~120 standard-builder call sites + ~60 bespoke `Reason{...}` lambdas. Mapping onto
+the variant (counts approximate):
+
+| Bucket | ~N | Examples | Target |
+|---|---|---|---|
+| A. full-domain | ~58 | count, among, element, knapsack, disjunctive, linear_equality, negative_table, cumulative, circuit | `GenericReasonOver` |
+| B. bounds-only | ~15 | lex, arg_sort (often `+ extra`) | `BothBoundsReasonOver` |
+| C. single fixed literal | ~14 | smart_table, vc_all_different, all_equal, increasing, inverse | `ExplicitReason` |
+| D. specific selected bounds over a known scope | ~50 | plus, minus, mult_bc, comparison, linear/propagate, abs, logical, parity | `LazyReasonOver` — or a declarative "picks" form (open) |
+| E. structural | ~4–6 | gac_all_different (Hall), gac/bounds global_cardinality (flow), lex scaffold | `LazyReasonOver`, reads state |
+| no reason | ~2 | all_different encoding/except | `NoReason` |
+
+Bucket D is the interesting one: it is **not** `generic_reason` (it does not dump
+the domain — it picks specific bound literals computed from snapshotted values),
+and for plus/minus/mult_bc it is coupled to the justification via positional
+access. Open question: give D a declarative form (best for G3) or sweep it into
+`LazyReasonOver` closures (simplest).
+
+## P2 — consumer audit summary
+
+On main, reason consumption is **uniformly eager and never escapes `infer()`**:
+
+- Only invokers of `reason()`: `ProofLogger::{infer, reason_to_lits,
+  emit_under_reason}` and a few justification callbacks (plus/minus/mult_bc index
+  into it; smart_table/circuit_scc/regular iterate it once to build a "short
+  reason" proof flag, then locally swap in `singleton_reason`).
+- Nothing stores a `ReasonFunction`; `_inferences` keeps only `(var, Inference)`,
+  no reason attached.
+- `ExplicitJustificationFunction` is `std::function<void(const ReasonFunction&)>`.
+  Change to `std::function<void(const ReasonLiterals&)>`: the logger materialises
+  once, hands the literals to the callback *and* reuses them for the trailing RUP.
+  Removes the `reason().at(i)` awkwardness and the double-materialise.
+
+## The seam, and coordination with #302
+
+This change rewrites the `reason` parameter of every `infer*()`/`track_impl`
+overload from `ReasonFunction` to `Reason`. PR #302 independently adds a
+`std::optional<AssertionAnnotation>` parameter to the *same* overloads. They
+collide textually on every signature, so the merge point is one agreed shape:
+
+```cpp
+auto infer(ProofLogger * logger, const Literal & lit,
+           const Justification & why,
+           const Reason & reason,                                   // this doc
+           const std::optional<AssertionAnnotation> & hints = std::nullopt)   // #302
+    -> void;
+```
+
+Beyond the signature, this doc does **not** depend on #302 and vice versa.
+Whoever lands second rebases. (The deeper, structural relationship — where
+reasons and justification hints share captured data — is the subject of
+`infer-redesign.md`, not this doc.)
+
+## Lifetime contract to preserve (from the #335 / RFC #315 stack)
+
+None of #318→#346 is in main, and none edits `reason.{hh,cc}` /
+`justification.hh` — no textual conflict. Two semantic dependencies must keep
+working:
+
+1. **#318** stores the contradiction's reason on the tracker
+   (`_last_contradiction_reason`, today `std::optional<ReasonFunction>`) across
+   the `throw TrackedPropagationFailed`, read at the catch site by
+   `ConflictObserver::note_conflict(...)`. Here it becomes
+   `std::optional<Reason>` (the cheap spec); `materialise(...)` is called at the
+   catch site with the still-current conflict state if an observer wants
+   literals. Today all observers *ignore* it; the future "Nogoods → wdeg
+   attribution" knob is the first consumer, and it wants implicated *vars* — so
+   add a cheap `vars_of(const Reason &)` that reads the handle without
+   materialising.
+2. **#330** nogood learning is decision-path + RUP based, reason-independent. No
+   conflict.
+
+## Open decisions
+
+1. **Bucket D shape:** declarative "selected bounds" variant vs `LazyReasonOver`
+   closures vs leave-as-is initially.
+2. **Per-constraint narrowability:** needs a pass with proof-soundness sign-off.
+   Default non-narrowable.
+3. **Sequencing:** range-literals (#303) has merged; the remaining gate is
+   coordinating the `infer()` signature with #302 before this lands.
+
+## Schedule
+
+Two tranches; tranche 1 is the whole perf win and can land alone.
+
+**Tranche 1 — the reason rework (G1/G2/G3):**
+1. Add `Reason` variant + `ReasonLiterals` rename + `materialise`; keep thin
+   constructors so nothing breaks.
+2. Move materialisation into the tracker; `ProofLogger` +
+   `ExplicitJustificationFunction` take `ReasonLiterals`. *Here the eager cost
+   disappears.* Verify proofs byte-identical on a sweep.
+3. Convert call sites bucket-by-bucket (A, then B/C, then D, then E), each a PR
+   with proof re-verification; D needs care around positional-justification
+   coupling.
+4. `NoReason{}` cleanup; delete `ReasonFunction` and the empty-`std::function`
+   sentinel.
+
+**Tranche 2 — reason-side G4 prerequisite (light):**
+5. `_last_contradiction_reason` → `std::optional<Reason>`; add `vars_of`. That is
+   all the reason side owes G4. Full lazy conflict analysis (storing reasons *and*
+   justifications per inference and replaying only the conflict path) is the
+   subject of `infer-redesign.md`.
+
+## Relationship to `infer-redesign.md`
+
+This doc is a strict subset of that one: the `Reason` variant, `ReasonLiterals`,
+`materialise`, and the narrowable axis are identical and reused there. You can do
+this doc and stop — it stands alone and delivers the performance win without
+disturbing justifications. If the larger redesign later happens, none of this is
+wasted; it is the reason layer of that design, already done.

--- a/dev_docs/reasons-improvement.md
+++ b/dev_docs/reasons-improvement.md
@@ -10,8 +10,9 @@ redesign (the `Reason` type defined here is reused there verbatim).
 ## IMPLEMENTED (2026-06-19)
 
 This is built on the `302-then-347` branch. As built: the `Reason` variant
-(`NoReason` / `ExplicitReason` / `{Generic,BothBounds,Lazy}ReasonOver` +
-`Narrowable*`) and `materialise()` live in `gcs/innards/reason.hh`; the
+(`NoReason` / `ExplicitReason` / `ExactSingleValue` /
+`{Generic,BothBounds,Lazy}ReasonOver` + `Narrowable*`) and `materialise()`
+live in `gcs/innards/reason.hh`; the
 materialise is deferred inside the inference tracker (`snapshot_reason` pins the
 eager-vs-lazy timing so eager reasons snapshot pre-inference into an
 `ExplicitReason` and lazy ones materialise post-inference). The old

--- a/dev_docs/reification.md
+++ b/dev_docs/reification.md
@@ -139,13 +139,14 @@ The recommended approach is to use the dispatcher helper:
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 
 auto install_reified_dispatcher(
-    Propagators &, const State & initial_state,
+    Propagators &, const ConstraintID &,
+    const EvaluatedReificationCondition & initial_evaluated,  // precomputed in prepare()
     const ReificationCondition &,
     Triggers,
     auto enforce_constraint_must_hold,       // (state, inference, logger, cond_lit) -> PropagatorState
     auto enforce_constraint_must_not_hold,   // ditto
-    auto infer_cond_when_undecided,          // (state, inference, logger, cond_var) -> ReificationVerdict
-    const std::string & name) -> void;
+    auto infer_cond_when_undecided)          // (state, inference, logger, cond_lit) -> ReificationVerdictFor<…>
+    -> void;
 ```
 
 You provide three callables, one for each non-trivial branch of
@@ -154,7 +155,7 @@ You provide three callables, one for each non-trivial branch of
 1. **`enforce_constraint_must_hold`** — the constraint is currently `TRUE`
    (or unconditional `MustHold`). Propagate the constraint, returning a
    `PropagatorState`. The `cond_lit` parameter is the literal to include in
-   reasons (use it via `bounds_reason(state, vars, cond_lit)` or similar).
+   reasons (use it via `bounds_reason(vars, cond_lit)` or similar).
 
 2. **`enforce_constraint_must_not_hold`** — the constraint is currently
    `FALSE` (or unconditional `MustNotHold`). Propagate the *negation* of
@@ -166,21 +167,35 @@ You provide three callables, one for each non-trivial branch of
    will use the `Undecided` struct's `cond_to_infer_*` methods to decide
    whether (and which) cond literal to actually infer.
 
-The `ReificationVerdict` variant lives in the same header:
+The `ReificationVerdict` variant lives in the same header. `MustHold` /
+`MustNotHold` are templated on the justification type (defaulting to the
+`Justification` variant) so a constraint can carry a typed witness — the
+`ReificationVerdictFor<Justification_>` alias names the variant for a given
+justification, e.g. `ReificationVerdictFor<JustifyUsingRUP<hints::Foo>>`:
 
 ```cpp
 namespace reification_verdict {
-    struct StillUndecided   { };
-    struct MustHold         { Justification justification; ReasonFunction reason; };
-    struct MustNotHold      { Justification justification; ReasonFunction reason; };
+    struct StillUndecided { };
+
+    template <typename Justification_ = Justification>
+    struct MustHold {
+        Justification_ justification;
+        Reason reason;                                       // declarative; materialised on demand
+        std::optional<AssertionAnnotation> assertion_hint = std::nullopt;
+        static constexpr bool affirmative = true;
+    };
+
+    template <typename Justification_ = Justification>
+    struct MustNotHold { /* same shape; affirmative = false */ };
 }
 ```
 
-For `MustHold`/`MustNotHold`, you provide the justification and reason for
-the cond inference. The dispatcher chooses the right cond literal (or skips
-the inference if the reif kind doesn't license one) and feeds them into
-`inference.infer(...)`. `PropagatorState` falls out of the visit:
-`StillUndecided` → `Enable`, anything else → `DisableUntilBacktrack`.
+For `MustHold`/`MustNotHold`, you provide the justification and the
+(declarative) `Reason` for the cond inference; a typed assertion hint may
+ride along via `assertion_hint`. The dispatcher chooses the right cond
+literal (or skips the inference if the reif kind doesn't license one) and
+feeds them into `inference.infer(...)`. `PropagatorState` falls out of the
+visit: `StillUndecided` → `Enable`, anything else → `DisableUntilBacktrack`.
 
 ### What the dispatcher does for you
 
@@ -242,13 +257,12 @@ auto infer_cond_when_undecided = [...](state, _, _, cond) -> ReificationVerdict 
     return reification_verdict::StillUndecided{};
 };
 
-// 3. Install
+// 3. Install (from install_propagators(); _evaluated_cond was computed in prepare())
 Triggers triggers{.on_bounds = {_v1, _v2}};
-install_reified_dispatcher(propagators, state, _reif_cond, triggers,
+install_reified_dispatcher(propagators, constraint_id(), _evaluated_cond, _reif_cond, triggers,
     std::move(enforce_must_hold),
     std::move(enforce_must_not_hold),
-    std::move(infer_cond_when_undecided),
-    "reified compare");
+    std::move(infer_cond_when_undecided));
 ```
 
 ## Where things live
@@ -292,8 +306,8 @@ install function's local scope — the install function returns long
 before the propagator first runs. Look for `[v1 = _v1, v2 = _v2, ...]`
 init-capture style.
 
-The justification lambdas inside a `JustifyExplicitlyThenRUP` are called
-synchronously from within `inference.infer(...)`, which is called from
+The justification emit lambdas inside a `JustifyExplicitly{…, ThenRUP::Yes}`
+are called synchronously from within `inference.infer(...)`, which is called from
 within the propagator's call. So they *can* capture the State and
 ProofLogger by reference (via `[&state, logger, ...]`) — those references
 live long enough.

--- a/dev_docs/state-and-variables.md
+++ b/dev_docs/state-and-variables.md
@@ -190,13 +190,15 @@ automatically on backtrack, use `add_constraint_state` — see the
 
 ## Inference: `change_state_for_*` and the `NoChange` rule
 
-Mutating a variable's domain goes through one of four entry points,
-exposed via the public `infer_*` family:
+Mutating a variable's domain goes through the public `infer_*` family:
 
 - `infer_equal(var, value)` → variable must equal `value`
 - `infer_not_equal(var, value)` → variable must not equal `value`
 - `infer_less_than(var, value)` → variable must be `< value`
 - `infer_greater_than_or_equal(var, value)` → variable must be `≥ value`
+- `infer_not_in_range(var, lo, hi)` → variable must avoid the interval
+  `[lo, hi]` (a single inference for a whole hole-run; see
+  [range_literals_spec.md](range_literals_spec.md))
 
 Each `infer_*` method:
 
@@ -264,12 +266,14 @@ distinction is made by reading the before-state.
 ## `CurrentState`: the public read-only view
 
 `gcs/current_state.hh` defines `CurrentState`, the read-only handle
-that every entry in `SolveCallbacks` receives — `solution`, `trace`,
-`branch`, and `after_proof_started`. It wraps a reference to a `State`
-and exposes only the queries — `bounds`, `in_domain`,
-`optional_single_value`, `each_value_*`, and the `operator()` that
-returns the unique value (or throws) for an instantiated variable.
-It cannot mutate the underlying `State`.
+that the variable-facing `SolveCallbacks` entries receive — `solution`,
+`trace`, `branch`, and `after_proof_started` (the argument-less
+`completed` callback does not). It wraps a reference to a `State`
+and exposes only the queries — `lower_bound`, `upper_bound`, `in_domain`,
+`has_single_value`, `domain_size`, `each_value` / `each_value_reversed`,
+`copy_of_values`, and the `operator()` that returns the unique value (or
+throws) for an instantiated variable. It cannot mutate the underlying
+`State`.
 
 This is the type a typical user-supplied solution callback receives; in
 the typical pattern you call `s(my_var)` to read out the value the

--- a/dev_docs/xcsp.md
+++ b/dev_docs/xcsp.md
@@ -173,16 +173,17 @@ is solved.
 
 ## Honest gaps
 
-Four XCSP3-core constraint families have no propagator yet:
-`noOverlap` (#146 — needs `Disjunctive`), `cumulative` (#147),
-`binPacking` (#148), and `mdd` (#149). The binding overrides each of
+Two XCSP3-core constraint families have no propagator yet:
+`binPacking` (#148) and `mdd` (#149). The binding overrides each of
 their callbacks with a `report_unsupported` call so the parser's
 default uncaught `runtime_error` doesn't terminate the process.
 `main()` also catches `std::runtime_error` as a safety net for any
 other unhandled callback the parser might throw on.
 
 Constraint forms we *partially* support get the same treatment for
-the unsupported cases — e.g. `precedence` with `covered=true`,
+the unsupported cases — e.g. `noOverlap` outside the 1D / 2D
+(`Disjunctive` / `Disjunctive2D`) shapes (#146), `cumulative` with a
+non-`le` condition (#147), `precedence` with `covered=true`,
 `channel` with the one-to-many shape, `nValues` with `<except>`.
 
 ## Testing

--- a/examples/cake/cake.cc
+++ b/examples/cake/cake.cc
@@ -92,8 +92,9 @@ auto main(int argc, char * argv[]) -> int
                 variable_order::dom_then_deg(vector<IntegerVariableID>{banana, chocolate}),
                 value_order::largest_first())},
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()},
-                  true, options_vars.count("full-proof-encoding"))
+            ? make_optional(options_vars.count("full-proof-encoding")
+                      ? ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding()
+                      : ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}})
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/examples/cake/cake.cc
+++ b/examples/cake/cake.cc
@@ -92,9 +92,7 @@ auto main(int argc, char * argv[]) -> int
                 variable_order::dom_then_deg(vector<IntegerVariableID>{banana, chocolate}),
                 value_order::largest_first())},
         options_vars.contains("prove")
-            ? make_optional(options_vars.count("full-proof-encoding")
-                      ? ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding()
-                      : ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}})
+            ? make_optional(ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding(options_vars.contains("full-proof-encoding")))
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -28,8 +28,7 @@ using namespace gcs;
 
 using std::cerr;
 using std::cout;
-using std::make_optional;
-using std::nullopt;
+using std::optional;
 using std::pair;
 using std::string;
 using std::to_string;
@@ -104,11 +103,14 @@ auto main(int argc, char * argv[]) -> int
         p.post(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")});
     }
 
-    auto proof_options = options_vars.contains("prove")
-        ? make_optional(options_vars.contains("assert")
-                  ? ProofOptions{options_vars["proof-files-basename"].as<string>()}.set_assertion_level(AssertionLevel::Inferences)
-                  : ProofOptions{options_vars["proof-files-basename"].as<string>()})
-        : nullopt;
+    optional<ProofOptions> proof_options;
+    if (options_vars.contains("prove")) {
+        proof_options = ProofOptions{options_vars["proof-files-basename"].as<string>()};
+        // Only mark the level explicitly when --assert is given, so the
+        // GCS_ASSERTION_LEVEL env var still applies in the plain --prove case.
+        if (options_vars.contains("assert"))
+            proof_options->set_assertion_level(AssertionLevel::Inferences);
+    }
 
     auto stats = solve_with(p,
         SolveCallbacks{

--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -3,11 +3,13 @@
 #include <gcs/constraints/equals.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/problem.hh>
+#include <gcs/proof.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -49,12 +51,13 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program options")                                                       //
-            ("help", "Display help information")                                                     //
-            ("prove", "Create a proof")                                                              //
-            ("proof-files-basename", "Basename for the .opb and .pbp files",                         //
-                cxxopts::value<string>()->default_value("crystal_maze"))                             //
-            ("stats", "Print solve statistics")                                                      //
+        options.add_options("Program options")                               //
+            ("help", "Display help information")                             //
+            ("prove", "Create a proof")                                      //
+            ("proof-files-basename", "Basename for the .opb and .pbp files", //
+                cxxopts::value<string>()->default_value("crystal_maze"))     //
+            ("stats", "Print solve statistics")                              //
+            ("assert", "Use annotated assertions")                           //
             ;
 
         options.add_options()             //
@@ -101,6 +104,12 @@ auto main(int argc, char * argv[]) -> int
         p.post(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i, options_vars.contains("gac")});
     }
 
+    auto proof_options = options_vars.contains("prove")
+        ? make_optional(options_vars.contains("assert")
+                  ? ProofOptions{options_vars["proof-files-basename"].as<string>()}.set_assertion_level(AssertionLevel::Inferences)
+                  : ProofOptions{options_vars["proof-files-basename"].as<string>()})
+        : nullopt;
+
     auto stats = solve_with(p,
         SolveCallbacks{
             .solution = [&](const CurrentState & s) -> bool {
@@ -111,9 +120,7 @@ auto main(int argc, char * argv[]) -> int
                 return true;
             },
             .branch = branch_with(variable_order::dom_then_deg(xs), value_order::smallest_first())},
-        options_vars.contains("prove")
-            ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>())
-            : nullopt);
+        proof_options);
 
     if (options_vars.contains("stats"))
         print("{}", stats);

--- a/examples/multiply_random/multiply_random.cc
+++ b/examples/multiply_random/multiply_random.cc
@@ -41,7 +41,7 @@ auto main(int argc, char * argv[]) -> int
             ("n", "Max bounds from -n..n", cxxopts::value<int>()->default_value("5"))  //
             ("stats", "Print stats")                                                   //
             ("display-problem", "Display problem and solution (if any)")               //
-            ("proof-files-basename", "Path and name of the opb and pbp files",                 //
+            ("proof-files-basename", "Path and name of the opb and pbp files",         //
                 cxxopts::value<string>()->default_value("multiply_random"));           //
 
         options_vars = options.parse(argc, argv);
@@ -91,7 +91,7 @@ auto main(int argc, char * argv[]) -> int
         println(cout, "z in {}..{}", z_lower, z_upper);
     }
     auto stats = solve(
-        p, [&](const CurrentState & s) -> bool { 
+        p, [&](const CurrentState & s) -> bool {
            if (display_problem) {
             println(cout, "solution: x = {}, y = {}, z = {}", s(x), s(y), s(z));
            }

--- a/examples/tutorial_proof/tutorial_proof.cc
+++ b/examples/tutorial_proof/tutorial_proof.cc
@@ -85,8 +85,9 @@ auto main(int argc, char * argv[]) -> int
             },
         },
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()},
-                  true, options_vars.count("full-proof-encoding"))
+            ? make_optional(options_vars.count("full-proof-encoding")
+                      ? ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding()
+                      : ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}})
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/examples/tutorial_proof/tutorial_proof.cc
+++ b/examples/tutorial_proof/tutorial_proof.cc
@@ -85,9 +85,7 @@ auto main(int argc, char * argv[]) -> int
             },
         },
         options_vars.contains("prove")
-            ? make_optional(options_vars.count("full-proof-encoding")
-                      ? ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding()
-                      : ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}})
+            ? make_optional(ProofOptions{ProofFileNames{options_vars["proof-files-basename"].as<string>()}}.enable_full_encoding(options_vars.contains("full-proof-encoding")))
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(glasgow_constraint_solver
         constraints/disjunctive_2d/disjunctive_2d.cc
         constraints/element/element.cc
         constraints/equals/equals.cc
+        constraints/extensional_utils.cc
         constraints/global_cardinality/bounds_global_cardinality.cc
         constraints/global_cardinality/gac_global_cardinality.cc
         constraints/global_cardinality/justify.cc
@@ -69,7 +70,6 @@ add_library(glasgow_constraint_solver
         constraints/table/negative_table.cc
         constraints/table/table.cc
         constraints/value_precede/value_precede.cc
-        innards/extensional_utils.cc
         innards/integer_overflow.cc
         innards/literal.cc
         innards/power.cc

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/abs/abs.hh>
+#include <gcs/constraints/abs/hints.hh>
 #include <gcs/constraints/abs/justify.hh>
 #include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -44,42 +45,6 @@ using std::print;
 using fmt::format;
 using fmt::print;
 #endif
-
-namespace gcs::innards::hints
-{
-    // The typed assertion-hint witness for *every* Abs inference -- this is the
-    // entire solver-side surface the external Justifier consumes for abs.
-    //
-    //   - `owner` ties the inference back to its model constraint; the Justifier
-    //     looks up that constraint's two half-reified definition lines (emitted by
-    //     Abs::define_proof_model) to rebuild the proof.
-    //   - `justifier` names the specific sub-rule, so the Justifier can dispatch
-    //     among abs's several derivations -- the per-shape discriminator from #377.
-    //     Each string labels one inference shape (e.g. v2_upper_from_v1); they are
-    //     not 1:1 with the justify_abs_* emit helpers in abs/justify.hh (a shape can
-    //     reuse a helper, and the pure-RUP v1_no_preimage shape has no helper at all).
-    //
-    // No operand data travels in the hint: each abs bound is re-derivable from the
-    // asserted literal + the reason + the definition lines, so carrying it would be
-    // redundant ("the fewer hints, the better"). A constraint whose Justifier genuinely
-    // *cannot* re-derive a value adds a typed field here and serialises it in
-    // hint_sexpr -- see all_different's AllDifferentHall for the multi-field shape.
-    //
-    // One witness serves both proof methods: it rides JustifyUsingRUP for abs's
-    // pure-RUP pruning and JustifyExplicitly for the explicit-steps bounds, because
-    // the assertion-hint axis is orthogonal to *how* the inference is proved.
-    struct AbsJustification
-    {
-        ConstraintID owner;
-        std::string_view justifier;
-        static constexpr std::string_view hint_name = "abs";
-    };
-
-    auto hint_sexpr(const AbsJustification & h, NamesAndIDsTracker &) -> SExpr
-    {
-        return hint_list(hint_constraint_id(h.owner), hint_justifier(h.justifier));
-    }
-}
 
 namespace
 {
@@ -153,7 +118,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
     // is constant we bail out -- the propagator's per-value loop will
     // discover any UNSAT.
     propagators.install_initialiser(
-        [v1 = _v1, v2 = _v2, owner = constraint_id(),
+        [v1 = _v1, v2 = _v2, originator = constraint_id(),
             abs_nonneg_le = _abs_nonneg_lines.first,
             abs_nonneg_ge = _abs_nonneg_lines.second,
             abs_neg_le = _abs_neg_lines.first,
@@ -166,7 +131,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 JustifyExplicitly{[logger, v1, v2, abs_nonneg_ge](const ReasonLiterals &) -> void {
                                       justify_abs_v2_ge_zero(*logger, v1, v2, *abs_nonneg_ge);
                                   },
-                    ThenRUP::Yes, hints::AbsJustification{owner, "v2_nonneg"}},
+                    ThenRUP::Yes, hints::Abs{originator}},
                 NoReason{});
 
             auto v2_ub = state.upper_bound(v2);
@@ -179,7 +144,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     JustifyExplicitly{[logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonLiterals & r) -> void {
                                           justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
                                       },
-                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_upper_from_v2"}},
+                        ThenRUP::Yes, hints::Abs{originator}},
                     NoReason{});
             }
 
@@ -189,7 +154,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     JustifyExplicitly{[logger, v1, v2, v2_ub, abs_neg_ge](const ReasonLiterals & r) -> void {
                                           justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
                                       },
-                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_lower_from_v2"}},
+                        ThenRUP::Yes, hints::Abs{originator}},
                     NoReason{});
             }
 
@@ -199,7 +164,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 JustifyExplicitly{[logger, v1, v2, v1_lb, v1_ub, big_m, abs_nonneg_le, abs_neg_le](const ReasonLiterals & r) -> void {
                                       justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, big_m, *abs_nonneg_le, *abs_neg_le, r);
                                   },
-                    ThenRUP::Yes, hints::AbsJustification{owner, "v2_upper_from_v1"}},
+                    ThenRUP::Yes, hints::Abs{originator}},
                 NoReason{});
         },
         InitialiserPriority::SimpleDefinition);
@@ -211,7 +176,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
     Triggers triggers{.on_change = {_v1, _v2}};
     propagators.install(
         constraint_id(),
-        [v1 = _v1, v2 = _v2, owner = constraint_id(),
+        [v1 = _v1, v2 = _v2, originator = constraint_id(),
             abs_nonneg_le = _abs_nonneg_lines.first,
             abs_nonneg_ge = _abs_nonneg_lines.second,
             abs_neg_le = _abs_neg_lines.first,
@@ -238,7 +203,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         JustifyExplicitly{[logger, v1, v2, v1_lb, v1_ub, image_ub, abs_nonneg_le, abs_neg_le](const ReasonLiterals & r) -> void {
                                               justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, image_ub, *abs_nonneg_le, *abs_neg_le, r);
                                           },
-                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_upper_from_v1"}},
+                            ThenRUP::Yes, hints::Abs{originator}},
                         ExplicitReason{ReasonLiterals{{v1 >= v1_lb, v1 <= v1_ub}}});
                 }
 
@@ -247,7 +212,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         JustifyExplicitly{[logger, v1, v2, v1_lb, abs_nonneg_ge](const ReasonLiterals & r) -> void {
                                               justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonneg, v1_lb, *abs_nonneg_ge, r);
                                           },
-                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_lower_from_v1"}},
+                            ThenRUP::Yes, hints::Abs{originator}},
                         ExplicitReason{ReasonLiterals{v1 >= v1_lb}});
                 }
                 else if (v1_ub <= -1_i && -v1_ub > v2_lb) {
@@ -255,7 +220,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         JustifyExplicitly{[logger, v1, v2, v1_ub, abs_neg_ge](const ReasonLiterals & r) -> void {
                                               justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonpos, -v1_ub, *abs_neg_ge, r);
                                           },
-                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_lower_from_v1"}},
+                            ThenRUP::Yes, hints::Abs{originator}},
                         ExplicitReason{ReasonLiterals{v1 <= v1_ub}});
                 }
             }
@@ -266,7 +231,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     JustifyExplicitly{[logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonLiterals & r) -> void {
                                           justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
                                       },
-                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_upper_from_v2"}},
+                        ThenRUP::Yes, hints::Abs{originator}},
                     ExplicitReason{ReasonLiterals{v2 <= v2_ub}});
             }
             if (-v2_ub > v1_lb) {
@@ -274,7 +239,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     JustifyExplicitly{[logger, v1, v2, v2_ub, abs_neg_ge](const ReasonLiterals & r) -> void {
                                           justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
                                       },
-                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_lower_from_v2"}},
+                        ThenRUP::Yes, hints::Abs{originator}},
                     ExplicitReason{ReasonLiterals{v2 <= v2_ub}});
             }
 
@@ -305,7 +270,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         JustifyExplicitly{[logger, v1, v2, val](const ReasonLiterals & r) {
                                               justify_abs_hole(*logger, r, v1, v2, val);
                                           },
-                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_hole"}},
+                            ThenRUP::Yes, hints::Abs{originator}},
                         ExplicitReason{ReasonLiterals{{v1 != val, v1 != -val}}});
                 }
             }
@@ -328,7 +293,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
                     if (! state.in_domain(v1, val))
                         continue;
-                    inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{hints::AbsJustification{owner, "v1_no_preimage"}},
+                    inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{hints::Abs{originator}},
                         ExplicitReason{ReasonLiterals{v2 != abs(val)}});
                 }
             }

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -45,6 +45,42 @@ using fmt::format;
 using fmt::print;
 #endif
 
+namespace gcs::innards::hints
+{
+    // The typed assertion-hint witness for *every* Abs inference -- this is the
+    // entire solver-side surface the external Justifier consumes for abs.
+    //
+    //   - `owner` ties the inference back to its model constraint; the Justifier
+    //     looks up that constraint's two half-reified definition lines (emitted by
+    //     Abs::define_proof_model) to rebuild the proof.
+    //   - `justifier` names the specific sub-rule, so the Justifier can dispatch
+    //     among abs's several derivations -- the per-shape discriminator from #377.
+    //     Each string labels one inference shape (e.g. v2_upper_from_v1); they are
+    //     not 1:1 with the justify_abs_* emit helpers in abs/justify.hh (a shape can
+    //     reuse a helper, and the pure-RUP v1_no_preimage shape has no helper at all).
+    //
+    // No operand data travels in the hint: each abs bound is re-derivable from the
+    // asserted literal + the reason + the definition lines, so carrying it would be
+    // redundant ("the fewer hints, the better"). A constraint whose Justifier genuinely
+    // *cannot* re-derive a value adds a typed field here and serialises it in
+    // hint_sexpr -- see all_different's AllDifferentHall for the multi-field shape.
+    //
+    // One witness serves both proof methods: it rides JustifyUsingRUP for abs's
+    // pure-RUP pruning and JustifyExplicitly for the explicit-steps bounds, because
+    // the assertion-hint axis is orthogonal to *how* the inference is proved.
+    struct AbsJustification
+    {
+        ConstraintID owner;
+        std::string_view justifier;
+        static constexpr std::string_view hint_name = "abs";
+    };
+
+    auto hint_sexpr(const AbsJustification & h, NamesAndIDsTracker &) -> SExpr
+    {
+        return hint_list(hint_constraint_id(h.owner), hint_justifier(h.justifier));
+    }
+}
+
 namespace
 {
     // Collect a set of (lower, upper) pieces (possibly unordered and
@@ -117,7 +153,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
     // is constant we bail out -- the propagator's per-value loop will
     // discover any UNSAT.
     propagators.install_initialiser(
-        [v1 = _v1, v2 = _v2,
+        [v1 = _v1, v2 = _v2, owner = constraint_id(),
             abs_nonneg_le = _abs_nonneg_lines.first,
             abs_nonneg_ge = _abs_nonneg_lines.second,
             abs_neg_le = _abs_neg_lines.first,
@@ -127,11 +163,11 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 return;
 
             inference.infer(logger, v2 >= 0_i,
-                JustifyExplicitlyThenRUP{
-                    [logger, v1, v2, abs_nonneg_ge](const ReasonFunction &) -> void {
-                        justify_abs_v2_ge_zero(*logger, v1, v2, *abs_nonneg_ge);
-                    }},
-                ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                JustifyExplicitly{[logger, v1, v2, abs_nonneg_ge](const ReasonLiterals &) -> void {
+                                      justify_abs_v2_ge_zero(*logger, v1, v2, *abs_nonneg_ge);
+                                  },
+                    ThenRUP::Yes, hints::AbsJustification{owner, "v2_nonneg"}},
+                NoReason{});
 
             auto v2_ub = state.upper_bound(v2);
 
@@ -140,31 +176,31 @@ auto Abs::install_propagators(Propagators & propagators) -> void
             // UNSAT directly.
             if (v2_ub >= 0_i) {
                 inference.infer(logger, v1 <= v2_ub,
-                    JustifyExplicitlyThenRUP{
-                        [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
-                            justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
-                        }},
-                    ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                    JustifyExplicitly{[logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonLiterals & r) -> void {
+                                          justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
+                                      },
+                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_upper_from_v2"}},
+                    NoReason{});
             }
 
             // Symmetric flag-collision concern: skip when ub(v2) <= 0.
             if (v2_ub > 0_i) {
                 inference.infer(logger, v1 >= -v2_ub,
-                    JustifyExplicitlyThenRUP{
-                        [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
-                            justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
-                        }},
-                    ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                    JustifyExplicitly{[logger, v1, v2, v2_ub, abs_neg_ge](const ReasonLiterals & r) -> void {
+                                          justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
+                                      },
+                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_lower_from_v2"}},
+                    NoReason{});
             }
 
             auto [v1_lb, v1_ub] = state.bounds(v1);
             auto big_m = max(v1_ub, -v1_lb);
             inference.infer(logger, v2 <= big_m,
-                JustifyExplicitlyThenRUP{
-                    [logger, v1, v2, v1_lb, v1_ub, big_m, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
-                        justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, big_m, *abs_nonneg_le, *abs_neg_le, r);
-                    }},
-                ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                JustifyExplicitly{[logger, v1, v2, v1_lb, v1_ub, big_m, abs_nonneg_le, abs_neg_le](const ReasonLiterals & r) -> void {
+                                      justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, big_m, *abs_nonneg_le, *abs_neg_le, r);
+                                  },
+                    ThenRUP::Yes, hints::AbsJustification{owner, "v2_upper_from_v1"}},
+                NoReason{});
         },
         InitialiserPriority::SimpleDefinition);
 
@@ -175,7 +211,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
     Triggers triggers{.on_change = {_v1, _v2}};
     propagators.install(
         constraint_id(),
-        [v1 = _v1, v2 = _v2,
+        [v1 = _v1, v2 = _v2, owner = constraint_id(),
             abs_nonneg_le = _abs_nonneg_lines.first,
             abs_nonneg_ge = _abs_nonneg_lines.second,
             abs_neg_le = _abs_neg_lines.first,
@@ -199,47 +235,47 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 auto image_ub = max(-v1_lb, v1_ub);
                 if (image_ub < v2_ub) {
                     inference.infer_less_than(logger, v2, image_ub + 1_i,
-                        JustifyExplicitlyThenRUP{
-                            [logger, v1, v2, v1_lb, v1_ub, image_ub, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
-                                justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, image_ub, *abs_nonneg_le, *abs_neg_le, r);
-                            }},
-                        ReasonFunction{[v1, v1_lb, v1_ub]() { return Reason{{v1 >= v1_lb, v1 <= v1_ub}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                        JustifyExplicitly{[logger, v1, v2, v1_lb, v1_ub, image_ub, abs_nonneg_le, abs_neg_le](const ReasonLiterals & r) -> void {
+                                              justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, image_ub, *abs_nonneg_le, *abs_neg_le, r);
+                                          },
+                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_upper_from_v1"}},
+                        ExplicitReason{ReasonLiterals{{v1 >= v1_lb, v1 <= v1_ub}}});
                 }
 
                 if (v1_lb >= 1_i && v1_lb > v2_lb) {
                     inference.infer_greater_than_or_equal(logger, v2, v1_lb,
-                        JustifyExplicitlyThenRUP{
-                            [logger, v1, v2, v1_lb, abs_nonneg_ge](const ReasonFunction & r) -> void {
-                                justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonneg, v1_lb, *abs_nonneg_ge, r);
-                            }},
-                        ReasonFunction{[v1, v1_lb]() { return Reason{v1 >= v1_lb}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                        JustifyExplicitly{[logger, v1, v2, v1_lb, abs_nonneg_ge](const ReasonLiterals & r) -> void {
+                                              justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonneg, v1_lb, *abs_nonneg_ge, r);
+                                          },
+                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_lower_from_v1"}},
+                        ExplicitReason{ReasonLiterals{v1 >= v1_lb}});
                 }
                 else if (v1_ub <= -1_i && -v1_ub > v2_lb) {
                     inference.infer_greater_than_or_equal(logger, v2, -v1_ub,
-                        JustifyExplicitlyThenRUP{
-                            [logger, v1, v2, v1_ub, abs_neg_ge](const ReasonFunction & r) -> void {
-                                justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonpos, -v1_ub, *abs_neg_ge, r);
-                            }},
-                        ReasonFunction{[v1, v1_ub]() { return Reason{v1 <= v1_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                        JustifyExplicitly{[logger, v1, v2, v1_ub, abs_neg_ge](const ReasonLiterals & r) -> void {
+                                              justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonpos, -v1_ub, *abs_neg_ge, r);
+                                          },
+                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_lower_from_v1"}},
+                        ExplicitReason{ReasonLiterals{v1 <= v1_ub}});
                 }
             }
 
             // Direction v2 -> v1: tighten v1 from the preimage of v2.
             if (v2_ub < v1_ub) {
                 inference.infer_less_than(logger, v1, v2_ub + 1_i,
-                    JustifyExplicitlyThenRUP{
-                        [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
-                            justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
-                        }},
-                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                    JustifyExplicitly{[logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonLiterals & r) -> void {
+                                          justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
+                                      },
+                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_upper_from_v2"}},
+                    ExplicitReason{ReasonLiterals{v2 <= v2_ub}});
             }
             if (-v2_ub > v1_lb) {
                 inference.infer_greater_than_or_equal(logger, v1, -v2_ub,
-                    JustifyExplicitlyThenRUP{
-                        [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
-                            justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
-                        }},
-                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                    JustifyExplicitly{[logger, v1, v2, v2_ub, abs_neg_ge](const ReasonLiterals & r) -> void {
+                                          justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
+                                      },
+                        ThenRUP::Yes, hints::AbsJustification{owner, "v1_lower_from_v2"}},
+                    ExplicitReason{ReasonLiterals{v2 <= v2_ub}});
             }
 
             // Interior pruning: remove values in v2 with no preimage in v1,
@@ -266,10 +302,11 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     if (! state.in_domain(v2, val))
                         continue;
                     inference.infer_not_equal(logger, v2, val,
-                        JustifyExplicitlyThenRUP{[logger, v1, v2, val](const ReasonFunction & r) {
-                            justify_abs_hole(*logger, r, v1, v2, val);
-                        }},
-                        ReasonFunction{[v1, val]() { return Reason{{v1 != val, v1 != -val}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                        JustifyExplicitly{[logger, v1, v2, val](const ReasonLiterals & r) {
+                                              justify_abs_hole(*logger, r, v1, v2, val);
+                                          },
+                            ThenRUP::Yes, hints::AbsJustification{owner, "v2_hole"}},
+                        ExplicitReason{ReasonLiterals{{v1 != val, v1 != -val}}});
                 }
             }
 
@@ -291,8 +328,8 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                 for (Integer val = clipped_lo; val <= clipped_hi; ++val) {
                     if (! state.in_domain(v1, val))
                         continue;
-                    inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{},
-                        ReasonFunction{[v2, val]() { return Reason{v2 != abs(val)}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
+                    inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{hints::AbsJustification{owner, "v1_no_preimage"}},
+                        ExplicitReason{ReasonLiterals{v2 != abs(val)}});
                 }
             }
 

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/abs/abs.hh>
 #include <gcs/constraints/abs/justify.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/interval_set.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -11,7 +12,6 @@
 
 #include <algorithm>
 #include <optional>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -131,7 +131,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     [logger, v1, v2, abs_nonneg_ge](const ReasonFunction &) -> void {
                         justify_abs_v2_ge_zero(*logger, v1, v2, *abs_nonneg_ge);
                     }},
-                ReasonFunction{});
+                ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
 
             auto v2_ub = state.upper_bound(v2);
 
@@ -144,7 +144,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
                         }},
-                    ReasonFunction{});
+                    ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
 
             // Symmetric flag-collision concern: skip when ub(v2) <= 0.
@@ -154,7 +154,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
                         }},
-                    ReasonFunction{});
+                    ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
 
             auto [v1_lb, v1_ub] = state.bounds(v1);
@@ -164,7 +164,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     [logger, v1, v2, v1_lb, v1_ub, big_m, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
                         justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, big_m, *abs_nonneg_le, *abs_neg_le, r);
                     }},
-                ReasonFunction{});
+                ReasonFunction{}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
         },
         InitialiserPriority::SimpleDefinition);
 
@@ -203,7 +203,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                             [logger, v1, v2, v1_lb, v1_ub, image_ub, abs_nonneg_le, abs_neg_le](const ReasonFunction & r) -> void {
                                 justify_abs_v2_le_big_m(*logger, v1, v2, v1_lb, v1_ub, image_ub, *abs_nonneg_le, *abs_neg_le, r);
                             }},
-                        ReasonFunction{[v1, v1_lb, v1_ub]() { return Reason{{v1 >= v1_lb, v1 <= v1_ub}}; }});
+                        ReasonFunction{[v1, v1_lb, v1_ub]() { return Reason{{v1 >= v1_lb, v1 <= v1_ub}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
 
                 if (v1_lb >= 1_i && v1_lb > v2_lb) {
@@ -212,7 +212,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                             [logger, v1, v2, v1_lb, abs_nonneg_ge](const ReasonFunction & r) -> void {
                                 justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonneg, v1_lb, *abs_nonneg_ge, r);
                             }},
-                        ReasonFunction{[v1, v1_lb]() { return Reason{v1 >= v1_lb}; }});
+                        ReasonFunction{[v1, v1_lb]() { return Reason{v1 >= v1_lb}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
                 else if (v1_ub <= -1_i && -v1_ub > v2_lb) {
                     inference.infer_greater_than_or_equal(logger, v2, -v1_ub,
@@ -220,7 +220,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                             [logger, v1, v2, v1_ub, abs_neg_ge](const ReasonFunction & r) -> void {
                                 justify_abs_v2_lb(*logger, v1, v2, AbsLbSide::Nonpos, -v1_ub, *abs_neg_ge, r);
                             }},
-                        ReasonFunction{[v1, v1_ub]() { return Reason{v1 <= v1_ub}; }});
+                        ReasonFunction{[v1, v1_ub]() { return Reason{v1 <= v1_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
             }
 
@@ -231,7 +231,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_nonneg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_le_v2_ub(*logger, v1, v2, v2_ub, *abs_nonneg_ge, r);
                         }},
-                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }});
+                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
             if (-v2_ub > v1_lb) {
                 inference.infer_greater_than_or_equal(logger, v1, -v2_ub,
@@ -239,7 +239,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         [logger, v1, v2, v2_ub, abs_neg_ge](const ReasonFunction & r) -> void {
                             justify_abs_v1_ge_neg_v2_ub(*logger, v1, v2, v2_ub, *abs_neg_ge, r);
                         }},
-                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }});
+                    ReasonFunction{[v2, v2_ub]() { return Reason{v2 <= v2_ub}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
             }
 
             // Interior pruning: remove values in v2 with no preimage in v1,
@@ -269,7 +269,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                         JustifyExplicitlyThenRUP{[logger, v1, v2, val](const ReasonFunction & r) {
                             justify_abs_hole(*logger, r, v1, v2, val);
                         }},
-                        ReasonFunction{[v1, val]() { return Reason{{v1 != val, v1 != -val}}; }});
+                        ReasonFunction{[v1, val]() { return Reason{{v1 != val, v1 != -val}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
             }
 
@@ -292,7 +292,7 @@ auto Abs::install_propagators(Propagators & propagators) -> void
                     if (! state.in_domain(v1, val))
                         continue;
                     inference.infer_not_equal(logger, v1, val, JustifyUsingRUP{},
-                        ReasonFunction{[v2, val]() { return Reason{v2 != abs(val)}; }});
+                        ReasonFunction{[v2, val]() { return Reason{v2 != abs(val)}; }}, AssertionAnnotation{.hint_name = AssertionHintName::Abs});
                 }
             }
 

--- a/gcs/constraints/abs/hints.hh
+++ b/gcs/constraints/abs/hints.hh
@@ -8,16 +8,7 @@
 namespace gcs::innards::hints
 {
     /**
-     * \brief abs's assertion hint: just the owning constraint.
-     *
-     * abs needs no per-shape discriminator. One justification function reads the
-     * asserted literal and the reason and dispatches on them, so there is nothing
-     * for the wire to disambiguate -- every abs bound is re-derivable from the
-     * asserted literal, the reason and the definition lines. The same hint rides
-     * both JustifyUsingRUP (the pure-RUP pruning) and JustifyExplicitly (the
-     * explicit-steps bounds): the assertion-hint axis is orthogonal to how the
-     * inference is proved. With no own hint_sexpr it takes the default wire form,
-     * `(constraint_id <originator>)`.
+     * \brief abs's assertion hint: just the owning constraint, no subhint.
      *
      * \ingroup Innards
      */

--- a/gcs/constraints/abs/hints.hh
+++ b/gcs/constraints/abs/hints.hh
@@ -1,0 +1,31 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ABS_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ABS_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief abs's assertion hint: just the owning constraint.
+     *
+     * abs needs no per-shape discriminator. One justification function reads the
+     * asserted literal and the reason and dispatches on them, so there is nothing
+     * for the wire to disambiguate -- every abs bound is re-derivable from the
+     * asserted literal, the reason and the definition lines. The same hint rides
+     * both JustifyUsingRUP (the pure-RUP pruning) and JustifyExplicitly (the
+     * explicit-steps bounds): the assertion-hint axis is orthogonal to how the
+     * inference is proved. With no own hint_sexpr it takes the default wire form,
+     * `(constraint_id <originator>)`.
+     *
+     * \ingroup Innards
+     */
+    struct Abs
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "abs";
+    };
+}
+
+#endif

--- a/gcs/constraints/abs/justify.cc
+++ b/gcs/constraints/abs/justify.cc
@@ -25,7 +25,7 @@ namespace
 
 auto gcs::innards::justify_abs_hole(
     ProofLogger & logger,
-    const ReasonFunction & reason,
+    const ReasonLiterals & reason,
     IntegerVariableID v1,
     IntegerVariableID v2,
     Integer val) -> void
@@ -63,7 +63,7 @@ auto gcs::innards::justify_abs_v2_lb(
     AbsLbSide side,
     Integer v2_lb,
     ProofLine abs_ge,
-    const ReasonFunction & reason) -> void
+    const ReasonLiterals & reason) -> void
 {
     if (holds_alternative<ConstantIntegerVariableID>(v1))
         return;
@@ -91,7 +91,7 @@ auto gcs::innards::justify_abs_v1_le_v2_ub(
     IntegerVariableID v2,
     Integer v2_ub,
     ProofLine abs_nonneg_ge,
-    const ReasonFunction & reason) -> void
+    const ReasonLiterals & reason) -> void
 {
     if (holds_alternative<ConstantIntegerVariableID>(v1))
         return;
@@ -113,7 +113,7 @@ auto gcs::innards::justify_abs_v1_ge_neg_v2_ub(
     IntegerVariableID v2,
     Integer v2_ub,
     ProofLine abs_neg_ge,
-    const ReasonFunction & reason) -> void
+    const ReasonLiterals & reason) -> void
 {
     if (holds_alternative<ConstantIntegerVariableID>(v1))
         return;
@@ -138,7 +138,7 @@ auto gcs::innards::justify_abs_v2_le_big_m(
     Integer big_m,
     ProofLine abs_nonneg_le,
     ProofLine abs_neg_le,
-    const ReasonFunction & reason) -> void
+    const ReasonLiterals & reason) -> void
 {
     if (holds_alternative<ConstantIntegerVariableID>(v1))
         return;

--- a/gcs/constraints/abs/justify.hh
+++ b/gcs/constraints/abs/justify.hh
@@ -10,14 +10,14 @@ namespace gcs::innards
     // from dom(v1).
     auto justify_abs_hole(
         ProofLogger & logger,
-        const ReasonFunction & reason,
+        const ReasonLiterals & reason,
         IntegerVariableID v1,
         IntegerVariableID v2,
         Integer val) -> void;
 
     // The bound proofs below share their resolution shape between the
     // prepare-time initialiser and the run-time propagator. The initialiser
-    // calls them with an empty ReasonFunction (the operand bound RUPs from
+    // calls them with empty ReasonLiterals (the operand bound RUPs from
     // the encoding's initial domain); the propagator passes its reason in
     // so the operand bound RUPs under that literal instead. In both cases
     // the helper short-circuits when v1 is constant -- the encoding's
@@ -54,7 +54,7 @@ namespace gcs::innards
         AbsLbSide side,
         Integer v2_lb,
         ProofLine abs_ge,
-        const ReasonFunction & reason) -> void;
+        const ReasonLiterals & reason) -> void;
 
     // v1 <= v2_ub.
     auto justify_abs_v1_le_v2_ub(
@@ -63,7 +63,7 @@ namespace gcs::innards
         IntegerVariableID v2,
         Integer v2_ub,
         ProofLine abs_nonneg_ge,
-        const ReasonFunction & reason) -> void;
+        const ReasonLiterals & reason) -> void;
 
     // v1 >= -v2_ub.
     auto justify_abs_v1_ge_neg_v2_ub(
@@ -72,7 +72,7 @@ namespace gcs::innards
         IntegerVariableID v2,
         Integer v2_ub,
         ProofLine abs_neg_ge,
-        const ReasonFunction & reason) -> void;
+        const ReasonLiterals & reason) -> void;
 
     // v2 <= big_m, where big_m = max(-v1_lb, v1_ub).
     auto justify_abs_v2_le_big_m(
@@ -84,7 +84,7 @@ namespace gcs::innards
         Integer big_m,
         ProofLine abs_nonneg_le,
         ProofLine abs_neg_le,
-        const ReasonFunction & reason) -> void;
+        const ReasonLiterals & reason) -> void;
 }
 
 #endif

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/all_different/all_different_except.hh>
 #include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/constraints/all_different/gac_all_different.hh>
+#include <gcs/constraints/all_different/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -130,7 +131,7 @@ auto AllDifferentExcept::define_proof_model(ProofModel & model) -> void
 auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicates && _sanitised_excluded.empty()) {
-        install_clique_duplicate_contradiction_initialiser(propagators);
+        install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferentExcept{constraint_id()});
         return;
     }
 
@@ -145,7 +146,8 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
         propagators.install_initialiser(
             [duplicated_vars = move(_duplicated_vars),
                 excluded = _sanitised_excluded,
-                duplicate_selectors = move(_duplicate_selectors)](
+                duplicate_selectors = move(_duplicate_selectors),
+                owner = constraint_id()](
                 const State & state, auto & inf, ProofLogger * const logger) -> void {
                 for (const auto & x : duplicated_vars) {
                     vector<Integer> non_excluded_values;
@@ -163,7 +165,7 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
                                                       WPBSum{} + 1_i * (x != v) + 1_i * (! selector) >= 1_i,
                                                       ProofLevel::Temporary);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::AllDifferentExcept{owner}},
                             NoReason{});
                     }
                 }

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -186,9 +187,10 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
         [vars = move(_sanitised_vars),
             vals = move(_compressed_vals),
             excluded = move(_sanitised_excluded),
-            value_am1_constraint_numbers = _value_am1_constraint_numbers](const State & state, auto & inference,
+            value_am1_constraint_numbers = _value_am1_constraint_numbers,
+            constraint_id = constraint_id()](const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState {
-            propagate_gac_all_different(vars, vals, excluded, *value_am1_constraint_numbers.get(), state, inference, logger);
+            propagate_gac_all_different(constraint_id, vars, vals, excluded, *value_am1_constraint_numbers.get(), state, inference, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -154,17 +154,17 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
                             non_excluded_values.push_back(v);
                     for (const auto & v : non_excluded_values) {
                         inf.infer(logger, x != v,
-                            JustifyExplicitlyThenRUP{
-                                [&logger, x, v, &duplicate_selectors](const ReasonFunction &) -> void {
-                                    const auto & selector = duplicate_selectors.at(x);
-                                    logger->emit(RUPProofRule{},
-                                        WPBSum{} + 1_i * (x != v) + 1_i * selector >= 1_i,
-                                        ProofLevel::Temporary);
-                                    logger->emit(RUPProofRule{},
-                                        WPBSum{} + 1_i * (x != v) + 1_i * (! selector) >= 1_i,
-                                        ProofLevel::Temporary);
-                                }},
-                            []() -> Reason { return Reason{}; });
+                            JustifyExplicitly{[&logger, x, v, &duplicate_selectors](const ReasonLiterals &) -> void {
+                                                  const auto & selector = duplicate_selectors.at(x);
+                                                  logger->emit(RUPProofRule{},
+                                                      WPBSum{} + 1_i * (x != v) + 1_i * selector >= 1_i,
+                                                      ProofLevel::Temporary);
+                                                  logger->emit(RUPProofRule{},
+                                                      WPBSum{} + 1_i * (x != v) + 1_i * (! selector) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                              },
+                                ThenRUP::Yes},
+                            NoReason{});
                     }
                 }
             });

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_different/encoding.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -1,5 +1,4 @@
 #include <gcs/constraints/all_different/encoding.hh>
-#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -46,7 +45,7 @@ auto gcs::innards::install_clique_duplicate_contradiction_initialiser(
     propagators.install_initialiser(
         [](
             State &, auto & inference, ProofLogger * const logger) -> void {
-            inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{});
+            inference.contradiction(logger, JustifyUsingRUP{}, NoReason{});
         },
         InitialiserPriority::SimpleDefinition);
 }

--- a/gcs/constraints/all_different/encoding.cc
+++ b/gcs/constraints/all_different/encoding.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_different/encoding.hh>
+#include <gcs/constraints/all_different/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -39,16 +40,20 @@ auto gcs::innards::define_clique_not_equals_encoding(ProofModel & model, const C
         }
 }
 
+template <typename Hint_>
 auto gcs::innards::install_clique_duplicate_contradiction_initialiser(
-    Propagators & propagators) -> void
+    Propagators & propagators, const Hint_ & hint) -> void
 {
     propagators.install_initialiser(
-        [](
+        [hint](
             State &, auto & inference, ProofLogger * const logger) -> void {
-            inference.contradiction(logger, JustifyUsingRUP{}, NoReason{});
+            inference.contradiction(logger, JustifyUsingRUP{hint}, NoReason{});
         },
         InitialiserPriority::SimpleDefinition);
 }
+
+template auto gcs::innards::install_clique_duplicate_contradiction_initialiser(Propagators &, const hints::AllDifferent &) -> void;
+template auto gcs::innards::install_clique_duplicate_contradiction_initialiser(Propagators &, const hints::AllDifferentExcept &) -> void;
 
 auto gcs::innards::define_clique_not_equals_except_encoding(ProofModel & model,
     const vector<gcs::IntegerVariableID> & vars,

--- a/gcs/constraints/all_different/encoding.hh
+++ b/gcs/constraints/all_different/encoding.hh
@@ -37,8 +37,12 @@ namespace gcs
 
         // Install a SimpleDefinition-priority contradiction initialiser that
         // proves the input was unsatisfiable because of a duplicate variable
-        // in a clique-of-not-equals encoding.
-        auto install_clique_duplicate_contradiction_initialiser(Propagators & propagators) -> void;
+        // in a clique-of-not-equals encoding. Templated on the hint type so each
+        // caller (AllDifferent's gac/vc/symmetric propagators, AllDifferentExcept)
+        // names the contradiction with its own constraint. Instantiated in
+        // encoding.cc for hints::AllDifferent and hints::AllDifferentExcept.
+        template <typename Hint_>
+        auto install_clique_duplicate_contradiction_initialiser(Propagators & propagators, const Hint_ & hint) -> void;
     }
 }
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -205,31 +205,6 @@ namespace
         }
     }
 
-    // Build the typed Hall hint shared by both GAC all_different Hall shapes (the
-    // matching-too-small contradiction and the SCC Hall-set deletion). The hall set
-    // and values, the variable scope and the at-most-one cache are all emit context
-    // for emit_justification -- the pointers reference constraint-owned data, valid
-    // for the whole solve including any later replay. None of it is serialised: the
-    // hint takes the default identity-plus-subhint wire form, so the assertion names
-    // only the constraint and the "hall" sub-rule.
-    auto hall_hint(
-        const vector<IntegerVariableID> & vars,
-        const vector<IntegerVariableID> & hall_variable_ids,
-        const vector<Integer> & hall_value_nrs,
-        const ConstraintID & constraint_id,
-        map<Integer, ProofLine> & value_am1_constraint_numbers) -> hints::AllDifferentHall
-    {
-        // Aggregate init: the AllDifferent base (originator) first, then the Hall
-        // emit context in declaration order (hall_vars, hall_vals, all_vars,
-        // value_am1_constraint_numbers).
-        return hints::AllDifferentHall{
-            {constraint_id},
-            hall_variable_ids,
-            hall_value_nrs,
-            &vars,
-            &value_am1_constraint_numbers};
-    }
-
     auto prove_matching_is_too_small(
         const ConstraintID & constraint_id,
         const vector<IntegerVariableID> & vars,
@@ -298,9 +273,9 @@ namespace
                 hall_value_nrs.push_back(vals[v.offset]);
 
         return tuple{
-            hall_hint(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers),
+            hints::AllDifferentHall{{constraint_id}, hall_variable_ids, hall_value_nrs, &vars, &value_am1_constraint_numbers},
             Reason{LazyReasonOver{hall_variable_ids, [hall_variable_ids, excluded](const State & st, ReasonLiterals & out) {
-                                      out = materialise(generic_reason(st, hall_variable_ids), st);
+                                      out = materialise(generic_reason(hall_variable_ids), st);
                                       for (const auto & v : hall_variable_ids)
                                           for (const auto & s : excluded)
                                               out.emplace_back(v != s);
@@ -408,9 +383,9 @@ namespace
                     hall_value_nrs.push_back(vals[v.offset]);
 
             return tuple{
-                DeletionJustification{hall_hint(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers)},
+                DeletionJustification{hints::AllDifferentHall{{constraint_id}, hall_variable_ids, hall_value_nrs, &vars, &value_am1_constraint_numbers}},
                 Reason{LazyReasonOver{hall_variable_ids, [hall_variable_ids, excluded](const State & st, ReasonLiterals & out) {
-                                          out = materialise(generic_reason(st, hall_variable_ids), st);
+                                          out = materialise(generic_reason(hall_variable_ids), st);
                                           for (const auto & v : hall_variable_ids)
                                               for (const auto & s : excluded)
                                                   out.emplace_back(v != s);

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -1,7 +1,9 @@
+#include <gcs/constraint.hh>
 #include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/constraints/all_different/gac_all_different.hh>
 #include <gcs/constraints/all_different/justify.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -11,6 +13,7 @@
 #include <gcs/innards/state.hh>
 #include <gcs/innards/variable_id_utils.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -48,6 +51,7 @@ using std::optional;
 using std::pair;
 using std::shared_ptr;
 using std::string;
+using std::tuple;
 using std::unique_ptr;
 using std::variant;
 using std::vector;
@@ -191,16 +195,17 @@ namespace
     }
 
     auto prove_matching_is_too_small(
+        const ConstraintID & constraint_id,
         const vector<IntegerVariableID> & vars,
         const vector<Integer> & vals,
         const vector<Integer> & excluded,
         size_t n_right,
         map<Integer, ProofLine> & value_am1_constraint_numbers,
         const State & state,
-        ProofLogger & logger,
+        ProofLogger * const logger,
         const vector<pair<Left, Right>> & edges,
         const vector<uint8_t> & left_covered,
-        const vector<optional<Right>> & matching) -> pair<JustifyExplicitlyThenRUP, ReasonFunction>
+        const vector<optional<Right>> & matching) -> std::tuple<JustifyExplicitlyThenRUP, ReasonFunction, optional<AssertionAnnotation>>
     {
         vector<optional<Left>> inverse_matching(n_right, nullopt);
         for (const auto & [l, r] : enumerate(matching))
@@ -256,17 +261,33 @@ namespace
             if (hall_values[v.offset])
                 hall_value_nrs.push_back(vals[v.offset]);
 
-        return pair{JustifyExplicitlyThenRUP{
-                        [vars, &logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](const ReasonFunction &) -> void {
-                            justify_all_different_hall_set_or_violator(logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
-                        }},
+        optional<AssertionAnnotation> assertion_annotation;
+        if (logger && logger->get_assertion_level() != AssertionLevel::Off) {
+            vector<SExpr> hall_var_terms;
+            for (const auto & v : hall_variable_ids)
+                hall_var_terms.push_back(logger->names_and_ids_tracker().s_expr_term_of(v));
+            assertion_annotation = std::make_optional(AssertionAnnotation{
+                .hint_name = AssertionHintName::AllDifferent,
+                .hint_fields = hint_list(
+                    hint_list(AssertionHintIdentifier::constraint_id, constraint_id),
+                    hint_list(AssertionHintIdentifier::hall_vars, SExpr::list(move(hall_var_terms))),
+                    hint_list(AssertionHintIdentifier::hall_vals, hint_seq(hall_value_nrs)),
+                    hint_list(AssertionHintIdentifier::justifier, AssertionHintIdentifier::hall_set_or_violator))});
+        }
+
+        return tuple{
+            JustifyExplicitlyThenRUP{
+                [vars, logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](const ReasonFunction &) -> void {
+                    justify_all_different_hall_set_or_violator(*logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
+                }},
             ReasonFunction{[hall_variable_ids, excluded, &state]() -> Reason {
                 auto reason = generic_reason(state, hall_variable_ids)();
                 for (const auto & v : hall_variable_ids)
                     for (const auto & s : excluded)
                         reason.emplace_back(v != s);
                 return reason;
-            }}};
+            }},
+            assertion_annotation};
     }
 
     using Vertex = variant<Left, Right>;
@@ -283,17 +304,18 @@ namespace
     }
 
     auto prove_deletion_using_sccs(
+        const ConstraintID & constraint_id,
         const vector<IntegerVariableID> & vars,
         const vector<Integer> & vals,
         const vector<Integer> & excluded,
         size_t n_right,
         map<Integer, ProofLine> & value_am1_constraint_numbers,
         const State & state,
-        ProofLogger & logger,
+        ProofLogger * const logger,
         const vector<vector<Right>> & edges_out_from_variable,
         const vector<vector<Left>> & edges_out_from_value,
         const Right delete_value,
-        const vector<int> & components) -> pair<Justification, ReasonFunction>
+        const vector<int> & components) -> tuple<Justification, ReasonFunction, optional<AssertionAnnotation>>
     {
         // we know a hall set exists, but we have to find it. starting
         // from but not including the end of the edge we're deleting,
@@ -350,8 +372,16 @@ namespace
             // some other variable has been given this value
             if (edges_out_from_value[delete_value.offset].empty())
                 throw UnexpectedException{"missing edge out from value in trivial scc"};
-            else
-                return pair{JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}; }}};
+
+            optional<AssertionAnnotation> assertion_annotation;
+            if (logger && logger->get_assertion_level() != AssertionLevel::Off)
+                assertion_annotation = std::make_optional(AssertionAnnotation{
+                    .hint_name = AssertionHintName::AllDifferent,
+                    .hint_fields = hint_list(hint_list(AssertionHintIdentifier::constraint_id, constraint_id))});
+
+            return tuple{Justification{JustifyUsingRUP{}},
+                ReasonFunction{[=]() { return Reason{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}; }},
+                assertion_annotation};
         }
         else {
             // a hall set is at work
@@ -360,23 +390,39 @@ namespace
                 if (hall_right[v.offset])
                     hall_value_nrs.push_back(vals[v.offset]);
 
-            return pair{JustifyExplicitlyThenRUP{
-                            [vars, &logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](
-                                const ReasonFunction &) -> void {
-                                justify_all_different_hall_set_or_violator(logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
-                            }},
+            optional<AssertionAnnotation> assertion_annotation;
+            if (logger && logger->get_assertion_level() != AssertionLevel::Off) {
+                vector<SExpr> hall_var_terms;
+                for (const auto & v : hall_variable_ids)
+                    hall_var_terms.push_back(logger->names_and_ids_tracker().s_expr_term_of(v));
+                assertion_annotation = std::make_optional(AssertionAnnotation{
+                    .hint_name = AssertionHintName::AllDifferent,
+                    .hint_fields = hint_list(
+                        hint_list(AssertionHintIdentifier::constraint_id, constraint_id),
+                        hint_list(AssertionHintIdentifier::hall_vars, SExpr::list(move(hall_var_terms))),
+                        hint_list(AssertionHintIdentifier::hall_vals, hint_seq(hall_value_nrs)),
+                        hint_list(AssertionHintIdentifier::justifier, AssertionHintIdentifier::hall_set_or_violator))});
+            }
+
+            return tuple{Justification{JustifyExplicitlyThenRUP{
+                             [vars, logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](
+                                 const ReasonFunction &) -> void {
+                                 justify_all_different_hall_set_or_violator(*logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
+                             }}},
                 ReasonFunction{[hall_variable_ids, excluded, &state]() -> Reason {
                     auto reason = generic_reason(state, hall_variable_ids)();
                     for (const auto & v : hall_variable_ids)
                         for (const auto & s : excluded)
                             reason.emplace_back(v != s);
                     return reason;
-                }}};
+                }},
+                assertion_annotation};
         }
     }
 }
 
 auto gcs::innards::propagate_gac_all_different(
+    const ConstraintID & constraint_id,
     const vector<IntegerVariableID> & vars,
     const vector<Integer> & vals,
     const vector<Integer> & excluded,
@@ -418,8 +464,8 @@ auto gcs::innards::propagate_gac_all_different(
     if (cmp_not_equal(count(left_covered.begin(), left_covered.end(), 1), vars.size())) {
         // nope. we've got a maximum cardinality matching that leaves at least
         // one thing on the left uncovered.
-        auto [just, reason] = prove_matching_is_too_small(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger, edges, left_covered, matching);
-        return tracker.infer(logger, FalseLiteral{}, just, reason);
+        auto [just, reason, annotation] = prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, edges, left_covered, matching);
+        return tracker.infer(logger, FalseLiteral{}, just, reason, annotation);
     }
 
     // we have a matching that uses every variable. however, some edges may
@@ -585,9 +631,9 @@ auto gcs::innards::propagate_gac_all_different(
         if (! representatives_for_scc[scc])
             continue;
 
-        auto [just, reason] = prove_deletion_using_sccs(vars, vals, excluded, n_right, value_am1_constraint_numbers, state, *logger,
+        auto [just, reason, annotation] = prove_deletion_using_sccs(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger,
             edges_out_from_variable, edges_out_from_value, *representatives_for_scc[scc], components);
-        tracker.infer_all(logger, deletions_by_scc[scc], just, reason);
+        tracker.infer_all(logger, deletions_by_scc[scc], just, reason, annotation);
     }
 }
 
@@ -644,15 +690,17 @@ auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
         constraint_id(),
         [vars = move(_sanitised_vars),
             vals = move(_compressed_vals),
-            value_am1_constraint_numbers = move(value_am1_constraint_numbers)](const State & state, auto & inference,
+            value_am1_constraint_numbers = move(value_am1_constraint_numbers),
+            constraint_id = constraint_id()](const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState {
-            propagate_gac_all_different(vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), state, inference, logger);
+            propagate_gac_all_different(constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), state, inference, logger);
             return PropagatorState::Enable;
         },
         triggers);
 }
 
 template auto gcs::innards::propagate_gac_all_different(
+    const ConstraintID & constraint_id,
     const std::vector<IntegerVariableID> & vars,
     const std::vector<Integer> & vals,
     const std::vector<Integer> & excluded,
@@ -662,6 +710,7 @@ template auto gcs::innards::propagate_gac_all_different(
     ProofLogger * const logger) -> void;
 
 template auto gcs::innards::propagate_gac_all_different(
+    const ConstraintID & constraint_id,
     const std::vector<IntegerVariableID> & vars,
     const std::vector<Integer> & vals,
     const std::vector<Integer> & excluded,

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -46,6 +46,7 @@ using std::is_same_v;
 using std::make_shared;
 using std::map;
 using std::min;
+using std::move;
 using std::nullopt;
 using std::optional;
 using std::pair;
@@ -66,6 +67,32 @@ using std::print;
 using fmt::format;
 using fmt::print;
 #endif
+
+namespace gcs::innards::hints
+{
+    auto hint_sexpr(const AllDifferentHall & hall, NamesAndIDsTracker & names) -> SExpr
+    {
+        vector<SExpr> hall_var_terms;
+        for (const auto & v : hall.hall_vars)
+            hall_var_terms.push_back(names.s_expr_term_of(v));
+        return hint_list(
+            hint_constraint_id(hall.owner),
+            hint_list(SExpr::atom("hall_vars"), SExpr::list(move(hall_var_terms))),
+            hint_list(SExpr::atom("hall_vals"), hint_seq(hall.hall_vals)),
+            hint_justifier(AllDifferentHall::justifier));
+    }
+
+    auto emit_justification(ProofLogger & logger, const AllDifferentHall & hall, const ReasonLiterals &) -> void
+    {
+        justify_all_different_hall_set_or_violator(logger, *hall.all_vars, hall.hall_vars, hall.hall_vals,
+            *hall.value_am1_constraint_numbers);
+    }
+
+    auto hint_sexpr(const AllDifferentForcedValue & forced, NamesAndIDsTracker &) -> SExpr
+    {
+        return hint_list(hint_constraint_id(forced.owner));
+    }
+}
 
 GACAllDifferent::GACAllDifferent(vector<IntegerVariableID> v) :
     _vars(move(v))
@@ -194,6 +221,28 @@ namespace
         }
     }
 
+    // Build the typed Hall witness shared by both GAC all_different Hall shapes
+    // (the matching-too-small contradiction and the SCC Hall-set deletion). The
+    // hall set and values are the serialisable part of the witness; the variable
+    // scope and the at-most-one cache are carried as emit context (both owned by
+    // the constraint, so valid for the whole solve, including any later replay).
+    // emit_justification reproduces the original closure, calling the existing Hall
+    // justifier; hint_sexpr serialises only the Hall set for assert mode.
+    auto hall_witness(
+        const vector<IntegerVariableID> & vars,
+        const vector<IntegerVariableID> & hall_variable_ids,
+        const vector<Integer> & hall_value_nrs,
+        const ConstraintID & constraint_id,
+        map<Integer, ProofLine> & value_am1_constraint_numbers) -> hints::AllDifferentHall
+    {
+        return hints::AllDifferentHall{
+            .hall_vars = hall_variable_ids,
+            .hall_vals = hall_value_nrs,
+            .owner = constraint_id,
+            .all_vars = &vars,
+            .value_am1_constraint_numbers = &value_am1_constraint_numbers};
+    }
+
     auto prove_matching_is_too_small(
         const ConstraintID & constraint_id,
         const vector<IntegerVariableID> & vars,
@@ -201,11 +250,11 @@ namespace
         const vector<Integer> & excluded,
         size_t n_right,
         map<Integer, ProofLine> & value_am1_constraint_numbers,
-        const State & state,
-        ProofLogger * const logger,
+        const State &,
+        ProofLogger * const,
         const vector<pair<Left, Right>> & edges,
         const vector<uint8_t> & left_covered,
-        const vector<optional<Right>> & matching) -> std::tuple<JustifyExplicitlyThenRUP, ReasonFunction, optional<AssertionAnnotation>>
+        const vector<optional<Right>> & matching) -> std::tuple<hints::AllDifferentHall, Reason>
     {
         vector<optional<Left>> inverse_matching(n_right, nullopt);
         for (const auto & [l, r] : enumerate(matching))
@@ -261,36 +310,23 @@ namespace
             if (hall_values[v.offset])
                 hall_value_nrs.push_back(vals[v.offset]);
 
-        optional<AssertionAnnotation> assertion_annotation;
-        if (logger && logger->get_assertion_level() != AssertionLevel::Off) {
-            vector<SExpr> hall_var_terms;
-            for (const auto & v : hall_variable_ids)
-                hall_var_terms.push_back(logger->names_and_ids_tracker().s_expr_term_of(v));
-            assertion_annotation = std::make_optional(AssertionAnnotation{
-                .hint_name = AssertionHintName::AllDifferent,
-                .hint_fields = hint_list(
-                    hint_list(AssertionHintIdentifier::constraint_id, constraint_id),
-                    hint_list(AssertionHintIdentifier::hall_vars, SExpr::list(move(hall_var_terms))),
-                    hint_list(AssertionHintIdentifier::hall_vals, hint_seq(hall_value_nrs)),
-                    hint_list(AssertionHintIdentifier::justifier, AssertionHintIdentifier::hall_set_or_violator))});
-        }
-
         return tuple{
-            JustifyExplicitlyThenRUP{
-                [vars, logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](const ReasonFunction &) -> void {
-                    justify_all_different_hall_set_or_violator(*logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
-                }},
-            ReasonFunction{[hall_variable_ids, excluded, &state]() -> Reason {
-                auto reason = generic_reason(state, hall_variable_ids)();
-                for (const auto & v : hall_variable_ids)
-                    for (const auto & s : excluded)
-                        reason.emplace_back(v != s);
-                return reason;
-            }},
-            assertion_annotation};
+            hall_witness(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers),
+            Reason{LazyReasonOver{hall_variable_ids, [hall_variable_ids, excluded](const State & st, ReasonLiterals & out) {
+                                      out = materialise(generic_reason(st, hall_variable_ids), st);
+                                      for (const auto & v : hall_variable_ids)
+                                          for (const auto & s : excluded)
+                                              out.emplace_back(v != s);
+                                  }}}};
     }
 
     using Vertex = variant<Left, Right>;
+
+    // The two justification shapes a single SCC deletion can take: a Hall set (real
+    // explicit steps) or a single forced value (pure RUP). A typed variant rather
+    // than an optional, so each shape names itself and carries its own assertion
+    // hint — there is no separate annotation channel.
+    using DeletionJustification = variant<hints::AllDifferentForcedValue, hints::AllDifferentHall>;
 
     auto vertex_to_offset(
         const vector<IntegerVariableID> & vars,
@@ -310,12 +346,12 @@ namespace
         const vector<Integer> & excluded,
         size_t n_right,
         map<Integer, ProofLine> & value_am1_constraint_numbers,
-        const State & state,
-        ProofLogger * const logger,
+        const State &,
+        ProofLogger * const,
         const vector<vector<Right>> & edges_out_from_variable,
         const vector<vector<Left>> & edges_out_from_value,
         const Right delete_value,
-        const vector<int> & components) -> tuple<Justification, ReasonFunction, optional<AssertionAnnotation>>
+        const vector<int> & components) -> tuple<DeletionJustification, Reason>
     {
         // we know a hall set exists, but we have to find it. starting
         // from but not including the end of the edge we're deleting,
@@ -373,15 +409,9 @@ namespace
             if (edges_out_from_value[delete_value.offset].empty())
                 throw UnexpectedException{"missing edge out from value in trivial scc"};
 
-            optional<AssertionAnnotation> assertion_annotation;
-            if (logger && logger->get_assertion_level() != AssertionLevel::Off)
-                assertion_annotation = std::make_optional(AssertionAnnotation{
-                    .hint_name = AssertionHintName::AllDifferent,
-                    .hint_fields = hint_list(hint_list(AssertionHintIdentifier::constraint_id, constraint_id))});
-
-            return tuple{Justification{JustifyUsingRUP{}},
-                ReasonFunction{[=]() { return Reason{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}; }},
-                assertion_annotation};
+            return tuple{
+                DeletionJustification{hints::AllDifferentForcedValue{constraint_id}},
+                Reason{ExplicitReason{ReasonLiterals{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}}}};
         }
         else {
             // a hall set is at work
@@ -390,33 +420,14 @@ namespace
                 if (hall_right[v.offset])
                     hall_value_nrs.push_back(vals[v.offset]);
 
-            optional<AssertionAnnotation> assertion_annotation;
-            if (logger && logger->get_assertion_level() != AssertionLevel::Off) {
-                vector<SExpr> hall_var_terms;
-                for (const auto & v : hall_variable_ids)
-                    hall_var_terms.push_back(logger->names_and_ids_tracker().s_expr_term_of(v));
-                assertion_annotation = std::make_optional(AssertionAnnotation{
-                    .hint_name = AssertionHintName::AllDifferent,
-                    .hint_fields = hint_list(
-                        hint_list(AssertionHintIdentifier::constraint_id, constraint_id),
-                        hint_list(AssertionHintIdentifier::hall_vars, SExpr::list(move(hall_var_terms))),
-                        hint_list(AssertionHintIdentifier::hall_vals, hint_seq(hall_value_nrs)),
-                        hint_list(AssertionHintIdentifier::justifier, AssertionHintIdentifier::hall_set_or_violator))});
-            }
-
-            return tuple{Justification{JustifyExplicitlyThenRUP{
-                             [vars, logger, &value_am1_constraint_numbers, hall_variable_ids, hall_value_nrs](
-                                 const ReasonFunction &) -> void {
-                                 justify_all_different_hall_set_or_violator(*logger, vars, hall_variable_ids, hall_value_nrs, value_am1_constraint_numbers);
-                             }}},
-                ReasonFunction{[hall_variable_ids, excluded, &state]() -> Reason {
-                    auto reason = generic_reason(state, hall_variable_ids)();
-                    for (const auto & v : hall_variable_ids)
-                        for (const auto & s : excluded)
-                            reason.emplace_back(v != s);
-                    return reason;
-                }},
-                assertion_annotation};
+            return tuple{
+                DeletionJustification{hall_witness(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers)},
+                Reason{LazyReasonOver{hall_variable_ids, [hall_variable_ids, excluded](const State & st, ReasonLiterals & out) {
+                                          out = materialise(generic_reason(st, hall_variable_ids), st);
+                                          for (const auto & v : hall_variable_ids)
+                                              for (const auto & s : excluded)
+                                                  out.emplace_back(v != s);
+                                      }}}};
         }
     }
 }
@@ -464,8 +475,10 @@ auto gcs::innards::propagate_gac_all_different(
     if (cmp_not_equal(count(left_covered.begin(), left_covered.end(), 1), vars.size())) {
         // nope. we've got a maximum cardinality matching that leaves at least
         // one thing on the left uncovered.
-        auto [just, reason, annotation] = prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, edges, left_covered, matching);
-        return tracker.infer(logger, FalseLiteral{}, just, reason, annotation);
+        auto [witness, reason] = prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, edges, left_covered, matching);
+        return tracker.infer(logger, FalseLiteral{},
+            JustifyExplicitly{[&logger, w = witness](const ReasonLiterals & r) { emit_justification(*logger, w, r); }, ThenRUP::Yes, move(witness)},
+            reason);
     }
 
     // we have a matching that uses every variable. however, some edges may
@@ -631,9 +644,15 @@ auto gcs::innards::propagate_gac_all_different(
         if (! representatives_for_scc[scc])
             continue;
 
-        auto [just, reason, annotation] = prove_deletion_using_sccs(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger,
+        auto [justification, reason] = prove_deletion_using_sccs(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger,
             edges_out_from_variable, edges_out_from_value, *representatives_for_scc[scc], components);
-        tracker.infer_all(logger, deletions_by_scc[scc], just, reason, annotation);
+        visit(overloaded{
+                  [&](hints::AllDifferentForcedValue & w) { tracker.infer_all(logger, deletions_by_scc[scc], JustifyUsingRUP{w}, reason); },
+                  [&](hints::AllDifferentHall & w) {
+                      tracker.infer_all(logger, deletions_by_scc[scc],
+                          JustifyExplicitly{[&logger, wc = w](const ReasonLiterals & r) { emit_justification(*logger, wc, r); }, ThenRUP::Yes, move(w)}, reason);
+                  }},
+            justification);
     }
 }
 

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraint.hh>
 #include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/constraints/all_different/gac_all_different.hh>
+#include <gcs/constraints/all_different/hints.hh>
 #include <gcs/constraints/all_different/justify.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/assertion_hints.hh>
@@ -70,27 +71,10 @@ using fmt::print;
 
 namespace gcs::innards::hints
 {
-    auto hint_sexpr(const AllDifferentHall & hall, NamesAndIDsTracker & names) -> SExpr
-    {
-        vector<SExpr> hall_var_terms;
-        for (const auto & v : hall.hall_vars)
-            hall_var_terms.push_back(names.s_expr_term_of(v));
-        return hint_list(
-            hint_constraint_id(hall.owner),
-            hint_list(SExpr::atom("hall_vars"), SExpr::list(move(hall_var_terms))),
-            hint_list(SExpr::atom("hall_vals"), hint_seq(hall.hall_vals)),
-            hint_justifier(AllDifferentHall::justifier));
-    }
-
     auto emit_justification(ProofLogger & logger, const AllDifferentHall & hall, const ReasonLiterals &) -> void
     {
         justify_all_different_hall_set_or_violator(logger, *hall.all_vars, hall.hall_vars, hall.hall_vals,
             *hall.value_am1_constraint_numbers);
-    }
-
-    auto hint_sexpr(const AllDifferentForcedValue & forced, NamesAndIDsTracker &) -> SExpr
-    {
-        return hint_list(hint_constraint_id(forced.owner));
     }
 }
 
@@ -221,26 +205,29 @@ namespace
         }
     }
 
-    // Build the typed Hall witness shared by both GAC all_different Hall shapes
-    // (the matching-too-small contradiction and the SCC Hall-set deletion). The
-    // hall set and values are the serialisable part of the witness; the variable
-    // scope and the at-most-one cache are carried as emit context (both owned by
-    // the constraint, so valid for the whole solve, including any later replay).
-    // emit_justification reproduces the original closure, calling the existing Hall
-    // justifier; hint_sexpr serialises only the Hall set for assert mode.
-    auto hall_witness(
+    // Build the typed Hall hint shared by both GAC all_different Hall shapes (the
+    // matching-too-small contradiction and the SCC Hall-set deletion). The hall set
+    // and values, the variable scope and the at-most-one cache are all emit context
+    // for emit_justification -- the pointers reference constraint-owned data, valid
+    // for the whole solve including any later replay. None of it is serialised: the
+    // hint takes the default identity-plus-subhint wire form, so the assertion names
+    // only the constraint and the "hall" sub-rule.
+    auto hall_hint(
         const vector<IntegerVariableID> & vars,
         const vector<IntegerVariableID> & hall_variable_ids,
         const vector<Integer> & hall_value_nrs,
         const ConstraintID & constraint_id,
         map<Integer, ProofLine> & value_am1_constraint_numbers) -> hints::AllDifferentHall
     {
+        // Aggregate init: the AllDifferent base (originator) first, then the Hall
+        // emit context in declaration order (hall_vars, hall_vals, all_vars,
+        // value_am1_constraint_numbers).
         return hints::AllDifferentHall{
-            .hall_vars = hall_variable_ids,
-            .hall_vals = hall_value_nrs,
-            .owner = constraint_id,
-            .all_vars = &vars,
-            .value_am1_constraint_numbers = &value_am1_constraint_numbers};
+            {constraint_id},
+            hall_variable_ids,
+            hall_value_nrs,
+            &vars,
+            &value_am1_constraint_numbers};
     }
 
     auto prove_matching_is_too_small(
@@ -311,7 +298,7 @@ namespace
                 hall_value_nrs.push_back(vals[v.offset]);
 
         return tuple{
-            hall_witness(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers),
+            hall_hint(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers),
             Reason{LazyReasonOver{hall_variable_ids, [hall_variable_ids, excluded](const State & st, ReasonLiterals & out) {
                                       out = materialise(generic_reason(st, hall_variable_ids), st);
                                       for (const auto & v : hall_variable_ids)
@@ -326,7 +313,7 @@ namespace
     // explicit steps) or a single forced value (pure RUP). A typed variant rather
     // than an optional, so each shape names itself and carries its own assertion
     // hint — there is no separate annotation channel.
-    using DeletionJustification = variant<hints::AllDifferentForcedValue, hints::AllDifferentHall>;
+    using DeletionJustification = variant<hints::AllDifferent, hints::AllDifferentHall>;
 
     auto vertex_to_offset(
         const vector<IntegerVariableID> & vars,
@@ -410,7 +397,7 @@ namespace
                 throw UnexpectedException{"missing edge out from value in trivial scc"};
 
             return tuple{
-                DeletionJustification{hints::AllDifferentForcedValue{constraint_id}},
+                DeletionJustification{hints::AllDifferent{constraint_id}},
                 Reason{ExplicitReason{ReasonLiterals{{vars[edges_out_from_value[delete_value.offset].begin()->offset] == vals[delete_value.offset]}}}}};
         }
         else {
@@ -421,7 +408,7 @@ namespace
                     hall_value_nrs.push_back(vals[v.offset]);
 
             return tuple{
-                DeletionJustification{hall_witness(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers)},
+                DeletionJustification{hall_hint(vars, hall_variable_ids, hall_value_nrs, constraint_id, value_am1_constraint_numbers)},
                 Reason{LazyReasonOver{hall_variable_ids, [hall_variable_ids, excluded](const State & st, ReasonLiterals & out) {
                                           out = materialise(generic_reason(st, hall_variable_ids), st);
                                           for (const auto & v : hall_variable_ids)
@@ -475,9 +462,9 @@ auto gcs::innards::propagate_gac_all_different(
     if (cmp_not_equal(count(left_covered.begin(), left_covered.end(), 1), vars.size())) {
         // nope. we've got a maximum cardinality matching that leaves at least
         // one thing on the left uncovered.
-        auto [witness, reason] = prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, edges, left_covered, matching);
+        auto [hall, reason] = prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, edges, left_covered, matching);
         return tracker.infer(logger, FalseLiteral{},
-            JustifyExplicitly{[&logger, w = witness](const ReasonLiterals & r) { emit_justification(*logger, w, r); }, ThenRUP::Yes, move(witness)},
+            JustifyExplicitly{[&logger, w = hall](const ReasonLiterals & r) { emit_justification(*logger, w, r); }, ThenRUP::Yes, move(hall)},
             reason);
     }
 
@@ -647,7 +634,7 @@ auto gcs::innards::propagate_gac_all_different(
         auto [justification, reason] = prove_deletion_using_sccs(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger,
             edges_out_from_variable, edges_out_from_value, *representatives_for_scc[scc], components);
         visit(overloaded{
-                  [&](hints::AllDifferentForcedValue & w) { tracker.infer_all(logger, deletions_by_scc[scc], JustifyUsingRUP{w}, reason); },
+                  [&](hints::AllDifferent & w) { tracker.infer_all(logger, deletions_by_scc[scc], JustifyUsingRUP{w}, reason); },
                   [&](hints::AllDifferentHall & w) {
                       tracker.infer_all(logger, deletions_by_scc[scc],
                           JustifyExplicitly{[&logger, wc = w](const ReasonLiterals & r) { emit_justification(*logger, wc, r); }, ThenRUP::Yes, move(w)}, reason);
@@ -697,7 +684,7 @@ auto GACAllDifferent::define_proof_model(ProofModel & model) -> void
 auto GACAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators);
+        install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferent{constraint_id()});
         return;
     }
 

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GAC_ALL_DIFFERENT_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GAC_ALL_DIFFERENT_HH
 
+#include <gcs/constraint.hh>
 #include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -17,6 +18,7 @@ namespace gcs
     namespace innards
     {
         auto propagate_gac_all_different(
+            const ConstraintID & constraint_id,
             const std::vector<IntegerVariableID> & vars,
             const std::vector<Integer> & vals,
             const std::vector<Integer> & excluded,

--- a/gcs/constraints/all_different/hints.hh
+++ b/gcs/constraints/all_different/hints.hh
@@ -1,0 +1,77 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_DIFFERENT_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_DIFFERENT_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <map>
+#include <string_view>
+#include <vector>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief all_different's base assertion hint: just the owning constraint.
+     *
+     * Used directly for the trivial SCC deletions, where a value is removed
+     * because a single other variable is forced to take it -- a pure-RUP
+     * inference with nothing to disambiguate, so it carries no subhint and takes
+     * the default `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct AllDifferent
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "all_different";
+    };
+
+    /**
+     * \brief all_different's GAC "Hall set or violator" hint.
+     *
+     * Extends the base with the per-shape `hall` subhint and the emit context the
+     * internal proof writer needs: the implicated Hall variables and values, the
+     * full variable scope, and the constraint's mutable at-most-one line cache.
+     * Those pointers reference constraint-owned data that outlives the search, so
+     * a built hint is valid both for eager emission and for replay at backtrack
+     * time. The data is held for emit_justification only; with no own hint_sexpr
+     * the hint takes the default identity-plus-subhint wire form
+     * (`(constraint_id <originator>)(subhint hall)`), keeping the Hall set off the
+     * wire unless an external justifier opts into serialising it.
+     *
+     * \ingroup Innards
+     */
+    struct AllDifferentHall : AllDifferent
+    {
+        static constexpr std::string_view subhint_name = "hall";
+        std::vector<IntegerVariableID> hall_vars;
+        std::vector<Integer> hall_vals;
+        const std::vector<IntegerVariableID> * all_vars = nullptr;
+        std::map<Integer, ProofLine> * value_am1_constraint_numbers = nullptr;
+    };
+
+    auto emit_justification(ProofLogger & logger, const AllDifferentHall & hall, const ReasonLiterals & reason) -> void;
+
+    /**
+     * \brief all_different_except's assertion hint: just the owning constraint.
+     *
+     * AllDifferentExcept is a distinct constraint (not a shape of AllDifferent), so
+     * it gets its own base hint rather than reusing AllDifferent's: its name lets the
+     * justifier dispatch on the right family. Carried by the duplicate-forcing
+     * prunings and the clique-duplicate contradiction, both RUP-derivable, so no
+     * subhint and the default `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct AllDifferentExcept
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "all_different_except";
+    };
+}
+
+#endif

--- a/gcs/constraints/all_different/justify.hh
+++ b/gcs/constraints/all_different/justify.hh
@@ -16,7 +16,6 @@ namespace gcs::innards
         const std::vector<IntegerVariableID> & hall_variables,
         const std::vector<Integer> & hall_values,
         std::map<Integer, ProofLine> & constraint_numbers) -> void;
-
 }
 
 #endif

--- a/gcs/constraints/all_different/justify.hh
+++ b/gcs/constraints/all_different/justify.hh
@@ -1,16 +1,11 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_DIFFERENT_JUSTIFY_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_DIFFERENT_JUSTIFY_HH
 
-#include <gcs/constraint_id.hh>
-#include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
-#include <gcs/innards/reason.hh>
-#include <gcs/innards/s_expr.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
 #include <map>
-#include <string_view>
 #include <vector>
 
 namespace gcs::innards
@@ -22,57 +17,6 @@ namespace gcs::innards
         const std::vector<Integer> & hall_values,
         std::map<Integer, ProofLine> & constraint_numbers) -> void;
 
-    // Typed assertion-hint witnesses live in gcs::innards::hints (reopened per
-    // constraint); the namespace is the enumerable "interface the justifier
-    // supports". Each struct owns its wire schema via a hint_sexpr overload and
-    // its sub-rule keyword via a static constexpr `justifier`.
-    namespace hints
-    {
-        /**
-         * \brief Witness for the GAC all_different "Hall set or violator"
-         * justification: the implicated variables, the values they collectively
-         * saturate, and the owning constraint. Shared by the matching-too-small
-         * contradiction and the SCC Hall-set deletion (same shape, different
-         * owner and call site).
-         *
-         * The two trailing pointers are the per-constraint emit context (the full
-         * variable scope and the constraint's mutable at-most-one line cache); they
-         * are read only by emit_justification, not serialised by hint_sexpr. Both
-         * point to data owned by the constraint, which outlives the whole search, so
-         * a built witness is valid not just for eager emission but for storing and
-         * replaying at backtrack time (the "fat witness" carrying emit context, with
-         * hint_sexpr serialising only the clean subset).
-         */
-        struct AllDifferentHall
-        {
-            std::vector<IntegerVariableID> hall_vars;
-            std::vector<Integer> hall_vals;
-            ConstraintID owner;
-            const std::vector<IntegerVariableID> * all_vars = nullptr;
-            std::map<Integer, ProofLine> * value_am1_constraint_numbers = nullptr;
-            static constexpr std::string_view justifier = "hall_set_or_violator";
-            static constexpr std::string_view hint_name = "all_different";
-        };
-
-        [[nodiscard]] auto hint_sexpr(const AllDifferentHall & hall, NamesAndIDsTracker & names) -> SExpr;
-
-        auto emit_justification(ProofLogger & logger, const AllDifferentHall & hall, const ReasonLiterals & reason) -> void;
-
-        /**
-         * \brief Witness for the trivial SCC deletion: a value is deleted because a
-         * single other variable is forced to take it. The justification is plain
-         * RUP (no explicit steps), so this hint has no emit_justification — it is
-         * the pure-RUP capability tier, carrying only an assertion hint with the
-         * owning constraint.
-         */
-        struct AllDifferentForcedValue
-        {
-            ConstraintID owner;
-            static constexpr std::string_view hint_name = "all_different";
-        };
-
-        [[nodiscard]] auto hint_sexpr(const AllDifferentForcedValue & forced, NamesAndIDsTracker & names) -> SExpr;
-    }
 }
 
 #endif

--- a/gcs/constraints/all_different/justify.hh
+++ b/gcs/constraints/all_different/justify.hh
@@ -1,11 +1,16 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_DIFFERENT_JUSTIFY_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_DIFFERENT_JUSTIFY_HH
 
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
 #include <map>
+#include <string_view>
 #include <vector>
 
 namespace gcs::innards
@@ -16,6 +21,58 @@ namespace gcs::innards
         const std::vector<IntegerVariableID> & hall_variables,
         const std::vector<Integer> & hall_values,
         std::map<Integer, ProofLine> & constraint_numbers) -> void;
+
+    // Typed assertion-hint witnesses live in gcs::innards::hints (reopened per
+    // constraint); the namespace is the enumerable "interface the justifier
+    // supports". Each struct owns its wire schema via a hint_sexpr overload and
+    // its sub-rule keyword via a static constexpr `justifier`.
+    namespace hints
+    {
+        /**
+         * \brief Witness for the GAC all_different "Hall set or violator"
+         * justification: the implicated variables, the values they collectively
+         * saturate, and the owning constraint. Shared by the matching-too-small
+         * contradiction and the SCC Hall-set deletion (same shape, different
+         * owner and call site).
+         *
+         * The two trailing pointers are the per-constraint emit context (the full
+         * variable scope and the constraint's mutable at-most-one line cache); they
+         * are read only by emit_justification, not serialised by hint_sexpr. Both
+         * point to data owned by the constraint, which outlives the whole search, so
+         * a built witness is valid not just for eager emission but for storing and
+         * replaying at backtrack time (the "fat witness" carrying emit context, with
+         * hint_sexpr serialising only the clean subset).
+         */
+        struct AllDifferentHall
+        {
+            std::vector<IntegerVariableID> hall_vars;
+            std::vector<Integer> hall_vals;
+            ConstraintID owner;
+            const std::vector<IntegerVariableID> * all_vars = nullptr;
+            std::map<Integer, ProofLine> * value_am1_constraint_numbers = nullptr;
+            static constexpr std::string_view justifier = "hall_set_or_violator";
+            static constexpr std::string_view hint_name = "all_different";
+        };
+
+        [[nodiscard]] auto hint_sexpr(const AllDifferentHall & hall, NamesAndIDsTracker & names) -> SExpr;
+
+        auto emit_justification(ProofLogger & logger, const AllDifferentHall & hall, const ReasonLiterals & reason) -> void;
+
+        /**
+         * \brief Witness for the trivial SCC deletion: a value is deleted because a
+         * single other variable is forced to take it. The justification is plain
+         * RUP (no explicit steps), so this hint has no emit_justification — it is
+         * the pure-RUP capability tier, carrying only an assertion hint with the
+         * owning constraint.
+         */
+        struct AllDifferentForcedValue
+        {
+            ConstraintID owner;
+            static constexpr std::string_view hint_name = "all_different";
+        };
+
+        [[nodiscard]] auto hint_sexpr(const AllDifferentForcedValue & forced, NamesAndIDsTracker & names) -> SExpr;
+    }
 }
 
 #endif

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -136,6 +136,8 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
         propagators.install_initialiser(
             [vars, start, n, value_am1s = _value_am1s](
                 const State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() >= AssertionLevel::Off)
+                    return;
                 for (Integer v = start; v < start + Integer(n); ++v) {
                     vector<IntegerVariableCondition> xieqvs;
                     for (const auto & var : vars)
@@ -160,7 +162,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
 
     propagators.install(
         constraint_id(),
-        [vars, start, values = move(values), value_am1s = _value_am1s](
+        [vars, start, values = move(values), value_am1s = _value_am1s, constraint_id = constraint_id()](
             const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
             // Channeling: x_i = v  =>  x_v = i. If i is not in D(x_v), prune
             // v from D(x_i). Single pass — Inverse(x, y) runs this in both
@@ -173,7 +175,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
                             [&]() { return Reason{vars.at((v - start).as_index()) != Integer(i) + start}; });
             }
 
-            propagate_gac_all_different(vars, values, vector<Integer>{}, *value_am1s.get(), state, inf, logger);
+            propagate_gac_all_different(constraint_id, vars, values, vector<Integer>{}, *value_am1s.get(), state, inf, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/all_different/encoding.hh>
 #include <gcs/constraints/all_different/gac_all_different.hh>
+#include <gcs/constraints/all_different/hints.hh>
 #include <gcs/constraints/all_different/symmetric_all_different.hh>
 #include <gcs/constraints/innards/recover_am1.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -124,7 +125,7 @@ auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
 auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators);
+        install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferent{constraint_id()});
         return;
     }
 
@@ -171,7 +172,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
                 for (auto v : state.each_value_mutable(x_i))
                     if (! state.in_domain(vars.at((v - start).as_index()), Integer(i) + start))
                         inf.infer(logger, x_i != v,
-                            JustifyUsingRUP{},
+                            JustifyUsingRUP{hints::AllDifferent{constraint_id}},
                             ExplicitReason{ReasonLiterals{vars.at((v - start).as_index()) != Integer(i) + start}});
             }
 

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -172,7 +172,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
                     if (! state.in_domain(vars.at((v - start).as_index()), Integer(i) + start))
                         inf.infer(logger, x_i != v,
                             JustifyUsingRUP{},
-                            [&]() { return Reason{vars.at((v - start).as_index()) != Integer(i) + start}; });
+                            ExplicitReason{ReasonLiterals{vars.at((v - start).as_index()) != Integer(i) + start}});
             }
 
             propagate_gac_all_different(constraint_id, vars, values, vector<Integer>{}, *value_am1s.get(), state, inf, logger);

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -76,14 +76,14 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
             if (other.second == val) {
                 // we're already in a contradicting state
                 inference.infer_not_equal(logger, var, val, JustifyUsingRUP{},
-                    ReasonFunction{[var = other.first, val = val]() { return Reason{{var == val}}; }});
+                    ExplicitReason{ReasonLiterals{{other.first == val}}});
             }
         }
 
         while (i != unassigned.end()) {
             auto other = *i;
             if (other != var) {
-                inference.infer_not_equal(logger, other, val, JustifyUsingRUP{}, ReasonFunction{[var = var, val = val]() { return Reason{{var == val}}; }});
+                inference.infer_not_equal(logger, other, val, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{var == val}}});
                 if (auto other_val = state.optional_single_value(other)) {
                     to_propagate.emplace_back(other, *other_val);
                     unassigned.erase(i++);

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_different/encoding.hh>
+#include <gcs/constraints/all_different/hints.hh>
 #include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -49,7 +50,7 @@ using fmt::print;
 #endif
 
 auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle,
-    const State & state, auto & inference, ProofLogger * const logger) -> void
+    const State & state, auto & inference, ProofLogger * const logger, const ConstraintID & owner) -> void
 {
     auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));
 
@@ -75,7 +76,7 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
         for (auto other : to_propagate) {
             if (other.second == val) {
                 // we're already in a contradicting state
-                inference.infer_not_equal(logger, var, val, JustifyUsingRUP{},
+                inference.infer_not_equal(logger, var, val, JustifyUsingRUP{hints::AllDifferent{owner}},
                     ExplicitReason{ReasonLiterals{{other.first == val}}});
             }
         }
@@ -83,7 +84,7 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
         while (i != unassigned.end()) {
             auto other = *i;
             if (other != var) {
-                inference.infer_not_equal(logger, other, val, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{var == val}}});
+                inference.infer_not_equal(logger, other, val, JustifyUsingRUP{hints::AllDifferent{owner}}, ExplicitReason{ReasonLiterals{{var == val}}});
                 if (auto other_val = state.optional_single_value(other)) {
                     to_propagate.emplace_back(other, *other_val);
                     unassigned.erase(i++);
@@ -149,7 +150,7 @@ auto VCAllDifferent::define_proof_model(ProofModel & model) -> void
 auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
 {
     if (_has_duplicate_vars) {
-        install_clique_duplicate_contradiction_initialiser(propagators);
+        install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferent{constraint_id()});
         return;
     }
 
@@ -158,18 +159,18 @@ auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [unassigned_handle = _unassigned_handle](const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
-            propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger);
+        [unassigned_handle = _unassigned_handle, owner = constraint_id()](const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
+            propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger, owner);
             return PropagatorState::Enable;
         },
         triggers);
 }
 
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
-    SimpleInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
+    SimpleInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> void;
 
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
-    EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
+    EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> void;
 
 auto VCAllDifferent::s_expr(const innards::ProofModel * const model) const -> SExpr
 {

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -17,7 +17,7 @@ namespace gcs
     {
         auto propagate_non_gac_alldifferent(
             const ConstraintStateHandle & unassigned_handle, const State & state,
-            auto & inference_tracker, ProofLogger * const logger) -> void;
+            auto & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> void;
     }
 
     /**

--- a/gcs/constraints/all_equal/all_equal.cc
+++ b/gcs/constraints/all_equal/all_equal.cc
@@ -107,11 +107,11 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
             if (state.lower_bound(vars[i]) < lo)
                 inference.infer_greater_than_or_equal(logger, vars[i], lo,
                     JustifyUsingRUP{},
-                    ReasonFunction{[w = argmax_lo, lo = lo]() { return Reason{{w >= lo}}; }});
+                    ExplicitReason{ReasonLiterals{{argmax_lo >= lo}}});
             if (state.upper_bound(vars[i]) > hi)
                 inference.infer_less_than(logger, vars[i], hi + 1_i,
                     JustifyUsingRUP{},
-                    ReasonFunction{[w = argmin_hi, hi = hi]() { return Reason{{w <= hi}}; }});
+                    ExplicitReason{ReasonLiterals{{argmin_hi <= hi}}});
         }
 
         // If any domain has holes, prune every var to the intersection of
@@ -141,7 +141,7 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
                             }
                         inference.infer_not_equal(logger, vars[i], val,
                             JustifyUsingRUP{},
-                            ReasonFunction{[w = witness, val]() { return Reason{{w != val}}; }});
+                            ExplicitReason{ReasonLiterals{{witness != val}}});
                     }
                 }
             }

--- a/gcs/constraints/all_equal/all_equal.cc
+++ b/gcs/constraints/all_equal/all_equal.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_equal/all_equal.hh>
+#include <gcs/constraints/all_equal/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -81,7 +82,7 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
 
-    propagators.install(constraint_id(), [vars = move(_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [vars = move(_vars), owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         auto n = vars.size();
 
         // Tighten each var to [lo, hi] where lo is the largest lower bound
@@ -106,11 +107,11 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
         for (size_t i = 0; i < n; ++i) {
             if (state.lower_bound(vars[i]) < lo)
                 inference.infer_greater_than_or_equal(logger, vars[i], lo,
-                    JustifyUsingRUP{},
+                    JustifyUsingRUP{hints::AllEqual{owner}},
                     ExplicitReason{ReasonLiterals{{argmax_lo >= lo}}});
             if (state.upper_bound(vars[i]) > hi)
                 inference.infer_less_than(logger, vars[i], hi + 1_i,
-                    JustifyUsingRUP{},
+                    JustifyUsingRUP{hints::AllEqual{owner}},
                     ExplicitReason{ReasonLiterals{{argmin_hi <= hi}}});
         }
 
@@ -140,7 +141,7 @@ auto AllEqual::install_propagators(Propagators & propagators) -> void
                                 break;
                             }
                         inference.infer_not_equal(logger, vars[i], val,
-                            JustifyUsingRUP{},
+                            JustifyUsingRUP{hints::AllEqual{owner}},
                             ExplicitReason{ReasonLiterals{{witness != val}}});
                     }
                 }

--- a/gcs/constraints/all_equal/hints.hh
+++ b/gcs/constraints/all_equal/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_EQUAL_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ALL_EQUAL_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief AllEqual's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct AllEqual
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "all_equal";
+    };
+}
+
+#endif

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/among/among.hh>
+#include <gcs/constraints/among/hints.hh>
 #include <gcs/constraints/innards/recover_am1.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -127,7 +128,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [vars = _vars, values_of_interest = _values_of_interest, how_many = _how_many, sum_line = _sum_line, am1_lines = am1_lines](
+        [vars = _vars, values_of_interest = _values_of_interest, how_many = _how_many, sum_line = _sum_line, am1_lines = am1_lines, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // partition variables to be 1) those that must not match, 2) those that must match, and 3) those
             // where they might match but don't have to.
@@ -154,44 +155,44 @@ auto Among::install_propagators(Propagators & propagators) -> void
             // many can't match, so we can derive bounds on the how many
             // variable.
             auto vars_reason = eager_reason(generic_reason(state, vars), state);
-            inference.infer(logger, how_many >= must_match_count, JustifyExplicitly{[&](const ReasonLiterals &) -> void {
-                                                                                        // Combine the (sum <= how_many) half of the Among encoding with the
-                                                                                        // at-least-one constraint for each must_match variable. After UP zeroes
-                                                                                        // the (var == v) literals for v outside the variable's current domain
-                                                                                        // (which, for must_match vars, includes everything outside voi), the
-                                                                                        // resulting line collapses to (how_many >= must_match_count) — directly
-                                                                                        // RUP-implying the inference. Without this scaffolding, RUP needs to
-                                                                                        // re-derive at-least-one over voi from the bit encoding for each
-                                                                                        // must_match var, which is not reliable when domains have width > 1.
-                                                                                        if (sum_line.first && must_match_count > 0_i) {
-                                                                                            PolBuilder b;
-                                                                                            b.add(*sum_line.first);
-                                                                                            for (const auto & m : must_match_vars) {
-                                                                                                // Constants in must_match are folded into sum_line.first's RHS at OPB
-                                                                                                // emission, so they don't need (and don't have) an at-least-one line.
-                                                                                                if (holds_alternative<ConstantIntegerVariableID>(m))
-                                                                                                    continue;
-                                                                                                b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
-                                                                                            }
-                                                                                            b.emit(*logger, ProofLevel::Temporary);
-                                                                                        }
-                                                                                    },
-                                                                      ThenRUP::Yes},
-                vars_reason);
+            auto at_least_justify = [&](const ReasonLiterals &) -> void {
+                // Combine the (sum <= how_many) half of the Among encoding with the
+                // at-least-one constraint for each must_match variable. After UP zeroes
+                // the (var == v) literals for v outside the variable's current domain
+                // (which, for must_match vars, includes everything outside voi), the
+                // resulting line collapses to (how_many >= must_match_count) -- directly
+                // RUP-implying the inference. Without this scaffolding, RUP needs to
+                // re-derive at-least-one over voi from the bit encoding for each
+                // must_match var, which is not reliable when domains have width > 1.
+                if (sum_line.first && must_match_count > 0_i) {
+                    PolBuilder b;
+                    b.add(*sum_line.first);
+                    for (const auto & m : must_match_vars) {
+                        // Constants in must_match are folded into sum_line.first's RHS at OPB
+                        // emission, so they don't need (and don't have) an at-least-one line.
+                        if (holds_alternative<ConstantIntegerVariableID>(m))
+                            continue;
+                        b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                    }
+                    b.emit(*logger, ProofLevel::Temporary);
+                }
+            };
+            inference.infer(logger, how_many >= must_match_count,
+                JustifyExplicitly{at_least_justify, ThenRUP::Yes, hints::Among{owner}}, vars_reason);
             auto less_than_this_many = Integer(vars.size()) - must_not_match_count + 1_i;
-            inference.infer(logger, how_many < less_than_this_many, JustifyExplicitly{[&](const ReasonLiterals &) -> void {
-                                                                                          // for any variable that isn't ruled out, show that it can contribute at
-                                                                                          // most one to the count.
-                                                                                          if (sum_line.second && ! empty(can_be_either_or_must_vars) && values_of_interest.size() > 1) {
-                                                                                              PolBuilder b;
-                                                                                              b.add(*sum_line.second);
-                                                                                              for (const auto & var : can_be_either_or_must_vars)
-                                                                                                  b.add(am1_lines->at(var));
-                                                                                              b.emit(*logger, ProofLevel::Temporary);
-                                                                                          }
-                                                                                      },
-                                                                        ThenRUP::Yes},
-                vars_reason);
+            auto at_most_justify = [&](const ReasonLiterals &) -> void {
+                // for any variable that isn't ruled out, show that it can contribute at
+                // most one to the count.
+                if (sum_line.second && ! empty(can_be_either_or_must_vars) && values_of_interest.size() > 1) {
+                    PolBuilder b;
+                    b.add(*sum_line.second);
+                    for (const auto & var : can_be_either_or_must_vars)
+                        b.add(am1_lines->at(var));
+                    b.emit(*logger, ProofLevel::Temporary);
+                }
+            };
+            inference.infer(logger, how_many < less_than_this_many,
+                JustifyExplicitly{at_most_justify, ThenRUP::Yes, hints::Among{owner}}, vars_reason);
 
             // potentially now we know that any undecided variables must actually be either
             // matching or not matching.
@@ -240,7 +241,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
                                                                                           b.emit(*logger, ProofLevel::Temporary);
                                                                                       }
                                                                                   },
-                                                                    ThenRUP::Yes},
+                                                                    ThenRUP::Yes, hints::Among{owner}},
                             vars_and_bounds_reason);
                     }
                 }
@@ -293,7 +294,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
                                                                                                   b.emit(*logger, ProofLevel::Temporary);
                                                                                               }
                                                                                           },
-                                                                            ThenRUP::Yes},
+                                                                            ThenRUP::Yes, hints::Among{owner}},
                                         vars_and_bounds_reason);
                                 }
                     }

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -153,54 +153,53 @@ auto Among::install_propagators(Propagators & propagators) -> void
             // we now know how many variables definitely match, and how
             // many can't match, so we can derive bounds on the how many
             // variable.
-            auto vars_reason = generic_reason(state, vars);
-            inference.infer(logger, how_many >= must_match_count, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) -> void {
-                // Combine the (sum <= how_many) half of the Among encoding with the
-                // at-least-one constraint for each must_match variable. After UP zeroes
-                // the (var == v) literals for v outside the variable's current domain
-                // (which, for must_match vars, includes everything outside voi), the
-                // resulting line collapses to (how_many >= must_match_count) — directly
-                // RUP-implying the inference. Without this scaffolding, RUP needs to
-                // re-derive at-least-one over voi from the bit encoding for each
-                // must_match var, which is not reliable when domains have width > 1.
-                if (sum_line.first && must_match_count > 0_i) {
-                    PolBuilder b;
-                    b.add(*sum_line.first);
-                    for (const auto & m : must_match_vars) {
-                        // Constants in must_match are folded into sum_line.first's RHS at OPB
-                        // emission, so they don't need (and don't have) an at-least-one line.
-                        if (holds_alternative<ConstantIntegerVariableID>(m))
-                            continue;
-                        b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
-                    }
-                    b.emit(*logger, ProofLevel::Temporary);
-                }
-            }},
+            auto vars_reason = eager_reason(generic_reason(state, vars), state);
+            inference.infer(logger, how_many >= must_match_count, JustifyExplicitly{[&](const ReasonLiterals &) -> void {
+                                                                                        // Combine the (sum <= how_many) half of the Among encoding with the
+                                                                                        // at-least-one constraint for each must_match variable. After UP zeroes
+                                                                                        // the (var == v) literals for v outside the variable's current domain
+                                                                                        // (which, for must_match vars, includes everything outside voi), the
+                                                                                        // resulting line collapses to (how_many >= must_match_count) — directly
+                                                                                        // RUP-implying the inference. Without this scaffolding, RUP needs to
+                                                                                        // re-derive at-least-one over voi from the bit encoding for each
+                                                                                        // must_match var, which is not reliable when domains have width > 1.
+                                                                                        if (sum_line.first && must_match_count > 0_i) {
+                                                                                            PolBuilder b;
+                                                                                            b.add(*sum_line.first);
+                                                                                            for (const auto & m : must_match_vars) {
+                                                                                                // Constants in must_match are folded into sum_line.first's RHS at OPB
+                                                                                                // emission, so they don't need (and don't have) an at-least-one line.
+                                                                                                if (holds_alternative<ConstantIntegerVariableID>(m))
+                                                                                                    continue;
+                                                                                                b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                                                                                            }
+                                                                                            b.emit(*logger, ProofLevel::Temporary);
+                                                                                        }
+                                                                                    },
+                                                                      ThenRUP::Yes},
                 vars_reason);
             auto less_than_this_many = Integer(vars.size()) - must_not_match_count + 1_i;
-            inference.infer(logger, how_many < less_than_this_many, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) -> void {
-                // for any variable that isn't ruled out, show that it can contribute at
-                // most one to the count.
-                if (sum_line.second && ! empty(can_be_either_or_must_vars) && values_of_interest.size() > 1) {
-                    PolBuilder b;
-                    b.add(*sum_line.second);
-                    for (const auto & var : can_be_either_or_must_vars)
-                        b.add(am1_lines->at(var));
-                    b.emit(*logger, ProofLevel::Temporary);
-                }
-            }},
+            inference.infer(logger, how_many < less_than_this_many, JustifyExplicitly{[&](const ReasonLiterals &) -> void {
+                                                                                          // for any variable that isn't ruled out, show that it can contribute at
+                                                                                          // most one to the count.
+                                                                                          if (sum_line.second && ! empty(can_be_either_or_must_vars) && values_of_interest.size() > 1) {
+                                                                                              PolBuilder b;
+                                                                                              b.add(*sum_line.second);
+                                                                                              for (const auto & var : can_be_either_or_must_vars)
+                                                                                                  b.add(am1_lines->at(var));
+                                                                                              b.emit(*logger, ProofLevel::Temporary);
+                                                                                          }
+                                                                                      },
+                                                                        ThenRUP::Yes},
                 vars_reason);
 
             // potentially now we know that any undecided variables must actually be either
             // matching or not matching.
             auto [at_least_how_many, at_most_how_many] = state.bounds(how_many);
 
-            auto vars_and_bounds_reason = [&vars_reason, how_many, at_least_how_many, at_most_how_many]() {
-                auto result = vars_reason();
-                result.push_back(how_many >= at_least_how_many);
-                result.push_back(how_many <= at_most_how_many);
-                return result;
-            };
+            auto vars_and_bounds_reason = vars_reason;
+            vars_and_bounds_reason.push_back(how_many >= at_least_how_many);
+            vars_and_bounds_reason.push_back(how_many <= at_most_how_many);
 
             // if we have enough definitely matching values, nothing else can match
             if (must_match_count == at_most_how_many) {
@@ -223,24 +222,25 @@ auto Among::install_propagators(Propagators & propagators) -> void
                         for (const auto & val : values_of_interest)
                             inferences.push_back(var != val);
 
-                        inference.infer_all(logger, inferences, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) -> void {
-                            // We need to bound the sum from BELOW: must_match vars each
-                            // contribute at least one to the Among sum, so combining the
-                            // (sum <= how_many) half with at-least-one constraints for
-                            // every must_match var derives that any extra contribution
-                            // from a non-must-match variable conflicts with the fixed
-                            // how_many = must_match_count value.
-                            if (sum_line.first && ! empty(must_match_vars)) {
-                                PolBuilder b;
-                                b.add(*sum_line.first);
-                                for (const auto & m : must_match_vars) {
-                                    if (holds_alternative<ConstantIntegerVariableID>(m))
-                                        continue;
-                                    b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
-                                }
-                                b.emit(*logger, ProofLevel::Temporary);
-                            }
-                        }},
+                        inference.infer_all(logger, inferences, JustifyExplicitly{[&](const ReasonLiterals &) -> void {
+                                                                                      // We need to bound the sum from BELOW: must_match vars each
+                                                                                      // contribute at least one to the Among sum, so combining the
+                                                                                      // (sum <= how_many) half with at-least-one constraints for
+                                                                                      // every must_match var derives that any extra contribution
+                                                                                      // from a non-must-match variable conflicts with the fixed
+                                                                                      // how_many = must_match_count value.
+                                                                                      if (sum_line.first && ! empty(must_match_vars)) {
+                                                                                          PolBuilder b;
+                                                                                          b.add(*sum_line.first);
+                                                                                          for (const auto & m : must_match_vars) {
+                                                                                              if (holds_alternative<ConstantIntegerVariableID>(m))
+                                                                                                  continue;
+                                                                                              b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                                                                                          }
+                                                                                          b.emit(*logger, ProofLevel::Temporary);
+                                                                                      }
+                                                                                  },
+                                                                    ThenRUP::Yes},
                             vars_and_bounds_reason);
                     }
                 }
@@ -273,26 +273,27 @@ auto Among::install_propagators(Propagators & propagators) -> void
                         if (might_match)
                             for (const auto & val : state.each_value_mutable(var))
                                 if (! contains(values_of_interest, val)) {
-                                    inference.infer(logger, var != val, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) {
-                                        // need to point out that if var == val then var != voi for each voi
-                                        for (const auto & voi : values_of_interest)
-                                            logger->emit(RUPProofRule{}, WPBSum{} + 1_i * (var != val) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
+                                    inference.infer(logger, var != val, JustifyExplicitly{[&](const ReasonLiterals &) {
+                                                                                              // need to point out that if var == val then var != voi for each voi
+                                                                                              for (const auto & voi : values_of_interest)
+                                                                                                  logger->emit(RUPProofRule{}, WPBSum{} + 1_i * (var != val) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
 
-                                        // now every other variable that contributes to the sum is
-                                        // capped at one — must_match vars (whose AM1 lines bound their
-                                        // contribution to the at-most-must_match_count tally) AND every
-                                        // other can_be_either var.
-                                        if (sum_line.second && values_of_interest.size() > 1) {
-                                            PolBuilder b;
-                                            b.add(*sum_line.second);
-                                            for (const auto & m : must_match_vars)
-                                                b.add(am1_lines->at(m));
-                                            for (const auto & other_var : can_be_either_vars)
-                                                if (var != other_var)
-                                                    b.add(am1_lines->at(other_var));
-                                            b.emit(*logger, ProofLevel::Temporary);
-                                        }
-                                    }},
+                                                                                              // now every other variable that contributes to the sum is
+                                                                                              // capped at one — must_match vars (whose AM1 lines bound their
+                                                                                              // contribution to the at-most-must_match_count tally) AND every
+                                                                                              // other can_be_either var.
+                                                                                              if (sum_line.second && values_of_interest.size() > 1) {
+                                                                                                  PolBuilder b;
+                                                                                                  b.add(*sum_line.second);
+                                                                                                  for (const auto & m : must_match_vars)
+                                                                                                      b.add(am1_lines->at(m));
+                                                                                                  for (const auto & other_var : can_be_either_vars)
+                                                                                                      if (var != other_var)
+                                                                                                          b.add(am1_lines->at(other_var));
+                                                                                                  b.emit(*logger, ProofLevel::Temporary);
+                                                                                              }
+                                                                                          },
+                                                                            ThenRUP::Yes},
                                         vars_and_bounds_reason);
                                 }
                     }

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -154,7 +154,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
             // we now know how many variables definitely match, and how
             // many can't match, so we can derive bounds on the how many
             // variable.
-            auto vars_reason = eager_reason(generic_reason(state, vars), state);
+            auto vars_reason = eager_reason(generic_reason(vars), state);
             auto at_least_justify = [&](const ReasonLiterals &) -> void {
                 // Combine the (sum <= how_many) half of the Among encoding with the
                 // at-least-one constraint for each must_match variable. After UP zeroes
@@ -223,26 +223,26 @@ auto Among::install_propagators(Propagators & propagators) -> void
                         for (const auto & val : values_of_interest)
                             inferences.push_back(var != val);
 
-                        inference.infer_all(logger, inferences, JustifyExplicitly{[&](const ReasonLiterals &) -> void {
-                                                                                      // We need to bound the sum from BELOW: must_match vars each
-                                                                                      // contribute at least one to the Among sum, so combining the
-                                                                                      // (sum <= how_many) half with at-least-one constraints for
-                                                                                      // every must_match var derives that any extra contribution
-                                                                                      // from a non-must-match variable conflicts with the fixed
-                                                                                      // how_many = must_match_count value.
-                                                                                      if (sum_line.first && ! empty(must_match_vars)) {
-                                                                                          PolBuilder b;
-                                                                                          b.add(*sum_line.first);
-                                                                                          for (const auto & m : must_match_vars) {
-                                                                                              if (holds_alternative<ConstantIntegerVariableID>(m))
-                                                                                                  continue;
-                                                                                              b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
-                                                                                          }
-                                                                                          b.emit(*logger, ProofLevel::Temporary);
-                                                                                      }
-                                                                                  },
-                                                                    ThenRUP::Yes, hints::Among{owner}},
-                            vars_and_bounds_reason);
+                        auto emit = [&](const ReasonLiterals &) -> void {
+                            // We need to bound the sum from BELOW: must_match vars each
+                            // contribute at least one to the Among sum, so combining the
+                            // (sum <= how_many) half with at-least-one constraints for
+                            // every must_match var derives that any extra contribution
+                            // from a non-must-match variable conflicts with the fixed
+                            // how_many = must_match_count value.
+                            if (sum_line.first && ! empty(must_match_vars)) {
+                                PolBuilder b;
+                                b.add(*sum_line.first);
+                                for (const auto & m : must_match_vars) {
+                                    if (holds_alternative<ConstantIntegerVariableID>(m))
+                                        continue;
+                                    b.add(logger->names_and_ids_tracker().need_constraint_saying_variable_takes_at_least_one_value(m));
+                                }
+                                b.emit(*logger, ProofLevel::Temporary);
+                            }
+                        };
+                        inference.infer_all(logger, inferences,
+                            JustifyExplicitly{emit, ThenRUP::Yes, hints::Among{owner}}, vars_and_bounds_reason);
                     }
                 }
 
@@ -274,28 +274,28 @@ auto Among::install_propagators(Propagators & propagators) -> void
                         if (might_match)
                             for (const auto & val : state.each_value_mutable(var))
                                 if (! contains(values_of_interest, val)) {
-                                    inference.infer(logger, var != val, JustifyExplicitly{[&](const ReasonLiterals &) {
-                                                                                              // need to point out that if var == val then var != voi for each voi
-                                                                                              for (const auto & voi : values_of_interest)
-                                                                                                  logger->emit(RUPProofRule{}, WPBSum{} + 1_i * (var != val) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
+                                    auto emit = [&](const ReasonLiterals &) {
+                                        // need to point out that if var == val then var != voi for each voi
+                                        for (const auto & voi : values_of_interest)
+                                            logger->emit(RUPProofRule{}, WPBSum{} + 1_i * (var != val) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
 
-                                                                                              // now every other variable that contributes to the sum is
-                                                                                              // capped at one — must_match vars (whose AM1 lines bound their
-                                                                                              // contribution to the at-most-must_match_count tally) AND every
-                                                                                              // other can_be_either var.
-                                                                                              if (sum_line.second && values_of_interest.size() > 1) {
-                                                                                                  PolBuilder b;
-                                                                                                  b.add(*sum_line.second);
-                                                                                                  for (const auto & m : must_match_vars)
-                                                                                                      b.add(am1_lines->at(m));
-                                                                                                  for (const auto & other_var : can_be_either_vars)
-                                                                                                      if (var != other_var)
-                                                                                                          b.add(am1_lines->at(other_var));
-                                                                                                  b.emit(*logger, ProofLevel::Temporary);
-                                                                                              }
-                                                                                          },
-                                                                            ThenRUP::Yes, hints::Among{owner}},
-                                        vars_and_bounds_reason);
+                                        // now every other variable that contributes to the sum is
+                                        // capped at one — must_match vars (whose AM1 lines bound their
+                                        // contribution to the at-most-must_match_count tally) AND every
+                                        // other can_be_either var.
+                                        if (sum_line.second && values_of_interest.size() > 1) {
+                                            PolBuilder b;
+                                            b.add(*sum_line.second);
+                                            for (const auto & m : must_match_vars)
+                                                b.add(am1_lines->at(m));
+                                            for (const auto & other_var : can_be_either_vars)
+                                                if (var != other_var)
+                                                    b.add(am1_lines->at(other_var));
+                                            b.emit(*logger, ProofLevel::Temporary);
+                                        }
+                                    };
+                                    inference.infer(logger, var != val,
+                                        JustifyExplicitly{emit, ThenRUP::Yes, hints::Among{owner}}, vars_and_bounds_reason);
                                 }
                     }
 

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -111,7 +112,7 @@ auto Among::install_propagators(Propagators & propagators) -> void
     auto am1_lines = make_shared<map<IntegerVariableID, ProofLine>>();
     propagators.install_initialiser([vars = _vars, values_of_interest = _values_of_interest, am1_lines = am1_lines](
                                         const State &, auto &, ProofLogger * const logger) -> void {
-        if (logger && values_of_interest.size() > 1) {
+        if (logger && values_of_interest.size() > 1 && logger->get_assertion_level() == AssertionLevel::Off) {
             for (auto & var : vars) {
                 vector<IntegerVariableCondition> var_eq_vois;
                 for (const auto & voi : values_of_interest)

--- a/gcs/constraints/among/hints.hh
+++ b/gcs/constraints/among/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_AMONG_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_AMONG_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Among's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Among
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "among";
+    };
+}
+
+#endif

--- a/gcs/constraints/arithmetic/arithmetic_test.cc
+++ b/gcs/constraints/arithmetic/arithmetic_test.cc
@@ -149,7 +149,7 @@ auto run_power_pinned_test(bool proofs, Integer base, Integer exp, pair<long lon
                 actual_results.insert(s(v3).raw_value);
                 return true;
             }},
-        proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}, true, false) : nullopt);
+        proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
 
     println(cerr, " got {} solutions", actual_results.size());
 

--- a/gcs/constraints/at_most_one/at_most_one.cc
+++ b/gcs/constraints/at_most_one/at_most_one.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/at_most_one/at_most_one.hh>
+#include <gcs/constraints/at_most_one/hints.hh>
 #include <gcs/constraints/smart_table.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -101,7 +102,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [vars = _vars, val = _val, all_vars = move(all_vars)](
+        [vars = _vars, val = _val, all_vars = move(all_vars), owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // For each candidate value v of `val`: if two or more vars
             // are fixed to v, infer val ≠ v. (RUP from the encoding's
@@ -115,7 +116,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
                     }
                 }
                 if (fixed_to_v >= 2)
-                    inference.infer(logger, val != v, JustifyUsingRUP{},
+                    inference.infer(logger, val != v, JustifyUsingRUP{hints::AtMostOne{owner}},
                         generic_reason(state, all_vars));
             }
 
@@ -136,7 +137,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
                 if (fixed_count == 1) {
                     for (size_t i = 0; cmp_less(i, vars.size()); ++i) {
                         if (i != fixed_idx)
-                            inference.infer(logger, vars[i] != *val_fixed, JustifyUsingRUP{},
+                            inference.infer(logger, vars[i] != *val_fixed, JustifyUsingRUP{hints::AtMostOne{owner}},
                                 generic_reason(state, all_vars));
                     }
                 }

--- a/gcs/constraints/at_most_one/at_most_one.cc
+++ b/gcs/constraints/at_most_one/at_most_one.cc
@@ -117,7 +117,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
                 }
                 if (fixed_to_v >= 2)
                     inference.infer(logger, val != v, JustifyUsingRUP{hints::AtMostOne{owner}},
-                        generic_reason(state, all_vars));
+                        generic_reason(all_vars));
             }
 
             // If val is now fixed to v and exactly one var is fixed to v,
@@ -138,7 +138,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
                     for (size_t i = 0; cmp_less(i, vars.size()); ++i) {
                         if (i != fixed_idx)
                             inference.infer(logger, vars[i] != *val_fixed, JustifyUsingRUP{hints::AtMostOne{owner}},
-                                generic_reason(state, all_vars));
+                                generic_reason(all_vars));
                     }
                 }
             }

--- a/gcs/constraints/at_most_one/hints.hh
+++ b/gcs/constraints/at_most_one/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_AT_MOST_ONE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_AT_MOST_ONE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief AtMostOne's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct AtMostOne
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "at_most_one";
+    };
+}
+
+#endif

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/circuit/circuit_base.hh>
+#include <gcs/constraints/circuit/hints.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -107,6 +108,7 @@ auto gcs::innards::circuit::output_cycle_to_proof(const vector<IntegerVariableID
 
 auto gcs::innards::circuit::prevent_small_cycles(
     const vector<IntegerVariableID> & succ,
+    const ConstraintID & owner,
     const PosVarDataMap & pos_var_data,
     const ConstraintStateHandle & unassigned_handle,
     const State & state,
@@ -132,7 +134,7 @@ auto gcs::innards::circuit::prevent_small_cycles(
                     if (j == j0) {
                         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             output_cycle_to_proof(succ, j0, length, pos_var_data, state, *logger);
-                        inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, succ));
+                        inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
                     }
                 } while (state.has_single_value(succ[j]));
                 end[j0] = j;
@@ -151,10 +153,10 @@ auto gcs::innards::circuit::prevent_small_cycles(
             auto justf = [&](const ReasonLiterals &) {
                 output_cycle_to_proof(succ, i, length, pos_var_data, state, *logger, Integer{end[i]}, Integer{i});
             };
-            inference.infer(logger, succ[end[i]] != Integer{i}, JustifyExplicitly{justf, ThenRUP::Yes}, generic_reason(state, succ));
+            inference.infer(logger, succ[end[i]] != Integer{i}, JustifyExplicitly{justf, ThenRUP::Yes, hints::Circuit{owner}}, generic_reason(state, succ));
         }
         else {
-            inference.infer(logger, succ[end[i]] == Integer{i}, JustifyUsingRUP{}, generic_reason(state, succ));
+            inference.infer(logger, succ[end[i]] == Integer{i}, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
         }
     }
 }
@@ -231,9 +233,9 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 
     // Infer succ[i] != i at top of search, but no other propagation defined here: use CircuitPrevent or CircuitSCC
     if (_succ.size() > 1) {
-        propagators.install(constraint_id(), [succ = _succ](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [succ = _succ, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             for (auto [idx, s] : enumerate(succ)) {
-                inference.infer_not_equal(logger, s, Integer(static_cast<long long>(idx)), JustifyUsingRUP{}, generic_reason(state, succ));
+                inference.infer_not_equal(logger, s, Integer(static_cast<long long>(idx)), JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
             }
             return PropagatorState::DisableUntilBacktrack; }, Triggers{});
     }
@@ -252,8 +254,8 @@ auto CircuitBase::s_expr(const innards::ProofModel * const model) const -> SExpr
         SExpr::list(std::move(vars))});
 }
 
-template auto gcs::innards::circuit::prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const PosVarDataMap & pos_var_data,
+template auto gcs::innards::circuit::prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
     const ConstraintStateHandle & unassigned_handle, const State & state, SimpleInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
 
-template auto gcs::innards::circuit::prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const PosVarDataMap & pos_var_data,
+template auto gcs::innards::circuit::prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
     const ConstraintStateHandle & unassigned_handle, const State & state, EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -134,7 +134,7 @@ auto gcs::innards::circuit::prevent_small_cycles(
                     if (j == j0) {
                         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             output_cycle_to_proof(succ, j0, length, pos_var_data, state, *logger);
-                        inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
+                        inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
                     }
                 } while (state.has_single_value(succ[j]));
                 end[j0] = j;
@@ -153,10 +153,10 @@ auto gcs::innards::circuit::prevent_small_cycles(
             auto justf = [&](const ReasonLiterals &) {
                 output_cycle_to_proof(succ, i, length, pos_var_data, state, *logger, Integer{end[i]}, Integer{i});
             };
-            inference.infer(logger, succ[end[i]] != Integer{i}, JustifyExplicitly{justf, ThenRUP::Yes, hints::Circuit{owner}}, generic_reason(state, succ));
+            inference.infer(logger, succ[end[i]] != Integer{i}, JustifyExplicitly{justf, ThenRUP::Yes, hints::Circuit{owner}}, generic_reason(succ));
         }
         else {
-            inference.infer(logger, succ[end[i]] == Integer{i}, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
+            inference.infer(logger, succ[end[i]] == Integer{i}, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
         }
     }
 }
@@ -233,9 +233,9 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 
     // Infer succ[i] != i at top of search, but no other propagation defined here: use CircuitPrevent or CircuitSCC
     if (_succ.size() > 1) {
-        propagators.install(constraint_id(), [succ = _succ, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [succ = _succ, owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
             for (auto [idx, s] : enumerate(succ)) {
-                inference.infer_not_equal(logger, s, Integer(static_cast<long long>(idx)), JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
+                inference.infer_not_equal(logger, s, Integer(static_cast<long long>(idx)), JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
             }
             return PropagatorState::DisableUntilBacktrack; }, Triggers{});
     }

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -148,10 +148,10 @@ auto gcs::innards::circuit::prevent_small_cycles(
         auto length = chain_lengths.back();
         chain_lengths.pop_back();
         if (cmp_less(length, succ.size() - 1)) {
-            auto justf = [&](const ReasonFunction &) {
+            auto justf = [&](const ReasonLiterals &) {
                 output_cycle_to_proof(succ, i, length, pos_var_data, state, *logger, Integer{end[i]}, Integer{i});
             };
-            inference.infer(logger, succ[end[i]] != Integer{i}, JustifyExplicitlyThenRUP{justf}, generic_reason(state, succ));
+            inference.infer(logger, succ[end[i]] != Integer{i}, JustifyExplicitly{justf, ThenRUP::Yes}, generic_reason(state, succ));
         }
         else {
             inference.infer(logger, succ[end[i]] == Integer{i}, JustifyUsingRUP{}, generic_reason(state, succ));

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -130,7 +130,7 @@ auto gcs::innards::circuit::prevent_small_cycles(
                     length++;
                     // Need to check this in case alldiff hasn't been fully propagated.
                     if (j == j0) {
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             output_cycle_to_proof(succ, j0, length, pos_var_data, state, *logger);
                         inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, succ));
                     }

--- a/gcs/constraints/circuit/circuit_base.hh
+++ b/gcs/constraints/circuit/circuit_base.hh
@@ -61,7 +61,7 @@ namespace gcs::innards::circuit
         const std::optional<Integer> & prevent_idx = std::nullopt,
         const std::optional<Integer> & prevent_value = std::nullopt) -> void;
 
-    auto prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const PosVarDataMap & pos_var_data,
+    auto prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
         const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference_tracker, ProofLogger * const logger) -> void;
 
     /**

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -48,7 +48,7 @@ namespace
                             if (cmp_less(cycle_length, n)) {
                                 if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                                     output_cycle_to_proof(succ, j0, cycle_length, pos_var_data, state, *logger);
-                                inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
+                                inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
                             }
 
                             else

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -45,7 +45,7 @@ namespace
                         cycle_length++;
                         if (j == j0) {
                             if (cmp_less(cycle_length, n)) {
-                                if (logger)
+                                if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                                     output_cycle_to_proof(succ, j0, cycle_length, pos_var_data, state, *logger);
                                 inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, succ));
                             }

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/circuit/circuit_base.hh>
 #include <gcs/constraints/circuit/circuit_prevent.hh>
+#include <gcs/constraints/circuit/hints.hh>
 
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/propagators.hh>
@@ -25,7 +26,7 @@ using std::vector;
 
 namespace
 {
-    auto check_small_cycles(const vector<IntegerVariableID> & succ, const PosVarDataMap & pos_var_data, const State & state,
+    auto check_small_cycles(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data, const State & state,
         auto & inference, ProofLogger * const logger) -> void
     {
         auto n = succ.size();
@@ -47,7 +48,7 @@ namespace
                             if (cmp_less(cycle_length, n)) {
                                 if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                                     output_cycle_to_proof(succ, j0, cycle_length, pos_var_data, state, *logger);
-                                inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, succ));
+                                inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(state, succ));
                             }
 
                             else
@@ -61,15 +62,16 @@ namespace
 
     auto propagate_circuit_using_prevent(
         const vector<IntegerVariableID> & succ,
+        const ConstraintID & owner,
         const PosVarDataMap & pos_var_data,
         const ConstraintStateHandle & unassigned_handle,
         const State & state,
         auto & inference,
         ProofLogger * const logger) -> void
     {
-        propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger);
-        check_small_cycles(succ, pos_var_data, state, inference, logger);
-        prevent_small_cycles(succ, pos_var_data, unassigned_handle, state, inference, logger);
+        propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner);
+        check_small_cycles(succ, owner, pos_var_data, state, inference, logger);
+        prevent_small_cycles(succ, owner, pos_var_data, unassigned_handle, state, inference, logger);
     }
 }
 
@@ -94,9 +96,9 @@ auto CircuitPrevent::install(innards::Propagators & propagators, innards::State 
     triggers.on_instantiated = {_succ.begin(), _succ.end()};
     propagators.install(
         constraint_id(),
-        [succ = _succ, pvd = pos_var_data,
+        [succ = _succ, owner = constraint_id(), pvd = pos_var_data,
             unassigned_handle = unassigned_handle](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_circuit_using_prevent(succ, pvd, unassigned_handle, state, inference, logger);
+            propagate_circuit_using_prevent(succ, owner, pvd, unassigned_handle, state, inference, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -2,9 +2,11 @@
 #include <gcs/constraints/circuit/circuit_base.hh>
 #include <gcs/constraints/circuit/circuit_scc.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 
 #include <list>
@@ -1027,7 +1029,7 @@ namespace
                     back_edges.emplace_back(node, next_node);
                 }
                 else if (options.prune_skip && data.visit_number[next_node] < data.start_prev_subtree) {
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (next_node == data.root) {
                             logger->emit_proof_comment(format("Pruning edge to the root from a subtree other than the first ({}, {})", node, next_node));
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.prev_subroot, options);
@@ -1038,16 +1040,18 @@ namespace
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                             prove_skipped_subtree(ctx, node, next_node, data.prev_subroot);
                         }
+                        inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, ReasonFunction{});
                     }
-
-                    inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, ReasonFunction{});
+                    else {
+                        inference.infer(logger, succ[node] != w, JustifyUsingRUP{}, ReasonFunction{});
+                    }
                 }
                 data.lowlink[node] = pos_min(data.lowlink[node], data.visit_number[next_node]);
             }
         }
 
         if (data.lowlink[node] == data.visit_number[node]) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 logger->emit_proof_comment("More than one SCC");
                 auto ctx = SCCProofContext{state, *logger, reason, succ, proof_data, node, options};
                 prove_reachable_set_too_small(ctx);
@@ -1076,7 +1080,7 @@ namespace
                 auto back_edges = explore(state, inference, logger, reason, next_node, succ, data, proof_data, options);
 
                 if (back_edges.empty()) {
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         logger->emit_proof_comment("No back edges");
                         auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, next_node, options);
                         prove_reachable_set_too_small(ctx);
@@ -1087,13 +1091,17 @@ namespace
                     auto from_node = back_edges[0].first;
                     auto to_node = back_edges[0].second;
                     if (! state.optional_single_value(succ[from_node])) {
-                        if (logger) {
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                             logger->emit_proof_comment(format("Fix required back edge ({}, {}):", from_node, to_node));
 
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, from_node, options);
                             prove_reachable_set_too_small(ctx, succ[from_node] != Integer{to_node});
+                            inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, ReasonFunction{});
                         }
-                        inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, ReasonFunction{});
+                        else {
+
+                            inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{}, ReasonFunction{});
+                        }
                     }
                 }
                 data.start_prev_subtree = data.end_prev_subtree + 1;
@@ -1103,7 +1111,7 @@ namespace
         }
 
         if (cmp_not_equal(data.count, succ.size())) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 logger->emit_proof_comment("Disconnected graph");
                 auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                 prove_reachable_set_too_small(ctx);
@@ -1114,7 +1122,7 @@ namespace
         if (options.prune_root && data.start_prev_subtree > 1) {
             for (const auto & v : state.each_value_mutable(succ[data.root])) {
                 if (data.visit_number[v.as_index()] < data.start_prev_subtree) {
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         logger->emit_proof_comment("Prune impossible edges from root node");
                         auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                         prove_reachable_set_too_small(ctx, succ[data.root] == v);

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/circuit/circuit_base.hh>
 #include <gcs/constraints/circuit/circuit_scc.hh>
+#include <gcs/constraints/circuit/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -1005,7 +1006,7 @@ namespace
     }
 
     auto explore(const State & state, auto & inference, ProofLogger * const logger, const ReasonLiterals & reason,
-        const long & node, const vector<IntegerVariableID> & succ, SCCPropagatorData & data, SCCProofData & proof_data,
+        const ConstraintID & owner, const long & node, const vector<IntegerVariableID> & succ, SCCPropagatorData & data, SCCProofData & proof_data,
         const SCCOptions & options)
         -> vector<pair<long, long>>
     {
@@ -1019,7 +1020,7 @@ namespace
             auto next_node = w.raw_value;
 
             if (data.visit_number[next_node] == -1) {
-                auto w_back_edges = explore(state, inference, logger, reason, next_node, succ, data, proof_data, options);
+                auto w_back_edges = explore(state, inference, logger, reason, owner, next_node, succ, data, proof_data, options);
                 back_edges.insert(back_edges.end(), w_back_edges.begin(), w_back_edges.end());
                 data.lowlink[node] = pos_min(data.lowlink[node], data.lowlink[next_node]);
             }
@@ -1043,7 +1044,7 @@ namespace
                         inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, NoReason{});
                     }
                     else {
-                        inference.infer(logger, succ[node] != w, JustifyUsingRUP{}, NoReason{});
+                        inference.infer(logger, succ[node] != w, JustifyUsingRUP{hints::Circuit{owner}}, NoReason{});
                     }
                 }
                 data.lowlink[node] = pos_min(data.lowlink[node], data.visit_number[next_node]);
@@ -1056,7 +1057,7 @@ namespace
                 auto ctx = SCCProofContext{state, *logger, reason, succ, proof_data, node, options};
                 prove_reachable_set_too_small(ctx);
             }
-            inference.contradiction(logger, JustifyUsingRUP{}, reason);
+            inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, reason);
         }
         else
             return back_edges;
@@ -1067,6 +1068,7 @@ namespace
         auto & inference,
         ProofLogger * const logger,
         const ReasonLiterals & reason,
+        const ConstraintID & owner,
         const vector<IntegerVariableID> & succ,
         const SCCOptions & options,
         SCCProofData & proof_data)
@@ -1077,7 +1079,7 @@ namespace
         for (const auto & v : state.each_value_mutable(succ[data.root])) {
             auto next_node = v.raw_value;
             if (data.visit_number[next_node] == -1) {
-                auto back_edges = explore(state, inference, logger, reason, next_node, succ, data, proof_data, options);
+                auto back_edges = explore(state, inference, logger, reason, owner, next_node, succ, data, proof_data, options);
 
                 if (back_edges.empty()) {
                     if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
@@ -1085,7 +1087,7 @@ namespace
                         auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, next_node, options);
                         prove_reachable_set_too_small(ctx);
                     }
-                    inference.contradiction(logger, JustifyUsingRUP{}, reason);
+                    inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, reason);
                 }
                 else if (options.fix_req && back_edges.size() == 1) {
                     auto from_node = back_edges[0].first;
@@ -1100,7 +1102,7 @@ namespace
                         }
                         else {
 
-                            inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{}, NoReason{});
+                            inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{hints::Circuit{owner}}, NoReason{});
                         }
                     }
                 }
@@ -1116,7 +1118,7 @@ namespace
                 auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                 prove_reachable_set_too_small(ctx);
             }
-            inference.contradiction(logger, JustifyUsingRUP{}, reason);
+            inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, reason);
         }
 
         if (options.prune_root && data.start_prev_subtree > 1) {
@@ -1127,7 +1129,7 @@ namespace
                         auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                         prove_reachable_set_too_small(ctx, succ[data.root] == v);
                     }
-                    inference.infer(logger, succ[data.root] != v, JustifyUsingRUP{}, reason);
+                    inference.infer(logger, succ[data.root] != v, JustifyUsingRUP{hints::Circuit{owner}}, reason);
                 }
             }
         }
@@ -1138,6 +1140,7 @@ namespace
         auto & inference,
         ProofLogger * const logger,
         const ReasonLiterals & reason,
+        const ConstraintID & owner,
         const vector<IntegerVariableID> & succ,
         const SCCOptions & scc_options,
         const ConstraintStateHandle & pos_var_data_handle,
@@ -1147,9 +1150,9 @@ namespace
         -> void
     {
         auto & pos_var_data = any_cast<PosVarDataMap &>(state.get_persistent_constraint_state(pos_var_data_handle));
-        propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger);
+        propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner);
         auto proof_data = SCCProofData{pos_var_data, proof_flag_data_handle, pos_alldiff_data_handle};
-        check_sccs(state, inference, logger, reason, succ, scc_options, proof_data);
+        check_sccs(state, inference, logger, reason, owner, succ, scc_options, proof_data);
         auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));
         // Remove any newly assigned vals from unassigned
         auto it = unassigned.begin();
@@ -1159,7 +1162,7 @@ namespace
             else
                 ++it;
         }
-        prevent_small_cycles(succ, pos_var_data, unassigned_handle, state, inference, logger);
+        prevent_small_cycles(succ, owner, pos_var_data, unassigned_handle, state, inference, logger);
     }
 }
 
@@ -1193,6 +1196,7 @@ auto CircuitSCC::install(Propagators & propagators, State & initial_state, Proof
     propagators.install(
         constraint_id(),
         [succ = _succ,
+            owner = constraint_id(),
             pos_var_data_handle = pos_var_data_handle,
             proof_flag_data_handle = proof_flag_data_handle,
             pos_alldiff_data_handle = pos_alldiff_data_handle,
@@ -1212,7 +1216,7 @@ auto CircuitSCC::install(Propagators & propagators, State & initial_state, Proof
                 reason = eager_reason(singleton_reason(reason_short), state);
             }
 
-            propagate_circuit_using_scc(state, inference, logger, reason,
+            propagate_circuit_using_scc(state, inference, logger, reason, owner,
                 succ, options, pos_var_data_handle, proof_flag_data_handle, pos_alldiff_data_handle, unassigned_handle);
             return PropagatorState::Enable;
         },

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -101,7 +101,7 @@ namespace
     {
         const State & state;
         ProofLogger & logger;
-        const ReasonFunction & reason;
+        const ReasonLiterals & reason;
         const vector<IntegerVariableID> & succ;
         const long root;
         PosVarDataMap & pos_var_data;
@@ -110,7 +110,7 @@ namespace
         PosAllDiffData & pos_alldiff_data;
         const SCCOptions & options;
 
-        SCCProofContext(const State & state, ProofLogger & logger, const ReasonFunction & reason, const vector<IntegerVariableID> & succ,
+        SCCProofContext(const State & state, ProofLogger & logger, const ReasonLiterals & reason, const vector<IntegerVariableID> & succ,
             SCCProofData & proof_data, const long root, const SCCOptions & options) :
             state(state),
             logger(logger),
@@ -1004,7 +1004,7 @@ namespace
             WPBSum{} + 1_i * (ctx.succ[node] != Integer{next_node}) >= 1_i, ProofLevel::Current);
     }
 
-    auto explore(const State & state, auto & inference, ProofLogger * const logger, const ReasonFunction & reason,
+    auto explore(const State & state, auto & inference, ProofLogger * const logger, const ReasonLiterals & reason,
         const long & node, const vector<IntegerVariableID> & succ, SCCPropagatorData & data, SCCProofData & proof_data,
         const SCCOptions & options)
         -> vector<pair<long, long>>
@@ -1040,10 +1040,10 @@ namespace
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, data.root, options);
                             prove_skipped_subtree(ctx, node, next_node, data.prev_subroot);
                         }
-                        inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, ReasonFunction{});
+                        inference.infer(logger, succ[node] != w, NoJustificationNeeded{}, NoReason{});
                     }
                     else {
-                        inference.infer(logger, succ[node] != w, JustifyUsingRUP{}, ReasonFunction{});
+                        inference.infer(logger, succ[node] != w, JustifyUsingRUP{}, NoReason{});
                     }
                 }
                 data.lowlink[node] = pos_min(data.lowlink[node], data.visit_number[next_node]);
@@ -1066,7 +1066,7 @@ namespace
         const State & state,
         auto & inference,
         ProofLogger * const logger,
-        const ReasonFunction & reason,
+        const ReasonLiterals & reason,
         const vector<IntegerVariableID> & succ,
         const SCCOptions & options,
         SCCProofData & proof_data)
@@ -1096,11 +1096,11 @@ namespace
 
                             auto ctx = SCCProofContext(state, *logger, reason, succ, proof_data, from_node, options);
                             prove_reachable_set_too_small(ctx, succ[from_node] != Integer{to_node});
-                            inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, ReasonFunction{});
+                            inference.infer(logger, succ[from_node] == Integer{to_node}, NoJustificationNeeded{}, NoReason{});
                         }
                         else {
 
-                            inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{}, ReasonFunction{});
+                            inference.infer(logger, succ[from_node] == Integer{to_node}, JustifyUsingRUP{}, NoReason{});
                         }
                     }
                 }
@@ -1137,7 +1137,7 @@ namespace
         const State & state,
         auto & inference,
         ProofLogger * const logger,
-        const ReasonFunction & reason,
+        const ReasonLiterals & reason,
         const vector<IntegerVariableID> & succ,
         const SCCOptions & scc_options,
         const ConstraintStateHandle & pos_var_data_handle,
@@ -1198,18 +1198,18 @@ auto CircuitSCC::install(Propagators & propagators, State & initial_state, Proof
             pos_alldiff_data_handle = pos_alldiff_data_handle,
             unassigned_handle = unassigned_handle,
             options = scc_options](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            auto reason = generic_reason(state, succ);
+            ReasonLiterals reason = eager_reason(generic_reason(state, succ), state);
 
             if (logger && options.short_reasons) {
                 auto reason_sum = WPBSum{};
-                for (const auto & lit : reason()) {
+                for (const auto & lit : reason) {
                     reason_sum += 1_i * get<ProofLiteral>(lit);
                 }
                 // We will manually delete this later.
                 auto [_reason_short, _line1, _line2] =
                     logger->create_proof_flag_reifying(reason_sum >= Integer(reason_sum.terms.size()), "sr", ProofLevel::Current);
                 ProofFlag reason_short = _reason_short;
-                reason = singleton_reason(reason_short);
+                reason = eager_reason(singleton_reason(reason_short), state);
             }
 
             propagate_circuit_using_scc(state, inference, logger, reason,

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -1202,7 +1202,7 @@ auto CircuitSCC::install(Propagators & propagators, State & initial_state, Proof
             pos_alldiff_data_handle = pos_alldiff_data_handle,
             unassigned_handle = unassigned_handle,
             options = scc_options](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            ReasonLiterals reason = eager_reason(generic_reason(state, succ), state);
+            ReasonLiterals reason = eager_reason(generic_reason(succ), state);
 
             if (logger && options.short_reasons) {
                 auto reason_sum = WPBSum{};

--- a/gcs/constraints/circuit/hints.hh
+++ b/gcs/constraints/circuit/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Circuit's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Circuit
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "circuit";
+    };
+}
+
+#endif

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -136,14 +136,14 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                 if (! holds)
                     propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
-                        inference.infer(logger, ! cond, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}; }});
+                        inference.infer(logger, ! cond, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
                     });
             },
             [&](const evaluated_reif::MustNotHold & reif) {
                 if (holds)
                     propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
-                        inference.infer(logger, ! cond, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}; }});
+                        inference.infer(logger, ! cond, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
                     });
             },
             [&](const evaluated_reif::Undecided & reif) {
@@ -153,7 +153,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                 if (lit)
                     propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, lit = *lit](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
-                        inference.infer(logger, lit, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{v1 == *v1_is_constant, v2 == *v2_is_constant}}; }});
+                        inference.infer(logger, lit, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{v1 == *v1_is_constant, v2 == *v2_is_constant}}});
                     });
             },
             [](const evaluated_reif::Deactivated &) {
@@ -166,9 +166,9 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                                                 const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
             inference.infer_less_than(logger, v1, v2_bounds.second + (or_equal ? 1_i : 0_i), JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v2 <= v2_bounds.second}}; }});
+                ExplicitReason{ReasonLiterals{{cond, v2 <= v2_bounds.second}}});
             inference.infer_greater_than_or_equal(logger, v2, v1_bounds.first + (or_equal ? 0_i : 1_i), JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v1 >= v1_bounds.first}}; }});
+                ExplicitReason{ReasonLiterals{{cond, v1 >= v1_bounds.first}}});
             return v1_bounds.second < (v2_bounds.first + (or_equal ? 1_i : 0_i))
                 ? PropagatorState::DisableUntilBacktrack
                 : PropagatorState::Enable;
@@ -179,9 +179,9 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                                                     const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
             inference.infer_less_than(logger, v2, v1_bounds.second + (! or_equal ? 1_i : 0_i), JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v1 <= v1_bounds.second}}; }});
+                ExplicitReason{ReasonLiterals{{cond, v1 <= v1_bounds.second}}});
             inference.infer_greater_than_or_equal(logger, v1, v2_bounds.first + (! or_equal ? 0_i : 1_i), JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v2 >= v2_bounds.first}}; }});
+                ExplicitReason{ReasonLiterals{{cond, v2 >= v2_bounds.first}}});
             return v2_bounds.second < (v1_bounds.first + (! or_equal ? 1_i : 0_i))
                 ? PropagatorState::DisableUntilBacktrack
                 : PropagatorState::Enable;
@@ -196,26 +196,26 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
             // shrinking to expose the contradiction.
             if (v1 == v2 && ! is_constant_variable(v1)) {
                 if (or_equal)
-                    return reification_verdict::MustHold{
+                    return reification_verdict::MustHold<Justification>{
                         .justification = JustifyUsingRUP{},
-                        .reason = ReasonFunction{}};
+                        .reason = NoReason{}};
                 else
-                    return reification_verdict::MustNotHold{
+                    return reification_verdict::MustNotHold<Justification>{
                         .justification = JustifyUsingRUP{},
-                        .reason = ReasonFunction{}};
+                        .reason = NoReason{}};
             }
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
             if (or_equal ? (v1_bounds.second <= v2_bounds.first) : (v1_bounds.second < v2_bounds.first)) {
                 // v1 has to be less than (or equal): constraint must hold.
-                return reification_verdict::MustHold{
+                return reification_verdict::MustHold<Justification>{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{{v1 <= v1_bounds.second, v2 >= v2_bounds.first}}; }}};
+                    .reason = ExplicitReason{ReasonLiterals{{v1 <= v1_bounds.second, v2 >= v2_bounds.first}}}};
             }
             else if (or_equal ? (v1_bounds.first > v2_bounds.second) : (v1_bounds.first >= v2_bounds.second)) {
                 // v1 has to be greater than (or equal): constraint cannot hold.
-                return reification_verdict::MustNotHold{
+                return reification_verdict::MustNotHold<Justification>{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{{v1 >= v1_bounds.first, v2 <= v2_bounds.second}}; }}};
+                    .reason = ExplicitReason{ReasonLiterals{{v1 >= v1_bounds.first, v2 <= v2_bounds.second}}}};
             }
             else
                 return reification_verdict::StillUndecided{};

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/comparison/comparison.hh>
+#include <gcs/constraints/comparison/hints.hh>
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/exception.hh>
@@ -134,16 +135,16 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
         overloaded{
             [&](const evaluated_reif::MustHold & reif) {
                 if (! holds)
-                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
+                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond, owner = constraint_id()](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
-                        inference.infer(logger, ! cond, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
+                        inference.infer(logger, ! cond, JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
                     });
             },
             [&](const evaluated_reif::MustNotHold & reif) {
                 if (holds)
-                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond](
+                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, cond = reif.cond, owner = constraint_id()](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
-                        inference.infer(logger, ! cond, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
+                        inference.infer(logger, ! cond, JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v1 == *v1_is_constant, v2 == *v2_is_constant}}});
                     });
             },
             [&](const evaluated_reif::Undecided & reif) {
@@ -151,9 +152,9 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
                     ? reif.cond_to_infer_if_constraint_must_hold()
                     : reif.cond_to_infer_if_constraint_must_not_hold();
                 if (lit)
-                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, lit = *lit](
+                    propagators.install_initialiser([v1 = _v1, v2 = _v2, v1_is_constant = _v1_is_constant, v2_is_constant = _v2_is_constant, lit = *lit, owner = constraint_id()](
                                                         const State &, auto & inference, ProofLogger * const logger) -> void {
-                        inference.infer(logger, lit, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{v1 == *v1_is_constant, v2 == *v2_is_constant}}});
+                        inference.infer(logger, lit, JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{v1 == *v1_is_constant, v2 == *v2_is_constant}}});
                     });
             },
             [](const evaluated_reif::Deactivated &) {
@@ -161,60 +162,60 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
             .visit(_evaluated_cond);
     }
     else {
-        auto enforce_constraint_must_hold = [v1 = _v1, v2 = _v2, or_equal = _or_equal](
+        auto enforce_constraint_must_hold = [v1 = _v1, v2 = _v2, or_equal = _or_equal, owner = constraint_id()](
                                                 const State & state, auto & inference, ProofLogger * const logger,
                                                 const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
-            inference.infer_less_than(logger, v1, v2_bounds.second + (or_equal ? 1_i : 0_i), JustifyUsingRUP{},
+            inference.infer_less_than(logger, v1, v2_bounds.second + (or_equal ? 1_i : 0_i), JustifyUsingRUP{hints::Comparison{owner}},
                 ExplicitReason{ReasonLiterals{{cond, v2 <= v2_bounds.second}}});
-            inference.infer_greater_than_or_equal(logger, v2, v1_bounds.first + (or_equal ? 0_i : 1_i), JustifyUsingRUP{},
+            inference.infer_greater_than_or_equal(logger, v2, v1_bounds.first + (or_equal ? 0_i : 1_i), JustifyUsingRUP{hints::Comparison{owner}},
                 ExplicitReason{ReasonLiterals{{cond, v1 >= v1_bounds.first}}});
             return v1_bounds.second < (v2_bounds.first + (or_equal ? 1_i : 0_i))
                 ? PropagatorState::DisableUntilBacktrack
                 : PropagatorState::Enable;
         };
 
-        auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2, or_equal = _or_equal](
+        auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2, or_equal = _or_equal, owner = constraint_id()](
                                                     const State & state, auto & inference, ProofLogger * const logger,
                                                     const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
-            inference.infer_less_than(logger, v2, v1_bounds.second + (! or_equal ? 1_i : 0_i), JustifyUsingRUP{},
+            inference.infer_less_than(logger, v2, v1_bounds.second + (! or_equal ? 1_i : 0_i), JustifyUsingRUP{hints::Comparison{owner}},
                 ExplicitReason{ReasonLiterals{{cond, v1 <= v1_bounds.second}}});
-            inference.infer_greater_than_or_equal(logger, v1, v2_bounds.first + (! or_equal ? 0_i : 1_i), JustifyUsingRUP{},
+            inference.infer_greater_than_or_equal(logger, v1, v2_bounds.first + (! or_equal ? 0_i : 1_i), JustifyUsingRUP{hints::Comparison{owner}},
                 ExplicitReason{ReasonLiterals{{cond, v2 >= v2_bounds.first}}});
             return v2_bounds.second < (v1_bounds.first + (! or_equal ? 1_i : 0_i))
                 ? PropagatorState::DisableUntilBacktrack
                 : PropagatorState::Enable;
         };
 
-        auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, or_equal = _or_equal](
+        auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, or_equal = _or_equal, owner = constraint_id()](
                                              const State & state, auto &, ProofLogger * const,
-                                             const IntegerVariableCondition &) -> ReificationVerdict {
+                                             const IntegerVariableCondition &) -> ReificationVerdictFor<JustifyUsingRUP<hints::Comparison>> {
             // Aliased non-constant operands: v1<v2 never (when strict),
             // v1≤v2 always. Returning the resolved verdict here lets the
             // dispatcher pin cond at root instead of relying on bounds
             // shrinking to expose the contradiction.
             if (v1 == v2 && ! is_constant_variable(v1)) {
                 if (or_equal)
-                    return reification_verdict::MustHold<Justification>{
-                        .justification = JustifyUsingRUP{},
+                    return reification_verdict::MustHold<JustifyUsingRUP<hints::Comparison>>{
+                        .justification = JustifyUsingRUP{hints::Comparison{owner}},
                         .reason = NoReason{}};
                 else
-                    return reification_verdict::MustNotHold<Justification>{
-                        .justification = JustifyUsingRUP{},
+                    return reification_verdict::MustNotHold<JustifyUsingRUP<hints::Comparison>>{
+                        .justification = JustifyUsingRUP{hints::Comparison{owner}},
                         .reason = NoReason{}};
             }
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
             if (or_equal ? (v1_bounds.second <= v2_bounds.first) : (v1_bounds.second < v2_bounds.first)) {
                 // v1 has to be less than (or equal): constraint must hold.
-                return reification_verdict::MustHold<Justification>{
-                    .justification = JustifyUsingRUP{},
+                return reification_verdict::MustHold<JustifyUsingRUP<hints::Comparison>>{
+                    .justification = JustifyUsingRUP{hints::Comparison{owner}},
                     .reason = ExplicitReason{ReasonLiterals{{v1 <= v1_bounds.second, v2 >= v2_bounds.first}}}};
             }
             else if (or_equal ? (v1_bounds.first > v2_bounds.second) : (v1_bounds.first >= v2_bounds.second)) {
                 // v1 has to be greater than (or equal): constraint cannot hold.
-                return reification_verdict::MustNotHold<Justification>{
-                    .justification = JustifyUsingRUP{},
+                return reification_verdict::MustNotHold<JustifyUsingRUP<hints::Comparison>>{
+                    .justification = JustifyUsingRUP{hints::Comparison{owner}},
                     .reason = ExplicitReason{ReasonLiterals{{v1 >= v1_bounds.first, v2 <= v2_bounds.second}}}};
             }
             else

--- a/gcs/constraints/comparison/hints.hh
+++ b/gcs/constraints/comparison/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_COMPARISON_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_COMPARISON_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Comparison's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Comparison
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "comparison";
+    };
+}
+
+#endif

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -135,7 +135,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
             };
             inference.infer(logger, how_many < how_many_is_less_than,
                 JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}},
-                generic_reason(state, all_vars));
+                generic_reason(all_vars));
 
             // must have at least this many occurrences of the value of interest
             int how_many_must = 0;
@@ -145,7 +145,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                     if (state.optional_single_value(v) == voi)
                         ++how_many_must;
             }
-            inference.infer(logger, how_many >= Integer(how_many_must), JustifyUsingRUP{hints::Count{owner}}, generic_reason(state, all_vars));
+            inference.infer(logger, how_many >= Integer(how_many_must), JustifyUsingRUP{hints::Count{owner}}, generic_reason(all_vars));
 
             // is each value of interest supported? also track how_many bounds supports
             // whilst we're here
@@ -175,12 +175,12 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             }
                         }
                     };
-                    inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, generic_reason(state, all_vars));
+                    inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, generic_reason(all_vars));
                 }
                 else if (how_many_must > state.upper_bound(how_many)) {
                     // unlike above, we don't need to help, because the equality flag will propagate
                     // from the fixed assignment
-                    inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{hints::Count{owner}}, generic_reason(state, all_vars));
+                    inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{hints::Count{owner}}, generic_reason(all_vars));
                 }
                 else {
                     if ((! lowest_how_many_must) || (how_many_must < *lowest_how_many_must))
@@ -192,48 +192,48 @@ auto Count::install_propagators(Propagators & propagators) -> void
 
             // what are the supports on possible values we've seen?
             if (lowest_how_many_must) {
-                auto just = JustifyExplicitly{[&](const ReasonLiterals & reason) -> void {
-                                                  for (const auto & voi : state.each_value_immutable(value_of_interest))
-                                                      logger->emit_rup_proof_line_under_reason(reason,
-                                                          WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i,
-                                                          ProofLevel::Temporary);
-                                              },
-                    ThenRUP::Yes, hints::Count{owner}};
-                inference.infer(logger, how_many >= *lowest_how_many_must, just, generic_reason(state, all_vars));
+                auto emit = [&](const ReasonLiterals & reason) -> void {
+                    for (const auto & voi : state.each_value_immutable(value_of_interest))
+                        logger->emit_rup_proof_line_under_reason(reason,
+                            WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i,
+                            ProofLevel::Temporary);
+                };
+                auto just = JustifyExplicitly{emit, ThenRUP::Yes, hints::Count{owner}};
+                inference.infer(logger, how_many >= *lowest_how_many_must, just, generic_reason(all_vars));
             }
 
             if (highest_how_many_might) {
-                auto just = JustifyExplicitly{[&](const ReasonLiterals & reason) -> void {
-                                                  // Per-(voi, var) conditional pairs: emit when voi is
-                                                  // in value_of_interest's domain but not var's. Outer
-                                                  // loop is over var so we can call each_interval_minus
-                                                  // once per var; the (A, B) pair for one (voi, var) is
-                                                  // order-sensitive but the (voi, var) iterations
-                                                  // themselves are not.
-                                                  auto voi_set = state.copy_of_values(value_of_interest);
-                                                  for (const auto & [idx, var] : enumerate(vars)) {
-                                                      auto var_set = state.copy_of_values(var);
-                                                      for (auto [lo, hi] : voi_set.each_interval_minus(var_set))
-                                                          for (Integer voi = lo; voi <= hi; ++voi) {
-                                                              logger->emit_rup_proof_line_under_reason(reason,
-                                                                  WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (! get<0>(flags[idx])) >= 1_i,
-                                                                  ProofLevel::Temporary);
-                                                              logger->emit_rup_proof_line_under_reason(reason,
-                                                                  WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (var != voi) >= 1_i,
-                                                                  ProofLevel::Temporary);
-                                                          }
-                                                  }
+                auto emit = [&](const ReasonLiterals & reason) -> void {
+                    // Per-(voi, var) conditional pairs: emit when voi is
+                    // in value_of_interest's domain but not var's. Outer
+                    // loop is over var so we can call each_interval_minus
+                    // once per var; the (A, B) pair for one (voi, var) is
+                    // order-sensitive but the (voi, var) iterations
+                    // themselves are not.
+                    auto voi_set = state.copy_of_values(value_of_interest);
+                    for (const auto & [idx, var] : enumerate(vars)) {
+                        auto var_set = state.copy_of_values(var);
+                        for (auto [lo, hi] : voi_set.each_interval_minus(var_set))
+                            for (Integer voi = lo; voi <= hi; ++voi) {
+                                logger->emit_rup_proof_line_under_reason(reason,
+                                    WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (! get<0>(flags[idx])) >= 1_i,
+                                    ProofLevel::Temporary);
+                                logger->emit_rup_proof_line_under_reason(reason,
+                                    WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (var != voi) >= 1_i,
+                                    ProofLevel::Temporary);
+                            }
+                    }
 
-                                                  // Per-voi unconditional lines: emit after all the
-                                                  // conditionals so they have the full set of pairwise
-                                                  // facts to RUP-derive against.
-                                                  for (const auto & voi : voi_set.each())
-                                                      logger->emit_rup_proof_line_under_reason(reason,
-                                                          WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many < *highest_how_many_might + 1_i) >= 1_i,
-                                                          ProofLevel::Temporary);
-                                              },
-                    ThenRUP::Yes, hints::Count{owner}};
-                inference.infer(logger, how_many < *highest_how_many_might + 1_i, just, generic_reason(state, all_vars));
+                    // Per-voi unconditional lines: emit after all the
+                    // conditionals so they have the full set of pairwise
+                    // facts to RUP-derive against.
+                    for (const auto & voi : voi_set.each())
+                        logger->emit_rup_proof_line_under_reason(reason,
+                            WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many < *highest_how_many_might + 1_i) >= 1_i,
+                            ProofLevel::Temporary);
+                };
+                auto just = JustifyExplicitly{emit, ThenRUP::Yes, hints::Count{owner}};
+                inference.infer(logger, how_many < *highest_how_many_might + 1_i, just, generic_reason(all_vars));
             }
 
             return PropagatorState::Enable;

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -121,7 +121,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
 
             // can't have more that this many occurrences of the value of interest
             auto how_many_is_less_than = Integer(vars.size() - how_many_definitely_do_not) + 1_i;
-            auto justf = [&](const ReasonFunction & reason) -> void {
+            auto justf = [&](const ReasonLiterals & reason) -> void {
                 for (const auto & [idx, var] : enumerate(vars)) {
                     if (! state.domains_intersect(var, value_of_interest)) {
                         for (const auto & val : state.each_value_immutable(value_of_interest))
@@ -133,7 +133,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                 }
             };
             inference.infer(logger, how_many < how_many_is_less_than,
-                JustifyExplicitlyThenRUP{justf},
+                JustifyExplicitly{justf, ThenRUP::Yes},
                 generic_reason(state, all_vars));
 
             // must have at least this many occurrences of the value of interest
@@ -163,7 +163,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                 }
 
                 if (how_many_might < state.lower_bound(how_many)) {
-                    auto justf = [&](const ReasonFunction & reason) -> void {
+                    auto justf = [&](const ReasonLiterals & reason) -> void {
                         for (const auto & [idx, var] : enumerate(vars)) {
                             if (! state.in_domain(var, voi)) {
                                 // need to help the checker see that the equality flag must be zero
@@ -174,7 +174,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             }
                         }
                     };
-                    inference.infer(logger, value_of_interest != voi, JustifyExplicitlyThenRUP{justf}, generic_reason(state, all_vars));
+                    inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes}, generic_reason(state, all_vars));
                 }
                 else if (how_many_must > state.upper_bound(how_many)) {
                     // unlike above, we don't need to help, because the equality flag will propagate
@@ -191,47 +191,47 @@ auto Count::install_propagators(Propagators & propagators) -> void
 
             // what are the supports on possible values we've seen?
             if (lowest_how_many_must) {
-                auto just = JustifyExplicitlyThenRUP{
-                    [&](const ReasonFunction & reason) -> void {
-                        for (const auto & voi : state.each_value_immutable(value_of_interest))
-                            logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i,
-                                ProofLevel::Temporary);
-                    }};
+                auto just = JustifyExplicitly{[&](const ReasonLiterals & reason) -> void {
+                                                  for (const auto & voi : state.each_value_immutable(value_of_interest))
+                                                      logger->emit_rup_proof_line_under_reason(reason,
+                                                          WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i,
+                                                          ProofLevel::Temporary);
+                                              },
+                    ThenRUP::Yes};
                 inference.infer(logger, how_many >= *lowest_how_many_must, just, generic_reason(state, all_vars));
             }
 
             if (highest_how_many_might) {
-                auto just = JustifyExplicitlyThenRUP{
-                    [&](const ReasonFunction & reason) -> void {
-                        // Per-(voi, var) conditional pairs: emit when voi is
-                        // in value_of_interest's domain but not var's. Outer
-                        // loop is over var so we can call each_interval_minus
-                        // once per var; the (A, B) pair for one (voi, var) is
-                        // order-sensitive but the (voi, var) iterations
-                        // themselves are not.
-                        auto voi_set = state.copy_of_values(value_of_interest);
-                        for (const auto & [idx, var] : enumerate(vars)) {
-                            auto var_set = state.copy_of_values(var);
-                            for (auto [lo, hi] : voi_set.each_interval_minus(var_set))
-                                for (Integer voi = lo; voi <= hi; ++voi) {
-                                    logger->emit_rup_proof_line_under_reason(reason,
-                                        WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (! get<0>(flags[idx])) >= 1_i,
-                                        ProofLevel::Temporary);
-                                    logger->emit_rup_proof_line_under_reason(reason,
-                                        WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (var != voi) >= 1_i,
-                                        ProofLevel::Temporary);
-                                }
-                        }
+                auto just = JustifyExplicitly{[&](const ReasonLiterals & reason) -> void {
+                                                  // Per-(voi, var) conditional pairs: emit when voi is
+                                                  // in value_of_interest's domain but not var's. Outer
+                                                  // loop is over var so we can call each_interval_minus
+                                                  // once per var; the (A, B) pair for one (voi, var) is
+                                                  // order-sensitive but the (voi, var) iterations
+                                                  // themselves are not.
+                                                  auto voi_set = state.copy_of_values(value_of_interest);
+                                                  for (const auto & [idx, var] : enumerate(vars)) {
+                                                      auto var_set = state.copy_of_values(var);
+                                                      for (auto [lo, hi] : voi_set.each_interval_minus(var_set))
+                                                          for (Integer voi = lo; voi <= hi; ++voi) {
+                                                              logger->emit_rup_proof_line_under_reason(reason,
+                                                                  WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (! get<0>(flags[idx])) >= 1_i,
+                                                                  ProofLevel::Temporary);
+                                                              logger->emit_rup_proof_line_under_reason(reason,
+                                                                  WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (var != voi) >= 1_i,
+                                                                  ProofLevel::Temporary);
+                                                          }
+                                                  }
 
-                        // Per-voi unconditional lines: emit after all the
-                        // conditionals so they have the full set of pairwise
-                        // facts to RUP-derive against.
-                        for (const auto & voi : voi_set.each())
-                            logger->emit_rup_proof_line_under_reason(reason,
-                                WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many < *highest_how_many_might + 1_i) >= 1_i,
-                                ProofLevel::Temporary);
-                    }};
+                                                  // Per-voi unconditional lines: emit after all the
+                                                  // conditionals so they have the full set of pairwise
+                                                  // facts to RUP-derive against.
+                                                  for (const auto & voi : voi_set.each())
+                                                      logger->emit_rup_proof_line_under_reason(reason,
+                                                          WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many < *highest_how_many_might + 1_i) >= 1_i,
+                                                          ProofLevel::Temporary);
+                                              },
+                    ThenRUP::Yes};
                 inference.infer(logger, how_many < *highest_how_many_might + 1_i, just, generic_reason(state, all_vars));
             }
 

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/count/count.hh>
+#include <gcs/constraints/count/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -106,7 +107,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [vars = _vars, value_of_interest = _value_of_interest, how_many = _how_many, flags = _flags, all_vars = move(all_vars)](
+        [vars = _vars, value_of_interest = _value_of_interest, how_many = _how_many, flags = _flags, all_vars = move(all_vars), owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // check support for how many by seeing how many array values
             // intersect with a potential value of interest
@@ -133,7 +134,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                 }
             };
             inference.infer(logger, how_many < how_many_is_less_than,
-                JustifyExplicitly{justf, ThenRUP::Yes},
+                JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}},
                 generic_reason(state, all_vars));
 
             // must have at least this many occurrences of the value of interest
@@ -144,7 +145,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                     if (state.optional_single_value(v) == voi)
                         ++how_many_must;
             }
-            inference.infer(logger, how_many >= Integer(how_many_must), JustifyUsingRUP{}, generic_reason(state, all_vars));
+            inference.infer(logger, how_many >= Integer(how_many_must), JustifyUsingRUP{hints::Count{owner}}, generic_reason(state, all_vars));
 
             // is each value of interest supported? also track how_many bounds supports
             // whilst we're here
@@ -174,12 +175,12 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             }
                         }
                     };
-                    inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes}, generic_reason(state, all_vars));
+                    inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, generic_reason(state, all_vars));
                 }
                 else if (how_many_must > state.upper_bound(how_many)) {
                     // unlike above, we don't need to help, because the equality flag will propagate
                     // from the fixed assignment
-                    inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                    inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{hints::Count{owner}}, generic_reason(state, all_vars));
                 }
                 else {
                     if ((! lowest_how_many_must) || (how_many_must < *lowest_how_many_must))
@@ -197,7 +198,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                                                           WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i,
                                                           ProofLevel::Temporary);
                                               },
-                    ThenRUP::Yes};
+                    ThenRUP::Yes, hints::Count{owner}};
                 inference.infer(logger, how_many >= *lowest_how_many_must, just, generic_reason(state, all_vars));
             }
 
@@ -231,7 +232,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                                                           WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many < *highest_how_many_might + 1_i) >= 1_i,
                                                           ProofLevel::Temporary);
                                               },
-                    ThenRUP::Yes};
+                    ThenRUP::Yes, hints::Count{owner}};
                 inference.infer(logger, how_many < *highest_how_many_might + 1_i, just, generic_reason(state, all_vars));
             }
 

--- a/gcs/constraints/count/hints.hh
+++ b/gcs/constraints/count/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_COUNT_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_COUNT_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Count's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Count
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "count";
+    };
+}
+
+#endif

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -481,7 +481,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                     };
 
                     inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}},
-                        generic_reason(state, reason_vars));
+                        generic_reason(reason_vars));
                     return PropagatorState::DisableUntilBacktrack;
                 }
 
@@ -602,7 +602,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
 
                     inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
                         JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}},
-                        generic_reason(state, reason_vars));
+                        generic_reason(reason_vars));
                 }
 
                 // ub-push: mirror image. Pick SMALLEST blocked t in each
@@ -636,7 +636,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
 
                     inference.infer_less_than(logger, starts[j], new_ub + 1_i,
                         JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}},
-                        generic_reason(state, reason_vars));
+                        generic_reason(reason_vars));
                 }
             }
 

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -372,7 +372,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
             // variable height it is "contrib >= lb(h_i)" with coefficient 1
             // (contrib is the proof-only product h_i·active in C_t). The
             // before/after RUPs give VeriPB the units to chase active's AND-gate.
-            auto pin_contributor = [&](const ReasonFunction & reason, size_t i, Integer t)
+            auto pin_contributor = [&](const ReasonLiterals & reason, size_t i, Integer t)
                 -> std::pair<ProofLine, Integer> {
                 auto fi = (t - per_task_t_lo[i]).raw_value;
                 logger->emit_rup_proof_line_under_reason(reason,
@@ -396,7 +396,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
             // variable height it deposits contrib_j + lb(h_j)·ext_lit ≥ lb(h_j)
             // (vacuous when ext_lit holds, "contrib_j ≥ lb(h_j)" otherwise) and
             // returns that line with coefficient 1.
-            auto pin_pushed = [&](const ReasonFunction & reason, size_t j_idx, Integer t,
+            auto pin_pushed = [&](const ReasonLiterals & reason, size_t j_idx, Integer t,
                                   IntegerVariableCondition ext_lit, Integer s_lo_after) -> std::pair<ProofLine, Integer> {
                 auto fj = (t - per_task_t_lo[j_idx]).raw_value;
                 logger->emit_rup_proof_line_under_reason(reason,
@@ -463,7 +463,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                             contributing.push_back(i);
                     }
 
-                    auto justify = [&, violating_t, contributing](const ReasonFunction & reason) -> void {
+                    auto justify = [&, violating_t, contributing](const ReasonLiterals & reason) -> void {
                         if (! logger) return;
                         // Pin every contributing task's guaranteed load at
                         // violating_t, then combine those lines with C_t in a
@@ -479,7 +479,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                         pol.emit(*logger, ProofLevel::Temporary);
                     };
 
-                    inference.contradiction(logger, JustifyExplicitlyThenRUP{justify},
+                    inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes},
                         generic_reason(state, reason_vars));
                     return PropagatorState::DisableUntilBacktrack;
                 }
@@ -511,7 +511,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                                        const vector<size_t> & contributing,
                                        IntegerVariableCondition ext_lit, Integer s_lo_after,
                                        bool emit_intermediate,
-                                       const ReasonFunction & reason) -> void {
+                                       const ReasonLiterals & reason) -> void {
                 // (a) Pin each task i ≠ j mandatory at t under the reason, and
                 // (b) pin the pushed task j under the EXTENDED reason. Then
                 // (c) combine all pinned load lines with C_t in one pol. After
@@ -591,7 +591,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                         if (! found) break;
                     }
 
-                    auto justify = [&, j, chain](const ReasonFunction & reason) -> void {
+                    auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
                         if (! logger) return;
                         for (size_t step = 0; step < chain.size(); ++step)
                             emit_chain_step(j, chain[step].t, chain[step].contributing,
@@ -600,7 +600,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                     };
 
                     inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
-                        JustifyExplicitlyThenRUP{justify},
+                        JustifyExplicitly{justify, ThenRUP::Yes},
                         generic_reason(state, reason_vars));
                 }
 
@@ -625,7 +625,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                         if (! found) break;
                     }
 
-                    auto justify = [&, j, chain](const ReasonFunction & reason) -> void {
+                    auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
                         if (! logger) return;
                         for (size_t step = 0; step < chain.size(); ++step)
                             emit_chain_step(j, chain[step].t, chain[step].contributing,
@@ -634,7 +634,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                     };
 
                     inference.infer_less_than(logger, starts[j], new_ub + 1_i,
-                        JustifyExplicitlyThenRUP{justify},
+                        JustifyExplicitly{justify, ThenRUP::Yes},
                         generic_reason(state, reason_vars));
                 }
             }

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/constraints/cumulative/hints.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -311,7 +312,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
             before_flags = move(_before_flags), after_flags = move(_after_flags),
             active_flags = move(_active_flags), contrib_vars = move(_contrib_vars),
             end_def_lines = move(_end_def_lines), capacity_lines = move(_capacity_lines),
-            per_task_t_lo = move(_per_task_t_lo)](
+            per_task_t_lo = move(_per_task_t_lo), owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // The capacity may be a variable: the load profile is infeasible
             // only when it exceeds the *largest* still-allowed capacity, so the
@@ -479,7 +480,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                         pol.emit(*logger, ProofLevel::Temporary);
                     };
 
-                    inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes},
+                    inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}},
                         generic_reason(state, reason_vars));
                     return PropagatorState::DisableUntilBacktrack;
                 }
@@ -600,7 +601,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                     };
 
                     inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
-                        JustifyExplicitly{justify, ThenRUP::Yes},
+                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}},
                         generic_reason(state, reason_vars));
                 }
 
@@ -634,7 +635,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                     };
 
                     inference.infer_less_than(logger, starts[j], new_ub + 1_i,
-                        JustifyExplicitly{justify, ThenRUP::Yes},
+                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}},
                         generic_reason(state, reason_vars));
                 }
             }

--- a/gcs/constraints/cumulative/hints.hh
+++ b/gcs/constraints/cumulative/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Cumulative's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Cumulative
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "cumulative";
+    };
+}
+
+#endif

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -552,7 +552,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             reason_vars.push_back(length_vars[pj]);
                         inference.contradiction(logger,
                             JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}},
-                            generic_reason(state, reason_vars));
+                            generic_reason(reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
 
@@ -759,7 +759,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 
                         inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
                             JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}},
-                            generic_reason(state, push_reason_vars));
+                            generic_reason(push_reason_vars));
                     }
 
                     // ub-push: mirror of lb-push, scanning downward. At each
@@ -801,7 +801,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
 
                         inference.infer_less_than(logger, starts[j], new_ub + 1_i,
                             JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}},
-                            generic_reason(state, push_reason_vars));
+                            generic_reason(push_reason_vars));
                     }
                 }
             }
@@ -841,7 +841,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         if (is_var_len(k))
                             reason_vars.push_back(length_vars[k]);
                         inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive{owner}},
-                            generic_reason(state, reason_vars));
+                            generic_reason(reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <gcs/proof.hh>
 #include <map>
 #include <memory>
 #include <optional>
@@ -748,7 +749,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         }
 
                         auto justify = [&, j, chain](const ReasonFunction & reason) -> void {
-                            if (! logger)
+                            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                                 return;
                             for (size_t step = 0; step < chain.size(); ++step)
                                 emit_chain_step(j, chain[step].t, chain[step].k,

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <gcs/proof.hh>
 #include <map>
 #include <memory>
 #include <optional>
@@ -294,7 +293,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         [starts = _starts, lengths = _length_vals, length_ub = _length_ub, ends = _end,
             active_tasks = _active_tasks, per_task_t_lo = _per_task_t_lo,
             per_task_t_hi = _per_task_t_hi, bridge](State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger)
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                 return;
             for (auto i : active_tasks) {
                 if (length_ub[i] == 0_i)
@@ -371,7 +370,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
             // flags false (RUP under reason) and add them to a clause pol so the
             // separation clause reduces to its before-flag disjunction. No-op in
             // strict mode / for always-positive durations.
-            auto add_escape_pins = [&](PolBuilder & pol, const ReasonFunction & reason, size_t i, size_t j) {
+            auto add_escape_pins = [&](PolBuilder & pol, const ReasonLiterals & reason, size_t i, size_t j) {
                 for (auto r : {i, j})
                     if (zero[r])
                         pol.add(logger->emit_rup_proof_line_under_reason(reason,
@@ -451,7 +450,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             throw UnexpectedException{
                                 "Disjunctive: mand_load > 1 without two contributing tasks"};
 
-                        auto justify = [&, violating_t, pi, pj](const ReasonFunction & reason) -> void {
+                        auto justify = [&, violating_t, pi, pj](const ReasonLiterals & reason) -> void {
                             auto & bf_i = bridge->at(make_pair(pi, violating_t));
                             auto & bf_j = bridge->at(make_pair(pj, violating_t));
 
@@ -551,7 +550,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         if (is_var_len(pj))
                             reason_vars.push_back(length_vars[pj]);
                         inference.contradiction(logger,
-                            JustifyExplicitlyThenRUP{justify},
+                            JustifyExplicitly{justify, ThenRUP::Yes},
                             generic_reason(state, reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
@@ -586,7 +585,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                 // reason for the next step's preconditions to close.
                 auto emit_chain_step = [&](size_t j, Integer t, size_t k,
                                            IntegerVariableCondition ext_lit, Integer s_lo_after,
-                                           bool emit_intermediate, const ReasonFunction & reason) -> void {
+                                           bool emit_intermediate, const ReasonLiterals & reason) -> void {
                     auto & bf_k = bridge->at(make_pair(k, t));
                     auto & bf_j = bridge->at(make_pair(j, t));
 
@@ -748,7 +747,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 break;
                         }
 
-                        auto justify = [&, j, chain](const ReasonFunction & reason) -> void {
+                        auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
                             if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                                 return;
                             for (size_t step = 0; step < chain.size(); ++step)
@@ -758,7 +757,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         };
 
                         inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
-                            JustifyExplicitlyThenRUP{justify},
+                            JustifyExplicitly{justify, ThenRUP::Yes},
                             generic_reason(state, push_reason_vars));
                     }
 
@@ -789,8 +788,8 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                                 break;
                         }
 
-                        auto justify = [&, j, chain](const ReasonFunction & reason) -> void {
-                            if (! logger)
+                        auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
+                            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                                 return;
                             // ext_lit (s_j <= t - l_j) == (s_j < s_lo_after).
                             for (size_t step = 0; step < chain.size(); ++step)
@@ -800,7 +799,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         };
 
                         inference.infer_less_than(logger, starts[j], new_ub + 1_i,
-                            JustifyExplicitlyThenRUP{justify},
+                            JustifyExplicitly{justify, ThenRUP::Yes},
                             generic_reason(state, push_reason_vars));
                     }
                 }

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/disjunctive/disjunctive.hh>
+#include <gcs/constraints/disjunctive/hints.hh>
 #include <gcs/constraints/innards/recover_am1.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -333,7 +334,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
         [starts = move(_starts), lengths = move(_length_vals), length_vars = move(_lengths),
             end_ge = move(_end_ge), end_le = move(_end_le), zero = move(_zero), strict = _strict,
             active_tasks = move(_active_tasks), before_flags = move(_before_flags),
-            clause_lines = move(_clause_lines), bridge](
+            clause_lines = move(_clause_lines), owner = constraint_id(), bridge](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Current guaranteed (min) and possible (max) duration of task i:
             // for a constant duration both are the value; for a variable
@@ -550,7 +551,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         if (is_var_len(pj))
                             reason_vars.push_back(length_vars[pj]);
                         inference.contradiction(logger,
-                            JustifyExplicitly{justify, ThenRUP::Yes},
+                            JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}},
                             generic_reason(state, reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
@@ -757,7 +758,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         };
 
                         inference.infer_greater_than_or_equal(logger, starts[j], new_lb,
-                            JustifyExplicitly{justify, ThenRUP::Yes},
+                            JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}},
                             generic_reason(state, push_reason_vars));
                     }
 
@@ -799,7 +800,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                         };
 
                         inference.infer_less_than(logger, starts[j], new_ub + 1_i,
-                            JustifyExplicitly{justify, ThenRUP::Yes},
+                            JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive{owner}},
                             generic_reason(state, push_reason_vars));
                     }
                 }
@@ -839,7 +840,7 @@ auto Disjunctive::install_propagators(Propagators & propagators) -> void
                             reason_vars.push_back(length_vars[z]);
                         if (is_var_len(k))
                             reason_vars.push_back(length_vars[k]);
-                        inference.contradiction(logger, JustifyUsingRUP{},
+                        inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive{owner}},
                             generic_reason(state, reason_vars));
                         return PropagatorState::DisableUntilBacktrack;
                     }

--- a/gcs/constraints/disjunctive/hints.hh
+++ b/gcs/constraints/disjunctive/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DISJUNCTIVE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DISJUNCTIVE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Disjunctive's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Disjunctive
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "disjunctive";
+    };
+}
+
+#endif

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <gcs/proof.hh>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -326,7 +327,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
             end_y = _end_y, active_rects = _active_rects, x_lo = _x_lo, x_hi = _x_hi, y_lo = _y_lo,
             y_hi = _y_hi, bridge_x, bridge_y](
             State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger)
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                 return;
             // "after" reifies on pos + size >= t+1; for a constant size that is
             // the single-variable pos >= t-size+1, for a variable size the
@@ -696,7 +697,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             break;
                     }
                     auto justify = [&, chain](const ReasonFunction & reason) -> void {
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             emit_proof(chain, +1, reason);
                     };
                     inference.infer_greater_than_or_equal(logger, free_pos[i], target,
@@ -721,7 +722,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             break;
                     }
                     auto justify = [&, chain](const ReasonFunction & reason) -> void {
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             emit_proof(chain, -1, reason);
                     };
                     inference.infer_less_than(logger, free_pos[i], target + 1_i,

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -520,7 +520,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             if (h_is_var(r)) rvars.push_back(height_var[r]);
                         }
                         inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}},
-                            generic_reason(state, rvars));
+                            generic_reason(rvars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }
@@ -701,7 +701,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             emit_proof(chain, +1, reason);
                     };
                     inference.infer_greater_than_or_equal(logger, free_pos[i], target,
-                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}}, generic_reason(state, rv));
+                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}}, generic_reason(rv));
                 }
                 // ub-push: i cannot fit above the blocker, push its origin down to
                 // blk_lo - sz -- capped at cur_lo - 1 by the same reasoning.
@@ -726,7 +726,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             emit_proof(chain, -1, reason);
                     };
                     inference.infer_less_than(logger, free_pos[i], target + 1_i,
-                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}}, generic_reason(state, rv));
+                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}}, generic_reason(rv));
                 }
             };
 
@@ -784,7 +784,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             if (w_is_var(r)) lr.push_back(width_var[r]);
                             if (h_is_var(r)) lr.push_back(height_var[r]);
                         }
-                        inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive2D{owner}}, generic_reason(state, lr));
+                        inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive2D{owner}}, generic_reason(lr));
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <gcs/proof.hh>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -394,7 +393,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
             // relevant sizes are >= 1, so pin those flags false (RUP) and add the
             // lines to the clause pol so it reduces to the before-flag
             // disjunction. No-op in strict mode / for always-positive sizes.
-            auto add_escape_pins = [&](PolBuilder & pol, const ReasonFunction & reason, size_t i, size_t j) {
+            auto add_escape_pins = [&](PolBuilder & pol, const ReasonLiterals & reason, size_t i, size_t j) {
                 for (auto r : {i, j}) {
                     if (zero_w[r])
                         pol.add(logger->emit_rup_proof_line_under_reason(reason,
@@ -428,7 +427,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                         auto p = max(lst_xi, lst_xj);
                         auto q = max(lst_yi, lst_yj);
 
-                        auto justify = [&, i, j, p, q](const ReasonFunction & reason) -> void {
+                        auto justify = [&, i, j, p, q](const ReasonLiterals & reason) -> void {
                             // Pin "rect r spans coord on this axis" = 1 under the
                             // bounds reason: before, then after, then active (UP
                             // can't chase active's AND-gate in one step). For a
@@ -519,7 +518,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             if (w_is_var(r)) rvars.push_back(width_var[r]);
                             if (h_is_var(r)) rvars.push_back(height_var[r]);
                         }
-                        inference.contradiction(logger, JustifyExplicitlyThenRUP{justify},
+                        inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes},
                             generic_reason(state, rvars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
@@ -587,7 +586,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                 // elimination), then one chain step per blocked free-cell. dir
                 // = +1 for an lb-push (ext_lit: pos > t), -1 for a ub-push.
                 auto emit_proof = [&, i, j, forced_col, sz](const vector<ChainStep> & chain, int dir,
-                                      const ReasonFunction & reason) {
+                                      const ReasonLiterals & reason) {
                     // Materialise end >= pos_lb + lb(size) (for a variable size).
                     auto materialise_end = [&](const optional<ProofOnlySimpleIntegerVariableID> & end_opt,
                                                const optional<ProofLine> & end_ge, IntegerVariableID pos,
@@ -696,12 +695,12 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                         if (! found)
                             break;
                     }
-                    auto justify = [&, chain](const ReasonFunction & reason) -> void {
+                    auto justify = [&, chain](const ReasonLiterals & reason) -> void {
                         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             emit_proof(chain, +1, reason);
                     };
                     inference.infer_greater_than_or_equal(logger, free_pos[i], target,
-                        JustifyExplicitlyThenRUP{justify}, generic_reason(state, rv));
+                        JustifyExplicitly{justify, ThenRUP::Yes}, generic_reason(state, rv));
                 }
                 // ub-push: i cannot fit above the blocker, push its origin down to
                 // blk_lo - sz -- capped at cur_lo - 1 by the same reasoning.
@@ -721,12 +720,12 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                         if (! found)
                             break;
                     }
-                    auto justify = [&, chain](const ReasonFunction & reason) -> void {
+                    auto justify = [&, chain](const ReasonLiterals & reason) -> void {
                         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             emit_proof(chain, -1, reason);
                     };
                     inference.infer_less_than(logger, free_pos[i], target + 1_i,
-                        JustifyExplicitlyThenRUP{justify}, generic_reason(state, rv));
+                        JustifyExplicitly{justify, ThenRUP::Yes}, generic_reason(state, rv));
                 }
             };
 

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/disjunctive_2d/disjunctive_2d.hh>
+#include <gcs/constraints/disjunctive_2d/hints.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -376,7 +377,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
             clause_lines = move(_clause_lines), end_x = move(_end_x), end_y = move(_end_y),
             end_x_ge = move(_end_x_ge), end_x_le = move(_end_x_le), end_y_ge = move(_end_y_ge),
             end_y_le = move(_end_y_le), zero_w = move(_zero_w), zero_h = move(_zero_h),
-            strict = _strict, bridge_x, bridge_y](
+            strict = _strict, owner = constraint_id(), bridge_x, bridge_y](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Pairwise 2D time-table. The mandatory box of rectangle i is
             //   [ub(x_i), lb(x_i)+lb(w_i)) x [ub(y_i), lb(y_i)+lb(h_i))
@@ -518,7 +519,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             if (w_is_var(r)) rvars.push_back(width_var[r]);
                             if (h_is_var(r)) rvars.push_back(height_var[r]);
                         }
-                        inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes},
+                        inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}},
                             generic_reason(state, rvars));
                         return PropagatorState::DisableUntilBacktrack;
                     }
@@ -700,7 +701,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             emit_proof(chain, +1, reason);
                     };
                     inference.infer_greater_than_or_equal(logger, free_pos[i], target,
-                        JustifyExplicitly{justify, ThenRUP::Yes}, generic_reason(state, rv));
+                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}}, generic_reason(state, rv));
                 }
                 // ub-push: i cannot fit above the blocker, push its origin down to
                 // blk_lo - sz -- capped at cur_lo - 1 by the same reasoning.
@@ -725,7 +726,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             emit_proof(chain, -1, reason);
                     };
                     inference.infer_less_than(logger, free_pos[i], target + 1_i,
-                        JustifyExplicitly{justify, ThenRUP::Yes}, generic_reason(state, rv));
+                        JustifyExplicitly{justify, ThenRUP::Yes, hints::Disjunctive2D{owner}}, generic_reason(state, rv));
                 }
             };
 
@@ -783,7 +784,7 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
                             if (w_is_var(r)) lr.push_back(width_var[r]);
                             if (h_is_var(r)) lr.push_back(height_var[r]);
                         }
-                        inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, lr));
+                        inference.contradiction(logger, JustifyUsingRUP{hints::Disjunctive2D{owner}}, generic_reason(state, lr));
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }

--- a/gcs/constraints/disjunctive_2d/hints.hh
+++ b/gcs/constraints/disjunctive_2d/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DISJUNCTIVE_2D_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DISJUNCTIVE_2D_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Disjunctive2D's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Disjunctive2D
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "disjunctive_2d";
+    };
+}
+
+#endif

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/element/element.hh>
+#include <gcs/constraints/element/hints.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -230,7 +231,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 {
     if (_has_empty_dim) {
         propagators.install_initial_contradiction("NDimensionalElement constraint with no values",
-            JustifyUsingRUP{});
+            JustifyUsingRUP{hints::Element{constraint_id()}});
         return;
     }
 
@@ -275,7 +276,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             if (idx != fixed_dim)
                 index_triggers.on_change.emplace_back(var);
 
-        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim, array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim, array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // for each index variable, update it to only contain values where
             // there's at least one supporting option. result_var's domain is
             // not modified by anything inside the loop body (the only infer_*
@@ -373,7 +374,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         };
 
                         show_no_support(0);
-                    }, ThenRUP::Yes},
+                    }, ThenRUP::Yes, hints::Element{owner}},
                         generic_reason(state, explored_vars));
                 }
             }
@@ -388,7 +389,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
         result_triggers.on_bounds.emplace_back(_result_var);
 
-        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // bounds only, so the result variable has to be in the range
             // (rather than the union) of possible values
             vector<size_t> elem;
@@ -451,7 +452,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         }
                     };
                     rule_out(0);
-                }, ThenRUP::Yes},
+                }, ThenRUP::Yes, hints::Element{owner}},
                     ExplicitReason{reason});
             };
 
@@ -469,7 +470,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             result_triggers.on_change.insert(result_triggers.on_change.end(), all_array_vars.begin(), all_array_vars.end());
         result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
 
-        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, array_has_nonconstants = array_has_nonconstants, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // the result variable has to be in the union of possible values
             vector<size_t> elem;
             IntervalSet<Integer> still_to_find_support_for = state.copy_of_values(result_var);
@@ -522,7 +523,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         }
                     };
                     rule_out(0);
-                }, ThenRUP::Yes},
+                }, ThenRUP::Yes, hints::Element{owner}},
                     ExplicitReason{reason});
             }
 

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -375,7 +375,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
                         show_no_support(0);
                     }, ThenRUP::Yes, hints::Element{owner}},
-                        generic_reason(state, explored_vars));
+                        generic_reason(explored_vars));
                 }
             }
 
@@ -423,7 +423,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             auto infer_bound = [&](Integer relevant_bound, bool ge) {
                 auto lit_to_infer = ge ? (result_var >= relevant_bound) : (result_var <= relevant_bound);
                 ReasonLiterals reason;
-                auto idx_reason = materialise(generic_reason(state, index_vars), state);
+                auto idx_reason = materialise(generic_reason(index_vars), state);
                 reason.insert(reason.end(), idx_reason.begin(), idx_reason.end());
                 for (const auto & var : considered_vars)
                     reason.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
@@ -497,7 +497,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             collect_supported_values(0);
 
             for (auto value : still_to_find_support_for.each()) {
-                ReasonLiterals reason = materialise(generic_reason(state, index_vars), state);
+                ReasonLiterals reason = materialise(generic_reason(index_vars), state);
                 for (const auto & var : considered_vars)
                     reason.push_back(var != value);
                 inference.infer_not_equal(logger, result_var, value, JustifyExplicitly{[&](const ReasonLiterals & reason) {

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -215,6 +215,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
     build_implication_constraints(0);
 }
 
+// GCC's -O3 scalar-replacement of aggregates picks apart the small-buffer storage
+// of ReasonLiterals (gch::small_vector<ProofLiteralOrFlag, 2>) used for the reason
+// literals below, then cannot prove one of the resulting temporaries initialised,
+// emitting a -Wmaybe-uninitialized false positive (attributed to the first
+// install() lambda). The reason locals are all default-constructed before use --
+// there is no real uninitialised read -- and clang's analysis does not warn.
+#if defined(__GNUC__) && ! defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagators & propagators) -> void
 {
@@ -319,7 +329,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 };
 
                 if (! look_for_support(0)) {
-                    inference.infer_not_equal(logger, index_vars.at(fixed_dim), test_val, JustifyExplicitlyThenRUP{[&](const ReasonFunction & reason) {
+                    inference.infer_not_equal(logger, index_vars.at(fixed_dim), test_val, JustifyExplicitly{[&](const ReasonLiterals & reason) {
                         // show there's no overlap between array_var and result, for any way the other
                         // index vars are assigned
                         vector<size_t> elem;
@@ -363,7 +373,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         };
 
                         show_no_support(0);
-                    }},
+                    }, ThenRUP::Yes},
                         generic_reason(state, explored_vars));
                 }
             }
@@ -411,14 +421,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
             auto infer_bound = [&](Integer relevant_bound, bool ge) {
                 auto lit_to_infer = ge ? (result_var >= relevant_bound) : (result_var <= relevant_bound);
-                Reason reason;
-                auto idx_reason = generic_reason(state, index_vars)();
+                ReasonLiterals reason;
+                auto idx_reason = materialise(generic_reason(state, index_vars), state);
                 reason.insert(reason.end(), idx_reason.begin(), idx_reason.end());
                 for (const auto & var : considered_vars)
                     reason.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
                 reason.push_back(result_var >= current_bounds.first);
                 reason.push_back(result_var <= current_bounds.second);
-                inference.infer(logger, lit_to_infer, JustifyExplicitlyThenRUP{[&](const ReasonFunction & reason) {
+                inference.infer(logger, lit_to_infer, JustifyExplicitly{[&](const ReasonLiterals & reason) {
                     // show that it doesn't work for any feasible choice of indices
                     WPBSum sum_so_far;
                     function<auto(unsigned)->void> rule_out = [&](unsigned d) {
@@ -441,8 +451,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         }
                     };
                     rule_out(0);
-                }},
-                    ReasonFunction{[=]() { return reason; }});
+                }, ThenRUP::Yes},
+                    ExplicitReason{reason});
             };
 
             if (lowest_found && *lowest_found > current_bounds.first)
@@ -486,10 +496,10 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             collect_supported_values(0);
 
             for (auto value : still_to_find_support_for.each()) {
-                Reason reason = generic_reason(state, index_vars)();
+                ReasonLiterals reason = materialise(generic_reason(state, index_vars), state);
                 for (const auto & var : considered_vars)
                     reason.push_back(var != value);
-                inference.infer_not_equal(logger, result_var, value, JustifyExplicitlyThenRUP{[&](const ReasonFunction & reason) {
+                inference.infer_not_equal(logger, result_var, value, JustifyExplicitly{[&](const ReasonLiterals & reason) {
                     // show that it doesn't work for any feasible choice of indices
                     WPBSum sum_so_far;
                     function<auto(unsigned)->void> rule_out = [&](unsigned d) {
@@ -512,8 +522,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         }
                     };
                     rule_out(0);
-                }},
-                    ReasonFunction{[=]() { return reason; }});
+                }, ThenRUP::Yes},
+                    ExplicitReason{reason});
             }
 
             return PropagatorState::Enable; }, result_triggers);
@@ -523,12 +533,12 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         Triggers equality_triggers;
         equality_triggers.on_change.insert(equality_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
         equality_triggers.on_change.emplace_back(_result_var);
-        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id(), [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // if there's only a single possible array variable left, it can only take values
             // that are present in the result variable
             bool index_is_fully_defined = true;
             vector<size_t> elem;
-            Reason index_reason;
+            ReasonLiterals index_reason;
             for (const auto & [p, i] : enumerate(index_vars)) {
                 auto v = state.optional_single_value(i);
                 if (! v) {
@@ -541,12 +551,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
             if (index_is_fully_defined) {
                 auto array_var = get_array_var<dimensions_>(elem, *array);
-                enforce_equality(logger, result_var, array_var, state, inference, index_reason);
+                enforce_equality(logger, result_var, array_var, state, inference, index_reason, owner);
             }
 
             return PropagatorState::Enable; }, equality_triggers);
     }
 }
+#if defined(__GNUC__) && ! defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/element/hints.hh
+++ b/gcs/constraints/element/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ELEMENT_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ELEMENT_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Element's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Element
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "element";
+    };
+}
+
+#endif

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/equals/equals.hh>
+#include <gcs/constraints/equals/hints.hh>
 #include <gcs/constraints/innards/justify_not_in_range.hh>
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/exception.hh>
@@ -42,30 +43,8 @@ using std::print;
 using fmt::print;
 #endif
 
-namespace
-{
-    // Coarse model-level hint name for equals's explicit-steps (JustifyExplicitly,
-    // including the EqualsNoOverlap fat witness) and the reified-verdict fallback
-    // annotation. The pure-RUP inferences use hints::EqualsRUP instead.
-    constexpr std::string_view equals_hint = "equals";
-}
-
 namespace gcs::innards::hints
 {
-    // Witness for the "domains don't overlap, so the reified equality cannot hold"
-    // justification, carried in a reified verdict (built by no_overlap_justification).
-    // Holds the operands, the bounds
-    // walked over, and the condition; the State pointer is valid because the verdict
-    // is consumed synchronously while the constraint is live.
-    struct EqualsNoOverlap
-    {
-        const State * state;
-        IntegerVariableID v1, v2;
-        std::pair<Integer, Integer> v1_bounds;
-        Literal cond;
-        static constexpr std::string_view hint_name = "equals";
-    };
-
     auto emit_justification(ProofLogger & logger, const EqualsNoOverlap & w, const ReasonLiterals &) -> void
     {
         for (Integer val = w.v1_bounds.first; val <= w.v1_bounds.second; ++val)
@@ -74,21 +53,6 @@ namespace gcs::innards::hints
             else
                 logger.emit_rup_proof_line(WPBSum{} + 1_i * (w.v2 != val) + 1_i * (w.v1 == val) + 1_i * ! w.cond >= 1_i, ProofLevel::Temporary);
     }
-
-    // The pure-RUP hint for "a value is forced out of the other operand because this
-    // one is fixed to it" (the bare-NotEquals propagator). RUP-derivable, so no
-    // emit_justification; carries the owning constraint id so assertion mode can name
-    // the source.
-    struct EqualsRUP
-    {
-        ConstraintID owner;
-        static constexpr std::string_view hint_name = "equals";
-    };
-
-    auto hint_sexpr(const EqualsRUP & forced, NamesAndIDsTracker &) -> SExpr
-    {
-        return hint_list(hint_constraint_id(forced.owner));
-    }
 }
 
 auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1, const auto & v2, const State & state,
@@ -96,13 +60,13 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 {
     auto val1 = state.optional_single_value(v1);
     if (val1) {
-        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 == *val1); return r; }()});
+        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{hints::Equals{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 == *val1); return r; }()});
         return PropagatorState::DisableUntilBacktrack;
     }
 
     auto val2 = state.optional_single_value(v2);
     if (val2) {
-        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 == *val2); return r; }()});
+        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{hints::Equals{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 == *val2); return r; }()});
         return PropagatorState::DisableUntilBacktrack;
     }
 
@@ -141,12 +105,12 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
                     ReasonLiterals not_in_range_reason = reason;
                     not_in_range_reason.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
                     inference.infer_not_in_range(logger, pruned, lo, hi,
-                        JustifyExplicitly{[=](const ReasonLiterals & r) { bridge(pruned, other, lo, hi, r); }, ThenRUP::Yes, hints::ModelName{equals_hint}},
+                        JustifyExplicitly{[=](const ReasonLiterals & r) { bridge(pruned, other, lo, hi, r); }, ThenRUP::Yes, hints::Equals{owner}},
                         ExplicitReason{std::move(not_in_range_reason)});
                 }
                 else
                     for (Integer val = lo; val <= hi; ++val)
-                        inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{hints::EqualsRUP{owner}},
+                        inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{hints::Equals{owner}},
                             ExplicitReason{[&] { auto r = reason; r.emplace_back(other != val); return r; }()});
             }
         };
@@ -157,10 +121,10 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
     else {
         auto bounds1 = state.bounds(v1), bounds2 = state.bounds(v2);
         if (bounds1 != bounds2) {
-            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 >= bounds1.first); return r; }()});
-            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 >= bounds2.first); return r; }()});
-            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 <= bounds1.second); return r; }()});
-            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 <= bounds2.second); return r; }()});
+            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{hints::Equals{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 >= bounds1.first); return r; }()});
+            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{hints::Equals{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 >= bounds2.first); return r; }()});
+            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{hints::Equals{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 <= bounds1.second); return r; }()});
+            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{hints::Equals{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 <= bounds2.second); return r; }()});
         }
     }
 
@@ -170,7 +134,7 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 namespace
 {
     auto no_overlap_justification(const State & state, ProofLogger * const,
-        IntegerVariableID v1, IntegerVariableID v2, Literal cond) -> pair<hints::EqualsNoOverlap, Reason>
+        IntegerVariableID v1, IntegerVariableID v2, Literal cond, const ConstraintID & owner) -> pair<hints::EqualsNoOverlap, Reason>
     {
         auto v1_bounds = state.bounds(v1);
         ReasonLiterals reason{{v1 >= v1_bounds.first, v1 <= v1_bounds.second}};
@@ -181,12 +145,12 @@ namespace
             else
                 reason.emplace_back(v1 != val);
 
-        return pair{hints::EqualsNoOverlap{&state, v1, v2, v1_bounds, cond}, ExplicitReason{reason}};
+        return pair{hints::EqualsNoOverlap{{owner}, &state, v1, v2, v1_bounds, cond}, ExplicitReason{reason}};
     }
 
     // equals's reified verdicts are either a plain RUP (the singleton / forced
     // cases) or the no-overlap witness; a variant of the two, visited inside infer.
-    using EqualsJustification = std::variant<JustifyUsingRUP<NoHint>, JustifyExplicitly<hints::EqualsNoOverlap>>;
+    using EqualsJustification = std::variant<JustifyUsingRUP<hints::Equals>, JustifyExplicitly<hints::EqualsNoOverlap>>;
 }
 
 ReifiedEquals::ReifiedEquals(const IntegerVariableID v1, const IntegerVariableID v2, ReificationCondition cond, bool neq) :
@@ -305,20 +269,20 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
                                                 const Literal & cond) -> PropagatorState {
         auto value1 = state.optional_single_value(v1);
         if (value1) {
-            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::EqualsRUP{owner}},
+            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
                 ExactSingleValue{ReasonVars{v1_scope.get()}, cond});
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
-            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::EqualsRUP{owner}},
+            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
                 ExactSingleValue{ReasonVars{v2_scope.get()}, cond});
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;
     };
 
-    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, v1v2_scope](
+    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, v1v2_scope, owner = constraint_id()](
                                          const State & state, auto &, ProofLogger * const logger,
                                          const IntegerVariableCondition & cond) -> ReificationVerdictFor<EqualsJustification> {
         // Aliased non-constant operands: equality definitely holds regardless of
@@ -327,39 +291,36 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         // value and the singleton check below fires.
         if (v1 == v2 && ! is_constant_variable(v1))
             return reification_verdict::MustHold<EqualsJustification>{
-                .justification = JustifyUsingRUP{},
-                .reason = NoReason{},
-                .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
+                .justification = JustifyUsingRUP{hints::Equals{owner}},
+                .reason = NoReason{}};
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {
             auto reason = Reason{ExactSingleValue{ReasonVars{v1v2_scope.get()}, std::nullopt}};
             if (*value1 == *value2)
-                return reification_verdict::MustHold<EqualsJustification>{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
+                return reification_verdict::MustHold<EqualsJustification>{.justification = JustifyUsingRUP{hints::Equals{owner}}, .reason = reason};
             else
-                return reification_verdict::MustNotHold<EqualsJustification>{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
+                return reification_verdict::MustNotHold<EqualsJustification>{.justification = JustifyUsingRUP{hints::Equals{owner}}, .reason = reason};
         }
         else if (value1) {
             if (! state.in_domain(v2, *value1))
                 return reification_verdict::MustNotHold<EqualsJustification>{
-                    .justification = JustifyUsingRUP{},
-                    .reason = ExplicitReason{ReasonLiterals{v1 == *value1, v2 != *value1}},
-                    .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
+                    .justification = JustifyUsingRUP{hints::Equals{owner}},
+                    .reason = ExplicitReason{ReasonLiterals{v1 == *value1, v2 != *value1}}};
             return reification_verdict::StillUndecided{};
         }
         else if (value2) {
             if (! state.in_domain(v1, *value2))
                 return reification_verdict::MustNotHold<EqualsJustification>{
-                    .justification = JustifyUsingRUP{},
-                    .reason = ExplicitReason{ReasonLiterals{v2 == *value2, v1 != *value2}},
-                    .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
+                    .justification = JustifyUsingRUP{hints::Equals{owner}},
+                    .reason = ExplicitReason{ReasonLiterals{v2 == *value2, v1 != *value2}}};
             return reification_verdict::StillUndecided{};
         }
         else {
             // not equals is forced if there's no overlap between domains
             if (! state.domains_intersect(v1, v2)) {
-                auto [witness, reason] = no_overlap_justification(state, logger, v1, v2, cond);
-                return reification_verdict::MustNotHold<EqualsJustification>{.justification = JustifyExplicitly{witness, ThenRUP::Yes}, .reason = reason};
+                auto [no_overlap, reason] = no_overlap_justification(state, logger, v1, v2, cond, owner);
+                return reification_verdict::MustNotHold<EqualsJustification>{.justification = JustifyExplicitly{no_overlap, ThenRUP::Yes}, .reason = reason};
             }
             return reification_verdict::StillUndecided{};
         }

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -42,18 +42,67 @@ using std::print;
 using fmt::print;
 #endif
 
+namespace
+{
+    // Coarse model-level hint name for equals's explicit-steps (JustifyExplicitly,
+    // including the EqualsNoOverlap fat witness) and the reified-verdict fallback
+    // annotation. The pure-RUP inferences use hints::EqualsRUP instead.
+    constexpr std::string_view equals_hint = "equals";
+}
+
+namespace gcs::innards::hints
+{
+    // Witness for the "domains don't overlap, so the reified equality cannot hold"
+    // justification, carried in a reified verdict (built by no_overlap_justification).
+    // Holds the operands, the bounds
+    // walked over, and the condition; the State pointer is valid because the verdict
+    // is consumed synchronously while the constraint is live.
+    struct EqualsNoOverlap
+    {
+        const State * state;
+        IntegerVariableID v1, v2;
+        std::pair<Integer, Integer> v1_bounds;
+        Literal cond;
+        static constexpr std::string_view hint_name = "equals";
+    };
+
+    auto emit_justification(ProofLogger & logger, const EqualsNoOverlap & w, const ReasonLiterals &) -> void
+    {
+        for (Integer val = w.v1_bounds.first; val <= w.v1_bounds.second; ++val)
+            if (w.state->in_domain(w.v1, val))
+                logger.emit_rup_proof_line(WPBSum{} + 1_i * (w.v1 != val) + 1_i * (w.v2 == val) + 1_i * ! w.cond >= 1_i, ProofLevel::Temporary);
+            else
+                logger.emit_rup_proof_line(WPBSum{} + 1_i * (w.v2 != val) + 1_i * (w.v1 == val) + 1_i * ! w.cond >= 1_i, ProofLevel::Temporary);
+    }
+
+    // The pure-RUP hint for "a value is forced out of the other operand because this
+    // one is fixed to it" (the bare-NotEquals propagator). RUP-derivable, so no
+    // emit_justification; carries the owning constraint id so assertion mode can name
+    // the source.
+    struct EqualsRUP
+    {
+        ConstraintID owner;
+        static constexpr std::string_view hint_name = "equals";
+    };
+
+    auto hint_sexpr(const EqualsRUP & forced, NamesAndIDsTracker &) -> SExpr
+    {
+        return hint_list(hint_constraint_id(forced.owner));
+    }
+}
+
 auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1, const auto & v2, const State & state,
-    auto & inference, const Reason & reason) -> PropagatorState
+    auto & inference, const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState
 {
     auto val1 = state.optional_single_value(v1);
     if (val1) {
-        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 == *val1); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 == *val1); return r; }()});
         return PropagatorState::DisableUntilBacktrack;
     }
 
     auto val2 = state.optional_single_value(v2);
     if (val2) {
-        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 == *val2); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 == *val2); return r; }()});
         return PropagatorState::DisableUntilBacktrack;
     }
 
@@ -75,7 +124,7 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
         auto both_simple = std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v1}) &&
             std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{v2});
 
-        auto bridge = [logger](const auto & pruned, const auto & other, Integer lo, Integer hi, const ReasonFunction & r) {
+        auto bridge = [logger](const auto & pruned, const auto & other, Integer lo, Integer hi, const ReasonLiterals & r) {
             // Plain equality pruned = other, so the flag forces other into the same [lo, hi].
             justify_not_in_range_across_equality(*logger, r,
                 std::get<SimpleIntegerVariableID>(IntegerVariableID{pruned}), lo, hi,
@@ -84,22 +133,21 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 
         auto prune = [&](const auto & pruned, const auto & other, const IntervalSet<Integer> & pruned_set, const IntervalSet<Integer> & other_set) {
             for (auto [lo, hi] : pruned_set.each_interval_minus(other_set)) {
-                if (both_simple)
+                if (both_simple) {
+                    // ExplicitReason holds an immutable snapshot (the base reason plus
+                    // the excluded interval), so the justification — which materialises
+                    // it once per bridge lemma plus once for the conclusion — gets a
+                    // fresh copy each time rather than an accumulating element.
+                    ReasonLiterals not_in_range_reason = reason;
+                    not_in_range_reason.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
                     inference.infer_not_in_range(logger, pruned, lo, hi,
-                        JustifyExplicitlyThenRUP{[=](const ReasonFunction & r) { bridge(pruned, other, lo, hi, r); }},
-                        // Build afresh per call: the justification calls the reason once
-                        // per bridge lemma plus once for the conclusion, so a mutable
-                        // accumulating lambda would duplicate the element on each call.
-                        ReasonFunction{[=, base = reason]() {
-                            auto r = base;
-                            r.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
-                            return r;
-                        }},
-                        AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+                        JustifyExplicitly{[=](const ReasonLiterals & r) { bridge(pruned, other, lo, hi, r); }, ThenRUP::Yes, hints::ModelName{equals_hint}},
+                        ExplicitReason{std::move(not_in_range_reason)});
+                }
                 else
                     for (Integer val = lo; val <= hi; ++val)
-                        inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{},
-                            ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(other != val); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+                        inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{hints::EqualsRUP{owner}},
+                            ExplicitReason{[&] { auto r = reason; r.emplace_back(other != val); return r; }()});
             }
         };
 
@@ -109,10 +157,10 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
     else {
         auto bounds1 = state.bounds(v1), bounds2 = state.bounds(v2);
         if (bounds1 != bounds2) {
-            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 >= bounds1.first); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
-            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 >= bounds2.first); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
-            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 <= bounds1.second); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
-            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 <= bounds2.second); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 >= bounds1.first); return r; }()});
+            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 >= bounds2.first); return r; }()});
+            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v1 <= bounds1.second); return r; }()});
+            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{hints::EqualsRUP{owner}}, ExplicitReason{[&] { auto r = reason; r.emplace_back(v2 <= bounds2.second); return r; }()});
         }
     }
 
@@ -121,11 +169,11 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 
 namespace
 {
-    auto no_overlap_justification(const State & state, ProofLogger * const logger,
-        IntegerVariableID v1, IntegerVariableID v2, Literal cond) -> pair<JustifyExplicitlyThenRUP, ReasonFunction>
+    auto no_overlap_justification(const State & state, ProofLogger * const,
+        IntegerVariableID v1, IntegerVariableID v2, Literal cond) -> pair<hints::EqualsNoOverlap, Reason>
     {
         auto v1_bounds = state.bounds(v1);
-        Reason reason{{v1 >= v1_bounds.first, v1 <= v1_bounds.second}};
+        ReasonLiterals reason{{v1 >= v1_bounds.first, v1 <= v1_bounds.second}};
 
         for (Integer val = v1_bounds.first; val <= v1_bounds.second; ++val)
             if (state.in_domain(v1, val))
@@ -133,17 +181,12 @@ namespace
             else
                 reason.emplace_back(v1 != val);
 
-        auto justify = [&state = state, logger = logger, v1 = v1, v2 = v2, v1_bounds = v1_bounds, cond = cond](
-                           const ReasonFunction &) {
-            for (Integer val = v1_bounds.first; val <= v1_bounds.second; ++val)
-                if (state.in_domain(v1, val))
-                    logger->emit_rup_proof_line(WPBSum{} + 1_i * (v1 != val) + 1_i * (v2 == val) + 1_i * ! cond >= 1_i, ProofLevel::Temporary);
-                else
-                    logger->emit_rup_proof_line(WPBSum{} + 1_i * (v2 != val) + 1_i * (v1 == val) + 1_i * ! cond >= 1_i, ProofLevel::Temporary);
-        };
-
-        return pair{JustifyExplicitlyThenRUP{justify}, ReasonFunction{[=]() { return reason; }}};
+        return pair{hints::EqualsNoOverlap{&state, v1, v2, v1_bounds, cond}, ExplicitReason{reason}};
     }
+
+    // equals's reified verdicts are either a plain RUP (the singleton / forced
+    // cases) or the no-overlap witness; a variant of the two, visited inside infer.
+    using EqualsJustification = std::variant<JustifyUsingRUP<NoHint>, JustifyExplicitly<hints::EqualsNoOverlap>>;
 }
 
 ReifiedEquals::ReifiedEquals(const IntegerVariableID v1, const IntegerVariableID v2, ReificationCondition cond, bool neq) :
@@ -245,75 +288,78 @@ auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
 
 auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
 {
-    auto enforce_constraint_must_hold = [v1 = _v1, v2 = _v2](
+    auto enforce_constraint_must_hold = [v1 = _v1, v2 = _v2, owner = constraint_id()](
                                             const State & state, auto & inference, ProofLogger * const logger,
                                             const Literal & cond) -> PropagatorState {
         return visit([&](auto & v1, auto & v2) {
-            return enforce_equality(logger, v1, v2, state, inference, Reason{cond});
+            return enforce_equality(logger, v1, v2, state, inference, ReasonLiterals{cond}, owner);
         },
             v1, v2);
     };
 
-    auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2](
+    auto v1_scope = std::make_shared<const std::vector<IntegerVariableID>>(std::vector<IntegerVariableID>{_v1});
+    auto v2_scope = std::make_shared<const std::vector<IntegerVariableID>>(std::vector<IntegerVariableID>{_v2});
+    auto v1v2_scope = std::make_shared<const std::vector<IntegerVariableID>>(std::vector<IntegerVariableID>{_v1, _v2});
+    auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2, v1_scope, v2_scope, owner = constraint_id()](
                                                 const State & state, auto & inference, ProofLogger * const logger,
                                                 const Literal & cond) -> PropagatorState {
         auto value1 = state.optional_single_value(v1);
         if (value1) {
-            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v1 == *value1}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::EqualsRUP{owner}},
+                ExactSingleValue{ReasonVars{v1_scope.get()}, cond});
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
-            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v2 == *value2}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::EqualsRUP{owner}},
+                ExactSingleValue{ReasonVars{v2_scope.get()}, cond});
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;
     };
 
-    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2](
+    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, v1v2_scope](
                                          const State & state, auto &, ProofLogger * const logger,
-                                         const IntegerVariableCondition & cond) -> ReificationVerdict {
+                                         const IntegerVariableCondition & cond) -> ReificationVerdictFor<EqualsJustification> {
         // Aliased non-constant operands: equality definitely holds regardless of
         // domain. Returning MustHold here lets the dispatcher pin the cond
         // immediately at root, instead of waiting until search fixes v1 to a
         // value and the singleton check below fires.
         if (v1 == v2 && ! is_constant_variable(v1))
-            return reification_verdict::MustHold{
+            return reification_verdict::MustHold<EqualsJustification>{
                 .justification = JustifyUsingRUP{},
-                .reason = ReasonFunction{},
-                .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
+                .reason = NoReason{},
+                .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {
-            auto reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 == *value2}; }};
+            auto reason = Reason{ExactSingleValue{ReasonVars{v1v2_scope.get()}, std::nullopt}};
             if (*value1 == *value2)
-                return reification_verdict::MustHold{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
+                return reification_verdict::MustHold<EqualsJustification>{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
             else
-                return reification_verdict::MustNotHold{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
+                return reification_verdict::MustNotHold<EqualsJustification>{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
         }
         else if (value1) {
             if (! state.in_domain(v2, *value1))
-                return reification_verdict::MustNotHold{
+                return reification_verdict::MustNotHold<EqualsJustification>{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 != *value1}; }},
-                    .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
+                    .reason = ExplicitReason{ReasonLiterals{v1 == *value1, v2 != *value1}},
+                    .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
             return reification_verdict::StillUndecided{};
         }
         else if (value2) {
             if (! state.in_domain(v1, *value2))
-                return reification_verdict::MustNotHold{
+                return reification_verdict::MustNotHold<EqualsJustification>{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{v2 == *value2, v1 != *value2}; }},
-                    .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
+                    .reason = ExplicitReason{ReasonLiterals{v2 == *value2, v1 != *value2}},
+                    .assertion_hint = AssertionAnnotation{.hint_name = equals_hint}};
             return reification_verdict::StillUndecided{};
         }
         else {
             // not equals is forced if there's no overlap between domains
             if (! state.domains_intersect(v1, v2)) {
-                auto [just, reason] = no_overlap_justification(state, logger, v1, v2, cond);
-                return reification_verdict::MustNotHold{.justification = just, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
+                auto [witness, reason] = no_overlap_justification(state, logger, v1, v2, cond);
+                return reification_verdict::MustNotHold<EqualsJustification>{.justification = JustifyExplicitly{witness, ThenRUP::Yes}, .reason = reason};
             }
             return reification_verdict::StillUndecided{};
         }
@@ -384,6 +430,6 @@ auto ReifiedEquals::s_expr(const innards::ProofModel * const model) const -> SEx
 }
 
 template auto gcs::innards::enforce_equality(ProofLogger * const logger, const IntegerVariableID & v1, const IntegerVariableID & v2, const State & state,
-    SimpleInferenceTracker & inference, const Reason & reason) -> PropagatorState;
+    SimpleInferenceTracker & inference, const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState;
 template auto gcs::innards::enforce_equality(ProofLogger * const logger, const IntegerVariableID & v1, const IntegerVariableID & v2, const State & state,
-    EagerProofLoggingInferenceTracker & inference, const Reason & reason) -> PropagatorState;
+    EagerProofLoggingInferenceTracker & inference, const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState;

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -2,6 +2,7 @@
 #include <gcs/constraints/innards/justify_not_in_range.hh>
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -46,13 +47,13 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
 {
     auto val1 = state.optional_single_value(v1);
     if (val1) {
-        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 == *val1); return reason; }});
+        inference.infer_equal(logger, v2, *val1, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 == *val1); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
         return PropagatorState::DisableUntilBacktrack;
     }
 
     auto val2 = state.optional_single_value(v2);
     if (val2) {
-        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 == *val2); return reason; }});
+        inference.infer_equal(logger, v1, *val2, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 == *val2); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
         return PropagatorState::DisableUntilBacktrack;
     }
 
@@ -93,11 +94,12 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
                             auto r = base;
                             r.emplace_back(not_in_range(IntegerVariableID{other}, lo, hi));
                             return r;
-                        }});
+                        }},
+                        AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
                 else
                     for (Integer val = lo; val <= hi; ++val)
                         inference.infer_not_equal(logger, pruned, val, JustifyUsingRUP{},
-                            ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(other != val); return reason; }});
+                            ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(other != val); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
             }
         };
 
@@ -107,10 +109,10 @@ auto gcs::innards::enforce_equality(ProofLogger * const logger, const auto & v1,
     else {
         auto bounds1 = state.bounds(v1), bounds2 = state.bounds(v2);
         if (bounds1 != bounds2) {
-            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 >= bounds1.first); return reason; }});
-            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 >= bounds2.first); return reason; }});
-            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 <= bounds1.second); return reason; }});
-            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 <= bounds2.second); return reason; }});
+            inference.infer_greater_than_or_equal(logger, v2, bounds1.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 >= bounds1.first); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_greater_than_or_equal(logger, v1, bounds2.first, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 >= bounds2.first); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_less_than(logger, v2, bounds1.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v1 <= bounds1.second); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
+            inference.infer_less_than(logger, v1, bounds2.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=, reason = reason]() mutable { reason.emplace_back(v2 <= bounds2.second); return reason; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
         }
     }
 
@@ -258,13 +260,13 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         auto value1 = state.optional_single_value(v1);
         if (value1) {
             inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v1 == *value1}}; }});
+                ReasonFunction{[=]() { return Reason{{cond, v1 == *value1}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
             inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{},
-                ReasonFunction{[=]() { return Reason{{cond, v2 == *value2}}; }});
+                ReasonFunction{[=]() { return Reason{{cond, v2 == *value2}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals});
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;
@@ -280,35 +282,38 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         if (v1 == v2 && ! is_constant_variable(v1))
             return reification_verdict::MustHold{
                 .justification = JustifyUsingRUP{},
-                .reason = ReasonFunction{}};
+                .reason = ReasonFunction{},
+                .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {
             auto reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 == *value2}; }};
             if (*value1 == *value2)
-                return reification_verdict::MustHold{.justification = JustifyUsingRUP{}, .reason = reason};
+                return reification_verdict::MustHold{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             else
-                return reification_verdict::MustNotHold{.justification = JustifyUsingRUP{}, .reason = reason};
+                return reification_verdict::MustNotHold{.justification = JustifyUsingRUP{}, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
         }
         else if (value1) {
             if (! state.in_domain(v2, *value1))
                 return reification_verdict::MustNotHold{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 != *value1}; }}};
+                    .reason = ReasonFunction{[=]() { return Reason{v1 == *value1, v2 != *value1}; }},
+                    .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             return reification_verdict::StillUndecided{};
         }
         else if (value2) {
             if (! state.in_domain(v1, *value2))
                 return reification_verdict::MustNotHold{
                     .justification = JustifyUsingRUP{},
-                    .reason = ReasonFunction{[=]() { return Reason{v2 == *value2, v1 != *value2}; }}};
+                    .reason = ReasonFunction{[=]() { return Reason{v2 == *value2, v1 != *value2}; }},
+                    .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             return reification_verdict::StillUndecided{};
         }
         else {
             // not equals is forced if there's no overlap between domains
             if (! state.domains_intersect(v1, v2)) {
                 auto [just, reason] = no_overlap_justification(state, logger, v1, v2, cond);
-                return reification_verdict::MustNotHold{.justification = just, .reason = reason};
+                return reification_verdict::MustNotHold{.justification = just, .reason = reason, .assertion_hint = AssertionAnnotation{.hint_name = AssertionHintName::ReifiedEquals}};
             }
             return reification_verdict::StillUndecided{};
         }

--- a/gcs/constraints/equals/equals.hh
+++ b/gcs/constraints/equals/equals.hh
@@ -16,7 +16,7 @@ namespace gcs
     namespace innards
     {
         auto enforce_equality(ProofLogger * const logger, const auto & v1, const auto & v2, const State & state,
-            auto & inference, const Reason & reason) -> PropagatorState;
+            auto & inference, const ReasonLiterals & reason, const ConstraintID & owner) -> PropagatorState;
     }
 
     /**

--- a/gcs/constraints/equals/hints.hh
+++ b/gcs/constraints/equals/hints.hh
@@ -1,0 +1,57 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_EQUALS_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_EQUALS_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state-fwd.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <string_view>
+#include <utility>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief equals's base assertion hint: just the owning constraint.
+     *
+     * Used directly for the pure-RUP prunings (a value forced out of one operand
+     * because the other is fixed, the bound tightenings, the singleton reified
+     * verdicts). RUP-derivable, so no emit_justification and no subhint; it takes
+     * the default `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct Equals
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "equals";
+    };
+
+    /**
+     * \brief equals's "domains don't overlap" hint, carried in a reified verdict.
+     *
+     * Extends the base with the `no_overlap` subhint and the emit context the
+     * internal proof writer reads to emit the per-value RUP lemmas: the operands,
+     * the bounds walked over, and the reification condition. The State pointer is
+     * valid because the verdict is consumed synchronously while the constraint is
+     * live. The data is held for emit_justification only; with no own hint_sexpr
+     * the hint takes the default identity-plus-subhint wire form.
+     *
+     * \ingroup Innards
+     */
+    struct EqualsNoOverlap : Equals
+    {
+        static constexpr std::string_view subhint_name = "no_overlap";
+        const State * state;
+        IntegerVariableID v1, v2;
+        std::pair<Integer, Integer> v1_bounds;
+        Literal cond;
+    };
+
+    auto emit_justification(ProofLogger & logger, const EqualsNoOverlap & no_overlap, const ReasonLiterals & reason) -> void;
+}
+
+#endif

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -81,13 +81,13 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
             else if (logger && logger->get_assertion_level() != AssertionLevel::Off && state.has_single_value(table.selector))
                 // Last selector val so infeasible -> we need an explicit contradiction at higher assertion levels
                 // since there's no table for the implicit one.
-                inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(state, table.vars));
+                inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(table.vars));
             else
                 inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, NoReason{});
         }
         if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
             // selector already empty on entry
-            inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(state, table.vars));
+            inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(table.vars));
     },
         table.tuples);
 
@@ -104,7 +104,7 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                 }
 
                 if (! supported) {
-                    inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, generic_reason(state, table.vars));
+                    inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, generic_reason(table.vars));
                 }
             }
         }

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -1,5 +1,7 @@
 #include <cmath>
-#include <gcs/innards/extensional_utils.hh>
+#include <gcs/constraints/extensional_utils.hh>
+#include <gcs/constraints/linear/hints.hh>
+#include <gcs/constraints/table/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -59,8 +61,9 @@ namespace
     }
 }
 
+template <typename Hint_>
 auto gcs::innards::propagate_extensional(const ExtensionalData & table, const State & state, auto & inference,
-    ProofLogger * const logger) -> PropagatorState
+    ProofLogger * const logger, const Hint_ & hint) -> PropagatorState
 {
     // check whether selectable tuples are still feasible
     visit([&](const auto & tuples) {
@@ -78,13 +81,13 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
             else if (logger && logger->get_assertion_level() != AssertionLevel::Off && state.has_single_value(table.selector))
                 // Last selector val so infeasible -> we need an explicit contradiction at higher assertion levels
                 // since there's no table for the implicit one.
-                inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, table.vars));
+                inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(state, table.vars));
             else
                 inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, NoReason{});
         }
         if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
             // selector already empty on entry
-            inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, table.vars));
+            inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(state, table.vars));
     },
         table.tuples);
 
@@ -101,7 +104,7 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                 }
 
                 if (! supported) {
-                    inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{}, generic_reason(state, table.vars));
+                    inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{hint}, generic_reason(state, table.vars));
                 }
             }
         }
@@ -111,5 +114,17 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
     return PropagatorState::Enable;
 }
 
-template auto gcs::innards::propagate_extensional(const ExtensionalData & table, const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
-template auto gcs::innards::propagate_extensional(const ExtensionalData & table, const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+// One instantiation per (inference tracker, hint) pair actually used: NoHint for
+// the unnamed AutoTable presolver, hints::Table for Table, hints::LinearEquality
+// for the GAC linear encoding. A new caller with its own hint adds a line here.
+#define GCS_INSTANTIATE_PROPAGATE_EXTENSIONAL(hint)                                                                                                                   \
+    template auto gcs::innards::propagate_extensional(const ExtensionalData &, const State &, SimpleInferenceTracker &, ProofLogger * const, const hint &)            \
+        -> PropagatorState;                                                                                                                                           \
+    template auto gcs::innards::propagate_extensional(const ExtensionalData &, const State &, EagerProofLoggingInferenceTracker &, ProofLogger * const, const hint &) \
+        -> PropagatorState;
+
+GCS_INSTANTIATE_PROPAGATE_EXTENSIONAL(NoHint)
+GCS_INSTANTIATE_PROPAGATE_EXTENSIONAL(hints::Table)
+GCS_INSTANTIATE_PROPAGATE_EXTENSIONAL(hints::LinearEquality)
+
+#undef GCS_INSTANTIATE_PROPAGATE_EXTENSIONAL

--- a/gcs/constraints/extensional_utils.hh
+++ b/gcs/constraints/extensional_utils.hh
@@ -1,8 +1,9 @@
-#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_EXTENSIONAL_UTILS_HH
-#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_EXTENSIONAL_UTILS_HH
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_EXTENSIONAL_UTILS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_EXTENSIONAL_UTILS_HH
 
 #include <gcs/extensional.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
@@ -33,10 +34,19 @@ namespace gcs::innards
      * This function performs propagation for the Table constraint, but also for
      * various other constraints that end up producing something table-like.
      *
+     * The optional \c hint is the typed assertion hint carried on the
+     * (RUP-derivable) prunings and contradictions: a constraint that owns its
+     * propagation -- Table, the GAC linear encoding -- passes its own hint so the
+     * assertions name it; a caller with no single owning constraint (e.g. the
+     * AutoTable presolver, installed unnamed) omits it and the default \c NoHint
+     * keeps the wire empty. Carried here rather than inside ExtensionalData since
+     * it is a proof-only concern, orthogonal to the table data.
+     *
      * \sa Table
      */
+    template <typename Hint_ = NoHint>
     auto propagate_extensional(const ExtensionalData &, const State &, auto & inference_tracker,
-        innards::ProofLogger * const) -> PropagatorState;
+        innards::ProofLogger * const, const Hint_ & hint = {}) -> PropagatorState;
 }
 
 #endif

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/global_cardinality/bounds_global_cardinality.hh>
+#include <gcs/constraints/global_cardinality/hints.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/constraints/innards/recover_am1.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -117,7 +118,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
 
     propagators.install(
         constraint_id(),
-        [vars = _vars, values = _values, counts = _counts, count_lines = _count_lines, all_vars = move(all_vars)](
+        [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, count_lines = _count_lines, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto m = values.size();
 
@@ -147,13 +148,13 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
 
                 // c_j >= must: the fixed variables alone force the count up.
                 if (must > lb_j)
-                    inference.infer(logger, counts[j] >= must, JustifyUsingRUP{},
+                    inference.infer(logger, counts[j] >= must, JustifyUsingRUP{hints::GlobalCardinality{owner}},
                         ExplicitReason{fixed_eq});
 
                 // c_j <= can: only the variables that can still take value may
                 // contribute to the count.
                 if (can < ub_j)
-                    inference.infer(logger, counts[j] <= can, JustifyUsingRUP{},
+                    inference.infer(logger, counts[j] <= can, JustifyUsingRUP{hints::GlobalCardinality{owner}},
                         ExplicitReason{absent_ne});
 
                 // Saturated capacity: if as many variables are already fixed to
@@ -164,7 +165,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                     sat.emplace_back(counts[j] <= ub_j);
                     for (const auto & var : vars)
                         if (state.in_domain(var, value) && ! state.has_single_value(var))
-                            inference.infer(logger, var != value, JustifyUsingRUP{},
+                            inference.infer(logger, var != value, JustifyUsingRUP{hints::GlobalCardinality{owner}},
                                 ExplicitReason{sat});
                 }
 
@@ -177,7 +178,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                         if (state.in_domain(var, value) && ! state.has_single_value(var))
                             for (const auto & w : state.each_value_mutable(var))
                                 if (w != value)
-                                    inference.infer(logger, var != w, JustifyUsingRUP{},
+                                    inference.infer(logger, var != w, JustifyUsingRUP{hints::GlobalCardinality{owner}},
                                         ExplicitReason{force});
                 }
             }
@@ -315,7 +316,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                                                       pb.add(*count_lines[j].first);
                                                       pb.emit(*logger, ProofLevel::Temporary);
                                                   },
-                                    ThenRUP::Yes},
+                                    ThenRUP::Yes, hints::GlobalCardinality{owner}},
                                 LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = capacity_reason(j); }});
                         auto upper = potential_count - (demand - lb_j);
                         if (upper < ub_j)
@@ -345,12 +346,12 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                                                       pb.add(*count_lines[j].second);
                                                       pb.emit(*logger, ProofLevel::Temporary);
                                                   },
-                                    ThenRUP::Yes},
+                                    ThenRUP::Yes, hints::GlobalCardinality{owner}},
                                 LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = demand_reason(j); }});
                     }
 
                     if (confined_count > cap) {
-                        inference.contradiction(logger, JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
+                        inference.contradiction(logger, JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes, hints::GlobalCardinality{owner}}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
                     }
                     else if (confined_count == cap) {
                         for (const auto & var : vars) {
@@ -358,7 +359,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                                 continue;
                             for (const auto & val : hall)
                                 if (state.in_domain(var, val))
-                                    inference.infer(logger, var != val, JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
+                                    inference.infer(logger, var != val, JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes, hints::GlobalCardinality{owner}}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
                         }
                     }
 
@@ -394,13 +395,13 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                     };
 
                     if (potential_count < demand) {
-                        inference.contradiction(logger, JustifyExplicitly{[&](const ReasonLiterals &) { emit_demand_pol(nullopt, 0_i); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
+                        inference.contradiction(logger, JustifyExplicitly{[&](const ReasonLiterals &) { emit_demand_pol(nullopt, 0_i); }, ThenRUP::Yes, hints::GlobalCardinality{owner}}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
                     }
                     else if (potential_count == demand) {
                         for (const auto & var : potential)
                             for (const auto & val : state.each_value_mutable(var))
                                 if (! hall.contains(val))
-                                    inference.infer(logger, var != val, JustifyExplicitly{[&, var = var, val = val](const ReasonLiterals &) { emit_demand_pol(var, val); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
+                                    inference.infer(logger, var != val, JustifyExplicitly{[&, var = var, val = val](const ReasonLiterals &) { emit_demand_pol(var, val); }, ThenRUP::Yes, hints::GlobalCardinality{owner}}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
                     }
                 }
             }

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -128,8 +128,8 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
             // it, and forces the variables into a value whose lower demand can
             // only just be met.
             for (const auto & [j, value] : enumerate(values)) {
-                Reason fixed_eq;  // var == value, for variables fixed to value
-                Reason absent_ne; // var != value, for variables without value
+                ReasonLiterals fixed_eq;  // var == value, for variables fixed to value
+                ReasonLiterals absent_ne; // var != value, for variables without value
                 Integer must = 0_i, can = 0_i;
                 for (const auto & var : vars) {
                     if (state.in_domain(var, value)) {
@@ -148,37 +148,37 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                 // c_j >= must: the fixed variables alone force the count up.
                 if (must > lb_j)
                     inference.infer(logger, counts[j] >= must, JustifyUsingRUP{},
-                        ReasonFunction{[fixed_eq]() -> Reason { return fixed_eq; }});
+                        ExplicitReason{fixed_eq});
 
                 // c_j <= can: only the variables that can still take value may
                 // contribute to the count.
                 if (can < ub_j)
                     inference.infer(logger, counts[j] <= can, JustifyUsingRUP{},
-                        ReasonFunction{[absent_ne]() -> Reason { return absent_ne; }});
+                        ExplicitReason{absent_ne});
 
                 // Saturated capacity: if as many variables are already fixed to
                 // value as the count's upper bound allows, no other variable may
                 // take it.
                 if (must == ub_j) {
-                    Reason sat = fixed_eq;
+                    ReasonLiterals sat = fixed_eq;
                     sat.emplace_back(counts[j] <= ub_j);
                     for (const auto & var : vars)
                         if (state.in_domain(var, value) && ! state.has_single_value(var))
                             inference.infer(logger, var != value, JustifyUsingRUP{},
-                                ReasonFunction{[sat]() -> Reason { return sat; }});
+                                ExplicitReason{sat});
                 }
 
                 // Just-met demand: if only `can` variables can take value and the
                 // count's lower bound needs all of them, each is forced to value.
                 if (can == lb_j && can > 0_i) {
-                    Reason force = absent_ne;
+                    ReasonLiterals force = absent_ne;
                     force.emplace_back(counts[j] >= lb_j);
                     for (const auto & var : vars)
                         if (state.in_domain(var, value) && ! state.has_single_value(var))
                             for (const auto & w : state.each_value_mutable(var))
                                 if (w != value)
                                     inference.infer(logger, var != w, JustifyUsingRUP{},
-                                        ReasonFunction{[force]() -> Reason { return force; }});
+                                        ExplicitReason{force});
                 }
             }
 
@@ -250,8 +250,8 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                         pb.emit(*logger, ProofLevel::Temporary);
                     };
 
-                    auto capacity_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> Reason {
-                        Reason r;
+                    auto capacity_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> ReasonLiterals {
+                        ReasonLiterals r;
                         for (const auto & var : confined) {
                             auto [v_lo, v_hi] = state.bounds(var);
                             for (Integer s = v_lo; s <= v_hi; ++s)
@@ -275,8 +275,8 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                     // boundary). These two true facts are asserted; everything
                     // built on top of them is real, so the surrounding Hall
                     // combinatorics is genuinely checked.
-                    auto demand_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> Reason {
-                        Reason r;
+                    auto demand_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> ReasonLiterals {
+                        ReasonLiterals r;
                         for (const auto & var : vars)
                             if (! domain_meets_hall(var))
                                 for (const auto & val : hall)
@@ -301,21 +301,22 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                             // The final RUP closes c_j >= L; its reason supplies
                             // c_v <= ub_v (v != j), discharging the gevars.
                             inference.infer(logger, counts[j] >= lower,
-                                JustifyExplicitlyThenRUP{[&, a = a, b = b, j = j](const ReasonFunction &) {
-                                    auto & tracker = logger->names_and_ids_tracker();
-                                    PolBuilder pb;
-                                    for (std::size_t v = a; v <= b; ++v)
-                                        if (v != j) {
-                                            pb.add(*count_lines[v].first);
-                                            if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                                pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
-                                        }
-                                    for (const auto & var : confined)
-                                        pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
-                                    pb.add(*count_lines[j].first);
-                                    pb.emit(*logger, ProofLevel::Temporary);
-                                }},
-                                ReasonFunction{[&, j = j]() { return capacity_reason(j); }});
+                                JustifyExplicitly{[&, a = a, b = b, j = j](const ReasonLiterals &) {
+                                                      auto & tracker = logger->names_and_ids_tracker();
+                                                      PolBuilder pb;
+                                                      for (std::size_t v = a; v <= b; ++v)
+                                                          if (v != j) {
+                                                              pb.add(*count_lines[v].first);
+                                                              if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                                                                  pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
+                                                          }
+                                                      for (const auto & var : confined)
+                                                          pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
+                                                      pb.add(*count_lines[j].first);
+                                                      pb.emit(*logger, ProofLevel::Temporary);
+                                                  },
+                                    ThenRUP::Yes},
+                                LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = capacity_reason(j); }});
                         auto upper = potential_count - (demand - lb_j);
                         if (upper < ub_j)
                             // Dual: at-most-one over H per potential variable, the
@@ -323,32 +324,33 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                             // c_v >= lb_v for v != j, and the j count line GE_j;
                             // RUP-closes c_j <= U, the reason discharging the gevars.
                             inference.infer(logger, counts[j] <= upper,
-                                JustifyExplicitlyThenRUP{[&, a = a, b = b, j = j](const ReasonFunction &) {
-                                    auto & tracker = logger->names_and_ids_tracker();
-                                    PolBuilder pb;
-                                    for (const auto & var : potential) {
-                                        vector<IntegerVariableCondition> atoms;
-                                        for (const auto & val : hall)
-                                            atoms.push_back(var == val);
-                                        pb.add(recover_am1<IntegerVariableCondition>(*logger, ProofLevel::Temporary, atoms,
-                                            [&](const IntegerVariableCondition & p, const IntegerVariableCondition & q) {
-                                                return logger->emit(RUPProofRule{}, WPBSum{} + 1_i * ! p + 1_i * ! q >= 1_i, ProofLevel::Temporary);
-                                            }));
-                                    }
-                                    for (std::size_t v = a; v <= b; ++v)
-                                        if (v != j) {
-                                            pb.add(*count_lines[v].second);
-                                            if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                                pb.add_for_literal(tracker, counts[v] >= state.bounds(counts[v]).first);
-                                        }
-                                    pb.add(*count_lines[j].second);
-                                    pb.emit(*logger, ProofLevel::Temporary);
-                                }},
-                                ReasonFunction{[&, j = j]() { return demand_reason(j); }});
+                                JustifyExplicitly{[&, a = a, b = b, j = j](const ReasonLiterals &) {
+                                                      auto & tracker = logger->names_and_ids_tracker();
+                                                      PolBuilder pb;
+                                                      for (const auto & var : potential) {
+                                                          vector<IntegerVariableCondition> atoms;
+                                                          for (const auto & val : hall)
+                                                              atoms.push_back(var == val);
+                                                          pb.add(recover_am1<IntegerVariableCondition>(*logger, ProofLevel::Temporary, atoms,
+                                                              [&](const IntegerVariableCondition & p, const IntegerVariableCondition & q) {
+                                                                  return logger->emit(RUPProofRule{}, WPBSum{} + 1_i * ! p + 1_i * ! q >= 1_i, ProofLevel::Temporary);
+                                                              }));
+                                                      }
+                                                      for (std::size_t v = a; v <= b; ++v)
+                                                          if (v != j) {
+                                                              pb.add(*count_lines[v].second);
+                                                              if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                                                                  pb.add_for_literal(tracker, counts[v] >= state.bounds(counts[v]).first);
+                                                          }
+                                                      pb.add(*count_lines[j].second);
+                                                      pb.emit(*logger, ProofLevel::Temporary);
+                                                  },
+                                    ThenRUP::Yes},
+                                LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = demand_reason(j); }});
                     }
 
                     if (confined_count > cap) {
-                        inference.contradiction(logger, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) { emit_capacity_pol(nullopt); }}, ReasonFunction{[&]() { return capacity_reason(nullopt); }});
+                        inference.contradiction(logger, JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
                     }
                     else if (confined_count == cap) {
                         for (const auto & var : vars) {
@@ -356,7 +358,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                                 continue;
                             for (const auto & val : hall)
                                 if (state.in_domain(var, val))
-                                    inference.infer(logger, var != val, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) { emit_capacity_pol(nullopt); }}, ReasonFunction{[&]() { return capacity_reason(nullopt); }});
+                                    inference.infer(logger, var != val, JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
                         }
                     }
 
@@ -392,13 +394,13 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
                     };
 
                     if (potential_count < demand) {
-                        inference.contradiction(logger, JustifyExplicitlyThenRUP{[&](const ReasonFunction &) { emit_demand_pol(nullopt, 0_i); }}, ReasonFunction{[&]() { return demand_reason(nullopt); }});
+                        inference.contradiction(logger, JustifyExplicitly{[&](const ReasonLiterals &) { emit_demand_pol(nullopt, 0_i); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
                     }
                     else if (potential_count == demand) {
                         for (const auto & var : potential)
                             for (const auto & val : state.each_value_mutable(var))
                                 if (! hall.contains(val))
-                                    inference.infer(logger, var != val, JustifyExplicitlyThenRUP{[&, var = var, val = val](const ReasonFunction &) { emit_demand_pol(var, val); }}, ReasonFunction{[&]() { return demand_reason(nullopt); }});
+                                    inference.infer(logger, var != val, JustifyExplicitly{[&, var = var, val = val](const ReasonLiterals &) { emit_demand_pol(var, val); }, ThenRUP::Yes}, LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
                     }
                 }
             }

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/global_cardinality/gac_global_cardinality.hh>
+#include <gcs/constraints/global_cardinality/hints.hh>
 #include <gcs/constraints/global_cardinality/justify.hh>
 #include <gcs/constraints/in.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -195,7 +196,7 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
 
     propagators.install(
         constraint_id(),
-        [vars = _vars, values = _values, counts = _counts, closed = _closed, count_lines = _count_lines, all_vars = move(all_vars)](
+        [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, closed = _closed, count_lines = _count_lines, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto m = values.size();
             auto n = vars.size();
@@ -219,10 +220,10 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                 }
                 auto [lb_j, ub_j] = state.bounds(counts[j]);
                 if (must > lb_j)
-                    inference.infer(logger, counts[j] >= must, JustifyUsingRUP{},
+                    inference.infer(logger, counts[j] >= must, JustifyUsingRUP{hints::GlobalCardinality{owner}},
                         ExplicitReason{fixed_eq});
                 if (can < ub_j)
-                    inference.infer(logger, counts[j] <= can, JustifyUsingRUP{},
+                    inference.infer(logger, counts[j] <= can, JustifyUsingRUP{hints::GlobalCardinality{owner}},
                         ExplicitReason{absent_ne});
             }
 
@@ -442,14 +443,14 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                         JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
                                               emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::GlobalCardinality{owner}},
                         LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) { out = gcc_capacity_reason(state, values, counts, cut_values, confined); }});
                 else if (! demand_cut.empty())
                     inference.contradiction(logger,
                         JustifyExplicitly{[&, demand_cut, suppliers](const ReasonLiterals &) {
                                               emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, demand_cut, suppliers, nullopt, nullopt);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::GlobalCardinality{owner}},
                         LazyReasonOver{vars, [&, demand_cut, suppliers](const State &, ReasonLiterals & out) { out = gcc_demand_reason(state, vars, values, counts, demand_cut, suppliers); }});
                 else if (closed && unmatched >= 0)
                     // A closed variable with no cover value left: the per-variable
@@ -565,7 +566,7 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                             JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
                                                   emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::GlobalCardinality{owner}},
                             LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) { out = gcc_capacity_reason(state, values, counts, cut_values, confined); }});
                     }
                     else {
@@ -591,7 +592,7 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                             JustifyExplicitly{[&, cut_values, potential, value = value, i = i](const ReasonLiterals &) {
                                                   emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], value);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::GlobalCardinality{owner}},
                             LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) { out = gcc_demand_reason(state, vars, values, counts, cut_values, potential); }});
                     }
                 }
@@ -626,7 +627,7 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                             JustifyExplicitly{[&, cut_values, potential, val = val, i = i](const ReasonLiterals &) {
                                                   emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], val);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::GlobalCardinality{owner}},
                             LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) { out = gcc_demand_reason(state, vars, values, counts, cut_values, potential); }});
             }
 

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -204,7 +204,7 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
             // must-occur..can-occur range (so they are determined at a leaf).
             // These are the certified per-value RUP steps from the BC propagator.
             for (const auto & [j, value] : enumerate(values)) {
-                Reason fixed_eq, absent_ne;
+                ReasonLiterals fixed_eq, absent_ne;
                 Integer must = 0_i, can = 0_i;
                 for (const auto & var : vars) {
                     if (state.in_domain(var, value)) {
@@ -220,10 +220,10 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                 auto [lb_j, ub_j] = state.bounds(counts[j]);
                 if (must > lb_j)
                     inference.infer(logger, counts[j] >= must, JustifyUsingRUP{},
-                        ReasonFunction{[fixed_eq]() -> Reason { return fixed_eq; }});
+                        ExplicitReason{fixed_eq});
                 if (can < ub_j)
                     inference.infer(logger, counts[j] <= can, JustifyUsingRUP{},
-                        ReasonFunction{[absent_ne]() -> Reason { return absent_ne; }});
+                        ExplicitReason{absent_ne});
             }
 
             // Build Régin's value graph as a flow network and find a feasible
@@ -439,16 +439,18 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
 
                 if (! cut_values.empty())
                     inference.contradiction(logger,
-                        JustifyExplicitlyThenRUP{[&, cut_values, confined](const ReasonFunction &) {
-                            emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
-                        }},
-                        ReasonFunction{[&, cut_values, confined]() { return gcc_capacity_reason(state, values, counts, cut_values, confined); }});
+                        JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
+                                              emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
+                                          },
+                            ThenRUP::Yes},
+                        LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) { out = gcc_capacity_reason(state, values, counts, cut_values, confined); }});
                 else if (! demand_cut.empty())
                     inference.contradiction(logger,
-                        JustifyExplicitlyThenRUP{[&, demand_cut, suppliers](const ReasonFunction &) {
-                            emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, demand_cut, suppliers, nullopt, nullopt);
-                        }},
-                        ReasonFunction{[&, demand_cut, suppliers]() { return gcc_demand_reason(state, vars, values, counts, demand_cut, suppliers); }});
+                        JustifyExplicitly{[&, demand_cut, suppliers](const ReasonLiterals &) {
+                                              emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, demand_cut, suppliers, nullopt, nullopt);
+                                          },
+                            ThenRUP::Yes},
+                        LazyReasonOver{vars, [&, demand_cut, suppliers](const State &, ReasonLiterals & out) { out = gcc_demand_reason(state, vars, values, counts, demand_cut, suppliers); }});
                 else if (closed && unmatched >= 0)
                     // A closed variable with no cover value left: the per-variable
                     // In constraint certifies this, so leave it to that rather
@@ -560,10 +562,11 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                                 confined.push_back(vars[k]);
                         }
                         inference.infer(logger, vars[i] != value,
-                            JustifyExplicitlyThenRUP{[&, cut_values, confined](const ReasonFunction &) {
-                                emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
-                            }},
-                            ReasonFunction{[&, cut_values, confined]() { return gcc_capacity_reason(state, values, counts, cut_values, confined); }});
+                            JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
+                                                  emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
+                                              },
+                                ThenRUP::Yes},
+                            LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) { out = gcc_capacity_reason(state, values, counts, cut_values, confined); }});
                     }
                     else {
                         // Demand cut: cover values inside the cut are at their lower bound.
@@ -585,10 +588,11 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                                 potential.push_back(vars[k]);
                         }
                         inference.infer(logger, vars[i] != value,
-                            JustifyExplicitlyThenRUP{[&, cut_values, potential, value = value, i = i](const ReasonFunction &) {
-                                emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], value);
-                            }},
-                            ReasonFunction{[&, cut_values, potential]() { return gcc_demand_reason(state, vars, values, counts, cut_values, potential); }});
+                            JustifyExplicitly{[&, cut_values, potential, value = value, i = i](const ReasonLiterals &) {
+                                                  emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], value);
+                                              },
+                                ThenRUP::Yes},
+                            LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) { out = gcc_demand_reason(state, vars, values, counts, cut_values, potential); }});
                     }
                 }
 
@@ -619,10 +623,11 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
                 for (const auto & val : state.each_value_mutable(vars[i]))
                     if (! cover.contains(val))
                         inference.infer(logger, vars[i] != val,
-                            JustifyExplicitlyThenRUP{[&, cut_values, potential, val = val, i = i](const ReasonFunction &) {
-                                emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], val);
-                            }},
-                            ReasonFunction{[&, cut_values, potential]() { return gcc_demand_reason(state, vars, values, counts, cut_values, potential); }});
+                            JustifyExplicitly{[&, cut_values, potential, val = val, i = i](const ReasonLiterals &) {
+                                                  emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], val);
+                                              },
+                                ThenRUP::Yes},
+                            LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) { out = gcc_demand_reason(state, vars, values, counts, cut_values, potential); }});
             }
 
             return PropagatorState::Enable;

--- a/gcs/constraints/global_cardinality/hints.hh
+++ b/gcs/constraints/global_cardinality/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_GLOBAL_CARDINALITY_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_GLOBAL_CARDINALITY_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief GlobalCardinality's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct GlobalCardinality
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "global_cardinality";
+    };
+}
+
+#endif

--- a/gcs/constraints/global_cardinality/justify.cc
+++ b/gcs/constraints/global_cardinality/justify.cc
@@ -46,10 +46,10 @@ auto gcs::innards::emit_gcc_capacity_pol(ProofLogger & logger, const State & sta
 
 auto gcs::innards::gcc_capacity_reason(const State & state, const vector<Integer> & values,
     const vector<IntegerVariableID> & counts, const vector<size_t> & cut_values,
-    const vector<IntegerVariableID> & confined) -> Reason
+    const vector<IntegerVariableID> & confined) -> ReasonLiterals
 {
     auto hall = hall_set(values, cut_values);
-    Reason r;
+    ReasonLiterals r;
     for (const auto & var : confined) {
         auto [v_lo, v_hi] = state.bounds(var);
         for (Integer s = v_lo; s <= v_hi; ++s)
@@ -99,7 +99,7 @@ auto gcs::innards::emit_gcc_demand_pol(ProofLogger & logger, const State & state
 
 auto gcs::innards::gcc_demand_reason(const State & state, const vector<IntegerVariableID> & vars,
     const vector<Integer> & values, const vector<IntegerVariableID> & counts,
-    const vector<size_t> & cut_values, const vector<IntegerVariableID> & potential) -> Reason
+    const vector<size_t> & cut_values, const vector<IntegerVariableID> & potential) -> ReasonLiterals
 {
     auto hall = hall_set(values, cut_values);
     auto meets_hall = [&](const IntegerVariableID & var) {
@@ -109,7 +109,7 @@ auto gcs::innards::gcc_demand_reason(const State & state, const vector<IntegerVa
         return false;
     };
     (void)potential;
-    Reason r;
+    ReasonLiterals r;
     for (const auto & var : vars)
         if (! meets_hall(var))
             for (const auto & val : hall)

--- a/gcs/constraints/global_cardinality/justify.hh
+++ b/gcs/constraints/global_cardinality/justify.hh
@@ -37,7 +37,7 @@ namespace gcs::innards
 
     auto gcc_capacity_reason(const State &, const std::vector<Integer> & values,
         const std::vector<IntegerVariableID> & counts, const std::vector<std::size_t> & cut_values,
-        const std::vector<IntegerVariableID> & confined) -> Reason;
+        const std::vector<IntegerVariableID> & confined) -> ReasonLiterals;
 
     /**
      * \brief Emit the demand-cut aggregate (dual of the capacity one) for a set
@@ -59,7 +59,7 @@ namespace gcs::innards
 
     auto gcc_demand_reason(const State &, const std::vector<IntegerVariableID> & vars,
         const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
-        const std::vector<std::size_t> & cut_values, const std::vector<IntegerVariableID> & potential) -> Reason;
+        const std::vector<std::size_t> & cut_values, const std::vector<IntegerVariableID> & potential) -> ReasonLiterals;
 }
 
 #endif

--- a/gcs/constraints/in/hints.hh
+++ b/gcs/constraints/in/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_IN_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_IN_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief In's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct In
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "in";
+    };
+}
+
+#endif

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -237,7 +237,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                     if (state.in_domain(var, val))
                         continue;
 
-                    ReasonLiterals reason = materialise(generic_reason(state, vector{var}), state);
+                    ReasonLiterals reason = materialise(generic_reason(vector{var}), state);
                     for (const auto & [j, V_j] : enumerate(var_vals)) {
                         if (j == i)
                             continue;

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/in/hints.hh>
 #include <gcs/constraints/in/in.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -143,7 +144,7 @@ auto In::install_propagators(Propagators & propagators) -> void
     if (_has_no_values) {
         propagators.install_initial_contradiction(
             "No values or variables present for an 'In' constraint",
-            JustifyUsingRUP{});
+            JustifyUsingRUP{hints::In{constraint_id()}});
         return;
     }
 
@@ -154,7 +155,7 @@ auto In::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [var = _var, var_vals = _var_vals, val_vals = _val_vals, selectors = _selectors](
+        [var = _var, var_vals = _var_vals, val_vals = _val_vals, selectors = _selectors, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // Step 1: filter dom(var) — drop any value that no source supports.
             if (var_vals.empty()) {
@@ -174,7 +175,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                         runs.emplace_back(v, v);
                 }
                 for (const auto & [lo, hi] : runs)
-                    inference.infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{}, NoReason{});
+                    inference.infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{hints::In{owner}}, NoReason{});
             }
             else {
                 for (auto v : state.each_value_mutable(var)) {
@@ -202,7 +203,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                                                       WPBSum{} + 1_i * ! sel + 1_i * (var != v) >= 1_i,
                                                       ProofLevel::Temporary);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::In{owner}},
                         ExplicitReason{reason});
                 }
             }
@@ -264,7 +265,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                                                       ProofLevel::Temporary);
                                               }
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::In{owner}},
                         ExplicitReason{reason});
                 }
             }

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -174,7 +174,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                         runs.emplace_back(v, v);
                 }
                 for (const auto & [lo, hi] : runs)
-                    inference.infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{}, ReasonFunction{});
+                    inference.infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{}, NoReason{});
             }
             else {
                 for (auto v : state.each_value_mutable(var)) {
@@ -191,18 +191,19 @@ auto In::install_propagators(Propagators & propagators) -> void
                     if (supported_by_var)
                         continue;
 
-                    Reason reason;
+                    ReasonLiterals reason;
                     for (const auto & V : var_vals)
                         reason.emplace_back(V != v);
 
                     inference.infer_not_equal(logger, var, v,
-                        JustifyExplicitlyThenRUP{[logger, var, v, &selectors](const ReasonFunction & reason) {
-                            for (const auto & sel : selectors)
-                                logger->emit_rup_proof_line_under_reason(reason,
-                                    WPBSum{} + 1_i * ! sel + 1_i * (var != v) >= 1_i,
-                                    ProofLevel::Temporary);
-                        }},
-                        ReasonFunction{[=]() { return reason; }});
+                        JustifyExplicitly{[logger, var, v, &selectors](const ReasonLiterals & reason) {
+                                              for (const auto & sel : selectors)
+                                                  logger->emit_rup_proof_line_under_reason(reason,
+                                                      WPBSum{} + 1_i * ! sel + 1_i * (var != v) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
+                        ExplicitReason{reason});
                 }
             }
 
@@ -235,7 +236,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                     if (state.in_domain(var, val))
                         continue;
 
-                    Reason reason = generic_reason(state, vector{var})();
+                    ReasonLiterals reason = materialise(generic_reason(state, vector{var}), state);
                     for (const auto & [j, V_j] : enumerate(var_vals)) {
                         if (j == i)
                             continue;
@@ -244,26 +245,27 @@ auto In::install_propagators(Propagators & propagators) -> void
                     }
 
                     inference.infer_not_equal(logger, V, val,
-                        JustifyExplicitlyThenRUP{[logger, &state, &var_vals, &selectors, var, i](const ReasonFunction & reason) {
-                            // When var is fixed, dom(var) is a single value and the inner-loop
-                            // scaffolding line `! sel_j + (var != w)` collapses (under the reason's
-                            // `var = w` literal) to the same constraint as the outer `! sel_j`, so
-                            // skip the inner loop entirely.
-                            bool var_fixed = state.has_single_value(var);
-                            for (const auto & [j, V_j] : enumerate(var_vals)) {
-                                if (j == i)
-                                    continue;
-                                if (! var_fixed)
-                                    for (const auto & w : state.each_value_immutable(var))
-                                        logger->emit_rup_proof_line_under_reason(reason,
-                                            WPBSum{} + 1_i * ! selectors[j] + 1_i * (var != w) >= 1_i,
-                                            ProofLevel::Temporary);
-                                logger->emit_rup_proof_line_under_reason(reason,
-                                    WPBSum{} + 1_i * ! selectors[j] >= 1_i,
-                                    ProofLevel::Temporary);
-                            }
-                        }},
-                        ReasonFunction{[=]() { return reason; }});
+                        JustifyExplicitly{[logger, &state, &var_vals, &selectors, var, i](const ReasonLiterals & reason) {
+                                              // When var is fixed, dom(var) is a single value and the inner-loop
+                                              // scaffolding line `! sel_j + (var != w)` collapses (under the reason's
+                                              // `var = w` literal) to the same constraint as the outer `! sel_j`, so
+                                              // skip the inner loop entirely.
+                                              bool var_fixed = state.has_single_value(var);
+                                              for (const auto & [j, V_j] : enumerate(var_vals)) {
+                                                  if (j == i)
+                                                      continue;
+                                                  if (! var_fixed)
+                                                      for (const auto & w : state.each_value_immutable(var))
+                                                          logger->emit_rup_proof_line_under_reason(reason,
+                                                              WPBSum{} + 1_i * ! selectors[j] + 1_i * (var != w) >= 1_i,
+                                                              ProofLevel::Temporary);
+                                                  logger->emit_rup_proof_line_under_reason(reason,
+                                                      WPBSum{} + 1_i * ! selectors[j] >= 1_i,
+                                                      ProofLevel::Temporary);
+                                              }
+                                          },
+                            ThenRUP::Yes},
+                        ExplicitReason{reason});
                 }
             }
 

--- a/gcs/constraints/increasing/hints.hh
+++ b/gcs/constraints/increasing/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INCREASING_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INCREASING_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Increasing's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Increasing
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "increasing";
+    };
+}
+
+#endif

--- a/gcs/constraints/increasing/increasing.cc
+++ b/gcs/constraints/increasing/increasing.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/increasing/increasing.hh>
+#include <gcs/constraints/increasing/hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -84,7 +85,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_bounds.insert(triggers.on_bounds.end(), _ordered_vars.begin(), _ordered_vars.end());
 
-    propagators.install(constraint_id(), [vars = move(_ordered_vars), step](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [vars = move(_ordered_vars), step, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         auto n = vars.size();
 
         // Forward sweep: lb(vars[i]) >= lb(vars[i-1]) + step.
@@ -95,7 +96,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
             if (needed > cur_lb) {
                 auto reason_lb = prev_lb;
                 inference.infer_greater_than_or_equal(logger, vars[i], needed,
-                    JustifyUsingRUP{},
+                    JustifyUsingRUP{hints::Increasing{owner}},
                     ExplicitReason{ReasonLiterals{{vars[i - 1] >= reason_lb}}});
                 prev_lb = needed;
             }
@@ -113,7 +114,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
             if (needed < cur_ub) {
                 auto reason_ub = prev_ub;
                 inference.infer_less_than(logger, vars[i], needed + 1_i,
-                    JustifyUsingRUP{},
+                    JustifyUsingRUP{hints::Increasing{owner}},
                     ExplicitReason{ReasonLiterals{{vars[i + 1] <= reason_ub}}});
                 prev_ub = needed;
             }

--- a/gcs/constraints/increasing/increasing.cc
+++ b/gcs/constraints/increasing/increasing.cc
@@ -96,7 +96,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
                 auto reason_lb = prev_lb;
                 inference.infer_greater_than_or_equal(logger, vars[i], needed,
                     JustifyUsingRUP{},
-                    ReasonFunction{[v = vars[i - 1], reason_lb]() { return Reason{{v >= reason_lb}}; }});
+                    ExplicitReason{ReasonLiterals{{vars[i - 1] >= reason_lb}}});
                 prev_lb = needed;
             }
             else {
@@ -114,7 +114,7 @@ auto IncreasingChain::install_propagators(Propagators & propagators) -> void
                 auto reason_ub = prev_ub;
                 inference.infer_less_than(logger, vars[i], needed + 1_i,
                     JustifyUsingRUP{},
-                    ReasonFunction{[v = vars[i + 1], reason_ub]() { return Reason{{v <= reason_ub}}; }});
+                    ExplicitReason{ReasonLiterals{{vars[i + 1] <= reason_ub}}});
                 prev_ub = needed;
             }
             else {

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -388,7 +388,7 @@ namespace gcs::test_innards
 
         solve_with(p,
             SolveCallbacks{.solution = capped_solution, .trace = capped_trace, .branch = random_branch_with_optional_seed(p)},
-            proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}, true, false) : std::nullopt);
+            proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}) : std::nullopt);
     }
 
     /**
@@ -404,7 +404,7 @@ namespace gcs::test_innards
             SolveCallbacks{
                 .trace = [](const CurrentState &) -> bool { return false; },
                 .branch = random_branch_with_optional_seed(p)},
-            std::make_optional<ProofOptions>(ProofFileNames{proof_name}, true, false));
+            std::make_optional<ProofOptions>(ProofFileNames{proof_name}));
 
         if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
             throw UnexpectedException{"veripb verification failed"};

--- a/gcs/constraints/innards/justify_not_in_range.cc
+++ b/gcs/constraints/innards/justify_not_in_range.cc
@@ -5,7 +5,7 @@ using namespace gcs::innards;
 
 auto gcs::innards::justify_not_in_range_across_equality(
     ProofLogger & logger,
-    const ReasonFunction & reason,
+    const ReasonLiterals & reason,
     const SimpleIntegerVariableID & pruned,
     Integer lo,
     Integer hi,

--- a/gcs/constraints/innards/justify_not_in_range.hh
+++ b/gcs/constraints/innards/justify_not_in_range.hh
@@ -25,7 +25,7 @@ namespace gcs::innards
     // infer_not_in_range.
     auto justify_not_in_range_across_equality(
         ProofLogger & logger,
-        const ReasonFunction & reason,
+        const ReasonLiterals & reason,
         const SimpleIntegerVariableID & pruned,
         Integer lo,
         Integer hi,

--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -3,6 +3,10 @@
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 
+#include <gcs/proof.hh>
+#include <util/enumerate.hh>
+
+#include <sstream>
 #include <type_traits>
 #include <variant>
 
@@ -21,6 +25,9 @@ template <typename Literal_>
     const vector<Literal_> & atoms,
     const function<auto(const Literal_ &, const Literal_ &)->ProofLine> & pair_ne) -> ProofLine
 {
+    if (logger.get_assertion_level() > AssertionLevel::Off)
+        return ProofLine{};
+
     if (atoms.size() < 2)
         // An at-most-one over fewer than two atoms is vacuous; the caller should
         // handle it directly rather than ask the helper to fold zero pairwise

--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -65,7 +65,7 @@ template <typename Literal_>
     // Temporary depth (active_proof_level + 1) — and our cleanup at that
     // depth would wipe out the caller's scope along with our own
     // intermediates. (Concrete failure mode: when the caller is itself
-    // inside JustifyExplicitlyThenRUP, which uses depth active+1 for its
+    // inside a JustifyExplicitly{…, ThenRUP::Yes}, which uses depth active+1 for its
     // callback's Temporary lines, a naive forget at that same depth from
     // inside recover_am1 deletes the framework's just-emitted lines
     // mid-justification.)
@@ -78,7 +78,7 @@ template <typename Literal_>
     // The result itself is emitted *after* restoring the caller's level, so
     // it records at the level the caller asked for: Top callers (in
     // initialisers, caching the line for reuse) get depth 0 as before;
-    // Temporary callers (e.g. inside a JustifyExplicitlyThenRUP that folds
+    // Temporary callers (e.g. inside a JustifyExplicitly{…, ThenRUP::Yes} that folds
     // the result into a further pol) get the caller's Temporary depth, so
     // the line survives our own deeper cleanup and is reclaimed when the
     // caller's scope is forgotten.

--- a/gcs/constraints/innards/reified_dispatcher.hh
+++ b/gcs/constraints/innards/reified_dispatcher.hh
@@ -35,21 +35,25 @@ namespace gcs::innards
          * dispatcher will infer the appropriate cond literal using the
          * given justification and reason.
          */
+        template <typename Justification_ = Justification>
         struct MustHold
         {
-            Justification justification;
-            ReasonFunction reason;
+            Justification_ justification;
+            Reason reason;
             std::optional<AssertionAnnotation> assertion_hint = std::nullopt;
+            static constexpr bool affirmative = true;
         };
 
         /**
          * \brief The constraint cannot hold. Same shape as MustHold.
          */
+        template <typename Justification_ = Justification>
         struct MustNotHold
         {
-            Justification justification;
-            ReasonFunction reason;
+            Justification_ justification;
+            Reason reason;
             std::optional<AssertionAnnotation> assertion_hint = std::nullopt;
+            static constexpr bool affirmative = false;
         };
     }
 
@@ -60,10 +64,16 @@ namespace gcs::innards
      * the cond inference, and the dispatcher decides whether and which
      * literal to infer).
      */
-    using ReificationVerdict = std::variant<
+    template <typename Justification_ = Justification>
+    using ReificationVerdictFor = std::variant<
         reification_verdict::StillUndecided,
-        reification_verdict::MustHold,
-        reification_verdict::MustNotHold>;
+        reification_verdict::MustHold<Justification_>,
+        reification_verdict::MustNotHold<Justification_>>;
+
+    // The default verdict, whose justification is the plain Justification variant.
+    // Constraints that put typed witnesses in a verdict name their own justification
+    // type and use ReificationVerdictFor<That> instead.
+    using ReificationVerdict = ReificationVerdictFor<>;
 
     /**
      * \brief Install a single propagator that dispatches on the current state
@@ -139,21 +149,28 @@ namespace gcs::innards
                         return enforce_constraint_must_not_hold(state, inference, logger, reif.cond);
                     },
                     [&](const evaluated_reif::Undecided & reif) {
-                        return overloaded{
-                            [&](const reification_verdict::StillUndecided &) {
+                        // The verdict's justification type varies per constraint
+                        // (plain Justification, a single typed JustifyExplicitly, or a
+                        // variant of justification shapes), so dispatch generically:
+                        // StillUndecided enables; a MustHold/MustNotHold infers the
+                        // appropriate cond literal under its justification, the
+                        // affirmative tag picking which literal. Forwarding
+                        // v.justification to infer() pushes any variant-visit into
+                        // infer() itself.
+                        return std::visit([&](const auto & v) -> PropagatorState {
+                            using V = std::decay_t<decltype(v)>;
+                            if constexpr (std::is_same_v<V, reification_verdict::StillUndecided>)
                                 return PropagatorState::Enable;
-                            },
-                            [&](const reification_verdict::MustHold & h) {
-                                if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                    inference.infer(logger, *lit, h.justification, h.reason, h.assertion_hint);
+                            else {
+                                auto lit = V::affirmative
+                                    ? reif.cond_to_infer_if_constraint_must_hold()
+                                    : reif.cond_to_infer_if_constraint_must_not_hold();
+                                if (lit)
+                                    inference.infer(logger, *lit, v.justification, v.reason, v.assertion_hint);
                                 return PropagatorState::DisableUntilBacktrack;
-                            },
-                            [&](const reification_verdict::MustNotHold & n) {
-                                if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                    inference.infer(logger, *lit, n.justification, n.reason, n.assertion_hint);
-                                return PropagatorState::DisableUntilBacktrack;
-                            }}
-                            .visit(infer_cond_when_undecided(state, inference, logger, reif.cond));
+                            }
+                        },
+                            infer_cond_when_undecided(state, inference, logger, reif.cond));
                     },
                     [&](const evaluated_reif::Deactivated &) {
                         return PropagatorState::DisableUntilBacktrack;

--- a/gcs/constraints/innards/reified_dispatcher.hh
+++ b/gcs/constraints/innards/reified_dispatcher.hh
@@ -4,15 +4,16 @@
 
 #include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/constraints/innards/triggers.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/reification.hh>
 
+#include <optional>
 #include <util/overloaded.hh>
 
-#include <string>
 #include <utility>
 #include <variant>
 
@@ -38,6 +39,7 @@ namespace gcs::innards
         {
             Justification justification;
             ReasonFunction reason;
+            std::optional<AssertionAnnotation> assertion_hint = std::nullopt;
         };
 
         /**
@@ -47,6 +49,7 @@ namespace gcs::innards
         {
             Justification justification;
             ReasonFunction reason;
+            std::optional<AssertionAnnotation> assertion_hint = std::nullopt;
         };
     }
 
@@ -142,12 +145,12 @@ namespace gcs::innards
                             },
                             [&](const reification_verdict::MustHold & h) {
                                 if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                    inference.infer(logger, *lit, h.justification, h.reason);
+                                    inference.infer(logger, *lit, h.justification, h.reason, h.assertion_hint);
                                 return PropagatorState::DisableUntilBacktrack;
                             },
                             [&](const reification_verdict::MustNotHold & n) {
                                 if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                    inference.infer(logger, *lit, n.justification, n.reason);
+                                    inference.infer(logger, *lit, n.justification, n.reason, n.assertion_hint);
                                 return PropagatorState::DisableUntilBacktrack;
                             }}
                             .visit(infer_cond_when_undecided(state, inference, logger, reif.cond));

--- a/gcs/constraints/inverse/hints.hh
+++ b/gcs/constraints/inverse/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INVERSE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INVERSE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Inverse's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Inverse
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "inverse";
+    };
+}
+
+#endif

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -170,7 +170,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
                 if (! state.in_domain(y.at((x_i_value - y_start).as_index()), Integer(i) + x_start))
                     inf.infer(logger, x_i != x_i_value,
                         JustifyUsingRUP{},
-                        [&]() { return Reason{y.at((x_i_value - y_start).as_index()) != Integer(i) + x_start}; });
+                        ExplicitReason{ReasonLiterals{y.at((x_i_value - y_start).as_index()) != Integer(i) + x_start}});
         }
 
         for (const auto & [i, y_i] : enumerate(y)) {
@@ -178,7 +178,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
                 if (! state.in_domain(x.at((y_i_value - x_start).as_index()), Integer(i) + y_start))
                     inf.infer(logger, y_i != y_i_value,
                         JustifyUsingRUP{},
-                        [&]() { return Reason{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}; });
+                        ExplicitReason{ReasonLiterals{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}});
         }
 
         propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -11,6 +11,7 @@
 #include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
 
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 
 #include <version>
@@ -149,6 +150,8 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
 
         propagators.install_initialiser([x = _x, x_start = _x_start, x_value_am1s = _x_value_am1s, build_am1s = build_am1s](
                                             const State & state, auto & inference, ProofLogger * const logger) -> void {
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                return;
             build_am1s(x, x_start, state, inference, logger, x_value_am1s);
         });
     }
@@ -161,7 +164,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
     for (const auto & [i, _] : enumerate(_x))
         x_values.push_back(Integer(i) + _x_start);
 
-    propagators.install(constraint_id(), [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s, constraint_id = constraint_id()](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
         for (const auto & [i, x_i] : enumerate(x)) {
             for (auto x_i_value : state.each_value_mutable(x_i))
                 if (! state.in_domain(y.at((x_i_value - y_start).as_index()), Integer(i) + x_start))
@@ -178,7 +181,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
                         [&]() { return Reason{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}; });
         }
 
-        propagate_gac_all_different(x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
+        propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
 
         return PropagatorState::Enable; }, triggers);
 }

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/all_different/gac_all_different.hh>
 #include <gcs/constraints/innards/recover_am1.hh>
+#include <gcs/constraints/inverse/hints.hh>
 #include <gcs/constraints/inverse/inverse.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -164,12 +165,12 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
     for (const auto & [i, _] : enumerate(_x))
         x_values.push_back(Integer(i) + _x_start);
 
-    propagators.install(constraint_id(), [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s, constraint_id = constraint_id()](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s, constraint_id = constraint_id(), owner = constraint_id()](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
         for (const auto & [i, x_i] : enumerate(x)) {
             for (auto x_i_value : state.each_value_mutable(x_i))
                 if (! state.in_domain(y.at((x_i_value - y_start).as_index()), Integer(i) + x_start))
                     inf.infer(logger, x_i != x_i_value,
-                        JustifyUsingRUP{},
+                        JustifyUsingRUP{hints::Inverse{owner}},
                         ExplicitReason{ReasonLiterals{y.at((x_i_value - y_start).as_index()) != Integer(i) + x_start}});
         }
 
@@ -177,7 +178,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
             for (auto y_i_value : state.each_value_mutable(y_i))
                 if (! state.in_domain(x.at((y_i_value - x_start).as_index()), Integer(i) + y_start))
                     inf.infer(logger, y_i != y_i_value,
-                        JustifyUsingRUP{},
+                        JustifyUsingRUP{hints::Inverse{owner}},
                         ExplicitReason{ReasonLiterals{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}});
         }
 

--- a/gcs/constraints/knapsack/hints.hh
+++ b/gcs/constraints/knapsack/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_KNAPSACK_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_KNAPSACK_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Knapsack's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Knapsack
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "knapsack";
+    };
+}
+
+#endif

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -9,6 +9,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -575,20 +576,20 @@ namespace
             boundses.emplace_back(state.bounds(t));
 
         int temporary_proof_level = 0;
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             temporary_proof_level = logger->temporary_proof_level();
 
         vector<IntegerVariableID> reason_variables;
         reason_variables.insert(reason_variables.end(), vars.begin(), vars.end());
         reason_variables.insert(reason_variables.end(), totals.begin(), totals.end());
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             knapsack_gac<true>(state, logger, reason_variables, inference, committed_sums,
                 boundses, coeffs, totals, vars, undetermined_vars, eqn_lines);
         else
             knapsack_gac<false>(state, logger, reason_variables, inference, committed_sums,
                 boundses, coeffs, totals, vars, undetermined_vars, nullopt);
 
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->forget_proof_level(temporary_proof_level);
 
         return PropagatorState::Enable;

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/knapsack/hints.hh>
 #include <gcs/constraints/knapsack/knapsack.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -103,6 +104,7 @@ namespace
         ProofLogger * const logger,
         const vector<IntegerVariableID> & reason_variables,
         auto & inference,
+        const ConstraintID & owner,
         const vector<Integer> & committed,
         const vector<pair<Integer, Integer>> & bounds,
         const vector<vector<Integer>> & coeffs,
@@ -366,7 +368,7 @@ namespace
                                 ProofLevel::Temporary);
                         }
                     }
-                    inference.infer(logger, vars_including_assigned.at(var_idx) != val, JustifyUsingRUP{},
+                    inference.infer(logger, vars_including_assigned.at(var_idx) != val, JustifyUsingRUP{hints::Knapsack{owner}},
                         eager_reason(generic_reason(state, reason_variables), state));
                 }
             }
@@ -441,7 +443,7 @@ namespace
                 logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), WPBSum{} >= 1_i, ProofLevel::Temporary);
             }
 
-            inference.contradiction(logger, JustifyUsingRUP{}, eager_reason(generic_reason(state, reason_variables), state));
+            inference.contradiction(logger, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, reason_variables), state));
         }
         else {
             vector<Literal> inferences;
@@ -500,7 +502,7 @@ namespace
                 }
             }
 
-            inference.infer_all(logger, inferences, JustifyUsingRUP{}, eager_reason(generic_reason(state, reason_variables), state));
+            inference.infer_all(logger, inferences, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, reason_variables), state));
 
             // now run backwards from the final state, eliminating states that
             // didn't lead to a feasible terminal state, and seeing if any
@@ -532,7 +534,7 @@ namespace
                 auto var = vars_including_assigned.at(undetermined_var_indices.at(var_number));
                 for (auto val : state.each_value_mutable(var)) {
                     if (! supported.contains(val))
-                        inference.infer(logger, var != val, JustifyUsingRUP{}, eager_reason(generic_reason(state, reason_variables), state));
+                        inference.infer(logger, var != val, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, reason_variables), state));
                 }
             }
         }
@@ -542,6 +544,7 @@ namespace
         const State & state,
         ProofLogger * const logger,
         auto & inference,
+        const ConstraintID & owner,
         const vector<vector<Integer>> & coeffs,
         const vector<IntegerVariableID> & vars,
         const vector<IntegerVariableID> & totals,
@@ -564,12 +567,12 @@ namespace
                 all_vars_assigned.push_back(v == state(v));
 
             for (const auto & [x, t] : enumerate(totals)) {
-                inference.infer(logger, totals.at(x) == committed_sums.at(x), JustifyUsingRUP{}, all_vars_assigned);
+                inference.infer(logger, totals.at(x) == committed_sums.at(x), JustifyUsingRUP{hints::Knapsack{owner}}, all_vars_assigned);
             }
         }
 
         for (const auto & [x, v] : enumerate(totals))
-            inference.infer(logger, v >= committed_sums.at(x), JustifyUsingRUP{}, eager_reason(generic_reason(state, vars), state));
+            inference.infer(logger, v >= committed_sums.at(x), JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, vars), state));
 
         vector<pair<Integer, Integer>> boundses;
         for (auto & t : totals)
@@ -583,10 +586,10 @@ namespace
         reason_variables.insert(reason_variables.end(), vars.begin(), vars.end());
         reason_variables.insert(reason_variables.end(), totals.begin(), totals.end());
         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-            knapsack_gac<true>(state, logger, reason_variables, inference, committed_sums,
+            knapsack_gac<true>(state, logger, reason_variables, inference, owner, committed_sums,
                 boundses, coeffs, totals, vars, undetermined_vars, eqn_lines);
         else
-            knapsack_gac<false>(state, logger, reason_variables, inference, committed_sums,
+            knapsack_gac<false>(state, logger, reason_variables, inference, owner, committed_sums,
                 boundses, coeffs, totals, vars, undetermined_vars, nullopt);
 
         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
@@ -655,9 +658,9 @@ auto Knapsack::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [coeffs = move(_coeffs), vars = move(_vars), totals = move(_totals), eqns_lines = move(_eqns_lines)](
+        [coeffs = move(_coeffs), vars = move(_vars), totals = move(_totals), eqns_lines = move(_eqns_lines), owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return knapsack(state, logger, inference, coeffs, vars, totals, eqns_lines);
+            return knapsack(state, logger, inference, owner, coeffs, vars, totals, eqns_lines);
         },
         triggers);
 }

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -251,10 +251,10 @@ namespace
                                     .add(ge_datas.at(x)->second.reverse_reif_line)
                                     .add(completed_node_data->ges.at(x).forward_reif_line)
                                     .emit(*logger, ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                 WPBSum{} + 1_i * not_in_ge_states.at(x) + 1_i * not_choice + 1_i * ge_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                 WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice + 1_i * ge_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
 
@@ -264,16 +264,16 @@ namespace
                                     .add(le_datas.at(x)->second.reverse_reif_line)
                                     .add(completed_node_data->les.at(x).forward_reif_line)
                                     .emit(*logger, ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                 WPBSum{} + 1_i * not_in_le_states.at(x) + 1_i * not_choice + 1_i * le_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                 WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice + 1_i * le_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
                         }
 
                         // current choices and branch -> current state
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                             WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice + 1_i * *node_data->second->reif_flag >= 1_i,
                             ProofLevel::Temporary);
 
@@ -287,10 +287,10 @@ namespace
                                     .add(opb_lines->at(x).first);
                                 add_bound_p_term_to(b, state, logger, totals.at(x), true);
                                 b.emit(*logger, ProofLevel::Temporary);
-                                logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                     WPBSum{} + 1_i * not_in_ge_states.at(x) + 1_i * not_choice >= 1_i,
                                     ProofLevel::Temporary);
-                                logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                     WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice >= 1_i,
                                     ProofLevel::Temporary);
                                 eliminated = true;
@@ -317,7 +317,7 @@ namespace
 
                     for (auto & f : feasible_choices)
                         must_pick_one_val += 1_i * (vars_including_assigned.at(var_idx) == f);
-                    logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                         must_pick_one_val >= 1_i, ProofLevel::Temporary);
 
                     for (const auto & [x, _] : enumerate(totals)) {
@@ -326,13 +326,13 @@ namespace
                             must_pick_one_le += 1_i * f;
                         for (auto & f : feasible_ge_flags.at(x))
                             must_pick_one_ge += 1_i * f;
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables), must_pick_one_le >= 1_i, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables), must_pick_one_ge >= 1_i, ProofLevel::Temporary);
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one_le >= 1_i, ProofLevel::Temporary);
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one_ge >= 1_i, ProofLevel::Temporary);
                     }
 
                     for (auto & f : feasible_node_flags)
                         must_pick_one_node += 1_i * f;
-                    logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables), must_pick_one_node >= 1_i, ProofLevel::Temporary);
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one_node >= 1_i, ProofLevel::Temporary);
                 }
             }
 
@@ -352,7 +352,7 @@ namespace
                 WPBSum must_pick_one;
                 for (auto & [_, data] : growing_layer_nodes)
                     must_pick_one += 1_i * *data->reif_flag;
-                logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables), must_pick_one >= 1_i, ProofLevel::Temporary);
+                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one >= 1_i, ProofLevel::Temporary);
             }
 
             // we might have some values that never allowed a state to be created
@@ -361,13 +361,13 @@ namespace
                     if constexpr (doing_proof_) {
                         logger->emit_proof_comment("unsupported value on forward pass");
                         for (auto & [_, data] : growing_layer_nodes) {
-                            logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                 WPBSum{} + 1_i * ! *data->reif_flag + 1_i * (vars_including_assigned.at(var_idx) != val) >= 1_i,
                                 ProofLevel::Temporary);
                         }
                     }
                     inference.infer(logger, vars_including_assigned.at(var_idx) != val, JustifyUsingRUP{},
-                        generic_reason(state, reason_variables));
+                        eager_reason(generic_reason(state, reason_variables), state));
                 }
             }
 
@@ -386,10 +386,10 @@ namespace
                             .add(opb_lines->at(x).second);
                         add_bound_p_term_to(b, state, logger, totals.at(x), false);
                         b.emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                             WPBSum{} + 1_i * ! final_states_iter->second->les.at(x).reif_flag >= 1_i,
                             ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                             WPBSum{} + 1_i * ! *final_states_iter->second->reif_flag >= 1_i,
                             ProofLevel::Temporary);
                     }
@@ -418,10 +418,10 @@ namespace
                             .add(final_states_iter->second->ges.at(x).forward_reif_line)
                             .add(opb_lines->at(x).first)
                             .emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                             WPBSum{} + 1_i * ! *final_states_iter->second->reif_flag + 1_i * (totals.at(x) == val) >= 1_i,
                             ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                             WPBSum{} + 1_i * ! *final_states_iter->second->reif_flag >= 1_i,
                             ProofLevel::Temporary);
                     }
@@ -438,10 +438,10 @@ namespace
         if (completed_layers.back().empty()) {
             if constexpr (doing_proof_) {
                 logger->emit_proof_comment("no feasible choices remaining");
-                logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables), WPBSum{} >= 1_i, ProofLevel::Temporary);
+                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), WPBSum{} >= 1_i, ProofLevel::Temporary);
             }
 
-            inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, reason_variables));
+            inference.contradiction(logger, JustifyUsingRUP{}, eager_reason(generic_reason(state, reason_variables), state));
         }
         else {
             vector<Literal> inferences;
@@ -476,7 +476,7 @@ namespace
                             .add(opb_lines->at(x).first)
                             .add(data->ges.at(x).forward_reif_line)
                             .emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                             no_support_ge + 1_i * (totals.at(x) >= committed.at(x) + lowest) >= 1_i,
                             ProofLevel::Temporary);
 
@@ -485,22 +485,22 @@ namespace
                             .add(opb_lines->at(x).second)
                             .add(data->les.at(x).forward_reif_line)
                             .emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                             no_support_le + 1_i * (totals.at(x) <= committed.at(x) + highest) >= 1_i,
                             ProofLevel::Temporary);
                     }
 
                     logger->emit_proof_comment("deduce overall conclusions");
-                    logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                         WPBSum{} + 1_i * (totals.at(x) >= committed.at(x) + lowest) >= 1_i,
                         ProofLevel::Temporary);
-                    logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                         WPBSum{} + 1_i * (totals.at(x) <= committed.at(x) + highest) >= 1_i,
                         ProofLevel::Temporary);
                 }
             }
 
-            inference.infer_all(logger, inferences, JustifyUsingRUP{}, generic_reason(state, reason_variables));
+            inference.infer_all(logger, inferences, JustifyUsingRUP{}, eager_reason(generic_reason(state, reason_variables), state));
 
             // now run backwards from the final state, eliminating states that
             // didn't lead to a feasible terminal state, and seeing if any
@@ -522,7 +522,7 @@ namespace
                     else {
                         if constexpr (doing_proof_)
                             if (state_iter->second->reif_flag)
-                                logger->emit_rup_proof_line_under_reason(generic_reason(state, reason_variables),
+                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
                                     WPBSum{} + 1_i * ! *state_iter->second->reif_flag >= 1_i,
                                     ProofLevel::Temporary);
                         next(layer)->erase(state_iter++);
@@ -532,7 +532,7 @@ namespace
                 auto var = vars_including_assigned.at(undetermined_var_indices.at(var_number));
                 for (auto val : state.each_value_mutable(var)) {
                     if (! supported.contains(val))
-                        inference.infer(logger, var != val, JustifyUsingRUP{}, generic_reason(state, reason_variables));
+                        inference.infer(logger, var != val, JustifyUsingRUP{}, eager_reason(generic_reason(state, reason_variables), state));
                 }
             }
         }
@@ -559,17 +559,17 @@ namespace
         }
 
         if (undetermined_vars.empty()) {
-            Reason all_vars_assigned;
+            ReasonLiterals all_vars_assigned;
             for (auto & v : vars)
                 all_vars_assigned.push_back(v == state(v));
 
             for (const auto & [x, t] : enumerate(totals)) {
-                inference.infer(logger, totals.at(x) == committed_sums.at(x), JustifyUsingRUP{}, [=]() { return all_vars_assigned; });
+                inference.infer(logger, totals.at(x) == committed_sums.at(x), JustifyUsingRUP{}, all_vars_assigned);
             }
         }
 
         for (const auto & [x, v] : enumerate(totals))
-            inference.infer(logger, v >= committed_sums.at(x), JustifyUsingRUP{}, generic_reason(state, vars));
+            inference.infer(logger, v >= committed_sums.at(x), JustifyUsingRUP{}, eager_reason(generic_reason(state, vars), state));
 
         vector<pair<Integer, Integer>> boundses;
         for (auto & t : totals)

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -253,10 +253,10 @@ namespace
                                     .add(ge_datas.at(x)->second.reverse_reif_line)
                                     .add(completed_node_data->ges.at(x).forward_reif_line)
                                     .emit(*logger, ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                 WPBSum{} + 1_i * not_in_ge_states.at(x) + 1_i * not_choice + 1_i * ge_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                 WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice + 1_i * ge_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
 
@@ -266,16 +266,16 @@ namespace
                                     .add(le_datas.at(x)->second.reverse_reif_line)
                                     .add(completed_node_data->les.at(x).forward_reif_line)
                                     .emit(*logger, ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                 WPBSum{} + 1_i * not_in_le_states.at(x) + 1_i * not_choice + 1_i * le_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
-                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                 WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice + 1_i * le_datas.at(x)->second.reif_flag >= 1_i,
                                 ProofLevel::Temporary);
                         }
 
                         // current choices and branch -> current state
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                             WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice + 1_i * *node_data->second->reif_flag >= 1_i,
                             ProofLevel::Temporary);
 
@@ -289,10 +289,10 @@ namespace
                                     .add(opb_lines->at(x).first);
                                 add_bound_p_term_to(b, state, logger, totals.at(x), true);
                                 b.emit(*logger, ProofLevel::Temporary);
-                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                     WPBSum{} + 1_i * not_in_ge_states.at(x) + 1_i * not_choice >= 1_i,
                                     ProofLevel::Temporary);
-                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                     WPBSum{} + 1_i * not_in_full_state + 1_i * not_choice >= 1_i,
                                     ProofLevel::Temporary);
                                 eliminated = true;
@@ -319,7 +319,7 @@ namespace
 
                     for (auto & f : feasible_choices)
                         must_pick_one_val += 1_i * (vars_including_assigned.at(var_idx) == f);
-                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                         must_pick_one_val >= 1_i, ProofLevel::Temporary);
 
                     for (const auto & [x, _] : enumerate(totals)) {
@@ -328,13 +328,13 @@ namespace
                             must_pick_one_le += 1_i * f;
                         for (auto & f : feasible_ge_flags.at(x))
                             must_pick_one_ge += 1_i * f;
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one_le >= 1_i, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one_ge >= 1_i, ProofLevel::Temporary);
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state), must_pick_one_le >= 1_i, ProofLevel::Temporary);
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state), must_pick_one_ge >= 1_i, ProofLevel::Temporary);
                     }
 
                     for (auto & f : feasible_node_flags)
                         must_pick_one_node += 1_i * f;
-                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one_node >= 1_i, ProofLevel::Temporary);
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state), must_pick_one_node >= 1_i, ProofLevel::Temporary);
                 }
             }
 
@@ -354,7 +354,7 @@ namespace
                 WPBSum must_pick_one;
                 for (auto & [_, data] : growing_layer_nodes)
                     must_pick_one += 1_i * *data->reif_flag;
-                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), must_pick_one >= 1_i, ProofLevel::Temporary);
+                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state), must_pick_one >= 1_i, ProofLevel::Temporary);
             }
 
             // we might have some values that never allowed a state to be created
@@ -363,13 +363,13 @@ namespace
                     if constexpr (doing_proof_) {
                         logger->emit_proof_comment("unsupported value on forward pass");
                         for (auto & [_, data] : growing_layer_nodes) {
-                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                            logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                 WPBSum{} + 1_i * ! *data->reif_flag + 1_i * (vars_including_assigned.at(var_idx) != val) >= 1_i,
                                 ProofLevel::Temporary);
                         }
                     }
                     inference.infer(logger, vars_including_assigned.at(var_idx) != val, JustifyUsingRUP{hints::Knapsack{owner}},
-                        eager_reason(generic_reason(state, reason_variables), state));
+                        eager_reason(generic_reason(reason_variables), state));
                 }
             }
 
@@ -388,10 +388,10 @@ namespace
                             .add(opb_lines->at(x).second);
                         add_bound_p_term_to(b, state, logger, totals.at(x), false);
                         b.emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                             WPBSum{} + 1_i * ! final_states_iter->second->les.at(x).reif_flag >= 1_i,
                             ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                             WPBSum{} + 1_i * ! *final_states_iter->second->reif_flag >= 1_i,
                             ProofLevel::Temporary);
                     }
@@ -420,10 +420,10 @@ namespace
                             .add(final_states_iter->second->ges.at(x).forward_reif_line)
                             .add(opb_lines->at(x).first)
                             .emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                             WPBSum{} + 1_i * ! *final_states_iter->second->reif_flag + 1_i * (totals.at(x) == val) >= 1_i,
                             ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                             WPBSum{} + 1_i * ! *final_states_iter->second->reif_flag >= 1_i,
                             ProofLevel::Temporary);
                     }
@@ -440,10 +440,10 @@ namespace
         if (completed_layers.back().empty()) {
             if constexpr (doing_proof_) {
                 logger->emit_proof_comment("no feasible choices remaining");
-                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state), WPBSum{} >= 1_i, ProofLevel::Temporary);
+                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state), WPBSum{} >= 1_i, ProofLevel::Temporary);
             }
 
-            inference.contradiction(logger, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, reason_variables), state));
+            inference.contradiction(logger, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(reason_variables), state));
         }
         else {
             vector<Literal> inferences;
@@ -478,7 +478,7 @@ namespace
                             .add(opb_lines->at(x).first)
                             .add(data->ges.at(x).forward_reif_line)
                             .emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                             no_support_ge + 1_i * (totals.at(x) >= committed.at(x) + lowest) >= 1_i,
                             ProofLevel::Temporary);
 
@@ -487,22 +487,22 @@ namespace
                             .add(opb_lines->at(x).second)
                             .add(data->les.at(x).forward_reif_line)
                             .emit(*logger, ProofLevel::Temporary);
-                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                        logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                             no_support_le + 1_i * (totals.at(x) <= committed.at(x) + highest) >= 1_i,
                             ProofLevel::Temporary);
                     }
 
                     logger->emit_proof_comment("deduce overall conclusions");
-                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                         WPBSum{} + 1_i * (totals.at(x) >= committed.at(x) + lowest) >= 1_i,
                         ProofLevel::Temporary);
-                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                    logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                         WPBSum{} + 1_i * (totals.at(x) <= committed.at(x) + highest) >= 1_i,
                         ProofLevel::Temporary);
                 }
             }
 
-            inference.infer_all(logger, inferences, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, reason_variables), state));
+            inference.infer_all(logger, inferences, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(reason_variables), state));
 
             // now run backwards from the final state, eliminating states that
             // didn't lead to a feasible terminal state, and seeing if any
@@ -524,7 +524,7 @@ namespace
                     else {
                         if constexpr (doing_proof_)
                             if (state_iter->second->reif_flag)
-                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(state, reason_variables), state),
+                                logger->emit_rup_proof_line_under_reason(eager_reason(generic_reason(reason_variables), state),
                                     WPBSum{} + 1_i * ! *state_iter->second->reif_flag >= 1_i,
                                     ProofLevel::Temporary);
                         next(layer)->erase(state_iter++);
@@ -534,7 +534,7 @@ namespace
                 auto var = vars_including_assigned.at(undetermined_var_indices.at(var_number));
                 for (auto val : state.each_value_mutable(var)) {
                     if (! supported.contains(val))
-                        inference.infer(logger, var != val, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, reason_variables), state));
+                        inference.infer(logger, var != val, JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(reason_variables), state));
                 }
             }
         }
@@ -572,7 +572,7 @@ namespace
         }
 
         for (const auto & [x, v] : enumerate(totals))
-            inference.infer(logger, v >= committed_sums.at(x), JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(state, vars), state));
+            inference.infer(logger, v >= committed_sums.at(x), JustifyUsingRUP{hints::Knapsack{owner}}, eager_reason(generic_reason(vars), state));
 
         vector<pair<Integer, Integer>> boundses;
         for (auto & t : totals)

--- a/gcs/constraints/lex/hints.hh
+++ b/gcs/constraints/lex/hints.hh
@@ -1,0 +1,63 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LEX_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LEX_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state-fwd.hh>
+#include <gcs/variable_id.hh>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief lex's base assertion hint: just the owning constraint.
+     *
+     * Carried by the direct lex-pass inferences (the prefix-equality tightenings and
+     * the contradiction when the order is violated). The explicit steps are emitted
+     * by inline closures, so the base carries no data -- only the constraint
+     * identity.
+     *
+     * \ingroup Innards
+     */
+    struct Lex
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "lex";
+    };
+
+    /**
+     * \brief lex's "the order is forced unsatisfiable" hint, carried in a reified
+     * verdict.
+     *
+     * Extends the base with the `unsat_scaffold` subhint and the emit context the
+     * scaffold builder reads: the implicated reason, the two variable lists, the
+     * compared prefix length, and the prefix-equal / decision-point aux-flag tables
+     * (by shared_ptr), with the State by pointer (the verdict is consumed
+     * synchronously while the constraint is live). Held for emit_justification only;
+     * with no own hint_sexpr the hint takes the default identity-plus-subhint wire
+     * form.
+     *
+     * \ingroup Innards
+     */
+    struct LexUnsatScaffold : Lex
+    {
+        static constexpr std::string_view subhint_name = "unsat_scaffold";
+        const State * state;
+        ReasonLiterals reason;
+        std::vector<IntegerVariableID> first_vars, second_vars;
+        std::size_t n;
+        std::shared_ptr<std::vector<std::optional<ProofFlag>>> prefix_equal_flags;
+        std::shared_ptr<std::vector<ProofFlag>> decision_at_flags;
+    };
+
+    auto emit_justification(ProofLogger & logger, const LexUnsatScaffold & scaffold, const ReasonLiterals & reason) -> void;
+}
+
+#endif

--- a/gcs/constraints/lex/lex.cc
+++ b/gcs/constraints/lex/lex.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/innards/reified_dispatcher.hh>
+#include <gcs/constraints/lex/hints.hh>
 #include <gcs/constraints/lex/lex.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -81,7 +82,7 @@ namespace
         const shared_ptr<vector<optional<ProofFlag>>> & prefix_equal_flags,
         const shared_ptr<vector<ProofFlag>> & decision_at_flags,
         const Literal & cond,
-        ConstraintStateHandle state_handle) -> PropagatorState
+        ConstraintStateHandle state_handle, const ConstraintID & owner) -> PropagatorState
     {
         auto n1 = vars_1.size();
         auto n2 = vars_2.size();
@@ -125,7 +126,7 @@ namespace
                         WPBSum{} + 1_i * ! decision_at_flags->at(k) >= 1_i,
                         ProofLevel::Temporary);
             };
-            inference.contradiction(logger, JustifyExplicitly{contradiction_proof, ThenRUP::Yes}, reason);
+            inference.contradiction(logger, JustifyExplicitly{contradiction_proof, ThenRUP::Yes, hints::Lex{owner}}, reason);
         }
 
         auto emit_not_d = [&](const ReasonLiterals & r, size_t k) -> void {
@@ -157,7 +158,7 @@ namespace
 
         inference.infer_all(logger,
             {vars_1[alpha] >= b2_alpha.first, vars_2[alpha] <= b1_alpha.second},
-            JustifyExplicitly{tighten_proof, ThenRUP::Yes}, reason);
+            JustifyExplicitly{tighten_proof, ThenRUP::Yes, hints::Lex{owner}}, reason);
 
         auto nb1_alpha = state.bounds(vars_1[alpha]);
         auto nb2_alpha = state.bounds(vars_2[alpha]);
@@ -202,7 +203,7 @@ namespace
                             emit_not_d(r, k);
                         emit_not_prefix_equal_if_credited(r);
                     };
-                    inference.contradiction(logger, JustifyExplicitly{contradiction_proof, ThenRUP::Yes}, reason);
+                    inference.contradiction(logger, JustifyExplicitly{contradiction_proof, ThenRUP::Yes, hints::Lex{owner}}, reason);
                 }
 
                 auto force_strict_proof = [&, alpha, n](const ReasonLiterals & r) -> void {
@@ -217,7 +218,7 @@ namespace
                 inference.infer_all(logger,
                     {vars_1[alpha] > nb2_alpha.first,
                         vars_2[alpha] < nb1_alpha.second},
-                    JustifyExplicitly{force_strict_proof, ThenRUP::Yes}, reason);
+                    JustifyExplicitly{force_strict_proof, ThenRUP::Yes, hints::Lex{owner}}, reason);
 
                 auto fb1 = state.bounds(vars_1[alpha]);
                 auto fb2 = state.bounds(vars_2[alpha]);
@@ -280,23 +281,6 @@ namespace
 
 namespace gcs::innards::hints
 {
-    // Witness for the lex "unsat scaffold" justification, carried in a reified
-    // verdict. It captures the scaffold inputs (variable scope + reason by value, the
-    // aux-flag tables by
-    // shared_ptr, the State by pointer — valid because the verdict is consumed
-    // synchronously while the constraint is live). No coarse hint name: the original
-    // verdict carried none.
-    struct LexUnsatScaffold
-    {
-        const State * state;
-        ReasonLiterals reason;
-        std::vector<IntegerVariableID> first_vars, second_vars;
-        std::size_t n;
-        std::shared_ptr<std::vector<std::optional<ProofFlag>>> prefix_equal_flags;
-        std::shared_ptr<std::vector<ProofFlag>> decision_at_flags;
-        static constexpr std::string_view hint_name = "";
-    };
-
     auto emit_justification(ProofLogger & logger, const LexUnsatScaffold & w, const ReasonLiterals &) -> void
     {
         if (w.prefix_equal_flags && w.decision_at_flags)
@@ -323,7 +307,7 @@ namespace
         const shared_ptr<vector<ProofFlag>> & decision_at_gt_flags,
         const shared_ptr<vector<optional<ProofFlag>>> & prefix_equal_lt_flags,
         const shared_ptr<vector<ProofFlag>> & decision_at_lt_flags,
-        const IntegerVariableCondition & cond) -> ReificationVerdictFor<JustifyExplicitly<hints::LexUnsatScaffold>>
+        const IntegerVariableCondition & cond, const ConstraintID & owner) -> ReificationVerdictFor<JustifyExplicitly<hints::LexUnsatScaffold>>
     {
         auto n1 = vars_1.size();
         auto n2 = vars_2.size();
@@ -384,7 +368,7 @@ namespace
             auto reason_under_cond_false = reason;
             reason_under_cond_false.push_back(! cond);
             return reification_verdict::MustHold<JustifyExplicitly<hints::LexUnsatScaffold>>{
-                .justification = JustifyExplicitly{hints::LexUnsatScaffold{&state, std::move(reason_under_cond_false),
+                .justification = JustifyExplicitly{hints::LexUnsatScaffold{{owner}, &state, std::move(reason_under_cond_false),
                                                        vars_2, vars_1, n, prefix_equal_lt_flags, decision_at_lt_flags},
                     ThenRUP::Yes},
                 .reason = std::move(reason)};
@@ -393,7 +377,7 @@ namespace
             auto reason_under_cond_true = reason;
             reason_under_cond_true.push_back(cond);
             return reification_verdict::MustNotHold<JustifyExplicitly<hints::LexUnsatScaffold>>{
-                .justification = JustifyExplicitly{hints::LexUnsatScaffold{&state, std::move(reason_under_cond_true),
+                .justification = JustifyExplicitly{hints::LexUnsatScaffold{{owner}, &state, std::move(reason_under_cond_true),
                                                        vars_1, vars_2, n, prefix_equal_gt_flags, decision_at_gt_flags},
                     ThenRUP::Yes},
                 .reason = std::move(reason)};
@@ -629,40 +613,40 @@ auto LexCompareGreaterThanOrMaybeEqual::install_propagators(Propagators & propag
     auto enforce_constraint_must_hold = [vars_1 = _vars_1, vars_2 = _vars_2, or_equal,
                                             prefix_equal_gt_flags = _prefix_equal_gt_flags,
                                             decision_at_gt_flags = _decision_at_gt_flags,
-                                            state_handle = _state_handle](
+                                            state_handle = _state_handle, owner = constraint_id()](
                                             const State & state, auto & inference, ProofLogger * const logger,
                                             const Literal & cond) -> PropagatorState {
         return run_lex_pass(state, inference, logger,
             vars_1, vars_2, or_equal,
             prefix_equal_gt_flags, decision_at_gt_flags,
-            cond, state_handle);
+            cond, state_handle, owner);
     };
 
     auto enforce_constraint_must_not_hold = [vars_1 = _vars_1, vars_2 = _vars_2, or_equal,
                                                 prefix_equal_lt_flags = _prefix_equal_lt_flags,
                                                 decision_at_lt_flags = _decision_at_lt_flags,
-                                                state_handle = _state_handle](
+                                                state_handle = _state_handle, owner = constraint_id()](
                                                 const State & state, auto & inference, ProofLogger * const logger,
                                                 const Literal & cond) -> PropagatorState {
         // Negation: enforce vars_2 (>|>=) vars_1 with or_equal flipped.
         return run_lex_pass(state, inference, logger,
             vars_2, vars_1, ! or_equal,
             prefix_equal_lt_flags, decision_at_lt_flags,
-            cond, state_handle);
+            cond, state_handle, owner);
     };
 
     auto infer_cond_when_undecided = [vars_1 = move(_vars_1), vars_2 = move(_vars_2), or_equal,
                                          prefix_equal_gt_flags = _prefix_equal_gt_flags,
                                          decision_at_gt_flags = _decision_at_gt_flags,
                                          prefix_equal_lt_flags = _prefix_equal_lt_flags,
-                                         decision_at_lt_flags = _decision_at_lt_flags](
+                                         decision_at_lt_flags = _decision_at_lt_flags, owner = constraint_id()](
                                          const State & state, auto &, ProofLogger * const logger,
                                          const IntegerVariableCondition & cond) -> ReificationVerdictFor<JustifyExplicitly<hints::LexUnsatScaffold>> {
         return run_lex_undecided_detection(state, logger,
             vars_1, vars_2, or_equal,
             prefix_equal_gt_flags, decision_at_gt_flags,
             prefix_equal_lt_flags, decision_at_lt_flags,
-            cond);
+            cond, owner);
     };
 
     install_reified_dispatcher(propagators, constraint_id(), _evaluated_cond, _reif_cond, triggers,

--- a/gcs/constraints/lex/lex.cc
+++ b/gcs/constraints/lex/lex.cc
@@ -107,7 +107,7 @@ namespace
 
         auto all_vars = vars_1;
         all_vars.insert(all_vars.end(), vars_2.begin(), vars_2.end());
-        auto reason = eager_reason(bounds_reason(state, all_vars, cond), state);
+        auto reason = eager_reason(bounds_reason(all_vars, cond), state);
 
         // Walking off the end means all common-prefix positions are forced
         // equal. Whether that satisfies the constraint depends on
@@ -316,7 +316,7 @@ namespace
 
         auto all_vars = vars_1;
         all_vars.insert(all_vars.end(), vars_2.begin(), vars_2.end());
-        auto reason = eager_reason(bounds_reason(state, all_vars), state);
+        auto reason = eager_reason(bounds_reason(all_vars), state);
 
         size_t k = 0;
         bool definitely_holds = false;

--- a/gcs/constraints/lex/lex.cc
+++ b/gcs/constraints/lex/lex.cc
@@ -106,7 +106,7 @@ namespace
 
         auto all_vars = vars_1;
         all_vars.insert(all_vars.end(), vars_2.begin(), vars_2.end());
-        auto reason = bounds_reason(state, all_vars, cond);
+        auto reason = eager_reason(bounds_reason(state, all_vars, cond), state);
 
         // Walking off the end means all common-prefix positions are forced
         // equal. Whether that satisfies the constraint depends on
@@ -118,17 +118,17 @@ namespace
             if (equal_prefix_satisfies)
                 return PropagatorState::DisableUntilBacktrack;
 
-            auto contradiction_proof = [&, n](const ReasonFunction & r) -> void {
+            auto contradiction_proof = [&, n](const ReasonLiterals & r) -> void {
                 if (! logger) return;
                 for (size_t k = 0; k < n; ++k)
                     logger->emit_rup_proof_line_under_reason(r,
                         WPBSum{} + 1_i * ! decision_at_flags->at(k) >= 1_i,
                         ProofLevel::Temporary);
             };
-            inference.contradiction(logger, JustifyExplicitlyThenRUP{contradiction_proof}, reason);
+            inference.contradiction(logger, JustifyExplicitly{contradiction_proof, ThenRUP::Yes}, reason);
         }
 
-        auto emit_not_d = [&](const ReasonFunction & r, size_t k) -> void {
+        auto emit_not_d = [&](const ReasonLiterals & r, size_t k) -> void {
             logger->emit_rup_proof_line_under_reason(r,
                 WPBSum{} + 1_i * ! decision_at_flags->at(k) >= 1_i,
                 ProofLevel::Temporary);
@@ -141,7 +141,7 @@ namespace
         auto b1_alpha = state.bounds(vars_1[alpha]);
         auto b2_alpha = state.bounds(vars_2[alpha]);
 
-        auto tighten_proof = [&, alpha](const ReasonFunction & r) -> void {
+        auto tighten_proof = [&, alpha](const ReasonLiterals & r) -> void {
             if (! logger) return;
             for (size_t k = 0; k < alpha; ++k)
                 emit_not_d(r, k);
@@ -157,7 +157,7 @@ namespace
 
         inference.infer_all(logger,
             {vars_1[alpha] >= b2_alpha.first, vars_2[alpha] <= b1_alpha.second},
-            JustifyExplicitlyThenRUP{tighten_proof}, reason);
+            JustifyExplicitly{tighten_proof, ThenRUP::Yes}, reason);
 
         auto nb1_alpha = state.bounds(vars_1[alpha]);
         auto nb2_alpha = state.bounds(vars_2[alpha]);
@@ -188,7 +188,7 @@ namespace
             if (must_force_strict) {
                 bool alpha_candidate = (nb1_alpha.second > nb2_alpha.first);
 
-                auto emit_not_prefix_equal_if_credited = [&](const ReasonFunction & r) -> void {
+                auto emit_not_prefix_equal_if_credited = [&](const ReasonLiterals & r) -> void {
                     if (equal_prefix_satisfies && prefix_blocked)
                         logger->emit_rup_proof_line_under_reason(r,
                             WPBSum{} + 1_i * ! *prefix_equal_flags->at(blocking_position + 1) >= 1_i,
@@ -196,16 +196,16 @@ namespace
                 };
 
                 if (! alpha_candidate) {
-                    auto contradiction_proof = [&, n](const ReasonFunction & r) -> void {
+                    auto contradiction_proof = [&, n](const ReasonLiterals & r) -> void {
                         if (! logger) return;
                         for (size_t k = 0; k < n; ++k)
                             emit_not_d(r, k);
                         emit_not_prefix_equal_if_credited(r);
                     };
-                    inference.contradiction(logger, JustifyExplicitlyThenRUP{contradiction_proof}, reason);
+                    inference.contradiction(logger, JustifyExplicitly{contradiction_proof, ThenRUP::Yes}, reason);
                 }
 
-                auto force_strict_proof = [&, alpha, n](const ReasonFunction & r) -> void {
+                auto force_strict_proof = [&, alpha, n](const ReasonLiterals & r) -> void {
                     if (! logger) return;
                     for (size_t k = 0; k < n; ++k) {
                         if (k == alpha) continue;
@@ -217,7 +217,7 @@ namespace
                 inference.infer_all(logger,
                     {vars_1[alpha] > nb2_alpha.first,
                         vars_2[alpha] < nb1_alpha.second},
-                    JustifyExplicitlyThenRUP{force_strict_proof}, reason);
+                    JustifyExplicitly{force_strict_proof, ThenRUP::Yes}, reason);
 
                 auto fb1 = state.bounds(vars_1[alpha]);
                 auto fb2 = state.bounds(vars_2[alpha]);
@@ -242,7 +242,7 @@ namespace
     auto emit_lex_unsat_scaffold(
         const State & state,
         ProofLogger * const logger,
-        const ReasonFunction & r,
+        const ReasonLiterals & r,
         const vector<IntegerVariableID> & vars_1,
         const vector<IntegerVariableID> & vars_2,
         size_t n,
@@ -276,7 +276,37 @@ namespace
                 WPBSum{} + 1_i * ! decision_at_flags->at(k) >= 1_i,
                 ProofLevel::Temporary);
     }
+}
 
+namespace gcs::innards::hints
+{
+    // Witness for the lex "unsat scaffold" justification, carried in a reified
+    // verdict. It captures the scaffold inputs (variable scope + reason by value, the
+    // aux-flag tables by
+    // shared_ptr, the State by pointer — valid because the verdict is consumed
+    // synchronously while the constraint is live). No coarse hint name: the original
+    // verdict carried none.
+    struct LexUnsatScaffold
+    {
+        const State * state;
+        ReasonLiterals reason;
+        std::vector<IntegerVariableID> first_vars, second_vars;
+        std::size_t n;
+        std::shared_ptr<std::vector<std::optional<ProofFlag>>> prefix_equal_flags;
+        std::shared_ptr<std::vector<ProofFlag>> decision_at_flags;
+        static constexpr std::string_view hint_name = "";
+    };
+
+    auto emit_justification(ProofLogger & logger, const LexUnsatScaffold & w, const ReasonLiterals &) -> void
+    {
+        if (w.prefix_equal_flags && w.decision_at_flags)
+            emit_lex_unsat_scaffold(*w.state, &logger, w.reason, w.first_vars, w.second_vars, w.n,
+                w.prefix_equal_flags, w.decision_at_flags);
+    }
+}
+
+namespace
+{
     // Detection-only logic for when the reification condition is undecided.
     // Walk through positions: if we can prove the constraint definitely
     // holds (or definitely doesn't hold) from the current bounds, return
@@ -285,7 +315,7 @@ namespace
     // StillUndecided.
     auto run_lex_undecided_detection(
         const State & state,
-        ProofLogger * const logger,
+        ProofLogger * const,
         const vector<IntegerVariableID> & vars_1,
         const vector<IntegerVariableID> & vars_2,
         bool or_equal,
@@ -293,7 +323,7 @@ namespace
         const shared_ptr<vector<ProofFlag>> & decision_at_gt_flags,
         const shared_ptr<vector<optional<ProofFlag>>> & prefix_equal_lt_flags,
         const shared_ptr<vector<ProofFlag>> & decision_at_lt_flags,
-        const IntegerVariableCondition & cond) -> ReificationVerdict
+        const IntegerVariableCondition & cond) -> ReificationVerdictFor<JustifyExplicitly<hints::LexUnsatScaffold>>
     {
         auto n1 = vars_1.size();
         auto n2 = vars_2.size();
@@ -302,7 +332,7 @@ namespace
 
         auto all_vars = vars_1;
         all_vars.insert(all_vars.end(), vars_2.begin(), vars_2.end());
-        auto reason = bounds_reason(state, all_vars);
+        auto reason = eager_reason(bounds_reason(state, all_vars), state);
 
         size_t k = 0;
         bool definitely_holds = false;
@@ -351,39 +381,21 @@ namespace
         // every aux flag to FALSE, violating it. We pre-emit those
         // ~aux_flag lines so VeriPB's PB unit propagation can chain.
         if (definitely_holds) {
-            auto reason_under_cond_false = [base = reason, cond]() {
-                auto rl = base();
-                rl.push_back(! cond);
-                return rl;
-            };
-            auto justify = [&state, logger, vars_1, vars_2, n,
-                               prefix_equal_lt_flags, decision_at_lt_flags,
-                               reason_under_cond_false](const ReasonFunction &) -> void {
-                if (logger && prefix_equal_lt_flags && decision_at_lt_flags)
-                    emit_lex_unsat_scaffold(state, logger, ReasonFunction{reason_under_cond_false},
-                        vars_2, vars_1, n,
-                        prefix_equal_lt_flags, decision_at_lt_flags);
-            };
-            return reification_verdict::MustHold{
-                .justification = JustifyExplicitlyThenRUP{justify},
+            auto reason_under_cond_false = reason;
+            reason_under_cond_false.push_back(! cond);
+            return reification_verdict::MustHold<JustifyExplicitly<hints::LexUnsatScaffold>>{
+                .justification = JustifyExplicitly{hints::LexUnsatScaffold{&state, std::move(reason_under_cond_false),
+                                                       vars_2, vars_1, n, prefix_equal_lt_flags, decision_at_lt_flags},
+                    ThenRUP::Yes},
                 .reason = std::move(reason)};
         }
         else {
-            auto reason_under_cond_true = [base = reason, cond]() {
-                auto rl = base();
-                rl.push_back(cond);
-                return rl;
-            };
-            auto justify = [&state, logger, vars_1, vars_2, n,
-                               prefix_equal_gt_flags, decision_at_gt_flags,
-                               reason_under_cond_true](const ReasonFunction &) -> void {
-                if (logger && prefix_equal_gt_flags && decision_at_gt_flags)
-                    emit_lex_unsat_scaffold(state, logger, ReasonFunction{reason_under_cond_true},
-                        vars_1, vars_2, n,
-                        prefix_equal_gt_flags, decision_at_gt_flags);
-            };
-            return reification_verdict::MustNotHold{
-                .justification = JustifyExplicitlyThenRUP{justify},
+            auto reason_under_cond_true = reason;
+            reason_under_cond_true.push_back(cond);
+            return reification_verdict::MustNotHold<JustifyExplicitly<hints::LexUnsatScaffold>>{
+                .justification = JustifyExplicitly{hints::LexUnsatScaffold{&state, std::move(reason_under_cond_true),
+                                                       vars_1, vars_2, n, prefix_equal_gt_flags, decision_at_gt_flags},
+                    ThenRUP::Yes},
                 .reason = std::move(reason)};
         }
     }
@@ -645,7 +657,7 @@ auto LexCompareGreaterThanOrMaybeEqual::install_propagators(Propagators & propag
                                          prefix_equal_lt_flags = _prefix_equal_lt_flags,
                                          decision_at_lt_flags = _decision_at_lt_flags](
                                          const State & state, auto &, ProofLogger * const logger,
-                                         const IntegerVariableCondition & cond) -> ReificationVerdict {
+                                         const IntegerVariableCondition & cond) -> ReificationVerdictFor<JustifyExplicitly<hints::LexUnsatScaffold>> {
         return run_lex_undecided_detection(state, logger,
             vars_1, vars_2, or_equal,
             prefix_equal_gt_flags, decision_at_gt_flags,

--- a/gcs/constraints/lex/lex.hh
+++ b/gcs/constraints/lex/lex.hh
@@ -58,8 +58,8 @@ namespace gcs
      * installed (one for the constraint, one for its negation) with
      * separate flag sets, half-reified on the cond and its negation
      * respectively. Inferences emit RUP scaffolding lines via
-     * JustifyExplicitlyThenRUP so VeriPB's PB unit propagation can verify
-     * each step in isolation.
+     * JustifyExplicitly{…, ThenRUP::Yes} so VeriPB's PB unit propagation can
+     * verify each step in isolation.
      *
      * \ingroup Constraints
      * \ingroup Innards

--- a/gcs/constraints/linear/hints.hh
+++ b/gcs/constraints/linear/hints.hh
@@ -1,0 +1,84 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LINEAR_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LINEAR_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state-fwd.hh>
+
+#include <optional>
+#include <string_view>
+#include <utility>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief linear equality's base assertion hint: just the owning constraint.
+     *
+     * Carried by every linear-equality inference -- the bound tightenings driven by
+     * propagate_linear and the inconsistency / unit detections. All RUP-derivable,
+     * so no emit_justification and no subhint; the default `(constraint_id
+     * <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct LinearEquality
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "linear_equality";
+    };
+
+    /**
+     * \brief linear inequality's base assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct LinearInequality
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "linear_inequality";
+    };
+
+    /**
+     * \brief linear not-equals' base assertion hint: just the owning constraint.
+     *
+     * Carried by propagate_linear_not_equals' single-unset pruning and its
+     * all-fixed contradiction. Both RUP-derivable, so no subhint and the default
+     * `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct LinearNotEquals
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "linear_not_equals";
+    };
+
+    /**
+     * \brief linear inequality's "the condition is forced" hint, carried in a
+     * reified verdict.
+     *
+     * Extends the base with the `cond` subhint and the emit context justify_cond
+     * reads: the sanitised coefficient vector (deduced by tidy_up_linear, hence the
+     * template) and the two definition lines, with the State by pointer (the verdict
+     * is consumed synchronously while the constraint is live). The data is held for
+     * emit_justification only; with no own hint_sexpr the hint takes the default
+     * identity-plus-subhint wire form.
+     *
+     * \ingroup Innards
+     */
+    template <typename CoeffVars_>
+    struct LinearInequalityCond : LinearInequality
+    {
+        static constexpr std::string_view subhint_name = "cond";
+        const State * state;
+        CoeffVars_ coeff_vars;
+        std::pair<std::optional<ProofLine>, std::optional<ProofLine>> proof_lines;
+    };
+
+    template <typename CoeffVars_>
+    auto emit_justification(ProofLogger & logger, const LinearInequalityCond<CoeffVars_> & cond, const ReasonLiterals & reason) -> void;
+}
+
+#endif

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -352,12 +352,12 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                     // reified)
                                     if (accum == value) {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                     else {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }
@@ -371,7 +371,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                             // no way for the remaining variable to take that value, so the condition
                                             // has to be false
                                             if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
+                                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
                                             return PropagatorState::DisableUntilBacktrack;
                                         }
                                         else {
@@ -383,7 +383,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                         // the value that would make the equality work isn't an integer, so the condition
                                         // has to be false
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -12,6 +12,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 #include <util/overloaded.hh>
 
@@ -95,7 +96,7 @@ namespace
 
                 if (match) {
                     permitted.emplace_back(current.begin(), current.end());
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         Integer sel_value(permitted.size() - 1);
                         logger->names_and_ids_tracker().create_literals_for_introduced_variable_value(future_var_id, sel_value, "lineq");
                         trail += 1_i * (future_var_id == sel_value);
@@ -125,7 +126,7 @@ namespace
                 }
             }
 
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 WPBSum backtrack = trail;
                 for (const auto & [idx, val] : enumerate(current))
                     backtrack += 1_i * (get_var(coeff_vars.terms[idx]) != val);
@@ -134,7 +135,7 @@ namespace
             }
         };
 
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->emit_proof_comment("building GAC table for linear equality");
         search(logger);
 
@@ -240,7 +241,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                                 State & state, auto & inference, ProofLogger * const logger) {
                 *data = build_table(coeff_vars, value, cond, state, logger);
                 if (! data->has_value())
-                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }});
+                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
             },
                 InitialiserPriority::Expensive);
 
@@ -259,7 +260,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // the (folded-out) constant part, so the equality holds iff _value + modifier == 0
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier != -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }});
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                     });
                 }
 
@@ -270,7 +271,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
 
                 visit(
                     [&, modifier = modifier](const auto & lin) {
-                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond); }, triggers);
+                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality}); }, triggers);
                     },
                     sanitised_cv);
             },
@@ -280,7 +281,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // the equality _value + modifier == 0 must NOT hold, so it is violated iff it does
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier == -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }});
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                     });
                 }
 
@@ -313,7 +314,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                         return overloaded{
                             [&](const evaluated_reif::MustHold & reif) {
                                 // we now know the condition definitely holds, so it's a linear equality
-                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond);
+                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                             },
 
                             [&](const evaluated_reif::MustNotHold &) {
@@ -349,12 +350,12 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                     // reified)
                                     if (accum == value) {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                     else {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }
@@ -368,7 +369,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                             // no way for the remaining variable to take that value, so the condition
                                             // has to be false
                                             if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                                inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                             return PropagatorState::DisableUntilBacktrack;
                                         }
                                         else {
@@ -380,7 +381,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                         // the value that would make the equality work isn't an integer, so the condition
                                         // has to be false
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -64,6 +64,31 @@ ReifiedLinearEquality::ReifiedLinearEquality(WeightedSum coeff_vars, Integer val
 
 namespace
 {
+    // Coarse model-level hint name for linear_equality's inferences, carried on the
+    // raw annotation passed into propagate_linear. The pure-RUP reified inferences
+    // use hints::LinearEqualityRUP instead.
+    constexpr std::string_view linear_equality_hint = "linear_equality";
+}
+
+namespace gcs::innards::hints
+{
+    // Pure-RUP hint for linear_equality's reified RUP inferences. RUP-derivable,
+    // so no emit_justification; carries the owning constraint id.
+    struct LinearEqualityRUP
+    {
+        ConstraintID owner;
+        static constexpr std::string_view hint_name = "linear_equality";
+    };
+
+    auto hint_sexpr(const LinearEqualityRUP & h, NamesAndIDsTracker &) -> SExpr
+    {
+        return hint_list(hint_constraint_id(h.owner));
+    }
+}
+
+namespace
+{
+
     template <typename CV_>
     auto build_table(const CV_ & coeff_vars, Integer value, ReificationCondition cond, State & state, ProofLogger * const logger) -> optional<ExtensionalData>
     {
@@ -237,11 +262,11 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 triggers.on_change.push_back(get_var(cv));
 
             auto data = make_shared<optional<ExtensionalData>>(nullopt);
-            propagators.install_initialiser([data = data, coeff_vars = sanitised_cv, value = _value + modifier, cond = _reif_cond](
+            propagators.install_initialiser([data = data, coeff_vars = sanitised_cv, value = _value + modifier, cond = _reif_cond, owner = constraint_id()](
                                                 State & state, auto & inference, ProofLogger * const logger) {
                 *data = build_table(coeff_vars, value, cond, state, logger);
                 if (! data->has_value())
-                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, ExplicitReason{ReasonLiterals{}});
             },
                 InitialiserPriority::Expensive);
 
@@ -259,8 +284,8 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // condition is definitely true; with no variable terms left the sum is just
                 // the (folded-out) constant part, so the equality holds iff _value + modifier == 0
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier != -_value) {
-                    propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                    propagators.install_initialiser([reason_from_cond = reif.cond, owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) {
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, ExplicitReason{ReasonLiterals{{reason_from_cond}}});
                     });
                 }
 
@@ -271,7 +296,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
 
                 visit(
                     [&, modifier = modifier](const auto & lin) {
-                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality}); }, triggers);
+                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond, AssertionAnnotation{.hint_name = linear_equality_hint}); }, triggers);
                     },
                     sanitised_cv);
             },
@@ -280,8 +305,8 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // condition is definitely false on a full reification; with no variable terms left
                 // the equality _value + modifier == 0 must NOT hold, so it is violated iff it does
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier == -_value) {
-                    propagators.install_initialiser([reason_from_cond = reif.cond](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{reason_from_cond}}; }}, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                    propagators.install_initialiser([reason_from_cond = reif.cond, owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) {
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, ExplicitReason{ReasonLiterals{{reason_from_cond}}});
                     });
                 }
 
@@ -310,11 +335,11 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 add_trigger_for(triggers, reif.cond);
 
                 visit([&, modifier = modifier](const auto & sanitised_cv) {
-                    propagators.install(constraint_id(), [sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line, all_vars = move(all_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { // This comment is needed to stop clang-format exploding
+                    propagators.install(constraint_id(), [sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line, all_vars = move(all_vars), owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { // This comment is needed to stop clang-format exploding
                         return overloaded{
                             [&](const evaluated_reif::MustHold & reif) {
                                 // we now know the condition definitely holds, so it's a linear equality
-                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, AssertionAnnotation{.hint_name = linear_equality_hint});
                             },
 
                             [&](const evaluated_reif::MustNotHold &) {
@@ -350,12 +375,12 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                     // reified)
                                     if (accum == value) {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                     else {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }
@@ -369,7 +394,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                             // no way for the remaining variable to take that value, so the condition
                                             // has to be false
                                             if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
                                             return PropagatorState::DisableUntilBacktrack;
                                         }
                                         else {
@@ -381,7 +406,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                         // the value that would make the equality work isn't an integer, so the condition
                                         // has to be false
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{}, generic_reason(state, all_vars), AssertionAnnotation{.hint_name = AssertionHintName::ReifiedLinearEquality});
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -1,10 +1,11 @@
+#include <gcs/constraints/extensional_utils.hh>
 #include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/constraints/innards/triggers.hh>
+#include <gcs/constraints/linear/hints.hh>
 #include <gcs/constraints/linear/linear_equality.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/exception.hh>
-#include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -60,30 +61,6 @@ ReifiedLinearEquality::ReifiedLinearEquality(WeightedSum coeff_vars, Integer val
     _gac(gac),
     _flipped_cond(flipped_cond)
 {
-}
-
-namespace
-{
-    // Coarse model-level hint name for linear_equality's inferences, carried on the
-    // raw annotation passed into propagate_linear. The pure-RUP reified inferences
-    // use hints::LinearEqualityRUP instead.
-    constexpr std::string_view linear_equality_hint = "linear_equality";
-}
-
-namespace gcs::innards::hints
-{
-    // Pure-RUP hint for linear_equality's reified RUP inferences. RUP-derivable,
-    // so no emit_justification; carries the owning constraint id.
-    struct LinearEqualityRUP
-    {
-        ConstraintID owner;
-        static constexpr std::string_view hint_name = "linear_equality";
-    };
-
-    auto hint_sexpr(const LinearEqualityRUP & h, NamesAndIDsTracker &) -> SExpr
-    {
-        return hint_list(hint_constraint_id(h.owner));
-    }
 }
 
 namespace
@@ -266,13 +243,13 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                                 State & state, auto & inference, ProofLogger * const logger) {
                 *data = build_table(coeff_vars, value, cond, state, logger);
                 if (! data->has_value())
-                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, ExplicitReason{ReasonLiterals{}});
+                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEquality{owner}}, ExplicitReason{ReasonLiterals{}});
             },
                 InitialiserPriority::Expensive);
 
-            propagators.install(constraint_id(), [data = data](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagators.install(constraint_id(), [data = data, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 if (data->has_value())
-                    return propagate_extensional(data.get()->value(), state, inference, logger);
+                    return propagate_extensional(data.get()->value(), state, inference, logger, hints::LinearEquality{owner});
                 else
                     return PropagatorState::DisableUntilBacktrack; }, triggers);
         },
@@ -285,7 +262,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // the (folded-out) constant part, so the equality holds iff _value + modifier == 0
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier != -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond, owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, ExplicitReason{ReasonLiterals{{reason_from_cond}}});
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEquality{owner}}, ExplicitReason{ReasonLiterals{{reason_from_cond}}});
                     });
                 }
 
@@ -296,7 +273,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
 
                 visit(
                     [&, modifier = modifier](const auto & lin) {
-                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond, AssertionAnnotation{.hint_name = linear_equality_hint}); }, triggers);
+                        propagators.install(constraint_id(), [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) { return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond, hints::LinearEquality{owner}); }, triggers);
                     },
                     sanitised_cv);
             },
@@ -306,7 +283,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                 // the equality _value + modifier == 0 must NOT hold, so it is violated iff it does
                 if (visit([](const auto & s) { return s.terms.empty(); }, sanitised_cv) && modifier == -_value) {
                     propagators.install_initialiser([reason_from_cond = reif.cond, owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) {
-                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, ExplicitReason{ReasonLiterals{{reason_from_cond}}});
+                        inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{hints::LinearEquality{owner}}, ExplicitReason{ReasonLiterals{{reason_from_cond}}});
                     });
                 }
 
@@ -317,7 +294,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                     triggers.on_change.push_back(v);
 
                 visit([&, modifier = modifier](const auto & sanitised_cv) {
-                    propagators.install(constraint_id(), [sanitised_cv = sanitised_cv, value = _value + modifier, all_vars = move(all_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars); }, triggers);
+                    propagators.install(constraint_id(), [sanitised_cv = sanitised_cv, value = _value + modifier, all_vars = move(all_vars), owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars, hints::LinearNotEquals{owner}); }, triggers);
                 },
                     sanitised_cv);
             },
@@ -339,12 +316,12 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                         return overloaded{
                             [&](const evaluated_reif::MustHold & reif) {
                                 // we now know the condition definitely holds, so it's a linear equality
-                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, AssertionAnnotation{.hint_name = linear_equality_hint});
+                                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, hints::LinearEquality{owner});
                             },
 
                             [&](const evaluated_reif::MustNotHold &) {
                                 // we now know the condition definitely doesn't hold, so it's a linear not-equals
-                                return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars);
+                                return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars, hints::LinearNotEquals{owner});
                             },
 
                             [](const evaluated_reif::Deactivated &) {
@@ -375,12 +352,12 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                     // reified)
                                     if (accum == value) {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                     else {
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }
@@ -394,7 +371,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                             // no way for the remaining variable to take that value, so the condition
                                             // has to be false
                                             if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
+                                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
                                             return PropagatorState::DisableUntilBacktrack;
                                         }
                                         else {
@@ -406,7 +383,7 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
                                         // the value that would make the equality work isn't an integer, so the condition
                                         // has to be false
                                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEqualityRUP{owner}}, generic_reason(state, all_vars));
+                                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(state, all_vars));
                                         return PropagatorState::DisableUntilBacktrack;
                                     }
                                 }

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/innards/reified_dispatcher.hh>
 #include <gcs/constraints/innards/reified_state.hh>
+#include <gcs/constraints/linear/hints.hh>
 #include <gcs/constraints/linear/linear_inequality.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
@@ -77,22 +78,6 @@ namespace
 
 namespace gcs::innards::hints
 {
-    // Witness for the reified linear-inequality "condition forced" justification,
-    // carried in a reified verdict. Templated
-    // on the sanitised coefficient-vector type that tidy_up_linear produces and the
-    // install-time visit deduces; it carries that and the proof lines by value and
-    // the State by pointer (the verdict is
-    // consumed synchronously while the constraint is live). No coarse hint name: the
-    // original verdict carried none.
-    template <typename CoeffVars_>
-    struct LinearInequalityCond
-    {
-        const State * state;
-        CoeffVars_ coeff_vars;
-        std::pair<std::optional<ProofLine>, std::optional<ProofLine>> proof_lines;
-        static constexpr std::string_view hint_name = "";
-    };
-
     template <typename CoeffVars_>
     auto emit_justification(ProofLogger & logger, const LinearInequalityCond<CoeffVars_> & w, const ReasonLiterals &) -> void
     {
@@ -191,7 +176,7 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
         };
 
         auto infer_cond_when_undecided = [sanitised_cv, sanitised_neg_cv, value = _value, modifier = modifier,
-                                             proof_lines, proof_lines_swapped, vars = vars](
+                                             proof_lines, proof_lines_swapped, vars = vars, owner = constraint_id()](
                                              const State & state, auto &, ProofLogger * const,
                                              const IntegerVariableCondition &) -> ReificationVerdictFor<LinearCondJustification> {
             Integer min_possible = 0_i, max_possible = 0_i;
@@ -210,13 +195,13 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
             if (min_possible > value + modifier) {
                 // cannot possibly hold
                 return reification_verdict::MustNotHold<LinearCondJustification>{
-                    .justification = JustifyExplicitly{hints::LinearInequalityCond<CV>{&state, sanitised_cv, proof_lines}, ThenRUP::Yes},
+                    .justification = JustifyExplicitly{hints::LinearInequalityCond<CV>{{owner}, &state, sanitised_cv, proof_lines}, ThenRUP::Yes},
                     .reason = generic_reason(state, vars)};
             }
             else if (max_possible <= value + modifier) {
                 // must definitely hold
                 return reification_verdict::MustHold<LinearCondJustification>{
-                    .justification = JustifyExplicitly{hints::LinearInequalityCond<NegCV>{&state, sanitised_neg_cv, proof_lines_swapped}, ThenRUP::Yes},
+                    .justification = JustifyExplicitly{hints::LinearInequalityCond<NegCV>{{owner}, &state, sanitised_neg_cv, proof_lines_swapped}, ThenRUP::Yes},
                     .reason = generic_reason(state, vars)};
             }
             else

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -75,6 +75,31 @@ namespace
     }
 }
 
+namespace gcs::innards::hints
+{
+    // Witness for the reified linear-inequality "condition forced" justification,
+    // carried in a reified verdict. Templated
+    // on the sanitised coefficient-vector type that tidy_up_linear produces and the
+    // install-time visit deduces; it carries that and the proof lines by value and
+    // the State by pointer (the verdict is
+    // consumed synchronously while the constraint is live). No coarse hint name: the
+    // original verdict carried none.
+    template <typename CoeffVars_>
+    struct LinearInequalityCond
+    {
+        const State * state;
+        CoeffVars_ coeff_vars;
+        std::pair<std::optional<ProofLine>, std::optional<ProofLine>> proof_lines;
+        static constexpr std::string_view hint_name = "";
+    };
+
+    template <typename CoeffVars_>
+    auto emit_justification(ProofLogger & logger, const LinearInequalityCond<CoeffVars_> & w, const ReasonLiterals &) -> void
+    {
+        justify_cond(*w.state, w.coeff_vars, logger, w.proof_lines);
+    }
+}
+
 auto ReifiedLinearInequality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
     if (! prepare(propagators, initial_state, optional_model))
@@ -143,6 +168,16 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
         triggers.on_bounds.push_back(v);
 
     visit([&, modifier = modifier, neg_modifier = neg_modifier](const auto & sanitised_cv, const auto & sanitised_neg_cv) -> void {
+        // The verdict justification is the linear "cond forced" witness over the
+        // sanitised coeff-vector type (and its negation for the must-hold side); a
+        // variant of the two, collapsing to a single witness when the two deduced
+        // types coincide.
+        using CV = std::decay_t<decltype(sanitised_cv)>;
+        using NegCV = std::decay_t<decltype(sanitised_neg_cv)>;
+        using LinearCondJustification = std::conditional_t<std::is_same_v<CV, NegCV>,
+            JustifyExplicitly<hints::LinearInequalityCond<CV>>,
+            std::variant<JustifyExplicitly<hints::LinearInequalityCond<CV>>, JustifyExplicitly<hints::LinearInequalityCond<NegCV>>>>;
+
         auto enforce_constraint_must_hold = [sanitised_cv, value = _value, modifier = modifier, proof_lines](
                                                 const State & state, auto & inference, ProofLogger * const logger,
                                                 const Literal & cond) -> PropagatorState {
@@ -157,8 +192,8 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
 
         auto infer_cond_when_undecided = [sanitised_cv, sanitised_neg_cv, value = _value, modifier = modifier,
                                              proof_lines, proof_lines_swapped, vars = vars](
-                                             const State & state, auto &, ProofLogger * const logger,
-                                             const IntegerVariableCondition &) -> ReificationVerdict {
+                                             const State & state, auto &, ProofLogger * const,
+                                             const IntegerVariableCondition &) -> ReificationVerdictFor<LinearCondJustification> {
             Integer min_possible = 0_i, max_possible = 0_i;
             for (const auto & cv : sanitised_cv.terms) {
                 auto bounds = state.bounds(get_var(cv));
@@ -174,18 +209,14 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
 
             if (min_possible > value + modifier) {
                 // cannot possibly hold
-                return reification_verdict::MustNotHold{
-                    .justification = JustifyExplicitlyThenRUP{[&state, sanitised_cv, logger, proof_lines](const ReasonFunction &) {
-                        justify_cond(state, sanitised_cv, *logger, proof_lines);
-                    }},
+                return reification_verdict::MustNotHold<LinearCondJustification>{
+                    .justification = JustifyExplicitly{hints::LinearInequalityCond<CV>{&state, sanitised_cv, proof_lines}, ThenRUP::Yes},
                     .reason = generic_reason(state, vars)};
             }
             else if (max_possible <= value + modifier) {
                 // must definitely hold
-                return reification_verdict::MustHold{
-                    .justification = JustifyExplicitlyThenRUP{[&state, sanitised_neg_cv, logger, proof_lines_swapped](const ReasonFunction &) {
-                        justify_cond(state, sanitised_neg_cv, *logger, proof_lines_swapped);
-                    }},
+                return reification_verdict::MustHold<LinearCondJustification>{
+                    .justification = JustifyExplicitly{hints::LinearInequalityCond<NegCV>{&state, sanitised_neg_cv, proof_lines_swapped}, ThenRUP::Yes},
                     .reason = generic_reason(state, vars)};
             }
             else

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -196,13 +196,13 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
                 // cannot possibly hold
                 return reification_verdict::MustNotHold<LinearCondJustification>{
                     .justification = JustifyExplicitly{hints::LinearInequalityCond<CV>{{owner}, &state, sanitised_cv, proof_lines}, ThenRUP::Yes},
-                    .reason = generic_reason(state, vars)};
+                    .reason = generic_reason(vars)};
             }
             else if (max_possible <= value + modifier) {
                 // must definitely hold
                 return reification_verdict::MustHold<LinearCondJustification>{
                     .justification = JustifyExplicitly{hints::LinearInequalityCond<NegCV>{{owner}, &state, sanitised_neg_cv, proof_lines_swapped}, ThenRUP::Yes},
-                    .reason = generic_reason(state, vars)};
+                    .reason = generic_reason(vars)};
             }
             else
                 return reification_verdict::StillUndecided{};

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/linear/hints.hh>
 #include <gcs/constraints/linear/justify.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
@@ -81,15 +82,15 @@ namespace
         const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars,
         int p, const SimpleIntegerVariableID & var, Integer remainder, const bool coeff, bool second_constraint_for_equality,
         const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-        const optional<AssertionAnnotation> & assertion_hint) -> void
+        const auto & hint) -> void
     {
         if (coeff) {
             if (bounds[p].second >= (1_i + remainder)) {
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
+                inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else {
@@ -97,8 +98,8 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
+                inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
     }
@@ -107,7 +108,7 @@ namespace
         const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars,
         int p, const SimpleIntegerVariableID & var, Integer remainder, const Integer coeff, bool second_constraint_for_equality,
         const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-        const optional<AssertionAnnotation> & assertion_hint) -> void
+        const auto & hint) -> void
     {
         // lots of conditionals to get the rounding right...
         if (coeff > 0_i && remainder >= 0_i) {
@@ -115,8 +116,8 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
+                inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff > 0_i && remainder < 0_i) {
@@ -125,8 +126,8 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
+                inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff < 0_i && remainder >= 0_i) {
@@ -134,8 +135,8 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
+                inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff < 0_i && remainder < 0_i) {
@@ -144,8 +145,8 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
+                inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else
@@ -153,10 +154,11 @@ namespace
     }
 }
 
+template <typename Hint_>
 auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, const State & state,
     auto & inference, ProofLogger * const logger,
     bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState
+    const Hint_ & hint) -> PropagatorState
 {
     vector<pair<Integer, Integer>> bounds;
     bounds.reserve(coeff_vars.terms.size());
@@ -165,7 +167,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
     // by inferring a specific variable has to take a value that it can't
     if (coeff_vars.terms.empty()) {
         if (! (0_i <= value)) {
-            inference.contradiction(logger, JustifyUsingRUP{}, linear_bounds_reason(coeff_vars, bounds, nullopt, false, add_to_reason));
+            inference.contradiction(logger, JustifyUsingRUP{hint}, linear_bounds_reason(coeff_vars, bounds, nullopt, false, add_to_reason));
         }
         return PropagatorState::DisableUntilBacktrack;
     }
@@ -197,7 +199,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
         Integer remainder = value - lower_without_me;
 
         infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv),
-            false, proof_line, add_to_reason, assertion_hint);
+            false, proof_line, add_to_reason, hint);
         bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
         if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -234,7 +236,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
             Integer inv_remainder = -value - inv_lower_without_me;
 
             infer(inference, logger, bounds, coeff_vars, p, get_var(cv), inv_remainder, negate(get_coeff_or_bool(cv)),
-                true, proof_line, add_to_reason, assertion_hint);
+                true, proof_line, add_to_reason, hint);
             bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
             if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -249,39 +251,36 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
     return PropagatorState::Enable;
 }
 
-template auto gcs::innards::propagate_linear(const SumOf<Weighted<SimpleIntegerVariableID>> & coeff_vars,
-    Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
+// Two hint instantiations per (coeff-vector type, tracker): hints::LinearEquality
+// for the equality propagator, NoHint for the reified-inequality propagators (which
+// pass no hint). The hint rides the JustifyExplicitly, so it is materialised lazily
+// in assertion mode rather than eagerly at the call site.
+#define GCS_INSTANTIATE_PROPAGATE_LINEAR(CoeffVars, Tracker, Hint)                                  \
+    template auto gcs::innards::propagate_linear(const CoeffVars & coeff_vars,                      \
+        Integer value, const State & state, Tracker &, ProofLogger * const logger,                  \
+        bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, \
+        const optional<Literal> & add_to_reason, const Hint & hint) -> PropagatorState
 
-template auto gcs::innards::propagate_linear(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & coeff_vars,
-    Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<Weighted<SimpleIntegerVariableID>>, SimpleInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, SimpleInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<SimpleIntegerVariableID>, SimpleInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<Weighted<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<SimpleIntegerVariableID>, EagerProofLoggingInferenceTracker, hints::LinearEquality);
 
-template auto gcs::innards::propagate_linear(const SumOf<SimpleIntegerVariableID> & coeff_vars,
-    Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<Weighted<SimpleIntegerVariableID>>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<SimpleIntegerVariableID>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<Weighted<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<SimpleIntegerVariableID>, EagerProofLoggingInferenceTracker, NoHint);
 
-template auto gcs::innards::propagate_linear(const SumOf<Weighted<SimpleIntegerVariableID>> & coeff_vars,
-    Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
+#undef GCS_INSTANTIATE_PROPAGATE_LINEAR
 
-template auto gcs::innards::propagate_linear(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & coeff_vars,
-    Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
-
-template auto gcs::innards::propagate_linear(const SumOf<SimpleIntegerVariableID> & coeff_vars,
-    Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
-    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
-
+template <typename Hint_>
 auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer value, const State & state,
     auto & inference, ProofLogger * const logger,
-    const vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState
+    const vector<IntegerVariableID> & all_vars_for_reason, const Hint_ & hint) -> PropagatorState
 {
     // condition is definitely false, so this is inequality. so long as at least two variables aren't
     // fixed, don't try to do anything.
@@ -305,7 +304,7 @@ auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer 
         // every variable is set, do a sanity check
         if (accum == value) {
             // we've set every variable and have equality
-            inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, all_vars_for_reason));
+            inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(state, all_vars_for_reason));
         }
         else
             return PropagatorState::DisableUntilBacktrack;
@@ -320,7 +319,7 @@ auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer 
                 // the forbidden value is in the domain, so disallow it, and then
                 // we won't do anything else.
                 inference.infer(logger, get_var(*single_unset) != forbidden,
-                    JustifyUsingRUP{}, generic_reason(state, all_vars_for_reason));
+                    JustifyUsingRUP{hint}, generic_reason(state, all_vars_for_reason));
                 return PropagatorState::DisableUntilBacktrack;
             }
             else {
@@ -336,26 +335,27 @@ auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer 
     }
 }
 
-template auto gcs::innards::propagate_linear_not_equals(const SumOf<Weighted<SimpleIntegerVariableID>> & terms, Integer,
-    const State &, SimpleInferenceTracker &, ProofLogger * const logger,
-    const vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState;
+// As with propagate_linear: one instantiation per (coeff vector, tracker, hint)
+// pair. hints::LinearNotEquals for the LinearNotEquals / LinearNotEqualsIf
+// propagators; NoHint kept for the defaulted hint so a future non-hinting caller
+// still links.
+#define GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(CoeffVars, Tracker, Hint)                 \
+    template auto gcs::innards::propagate_linear_not_equals(const CoeffVars & terms, Integer, \
+        const State &, Tracker &, ProofLogger * const logger,                                 \
+        const vector<IntegerVariableID> & all_vars_for_reason, const Hint & hint) -> PropagatorState
 
-template auto gcs::innards::propagate_linear_not_equals(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & terms, Integer,
-    const State &, SimpleInferenceTracker &, ProofLogger * const logger,
-    const vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState;
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<Weighted<SimpleIntegerVariableID>>, SimpleInferenceTracker, hints::LinearNotEquals);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, SimpleInferenceTracker, hints::LinearNotEquals);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<SimpleIntegerVariableID>, SimpleInferenceTracker, hints::LinearNotEquals);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<Weighted<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, hints::LinearNotEquals);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, hints::LinearNotEquals);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<SimpleIntegerVariableID>, EagerProofLoggingInferenceTracker, hints::LinearNotEquals);
 
-template auto gcs::innards::propagate_linear_not_equals(const SumOf<SimpleIntegerVariableID> & terms, Integer,
-    const State &, SimpleInferenceTracker &, ProofLogger * const logger,
-    const vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState;
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<Weighted<SimpleIntegerVariableID>>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<SimpleIntegerVariableID>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<Weighted<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS(SumOf<SimpleIntegerVariableID>, EagerProofLoggingInferenceTracker, NoHint);
 
-template auto gcs::innards::propagate_linear_not_equals(const SumOf<Weighted<SimpleIntegerVariableID>> & terms, Integer,
-    const State &, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    const vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState;
-
-template auto gcs::innards::propagate_linear_not_equals(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & terms, Integer,
-    const State &, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    const vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState;
-
-template auto gcs::innards::propagate_linear_not_equals(const SumOf<SimpleIntegerVariableID> & terms, Integer,
-    const State &, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    const vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState;
+#undef GCS_INSTANTIATE_PROPAGATE_LINEAR_NOT_EQUALS

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -57,9 +57,9 @@ namespace
         const auto & coeff_vars,
         const vector<pair<Integer, Integer>> & bounds,
         const optional<SimpleIntegerVariableID> & var, bool invert,
-        const optional<Literal> & add_to_reason) -> ReasonFunction
+        const optional<Literal> & add_to_reason) -> Reason
     {
-        Reason reason;
+        ReasonLiterals reason;
         for (const auto & [idx, cv] : enumerate(coeff_vars.terms)) {
             if (var && get_var(cv) != *var) {
                 if ((get_coeff(cv) < 0_i) != invert) {
@@ -74,7 +74,7 @@ namespace
         if (add_to_reason)
             reason.push_back(*add_to_reason);
 
-        return ReasonFunction{[=]() { return reason; }};
+        return ExplicitReason{reason};
     }
 
     auto infer(auto & inference, ProofLogger * const logger,
@@ -85,19 +85,19 @@ namespace
     {
         if (coeff) {
             if (bounds[p].second >= (1_i + remainder)) {
-                auto justf = [&](const ReasonFunction &) {
+                auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitlyThenRUP{justf},
+                inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes},
                     linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else {
             if (bounds[p].first < -remainder) {
-                auto justf = [&](const ReasonFunction &) {
+                auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitlyThenRUP{justf},
+                inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes},
                     linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
@@ -112,39 +112,39 @@ namespace
         // lots of conditionals to get the rounding right...
         if (coeff > 0_i && remainder >= 0_i) {
             if (bounds[p].second >= (1_i + remainder / coeff)) {
-                auto justf = [&](const ReasonFunction &) {
+                auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitlyThenRUP{justf},
+                inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes},
                     linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff > 0_i && remainder < 0_i) {
             auto div_with_rounding = -((-remainder + coeff - 1_i) / coeff);
             if (bounds[p].second >= 1_i + div_with_rounding) {
-                auto justf = [&](const ReasonFunction &) {
+                auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitlyThenRUP{justf},
+                inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes},
                     linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff < 0_i && remainder >= 0_i) {
             if (bounds[p].first < remainder / coeff) {
-                auto justf = [&](const ReasonFunction &) {
+                auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitlyThenRUP{justf},
+                inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes},
                     linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff < 0_i && remainder < 0_i) {
             auto div_with_rounding = (-remainder + -coeff - 1_i) / -coeff;
             if (bounds[p].first < div_with_rounding) {
-                auto justf = [&](const ReasonFunction &) {
+                auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitlyThenRUP{justf},
+                inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes},
                     linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -304,7 +304,7 @@ auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer 
         // every variable is set, do a sanity check
         if (accum == value) {
             // we've set every variable and have equality
-            inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(state, all_vars_for_reason));
+            inference.contradiction(logger, JustifyUsingRUP{hint}, generic_reason(all_vars_for_reason));
         }
         else
             return PropagatorState::DisableUntilBacktrack;
@@ -319,7 +319,7 @@ auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer 
                 // the forbidden value is in the domain, so disallow it, and then
                 // we won't do anything else.
                 inference.infer(logger, get_var(*single_unset) != forbidden,
-                    JustifyUsingRUP{hint}, generic_reason(state, all_vars_for_reason));
+                    JustifyUsingRUP{hint}, generic_reason(all_vars_for_reason));
                 return PropagatorState::DisableUntilBacktrack;
             }
             else {

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/linear/justify.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -79,7 +80,8 @@ namespace
     auto infer(auto & inference, ProofLogger * const logger,
         const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars,
         int p, const SimpleIntegerVariableID & var, Integer remainder, const bool coeff, bool second_constraint_for_equality,
-        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> void
+        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+        const optional<AssertionAnnotation> & assertion_hint) -> void
     {
         if (coeff) {
             if (bounds[p].second >= (1_i + remainder)) {
@@ -87,7 +89,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else {
@@ -96,7 +98,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
     }
@@ -104,7 +106,8 @@ namespace
     auto infer(auto & inference, ProofLogger * const logger,
         const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars,
         int p, const SimpleIntegerVariableID & var, Integer remainder, const Integer coeff, bool second_constraint_for_equality,
-        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> void
+        const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+        const optional<AssertionAnnotation> & assertion_hint) -> void
     {
         // lots of conditionals to get the rounding right...
         if (coeff > 0_i && remainder >= 0_i) {
@@ -113,7 +116,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff > 0_i && remainder < 0_i) {
@@ -123,7 +126,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff < 0_i && remainder >= 0_i) {
@@ -132,7 +135,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else if (coeff < 0_i && remainder < 0_i) {
@@ -142,7 +145,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitlyThenRUP{justf},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason), assertion_hint);
             }
         }
         else
@@ -152,7 +155,8 @@ namespace
 
 auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, const State & state,
     auto & inference, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState
 {
     vector<pair<Integer, Integer>> bounds;
     bounds.reserve(coeff_vars.terms.size());
@@ -193,7 +197,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
         Integer remainder = value - lower_without_me;
 
         infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv),
-            false, proof_line, add_to_reason);
+            false, proof_line, add_to_reason, assertion_hint);
         bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
         if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -230,7 +234,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
             Integer inv_remainder = -value - inv_lower_without_me;
 
             infer(inference, logger, bounds, coeff_vars, p, get_var(cv), inv_remainder, negate(get_coeff_or_bool(cv)),
-                true, proof_line, add_to_reason);
+                true, proof_line, add_to_reason, assertion_hint);
             bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
             if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -247,27 +251,33 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
 
 template auto gcs::innards::propagate_linear(const SumOf<Weighted<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<SimpleIntegerVariableID> & coeff_vars,
     Integer value, const State & state, SimpleInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<Weighted<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & coeff_vars,
     Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 template auto gcs::innards::propagate_linear(const SumOf<SimpleIntegerVariableID> & coeff_vars,
     Integer value, const State & state, EagerProofLoggingInferenceTracker &, ProofLogger * const logger,
-    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason) -> PropagatorState;
+    bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
+    const optional<AssertionAnnotation> & assertion_hint) -> PropagatorState;
 
 auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer value, const State & state,
     auto & inference, ProofLogger * const logger,

--- a/gcs/constraints/linear/propagate.hh
+++ b/gcs/constraints/linear/propagate.hh
@@ -3,8 +3,8 @@
 
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/expression.hh>
-#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
@@ -19,20 +19,23 @@ namespace gcs::innards
      *
      * \ingroup Innards
      */
+    template <typename Hint_ = NoHint>
     auto propagate_linear(const auto & terms, Integer, const State &, auto & inference_tracker,
         ProofLogger * const logger, bool equality,
         const std::optional<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & proof_line,
         const std::optional<Literal> & add_to_reason,
-        const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> PropagatorState;
+        const Hint_ & hint = {}) -> PropagatorState;
 
     /**
      * \brief Propagate a not-equals
      *
      * \ingroup Innards
      */
+    template <typename Hint_ = NoHint>
     auto propagate_linear_not_equals(const auto & terms, Integer, const State &, auto & inference_tracker,
         ProofLogger * const logger,
-        const std::vector<IntegerVariableID> & all_vars_for_reason) -> PropagatorState;
+        const std::vector<IntegerVariableID> & all_vars_for_reason,
+        const Hint_ & hint = {}) -> PropagatorState;
 }
 
 #endif

--- a/gcs/constraints/linear/propagate.hh
+++ b/gcs/constraints/linear/propagate.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/expression.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
@@ -21,7 +22,8 @@ namespace gcs::innards
     auto propagate_linear(const auto & terms, Integer, const State &, auto & inference_tracker,
         ProofLogger * const logger, bool equality,
         const std::optional<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & proof_line,
-        const std::optional<Literal> & add_to_reason) -> PropagatorState;
+        const std::optional<Literal> & add_to_reason,
+        const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> PropagatorState;
 
     /**
      * \brief Propagate a not-equals

--- a/gcs/constraints/logical/hints.hh
+++ b/gcs/constraints/logical/hints.hh
@@ -1,0 +1,43 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LOGICAL_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_LOGICAL_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief And's assertion hint: just the owning constraint.
+     *
+     * And and Or share one reified-conjunction propagator (Or is And over the
+     * negated literals and reif), but each posts its own constraint id, so the
+     * hint family name distinguishes the two on the wire. Every inference is
+     * re-derivable from the asserted literal, the reason and the definition
+     * lines, so there is no per-shape discriminator and the hint takes the
+     * default `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct And
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "and";
+    };
+
+    /**
+     * \brief Or's assertion hint: just the owning constraint.
+     *
+     * The mirror of And (see above): same shared propagator, distinct family
+     * name, no per-shape discriminator.
+     *
+     * \ingroup Innards
+     */
+    struct Or
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "or";
+    };
+}
+
+#endif

--- a/gcs/constraints/logical/logical.cc
+++ b/gcs/constraints/logical/logical.cc
@@ -59,7 +59,7 @@ namespace
             propagators.install_initialiser([full_reif = full_reif, lits = lits](
                                                 const State &, auto & inference, ProofLogger * const logger) {
                 for (auto & l : lits)
-                    inference.infer(logger, l, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{full_reif}}; }});
+                    inference.infer(logger, l, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{full_reif}}});
             });
             return;
         }
@@ -77,7 +77,7 @@ namespace
             // then we don't do anything else
             propagators.install_initialiser([full_reif = full_reif](
                                                 const State &, auto & inference, ProofLogger * const logger) -> void {
-                inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ReasonFunction{});
+                inference.infer(logger, ! full_reif, JustifyUsingRUP{}, NoReason{});
             });
             return;
         }
@@ -86,7 +86,7 @@ namespace
             switch (state.test_literal(full_reif)) {
             case DefinitelyTrue: {
                 for (auto & l : lits)
-                    inference.infer(logger, l, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{full_reif}}; }});
+                    inference.infer(logger, l, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{full_reif}}});
                 return PropagatorState::DisableUntilBacktrack;
             }
 
@@ -109,20 +109,20 @@ namespace
                     return PropagatorState::DisableUntilBacktrack;
                 else if (! undecided1) {
                     // literals are all true, but reif is false
-                    Reason why;
+                    ReasonLiterals why;
                     for (auto & lit : lits)
                         why.push_back(lit);
                     why.push_back(! full_reif);
-                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ReasonFunction{[=]() { return why; }});
+                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ExplicitReason{why});
                     return PropagatorState::Enable;
                 }
                 else {
-                    Reason why;
+                    ReasonLiterals why;
                     for (auto & l : lits)
                         if (l != *undecided1)
                             why.push_back(l);
                     why.push_back(! full_reif);
-                    inference.infer(logger, ! *undecided1, JustifyUsingRUP{}, ReasonFunction{[=]() { return why; }});
+                    inference.infer(logger, ! *undecided1, JustifyUsingRUP{}, ExplicitReason{why});
                     return PropagatorState::DisableUntilBacktrack;
                 }
             }
@@ -142,21 +142,20 @@ namespace
                     }
 
                 if (any_false) {
-                    inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{! *any_false}}; }});
+                    inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{! *any_false}}});
                     return PropagatorState::DisableUntilBacktrack;
                 }
                 else if (all_true) {
-                    auto justf = [&](const ReasonFunction & reason) {
+                    auto justf = [&](const ReasonLiterals & reason) {
                         for (auto & l : lits)
                             logger->emit_rup_proof_line_under_reason(reason,
                                 WPBSum{} + 1_i * l >= 1_i, ProofLevel::Temporary);
                     };
-                    inference.infer(logger, full_reif, JustifyExplicitlyThenRUP{justf}, ReasonFunction{[=]() {
-                        vector<ProofLiteral> reason_lits{};
-                        for (auto & l : lits)
-                            reason_lits.emplace_back(l);
-                        return Reason(reason_lits.begin(), reason_lits.end());
-                    }});
+                    vector<ProofLiteral> reason_lits{};
+                    for (auto & l : lits)
+                        reason_lits.emplace_back(l);
+                    inference.infer(logger, full_reif, JustifyExplicitly{justf, ThenRUP::Yes},
+                        ExplicitReason{ReasonLiterals(reason_lits.begin(), reason_lits.end())});
                     return PropagatorState::DisableUntilBacktrack;
                 }
                 else

--- a/gcs/constraints/logical/logical.cc
+++ b/gcs/constraints/logical/logical.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/innards/triggers.hh>
+#include <gcs/constraints/logical/hints.hh>
 #include <gcs/constraints/logical/logical.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -49,6 +50,7 @@ namespace
         return result;
     }
 
+    template <typename Hint_>
     auto install_propagators_logical(Propagators & propagators, const ConstraintID & constraint_id, const Literals & lits,
         const Literal & full_reif, LiteralIs reif_state) -> void
     {
@@ -56,10 +58,10 @@ namespace
 
         if (reif_state == DefinitelyTrue) {
             // definitely true, just force all the literals
-            propagators.install_initialiser([full_reif = full_reif, lits = lits](
+            propagators.install_initialiser([full_reif = full_reif, lits = lits, owner = constraint_id](
                                                 const State &, auto & inference, ProofLogger * const logger) {
                 for (auto & l : lits)
-                    inference.infer(logger, l, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{full_reif}}});
+                    inference.infer(logger, l, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{{full_reif}}});
             });
             return;
         }
@@ -75,18 +77,18 @@ namespace
         if (saw_false) {
             // we saw a false literal, the reif variable must be forced off and
             // then we don't do anything else
-            propagators.install_initialiser([full_reif = full_reif](
+            propagators.install_initialiser([full_reif = full_reif, owner = constraint_id](
                                                 const State &, auto & inference, ProofLogger * const logger) -> void {
-                inference.infer(logger, ! full_reif, JustifyUsingRUP{}, NoReason{});
+                inference.infer(logger, ! full_reif, JustifyUsingRUP{Hint_{owner}}, NoReason{});
             });
             return;
         }
 
-        propagators.install(constraint_id, [lits = lits, full_reif = full_reif](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagators.install(constraint_id, [lits = lits, full_reif = full_reif, owner = constraint_id](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             switch (state.test_literal(full_reif)) {
             case DefinitelyTrue: {
                 for (auto & l : lits)
-                    inference.infer(logger, l, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{full_reif}}});
+                    inference.infer(logger, l, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{{full_reif}}});
                 return PropagatorState::DisableUntilBacktrack;
             }
 
@@ -113,7 +115,7 @@ namespace
                     for (auto & lit : lits)
                         why.push_back(lit);
                     why.push_back(! full_reif);
-                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{}, ExplicitReason{why});
+                    inference.infer(logger, FalseLiteral{}, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{why});
                     return PropagatorState::Enable;
                 }
                 else {
@@ -122,7 +124,7 @@ namespace
                         if (l != *undecided1)
                             why.push_back(l);
                     why.push_back(! full_reif);
-                    inference.infer(logger, ! *undecided1, JustifyUsingRUP{}, ExplicitReason{why});
+                    inference.infer(logger, ! *undecided1, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{why});
                     return PropagatorState::DisableUntilBacktrack;
                 }
             }
@@ -142,7 +144,7 @@ namespace
                     }
 
                 if (any_false) {
-                    inference.infer(logger, ! full_reif, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{! *any_false}}});
+                    inference.infer(logger, ! full_reif, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{{! *any_false}}});
                     return PropagatorState::DisableUntilBacktrack;
                 }
                 else if (all_true) {
@@ -154,7 +156,7 @@ namespace
                     vector<ProofLiteral> reason_lits{};
                     for (auto & l : lits)
                         reason_lits.emplace_back(l);
-                    inference.infer(logger, full_reif, JustifyExplicitly{justf, ThenRUP::Yes},
+                    inference.infer(logger, full_reif, JustifyExplicitly{justf, ThenRUP::Yes, Hint_{owner}},
                         ExplicitReason{ReasonLiterals(reason_lits.begin(), reason_lits.end())});
                     return PropagatorState::DisableUntilBacktrack;
                 }
@@ -249,7 +251,7 @@ auto And::define_proof_model(ProofModel & model) -> void
 
 auto And::install_propagators(Propagators & propagators) -> void
 {
-    install_propagators_logical(propagators, constraint_id(), _lits, _full_reif, _reif_state);
+    install_propagators_logical<hints::And>(propagators, constraint_id(), _lits, _full_reif, _reif_state);
 }
 
 auto And::s_expr(const innards::ProofModel * const model) const -> SExpr
@@ -314,7 +316,7 @@ auto Or::install_propagators(Propagators & propagators) -> void
     Literals lits = _lits;
     for (auto & l : lits)
         l = ! l;
-    install_propagators_logical(propagators, constraint_id(), move(lits), ! _full_reif, _reif_state);
+    install_propagators_logical<hints::Or>(propagators, constraint_id(), move(lits), ! _full_reif, _reif_state);
 }
 
 auto Or::s_expr(const innards::ProofModel * const model) const -> SExpr

--- a/gcs/constraints/min_max/hints.hh
+++ b/gcs/constraints/min_max/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MIN_MAX_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MIN_MAX_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief MinMax's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct MinMax
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "min_max";
+    };
+}
+
+#endif

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -152,7 +152,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
         else if (! support_2) {
             // no, there's only a single var left that has any intersection with result. so, that
             // variable has to lose any values not present in result.
-            ReasonLiterals reason = materialise(generic_reason(state, vector{result}), state);
+            ReasonLiterals reason = materialise(generic_reason(vector{result}), state);
 
             for (auto & var : vars) {
                 if (var == *support_1)

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -94,18 +94,18 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
         for (auto & var : vars) {
             auto var_bounds = state.bounds(var);
             if (min)
-                inference.infer_less_than(logger, result, var_bounds.second + 1_i, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{var <= var_bounds.second}}; }});
+                inference.infer_less_than(logger, result, var_bounds.second + 1_i, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{var <= var_bounds.second}}});
             else
-                inference.infer_greater_than_or_equal(logger, result, var_bounds.first, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{var >= var_bounds.first}}; }});
+                inference.infer_greater_than_or_equal(logger, result, var_bounds.first, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{var >= var_bounds.first}}});
         }
 
         // each var >= result
         auto result_bounds = state.bounds(result);
         for (auto & var : vars) {
             if (min)
-                inference.infer_greater_than_or_equal(logger, var, result_bounds.first, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{result >= result_bounds.first}}; }});
+                inference.infer_greater_than_or_equal(logger, var, result_bounds.first, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{result >= result_bounds.first}}});
             else
-                inference.infer_less_than(logger, var, state.upper_bound(result) + 1_i, JustifyUsingRUP{}, ReasonFunction{[=]() { return Reason{{result <= result_bounds.second}}; }});
+                inference.infer_less_than(logger, var, state.upper_bound(result) + 1_i, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{result <= result_bounds.second}}});
         }
 
         // result in union(vars)
@@ -119,17 +119,17 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
             }
 
             if (! found_support) {
-                Reason reason;
+                ReasonLiterals reason;
                 for (auto & var : vars)
                     reason.emplace_back(var != value);
 
-                inference.infer_not_equal(logger, result, value, JustifyExplicitlyThenRUP{[logger, result, value, &selectors](const ReasonFunction & reason) {
+                inference.infer_not_equal(logger, result, value, JustifyExplicitly{[logger, result, value, &selectors](const ReasonLiterals & reason) {
                     // show that none of the selectors work, if we're taking the result to be that value and also
                     // that the value is missing from all of the vars
                     for (const auto & sel : selectors)
                         logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + (1_i * ! sel) + (1_i * (result != value)) >= 1_i, ProofLevel::Temporary);
-                }},
-                    ReasonFunction{[=]() { return reason; }});
+                }, ThenRUP::Yes},
+                    ExplicitReason{reason});
             }
         }
 
@@ -151,7 +151,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
         else if (! support_2) {
             // no, there's only a single var left that has any intersection with result. so, that
             // variable has to lose any values not present in result.
-            Reason reason = generic_reason(state, vector{result})();
+            ReasonLiterals reason = materialise(generic_reason(state, vector{result}), state);
 
             for (auto & var : vars) {
                 if (var == *support_1)
@@ -167,7 +167,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
             // is missing all of result's values, so its model selector must be false. This
             // is value-independent, so the range path emits it once per interval rather
             // than once per removed value.
-            auto rule_out_other_selectors = [&](const ReasonFunction & reason) {
+            auto rule_out_other_selectors = [&](const ReasonLiterals & reason) {
                 for (const auto & [idx, var] : enumerate(vars))
                     if (var != *support_1) {
                         for (const auto & rval : state.each_value_immutable(result))
@@ -187,31 +187,32 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                 std::holds_alternative<SimpleIntegerVariableID>(IntegerVariableID{result});
 
             for (auto [lo, hi] : support_1_set.each_interval_minus(result_set)) {
-                if (both_simple)
-                    inference.infer_not_in_range(logger, *support_1, lo, hi, JustifyExplicitlyThenRUP{[&, lo = lo, hi = hi](const ReasonFunction & reason) {
+                if (both_simple) {
+                    // The support reason is the base reason plus the just-excluded
+                    // interval. ExplicitReason holds an immutable snapshot, so the
+                    // justification (which materialises it once per bridge lemma plus
+                    // once for the conclusion) gets a fresh copy each time rather than
+                    // an accumulating literal.
+                    ReasonLiterals support_reason = reason;
+                    support_reason.emplace_back(not_in_range(result, lo, hi));
+                    inference.infer_not_in_range(logger, *support_1, lo, hi, JustifyExplicitly{[&, lo = lo, hi = hi](const ReasonLiterals & reason) {
                         rule_out_other_selectors(reason);
                         justify_not_in_range_across_equality(*logger, reason,
                             std::get<SimpleIntegerVariableID>(IntegerVariableID{*support_1}), lo, hi,
                             result, lo, hi);
-                    }},
-                        // Built afresh per call: the justification calls the reason once per
-                        // bridge lemma plus once for the conclusion, so a mutable accumulating
-                        // lambda would duplicate the appended literal on each call.
-                        ReasonFunction{[=, base = reason]() {
-                            auto r = base;
-                            r.emplace_back(not_in_range(result, lo, hi));
-                            return r;
-                        }});
+                    }, ThenRUP::Yes},
+                        ExplicitReason{std::move(support_reason)});
+                }
                 else
                     for (Integer val = lo; val <= hi; ++val)
-                        inference.infer(logger, *support_1 != val, JustifyExplicitlyThenRUP{[&, val = val](const ReasonFunction & reason) {
+                        inference.infer(logger, *support_1 != val, JustifyExplicitly{[&, val = val](const ReasonLiterals & reason) {
                             rule_out_other_selectors(reason);
                             // now fish out the supporting variable, and show that it has to have its selector true
                             for (const auto & [idx, var] : enumerate(vars))
                                 if (var == *support_1)
                                     logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + (1_i * (*support_1 == val)) + (1_i * selectors.at(idx)) >= 1_i, ProofLevel::Temporary);
-                        }},
-                            ReasonFunction{[=]() { return reason; }});
+                        }, ThenRUP::Yes},
+                            ExplicitReason{reason});
             }
         }
 

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/innards/justify_not_in_range.hh>
+#include <gcs/constraints/min_max/hints.hh>
 #include <gcs/constraints/min_max/min_max.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -89,23 +90,23 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
     for (const auto & v : _vars)
         triggers.on_change.emplace_back(v);
 
-    propagators.install(constraint_id(), [vars = _vars, result = _result, min = _min, selectors = _selectors](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [vars = _vars, result = _result, min = _min, selectors = _selectors, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         // result <= upper bound of each vars
         for (auto & var : vars) {
             auto var_bounds = state.bounds(var);
             if (min)
-                inference.infer_less_than(logger, result, var_bounds.second + 1_i, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{var <= var_bounds.second}}});
+                inference.infer_less_than(logger, result, var_bounds.second + 1_i, JustifyUsingRUP{hints::MinMax{owner}}, ExplicitReason{ReasonLiterals{{var <= var_bounds.second}}});
             else
-                inference.infer_greater_than_or_equal(logger, result, var_bounds.first, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{var >= var_bounds.first}}});
+                inference.infer_greater_than_or_equal(logger, result, var_bounds.first, JustifyUsingRUP{hints::MinMax{owner}}, ExplicitReason{ReasonLiterals{{var >= var_bounds.first}}});
         }
 
         // each var >= result
         auto result_bounds = state.bounds(result);
         for (auto & var : vars) {
             if (min)
-                inference.infer_greater_than_or_equal(logger, var, result_bounds.first, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{result >= result_bounds.first}}});
+                inference.infer_greater_than_or_equal(logger, var, result_bounds.first, JustifyUsingRUP{hints::MinMax{owner}}, ExplicitReason{ReasonLiterals{{result >= result_bounds.first}}});
             else
-                inference.infer_less_than(logger, var, state.upper_bound(result) + 1_i, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{{result <= result_bounds.second}}});
+                inference.infer_less_than(logger, var, state.upper_bound(result) + 1_i, JustifyUsingRUP{hints::MinMax{owner}}, ExplicitReason{ReasonLiterals{{result <= result_bounds.second}}});
         }
 
         // result in union(vars)
@@ -128,7 +129,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                     // that the value is missing from all of the vars
                     for (const auto & sel : selectors)
                         logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + (1_i * ! sel) + (1_i * (result != value)) >= 1_i, ProofLevel::Temporary);
-                }, ThenRUP::Yes},
+                }, ThenRUP::Yes, hints::MinMax{owner}},
                     ExplicitReason{reason});
             }
         }
@@ -200,7 +201,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                         justify_not_in_range_across_equality(*logger, reason,
                             std::get<SimpleIntegerVariableID>(IntegerVariableID{*support_1}), lo, hi,
                             result, lo, hi);
-                    }, ThenRUP::Yes},
+                    }, ThenRUP::Yes, hints::MinMax{owner}},
                         ExplicitReason{std::move(support_reason)});
                 }
                 else
@@ -211,7 +212,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                             for (const auto & [idx, var] : enumerate(vars))
                                 if (var == *support_1)
                                     logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + (1_i * (*support_1 == val)) + (1_i * selectors.at(idx)) >= 1_i, ProofLevel::Temporary);
-                        }, ThenRUP::Yes},
+                        }, ThenRUP::Yes, hints::MinMax{owner}},
                             ExplicitReason{reason});
             }
         }

--- a/gcs/constraints/mult_bc/hints.hh
+++ b/gcs/constraints/mult_bc/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MULT_BC_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MULT_BC_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief MultBC's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct MultBC
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "multiply";
+    };
+}
+
+#endif

--- a/gcs/constraints/mult_bc/mult_bc.cc
+++ b/gcs/constraints/mult_bc/mult_bc.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/mult_bc/hints.hh>
 #include <gcs/constraints/mult_bc/mult_bc.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -1018,7 +1019,8 @@ namespace
         ProofLogger * const logger,
         vector<vector<BitProductData>> & bit_products,
         const bool x_is_first,
-        const vector<ProofLine> & sign_lines)
+        const vector<ProofLine> & sign_lines,
+        const ConstraintID & owner)
         -> void
     {
         // This is based on the case breakdown in JaCoP
@@ -1029,7 +1031,7 @@ namespace
         }
         else if (y_min == 0_i && y_max == 0_i) {
             // y == 0 and 0 not in bounds of z => no possible values for x
-            inference.contradiction(logger, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{y_var == 0_i, z_var != 0_i}});
+            inference.contradiction(logger, JustifyUsingRUP{hints::MultBC{owner}}, ExplicitReason{ReasonLiterals{y_var == 0_i, z_var != 0_i}});
         }
         else if (y_min < 0_i && y_max > 0_i && (z_min > 0_i || z_max < 0_i)) {
             // y contains -1, 0, 1 and z has either all positive or all negative values
@@ -1046,7 +1048,7 @@ namespace
             };
 
             inference.infer(logger, x_var <= largest_possible_quotient,
-                JustifyExplicitly{lower_justf, ThenRUP::No},
+                JustifyExplicitly{lower_justf, ThenRUP::No, hints::MultBC{owner}},
                 ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second, y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
 
             var_bounds.at(x_var).first = min(var_bounds.at(x_var).first, largest_possible_quotient);
@@ -1059,18 +1061,18 @@ namespace
             };
 
             inference.infer(logger, x_var >= smallest_possible_quotient,
-                JustifyExplicitly{upper_justf, ThenRUP::No},
+                JustifyExplicitly{upper_justf, ThenRUP::No, hints::MultBC{owner}},
                 ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second, y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
         }
         else if (y_min == 0_i && y_max != 0_i && (z_min > 0_i || z_max < 0_i)) {
             // y is either 0 or strictly positive and z has either all positive or all negative values
             filter_quotient(x_var, y_var, z_var, z_min, z_max, 1_i, y_max, all_vars, state,
-                inference, channelling_constraints, mag_var, z_eq_product_lines, logger, bit_products, x_is_first, sign_lines);
+                inference, channelling_constraints, mag_var, z_eq_product_lines, logger, bit_products, x_is_first, sign_lines, owner);
         }
         else if (y_min != 0_i && y_max == 0_i && (z_min > 0_i || z_max < 0_i)) {
             // y is either 0 or strictly negative z has either all positive or all negative values
             filter_quotient(x_var, y_var, z_var, z_min, z_max, y_min, -1_i, all_vars, state, inference,
-                channelling_constraints, mag_var, z_eq_product_lines, logger, bit_products, x_is_first, sign_lines);
+                channelling_constraints, mag_var, z_eq_product_lines, logger, bit_products, x_is_first, sign_lines, owner);
         }
         else if ((y_min > 0_i || y_max < 0_i) && y_min <= y_max) {
             auto smallest_possible_quotient = min({div_ceil(z_min, y_min), div_ceil(z_min, y_max), div_ceil(z_max, y_min), div_ceil(z_max, y_max)});
@@ -1099,17 +1101,17 @@ namespace
             };
 
             if (smallest_possible_quotient > largest_possible_quotient) {
-                inference.infer(logger, FalseLiteral{}, JustifyExplicitly{both_justf, ThenRUP::No},
+                inference.infer(logger, FalseLiteral{}, JustifyExplicitly{both_justf, ThenRUP::No, hints::MultBC{owner}},
                     ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
                         y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
             }
             else {
                 inference.infer(logger, x_var <= largest_possible_quotient,
-                    JustifyExplicitly{upper_justf, ThenRUP::No},
+                    JustifyExplicitly{upper_justf, ThenRUP::No, hints::MultBC{owner}},
                     ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
                         y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
                 inference.infer(logger, x_var >= smallest_possible_quotient,
-                    JustifyExplicitly{lower_justf, ThenRUP::No},
+                    JustifyExplicitly{lower_justf, ThenRUP::No, hints::MultBC{owner}},
                     ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
                         y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
             }
@@ -1248,7 +1250,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
 
     ConstraintStateHandle bit_products_handle = initial_state.add_persistent_constraint_state(bit_products);
 
-    propagators.install(constraint_id(), [v1 = _v1, v2 = _v2, v3 = _v3, bit_products_h = bit_products_handle, channelling_constraints = channelling_constraints, mag_var = mag_var, v3_eq_product_lines = v3_eq_product_lines, sign_lines = sign_lines](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [v1 = _v1, v2 = _v2, v3 = _v3, bit_products_h = bit_products_handle, channelling_constraints = channelling_constraints, mag_var = mag_var, v3_eq_product_lines = v3_eq_product_lines, sign_lines = sign_lines, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         vector<IntegerVariableID> all_vars = {v1, v2, v3};
 
         do {
@@ -1267,17 +1269,17 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
             };
 
             inference.infer_all(logger, {v3 <= largest_product, v3 >= smallest_product},
-                JustifyExplicitly{justf, ThenRUP::No},
+                JustifyExplicitly{justf, ThenRUP::No, hints::MultBC{owner}},
                 ReasonLiterals{v1 >= var_bounds.at(v1).first, v1 <= var_bounds.at(v1).second,
                     v2 >= var_bounds.at(v2).first, v2 <= var_bounds.at(v2).second});
 
             auto bounds3 = state.bounds(v3);
             filter_quotient(v1, v2, v3, bounds3.first, bounds3.second, bounds2.first, bounds2.second, all_vars, state, inference,
-                channelling_constraints, mag_var, v3_eq_product_lines, logger, bit_products, true, sign_lines);
+                channelling_constraints, mag_var, v3_eq_product_lines, logger, bit_products, true, sign_lines, owner);
 
             bounds1 = state.bounds(v1);
             filter_quotient(v2, v1, v3, bounds3.first, bounds3.second, bounds1.first, bounds1.second, all_vars, state, inference,
-                channelling_constraints, mag_var, v3_eq_product_lines, logger, bit_products, false, sign_lines);
+                channelling_constraints, mag_var, v3_eq_product_lines, logger, bit_products, false, sign_lines, owner);
         } while (inference.did_anything_since_last_call_inside_propagator());
 
         return PropagatorState::Enable; }, triggers);

--- a/gcs/constraints/mult_bc/mult_bc.cc
+++ b/gcs/constraints/mult_bc/mult_bc.cc
@@ -86,7 +86,7 @@ namespace
         WPBSum sum = WPBSum{};
         Integer rhs = 0_i;
         HalfReifyOnConjunctionOf half_reif = HalfReifyOnConjunctionOf{};
-        optional<ReasonFunction> reason = nullopt;
+        optional<ReasonLiterals> reason = nullopt;
         ProofLine line;
     };
 
@@ -97,7 +97,7 @@ namespace
     };
 
     auto result_of_deriving(ProofLogger & logger, ProofRule rule, const WPBSumLE & ineq,
-        const HalfReifyOnConjunctionOf & reif, const ProofLevel & proof_level, const ReasonFunction & reason) -> DerivedPBConstraint
+        const HalfReifyOnConjunctionOf & reif, const ProofLevel & proof_level, const ReasonLiterals & reason) -> DerivedPBConstraint
     {
         // Have to flip it again to store in the form lhs >= rhs
         WPBSum ge_lhs{};
@@ -203,7 +203,7 @@ namespace
         const DerivedPBConstraint & constr,
         const map<SimpleIntegerVariableID, ChannellingData> & channelling_constraints,
         const map<SimpleIntegerVariableID, ProofOnlySimpleIntegerVariableID> & mag_var,
-        const ReasonFunction & reason,
+        const ReasonLiterals & reason,
         const optional<HalfReifyOnConjunctionOf> & assumption = nullopt) -> DerivedPBConstraint
     {
         if (constr.sum.terms.size() != 1 || abs(constr.sum.terms[0].coefficient) != 1_i)
@@ -276,7 +276,7 @@ namespace
 
         // logger.emit_proof_comment("Chanelling RUP");
         // This might be a horribly bad idea...
-        for (const auto & lit : reason()) {
+        for (const auto & lit : reason) {
             auto cond = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(lit)));
             auto line = get_def_line_for_lit(logger, cond);
             if (line) {
@@ -307,7 +307,7 @@ namespace
         const SimpleIntegerVariableID & y,
         const SimpleIntegerVariableID & z,
         const map<SimpleIntegerVariableID, ChannellingData> & channelling_constraints,
-        const ReasonFunction & reason)
+        const ReasonLiterals & reason)
         -> DerivedPBConstraint
     {
         auto channel_reif = HalfReifyOnConjunctionOf{constr.half_reif};
@@ -385,7 +385,7 @@ namespace
         auto result = add_lines(logger, channel_line, rup_sign);
         auto channel_sum = WPBSum{} + constr.sum.terms[0].coefficient * (z_negative ? -1_i : 1_i) * z;
         vector<ProofLine> rup_hints = {result};
-        for (const auto & lit : reason()) {
+        for (const auto & lit : reason) {
             auto cond = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(lit)));
             auto line = get_def_line_for_lit(logger, cond);
             if (line) {
@@ -522,7 +522,7 @@ namespace
                 rup_hints.insert(rup_hints.end(), further_hints.begin(), further_hints.end());
                 rup_hints.emplace_back(p.line);
                 weakened_premises.emplace_back(result_of_deriving(logger, RUPProofRule{rup_hints}, // implies?
-                    want_to_derive, p.half_reif, ProofLevel::Temporary, ReasonFunction{}));
+                    want_to_derive, p.half_reif, ProofLevel::Temporary, ReasonLiterals{}));
             }
 
             //  Then add the negation of our desired constraint to each of the weakened premises
@@ -566,7 +566,7 @@ namespace
         const map<SimpleIntegerVariableID, ProofOnlySimpleIntegerVariableID> & mag_var,
         const pair<ProofLine, ProofLine> z_eq_product_lines,
         vector<vector<BitProductData>> & bit_products,
-        const ReasonFunction & reason)
+        const ReasonLiterals & reason)
         -> DerivedPBConstraint
     {
         // logger.emit_proof_comment("Prove Conditional Product Lower Bound:");
@@ -619,7 +619,7 @@ namespace
         const map<SimpleIntegerVariableID, ProofOnlySimpleIntegerVariableID> & mag_var,
         const pair<ProofLine, ProofLine> z_eq_product_lines,
         vector<vector<BitProductData>> & bit_products,
-        const ReasonFunction & reason)
+        const ReasonLiterals & reason)
         -> DerivedPBConstraint
     {
         auto mag_z_sum = WPBSum{};
@@ -708,7 +708,7 @@ namespace
             ProofLevel::Temporary, reason);
     }
 
-    auto prove_product_bounds(const ReasonFunction & reason, ProofLogger & logger,
+    auto prove_product_bounds(const ReasonLiterals & reason, ProofLogger & logger,
         vector<vector<BitProductData>> & bit_products,
         const SimpleIntegerVariableID x, const SimpleIntegerVariableID y, const SimpleIntegerVariableID z,
         const map<IntegerVariableID, pair<Integer, Integer>> & var_bounds,
@@ -830,7 +830,7 @@ namespace
     }
 
     auto prove_quotient_bounds(
-        const ReasonFunction & reason,
+        const ReasonLiterals & reason,
         ProofLogger & logger,
         vector<vector<BitProductData>> & bit_products,
         const SimpleIntegerVariableID x, const SimpleIntegerVariableID y, const SimpleIntegerVariableID z,
@@ -1029,7 +1029,7 @@ namespace
         }
         else if (y_min == 0_i && y_max == 0_i) {
             // y == 0 and 0 not in bounds of z => no possible values for x
-            inference.contradiction(logger, JustifyUsingRUP{}, [y_var, z_var]() { return Reason{y_var == 0_i, z_var != 0_i}; });
+            inference.contradiction(logger, JustifyUsingRUP{}, ExplicitReason{ReasonLiterals{y_var == 0_i, z_var != 0_i}});
         }
         else if (y_min < 0_i && y_max > 0_i && (z_min > 0_i || z_max < 0_i)) {
             // y contains -1, 0, 1 and z has either all positive or all negative values
@@ -1037,7 +1037,7 @@ namespace
             auto smallest_possible_quotient = -largest_possible_quotient;
 
             auto var_bounds = map<IntegerVariableID, pair<Integer, Integer>>{{x_var, state.bounds(x_var)}, {y_var, state.bounds(y_var)}, {z_var, state.bounds(z_var)}};
-            auto lower_justf = [&](const ReasonFunction & reason) {
+            auto lower_justf = [&](const ReasonLiterals & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, false);
@@ -1046,11 +1046,11 @@ namespace
             };
 
             inference.infer(logger, x_var <= largest_possible_quotient,
-                JustifyExplicitlyOnly{lower_justf},
-                [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second, y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second}]() { return lits; });
+                JustifyExplicitly{lower_justf, ThenRUP::No},
+                ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second, y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
 
             var_bounds.at(x_var).first = min(var_bounds.at(x_var).first, largest_possible_quotient);
-            auto upper_justf = [&](const ReasonFunction & reason) {
+            auto upper_justf = [&](const ReasonLiterals & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, true);
@@ -1059,8 +1059,8 @@ namespace
             };
 
             inference.infer(logger, x_var >= smallest_possible_quotient,
-                JustifyExplicitlyOnly{upper_justf},
-                [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second, y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second}]() { return lits; });
+                JustifyExplicitly{upper_justf, ThenRUP::No},
+                ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second, y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
         }
         else if (y_min == 0_i && y_max != 0_i && (z_min > 0_i || z_max < 0_i)) {
             // y is either 0 or strictly positive and z has either all positive or all negative values
@@ -1077,7 +1077,7 @@ namespace
             auto largest_possible_quotient = max({div_floor(z_min, y_min), div_floor(z_min, y_max), div_floor(z_max, y_min), div_floor(z_max, y_max)});
 
             auto var_bounds = map<IntegerVariableID, pair<Integer, Integer>>{{x_var, state.bounds(x_var)}, {y_var, state.bounds(y_var)}, {z_var, state.bounds(z_var)}};
-            auto upper_justf = [&](const ReasonFunction & reason) {
+            auto upper_justf = [&](const ReasonLiterals & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, false);
@@ -1085,7 +1085,7 @@ namespace
                     WPBSum{} + 1_i * (x_var <= largest_possible_quotient) >= 1_i, ProofLevel::Current);
             };
 
-            auto lower_justf = [&](const ReasonFunction & reason) {
+            auto lower_justf = [&](const ReasonLiterals & reason) {
                 prove_quotient_bounds(reason, *logger, bit_products, x_var, y_var, z_var, var_bounds,
                     smallest_possible_quotient, largest_possible_quotient,
                     channelling_constraints, mag_var, z_eq_product_lines, x_is_first, true);
@@ -1093,25 +1093,25 @@ namespace
                     WPBSum{} + 1_i * (x_var >= smallest_possible_quotient) >= 1_i, ProofLevel::Current);
             };
 
-            auto both_justf = [&](const ReasonFunction & reason) {
+            auto both_justf = [&](const ReasonLiterals & reason) {
                 upper_justf(reason);
                 lower_justf(reason);
             };
 
             if (smallest_possible_quotient > largest_possible_quotient) {
-                inference.infer(logger, FalseLiteral{}, JustifyExplicitlyOnly{both_justf},
-                    [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
-                         y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second}]() { return lits; });
+                inference.infer(logger, FalseLiteral{}, JustifyExplicitly{both_justf, ThenRUP::No},
+                    ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
+                        y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
             }
             else {
                 inference.infer(logger, x_var <= largest_possible_quotient,
-                    JustifyExplicitlyOnly{upper_justf},
-                    [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
-                         y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second}]() { return lits; });
+                    JustifyExplicitly{upper_justf, ThenRUP::No},
+                    ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
+                        y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
                 inference.infer(logger, x_var >= smallest_possible_quotient,
-                    JustifyExplicitlyOnly{lower_justf},
-                    [lits = Reason{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
-                         y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second}]() { return lits; });
+                    JustifyExplicitly{lower_justf, ThenRUP::No},
+                    ReasonLiterals{z_var >= var_bounds.at(z_var).first, z_var <= var_bounds.at(z_var).second,
+                        y_var >= var_bounds.at(y_var).first, y_var <= var_bounds.at(y_var).second});
             }
         }
         else {
@@ -1257,7 +1257,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
             auto [smallest_product, largest_product] = get_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second);
             auto & bit_products = any_cast<vector<vector<BitProductData>> &>(state.get_persistent_constraint_state(bit_products_h));
 
-            auto justf = [&](const ReasonFunction & reason) {
+            auto justf = [&](const ReasonLiterals & reason) {
                 prove_product_bounds(reason, *logger, bit_products, v1, v2, v3, var_bounds,
                     smallest_product, largest_product, channelling_constraints, mag_var, v3_eq_product_lines, sign_lines);
                 logger->emit_rup_proof_line_under_reason(reason,
@@ -1267,9 +1267,9 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
             };
 
             inference.infer_all(logger, {v3 <= largest_product, v3 >= smallest_product},
-                JustifyExplicitlyOnly{justf},
-                [lits = Reason{v1 >= var_bounds.at(v1).first, v1 <= var_bounds.at(v1).second,
-                     v2 >= var_bounds.at(v2).first, v2 <= var_bounds.at(v2).second}]() { return lits; });
+                JustifyExplicitly{justf, ThenRUP::No},
+                ReasonLiterals{v1 >= var_bounds.at(v1).first, v1 <= var_bounds.at(v1).second,
+                    v2 >= var_bounds.at(v2).first, v2 <= var_bounds.at(v2).second});
 
             auto bounds3 = state.bounds(v3);
             filter_quotient(v1, v2, v3, bounds3.first, bounds3.second, bounds2.first, bounds2.second, all_vars, state, inference,

--- a/gcs/constraints/n_value/hints.hh
+++ b/gcs/constraints/n_value/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_N_VALUE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_N_VALUE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief NValue's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct NValue
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "nvalue";
+    };
+}
+
+#endif

--- a/gcs/constraints/n_value/n_value.cc
+++ b/gcs/constraints/n_value/n_value.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/n_value/hints.hh>
 #include <gcs/constraints/n_value/n_value.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -100,14 +101,14 @@ auto NValue::install_propagators(Propagators & propagators) -> void
     vector<IntegerVariableID> all_vars = _vars;
     all_vars.push_back(_n_values);
 
-    propagators.install(constraint_id(), [all_vars = move(all_vars), n_values = _n_values, vars = _vars](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [all_vars = move(all_vars), n_values = _n_values, vars = _vars, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         set<Integer> all_possible_values;
         for (const auto & var : vars) {
             for (auto v : state.each_value_immutable(var))
                 all_possible_values.insert(v);
         }
 
-        inference.infer(logger, n_values <= Integer(all_possible_values.size()), JustifyUsingRUP{},
+        inference.infer(logger, n_values <= Integer(all_possible_values.size()), JustifyUsingRUP{hints::NValue{owner}},
             generic_reason(state, all_vars));
 
         set<Integer> all_definite_values;
@@ -120,7 +121,7 @@ auto NValue::install_propagators(Propagators & propagators) -> void
         // The "at least 1" floor only applies when the array is non-empty;
         // an empty array contributes 0 distinct values.
         auto distinct_floor = vars.empty() ? 0_i : 1_i;
-        inference.infer(logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{}, generic_reason(state, all_vars));
+        inference.infer(logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{hints::NValue{owner}}, generic_reason(state, all_vars));
 
         return PropagatorState::Enable; }, triggers);
 }

--- a/gcs/constraints/n_value/n_value.cc
+++ b/gcs/constraints/n_value/n_value.cc
@@ -109,7 +109,7 @@ auto NValue::install_propagators(Propagators & propagators) -> void
         }
 
         inference.infer(logger, n_values <= Integer(all_possible_values.size()), JustifyUsingRUP{hints::NValue{owner}},
-            generic_reason(state, all_vars));
+            generic_reason(all_vars));
 
         set<Integer> all_definite_values;
         for (const auto & var : vars) {
@@ -121,7 +121,7 @@ auto NValue::install_propagators(Propagators & propagators) -> void
         // The "at least 1" floor only applies when the array is non-empty;
         // an empty array contributes 0 distinct values.
         auto distinct_floor = vars.empty() ? 0_i : 1_i;
-        inference.infer(logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{hints::NValue{owner}}, generic_reason(state, all_vars));
+        inference.infer(logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{hints::NValue{owner}}, generic_reason(all_vars));
 
         return PropagatorState::Enable; }, triggers);
 }

--- a/gcs/constraints/parity/hints.hh
+++ b/gcs/constraints/parity/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PARITY_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief ParityOdd's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Parity
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "parity";
+    };
+}
+
+#endif

--- a/gcs/constraints/parity/parity.cc
+++ b/gcs/constraints/parity/parity.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/innards/triggers.hh>
+#include <gcs/constraints/parity/hints.hh>
 #include <gcs/constraints/parity/parity.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -96,7 +97,7 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
     for (const auto & l : _lits)
         add_trigger_for(triggers, l);
 
-    propagators.install(constraint_id(), [lits = _lits](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [lits = _lits, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         long how_many_1 = 0, how_many_unknown = 0;
         optional<Literal> an_unknown;
         ReasonLiterals reason;
@@ -125,15 +126,15 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
             if (how_many_1 % 2 == 1)
                 return PropagatorState::DisableUntilBacktrack;
             else
-                inference.contradiction(logger, JustifyUsingRUP{}, ExplicitReason{reason});
+                inference.contradiction(logger, JustifyUsingRUP{hints::Parity{owner}}, ExplicitReason{reason});
         }
         else {
             if (how_many_1 % 2 == 1) {
-                inference.infer(logger, ! *an_unknown, JustifyUsingRUP{}, ExplicitReason{reason});
+                inference.infer(logger, ! *an_unknown, JustifyUsingRUP{hints::Parity{owner}}, ExplicitReason{reason});
                 return PropagatorState::DisableUntilBacktrack;
             }
             else {
-                inference.infer(logger, *an_unknown, JustifyUsingRUP{}, ExplicitReason{reason});
+                inference.infer(logger, *an_unknown, JustifyUsingRUP{hints::Parity{owner}}, ExplicitReason{reason});
                 return PropagatorState::DisableUntilBacktrack;
             }
         } }, triggers);

--- a/gcs/constraints/parity/parity.cc
+++ b/gcs/constraints/parity/parity.cc
@@ -99,7 +99,7 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
     propagators.install(constraint_id(), [lits = _lits](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         long how_many_1 = 0, how_many_unknown = 0;
         optional<Literal> an_unknown;
-        Reason reason;
+        ReasonLiterals reason;
         for (const auto & l : lits) {
             switch (state.test_literal(l)) {
                 using enum LiteralIs;
@@ -125,15 +125,15 @@ auto ParityOdd::install_propagators(Propagators & propagators) -> void
             if (how_many_1 % 2 == 1)
                 return PropagatorState::DisableUntilBacktrack;
             else
-                inference.contradiction(logger, JustifyUsingRUP{}, ReasonFunction{[=]() { return reason; }});
+                inference.contradiction(logger, JustifyUsingRUP{}, ExplicitReason{reason});
         }
         else {
             if (how_many_1 % 2 == 1) {
-                inference.infer(logger, ! *an_unknown, JustifyUsingRUP{}, ReasonFunction{[=]() { return reason; }});
+                inference.infer(logger, ! *an_unknown, JustifyUsingRUP{}, ExplicitReason{reason});
                 return PropagatorState::DisableUntilBacktrack;
             }
             else {
-                inference.infer(logger, *an_unknown, JustifyUsingRUP{}, ReasonFunction{[=]() { return reason; }});
+                inference.infer(logger, *an_unknown, JustifyUsingRUP{}, ExplicitReason{reason});
                 return PropagatorState::DisableUntilBacktrack;
             }
         } }, triggers);

--- a/gcs/constraints/plus_minus/hints.hh
+++ b/gcs/constraints/plus_minus/hints.hh
@@ -1,0 +1,57 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PLUS_MINUS_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_PLUS_MINUS_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/reason.hh>
+
+#include <optional>
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief plus's assertion hint for a bound push: the owning constraint and the
+     * sum-definition line to start the cut from.
+     *
+     * plus has a single inference shape, so there is no subhint. emit_justification
+     * starts the cut from pol_line and reads the two operand bounds positionally
+     * from the reason -- a genuinely hint-driven emit -- but with no own hint_sexpr
+     * the hint takes the default `(constraint_id <originator>)` wire form; pol_line
+     * is held for emission, not serialised. pol_line is optional: with no sum line
+     * (e.g. proofs without a model) emit does nothing and only the trailing RUP
+     * stands.
+     *
+     * \ingroup Innards
+     */
+    struct Plus
+    {
+        ConstraintID originator;
+        std::optional<ProofLine> pol_line;
+        static constexpr std::string_view hint_name = "plus";
+    };
+
+    auto emit_justification(ProofLogger & logger, const Plus & plus, const ReasonLiterals & reason) -> void;
+
+    /**
+     * \brief minus's assertion hint for a bound push: the owning constraint and the
+     * sum-definition line to start the cut from.
+     *
+     * The same shape as Plus (minus shares the bound-push proof pattern); a single
+     * inference shape, so no subhint, and pol_line is held for emit_justification
+     * rather than serialised.
+     *
+     * \ingroup Innards
+     */
+    struct Minus
+    {
+        ConstraintID originator;
+        std::optional<ProofLine> pol_line;
+        static constexpr std::string_view hint_name = "minus";
+    };
+
+    auto emit_justification(ProofLogger & logger, const Minus & minus, const ReasonLiterals & reason) -> void;
+}
+
+#endif

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -61,31 +61,31 @@ namespace
             LE
         };
 
-        auto justify = [&](Conclude c) -> JustifyExplicitlyThenRUP {
-            return JustifyExplicitlyThenRUP{
-                [c, sum_line, logger](const ReasonFunction & reason) {
-                    auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
-                    if (! sum_line_value)
-                        return;
+        auto justify = [&](Conclude c) {
+            return JustifyExplicitly{[c, sum_line, logger](const ReasonLiterals & reason) {
+                                         auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
+                                         if (! sum_line_value)
+                                             return;
 
-                    PolBuilder b;
-                    b.add(*sum_line_value);
+                                         PolBuilder b;
+                                         b.add(*sum_line_value);
 
-                    // Constants in WPBSum are baked into the OPB sum_line directly
-                    // (see emit_inequality_to.cc:58–60), so a reason literal whose
-                    // variable is a ConstantIntegerVariableID already contributes
-                    // to sum_line and doesn't need (or have) a pol-side defining
-                    // line — need_pol_item_defining_literal would throw on it.
-                    // Issue #166.
-                    for (size_t i = 0; i < 2; ++i) {
-                        auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason().at(i))));
-                        if (holds_alternative<ConstantIntegerVariableID>(lit.var))
-                            continue;
-                        b.add_for_literal(logger->names_and_ids_tracker(), lit);
-                    }
+                                         // Constants in WPBSum are baked into the OPB sum_line directly
+                                         // (see emit_inequality_to.cc:58–60), so a reason literal whose
+                                         // variable is a ConstantIntegerVariableID already contributes
+                                         // to sum_line and doesn't need (or have) a pol-side defining
+                                         // line — need_pol_item_defining_literal would throw on it.
+                                         // Issue #166.
+                                         for (size_t i = 0; i < 2; ++i) {
+                                             auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason.at(i))));
+                                             if (holds_alternative<ConstantIntegerVariableID>(lit.var))
+                                                 continue;
+                                             b.add_for_literal(logger->names_and_ids_tracker(), lit);
+                                         }
 
-                    b.emit(*logger, ProofLevel::Temporary);
-                }};
+                                         b.emit(*logger, ProofLevel::Temporary);
+                                     },
+                ThenRUP::Yes};
         };
 
         // Conclude side picked so the OPB sum_line half contributes the same
@@ -96,32 +96,32 @@ namespace
         // min(result) = min(a) - max(b);
         inference.infer(logger, result >= a_vals.first - b_vals.second,
             justify(Conclude::LE),
-            [=]() { return Reason{a >= a_vals.first, b <= b_vals.second}; });
+            ExplicitReason{ReasonLiterals{a >= a_vals.first, b <= b_vals.second}});
 
         // max(result) = max(a) - min(b);
         inference.infer(logger, result <= a_vals.second - b_vals.first,
             justify(Conclude::GE),
-            [=]() { return Reason{a <= a_vals.second, b >= b_vals.first}; });
+            ExplicitReason{ReasonLiterals{a <= a_vals.second, b >= b_vals.first}});
 
         // min(a) = min(result) + min(b);
         inference.infer(logger, a >= result_vals.first + b_vals.first,
             justify(Conclude::GE),
-            [=]() { return Reason{result >= result_vals.first, b >= b_vals.first}; });
+            ExplicitReason{ReasonLiterals{result >= result_vals.first, b >= b_vals.first}});
 
         // max(a) = max(result) + max(b);
         inference.infer(logger, a <= result_vals.second + b_vals.second,
             justify(Conclude::LE),
-            [=]() { return Reason{result <= result_vals.second, b <= b_vals.second}; });
+            ExplicitReason{ReasonLiterals{result <= result_vals.second, b <= b_vals.second}});
 
         // min(b) = min(a) - max(result);
         inference.infer(logger, b >= a_vals.first - result_vals.second,
             justify(Conclude::LE),
-            [=]() { return Reason{a >= a_vals.first, result <= result_vals.second}; });
+            ExplicitReason{ReasonLiterals{a >= a_vals.first, result <= result_vals.second}});
 
         // max(b) = max(a) - min(result);
         inference.infer(logger, b <= a_vals.second - result_vals.first,
             justify(Conclude::GE),
-            [=]() { return Reason{a <= a_vals.second, result >= result_vals.first}; });
+            ExplicitReason{ReasonLiterals{a <= a_vals.second, result >= result_vals.first}});
 
         return PropagatorState::Enable;
     }

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/plus_minus/hints.hh>
 #include <gcs/constraints/plus_minus/minus.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -35,6 +36,31 @@ using std::print;
 using fmt::print;
 #endif
 
+namespace gcs::innards::hints
+{
+    auto emit_justification(ProofLogger & logger, const Minus & minus, const ReasonLiterals & reason) -> void
+    {
+        if (! minus.pol_line)
+            return;
+
+        PolBuilder b;
+        b.add(*minus.pol_line);
+
+        // Constants in WPBSum are baked into the OPB sum_line directly (see
+        // emit_inequality_to.cc:58-60), so a reason literal whose variable is a
+        // ConstantIntegerVariableID already contributes to sum_line and doesn't
+        // need (or have) a pol-side defining line. Issue #166.
+        for (size_t i = 0; i < 2; ++i) {
+            auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason.at(i))));
+            if (holds_alternative<ConstantIntegerVariableID>(lit.var))
+                continue;
+            b.add_for_literal(logger.names_and_ids_tracker(), lit);
+        }
+
+        b.emit(logger, ProofLevel::Temporary);
+    }
+}
+
 namespace
 {
     // Direct propagator for a - b = result. Deliberately not implemented via
@@ -49,7 +75,7 @@ namespace
         const State & state,
         auto & inference,
         ProofLogger * const logger,
-        const pair<optional<ProofLine>, optional<ProofLine>> & sum_line) -> PropagatorState
+        const pair<optional<ProofLine>, optional<ProofLine>> & sum_line, const ConstraintID & owner) -> PropagatorState
     {
         auto a_vals = state.bounds(a);
         auto b_vals = state.bounds(b);
@@ -62,30 +88,8 @@ namespace
         };
 
         auto justify = [&](Conclude c) {
-            return JustifyExplicitly{[c, sum_line, logger](const ReasonLiterals & reason) {
-                                         auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
-                                         if (! sum_line_value)
-                                             return;
-
-                                         PolBuilder b;
-                                         b.add(*sum_line_value);
-
-                                         // Constants in WPBSum are baked into the OPB sum_line directly
-                                         // (see emit_inequality_to.cc:58–60), so a reason literal whose
-                                         // variable is a ConstantIntegerVariableID already contributes
-                                         // to sum_line and doesn't need (or have) a pol-side defining
-                                         // line — need_pol_item_defining_literal would throw on it.
-                                         // Issue #166.
-                                         for (size_t i = 0; i < 2; ++i) {
-                                             auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason.at(i))));
-                                             if (holds_alternative<ConstantIntegerVariableID>(lit.var))
-                                                 continue;
-                                             b.add_for_literal(logger->names_and_ids_tracker(), lit);
-                                         }
-
-                                         b.emit(*logger, ProofLevel::Temporary);
-                                     },
-                ThenRUP::Yes};
+            auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
+            return JustifyExplicitly{hints::Minus{owner, sum_line_value}, ThenRUP::Yes};
         };
 
         // Conclude side picked so the OPB sum_line half contributes the same
@@ -168,9 +172,9 @@ auto Minus::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [a = _a, b = _b, result = _result, sum_line = _sum_line](
+        [a = _a, b = _b, result = _result, sum_line = _sum_line, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return propagate_minus(a, b, result, state, inference, logger, sum_line);
+            return propagate_minus(a, b, result, state, inference, logger, sum_line, owner);
         },
         triggers);
 }

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -35,6 +35,49 @@ using std::print;
 using fmt::print;
 #endif
 
+namespace gcs::innards::hints
+{
+    // Witness for a plus bound push: the sum-definition line to start the cut
+    // from. The two operand bounds come from the reason (read positionally), so
+    // emit_justification consumes the reason — the opposite of all_different's
+    // Hall emit, which ignores it. A genuinely witness-driven emit (nothing
+    // captured but the witness and logger), in contrast to all_different's, whose
+    // emit must capture per-constraint state. No hint_sexpr overload: plus has no
+    // typed external hint yet (its witness is the reason, already in the
+    // assertion), so it carries only the coarse hint_name.
+    //
+    // pol_line is optional: with no sum line (e.g. proofs without a model) there
+    // is no explicit lemma, just the trailing RUP, so emit does nothing — an
+    // empty-emit explicit step, byte-identical to the pre-witness early return.
+    struct PlusBound
+    {
+        std::optional<ProofLine> pol_line;
+        static constexpr std::string_view hint_name = "plus";
+    };
+
+    auto emit_justification(ProofLogger & logger, const PlusBound & d, const ReasonLiterals & reason) -> void
+    {
+        if (! d.pol_line)
+            return;
+
+        PolBuilder b;
+        b.add(*d.pol_line);
+
+        // Constants in WPBSum are baked into the OPB sum_line directly (see
+        // emit_inequality_to.cc:58-60), so a reason literal whose variable is a
+        // ConstantIntegerVariableID already contributes to sum_line and doesn't
+        // need (or have) a pol-side defining line. Issue #166.
+        for (size_t i = 0; i < 2; ++i) {
+            auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason.at(i))));
+            if (holds_alternative<ConstantIntegerVariableID>(lit.var))
+                continue;
+            b.add_for_literal(logger.names_and_ids_tracker(), lit);
+        }
+
+        b.emit(logger, ProofLevel::Temporary);
+    }
+}
+
 namespace
 {
     auto propagate_plus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result,
@@ -53,62 +96,40 @@ namespace
             LE
         };
 
-        auto justify = [&](Conclude c) -> JustifyExplicitlyThenRUP {
-            return JustifyExplicitlyThenRUP{
-                [c, sum_line, logger](const ReasonFunction & reason) {
-                    auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
-                    if (! sum_line_value)
-                        return;
-
-                    PolBuilder b;
-                    b.add(*sum_line_value);
-
-                    // Constants in WPBSum are baked into the OPB sum_line directly
-                    // (see emit_inequality_to.cc:58–60), so a reason literal whose
-                    // variable is a ConstantIntegerVariableID already contributes
-                    // to sum_line and doesn't need (or have) a pol-side defining
-                    // line — need_pol_item_defining_literal would throw on it.
-                    // Issue #166.
-                    for (size_t i = 0; i < 2; ++i) {
-                        auto lit = get<IntegerVariableCondition>(get<Literal>(get<ProofLiteral>(reason().at(i))));
-                        if (holds_alternative<ConstantIntegerVariableID>(lit.var))
-                            continue;
-                        b.add_for_literal(logger->names_and_ids_tracker(), lit);
-                    }
-
-                    b.emit(*logger, ProofLevel::Temporary);
-                }};
+        auto justify = [&](Conclude c) {
+            auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
+            return JustifyExplicitly{hints::PlusBound{sum_line_value}, ThenRUP::Yes};
         };
 
         // min(result) = min(a) + min(b);
         inference.infer(logger, result >= a_vals.first + b_vals.first,
             justify(Conclude::LE),
-            [=]() { return Reason{a >= a_vals.first, b >= b_vals.first}; });
+            ExplicitReason{ReasonLiterals{a >= a_vals.first, b >= b_vals.first}});
 
         // max(result) = max(a) + max(b);
         inference.infer(logger, result <= a_vals.second + b_vals.second,
             justify(Conclude::GE),
-            [=]() { return Reason{a <= a_vals.second, b <= b_vals.second}; });
+            ExplicitReason{ReasonLiterals{a <= a_vals.second, b <= b_vals.second}});
 
         // min(a) = min(result) - max(b);
         inference.infer(logger, a >= result_vals.first - b_vals.second,
             justify(Conclude::GE),
-            [=]() { return Reason{result >= result_vals.first, b <= b_vals.second}; });
+            ExplicitReason{ReasonLiterals{result >= result_vals.first, b <= b_vals.second}});
 
         // max(a) = max(result) - min(b);
         inference.infer(logger, a <= result_vals.second - b_vals.first,
             justify(Conclude::LE),
-            [=]() { return Reason{result <= result_vals.second, b >= b_vals.first}; });
+            ExplicitReason{ReasonLiterals{result <= result_vals.second, b >= b_vals.first}});
 
         // min(b) = min(result) - max(a);
         inference.infer(logger, b >= result_vals.first - a_vals.second,
             justify(Conclude::GE),
-            [=]() { return Reason{result >= result_vals.first, a <= a_vals.second}; });
+            ExplicitReason{ReasonLiterals{result >= result_vals.first, a <= a_vals.second}});
 
         // max(b) = max(result) - min(a);
         inference.infer(logger, b <= result_vals.second - a_vals.first,
             justify(Conclude::LE),
-            [=]() { return Reason{result <= result_vals.second, a >= a_vals.first}; });
+            ExplicitReason{ReasonLiterals{result <= result_vals.second, a >= a_vals.first}});
 
         return PropagatorState::Enable;
     }

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/plus_minus/hints.hh>
 #include <gcs/constraints/plus_minus/plus.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -37,31 +38,13 @@ using fmt::print;
 
 namespace gcs::innards::hints
 {
-    // Witness for a plus bound push: the sum-definition line to start the cut
-    // from. The two operand bounds come from the reason (read positionally), so
-    // emit_justification consumes the reason — the opposite of all_different's
-    // Hall emit, which ignores it. A genuinely witness-driven emit (nothing
-    // captured but the witness and logger), in contrast to all_different's, whose
-    // emit must capture per-constraint state. No hint_sexpr overload: plus has no
-    // typed external hint yet (its witness is the reason, already in the
-    // assertion), so it carries only the coarse hint_name.
-    //
-    // pol_line is optional: with no sum line (e.g. proofs without a model) there
-    // is no explicit lemma, just the trailing RUP, so emit does nothing — an
-    // empty-emit explicit step, byte-identical to the pre-witness early return.
-    struct PlusBound
+    auto emit_justification(ProofLogger & logger, const Plus & plus, const ReasonLiterals & reason) -> void
     {
-        std::optional<ProofLine> pol_line;
-        static constexpr std::string_view hint_name = "plus";
-    };
-
-    auto emit_justification(ProofLogger & logger, const PlusBound & d, const ReasonLiterals & reason) -> void
-    {
-        if (! d.pol_line)
+        if (! plus.pol_line)
             return;
 
         PolBuilder b;
-        b.add(*d.pol_line);
+        b.add(*plus.pol_line);
 
         // Constants in WPBSum are baked into the OPB sum_line directly (see
         // emit_inequality_to.cc:58-60), so a reason literal whose variable is a
@@ -84,7 +67,7 @@ namespace
         const State & state,
         auto & inference,
         ProofLogger * const logger,
-        const pair<optional<ProofLine>, optional<ProofLine>> & sum_line) -> PropagatorState
+        const pair<optional<ProofLine>, optional<ProofLine>> & sum_line, const ConstraintID & owner) -> PropagatorState
     {
         auto a_vals = state.bounds(a);
         auto b_vals = state.bounds(b);
@@ -98,7 +81,7 @@ namespace
 
         auto justify = [&](Conclude c) {
             auto sum_line_value = (c == Conclude::LE ? sum_line.first : sum_line.second);
-            return JustifyExplicitly{hints::PlusBound{sum_line_value}, ThenRUP::Yes};
+            return JustifyExplicitly{hints::Plus{owner, sum_line_value}, ThenRUP::Yes};
         };
 
         // min(result) = min(a) + min(b);
@@ -176,9 +159,9 @@ auto Plus::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [a = _a, b = _b, result = _result, sum_line = _sum_line](
+        [a = _a, b = _b, result = _result, sum_line = _sum_line, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return propagate_plus(a, b, result, state, inference, logger, sum_line);
+            return propagate_plus(a, b, result, state, inference, logger, sum_line, owner);
         },
         triggers);
 }

--- a/gcs/constraints/regular/hints.hh
+++ b/gcs/constraints/regular/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Regular's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct Regular
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "regular";
+    };
+}
+
+#endif

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -94,7 +94,7 @@ namespace
     };
 
     auto log_additional_inference(ProofLogger * const logger, const vector<Literal> & literals, const vector<ProofFlag> & proof_flags,
-        const State &, const ReasonFunction & reason, string comment = "") -> void
+        const State &, const ReasonLiterals & reason, string comment = "") -> void
     {
         if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
             // Trying to cut down on repeated code
@@ -113,7 +113,7 @@ namespace
     auto initialise_graph(RegularGraph & graph, const vector<IntegerVariableID> & vars,
         const long num_states, const vector<unordered_map<Integer, set<long>>> & transitions,
         const vector<long> & final_states, const vector<vector<ProofFlag>> & state_at_pos_flags,
-        const State & state, const ReasonFunction & reason, ProofLogger * const logger)
+        const State & state, const ReasonLiterals & reason, ProofLogger * const logger)
     {
         auto num_vars = vars.size();
 
@@ -215,7 +215,7 @@ namespace
     }
 
     auto decrement_outdeg(RegularGraph & graph, const long i, const long k, const vector<IntegerVariableID> & vars,
-        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonFunction & reason, ProofLogger * const logger) -> void
+        const vector<vector<ProofFlag>> & state_at_pos_flags, const State & state, const ReasonLiterals & reason, ProofLogger * const logger) -> void
     {
         graph.out_deg[i][k]--;
         if (graph.out_deg[i][k] == 0 && i > 0) {
@@ -243,7 +243,7 @@ namespace
 
     auto decrement_indeg(RegularGraph & graph, const long i, const long k,
         const vector<IntegerVariableID> & vars, const vector<vector<ProofFlag>> & state_at_pos_flags,
-        const State & state, const ReasonFunction & reason, ProofLogger * const logger) -> void
+        const State & state, const ReasonLiterals & reason, ProofLogger * const logger) -> void
     {
         graph.in_deg[i][k]--;
         if (graph.in_deg[i][k] == 0 && cmp_less(i, graph.in_deg.size() - 1)) {
@@ -289,7 +289,7 @@ namespace
         const bool short_reasons) -> void
     {
         auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
-        auto gen_reason = generic_reason(state, vars);
+        auto gen_reason = eager_reason(generic_reason(state, vars), state);
 
         // Degenerate empty sequence (issue #254): with no variables there is
         // nothing to propagate over, but the empty word is accepted only if the
@@ -310,12 +310,12 @@ namespace
             return;
         }
 
-        ReasonFunction reason;
+        ReasonLiterals reason;
         ProofLine reason_definition_1, reason_definition_2;
 
         if (logger && short_reasons) {
             auto reason_sum = WPBSum{};
-            for (const auto & lit : gen_reason()) {
+            for (const auto & lit : gen_reason) {
                 reason_sum += 1_i * get<ProofLiteral>(lit);
             }
             // We will manually delete this later.
@@ -324,7 +324,7 @@ namespace
             ProofFlag reason_short = _reason_short;
             reason_definition_1 = _line1;
             reason_definition_2 = _line2;
-            reason = singleton_reason(reason_short);
+            reason = eager_reason(singleton_reason(reason_short), state);
         }
         else {
             reason = gen_reason;

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -291,7 +291,7 @@ namespace
         const ConstraintID & owner) -> void
     {
         auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
-        auto gen_reason = eager_reason(generic_reason(state, vars), state);
+        auto gen_reason = eager_reason(generic_reason(vars), state);
 
         // Degenerate empty sequence (issue #254): with no variables there is
         // nothing to propagate over, but the empty word is accepted only if the

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <gcs/constraints/regular/regex.hh>
 #include <gcs/constraints/regular/regular.hh>
 #include <gcs/exception.hh>
@@ -8,6 +9,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 
+#include <gcs/proof.hh>
 #include <version>
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -94,7 +96,7 @@ namespace
     auto log_additional_inference(ProofLogger * const logger, const vector<Literal> & literals, const vector<ProofFlag> & proof_flags,
         const State &, const ReasonFunction & reason, string comment = "") -> void
     {
-        if (logger) {
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
             // Trying to cut down on repeated code
             if (! comment.empty())
                 logger->emit_proof_comment(comment);
@@ -115,7 +117,7 @@ namespace
     {
         auto num_vars = vars.size();
 
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->emit_proof_comment("Initialising graph");
 
         // Forward phase: accumulate
@@ -132,7 +134,7 @@ namespace
                 }
             }
 
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 for (long next_q = 0; next_q < num_states; ++next_q) {
                     if (graph.nodes[i + 1].contains(next_q)) continue;
                     // Want to eliminate this node i.e. prove !state[i+1][next_q]
@@ -182,7 +184,7 @@ namespace
                         state_is_support[q] = 1;
                     else {
                         graph.states_supporting[i][val].erase(q);
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             log_additional_inference(logger, {vars[i] != val}, {! state_at_pos_flags[i][q]}, state, reason);
                     }
                 }
@@ -192,7 +194,7 @@ namespace
             for (const auto & q : gn) {
                 if (! state_is_support[q]) {
                     graph.nodes[i].erase(q);
-                    if (logger)
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                         log_additional_inference(logger, {}, {! state_at_pos_flags[i][q]}, state, reason, "back pass");
                 }
             }
@@ -226,7 +228,7 @@ namespace
                     // once no such edge remains.
                     if (! still_supports(graph, i - 1, l, val)) {
                         graph.states_supporting[i - 1][val].erase(l);
-                        if (logger)
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                             log_additional_inference(logger, {vars[i - 1] != val}, {! state_at_pos_flags[i - 1][l]}, state, reason,
                                 "dec outdeg inner");
                     }
@@ -234,7 +236,7 @@ namespace
                 }
             }
             graph.in_edges[i][k] = {};
-            if (logger)
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off)
                 log_additional_inference(logger, {}, {! state_at_pos_flags[i][k]}, state, reason, "dec outdeg");
         }
     }
@@ -245,7 +247,7 @@ namespace
     {
         graph.in_deg[i][k]--;
         if (graph.in_deg[i][k] == 0 && cmp_less(i, graph.in_deg.size() - 1)) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 // Again, want to eliminate this node i.e. prove !state[i][k]
                 for (const auto & q : graph.nodes[i - 1]) {
                     // So first eliminate each previous state/variable combo

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <gcs/constraints/regular/hints.hh>
 #include <gcs/constraints/regular/regex.hh>
 #include <gcs/constraints/regular/regular.hh>
 #include <gcs/exception.hh>
@@ -286,7 +287,8 @@ namespace
         const State & state,
         auto & inference,
         ProofLogger * const logger,
-        const bool short_reasons) -> void
+        const bool short_reasons,
+        const ConstraintID & owner) -> void
     {
         auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
         auto gen_reason = eager_reason(generic_reason(state, vars), state);
@@ -306,7 +308,7 @@ namespace
                     break;
                 }
             if (! initial_is_final)
-                inference.contradiction(logger, JustifyUsingRUP{}, gen_reason);
+                inference.contradiction(logger, JustifyUsingRUP{hints::Regular{owner}}, gen_reason);
             return;
         }
 
@@ -372,7 +374,7 @@ namespace
             for (auto val : state.each_value_mutable(vars[i])) {
                 // Clean up domains
                 if (graph.states_supporting[i][val].empty())
-                    inference.infer_not_equal(logger, vars[i], val, JustifyUsingRUP{}, reason);
+                    inference.infer_not_equal(logger, vars[i], val, JustifyUsingRUP{hints::Regular{owner}}, reason);
             }
         }
 
@@ -559,8 +561,8 @@ auto Regular::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change = {_vars.begin(), _vars.end()};
 
-    propagators.install(constraint_id(), [v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = _graph_idx, flags = move(_state_at_pos_flags), sr = _short_reasons](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        propagate_regular(v, n, t, f, flags, g, state, inference, logger, sr);
+    propagators.install(constraint_id(), [v = move(_vars), n = _num_states, t = move(_transitions), f = move(_final_states), g = _graph_idx, flags = move(_state_at_pos_flags), sr = _short_reasons, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagate_regular(v, n, t, f, flags, g, state, inference, logger, sr, owner);
         return PropagatorState::Enable; }, triggers);
 }
 

--- a/gcs/constraints/smart_table/hints.hh
+++ b/gcs/constraints/smart_table/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_SMART_TABLE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_SMART_TABLE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief SmartTable's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct SmartTable
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "smart_table";
+    };
+}
+
+#endif

--- a/gcs/constraints/smart_table/smart_table.cc
+++ b/gcs/constraints/smart_table/smart_table.cc
@@ -1,6 +1,7 @@
 #include <gcs/constraints/smart_table/smart_table.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -8,6 +9,7 @@
 #include <gcs/innards/s_expr.hh>
 
 #include <algorithm>
+#include <gcs/proof.hh>
 #include <map>
 #include <set>
 #include <sstream>
@@ -194,7 +196,7 @@ namespace
                         [&](Integer val) { return val > dom_1[0]; });
                     copy_if(dom_1, back_inserter(new_dom_1),
                         [&](Integer val) { return val < dom_2[dom_2.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_2.size() < dom_2.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_2) >= (dom_1[0] + 1_i),
                                 state, inference, singleton_reason(binary_entry.var_1 >= dom_1[0]));
@@ -208,7 +210,7 @@ namespace
                         [&](Integer val) { return val >= dom_1[0]; });
                     copy_if(dom_1, back_inserter(new_dom_1),
                         [&](Integer val) { return val <= dom_2[dom_2.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_2.size() < dom_2.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_2) >= (dom_1[0]), state, inference, singleton_reason(binary_entry.var_1 >= dom_1[0]));
                         if (new_dom_1.size() < dom_1.size())
@@ -219,7 +221,7 @@ namespace
                     set_intersection(dom_1, dom_2, back_inserter(new_dom_1));
                     new_dom_2 = new_dom_1;
 
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         // This one seems particularly annoying. Is it necessary? - not sure
                         if (new_dom_1.size() < dom_1.size()) {
                             vector<Integer> discarded_dom1;
@@ -242,14 +244,14 @@ namespace
                     if (dom_1.size() == 1) {
                         new_dom_1 = dom_1;
                         set_difference(dom_2, dom_1, back_inserter(new_dom_2));
-                        if (logger && new_dom_2.size() < dom_2.size()) {
+                        if (logger && new_dom_2.size() < dom_2.size() && logger->get_assertion_level() == AssertionLevel::Off) {
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_2) != (dom_1[0]), state, inference, singleton_reason(binary_entry.var_1 == dom_1[0]));
                         }
                     }
                     else if (dom_2.size() == 1) {
                         new_dom_2 = dom_2;
                         set_difference(dom_1, dom_2, back_inserter(new_dom_1));
-                        if (logger && new_dom_1.size() < dom_1.size()) {
+                        if (logger && new_dom_1.size() < dom_1.size() && logger->get_assertion_level() == AssertionLevel::Off) {
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_1) != (dom_2[0]), state, inference, singleton_reason(binary_entry.var_2 == dom_2[0]));
                         }
                     }
@@ -263,7 +265,7 @@ namespace
                         [&](Integer val) { return val > dom_2[0]; });
                     copy_if(dom_2, back_inserter(new_dom_2),
                         [&](Integer val) { return val < dom_1[dom_1.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_1.size() < dom_1.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_1) >= (dom_2[0] + 1_i), state, inference, singleton_reason(binary_entry.var_2 >= dom_2[0]));
                         if (new_dom_2.size() < dom_2.size())
@@ -275,7 +277,7 @@ namespace
                         [&](Integer val) { return val >= dom_2[0]; });
                     copy_if(dom_2, back_inserter(new_dom_2),
                         [&](Integer val) { return val <= dom_1[dom_1.size() - 1]; });
-                    if (logger) {
+                    if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                         if (new_dom_1.size() < dom_1.size())
                             log_filtering_inference(logger, tuple_selector, deview(binary_entry.var_1) >= (dom_2[0]), state, inference, singleton_reason(binary_entry.var_2 >= dom_2[0]));
                         if (new_dom_2.size() < dom_2.size())
@@ -521,7 +523,7 @@ namespace
         }
 
         if (! some_tuple_still_feasible) {
-            if (logger) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                 auto justf = [&](const ReasonFunction & reason) -> void {
                     for (unsigned int tuple_idx = 0; tuple_idx < tuples.size(); ++tuple_idx) {
                         logger->emit_rup_proof_line_under_reason(
@@ -538,11 +540,11 @@ namespace
                 // }
             }
             else {
-                inference.contradiction(logger, NoJustificationNeeded{}, reason);
+                inference.contradiction(logger, JustifyUsingRUP{}, reason);
             }
             return;
         }
-        if (logger) {
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
 
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {
@@ -566,7 +568,7 @@ namespace
         else {
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {
-                    inference.infer_not_equal(logger, var, value, NoJustificationNeeded{}, ReasonFunction{});
+                    inference.infer_not_equal(logger, var, value, JustifyUsingRUP{}, ReasonFunction{});
                 }
             }
         }

--- a/gcs/constraints/smart_table/smart_table.cc
+++ b/gcs/constraints/smart_table/smart_table.cc
@@ -946,7 +946,7 @@ auto SmartTable::install(Propagators & propagators, State & initial_state, Proof
         constraint_id(),
         [selectors, vars = _vars, tuples = move(_tuples), forests = move(forests), pb_selectors = move(pb_selectors), short_reasons = _short_reasons, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            auto reason = eager_reason(generic_reason(state, vars), state);
+            auto reason = eager_reason(generic_reason(vars), state);
             propagate_using_smart_str(selectors, vars, tuples, forests, state, inference, reason, pb_selectors, logger, short_reasons, owner);
             return PropagatorState::Enable;
         },

--- a/gcs/constraints/smart_table/smart_table.cc
+++ b/gcs/constraints/smart_table/smart_table.cc
@@ -164,9 +164,9 @@ namespace
     }
 
     auto log_filtering_inference(ProofLogger * const logger, const ProofFlag * tuple_selector, const Literal & lit,
-        const State &, auto &, const ReasonFunction & reason)
+        const State & state, auto &, const Reason & reason)
     {
-        logger->emit_rup_proof_line_under_reason(reason,
+        logger->emit_rup_proof_line_under_reason(eager_reason(reason, state),
             WPBSum{} + 1_i * (! *tuple_selector) + 1_i * lit >= 1_i, ProofLevel::Current);
     }
 
@@ -175,7 +175,7 @@ namespace
     // so passing nullptr is safe in that case and avoids forming a reference into an
     // empty pb_selectors vector at the call site.
     auto filter_edge(const SmartEntry & edge, VariableDomainMap & supported_by_tree, const ProofFlag * tuple_selector,
-        const State & state, auto & inference, const ReasonFunction &, ProofLogger * const logger) -> void
+        const State & state, auto & inference, const ReasonLiterals &, ProofLogger * const logger) -> void
     {
         // Currently filter both domains - might be overkill
         // If the tree was in a better form, think this can be optimised to do less redundant filtering.
@@ -348,7 +348,7 @@ namespace
 
     [[nodiscard]] auto filter_and_check_valid(const TreeEdges & tree, VariableDomainMap & supported_by_tree,
         const ProofFlag * tuple_selector, const State & state, auto & inference,
-        const ReasonFunction & reason, ProofLogger * const logger) -> bool
+        const ReasonLiterals & reason, ProofLogger * const logger) -> bool
     {
         for (int l = tree.size() - 1; l >= 0; --l) {
             for (const auto & edge : tree[l]) {
@@ -389,7 +389,7 @@ namespace
 
     auto filter_again_and_remove_supported(const TreeEdges & tree, VariableDomainMap & supported_by_tree,
         VariableDomainMap & unsupported, const ProofFlag * tuple_selector, const State & state,
-        auto & inference, const ReasonFunction & reason, ProofLogger * const logger) -> void
+        auto & inference, const ReasonLiterals & reason, ProofLogger * const logger) -> void
     {
         for (int l = tree.size() - 1; l >= 0; --l) {
             for (const auto & edge : tree[l]) {
@@ -443,7 +443,7 @@ namespace
     }
 
     auto propagate_using_smart_str(const vector<IntegerVariableID> & selectors, const vector<IntegerVariableID> & vars,
-        const SmartTuples & tuples, const vector<Forest> & forests, const State & state, auto & inference, const ReasonFunction & reason,
+        const SmartTuples & tuples, const vector<Forest> & forests, const State & state, auto & inference, const ReasonLiterals & reason,
         vector<ProofFlag> pb_selectors, ProofLogger * const logger, bool short_reasons) -> void
     {
         VariableDomainMap unsupported{};
@@ -477,7 +477,7 @@ namespace
                 // First pass of filtering supported_by_tree and check of validity
                 if (! filter_and_check_valid(tree, supported_by_tree, pb_selector, state, inference, reason, logger)) {
                     // Not feasible
-                    inference.infer_equal(logger, selectors[tuple_idx], 0_i, NoJustificationNeeded{}, ReasonFunction{});
+                    inference.infer_equal(logger, selectors[tuple_idx], 0_i, NoJustificationNeeded{}, NoReason{});
                     break;
                 }
 
@@ -503,11 +503,11 @@ namespace
 
         auto unsupported_sum = WPBSum{};
 
-        ReasonFunction reason_to_use;
+        Reason reason_to_use;
         ProofLine reason_definition_1, reason_definition_2;
         if (logger && short_reasons) {
             auto reason_sum = WPBSum{};
-            for (const auto & lit : reason()) {
+            for (const auto & lit : reason) {
                 reason_sum += 1_i * get<ProofLiteral>(lit);
             }
             // We will manually delete this later.
@@ -524,7 +524,7 @@ namespace
 
         if (! some_tuple_still_feasible) {
             if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
-                auto justf = [&](const ReasonFunction & reason) -> void {
+                auto justf = [&](const ReasonLiterals & reason) -> void {
                     for (unsigned int tuple_idx = 0; tuple_idx < tuples.size(); ++tuple_idx) {
                         logger->emit_rup_proof_line_under_reason(
                             reason,
@@ -534,7 +534,7 @@ namespace
                             ProofLevel::Temporary);
                     }
                 };
-                inference.contradiction(logger, JustifyExplicitlyThenRUP{justf}, reason_to_use);
+                inference.contradiction(logger, JustifyExplicitly{justf, ThenRUP::Yes}, reason_to_use);
                 // if (short_reasons) {
                 //     logger->delete_range(reason_definition_1, reason_definition_2 + 1);
                 // }
@@ -548,7 +548,7 @@ namespace
 
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {
-                    auto justf = [&](const ReasonFunction & reason) -> void {
+                    auto justf = [&](const ReasonLiterals & reason) -> void {
                         for (unsigned int tuple_idx = 0; tuple_idx < tuples.size(); ++tuple_idx) {
                             logger->emit_rup_proof_line_under_reason(
                                 reason,
@@ -558,7 +558,7 @@ namespace
                                 ProofLevel::Temporary);
                         }
                     };
-                    inference.infer_not_equal(logger, var, value, JustifyExplicitlyThenRUP{justf}, reason_to_use);
+                    inference.infer_not_equal(logger, var, value, JustifyExplicitly{justf, ThenRUP::Yes}, reason_to_use);
                 }
             }
             // if (short_reasons) {
@@ -568,7 +568,7 @@ namespace
         else {
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {
-                    inference.infer_not_equal(logger, var, value, JustifyUsingRUP{}, ReasonFunction{});
+                    inference.infer_not_equal(logger, var, value, JustifyUsingRUP{}, NoReason{});
                 }
             }
         }
@@ -945,7 +945,7 @@ auto SmartTable::install(Propagators & propagators, State & initial_state, Proof
         constraint_id(),
         [selectors, vars = _vars, tuples = move(_tuples), forests = move(forests), pb_selectors = move(pb_selectors), short_reasons = _short_reasons](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            auto reason = generic_reason(state, vars);
+            auto reason = eager_reason(generic_reason(state, vars), state);
             propagate_using_smart_str(selectors, vars, tuples, forests, state, inference, reason, pb_selectors, logger, short_reasons);
             return PropagatorState::Enable;
         },

--- a/gcs/constraints/smart_table/smart_table.cc
+++ b/gcs/constraints/smart_table/smart_table.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/smart_table/hints.hh>
 #include <gcs/constraints/smart_table/smart_table.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -444,7 +445,7 @@ namespace
 
     auto propagate_using_smart_str(const vector<IntegerVariableID> & selectors, const vector<IntegerVariableID> & vars,
         const SmartTuples & tuples, const vector<Forest> & forests, const State & state, auto & inference, const ReasonLiterals & reason,
-        vector<ProofFlag> pb_selectors, ProofLogger * const logger, bool short_reasons) -> void
+        vector<ProofFlag> pb_selectors, ProofLogger * const logger, bool short_reasons, const ConstraintID & owner) -> void
     {
         VariableDomainMap unsupported{};
         // Initialise unsupported values to everything in each variable's current domain.
@@ -534,13 +535,13 @@ namespace
                             ProofLevel::Temporary);
                     }
                 };
-                inference.contradiction(logger, JustifyExplicitly{justf, ThenRUP::Yes}, reason_to_use);
+                inference.contradiction(logger, JustifyExplicitly{justf, ThenRUP::Yes, hints::SmartTable{owner}}, reason_to_use);
                 // if (short_reasons) {
                 //     logger->delete_range(reason_definition_1, reason_definition_2 + 1);
                 // }
             }
             else {
-                inference.contradiction(logger, JustifyUsingRUP{}, reason);
+                inference.contradiction(logger, JustifyUsingRUP{hints::SmartTable{owner}}, reason);
             }
             return;
         }
@@ -558,7 +559,7 @@ namespace
                                 ProofLevel::Temporary);
                         }
                     };
-                    inference.infer_not_equal(logger, var, value, JustifyExplicitly{justf, ThenRUP::Yes}, reason_to_use);
+                    inference.infer_not_equal(logger, var, value, JustifyExplicitly{justf, ThenRUP::Yes, hints::SmartTable{owner}}, reason_to_use);
                 }
             }
             // if (short_reasons) {
@@ -568,7 +569,7 @@ namespace
         else {
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {
-                    inference.infer_not_equal(logger, var, value, JustifyUsingRUP{}, NoReason{});
+                    inference.infer_not_equal(logger, var, value, JustifyUsingRUP{hints::SmartTable{owner}}, NoReason{});
                 }
             }
         }
@@ -943,10 +944,10 @@ auto SmartTable::install(Propagators & propagators, State & initial_state, Proof
 
     propagators.install(
         constraint_id(),
-        [selectors, vars = _vars, tuples = move(_tuples), forests = move(forests), pb_selectors = move(pb_selectors), short_reasons = _short_reasons](
+        [selectors, vars = _vars, tuples = move(_tuples), forests = move(forests), pb_selectors = move(pb_selectors), short_reasons = _short_reasons, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto reason = eager_reason(generic_reason(state, vars), state);
-            propagate_using_smart_str(selectors, vars, tuples, forests, state, inference, reason, pb_selectors, logger, short_reasons);
+            propagate_using_smart_str(selectors, vars, tuples, forests, state, inference, reason, pb_selectors, logger, short_reasons, owner);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -435,8 +435,8 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     Triggers ad_triggers;
     ad_triggers.on_change.insert(ad_triggers.on_change.end(), _p.begin(), _p.end());
 
-    propagators.install(constraint_id(), [p = _p, vals = move(p_vals), am1_lines](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        propagate_gac_all_different(p, vals, vector<Integer>{}, *am1_lines, state, inference, logger);
+    propagators.install(constraint_id(), [p = _p, vals = move(p_vals), am1_lines, constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagate_gac_all_different(constraint_id, p, vals, vector<Integer>{}, *am1_lines, state, inference, logger);
         return PropagatorState::Enable; }, ad_triggers);
 
     // No leaf-checking propagator is needed: once every x is fixed, each

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/all_different/gac_all_different.hh>
 #include <gcs/constraints/sort/arg_sort.hh>
+#include <gcs/constraints/sort/hints.hh>
 #include <gcs/constraints/sort/sortedness.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -196,7 +197,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     channel_triggers.on_bounds.insert(channel_triggers.on_bounds.end(), y_ids.begin(), y_ids.end());
     channel_triggers.on_change.insert(channel_triggers.on_change.end(), _p.begin(), _p.end());
 
-    propagators.install(constraint_id(), [x = _x, y = y_ids, p = _p, offset = _offset, n](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, y = y_ids, p = _p, offset = _offset, n, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         for (size_t j = 0; j < n; ++j) {
             auto [ylo, yhi] = state.bounds(y[j]);
 
@@ -209,7 +210,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
 
                 // (1) Disjoint domains rule out position j taking original index k.
                 if (xhi < ylo || xlo > yhi) {
-                    inference.infer_not_equal(logger, p[j], pv, JustifyUsingRUP{},
+                    inference.infer_not_equal(logger, p[j], pv, JustifyUsingRUP{hints::ArgSort{owner}},
                         bounds_reason(state, {x[k], y[j]}));
                 }
             }
@@ -221,16 +222,16 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                 auto [xlo, xhi] = state.bounds(x[k]);
                 auto extra = p[j] == *pj;
                 if (xlo > ylo)
-                    inference.infer_greater_than_or_equal(logger, y[j], xlo, JustifyUsingRUP{},
+                    inference.infer_greater_than_or_equal(logger, y[j], xlo, JustifyUsingRUP{hints::ArgSort{owner}},
                         bounds_reason(state, {x[k]}, extra));
                 if (xhi < yhi)
-                    inference.infer_less_than(logger, y[j], xhi + 1_i, JustifyUsingRUP{},
+                    inference.infer_less_than(logger, y[j], xhi + 1_i, JustifyUsingRUP{hints::ArgSort{owner}},
                         bounds_reason(state, {x[k]}, extra));
                 if (ylo > xlo)
-                    inference.infer_greater_than_or_equal(logger, x[k], ylo, JustifyUsingRUP{},
+                    inference.infer_greater_than_or_equal(logger, x[k], ylo, JustifyUsingRUP{hints::ArgSort{owner}},
                         bounds_reason(state, {y[j]}, extra));
                 if (yhi < xhi)
-                    inference.infer_less_than(logger, x[k], yhi + 1_i, JustifyUsingRUP{},
+                    inference.infer_less_than(logger, x[k], yhi + 1_i, JustifyUsingRUP{hints::ArgSort{owner}},
                         bounds_reason(state, {y[j]}, extra));
             }
         }
@@ -248,7 +249,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     rank_triggers.on_bounds.insert(rank_triggers.on_bounds.end(), _x.begin(), _x.end());
     rank_triggers.on_change.insert(rank_triggers.on_change.end(), _p.begin(), _p.end());
 
-    propagators.install(constraint_id(), [x = _x, p = _p, offset = _offset, n, witness = _witness](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+    propagators.install(constraint_id(), [x = _x, p = _p, offset = _offset, n, witness = _witness, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
         for (size_t k = 0; k < n; ++k) {
             auto [lk, uk] = state.bounds(x[k]);
 
@@ -343,7 +344,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                                             WPBSum{} + 1_i * ! witness.before[i][k] >= 1_i, ProofLevel::Temporary));
                             }
                             pol.emit(*logger, ProofLevel::Temporary);
-                        }, ThenRUP::Yes},
+                        }, ThenRUP::Yes, hints::ArgSort{owner}},
                         bounds_reason(state, x));
                 }
                 else {
@@ -414,7 +415,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                                         ProofLevel::Temporary));
                             }
                             polB.emit(*logger, ProofLevel::Temporary);
-                        }, ThenRUP::Yes},
+                        }, ThenRUP::Yes, hints::ArgSort{owner}},
                         bounds_reason(state, x));
                 }
             }

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -326,24 +326,24 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                     // lines. The inverse channel (p[j]=offset+k -> pos[k]=j) then
                     // makes p[j] != offset+k RUP.
                     inference.infer_not_equal(logger, p[j], pv,
-                        JustifyExplicitlyThenRUP{[&, k, below](const ReasonFunction & reason_fn) -> void {
+                        JustifyExplicitly{[&, k, below](const ReasonLiterals & reason_lits) -> void {
                             PolBuilder pol;
                             if (below) {
                                 pol.add(witness.rank_ge[k]);
                                 for (size_t i = 0; i < n; ++i)
                                     if (i != k && must_precede[i])
-                                        pol.add(logger->emit_rup_proof_line_under_reason(reason_fn,
+                                        pol.add(logger->emit_rup_proof_line_under_reason(reason_lits,
                                             WPBSum{} + 1_i * witness.before[i][k] >= 1_i, ProofLevel::Temporary));
                             }
                             else {
                                 pol.add(witness.rank_le[k]);
                                 for (size_t i = 0; i < n; ++i)
                                     if (i != k && ! can_precede[i])
-                                        pol.add(logger->emit_rup_proof_line_under_reason(reason_fn,
+                                        pol.add(logger->emit_rup_proof_line_under_reason(reason_lits,
                                             WPBSum{} + 1_i * ! witness.before[i][k] >= 1_i, ProofLevel::Temporary));
                             }
                             pol.emit(*logger, ProofLevel::Temporary);
-                        }},
+                        }, ThenRUP::Yes},
                         bounds_reason(state, x));
                 }
                 else {
@@ -378,7 +378,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                     }
 
                     inference.infer_not_equal(logger, p[j], pv,
-                        JustifyExplicitlyThenRUP{[&, k, U](const ReasonFunction & reason_fn) -> void {
+                        JustifyExplicitly{[&, k, U](const ReasonLiterals & reason_lits) -> void {
                             // Line A: x[k] <= U => pos[k] <= #possible(U).
                             // For each i that cannot precede k at x[k]=U, the clause
                             // (x[k] >= U+1) v !before[i][k] is RUP from before_fwd +
@@ -391,7 +391,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                                 auto [li, ui] = state.bounds(x[i]);
                                 bool cannot = (i < k) ? (li.raw_value > U) : (li.raw_value >= U);
                                 if (cannot)
-                                    polA.add(logger->emit_rup_proof_line_under_reason(reason_fn,
+                                    polA.add(logger->emit_rup_proof_line_under_reason(reason_lits,
                                         WPBSum{} + 1_i * (x[k] >= Integer{U + 1}) + 1_i * ! witness.before[i][k] >= 1_i,
                                         ProofLevel::Temporary));
                             }
@@ -409,12 +409,12 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                                 auto [li, ui] = state.bounds(x[i]);
                                 bool forced = (i < k) ? (ui.raw_value <= U + 1) : (ui.raw_value <= U);
                                 if (forced)
-                                    polB.add(logger->emit_rup_proof_line_under_reason(reason_fn,
+                                    polB.add(logger->emit_rup_proof_line_under_reason(reason_lits,
                                         WPBSum{} + 1_i * (x[k] < Integer{U + 1}) + 1_i * witness.before[i][k] >= 1_i,
                                         ProofLevel::Temporary));
                             }
                             polB.emit(*logger, ProofLevel::Temporary);
-                        }},
+                        }, ThenRUP::Yes},
                         bounds_reason(state, x));
                 }
             }

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -211,7 +211,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                 // (1) Disjoint domains rule out position j taking original index k.
                 if (xhi < ylo || xlo > yhi) {
                     inference.infer_not_equal(logger, p[j], pv, JustifyUsingRUP{hints::ArgSort{owner}},
-                        bounds_reason(state, {x[k], y[j]}));
+                        bounds_reason({x[k], y[j]}));
                 }
             }
 
@@ -223,16 +223,16 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                 auto extra = p[j] == *pj;
                 if (xlo > ylo)
                     inference.infer_greater_than_or_equal(logger, y[j], xlo, JustifyUsingRUP{hints::ArgSort{owner}},
-                        bounds_reason(state, {x[k]}, extra));
+                        bounds_reason({x[k]}, extra));
                 if (xhi < yhi)
                     inference.infer_less_than(logger, y[j], xhi + 1_i, JustifyUsingRUP{hints::ArgSort{owner}},
-                        bounds_reason(state, {x[k]}, extra));
+                        bounds_reason({x[k]}, extra));
                 if (ylo > xlo)
                     inference.infer_greater_than_or_equal(logger, x[k], ylo, JustifyUsingRUP{hints::ArgSort{owner}},
-                        bounds_reason(state, {y[j]}, extra));
+                        bounds_reason({y[j]}, extra));
                 if (yhi < xhi)
                     inference.infer_less_than(logger, x[k], yhi + 1_i, JustifyUsingRUP{hints::ArgSort{owner}},
-                        bounds_reason(state, {y[j]}, extra));
+                        bounds_reason({y[j]}, extra));
             }
         }
 
@@ -345,7 +345,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                             }
                             pol.emit(*logger, ProofLevel::Temporary);
                         }, ThenRUP::Yes, hints::ArgSort{owner}},
-                        bounds_reason(state, x));
+                        bounds_reason(x));
                 }
                 else {
                     // Hole inside [a_k, b_k]: rank j is unreachable because of a
@@ -416,7 +416,7 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
                             }
                             polB.emit(*logger, ProofLevel::Temporary);
                         }, ThenRUP::Yes, hints::ArgSort{owner}},
-                        bounds_reason(state, x));
+                        bounds_reason(x));
                 }
             }
         }

--- a/gcs/constraints/sort/hints.hh
+++ b/gcs/constraints/sort/hints.hh
@@ -1,0 +1,45 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_SORT_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_SORT_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Sort's assertion hint: just the owning constraint.
+     *
+     * Sort and ArgSort share the Mehlhorn-Thiel sortedness propagator; its
+     * inferences carry this hint with the real owning constraint id (Sort's own
+     * id, or ArgSort's, depending on who installed the propagator). Every bound
+     * and contradiction is re-derivable from the asserted literal, the reason and
+     * the witness definition lines, so there is no per-shape discriminator and the
+     * hint takes the default `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct Sort
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "sort";
+    };
+
+    /**
+     * \brief ArgSort's assertion hint: just the owning constraint.
+     *
+     * Carried by ArgSort's own channel-consistency and achievable-rank-set
+     * propagators (the inner sortedness propagator uses the Sort hint above, and
+     * the permutation all_different reuse carries the all_different hints). No
+     * per-shape discriminator; default `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct ArgSort
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "arg_sort";
+    };
+}
+
+#endif

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -239,12 +239,13 @@ namespace
                         break;
                     }
                 inference.contradiction(logger,
-                    JustifyExplicitlyThenRUP{[&y, k1, k2, V = uy[j], logger](const ReasonFunction &) -> void {
-                        for (size_t m = k1; m < k2; ++m)
-                            logger->emit(RUPProofRule{},
-                                WPBSum{} + 1_i * (y[m] < Integer{V + 1}) + 1_i * (y[m + 1] >= Integer{V + 1}) >= 1_i,
-                                ProofLevel::Temporary);
-                    }},
+                    JustifyExplicitly{[&y, k1, k2, V = uy[j], logger](const ReasonLiterals &) -> void {
+                                          for (size_t m = k1; m < k2; ++m)
+                                              logger->emit(RUPProofRule{},
+                                                  WPBSum{} + 1_i * (y[m] < Integer{V + 1}) + 1_i * (y[m + 1] >= Integer{V + 1}) >= 1_i,
+                                                  ProofLevel::Temporary);
+                                      },
+                        ThenRUP::Yes},
                     reason);
             }
 
@@ -290,45 +291,46 @@ namespace
                 throw UnexpectedException{"Sort: no Hall violator for an infeasible matching"};
 
             inference.contradiction(logger,
-                JustifyExplicitlyThenRUP{[&, S, fa, fb](const ReasonFunction & reason_fn) -> void {
-                    // Normalized y-bound lemmas as RUP chains: NUY[k] : y_k <= uy[k]
-                    // (top-down, from y_k <= y_{k+1} <= uy[k+1] and y_k <= ouy[k]);
-                    // NLY[k] : y_k >= ly[k] (bottom-up). These let each rank
-                    // exclusion be a single-step RUP.
-                    for (size_t k = n; k-- > 0;)
-                        logger->emit_rup_proof_line_under_reason(reason_fn,
-                            WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
-                    for (size_t k = 0; k < n; ++k)
-                        logger->emit_rup_proof_line_under_reason(reason_fn,
-                            WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
-                    // Per i in S: pin pos[i] into [fa,fb] by excluding every
-                    // outside rank k (k < fa <= lo_i: y_k <= uy[k] < lx[i] breaks
-                    // the channel; k > fb >= hi_i-1: y_k >= ly[k] > ux[i]). The
-                    // restricted at-least-one then follows from the root al1[i].
-                    vector<ProofLine> restricted(S.size());
-                    for (const auto & [idx, i] : enumerate(S)) {
-                        for (long long k = 0; cmp_less(k, n); ++k)
-                            if (k < fa || k > fb)
-                                logger->emit_rup_proof_line_under_reason(reason_fn,
-                                    WPBSum{} + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                        WPBSum in_band;
-                        for (long long k = fa; k <= fb; ++k)
-                            in_band += 1_i * (pos[i] == Integer{k});
-                        restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_fn,
-                            move(in_band) >= 1_i, ProofLevel::Temporary);
-                    }
-                    // Pigeonhole: |S| pins into [fa,fb] but injectivity caps it at
-                    // fb-fa+1 < |S|. (For an empty band the restricted lines are
-                    // already 0 >= 1 and the closing RUP suffices.)
-                    if (fb >= fa) {
-                        PolBuilder pol;
-                        for (auto l : restricted)
-                            pol.add(l);
-                        for (long long k = fa; k <= fb; ++k)
-                            pol.add(inj_lines[static_cast<size_t>(k)]);
-                        pol.emit(*logger, ProofLevel::Temporary);
-                    }
-                }},
+                JustifyExplicitly{[&, S, fa, fb](const ReasonLiterals & reason_lits) -> void {
+                                      // Normalized y-bound lemmas as RUP chains: NUY[k] : y_k <= uy[k]
+                                      // (top-down, from y_k <= y_{k+1} <= uy[k+1] and y_k <= ouy[k]);
+                                      // NLY[k] : y_k >= ly[k] (bottom-up). These let each rank
+                                      // exclusion be a single-step RUP.
+                                      for (size_t k = n; k-- > 0;)
+                                          logger->emit_rup_proof_line_under_reason(reason_lits,
+                                              WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
+                                      for (size_t k = 0; k < n; ++k)
+                                          logger->emit_rup_proof_line_under_reason(reason_lits,
+                                              WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
+                                      // Per i in S: pin pos[i] into [fa,fb] by excluding every
+                                      // outside rank k (k < fa <= lo_i: y_k <= uy[k] < lx[i] breaks
+                                      // the channel; k > fb >= hi_i-1: y_k >= ly[k] > ux[i]). The
+                                      // restricted at-least-one then follows from the root al1[i].
+                                      vector<ProofLine> restricted(S.size());
+                                      for (const auto & [idx, i] : enumerate(S)) {
+                                          for (long long k = 0; cmp_less(k, n); ++k)
+                                              if (k < fa || k > fb)
+                                                  logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                      WPBSum{} + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                          WPBSum in_band;
+                                          for (long long k = fa; k <= fb; ++k)
+                                              in_band += 1_i * (pos[i] == Integer{k});
+                                          restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_lits,
+                                              move(in_band) >= 1_i, ProofLevel::Temporary);
+                                      }
+                                      // Pigeonhole: |S| pins into [fa,fb] but injectivity caps it at
+                                      // fb-fa+1 < |S|. (For an empty band the restricted lines are
+                                      // already 0 >= 1 and the closing RUP suffices.)
+                                      if (fb >= fa) {
+                                          PolBuilder pol;
+                                          for (auto l : restricted)
+                                              pol.add(l);
+                                          for (long long k = fa; k <= fb; ++k)
+                                              pol.add(inj_lines[static_cast<size_t>(k)]);
+                                          pol.emit(*logger, ProofLevel::Temporary);
+                                      }
+                                  },
+                    ThenRUP::Yes},
                 reason);
         };
 
@@ -509,72 +511,74 @@ namespace
                     // from the sortedness constraint y[k-1] <= y[k]; the closing
                     // RUP walks the chain down to the witnessing earlier position.
                     inference.infer_greater_than_or_equal(logger, y[j], Integer{L},
-                        JustifyExplicitlyThenRUP{[&y, j, L, logger](const ReasonFunction &) -> void {
-                            for (size_t k = 1; k <= j; ++k)
-                                logger->emit(RUPProofRule{},
-                                    WPBSum{} + 1_i * (y[k] >= Integer{L}) + 1_i * (y[k - 1] < Integer{L}) >= 1_i,
-                                    ProofLevel::Temporary);
-                        }},
+                        JustifyExplicitly{[&y, j, L, logger](const ReasonLiterals &) -> void {
+                                              for (size_t k = 1; k <= j; ++k)
+                                                  logger->emit(RUPProofRule{},
+                                                      WPBSum{} + 1_i * (y[k] >= Integer{L}) + 1_i * (y[k - 1] < Integer{L}) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
                         reason);
                 }
                 else if (forced_above >= n - j) {
                     inference.infer_greater_than_or_equal(logger, y[j], Integer{L},
-                        JustifyExplicitlyThenRUP{[&x, &y, &before, &pos, &rank_le_lines, &anti_lines, &inj_lines, &al1_lines, n, j, L, logger](const ReasonFunction & reason_fn) -> void {
-                            // PIVOT' (mirror): (x_i >= L) v (x_m < L) v before[i][m],
-                            // RUP from before[i][m]'s reverse half and the constant
-                            // threshold L (x_i < L <= x_m forces i before m).
-                            std::vector<std::vector<ProofLine>> pivot(n, std::vector<ProofLine>(n));
-                            for (size_t i = 0; i < n; ++i)
-                                for (size_t m = 0; m < n; ++m) {
-                                    if (m == i)
-                                        continue;
-                                    pivot[i][m] = logger->emit(RUPProofRule{},
-                                        WPBSum{} + 1_i * (x[i] >= Integer{L}) + 1_i * (x[m] < Integer{L}) + 1_i * before[i][m] >= 1_i,
-                                        ProofLevel::Temporary);
-                                }
-                            // BND[i][m] : before[m][i] <= [x_i>=L] + [x_m<L], from
-                            // pivot'[i][m] + antisymmetry (flip the "out" flag
-                            // before[i][m] to the "in" flag before[m][i]).
-                            // RANKUB_i = rank_le[i] + sum_m BND[i][m] :
-                            //   pos[i] <= (n-1)[x_i>=L] + sum_{m!=i}[x_m<L].
-                            std::vector<ProofLine> rankub(n);
-                            for (size_t i = 0; i < n; ++i) {
-                                PolBuilder pol;
-                                pol.add(rank_le_lines[i]);
-                                for (size_t m = 0; m < n; ++m)
-                                    if (m != i)
-                                        pol.add(PolBuilder{}.add(pivot[i][m]).add(anti_lines[i][m]).emit(*logger, ProofLevel::Temporary));
-                                rankub[i] = pol.emit(*logger, ProofLevel::Temporary);
-                            }
-                            // count_L : at most j of the x's are < L (i.e. >= n-j
-                            // are >= L), RUP under the reason -- the >= n-j indices
-                            // with lb(x_k) >= L have (x_k >= L) forced by their
-                            // lower bound.
-                            WPBSum xcount;
-                            for (size_t k = 0; k < n; ++k)
-                                xcount += 1_i * (x[k] < Integer{L});
-                            auto xcount_line = logger->emit_rup_proof_line_under_reason(reason_fn,
-                                move(xcount) <= Integer{static_cast<long long>(j)}, ProofLevel::Temporary);
-                            // RANKUB2_i : pos[i] <= n[x_i>=L] + j-1 (fold count_L in,
-                            // cross-constraint sum so a pol not RUP).
-                            for (size_t i = 0; i < n; ++i)
-                                PolBuilder{}.add(rankub[i]).add(xcount_line).emit(*logger, ProofLevel::Temporary);
-                            // per i : (pos[i] != j) v (y[j] >= L). RUP under reason
-                            // from RANKUB2_i + channel: pos[i]=j forces [x_i>=L]=1,
-                            // and the channel gives y[j] = x_i >= L.
-                            for (size_t i = 0; i < n; ++i)
-                                logger->emit_rup_proof_line_under_reason(reason_fn,
-                                    WPBSum{} + 1_i * (pos[i] != Integer(j)) + 1_i * (y[j] >= Integer{L}) >= 1_i,
-                                    ProofLevel::Temporary);
-                            // surjectivity (same counting pol as the upper bound).
-                            PolBuilder surj;
-                            for (size_t i = 0; i < n; ++i)
-                                surj.add(al1_lines[i]);
-                            for (size_t k = 0; k < n; ++k)
-                                if (k != j)
-                                    surj.add(inj_lines[k]);
-                            surj.emit(*logger, ProofLevel::Temporary);
-                        }},
+                        JustifyExplicitly{[&x, &y, &before, &pos, &rank_le_lines, &anti_lines, &inj_lines, &al1_lines, n, j, L, logger](const ReasonLiterals & reason_lits) -> void {
+                                              // PIVOT' (mirror): (x_i >= L) v (x_m < L) v before[i][m],
+                                              // RUP from before[i][m]'s reverse half and the constant
+                                              // threshold L (x_i < L <= x_m forces i before m).
+                                              std::vector<std::vector<ProofLine>> pivot(n, std::vector<ProofLine>(n));
+                                              for (size_t i = 0; i < n; ++i)
+                                                  for (size_t m = 0; m < n; ++m) {
+                                                      if (m == i)
+                                                          continue;
+                                                      pivot[i][m] = logger->emit(RUPProofRule{},
+                                                          WPBSum{} + 1_i * (x[i] >= Integer{L}) + 1_i * (x[m] < Integer{L}) + 1_i * before[i][m] >= 1_i,
+                                                          ProofLevel::Temporary);
+                                                  }
+                                              // BND[i][m] : before[m][i] <= [x_i>=L] + [x_m<L], from
+                                              // pivot'[i][m] + antisymmetry (flip the "out" flag
+                                              // before[i][m] to the "in" flag before[m][i]).
+                                              // RANKUB_i = rank_le[i] + sum_m BND[i][m] :
+                                              //   pos[i] <= (n-1)[x_i>=L] + sum_{m!=i}[x_m<L].
+                                              std::vector<ProofLine> rankub(n);
+                                              for (size_t i = 0; i < n; ++i) {
+                                                  PolBuilder pol;
+                                                  pol.add(rank_le_lines[i]);
+                                                  for (size_t m = 0; m < n; ++m)
+                                                      if (m != i)
+                                                          pol.add(PolBuilder{}.add(pivot[i][m]).add(anti_lines[i][m]).emit(*logger, ProofLevel::Temporary));
+                                                  rankub[i] = pol.emit(*logger, ProofLevel::Temporary);
+                                              }
+                                              // count_L : at most j of the x's are < L (i.e. >= n-j
+                                              // are >= L), RUP under the reason -- the >= n-j indices
+                                              // with lb(x_k) >= L have (x_k >= L) forced by their
+                                              // lower bound.
+                                              WPBSum xcount;
+                                              for (size_t k = 0; k < n; ++k)
+                                                  xcount += 1_i * (x[k] < Integer{L});
+                                              auto xcount_line = logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                  move(xcount) <= Integer{static_cast<long long>(j)}, ProofLevel::Temporary);
+                                              // RANKUB2_i : pos[i] <= n[x_i>=L] + j-1 (fold count_L in,
+                                              // cross-constraint sum so a pol not RUP).
+                                              for (size_t i = 0; i < n; ++i)
+                                                  PolBuilder{}.add(rankub[i]).add(xcount_line).emit(*logger, ProofLevel::Temporary);
+                                              // per i : (pos[i] != j) v (y[j] >= L). RUP under reason
+                                              // from RANKUB2_i + channel: pos[i]=j forces [x_i>=L]=1,
+                                              // and the channel gives y[j] = x_i >= L.
+                                              for (size_t i = 0; i < n; ++i)
+                                                  logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                      WPBSum{} + 1_i * (pos[i] != Integer(j)) + 1_i * (y[j] >= Integer{L}) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                              // surjectivity (same counting pol as the upper bound).
+                                              PolBuilder surj;
+                                              for (size_t i = 0; i < n; ++i)
+                                                  surj.add(al1_lines[i]);
+                                              for (size_t k = 0; k < n; ++k)
+                                                  if (k != j)
+                                                      surj.add(inj_lines[k]);
+                                              surj.emit(*logger, ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
                         reason);
                 }
                 else {
@@ -593,45 +597,46 @@ namespace
                         throw UnexpectedException{"Sort: no Hall band for a valid lb(y) tightening"};
                     else
                         inference.infer_greater_than_or_equal(logger, y[j], Integer{L},
-                            JustifyExplicitlyThenRUP{[&y, &pos, &lo_i, &hi_i, &ly, &uy, &inj_lines, S, fa, fb, n, j, L, logger](const ReasonFunction & reason_fn) -> void {
-                                for (size_t k = n; k-- > 0;)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn,
-                                        WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
-                                for (size_t k = 0; k < n; ++k)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn,
-                                        WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
-                                // BNUY[k], k <= j : (y[j] >= L) v (y[k] <= L-1),
-                                // chain down from j (RUP from sortedness + prev).
-                                for (size_t k = j + 1; k-- > 0;)
-                                    logger->emit(RUPProofRule{},
-                                        WPBSum{} + 1_i * (y[j] >= Integer{L}) + 1_i * (y[k] < Integer{L}) >= 1_i,
-                                        ProofLevel::Temporary);
-                                std::vector<ProofLine> restricted(S.size());
-                                for (const auto & [idx, i] : enumerate(S)) {
-                                    for (long long k = 0; cmp_less(k, n); ++k) {
-                                        if (k >= fa && k <= fb)
-                                            continue;
-                                        if (cmp_less(k, lo_i[i]) || cmp_greater_equal(k, hi_i[i]))
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                        else
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (y[j] >= Integer{L}) + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                    }
-                                    WPBSum in_band;
-                                    in_band += 1_i * (y[j] >= Integer{L});
-                                    for (long long k = fa; k <= fb; ++k)
-                                        in_band += 1_i * (pos[i] == Integer{k});
-                                    restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_fn,
-                                        move(in_band) >= 1_i, ProofLevel::Temporary);
-                                }
-                                PolBuilder pol;
-                                for (auto l : restricted)
-                                    pol.add(l);
-                                for (long long k = fa; k <= fb; ++k)
-                                    pol.add(inj_lines[static_cast<size_t>(k)]);
-                                pol.emit(*logger, ProofLevel::Temporary);
-                            }},
+                            JustifyExplicitly{[&y, &pos, &lo_i, &hi_i, &ly, &uy, &inj_lines, S, fa, fb, n, j, L, logger](const ReasonLiterals & reason_lits) -> void {
+                                                  for (size_t k = n; k-- > 0;)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                          WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
+                                                  for (size_t k = 0; k < n; ++k)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                          WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
+                                                  // BNUY[k], k <= j : (y[j] >= L) v (y[k] <= L-1),
+                                                  // chain down from j (RUP from sortedness + prev).
+                                                  for (size_t k = j + 1; k-- > 0;)
+                                                      logger->emit(RUPProofRule{},
+                                                          WPBSum{} + 1_i * (y[j] >= Integer{L}) + 1_i * (y[k] < Integer{L}) >= 1_i,
+                                                          ProofLevel::Temporary);
+                                                  std::vector<ProofLine> restricted(S.size());
+                                                  for (const auto & [idx, i] : enumerate(S)) {
+                                                      for (long long k = 0; cmp_less(k, n); ++k) {
+                                                          if (k >= fa && k <= fb)
+                                                              continue;
+                                                          if (cmp_less(k, lo_i[i]) || cmp_greater_equal(k, hi_i[i]))
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                          else
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (y[j] >= Integer{L}) + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                      }
+                                                      WPBSum in_band;
+                                                      in_band += 1_i * (y[j] >= Integer{L});
+                                                      for (long long k = fa; k <= fb; ++k)
+                                                          in_band += 1_i * (pos[i] == Integer{k});
+                                                      restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                          move(in_band) >= 1_i, ProofLevel::Temporary);
+                                                  }
+                                                  PolBuilder pol;
+                                                  for (auto l : restricted)
+                                                      pol.add(l);
+                                                  for (long long k = fa; k <= fb; ++k)
+                                                      pol.add(inj_lines[static_cast<size_t>(k)]);
+                                                  pol.emit(*logger, ProofLevel::Temporary);
+                                              },
+                                ThenRUP::Yes},
                             reason);
                 }
             }
@@ -664,12 +669,13 @@ namespace
                     // to the witnessing later position (whose ub <= U is in the
                     // reason), reaching a contradiction.
                     inference.infer_less_than(logger, y[j], Integer{U + 1},
-                        JustifyExplicitlyThenRUP{[&y, n, j, U, logger](const ReasonFunction &) -> void {
-                            for (size_t k = j; k + 1 < n; ++k)
-                                logger->emit(RUPProofRule{},
-                                    WPBSum{} + 1_i * (y[k] < Integer{U + 1}) + 1_i * (y[k + 1] >= Integer{U + 1}) >= 1_i,
-                                    ProofLevel::Temporary);
-                        }},
+                        JustifyExplicitly{[&y, n, j, U, logger](const ReasonLiterals &) -> void {
+                                              for (size_t k = j; k + 1 < n; ++k)
+                                                  logger->emit(RUPProofRule{},
+                                                      WPBSum{} + 1_i * (y[k] < Integer{U + 1}) + 1_i * (y[k + 1] >= Integer{U + 1}) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
                         reason);
                 }
                 else if (forced_below >= j + 1) {
@@ -679,78 +685,79 @@ namespace
                     // permutation lines) surjectivity give y[j] <= U; the count
                     // line "count_U >= j+1" is plain RUP under the reason.
                     inference.infer_less_than(logger, y[j], Integer{U + 1},
-                        JustifyExplicitlyThenRUP{[&x, &y, &before, &pos, &rank_lines, &inj_lines, &al1_lines, n, j, U, logger](const ReasonFunction & reason_fn) -> void {
-                            // PIVOT BRIDGE (honest, transitivity-free). For each i, m the
-                            // clause (x_m > U) v (x_i <= U) v before[m][i] is RUP from
-                            // before[m][i]'s reverse half and the bound on the constant
-                            // threshold U -- comparisons go through U, never a middle
-                            // variable, so it is O(1) per pair (no transitivity).
-                            std::vector<std::vector<ProofLine>> clause_line(n, std::vector<ProofLine>(n));
-                            for (size_t i = 0; i < n; ++i)
-                                for (size_t m = 0; m < n; ++m) {
-                                    if (m == i)
-                                        continue;
-                                    clause_line[i][m] = logger->emit(RUPProofRule{},
-                                        WPBSum{} + 1_i * before[m][i] + 1_i * (x[m] >= Integer{U + 1}) + 1_i * (x[i] < Integer{U + 1}) >= 1_i,
-                                        ProofLevel::Temporary);
-                                }
-                            // RANKLB_i : pos[i] + n*[x_i<=U] - count_U >= 0, i.e.
-                            // "x_i > U  =>  pos[i] >= count_U" (the rank line folded with
-                            // the n-1 clauses).
-                            std::vector<ProofLine> ranklb(n);
-                            for (size_t i = 0; i < n; ++i) {
-                                PolBuilder pol;
-                                pol.add(rank_lines[i]);
-                                for (size_t m = 0; m < n; ++m)
-                                    if (m != i)
-                                        pol.add(clause_line[i][m]);
-                                ranklb[i] = pol.emit(*logger, ProofLevel::Temporary);
-                            }
-                            // count_U >= j+1: at least j+1 of the x's are <= U,
-                            // RUP under the reason -- each of the >= j+1 indices
-                            // with ub(x_k) <= U has (x_k <= U) forced by its upper
-                            // bound (in the reason), so the sum is >= j+1; no
-                            // cross-constraint step, single-shot RUP.
-                            WPBSum xcount;
-                            for (size_t k = 0; k < n; ++k)
-                                xcount += 1_i * (x[k] < Integer{U + 1});
-                            auto xcount_line = logger->emit_rup_proof_line_under_reason(reason_fn,
-                                move(xcount) >= Integer{static_cast<long long>(j) + 1}, ProofLevel::Temporary);
-                            // RANKLB2_i : pos[i] + n*[x_i<=U] >= j+1, folding count_U away
-                            // with the x-count (cross-constraint sum, hence a pol not RUP).
-                            // Emitted for their RUP side effect; consumed by the per-i lines
-                            // below via the database, never by explicit reference.
-                            for (size_t i = 0; i < n; ++i)
-                                PolBuilder{}.add(ranklb[i]).add(xcount_line).emit(*logger, ProofLevel::Temporary);
-                            // HONEST (extended reason): per i, (pos[i] != j) v (y[j] <= U).
-                            // RUP from RANKLB2_i + channel: negate -> pos[i]=j and
-                            // y[j] >= U+1; channel gives x_i = y[j] >= U+1 so [x_i<=U]=0,
-                            // and then RANKLB2_i forces pos[i] >= j+1, contradicting
-                            // pos[i]=j. Emitted under the reason: RANKLB2_i carries the
-                            // reason literals (it was pol'd with the reason-conditional
-                            // count line), so the per-i RUP check must assume the reason
-                            // true to activate it.
-                            for (size_t i = 0; i < n; ++i)
-                                logger->emit_rup_proof_line_under_reason(reason_fn,
-                                    WPBSum{} + 1_i * (pos[i] != Integer(j)) + 1_i * (y[j] < Integer{U + 1}) >= 1_i,
-                                    ProofLevel::Temporary);
-                            // HONEST (surjectivity): rank j is occupied,
-                            // sum_i [pos[i] = j] >= 1. Counting pol over the
-                            // root permutation lines: sum_i al1_i (each pos takes
-                            // a rank) minus sum_{k != j} inj_k (each other rank
-                            // used at most once) leaves rank j with >= 1 occupant
-                            // -- the n(n-1) constants cancel exactly. With the
-                            // per-i lines above, the closing RUP then closes:
-                            // under y[j] >= U+1 each gives pos[i] != j,
-                            // contradicting this.
-                            PolBuilder surj;
-                            for (size_t i = 0; i < n; ++i)
-                                surj.add(al1_lines[i]);
-                            for (size_t k = 0; k < n; ++k)
-                                if (k != j)
-                                    surj.add(inj_lines[k]);
-                            surj.emit(*logger, ProofLevel::Temporary);
-                        }},
+                        JustifyExplicitly{[&x, &y, &before, &pos, &rank_lines, &inj_lines, &al1_lines, n, j, U, logger](const ReasonLiterals & reason_lits) -> void {
+                                              // PIVOT BRIDGE (honest, transitivity-free). For each i, m the
+                                              // clause (x_m > U) v (x_i <= U) v before[m][i] is RUP from
+                                              // before[m][i]'s reverse half and the bound on the constant
+                                              // threshold U -- comparisons go through U, never a middle
+                                              // variable, so it is O(1) per pair (no transitivity).
+                                              std::vector<std::vector<ProofLine>> clause_line(n, std::vector<ProofLine>(n));
+                                              for (size_t i = 0; i < n; ++i)
+                                                  for (size_t m = 0; m < n; ++m) {
+                                                      if (m == i)
+                                                          continue;
+                                                      clause_line[i][m] = logger->emit(RUPProofRule{},
+                                                          WPBSum{} + 1_i * before[m][i] + 1_i * (x[m] >= Integer{U + 1}) + 1_i * (x[i] < Integer{U + 1}) >= 1_i,
+                                                          ProofLevel::Temporary);
+                                                  }
+                                              // RANKLB_i : pos[i] + n*[x_i<=U] - count_U >= 0, i.e.
+                                              // "x_i > U  =>  pos[i] >= count_U" (the rank line folded with
+                                              // the n-1 clauses).
+                                              std::vector<ProofLine> ranklb(n);
+                                              for (size_t i = 0; i < n; ++i) {
+                                                  PolBuilder pol;
+                                                  pol.add(rank_lines[i]);
+                                                  for (size_t m = 0; m < n; ++m)
+                                                      if (m != i)
+                                                          pol.add(clause_line[i][m]);
+                                                  ranklb[i] = pol.emit(*logger, ProofLevel::Temporary);
+                                              }
+                                              // count_U >= j+1: at least j+1 of the x's are <= U,
+                                              // RUP under the reason -- each of the >= j+1 indices
+                                              // with ub(x_k) <= U has (x_k <= U) forced by its upper
+                                              // bound (in the reason), so the sum is >= j+1; no
+                                              // cross-constraint step, single-shot RUP.
+                                              WPBSum xcount;
+                                              for (size_t k = 0; k < n; ++k)
+                                                  xcount += 1_i * (x[k] < Integer{U + 1});
+                                              auto xcount_line = logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                  move(xcount) >= Integer{static_cast<long long>(j) + 1}, ProofLevel::Temporary);
+                                              // RANKLB2_i : pos[i] + n*[x_i<=U] >= j+1, folding count_U away
+                                              // with the x-count (cross-constraint sum, hence a pol not RUP).
+                                              // Emitted for their RUP side effect; consumed by the per-i lines
+                                              // below via the database, never by explicit reference.
+                                              for (size_t i = 0; i < n; ++i)
+                                                  PolBuilder{}.add(ranklb[i]).add(xcount_line).emit(*logger, ProofLevel::Temporary);
+                                              // HONEST (extended reason): per i, (pos[i] != j) v (y[j] <= U).
+                                              // RUP from RANKLB2_i + channel: negate -> pos[i]=j and
+                                              // y[j] >= U+1; channel gives x_i = y[j] >= U+1 so [x_i<=U]=0,
+                                              // and then RANKLB2_i forces pos[i] >= j+1, contradicting
+                                              // pos[i]=j. Emitted under the reason: RANKLB2_i carries the
+                                              // reason literals (it was pol'd with the reason-conditional
+                                              // count line), so the per-i RUP check must assume the reason
+                                              // true to activate it.
+                                              for (size_t i = 0; i < n; ++i)
+                                                  logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                      WPBSum{} + 1_i * (pos[i] != Integer(j)) + 1_i * (y[j] < Integer{U + 1}) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                              // HONEST (surjectivity): rank j is occupied,
+                                              // sum_i [pos[i] = j] >= 1. Counting pol over the
+                                              // root permutation lines: sum_i al1_i (each pos takes
+                                              // a rank) minus sum_{k != j} inj_k (each other rank
+                                              // used at most once) leaves rank j with >= 1 occupant
+                                              // -- the n(n-1) constants cancel exactly. With the
+                                              // per-i lines above, the closing RUP then closes:
+                                              // under y[j] >= U+1 each gives pos[i] != j,
+                                              // contradicting this.
+                                              PolBuilder surj;
+                                              for (size_t i = 0; i < n; ++i)
+                                                  surj.add(al1_lines[i]);
+                                              for (size_t k = 0; k < n; ++k)
+                                                  if (k != j)
+                                                      surj.add(inj_lines[k]);
+                                              surj.emit(*logger, ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
                         reason);
                 }
                 else {
@@ -770,55 +777,56 @@ namespace
                         throw UnexpectedException{"Sort: no Hall band for a valid ub(y) tightening"};
                     else
                         inference.infer_less_than(logger, y[j], Integer{U + 1},
-                            JustifyExplicitlyThenRUP{[&y, &pos, &lo_i, &hi_i, &ly, &uy, &inj_lines, S, fa, fb, n, j, U, logger](const ReasonFunction & reason_fn) -> void {
-                                // Normalized y-bounds for the unconditional rank
-                                // exclusions (k < lo_i: y_k <= uy[k] < lx_i;
-                                // k >= hi_i: y_k >= ly[k] > ux_i).
-                                for (size_t k = n; k-- > 0;)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn,
-                                        WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
-                                for (size_t k = 0; k < n; ++k)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn,
-                                        WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
-                                // BNLY[k], k >= j : (y[j] <= U) v (y[k] >= U+1),
-                                // a chain up from j (each RUP from sortedness and
-                                // the previous). Makes the assumption-dependent
-                                // exclusions (ranks in [j, hi_i)) one-step RUPs.
-                                for (size_t k = j; k < n; ++k)
-                                    logger->emit(RUPProofRule{},
-                                        WPBSum{} + 1_i * (y[j] < Integer{U + 1}) + 1_i * (y[k] >= Integer{U + 1}) >= 1_i,
-                                        ProofLevel::Temporary);
-                                // Per i in S: pin pos[i] into [fa,fb].
-                                std::vector<ProofLine> restricted(S.size());
-                                for (const auto & [idx, i] : enumerate(S)) {
-                                    for (long long k = 0; cmp_less(k, n); ++k) {
-                                        if (k >= fa && k <= fb)
-                                            continue;
-                                        if (cmp_less(k, lo_i[i]) || cmp_greater_equal(k, hi_i[i]))
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                        else
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (y[j] < Integer{U + 1}) + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                    }
-                                    WPBSum in_band;
-                                    in_band += 1_i * (y[j] < Integer{U + 1});
-                                    for (long long k = fa; k <= fb; ++k)
-                                        in_band += 1_i * (pos[i] == Integer{k});
-                                    restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_fn,
-                                        move(in_band) >= 1_i, ProofLevel::Temporary);
-                                }
-                                // Pigeonhole: the |S| restricted-at-least-ones
-                                // against inj_k for k in [fa,fb] force the goal
-                                // (the contradiction core conflicts with the
-                                // negated goal in the closing RUP).
-                                PolBuilder pol;
-                                for (auto l : restricted)
-                                    pol.add(l);
-                                for (long long k = fa; k <= fb; ++k)
-                                    pol.add(inj_lines[static_cast<size_t>(k)]);
-                                pol.emit(*logger, ProofLevel::Temporary);
-                            }},
+                            JustifyExplicitly{[&y, &pos, &lo_i, &hi_i, &ly, &uy, &inj_lines, S, fa, fb, n, j, U, logger](const ReasonLiterals & reason_lits) -> void {
+                                                  // Normalized y-bounds for the unconditional rank
+                                                  // exclusions (k < lo_i: y_k <= uy[k] < lx_i;
+                                                  // k >= hi_i: y_k >= ly[k] > ux_i).
+                                                  for (size_t k = n; k-- > 0;)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                          WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
+                                                  for (size_t k = 0; k < n; ++k)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                          WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
+                                                  // BNLY[k], k >= j : (y[j] <= U) v (y[k] >= U+1),
+                                                  // a chain up from j (each RUP from sortedness and
+                                                  // the previous). Makes the assumption-dependent
+                                                  // exclusions (ranks in [j, hi_i)) one-step RUPs.
+                                                  for (size_t k = j; k < n; ++k)
+                                                      logger->emit(RUPProofRule{},
+                                                          WPBSum{} + 1_i * (y[j] < Integer{U + 1}) + 1_i * (y[k] >= Integer{U + 1}) >= 1_i,
+                                                          ProofLevel::Temporary);
+                                                  // Per i in S: pin pos[i] into [fa,fb].
+                                                  std::vector<ProofLine> restricted(S.size());
+                                                  for (const auto & [idx, i] : enumerate(S)) {
+                                                      for (long long k = 0; cmp_less(k, n); ++k) {
+                                                          if (k >= fa && k <= fb)
+                                                              continue;
+                                                          if (cmp_less(k, lo_i[i]) || cmp_greater_equal(k, hi_i[i]))
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                          else
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (y[j] < Integer{U + 1}) + 1_i * (pos[i] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                      }
+                                                      WPBSum in_band;
+                                                      in_band += 1_i * (y[j] < Integer{U + 1});
+                                                      for (long long k = fa; k <= fb; ++k)
+                                                          in_band += 1_i * (pos[i] == Integer{k});
+                                                      restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                          move(in_band) >= 1_i, ProofLevel::Temporary);
+                                                  }
+                                                  // Pigeonhole: the |S| restricted-at-least-ones
+                                                  // against inj_k for k in [fa,fb] force the goal
+                                                  // (the contradiction core conflicts with the
+                                                  // negated goal in the closing RUP).
+                                                  PolBuilder pol;
+                                                  for (auto l : restricted)
+                                                      pol.add(l);
+                                                  for (long long k = fa; k <= fb; ++k)
+                                                      pol.add(inj_lines[static_cast<size_t>(k)]);
+                                                  pol.emit(*logger, ProofLevel::Temporary);
+                                              },
+                                ThenRUP::Yes},
                             reason);
                 }
             }
@@ -835,12 +843,13 @@ namespace
                 // for pos[i] then closes it. HALL (jl_in > lo_i): asserted.
                 if (jl_in[i] == lo_i[i])
                     inference.infer_greater_than_or_equal(logger, x[i], Integer{L},
-                        JustifyExplicitlyThenRUP{[&x, &pos, n, i, L, logger](const ReasonFunction & reason_fn) -> void {
-                            for (size_t k = 0; k < n; ++k)
-                                logger->emit_rup_proof_line_under_reason(reason_fn,
-                                    WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (x[i] >= Integer{L}) >= 1_i,
-                                    ProofLevel::Temporary);
-                        }},
+                        JustifyExplicitly{[&x, &pos, n, i, L, logger](const ReasonLiterals & reason_lits) -> void {
+                                              for (size_t k = 0; k < n; ++k)
+                                                  logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                      WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (x[i] >= Integer{L}) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
                         reason);
                 else {
                     // HALL: lb(x[i]) = ly[jl] with jl = jl_in[i] > lo_i (the SCC
@@ -857,40 +866,41 @@ namespace
                         throw UnexpectedException{"Sort: no Hall band for a valid lb(x) tightening"};
                     else
                         inference.infer_greater_than_or_equal(logger, x[i], Integer{L},
-                            JustifyExplicitlyThenRUP{[&x, &y, &pos, &ly, &uy, &inj_lines, S, fa, fb, i, n, L, logger](const ReasonFunction & reason_fn) -> void {
-                                for (size_t k = n; k-- > 0;)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn, WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
-                                for (size_t k = 0; k < n; ++k)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn, WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
-                                std::vector<ProofLine> restricted(S.size());
-                                for (const auto & [idx, m] : enumerate(S)) {
-                                    for (long long k = 0; cmp_less(k, n); ++k) {
-                                        if (k >= fa && k <= fb)
-                                            continue;
-                                        // i excluded from ranks > fb (>= jl) needs the
-                                        // assumption (NLY: y_k >= ly[k] >= L); all other
-                                        // exclusions are unconditional.
-                                        if (m == i && k > fb)
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (x[i] >= Integer{L}) + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                        else
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                    }
-                                    WPBSum in_band;
-                                    if (m == i)
-                                        in_band += 1_i * (x[i] >= Integer{L});
-                                    for (long long k = fa; k <= fb; ++k)
-                                        in_band += 1_i * (pos[m] == Integer{k});
-                                    restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_fn, move(in_band) >= 1_i, ProofLevel::Temporary);
-                                }
-                                PolBuilder pol;
-                                for (auto l : restricted)
-                                    pol.add(l);
-                                for (long long k = fa; k <= fb; ++k)
-                                    pol.add(inj_lines[static_cast<size_t>(k)]);
-                                pol.emit(*logger, ProofLevel::Temporary);
-                            }},
+                            JustifyExplicitly{[&x, &y, &pos, &ly, &uy, &inj_lines, S, fa, fb, i, n, L, logger](const ReasonLiterals & reason_lits) -> void {
+                                                  for (size_t k = n; k-- > 0;)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits, WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
+                                                  for (size_t k = 0; k < n; ++k)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits, WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
+                                                  std::vector<ProofLine> restricted(S.size());
+                                                  for (const auto & [idx, m] : enumerate(S)) {
+                                                      for (long long k = 0; cmp_less(k, n); ++k) {
+                                                          if (k >= fa && k <= fb)
+                                                              continue;
+                                                          // i excluded from ranks > fb (>= jl) needs the
+                                                          // assumption (NLY: y_k >= ly[k] >= L); all other
+                                                          // exclusions are unconditional.
+                                                          if (m == i && k > fb)
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (x[i] >= Integer{L}) + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                          else
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                      }
+                                                      WPBSum in_band;
+                                                      if (m == i)
+                                                          in_band += 1_i * (x[i] >= Integer{L});
+                                                      for (long long k = fa; k <= fb; ++k)
+                                                          in_band += 1_i * (pos[m] == Integer{k});
+                                                      restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_lits, move(in_band) >= 1_i, ProofLevel::Temporary);
+                                                  }
+                                                  PolBuilder pol;
+                                                  for (auto l : restricted)
+                                                      pol.add(l);
+                                                  for (long long k = fa; k <= fb; ++k)
+                                                      pol.add(inj_lines[static_cast<size_t>(k)]);
+                                                  pol.emit(*logger, ProofLevel::Temporary);
+                                              },
+                                ThenRUP::Yes},
                             reason);
                 }
             }
@@ -900,12 +910,13 @@ namespace
                 // uy[hi_i-1] (jh_in[i] == hi_i[i]-1).
                 if (jh_in[i] + 1 == hi_i[i])
                     inference.infer_less_than(logger, x[i], Integer{U + 1},
-                        JustifyExplicitlyThenRUP{[&x, &pos, n, i, U, logger](const ReasonFunction & reason_fn) -> void {
-                            for (size_t k = 0; k < n; ++k)
-                                logger->emit_rup_proof_line_under_reason(reason_fn,
-                                    WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (x[i] < Integer{U + 1}) >= 1_i,
-                                    ProofLevel::Temporary);
-                        }},
+                        JustifyExplicitly{[&x, &pos, n, i, U, logger](const ReasonLiterals & reason_lits) -> void {
+                                              for (size_t k = 0; k < n; ++k)
+                                                  logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                      WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (x[i] < Integer{U + 1}) >= 1_i,
+                                                      ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
                         reason);
                 else {
                     // HALL mirror: ub(x[i]) = uy[jh] with jh = jh_in[i] < hi_i-1.
@@ -919,39 +930,40 @@ namespace
                         throw UnexpectedException{"Sort: no Hall band for a valid ub(x) tightening"};
                     else
                         inference.infer_less_than(logger, x[i], Integer{U + 1},
-                            JustifyExplicitlyThenRUP{[&x, &y, &pos, &ly, &uy, &inj_lines, S, fa, fb, i, n, U, logger](const ReasonFunction & reason_fn) -> void {
-                                for (size_t k = n; k-- > 0;)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn, WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
-                                for (size_t k = 0; k < n; ++k)
-                                    logger->emit_rup_proof_line_under_reason(reason_fn, WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
-                                std::vector<ProofLine> restricted(S.size());
-                                for (const auto & [idx, m] : enumerate(S)) {
-                                    for (long long k = 0; cmp_less(k, n); ++k) {
-                                        if (k >= fa && k <= fb)
-                                            continue;
-                                        // i excluded from ranks < fa (<= jh) needs the
-                                        // assumption (NUY: y_k <= uy[k] <= U).
-                                        if (m == i && k < fa)
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (x[i] < Integer{U + 1}) + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                        else
-                                            logger->emit_rup_proof_line_under_reason(reason_fn,
-                                                WPBSum{} + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
-                                    }
-                                    WPBSum in_band;
-                                    if (m == i)
-                                        in_band += 1_i * (x[i] < Integer{U + 1});
-                                    for (long long k = fa; k <= fb; ++k)
-                                        in_band += 1_i * (pos[m] == Integer{k});
-                                    restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_fn, move(in_band) >= 1_i, ProofLevel::Temporary);
-                                }
-                                PolBuilder pol;
-                                for (auto l : restricted)
-                                    pol.add(l);
-                                for (long long k = fa; k <= fb; ++k)
-                                    pol.add(inj_lines[static_cast<size_t>(k)]);
-                                pol.emit(*logger, ProofLevel::Temporary);
-                            }},
+                            JustifyExplicitly{[&x, &y, &pos, &ly, &uy, &inj_lines, S, fa, fb, i, n, U, logger](const ReasonLiterals & reason_lits) -> void {
+                                                  for (size_t k = n; k-- > 0;)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits, WPBSum{} + 1_i * y[k] <= Integer{uy[k]}, ProofLevel::Temporary);
+                                                  for (size_t k = 0; k < n; ++k)
+                                                      logger->emit_rup_proof_line_under_reason(reason_lits, WPBSum{} + 1_i * y[k] >= Integer{ly[k]}, ProofLevel::Temporary);
+                                                  std::vector<ProofLine> restricted(S.size());
+                                                  for (const auto & [idx, m] : enumerate(S)) {
+                                                      for (long long k = 0; cmp_less(k, n); ++k) {
+                                                          if (k >= fa && k <= fb)
+                                                              continue;
+                                                          // i excluded from ranks < fa (<= jh) needs the
+                                                          // assumption (NUY: y_k <= uy[k] <= U).
+                                                          if (m == i && k < fa)
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (x[i] < Integer{U + 1}) + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                          else
+                                                              logger->emit_rup_proof_line_under_reason(reason_lits,
+                                                                  WPBSum{} + 1_i * (pos[m] != Integer{k}) >= 1_i, ProofLevel::Temporary);
+                                                      }
+                                                      WPBSum in_band;
+                                                      if (m == i)
+                                                          in_band += 1_i * (x[i] < Integer{U + 1});
+                                                      for (long long k = fa; k <= fb; ++k)
+                                                          in_band += 1_i * (pos[m] == Integer{k});
+                                                      restricted[idx] = logger->emit_rup_proof_line_under_reason(reason_lits, move(in_band) >= 1_i, ProofLevel::Temporary);
+                                                  }
+                                                  PolBuilder pol;
+                                                  for (auto l : restricted)
+                                                      pol.add(l);
+                                                  for (long long k = fa; k <= fb; ++k)
+                                                      pol.add(inj_lines[static_cast<size_t>(k)]);
+                                                  pol.emit(*logger, ProofLevel::Temporary);
+                                              },
+                                ThenRUP::Yes},
                             reason);
                 }
             }

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -210,7 +210,7 @@ namespace
 
         vector<IntegerVariableID> all_vars = x;
         all_vars.insert(all_vars.end(), y.begin(), y.end());
-        auto reason = bounds_reason(state, all_vars);
+        auto reason = bounds_reason(all_vars);
 
         // (1) Normalize the y-ranges: they index the sorted output, so the lower
         // bounds are non-decreasing and the upper bounds non-decreasing.

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -10,6 +10,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <gcs/proof.hh>
 #include <util/enumerate.hh>
 
 #include <version>
@@ -981,7 +982,7 @@ auto gcs::innards::install_sortedness_propagator(Propagators & propagators, cons
             rank_ge = witness.rank_ge, rank_le = witness.rank_le, pos = witness.pos,
             inj_lines, al1_lines, anti_lines](
             State &, auto &, ProofLogger * const logger) -> void {
-            if (! logger)
+            if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                 return;
 
             // Totality + antisymmetry. The reverse (resp. forward) halves of the

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/sort/hints.hh>
 #include <gcs/constraints/sort/sort.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -188,7 +189,7 @@ namespace
         const vector<vector<ProofFlag>> & before, const vector<ProofOnlySimpleIntegerVariableID> & pos,
         const vector<ProofLine> & rank_lines, const vector<ProofLine> & rank_le_lines,
         const vector<ProofLine> & inj_lines, const vector<ProofLine> & al1_lines,
-        const vector<vector<ProofLine>> & anti_lines,
+        const vector<vector<ProofLine>> & anti_lines, const ConstraintID & owner,
         const State & state, Inference_ & inference, ProofLogger * const logger) -> void
     {
         auto n = x.size();
@@ -245,7 +246,7 @@ namespace
                                                   WPBSum{} + 1_i * (y[m] < Integer{V + 1}) + 1_i * (y[m + 1] >= Integer{V + 1}) >= 1_i,
                                                   ProofLevel::Temporary);
                                       },
-                        ThenRUP::Yes},
+                        ThenRUP::Yes, hints::Sort{owner}},
                     reason);
             }
 
@@ -330,7 +331,7 @@ namespace
                                           pol.emit(*logger, ProofLevel::Temporary);
                                       }
                                   },
-                    ThenRUP::Yes},
+                    ThenRUP::Yes, hints::Sort{owner}},
                 reason);
         };
 
@@ -517,7 +518,7 @@ namespace
                                                       WPBSum{} + 1_i * (y[k] >= Integer{L}) + 1_i * (y[k - 1] < Integer{L}) >= 1_i,
                                                       ProofLevel::Temporary);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::Sort{owner}},
                         reason);
                 }
                 else if (forced_above >= n - j) {
@@ -578,7 +579,7 @@ namespace
                                                       surj.add(inj_lines[k]);
                                               surj.emit(*logger, ProofLevel::Temporary);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::Sort{owner}},
                         reason);
                 }
                 else {
@@ -636,7 +637,7 @@ namespace
                                                       pol.add(inj_lines[static_cast<size_t>(k)]);
                                                   pol.emit(*logger, ProofLevel::Temporary);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::Sort{owner}},
                             reason);
                 }
             }
@@ -675,7 +676,7 @@ namespace
                                                       WPBSum{} + 1_i * (y[k] < Integer{U + 1}) + 1_i * (y[k + 1] >= Integer{U + 1}) >= 1_i,
                                                       ProofLevel::Temporary);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::Sort{owner}},
                         reason);
                 }
                 else if (forced_below >= j + 1) {
@@ -757,7 +758,7 @@ namespace
                                                       surj.add(inj_lines[k]);
                                               surj.emit(*logger, ProofLevel::Temporary);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::Sort{owner}},
                         reason);
                 }
                 else {
@@ -826,7 +827,7 @@ namespace
                                                       pol.add(inj_lines[static_cast<size_t>(k)]);
                                                   pol.emit(*logger, ProofLevel::Temporary);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::Sort{owner}},
                             reason);
                 }
             }
@@ -849,7 +850,7 @@ namespace
                                                       WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (x[i] >= Integer{L}) >= 1_i,
                                                       ProofLevel::Temporary);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::Sort{owner}},
                         reason);
                 else {
                     // HALL: lb(x[i]) = ly[jl] with jl = jl_in[i] > lo_i (the SCC
@@ -900,7 +901,7 @@ namespace
                                                       pol.add(inj_lines[static_cast<size_t>(k)]);
                                                   pol.emit(*logger, ProofLevel::Temporary);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::Sort{owner}},
                             reason);
                 }
             }
@@ -916,7 +917,7 @@ namespace
                                                       WPBSum{} + 1_i * (pos[i] != Integer(k)) + 1_i * (x[i] < Integer{U + 1}) >= 1_i,
                                                       ProofLevel::Temporary);
                                           },
-                            ThenRUP::Yes},
+                            ThenRUP::Yes, hints::Sort{owner}},
                         reason);
                 else {
                     // HALL mirror: ub(x[i]) = uy[jh] with jh = jh_in[i] < hi_i-1.
@@ -963,7 +964,7 @@ namespace
                                                       pol.add(inj_lines[static_cast<size_t>(k)]);
                                                   pol.emit(*logger, ProofLevel::Temporary);
                                               },
-                                ThenRUP::Yes},
+                                ThenRUP::Yes, hints::Sort{owner}},
                             reason);
                 }
             }
@@ -1102,8 +1103,8 @@ auto gcs::innards::install_sortedness_propagator(Propagators & propagators, cons
     triggers.on_bounds.insert(triggers.on_bounds.end(), x.begin(), x.end());
     triggers.on_bounds.insert(triggers.on_bounds.end(), y.begin(), y.end());
 
-    propagators.install(constraint_id, [x, y, before = witness.before, pos = witness.pos, rank_lines = witness.rank_ge, rank_le_lines = witness.rank_le, inj_lines, al1_lines, anti_lines](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-        propagate_sortedness(x, y, before, pos, rank_lines, rank_le_lines, *inj_lines, *al1_lines, *anti_lines,
+    propagators.install(constraint_id, [x, y, before = witness.before, pos = witness.pos, rank_lines = witness.rank_ge, rank_le_lines = witness.rank_le, inj_lines, al1_lines, anti_lines, owner = constraint_id](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        propagate_sortedness(x, y, before, pos, rank_lines, rank_le_lines, *inj_lines, *al1_lines, *anti_lines, owner,
             state, inference, logger);
         return PropagatorState::Enable; }, triggers);
 }

--- a/gcs/constraints/table/hints.hh
+++ b/gcs/constraints/table/hints.hh
@@ -1,0 +1,45 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_TABLE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief Table's assertion hint: just the owning constraint.
+     *
+     * Table's propagation runs through the shared helper propagate_extensional()
+     * (gcs/constraints/extensional_utils.hh), which takes a typed hint; Table passes
+     * this so the helper's RUP prunings and contradictions name it. Each is
+     * re-derivable from the asserted literal, the reason and the tuple definition
+     * lines, so the hint carries no per-shape discriminator and takes the default
+     * `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct Table
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "table";
+    };
+
+    /**
+     * \brief NegativeTable's assertion hint: just the owning constraint.
+     *
+     * The watched-literal propagator's prunings and contradictions are each
+     * re-derivable from the asserted literal, the reason and the forbidden-tuple
+     * definition lines, so the hint carries no per-shape discriminator and takes
+     * the default `(constraint_id <originator>)` wire form.
+     *
+     * \ingroup Innards
+     */
+    struct NegativeTable
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "negative_table";
+    };
+}
+
+#endif

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -206,7 +206,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                     auto w1 = find_unbroken(no_watch);
                     if (! w1) {
                         inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}},
-                            generic_reason(state, vars));
+                            generic_reason(vars));
                     }
 
                     auto w2 = find_unbroken(*w1);
@@ -214,7 +214,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                         // Unit clause: vars[*w1] != t[*w1] is the only possibly-true
                         // disjunct, so it must hold.
                         inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{hints::NegativeTable{owner}},
-                            generic_reason(state, vars));
+                            generic_reason(vars));
                         // Mark the tuple as already handled — both watches at the same
                         // position will read as broken on every subsequent fire, and
                         // any rescue search will discover the inference is now redundant.
@@ -260,12 +260,12 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                         auto new1 = find_unbroken(t, no_watch, no_watch);
                         if (! new1) {
                             inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}},
-                                generic_reason(state, vars));
+                                generic_reason(vars));
                         }
                         auto new2 = find_unbroken(t, *new1, no_watch);
                         if (! new2) {
                             inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{hints::NegativeTable{owner}},
-                                generic_reason(state, vars));
+                                generic_reason(vars));
                         }
                         else {
                             w.first = *new1;
@@ -276,7 +276,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                         auto new1 = find_unbroken(t, w.second, no_watch);
                         if (! new1) {
                             inference.infer(logger, vars[w.second] != t[w.second], JustifyUsingRUP{hints::NegativeTable{owner}},
-                                generic_reason(state, vars));
+                                generic_reason(vars));
                         }
                         else {
                             w.first = *new1;
@@ -286,7 +286,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                         auto new2 = find_unbroken(t, w.first, no_watch);
                         if (! new2) {
                             inference.infer(logger, vars[w.first] != t[w.first], JustifyUsingRUP{hints::NegativeTable{owner}},
-                                generic_reason(state, vars));
+                                generic_reason(vars));
                         }
                         else {
                             w.second = *new2;

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/table/hints.hh>
 #include <gcs/constraints/table/negative_table.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -184,7 +185,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
         // case and the "t[pos] is a wildcard" case (since `var == Wildcard` overloads
         // to TrueLiteral, which tests as DefinitelyTrue).
         propagators.install_initialiser(
-            [vars = _vars, tuples = tuples, watches = watches](
+            [vars = _vars, tuples = tuples, watches = watches, owner = constraint_id()](
                 const State & state, auto & inference, ProofLogger * const logger) -> void {
                 const auto & tuple_data = depointinate(tuples);
                 watches->reserve(tuple_data.size());
@@ -204,7 +205,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
 
                     auto w1 = find_unbroken(no_watch);
                     if (! w1) {
-                        inference.contradiction(logger, JustifyUsingRUP{},
+                        inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}},
                             generic_reason(state, vars));
                     }
 
@@ -212,7 +213,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                     if (! w2) {
                         // Unit clause: vars[*w1] != t[*w1] is the only possibly-true
                         // disjunct, so it must hold.
-                        inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{},
+                        inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{hints::NegativeTable{owner}},
                             generic_reason(state, vars));
                         // Mark the tuple as already handled — both watches at the same
                         // position will read as broken on every subsequent fire, and
@@ -227,7 +228,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
 
         propagators.install(
             constraint_id(),
-            [vars = move(_vars), tuples = move(tuples), watches = watches](
+            [vars = move(_vars), tuples = move(tuples), watches = watches, owner = constraint_id()](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 const auto & tuple_data = depointinate(tuples);
 
@@ -258,12 +259,12 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                     if (b1 && b2) {
                         auto new1 = find_unbroken(t, no_watch, no_watch);
                         if (! new1) {
-                            inference.contradiction(logger, JustifyUsingRUP{},
+                            inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}},
                                 generic_reason(state, vars));
                         }
                         auto new2 = find_unbroken(t, *new1, no_watch);
                         if (! new2) {
-                            inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{},
+                            inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{hints::NegativeTable{owner}},
                                 generic_reason(state, vars));
                         }
                         else {
@@ -274,7 +275,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                     else if (b1) {
                         auto new1 = find_unbroken(t, w.second, no_watch);
                         if (! new1) {
-                            inference.infer(logger, vars[w.second] != t[w.second], JustifyUsingRUP{},
+                            inference.infer(logger, vars[w.second] != t[w.second], JustifyUsingRUP{hints::NegativeTable{owner}},
                                 generic_reason(state, vars));
                         }
                         else {
@@ -284,7 +285,7 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
                     else {
                         auto new2 = find_unbroken(t, w.first, no_watch);
                         if (! new2) {
-                            inference.infer(logger, vars[w.first] != t[w.first], JustifyUsingRUP{},
+                            inference.infer(logger, vars[w.first] != t[w.first], JustifyUsingRUP{hints::NegativeTable{owner}},
                                 generic_reason(state, vars));
                         }
                         else {

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -1,6 +1,7 @@
+#include <gcs/constraints/extensional_utils.hh>
+#include <gcs/constraints/table/hints.hh>
 #include <gcs/constraints/table/table.hh>
 #include <gcs/exception.hh>
-#include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -181,7 +182,7 @@ auto Table::install_propagators(Propagators & propagators) -> void
 {
     if (_has_no_tuples) {
         propagators.install_initial_contradiction("Empty table constraint from table",
-            JustifyUsingRUP{});
+            JustifyUsingRUP{hints::Table{constraint_id()}});
         return;
     }
 
@@ -191,7 +192,7 @@ auto Table::install_propagators(Propagators & propagators) -> void
             triggers.on_change.push_back(v);
         triggers.on_change.push_back(_selector);
 
-        propagators.install(constraint_id(), [table = ExtensionalData{_selector, move(_vars), move(tuples)}](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return propagate_extensional(table, state, inference, logger); }, triggers);
+        propagators.install(constraint_id(), [table = ExtensionalData{_selector, move(_vars), move(tuples)}, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState { return propagate_extensional(table, state, inference, logger, hints::Table{owner}); }, triggers);
     },
         move(_tuples));
 }

--- a/gcs/constraints/value_precede/hints.hh
+++ b/gcs/constraints/value_precede/hints.hh
@@ -1,0 +1,22 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_VALUE_PRECEDE_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_VALUE_PRECEDE_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief ValuePrecede's assertion hint: just the owning constraint.
+     *
+     * \ingroup Innards
+     */
+    struct ValuePrecede
+    {
+        ConstraintID originator;
+        static constexpr std::string_view hint_name = "value_precede";
+    };
+}
+
+#endif

--- a/gcs/constraints/value_precede/value_precede.cc
+++ b/gcs/constraints/value_precede/value_precede.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/value_precede/hints.hh>
 #include <gcs/constraints/value_precede/value_precede.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -170,7 +171,7 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
 
         propagators.install(
             constraint_id(),
-            [vars = _vars, s, t](
+            [vars = _vars, s, t, owner = constraint_id()](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 auto n = vars.size();
 
@@ -190,7 +191,7 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
                 auto prune_up_to = (alpha == n) ? n : alpha + 1;
                 for (size_t i = 0; i < prune_up_to; ++i) {
                     if (state.in_domain(vars[i], t))
-                        inference.infer(logger, vars[i] != t, JustifyUsingRUP{}, reason);
+                        inference.infer(logger, vars[i] != t, JustifyUsingRUP{hints::ValuePrecede{owner}}, reason);
                 }
 
                 if (alpha == n)

--- a/gcs/constraints/value_precede/value_precede.cc
+++ b/gcs/constraints/value_precede/value_precede.cc
@@ -183,7 +183,7 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
                     }
                 }
 
-                auto reason = generic_reason(state, vars);
+                auto reason = generic_reason(vars);
 
                 // Prune t from positions [0, min(alpha+1, n)). If alpha == n
                 // this is all positions; otherwise it's positions 0..alpha

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -10,6 +10,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include <version>
@@ -26,101 +27,19 @@ namespace gcs::innards
 {
 
     /**
-     * \brief The allowed names for annotated assertions.
-     *
-     * \ingroup Innards
-     * \sa AssertionAnnotation
-     */
-    enum class AssertionHintName
-    {
-        None,
-        AllDifferent,
-        ReifiedEquals,
-        Abs,
-        ReifiedLinearEquality,
-        InitialBound,
-        BoundLink,
-        Backtrack,
-        SolxBlock,
-        SoliImprove,
-    };
-
-    /**
-     * \brief An assertion hint can be written as a string
-     *
-     * \ingroup Innards
-     */
-    inline auto operator<<(std::ostream & s, const AssertionHintName & hint_name) -> std::ostream &
-    {
-        switch (hint_name) {
-        case AssertionHintName::None:
-            return s << "None";
-        case AssertionHintName::AllDifferent:
-            return s << "AllDifferent";
-        case AssertionHintName::ReifiedEquals:
-            return s << "ReifiedEquals";
-        case AssertionHintName::Abs:
-            return s << "Abs";
-        case AssertionHintName::ReifiedLinearEquality:
-            return s << "ReifiedLinearEquality";
-        case AssertionHintName::InitialBound:
-            return s << "InitialBound";
-        case AssertionHintName::BoundLink:
-            return s << "BoundLink";
-        case AssertionHintName::Backtrack:
-            return s << "Backtrack";
-        case AssertionHintName::SolxBlock:
-            return s << "SolxBlock";
-        case AssertionHintName::SoliImprove:
-            return s << "SoliImprove";
-        }
-        return s;
-    }
-
-    /**
-     * \brief Keywords that can be used in an assertion hint.
-     *
-     * \ingroup Innards
-     */
-    enum class AssertionHintIdentifier
-    {
-        constraint_id,
-        hall_vars,
-        hall_vals,
-        justifier,
-        hall_set_or_violator,
-    };
-
-    inline auto as_string(AssertionHintIdentifier identifier) -> std::string
-    {
-        switch (identifier) {
-        case AssertionHintIdentifier::constraint_id:
-            return "constraint_id";
-        case AssertionHintIdentifier::hall_vars:
-            return "hall_vars";
-        case AssertionHintIdentifier::hall_vals:
-            return "hall_vals";
-        case AssertionHintIdentifier::justifier:
-            return "justifier";
-        case AssertionHintIdentifier::hall_set_or_violator:
-            return "hall_set_or_violator";
-        }
-        return "";
-    }
-
-    /**
      * \brief Render a single hint field as an s-expression atom.
+     *
+     * Field keys are plain s-expression atoms (e.g. \c SExpr::atom("hall_vars")),
+     * not a fixed enum: the vocabulary of a hint's fields lives with that hint's
+     * typed Data struct in \c gcs::innards::hints, not in one central list. The
+     * \c hint_sexpr overloads below cover the leaf field values; per-hint Data
+     * structs add their own \c hint_sexpr overload next to the constraint.
      *
      * \ingroup Innards
      */
     inline auto hint_sexpr(SExpr expr) -> SExpr
     {
         return expr;
-    }
-
-    inline auto hint_sexpr(AssertionHintIdentifier identifier) -> SExpr
-    {
-        return SExpr::atom(as_string(identifier));
     }
 
     inline auto hint_sexpr(const ProofLineLabel & label) -> SExpr
@@ -168,6 +87,26 @@ namespace gcs::innards
     }
 
     /**
+     * \brief The two ubiquitous hint fields, as named constructors.
+     *
+     * Almost every typed hint carries the owning constraint id, and the multi-shape
+     * ones add a per-shape \c justifier keyword. These spell those two
+     * `(constraint_id <id>)` / `(justifier <name>)` field pairs once, so each
+     * witness's \c hint_sexpr names them rather than respelling the atom pairs.
+     *
+     * \ingroup Innards
+     */
+    inline auto hint_constraint_id(const ConstraintID & owner) -> SExpr
+    {
+        return hint_list(SExpr::atom("constraint_id"), owner);
+    }
+
+    inline auto hint_justifier(std::string_view justifier) -> SExpr
+    {
+        return hint_list(SExpr::atom("justifier"), SExpr::atom(std::string{justifier}));
+    }
+
+    /**
      * \brief An annotation for an annotated assertion step.
      *
      * \ingroup Innards
@@ -175,7 +114,12 @@ namespace gcs::innards
     struct AssertionAnnotation
     {
         std::vector<ProofLineLabel> derivable_from = {};
-        AssertionHintName hint_name = AssertionHintName::None;
+        // A coarse, model-level constraint-type name (e.g. "all_different",
+        // "abs"), carried in the second annotation field for vanilla-VeriPB
+        // statistics. The fine, per-justification-shape discriminator (the
+        // "justifier" keyword) lives in hint_fields, set by the typed Data
+        // struct. A string literal, so this stays allocation-free.
+        std::string_view hint_name = "";
         std::optional<SExpr> hint_fields = std::nullopt;
     };
 

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -3,6 +3,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ASSERTION_HINTS_HH
 
 #include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/integer.hh>
@@ -25,15 +26,16 @@ using fmt::format;
 
 namespace gcs::innards
 {
+    class NamesAndIDsTracker;
 
     /**
-     * \brief Render a single hint field as an s-expression atom.
+     * \brief Render a single hint field's value as an s-expression atom.
      *
-     * Field keys are plain s-expression atoms (e.g. \c SExpr::atom("hall_vars")),
-     * not a fixed enum: the vocabulary of a hint's fields lives with that hint's
-     * typed Data struct in \c gcs::innards::hints, not in one central list. The
-     * \c hint_sexpr overloads below cover the leaf field values; per-hint Data
-     * structs add their own \c hint_sexpr overload next to the constraint.
+     * These \c hint_sexpr overloads cover the leaf field *values* (a label, a
+     * constraint id, an integer). The common field *keys* are named in
+     * \c hints::field (gcs/innards/proofs/hints.hh) so the wire vocabulary the
+     * justifier matches on stays extractable; a per-hint \c hint_sexpr that
+     * serialises extra data names its own keys next to the constraint.
      *
      * \ingroup Innards
      */
@@ -87,23 +89,60 @@ namespace gcs::innards
     }
 
     /**
-     * \brief The two ubiquitous hint fields, as named constructors.
+     * \brief The owning-constraint-id field, as a named constructor.
      *
-     * Almost every typed hint carries the owning constraint id, and the multi-shape
-     * ones add a per-shape \c justifier keyword. These spell those two
-     * `(constraint_id <id>)` / `(justifier <name>)` field pairs once, so each
-     * witness's \c hint_sexpr names them rather than respelling the atom pairs.
+     * Almost every typed hint carries the owning constraint id; the default
+     * \c hint_sexpr (in the \c hints namespace below) spells the
+     * `(constraint_id <id>)` field once so each hint names it rather than
+     * respelling the atom pair. The per-shape `(subhint <name>)` field has its own
+     * spelling, \c hint_subhint.
      *
      * \ingroup Innards
      */
     inline auto hint_constraint_id(const ConstraintID & owner) -> SExpr
     {
-        return hint_list(SExpr::atom("constraint_id"), owner);
+        return hint_list(SExpr::atom(std::string{hints::field::constraint_id}), owner);
     }
 
-    inline auto hint_justifier(std::string_view justifier) -> SExpr
+    namespace hints
     {
-        return hint_list(SExpr::atom("justifier"), SExpr::atom(std::string{justifier}));
+        /**
+         * \brief The `(subhint <name>)` field: the per-shape discriminator for a
+         * constraint family whose internal proof writer distinguishes more than one
+         * inference shape (e.g. all_different's "hall" vs "forced_value"). Spelled
+         * once here so every derived hint struct names it the same way.
+         *
+         * \ingroup Innards
+         */
+        inline auto hint_subhint(std::string_view name) -> SExpr
+        {
+            return hint_list(SExpr::atom(std::string{field::subhint}), SExpr::atom(std::string{name}));
+        }
+
+        /**
+         * \brief The default wire form for a typed assertion hint: the identity
+         * only.
+         *
+         * Emits just `(constraint_id <originator>)`, plus `(subhint <name>)` when the
+         * hint struct names one. It carries NO operand data: everything an external
+         * justifier needs that is re-derivable from the asserted literal, the reason
+         * and the definition lines stays off the wire (the internal proof writer
+         * holds it for its own emission). A constraint opts into serialising more by
+         * defining its own `hint_sexpr` overload next to its hint struct; that is the
+         * single place where the external data is allowed to be a (possibly strict)
+         * subset of the internal data.
+         *
+         * \ingroup Innards
+         */
+        template <typename Hint_>
+            requires requires(const Hint_ & h) { h.originator; }
+        auto hint_sexpr(const Hint_ & h, NamesAndIDsTracker &) -> SExpr
+        {
+            if constexpr (requires { Hint_::subhint_name; })
+                return hint_list(hint_constraint_id(h.originator), hint_subhint(Hint_::subhint_name));
+            else
+                return hint_list(hint_constraint_id(h.originator));
+        }
     }
 
     /**
@@ -115,10 +154,12 @@ namespace gcs::innards
     {
         std::vector<ProofLineLabel> derivable_from = {};
         // A coarse, model-level constraint-type name (e.g. "all_different",
-        // "abs"), carried in the second annotation field for vanilla-VeriPB
-        // statistics. The fine, per-justification-shape discriminator (the
-        // "justifier" keyword) lives in hint_fields, set by the typed Data
-        // struct. A string literal, so this stays allocation-free.
+        // "abs"): the first port-of-call for justification dispatch. A justifier
+        // picks its function by constraint family from this name, and only reads
+        // the structured hint_fields below -- the per-shape "subhint", plus any
+        // data -- when the family alone doesn't determine the function. It is also
+        // what a vanilla VeriPB run can aggregate for statistics. A string literal,
+        // so this stays allocation-free.
         std::string_view hint_name = "";
         std::optional<SExpr> hint_fields = std::nullopt;
     };

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -1,0 +1,200 @@
+
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ASSERTION_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ASSERTION_HINTS_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/integer.hh>
+
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/core.h>
+using fmt::format;
+#endif
+
+namespace gcs::innards
+{
+
+    /**
+     * \brief The allowed names for annotated assertions.
+     *
+     * \ingroup Innards
+     * \sa AssertionAnnotation
+     */
+    enum class AssertionHintName
+    {
+        None,
+        AllDifferent,
+        ReifiedEquals,
+        Abs,
+        ReifiedLinearEquality,
+        InitialBound,
+        BoundLink,
+        Backtrack,
+        SolxBlock,
+        SoliImprove,
+    };
+
+    /**
+     * \brief An assertion hint can be written as a string
+     *
+     * \ingroup Innards
+     */
+    inline auto operator<<(std::ostream & s, const AssertionHintName & hint_name) -> std::ostream &
+    {
+        switch (hint_name) {
+        case AssertionHintName::None:
+            return s << "None";
+        case AssertionHintName::AllDifferent:
+            return s << "AllDifferent";
+        case AssertionHintName::ReifiedEquals:
+            return s << "ReifiedEquals";
+        case AssertionHintName::Abs:
+            return s << "Abs";
+        case AssertionHintName::ReifiedLinearEquality:
+            return s << "ReifiedLinearEquality";
+        case AssertionHintName::InitialBound:
+            return s << "InitialBound";
+        case AssertionHintName::BoundLink:
+            return s << "BoundLink";
+        case AssertionHintName::Backtrack:
+            return s << "Backtrack";
+        case AssertionHintName::SolxBlock:
+            return s << "SolxBlock";
+        case AssertionHintName::SoliImprove:
+            return s << "SoliImprove";
+        }
+        return s;
+    }
+
+    /**
+     * \brief Keywords that can be used in an assertion hint.
+     *
+     * \ingroup Innards
+     */
+    enum class AssertionHintIdentifier
+    {
+        constraint_id,
+        hall_vars,
+        hall_vals,
+        justifier,
+        hall_set_or_violator,
+    };
+
+    inline auto as_string(AssertionHintIdentifier identifier) -> std::string
+    {
+        switch (identifier) {
+        case AssertionHintIdentifier::constraint_id:
+            return "constraint_id";
+        case AssertionHintIdentifier::hall_vars:
+            return "hall_vars";
+        case AssertionHintIdentifier::hall_vals:
+            return "hall_vals";
+        case AssertionHintIdentifier::justifier:
+            return "justifier";
+        case AssertionHintIdentifier::hall_set_or_violator:
+            return "hall_set_or_violator";
+        }
+        return "";
+    }
+
+    /**
+     * \brief Render a single hint field as an s-expression atom.
+     *
+     * \ingroup Innards
+     */
+    inline auto hint_sexpr(SExpr expr) -> SExpr
+    {
+        return expr;
+    }
+
+    inline auto hint_sexpr(AssertionHintIdentifier identifier) -> SExpr
+    {
+        return SExpr::atom(as_string(identifier));
+    }
+
+    inline auto hint_sexpr(const ProofLineLabel & label) -> SExpr
+    {
+        return SExpr::atom("@" + label.label);
+    }
+
+    inline auto hint_sexpr(const ConstraintID & id) -> SExpr
+    {
+        return SExpr::atom(as_string(id));
+    }
+
+    inline auto hint_sexpr(Integer value) -> SExpr
+    {
+        return SExpr::atom(value.to_string());
+    }
+
+    // NB: To put a variable in a hint, pass names_and_ids_tracker().s_expr_term_of(var)
+
+    /**
+     * \brief Build an s-expression hint from an arbitrary mix of fields and
+     * nested hint lists. This is intended to cover every conceivable hint shape, even if
+     * we're not in practice using the full generality at the moment.
+     *
+     * \ingroup Innards
+     */
+    template <typename... Ts_>
+    inline auto hint_list(Ts_ &&... xs) -> SExpr
+    {
+        return SExpr::list({hint_sexpr(std::forward<Ts_>(xs))...});
+    }
+
+    /**
+     * \brief Build an s-expression list from a runtime range
+     *
+     * \ingroup Innards
+     */
+    template <typename Range_>
+    inline auto hint_seq(const Range_ & xs) -> SExpr
+    {
+        std::vector<SExpr> children;
+        for (const auto & x : xs)
+            children.push_back(hint_sexpr(x));
+        return SExpr::list(std::move(children));
+    }
+
+    /**
+     * \brief An annotation for an annotated assertion step.
+     *
+     * \ingroup Innards
+     */
+    struct AssertionAnnotation
+    {
+        std::vector<ProofLineLabel> derivable_from = {};
+        AssertionHintName hint_name = AssertionHintName::None;
+        std::optional<SExpr> hint_fields = std::nullopt;
+    };
+
+    /**
+     * \brief An assertion annotation can be written to an ostream.
+     *
+     * \ingroup Innards
+     */
+    inline auto operator<<(std::ostream & s, const AssertionAnnotation & annotation) -> std::ostream &
+    {
+        s << ":";
+        for (const auto & id_or_label : annotation.derivable_from) {
+            s << id_or_label << " ";
+        }
+        s << ":" << annotation.hint_name << ":";
+        if (annotation.hint_fields)
+            s << format("{}", *annotation.hint_fields);
+        return s;
+    }
+
+} // namespace gcs::innards
+#endif

--- a/gcs/innards/extensional_utils.cc
+++ b/gcs/innards/extensional_utils.cc
@@ -80,7 +80,7 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                 // since there's no table for the implicit one.
                 inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, table.vars));
             else
-                inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, ReasonFunction{});
+                inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, NoReason{});
         }
         if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
             // selector already empty on entry

--- a/gcs/innards/extensional_utils.cc
+++ b/gcs/innards/extensional_utils.cc
@@ -1,7 +1,12 @@
+#include <cmath>
 #include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state-fwd.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/proof.hh>
 
 using std::vector;
 using std::visit;
@@ -59,6 +64,7 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
 {
     // check whether selectable tuples are still feasible
     visit([&](const auto & tuples) {
+        auto none_feasible = true;
         for (auto tuple_idx : state.each_value_mutable(table.selector)) {
             bool is_feasible = true;
             for (unsigned idx = 0; idx < table.vars.size(); ++idx)
@@ -67,9 +73,18 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                     break;
                 }
 
-            if (! is_feasible)
+            if (is_feasible)
+                none_feasible = false;
+            else if (logger && logger->get_assertion_level() != AssertionLevel::Off && state.has_single_value(table.selector))
+                // Last selector val so infeasible -> we need an explicit contradiction at higher assertion levels
+                // since there's no table for the implicit one.
+                inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, table.vars));
+            else
                 inference.infer(logger, table.selector != Integer(tuple_idx), NoJustificationNeeded{}, ReasonFunction{});
         }
+        if (none_feasible && logger && logger->get_assertion_level() != AssertionLevel::Off)
+            // selector already empty on entry
+            inference.contradiction(logger, JustifyUsingRUP{}, generic_reason(state, table.vars));
     },
         table.tuples);
 
@@ -85,8 +100,9 @@ auto gcs::innards::propagate_extensional(const ExtensionalData & table, const St
                     }
                 }
 
-                if (! supported)
+                if (! supported) {
                     inference.infer(logger, table.vars[idx] != val, JustifyUsingRUP{}, generic_reason(state, table.vars));
+                }
             }
         }
     },

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -263,6 +263,20 @@ namespace gcs::innards
             infer_all(logger, lits, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
         }
 
+        template <typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            contradiction(logger, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer_not_in_range(logger, var, lo, hi, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
         template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
         auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
         {

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -1,14 +1,14 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_INFERENCE_TRACKER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_INFERENCE_TRACKER_HH
 
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/state.hh>
 
-#include <algorithm>
 #include <deque>
-#include <type_traits>
+#include <optional>
 #include <utility>
 #include <version>
 
@@ -34,9 +34,9 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
 
-        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
+        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason);
+            return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason, assertion_hints);
         }
 
     public:
@@ -51,66 +51,66 @@ namespace gcs::innards
 
         auto operator=(const InferenceTrackerBase &) -> InferenceTrackerBase & = delete;
 
-        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer(lit), lit, why, reason);
+            track(logger, _state.infer(lit), lit, why, reason, assertion_hints);
         }
 
-        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason) -> void
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             if (logger)
-                logger->infer(FalseLiteral{}, why, reason);
+                logger->infer(FalseLiteral{}, why, reason, assertion_hints);
             throw TrackedPropagationFailed{};
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer(lit), lit, why, reason);
+            track(logger, _state.infer(lit), lit, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_equal(var, value), var == value, why, reason);
+            track(logger, _state.infer_equal(var, value), var == value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_not_equal(var, value), var != value, why, reason);
+            track(logger, _state.infer_not_equal(var, value), var != value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_less_than(var, value), var < value, why, reason);
+            track(logger, _state.infer_less_than(var, value), var < value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, reason);
+            track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, reason, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             // The conclusion is the ordinary range condition; the state update
             // batches the whole removal into one erase_range pass.
             if (lo > hi)
                 return;
-            track(logger, _state.infer_not_in_range(var, lo, hi), not_in_range(var, lo, hi), why, reason);
+            track(logger, _state.infer_not_in_range(var, lo, hi), not_in_range(var, lo, hi), why, reason, assertion_hints);
         }
 
-        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const ReasonFunction & reason) -> void
+        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             // For JustifyExplicitlyThenRUP: enter the temporary proof level once,
             // run the explicit scaffolding once, then RUP each inference under the
             // shared scaffolding. Without this, each infer() would enter and exit
             // its own temporary level, wiping the scaffolding before subsequent
             // inferences can use it.
-            if (logger && std::holds_alternative<JustifyExplicitlyThenRUP>(why)) {
+            if (logger && logger->get_assertion_level() == AssertionLevel::Off && std::holds_alternative<JustifyExplicitlyThenRUP>(why)) {
                 // The scaffolding is shared across the batch, but each inference's
                 // RUP is only emitted if it actually changes something (track_impl
                 // drops NoChange). If *every* inference is already entailed, no RUP
@@ -137,7 +137,7 @@ namespace gcs::innards
             }
             else {
                 for (const auto & lit : lits)
-                    infer(logger, lit, why, reason);
+                    infer(logger, lit, why, reason, assertion_hints);
             }
         }
 
@@ -172,7 +172,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &) -> void
+        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &, const std::optional<AssertionAnnotation> &) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -214,7 +214,7 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason) -> void
+        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -224,7 +224,7 @@ namespace gcs::innards
             case Inference::BoundsChanged:
             case Inference::Instantiated:
                 if (logger)
-                    logger->infer(lit, just, reason);
+                    logger->infer(lit, just, reason, assertion_hints);
 
                 overloaded{
                     [&](const TrueLiteral &) {},
@@ -248,7 +248,7 @@ namespace gcs::innards
 
             [[unlikely]] case Inference::Contradiction:
                 if (logger)
-                    logger->infer(lit, just, reason);
+                    logger->infer(lit, just, reason, assertion_hints);
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
                 throw TrackedPropagationFailed{};

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -4,9 +4,11 @@
 #include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/justification.hh>
+#include <gcs/innards/proofs/infer_explicitly.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/state.hh>
 
+#include <concepts>
 #include <deque>
 #include <optional>
 #include <utility>
@@ -34,9 +36,101 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
 
-        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason, assertion_hints);
+        }
+
+        // Pin a reason's materialisation *timing* so it can be carried across the
+        // domain change in track() and materialised by the logger-side tracker
+        // afterwards, while staying byte-identical to the old eager call sites:
+        //   - proofs off (logger == nullptr): never materialise. The reason is
+        //     ignored by the simple tracker, so building its literals would be
+        //     the wasted eager-build-then-discard this rework removes (G1).
+        //   - the *_reason() factories (Generic / BothBounds / Explicit): these
+        //     used to be built eagerly at the call site, against the pre-inference
+        //     state. Snapshot them now, before _state.infer(), into an
+        //     ExplicitReason that later re-materialises to the same literals
+        //     regardless of state.
+        //   - the Lazy variants: these used to be evaluated by the logger, after
+        //     the inference. Carry the declarative reason unchanged so it
+        //     materialises against the (post-inference) state later.
+        [[nodiscard]] static auto snapshot_reason(ProofLogger * const logger, const Reason & reason, State & state) -> Reason
+        {
+            // The proofs-off (non-materialising) tracker never reads the reason, so
+            // this collapses to a constant NoReason there and the whole call — and
+            // the snapshotted Reason it would have produced — is dead-code eliminated.
+            if constexpr (! Actual_::materialises_reasons)
+                return NoReason{};
+            else {
+                if (! logger)
+                    return NoReason{};
+
+                return reason.visit(overloaded{
+                    [&](const NoReason &) -> Reason { return NoReason{}; },
+                    [&](const LazyReasonOver &) -> Reason { return reason; },
+                    [&](const NarrowableLazyReasonOver &) -> Reason { return reason; },
+                    [&](const auto &) -> Reason { return ExplicitReason{materialise(reason, state)}; }});
+            }
+        }
+
+        // The bookkeeping for a firing (non-NoChange, non-Contradiction) inference:
+        // record the affected variable for later replay and mark that propagation
+        // did something. Shared by the explicit path (track_explicit) and the variant
+        // track_impl bodies below.
+        auto record_firing_inference(const Inference inf, const Literal & lit) -> void
+        {
+            overloaded{
+                [&](const TrueLiteral &) {},
+                [&](const FalseLiteral &) {},
+                [&](const IntegerVariableCondition & cond) {
+                    overloaded{
+                        [&](const ConstantIntegerVariableID &) {},
+                        [&](const SimpleIntegerVariableID & var) {
+                            _inferences.emplace_back(var, inf);
+                        },
+                        [&](const ViewOfIntegerVariableID & var) {
+                            _inferences.emplace_back(var.actual_variable, inf);
+                        }}
+                        .visit(cond.var);
+                }}
+                .visit(lit);
+
+            _did_anything_since_last_call_by_propagation_queue = true;
+            _did_anything_since_last_call_inside_propagator = true;
+        }
+
+        // The JustifyExplicitly counterpart of track_impl. Lives in the base class
+        // because it needs no per-tracker behaviour: the emit/hint are consumed (built
+        // into proof steps or an assertion) only when there is a logger, so the
+        // Simple, proofs-off tracker never touches them (pay-for-use) and the same
+        // body serves both trackers. Dispatch is compile-time overload resolution
+        // inside infer_explicitly; no std::function is involved.
+        template <typename Emit_, typename Hint_>
+        auto track_explicit(ProofLogger * const logger, const Inference inf, const Literal & lit,
+            const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback) -> void
+        {
+            switch (inf) {
+            case Inference::NoChange:
+                break;
+
+            case Inference::InteriorValuesChanged:
+            case Inference::BoundsChanged:
+            case Inference::Instantiated:
+                if constexpr (Actual_::materialises_reasons)
+                    if (logger)
+                        infer_explicitly(*logger, lit, why.emit, why.then_rup, materialise(reason, _state), why.hint, fallback);
+                record_firing_inference(inf, lit);
+                break;
+
+            [[unlikely]] case Inference::Contradiction:
+                if constexpr (Actual_::materialises_reasons)
+                    if (logger)
+                        infer_explicitly(*logger, lit, why.emit, why.then_rup, materialise(reason, _state), why.hint, fallback);
+                _did_anything_since_last_call_by_propagation_queue = true;
+                _did_anything_since_last_call_inside_propagator = true;
+                throw TrackedPropagationFailed{};
+            }
         }
 
     public:
@@ -51,94 +145,250 @@ namespace gcs::innards
 
         auto operator=(const InferenceTrackerBase &) -> InferenceTrackerBase & = delete;
 
-        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer(lit), lit, why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer(lit), lit, why, snapshotted, assertion_hints);
         }
 
-        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        // Justify an inference with explicit proof steps (JustifyExplicitly): the
+        // pay-for-use, std::function-free explicit-steps path. The fallback
+        // annotation is used in assertion mode only when the justification carries no
+        // hint of its own. There is an overload for each plain infer entry point
+        // (general literal, the typed condition/bound helpers, and contradiction);
+        // each just routes to track_explicit instead of track.
+        template <typename Emit_, typename Hint_>
+        auto infer(ProofLogger * const logger, const Literal & lit, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
         {
-            if (logger)
-                logger->infer(FalseLiteral{}, why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer(lit), lit, why, snapshotted, fallback);
+        }
+
+        // Visit a variant of justifications and dispatch each alternative to its
+        // matching infer overload. This is how the reified dispatcher's verdict —
+        // which carries a per-constraint variant of justification shapes (plain
+        // Justification alternatives and/or typed JustifyExplicitly) — is applied:
+        // the dispatcher just forwards the verdict's justification here, so the
+        // visit lives in infer() rather than at the call site. (The non-template
+        // const Justification & overload is preferred for a Justification argument,
+        // so the variant overload only catches the per-constraint variants.)
+        template <typename... Alts_>
+        auto infer(ProofLogger * const logger, const Literal & lit, const std::variant<Alts_...> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            std::visit([&](const auto & alt) { infer(logger, lit, alt, reason, fallback); }, why);
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer(lit), lit, why, snapshotted, fallback);
+        }
+
+        template <typename Emit_, typename Hint_>
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            if constexpr (Actual_::materialises_reasons)
+                if (logger)
+                    infer_explicitly(*logger, FalseLiteral{}, why.emit, why.then_rup, materialise(reason, _state), why.hint, fallback);
+            throw TrackedPropagationFailed{};
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_equal(var, value), var == value, why, snapshotted, fallback);
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_not_equal(var, value), var != value, why, snapshotted, fallback);
+        }
+
+        // A JustifyUsingRUP carrying a typed hint is a RUP inference (no explicit
+        // steps) that wants a typed assertion hint. Each overload below turns the
+        // hint into an annotation (only when something will be asserted — Off mode
+        // builds nothing, so it stays byte-identical to a bare RUP) and delegates to
+        // the plain JustifyUsingRUP{} path. No explicit-steps machinery is involved.
+        template <typename Hint_>
+        [[nodiscard]] auto rup_hint_annotation(ProofLogger * const logger, const Hint_ & hint, const std::optional<AssertionAnnotation> & fallback) -> std::optional<AssertionAnnotation>
+        {
+            if (logger && logger->get_assertion_level() != AssertionLevel::Off)
+                return hint_annotation(*logger, hint, fallback);
+            return fallback;
+        }
+
+        template <typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        auto infer(ProofLogger * const logger, const Literal & lit, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer(logger, lit, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer_equal(logger, var, value, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer_not_equal(logger, var, value, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer_less_than(logger, var, value, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer_greater_than_or_equal(logger, var, value, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
+        template <typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer_all(logger, lits, JustifyUsingRUP{}, reason, rup_hint_annotation(logger, why.hint, fallback));
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_less_than(var, value), var < value, why, snapshotted, fallback);
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, snapshotted, fallback);
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            if (lo > hi)
+                return;
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_not_in_range(var, lo, hi), not_in_range(var, lo, hi), why, snapshotted, fallback);
+        }
+
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        {
+            // No domain change happens here, so the reason materialises against
+            // the current state directly (the eager/lazy timing distinction only
+            // matters when there is an inference to straddle).
+            if constexpr (Actual_::materialises_reasons)
+                if (logger)
+                    logger->infer(FalseLiteral{}, why, materialise(reason, _state), assertion_hints);
             throw TrackedPropagationFailed{};
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer(ProofLogger * const logger, const VariableConditionFrom<VarType_> & lit, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer(lit), lit, why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer(lit), lit, why, snapshotted, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_equal(var, value), var == value, why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_equal(var, value), var == value, why, snapshotted, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_not_equal(var, value), var != value, why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_not_equal(var, value), var != value, why, snapshotted, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_less_than(var, value), var < value, why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_less_than(var, value), var < value, why, snapshotted, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, snapshotted, assertion_hints);
         }
 
         template <IntegerVariableIDLike VarType_>
-        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             // The conclusion is the ordinary range condition; the state update
             // batches the whole removal into one erase_range pass.
             if (lo > hi)
                 return;
-            track(logger, _state.infer_not_in_range(var, lo, hi), not_in_range(var, lo, hi), why, reason, assertion_hints);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_not_in_range(var, lo, hi), not_in_range(var, lo, hi), why, snapshotted, assertion_hints);
         }
 
-        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const Justification & why, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
-            // For JustifyExplicitlyThenRUP: enter the temporary proof level once,
-            // run the explicit scaffolding once, then RUP each inference under the
-            // shared scaffolding. Without this, each infer() would enter and exit
-            // its own temporary level, wiping the scaffolding before subsequent
-            // inferences can use it.
-            if (logger && logger->get_assertion_level() == AssertionLevel::Off && std::holds_alternative<JustifyExplicitlyThenRUP>(why)) {
-                // The scaffolding is shared across the batch, but each inference's
-                // RUP is only emitted if it actually changes something (track_impl
-                // drops NoChange). If *every* inference is already entailed, no RUP
-                // would reference the scaffolding, so emitting it is wasted work
-                // (and leaves an unreferenced constraint for forget to delete).
-                // Only emit when at least one inference will fire. (A single infer()
-                // is already lazy this way: track_impl gates logger->infer on the
-                // inference changing something.)
-                auto any_will_fire = false;
-                for (const auto & lit : lits)
-                    if (_state.test_literal(lit) != LiteralIs::DefinitelyTrue) {
-                        any_will_fire = true;
-                        break;
-                    }
-                if (! any_will_fire)
-                    return;
+            // The plain justifications (RUP / assert / none) carry no shared
+            // scaffolding to batch, so infer each literal in turn. The
+            // explicit-steps batching (enter one temporary level, emit the
+            // scaffolding once, RUP each inference under it) lives on the
+            // JustifyExplicitly infer_all overload below.
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            for (const auto & lit : lits)
+                infer(logger, lit, why, snapshotted, assertion_hints);
+        }
 
-                const auto & j = std::get<JustifyExplicitlyThenRUP>(why);
-                auto t = logger->temporary_proof_level();
-                j.add_proof_steps(reason);
-                for (const auto & lit : lits)
-                    infer(logger, lit, JustifyUsingRUP{}, reason);
-                logger->forget_proof_level(t);
+        // The JustifyExplicitly counterpart of infer_all. When the steps end in a
+        // RUP (ThenRUP::Yes) and proofs are Off, it does the shared-temporary-level
+        // batching: emit the scaffolding once via the emit callable, then RUP each
+        // inference under it. Otherwise (assertion mode, or ThenRUP::No) it falls
+        // through to the per-literal path, where each inference carries the
+        // assertion hint in assert mode.
+        template <typename Emit_, typename Hint_>
+        auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            if constexpr (Actual_::materialises_reasons) {
+                if (logger && logger->get_assertion_level() == AssertionLevel::Off && why.then_rup == ThenRUP::Yes) {
+                    auto any_will_fire = false;
+                    for (const auto & lit : lits)
+                        if (_state.test_literal(lit) != LiteralIs::DefinitelyTrue) {
+                            any_will_fire = true;
+                            break;
+                        }
+                    if (! any_will_fire)
+                        return;
+
+                    auto snapshotted = snapshot_reason(logger, reason, _state);
+                    ReasonLiterals reason_lits = materialise(snapshotted, _state);
+                    auto t = logger->temporary_proof_level();
+                    emit_explicit_steps(*logger, why.emit, reason_lits);
+                    for (const auto & lit : lits)
+                        infer(logger, lit, JustifyUsingRUP{}, snapshotted);
+                    logger->forget_proof_level(t);
+                    return;
+                }
             }
-            else {
-                for (const auto & lit : lits)
-                    infer(logger, lit, why, reason, assertion_hints);
-            }
+
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            for (const auto & lit : lits)
+                infer(logger, lit, why, snapshotted, fallback);
         }
 
         auto each_inference() const -> std::generator<std::pair<SimpleIntegerVariableID, Inference>>
@@ -172,7 +422,11 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const ReasonFunction &, const std::optional<AssertionAnnotation> &) -> void
+        // Proofs-off tracker: it never materialises a reason, so the base infer()
+        // path skips snapshot_reason and every proof-only block compiles out.
+        static constexpr bool materialises_reasons = false;
+
+        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const Reason &, const std::optional<AssertionAnnotation> &) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -214,7 +468,9 @@ namespace gcs::innards
     public:
         using InferenceTrackerBase::InferenceTrackerBase;
 
-        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+        static constexpr bool materialises_reasons = true;
+
+        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {
             switch (inf) {
             case Inference::NoChange:
@@ -223,8 +479,15 @@ namespace gcs::innards
             case Inference::InteriorValuesChanged:
             case Inference::BoundsChanged:
             case Inference::Instantiated:
-                if (logger)
-                    logger->infer(lit, just, reason, assertion_hints);
+                if (logger) {
+                    // Materialise the reason here, post-inference: snapshot_reason
+                    // already pinned the timing (eager kinds are a fixed
+                    // ExplicitReason snapshot taken pre-inference, Lazy kinds stay
+                    // declarative and materialise against the now-current state),
+                    // so materialising now gives both kinds the literals the logger
+                    // used to compute internally.
+                    logger->infer(lit, just, materialise(reason, _state), assertion_hints);
+                }
 
                 overloaded{
                     [&](const TrueLiteral &) {},
@@ -248,7 +511,7 @@ namespace gcs::innards
 
             [[unlikely]] case Inference::Contradiction:
                 if (logger)
-                    logger->infer(lit, just, reason, assertion_hints);
+                    logger->infer(lit, just, materialise(reason, _state), assertion_hints);
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
                 throw TrackedPropagationFailed{};

--- a/gcs/innards/justification.hh
+++ b/gcs/innards/justification.hh
@@ -1,71 +1,90 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_JUSTIFICATION_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_JUSTIFICATION_HH
 
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/reason.hh>
 
-#include <functional>
+#include <string_view>
+#include <utility>
 #include <variant>
 
 namespace gcs::innards
 {
     /**
-     * \brief Write an explicit justification to the proof. Any ProofLevel::Temporary
-     * constraints will be wiped after the conclusion is derived. The reason used for
-     * the outside inference is provided for convenience.
+     * \brief The empty hint: a bare justification carrying no assertion hint. This
+     * is what JustifyUsingRUP{} / JustifyExplicitly{emit, then_rup} hold by default
+     * (and hence what lives in the Justification variant).
      *
      * \ingroup Innards
-     * \sa JustifyExplicitlyThenRUP
      */
-    using ExplicitJustificationFunction = std::function<auto(const ReasonFunction & reason)->void>;
-
-    /**
-     * \brief Specify that an inference requires an explicit justification in
-     * the proof log. There will be no RUP step at the end of the explicit justifiction.
-     *
-     * \ingroup Innards
-     * \sa Justification
-     */
-    struct JustifyExplicitlyOnly
+    struct NoHint
     {
-        ExplicitJustificationFunction add_proof_steps;
-
-        explicit JustifyExplicitlyOnly(const ExplicitJustificationFunction & a) :
-            add_proof_steps(a)
-        {
-        }
     };
 
+    namespace hints
+    {
+        /**
+         * \brief A bare coarse model-level name, with no structured fields.
+         *
+         * The minimal assertion hint: in assertion mode it annotates the inference
+         * with just this name (no \c hint_sexpr), telling the justifier which
+         * constraint family the step came from without serialising any operands. The
+         * tier between NoHint (annotate with nothing, fall back to the call site's
+         * annotation) and a per-constraint typed hint (name plus structured fields).
+         *
+         * \ingroup Innards
+         */
+        struct ModelName
+        {
+            std::string_view hint_name;
+        };
+    }
+
     /**
-     * \brief Specify that an inference requires an explicit justification in
-     * the proof log. This will be followed by a final RUP step for the inference itself.
+     * \brief Whether a JustifyExplicitly appends a RUP derivation of the inferred
+     * literal after its explicit proof steps, or lets the steps stand alone.
+     *
+     * This was historically a bare `bool then_rup`; it is spelled as an enum, and is
+     * a mandatory argument at every JustifyExplicitly call site, so the proof shape
+     * is always legible rather than hidden behind an unlabelled true/false.
      *
      * \ingroup Innards
-     * \sa Justification
+     * \sa JustifyExplicitly
      */
-    struct JustifyExplicitlyThenRUP
+    enum class ThenRUP
     {
-        ExplicitJustificationFunction add_proof_steps;
-
-        explicit JustifyExplicitlyThenRUP(const ExplicitJustificationFunction & a) :
-            add_proof_steps(a)
-        {
-        }
+        Yes, ///< emit the explicit steps, then RUP the inferred literal under the reason
+        No   ///< the explicit steps stand alone (they conclude the inference themselves)
     };
+
     /**
      * \brief Specify that an inference can be justified using reverse unit
-     * propagation.
+     * propagation, optionally carrying a typed assertion hint.
+     *
+     * `JustifyUsingRUP{}` is the bare, nameless RUP (the common case, and the one
+     * that lives in the Justification variant). `JustifyUsingRUP{hints::Foo{...}}`
+     * is the same RUP inference, but in assertion mode it is asserted under a typed
+     * hint (model name plus optional structured fields, e.g. the owning constraint
+     * id) built by hint_annotation. The hint never carries explicit proof steps —
+     * that is what JustifyExplicitly is for — so in normal (Off) proof mode this is
+     * byte-identical to a bare RUP regardless of the hint.
      *
      * \ingroup Innards
      * \sa Justification
      */
+    template <typename Hint_ = NoHint>
     struct JustifyUsingRUP
     {
-        explicit JustifyUsingRUP()
-        {
-        }
+        [[no_unique_address]] Hint_ hint{};
     };
+
+    JustifyUsingRUP() -> JustifyUsingRUP<NoHint>;
+
+    template <typename Hint_>
+    JustifyUsingRUP(Hint_) -> JustifyUsingRUP<Hint_>;
 
     /**
      * \brief Specify that an inference will be asserted rather than justified.
@@ -91,11 +110,56 @@ namespace gcs::innards
     };
 
     /**
+     * \brief Justify an inference with *explicit proof steps*, dispatched by proof
+     * mode, optionally carrying a typed assertion hint.
+     *
+     * The pay-for-use, std::function-free explicit-justification interface, mirroring
+     * JustifyUsingRUP: both are parameterised on an optional \c Hint_, and the hint
+     * means the same thing in both (a typed assertion annotation, orthogonal to how
+     * the inference is proved). The difference is the \c emit:
+     *
+     *   - \c emit is a callable `(const ReasonLiterals &) -> void` that writes the
+     *     real proof steps. It is built by value at the call site (a lambda, or a
+     *     storable struct with operator() for replay at backtrack time) — no type
+     *     erasure, no heap, no std::function. The Simple (proofs-off) tracker never
+     *     touches it, so nothing is emitted or materialised when proofs are off.
+     *   - \c then_rup picks the proof shape: ThenRUP::Yes emits the steps at a
+     *     temporary level then RUPs the inferred literal under the reason; ThenRUP::No
+     *     lets the steps conclude the inference themselves.
+     *   - \c hint is the assertion-mode annotation (NoHint by default), resolved by
+     *     hint_annotation exactly as for JustifyUsingRUP. In Off mode it is ignored,
+     *     so the hint never changes the emitted proof.
+     *
+     * The only erasure is the future lazy-storage boundary (a per-type emit function
+     * pointer).
+     *
+     * \ingroup Innards
+     * \sa Justification
+     */
+    template <typename Emit_, typename Hint_ = NoHint>
+    struct JustifyExplicitly
+    {
+        Emit_ emit;
+        ThenRUP then_rup;
+        [[no_unique_address]] Hint_ hint{};
+    };
+
+    template <typename Emit_>
+    JustifyExplicitly(Emit_, ThenRUP) -> JustifyExplicitly<Emit_, NoHint>;
+
+    template <typename Emit_, typename Hint_>
+    JustifyExplicitly(Emit_, ThenRUP, Hint_) -> JustifyExplicitly<Emit_, Hint_>;
+
+    /**
      * \brief Specify why an inference is justified, for proof logging.
+     *
+     * The plain (emit-free) justifications. Explicit proof steps are supplied by a
+     * JustifyExplicitly instead, dispatched by overload resolution rather than
+     * carried in this variant.
      *
      * \ingroup Innards
      */
-    using Justification = std::variant<JustifyUsingRUP, JustifyExplicitlyOnly, JustifyExplicitlyThenRUP, AssertRatherThanJustifying, NoJustificationNeeded>;
+    using Justification = std::variant<JustifyUsingRUP<NoHint>, AssertRatherThanJustifying, NoJustificationNeeded>;
 }
 
 #endif

--- a/gcs/innards/justification.hh
+++ b/gcs/innards/justification.hh
@@ -1,48 +1,17 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_JUSTIFICATION_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_JUSTIFICATION_HH
 
-#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/reason.hh>
 
-#include <string_view>
 #include <utility>
 #include <variant>
 
 namespace gcs::innards
 {
-    /**
-     * \brief The empty hint: a bare justification carrying no assertion hint. This
-     * is what JustifyUsingRUP{} / JustifyExplicitly{emit, then_rup} hold by default
-     * (and hence what lives in the Justification variant).
-     *
-     * \ingroup Innards
-     */
-    struct NoHint
-    {
-    };
-
-    namespace hints
-    {
-        /**
-         * \brief A bare coarse model-level name, with no structured fields.
-         *
-         * The minimal assertion hint: in assertion mode it annotates the inference
-         * with just this name (no \c hint_sexpr), telling the justifier which
-         * constraint family the step came from without serialising any operands. The
-         * tier between NoHint (annotate with nothing, fall back to the call site's
-         * annotation) and a per-constraint typed hint (name plus structured fields).
-         *
-         * \ingroup Innards
-         */
-        struct ModelName
-        {
-            std::string_view hint_name;
-        };
-    }
-
     /**
      * \brief Whether a JustifyExplicitly appends a RUP derivation of the inferred
      * literal after its explicit proof steps, or lets the steps stand alone.

--- a/gcs/innards/proofs/hints.hh
+++ b/gcs/innards/proofs/hints.hh
@@ -1,0 +1,63 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_HINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_HINTS_HH
+
+#include <string_view>
+
+namespace gcs::innards::hints
+{
+    /**
+     * \brief The s-expression field keys that make up a hint's wire form.
+     *
+     * A hint serialises as `((constraint_id <id>)(subhint <name>) ...)`; these are
+     * the inner keys a justifier matches on. They live here, named, rather than as
+     * `SExpr::atom("...")` literals scattered through the hint builders, so the wire
+     * vocabulary the justifier consumes stays extractable in one place.
+     *
+     * \ingroup Innards
+     */
+    namespace field
+    {
+        inline constexpr std::string_view constraint_id = "constraint_id";
+        inline constexpr std::string_view subhint = "subhint";
+    }
+
+    /**
+     * \brief Assertion hints for the proof machinery itself, as opposed to a model
+     * constraint's inferences.
+     *
+     * These name the framework-level assertions the prover emits around search and
+     * solution handling. They are not owned by any model constraint, so -- unlike the
+     * per-constraint hints -- they carry no \c originator and (for now) no fields, just
+     * the coarse \c hint_name. If a justifier later needs the implicated variable, the
+     * relevant struct gains a field and a \c hint_sexpr; until then they sit here so the
+     * names live in the \c hints namespace rather than as scattered string literals.
+     *
+     * \ingroup Innards
+     */
+    struct InitialBound
+    {
+        static constexpr std::string_view hint_name = "initial_bound";
+    };
+
+    struct BoundLink
+    {
+        static constexpr std::string_view hint_name = "bound_link";
+    };
+
+    struct Backtrack
+    {
+        static constexpr std::string_view hint_name = "backtrack";
+    };
+
+    struct SolxBlock
+    {
+        static constexpr std::string_view hint_name = "solx_block";
+    };
+
+    struct SoliImprove
+    {
+        static constexpr std::string_view hint_name = "soli_improve";
+    };
+}
+
+#endif

--- a/gcs/innards/proofs/hints.hh
+++ b/gcs/innards/proofs/hints.hh
@@ -3,61 +3,103 @@
 
 #include <string_view>
 
-namespace gcs::innards::hints
+namespace gcs::innards
 {
     /**
-     * \brief The s-expression field keys that make up a hint's wire form.
+     * \brief The empty hint: a bare justification carrying no assertion hint. This
+     * is what JustifyUsingRUP{} / JustifyExplicitly{emit, then_rup} hold by default
+     * (and hence what lives in the Justification variant).
      *
-     * A hint serialises as `((constraint_id <id>)(subhint <name>) ...)`; these are
-     * the inner keys a justifier matches on. They live here, named, rather than as
-     * `SExpr::atom("...")` literals scattered through the hint builders, so the wire
-     * vocabulary the justifier consumes stays extractable in one place.
+     * It lives here, the lightweight (\c string_view-only) hint-vocabulary leaf,
+     * rather than next to the heavier s-expression machinery in assertion_hints.hh,
+     * because it is the pervasive default: it is named by JustifyUsingRUP /
+     * JustifyExplicitly and by lightweight propagator headers that must not pull in
+     * the serialisation apparatus for a hint they never serialise.
      *
      * \ingroup Innards
      */
-    namespace field
+    struct NoHint
     {
-        inline constexpr std::string_view constraint_id = "constraint_id";
-        inline constexpr std::string_view subhint = "subhint";
-    }
+    };
 
     /**
-     * \brief Assertion hints for the proof machinery itself, as opposed to a model
-     * constraint's inferences.
+     * \brief The typed-assertion-hint customization surface.
      *
-     * These name the framework-level assertions the prover emits around search and
-     * solution handling. They are not owned by any model constraint, so -- unlike the
-     * per-constraint hints -- they carry no \c originator and (for now) no fields, just
-     * the coarse \c hint_name. If a justifier later needs the implicated variable, the
-     * relevant struct gains a field and a \c hint_sexpr; until then they sit here so the
-     * names live in the \c hints namespace rather than as scattered string literals.
+     * More than a bag of constants: this is where a typed hint and the two ADL
+     * customization points it can opt into are co-located. A per-constraint hint
+     * struct (in gcs/constraints/<foo>/hints.hh) is declared in this namespace so
+     * that its
+     *
+     *   - \c hint_sexpr(hint, tracker) -- the wire-serialisation side, and
+     *   - \c emit_justification(logger, hint, reason) -- the proof-emission side
+     *
+     * are found by argument-dependent lookup on the hint type (both are invoked
+     * unqualified from infer_explicitly.hh). Co-locating the struct with its
+     * \c hint_sexpr and \c emit_justification is the \c operator<< idiom: free
+     * functions defined next to the type they customise.
+     *
+     * Defined here are the framework-owned hints (below) and the wire field-key
+     * vocabulary (\c field); the generic s-expression machinery that consumes them
+     * lives in assertion_hints.hh.
      *
      * \ingroup Innards
      */
-    struct InitialBound
+    namespace hints
     {
-        static constexpr std::string_view hint_name = "initial_bound";
-    };
+        /**
+         * \brief The s-expression field keys that make up a hint's wire form.
+         *
+         * A hint serialises as `((constraint_id <id>)(subhint <name>) ...)`; these are
+         * the inner keys a justifier matches on. They live here, named, rather than as
+         * `SExpr::atom("...")` literals scattered through the hint builders, so the wire
+         * vocabulary the justifier consumes stays extractable in one place.
+         *
+         * \ingroup Innards
+         */
+        namespace field
+        {
+            inline constexpr std::string_view constraint_id = "constraint_id";
+            inline constexpr std::string_view subhint = "subhint";
+        }
 
-    struct BoundLink
-    {
-        static constexpr std::string_view hint_name = "bound_link";
-    };
+        /**
+         * \brief Assertion hints for the proof machinery itself, as opposed to a model
+         * constraint's inferences.
+         *
+         * These name the framework-level assertions the prover emits around search and
+         * solution handling. They are not owned by any model constraint, so -- unlike the
+         * per-constraint hints -- they carry no \c originator and (for now) no fields, just
+         * the coarse \c hint_name. If a justifier later needs the implicated variable, the
+         * relevant struct gains a field and a \c hint_sexpr; until then they sit here so the
+         * names live in the \c hints namespace rather than as scattered string literals.
+         *
+         * \ingroup Innards
+         */
+        struct InitialBound
+        {
+            static constexpr std::string_view hint_name = "initial_bound";
+        };
 
-    struct Backtrack
-    {
-        static constexpr std::string_view hint_name = "backtrack";
-    };
+        struct BoundLink
+        {
+            static constexpr std::string_view hint_name = "bound_link";
+        };
 
-    struct SolxBlock
-    {
-        static constexpr std::string_view hint_name = "solx_block";
-    };
+        struct Backtrack
+        {
+            static constexpr std::string_view hint_name = "backtrack";
+        };
 
-    struct SoliImprove
-    {
-        static constexpr std::string_view hint_name = "soli_improve";
-    };
+        struct SolxBlock
+        {
+            static constexpr std::string_view hint_name = "solx_block";
+        };
+
+        struct SoliImprove
+        {
+            static constexpr std::string_view hint_name = "soli_improve";
+        };
+    }
 }
 
 #endif

--- a/gcs/innards/proofs/infer_explicitly.hh
+++ b/gcs/innards/proofs/infer_explicitly.hh
@@ -55,25 +55,6 @@ namespace gcs::innards
     }
 
     /**
-     * \brief Resolve the assertion annotation for a JustifyExplicitly inference.
-     *
-     * Precedence: the explicit \c hint wins if it advertises anything; otherwise the
-     * \c emit's own advertisement is used (a named fat witness that carries its own
-     * \c hint_sexpr / \c hint_name); otherwise the call site's \c fallback. A bare
-     * emit closure advertises nothing, so a closure with no hint resolves straight to
-     * the fallback. This reproduces the old witness-carried annotation exactly while
-     * letting an inline closure carry a separate ModelName / structured hint.
-     *
-     * \ingroup Innards
-     */
-    template <typename Hint_, typename Emit_>
-    [[nodiscard]] auto resolve_annotation(ProofLogger & logger, const Hint_ & hint, const Emit_ & emit,
-        const std::optional<AssertionAnnotation> & fallback) -> std::optional<AssertionAnnotation>
-    {
-        return hint_annotation(logger, hint, hint_annotation(logger, emit, fallback));
-    }
-
-    /**
      * \brief Emit a JustifyExplicitly's explicit proof steps.
      *
      * The \c emit is either a `(const ReasonLiterals &) -> void` callable (an inline
@@ -138,7 +119,12 @@ namespace gcs::innards
 
         if (logger.get_assertion_level() != AssertionLevel::Off) {
             if (! is_literally_true(lit)) {
-                auto annotation = resolve_annotation(logger, hint, emit, fallback_annotation);
+                // Annotation precedence: the explicit hint wins if it advertises
+                // anything; else the emit's own advertisement (a named fat witness
+                // carrying its own hint_sexpr / hint_name); else the call site's
+                // fallback. A bare emit closure advertises nothing, so it resolves
+                // straight to the fallback.
+                auto annotation = hint_annotation(logger, hint, hint_annotation(logger, emit, fallback_annotation));
                 logger.emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
             }
             return;

--- a/gcs/innards/proofs/infer_explicitly.hh
+++ b/gcs/innards/proofs/infer_explicitly.hh
@@ -1,0 +1,162 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_INFER_EXPLICITLY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_INFER_EXPLICITLY_HH
+
+#include <gcs/expression.hh>
+#include <gcs/innards/assertion_hints.hh>
+#include <gcs/innards/justification.hh>
+#include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/pseudo_boolean.hh>
+#include <gcs/innards/proofs/simplify_literal.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <string_view>
+
+#include <util/overloaded.hh>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Build the assertion annotation for a typed hint.
+     *
+     * Shared by JustifyUsingRUP and JustifyExplicitly: the hint axis is the same for
+     * both. Three tiers, resolved at compile time on the hint type:
+     *
+     *   - if the hint has a \c hint_sexpr overload (found by ADL) it is a structured
+     *     hint: emit the coarse \c hint_name plus the serialised fields;
+     *   - else if it carries a (non-empty) \c hint_name member it is a coarse hint:
+     *     emit just that name;
+     *   - else (NoHint, an empty name, or a bare emit closure) fall back to the
+     *     supplied annotation.
+     *
+     * \ingroup Innards
+     */
+    template <typename Hint_>
+    [[nodiscard]] auto hint_annotation(ProofLogger & logger, const Hint_ & hint,
+        const std::optional<AssertionAnnotation> & fallback) -> std::optional<AssertionAnnotation>
+    {
+        if constexpr (requires { hint_sexpr(hint, logger.names_and_ids_tracker()); }) {
+            return AssertionAnnotation{.hint_name = hint.hint_name,
+                .hint_fields = hint_sexpr(hint, logger.names_and_ids_tracker())};
+        }
+        else if constexpr (requires { std::string_view{hint.hint_name}; }) {
+            if (! std::string_view{hint.hint_name}.empty())
+                return AssertionAnnotation{.hint_name = hint.hint_name};
+            else
+                return fallback;
+        }
+        else {
+            return fallback;
+        }
+    }
+
+    /**
+     * \brief Resolve the assertion annotation for a JustifyExplicitly inference.
+     *
+     * Precedence: the explicit \c hint wins if it advertises anything; otherwise the
+     * \c emit's own advertisement is used (a named fat witness that carries its own
+     * \c hint_sexpr / \c hint_name); otherwise the call site's \c fallback. A bare
+     * emit closure advertises nothing, so a closure with no hint resolves straight to
+     * the fallback. This reproduces the old witness-carried annotation exactly while
+     * letting an inline closure carry a separate ModelName / structured hint.
+     *
+     * \ingroup Innards
+     */
+    template <typename Hint_, typename Emit_>
+    [[nodiscard]] auto resolve_annotation(ProofLogger & logger, const Hint_ & hint, const Emit_ & emit,
+        const std::optional<AssertionAnnotation> & fallback) -> std::optional<AssertionAnnotation>
+    {
+        return hint_annotation(logger, hint, hint_annotation(logger, emit, fallback));
+    }
+
+    /**
+     * \brief Emit a JustifyExplicitly's explicit proof steps.
+     *
+     * The \c emit is either a `(const ReasonLiterals &) -> void` callable (an inline
+     * lambda, the common case) or a named struct providing an \c emit_justification
+     * overload by ADL (a fat witness stored in a reification verdict, where the
+     * logger is necessarily deferred to emit time because a lambda type cannot be
+     * named in the verdict's return type). Dispatch is compile time.
+     *
+     * \ingroup Innards
+     */
+    template <typename Emit_>
+    auto emit_explicit_steps(ProofLogger & logger, const Emit_ & emit, const ReasonLiterals & reason) -> void
+    {
+        if constexpr (requires { emit(reason); })
+            emit(reason);
+        else
+            emit_justification(logger, emit, reason);
+    }
+
+    /**
+     * \brief The mode-dispatched back end for a JustifyExplicitly inference.
+     *
+     * The explicit-steps counterpart to ProofLogger::infer's plain arms, taking the
+     * emit and the assertion hint as separate arguments (rather than a std::function
+     * or a single bundled justification struct):
+     *
+     *   - above AssertionLevel::Inferences: nothing (the inference is not asserted);
+     *   - assertion mode: assert the inference under its reason, annotated by
+     *     resolve_annotation;
+     *   - eager mode: run the explicit steps at a temporary level, then RUP the
+     *     inference under the reason when \c then_rup is ThenRUP::Yes.
+     *
+     * A NotInRange conclusion that cannot become a single range literal falls back
+     * to one per-value inference, exactly as ProofLogger::infer does.
+     *
+     * Only ever reached with a non-null logger (the Simple tracker never builds or
+     * consumes the emit/hint), so this is pure proof-on work.
+     *
+     * \ingroup Innards
+     */
+    template <typename Emit_, typename Hint_>
+    auto infer_explicitly(ProofLogger & logger, const Literal & lit, const Emit_ & emit, ThenRUP then_rup,
+        const ReasonLiterals & reason, const Hint_ & hint,
+        const std::optional<AssertionAnnotation> & fallback_annotation = std::nullopt) -> void
+    {
+        if (const auto * cond = std::get_if<IntegerVariableCondition>(&lit))
+            if (cond->op == VariableConditionOperator::NotInRange) {
+                auto needs_per_value_fallback = overloaded{
+                    [&](const SimpleIntegerVariableID & v) { return ! logger.names_and_ids_tracker().has_bit_representation(v); },
+                    [&](const ViewOfIntegerVariableID &) { return true; },
+                    [&](const ConstantIntegerVariableID &) { return false; }}
+                                                    .visit(cond->var);
+                if (needs_per_value_fallback) {
+                    for (Integer val = cond->value; val <= cond->upper_value; ++val)
+                        infer_explicitly(logger, cond->var != val, emit, then_rup, reason, hint, fallback_annotation);
+                    return;
+                }
+            }
+
+        if (logger.get_assertion_level() > AssertionLevel::Inferences)
+            return;
+
+        if (logger.get_assertion_level() != AssertionLevel::Off) {
+            if (! is_literally_true(lit)) {
+                auto annotation = resolve_annotation(logger, hint, emit, fallback_annotation);
+                logger.emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
+            }
+            return;
+        }
+
+        if (then_rup == ThenRUP::Yes) {
+            overloaded{
+                [&](const TrueLiteral &) {},
+                [&](const FalseLiteral &) {},
+                [&]<typename T_>(const VariableConditionFrom<T_> & cond) { logger.names_and_ids_tracker().need_proof_name(cond); }}
+                .visit(simplify_literal(logger.names_and_ids_tracker(), lit));
+        }
+        auto t = logger.temporary_proof_level();
+        emit_explicit_steps(logger, emit, reason);
+        if (then_rup == ThenRUP::Yes)
+            logger.infer(lit, JustifyUsingRUP{}, reason);
+        logger.forget_proof_level(t);
+    }
+}
+
+#endif

--- a/gcs/innards/proofs/infer_explicitly.hh
+++ b/gcs/innards/proofs/infer_explicitly.hh
@@ -83,7 +83,7 @@ namespace gcs::innards
      *
      *   - above AssertionLevel::Inferences: nothing (the inference is not asserted);
      *   - assertion mode: assert the inference under its reason, annotated by
-     *     resolve_annotation;
+     *     the resolved hint (explicit hint, else emit's own, else the fallback);
      *   - eager mode: run the explicit steps at a temporary level, then RUP the
      *     inference under the reason when \c then_rup is ThenRUP::Yes.
      *

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1,5 +1,6 @@
 #include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/interval_tree.hh>
+#include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
@@ -714,7 +715,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 return;
 
             ProofRule assert_or_rup = _imp->logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-            auto annotation = AssertionAnnotation{.hint_name = "initial_bound"};
+            auto annotation = AssertionAnnotation{.hint_name = hints::InitialBound::hint_name};
             visit([&](auto id) { _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i, ProofLevel::Top, annotation); }, id);
         }
         else
@@ -750,16 +751,16 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     };
 
     // implied by the next highest gevar, if there is one?
-    auto link_hint = AssertionAnnotation{.hint_name = "bound_link"};
+    auto link_hint = AssertionAnnotation{.hint_name = hints::BoundLink::hint_name};
     if (higher_gevar != other_gevars.end()) {
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) { 
-						if (logger->get_assertion_level() > AssertionLevel::Links)
-							return;
-            			ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
+                emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) {
+                        if (logger->get_assertion_level() > AssertionLevel::Links)
+                            return;
+                        ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+                        logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
                 if (_imp->assertion_level > AssertionLevel::Links) {
@@ -782,11 +783,11 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) { 
-						if (logger->get_assertion_level() > AssertionLevel::Links)
-							return;
-            			ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
+                emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) {
+                        if (logger->get_assertion_level() > AssertionLevel::Links)
+                            return;
+                        ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+                        logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
                 if (_imp->assertion_level > AssertionLevel::Links) {

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1177,11 +1177,9 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
 
     Integer s_coeff = view.negate_first ? -1_i : 1_i;
 
-    auto will_define = true;              // We do need to define views properly in the model!
-    auto [link_le, link_ge] = will_define //
-        ? _imp->model->add_constraint(StringLiteral{"view link"}, StringLiteral{"definitional"},
-              WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add)
-        : make_pair(ProofLine{}, ProofLine{});
+    // Views must be defined properly in the model.
+    auto [link_le, link_ge] = _imp->model->add_constraint(StringLiteral{"view link"}, StringLiteral{"definitional"},
+        WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add);
 
     _imp->view_proof_only_vars.emplace(view, v_id);
     _imp->view_proof_only_to_view.emplace(v_id, view);

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -714,7 +714,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 return;
 
             ProofRule assert_or_rup = _imp->logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-            auto annotation = AssertionAnnotation{.hint_name = AssertionHintName::InitialBound};
+            auto annotation = AssertionAnnotation{.hint_name = "initial_bound"};
             visit([&](auto id) { _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i, ProofLevel::Top, annotation); }, id);
         }
         else
@@ -750,7 +750,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     };
 
     // implied by the next highest gevar, if there is one?
-    auto link_hint = AssertionAnnotation{.hint_name = AssertionHintName::BoundLink};
+    auto link_hint = AssertionAnnotation{.hint_name = "bound_link"};
     if (higher_gevar != other_gevars.end()) {
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1,9 +1,12 @@
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/interval_tree.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_line-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/proof_only_variables-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/variable_id_utils.hh>
@@ -12,6 +15,7 @@
 #include <cstdlib>
 #include <exception>
 #include <fstream>
+#include <gcs/proof.hh>
 #include <list>
 #include <map>
 #include <set>
@@ -136,12 +140,14 @@ struct NamesAndIDsTracker::Imp
     bool first_varmap_entry = true;
     bool finalised = false;
     bool verbose_names;
+    AssertionLevel assertion_level = AssertionLevel::Off;
 };
 
 NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) :
     _imp(make_unique<Imp>())
 {
     _imp->verbose_names = proof_options.verbose_names;
+    _imp->assertion_level = proof_options.assertion_level;
 
     if (proof_options.proof_file_names.variables_map_file) {
         _imp->variables_map_file_name = *proof_options.proof_file_names.variables_map_file;
@@ -518,7 +524,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     ProofLine forwards_line, reverse_line;
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first == v) {
         // it's a lower bound
-        if (_imp->logger) {
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i,
                     id == v, ProofLevel::Top);
@@ -527,7 +533,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             },
                 id);
         }
-        else {
+        else if (! _imp->logger) {
             visit([&](const auto & id) {
                 forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
                 reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
@@ -538,7 +544,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second == v) {
         // it's an upper bound
-        if (_imp->logger) {
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, ProofLevel::Top);
                 forwards_line = _f_line;
@@ -546,7 +552,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             },
                 id);
         }
-        else {
+        else if (! _imp->logger) {
             visit([&](const auto & id) {
                 forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
                 reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
@@ -557,7 +563,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
     else {
         // neither a lower nor an upper bound
-        if (_imp->logger)
+        if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links)
             visit([&](const auto & id) {
                 auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(
                     WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i,
@@ -566,7 +572,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
                 reverse_line = _r_line;
             },
                 id);
-        else {
+        else if (! _imp->logger) {
             visit([&](const auto & id) {
                 forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
                 reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
@@ -606,12 +612,27 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             ProofVariableCondition v_cond{*pid_ptr, VariableConditionOperator::Equal, v};
             IntegerVariableID x_var{view.actual_variable};
             auto x_cond = (x_var == x_threshold);
+            // Always queue this (it delays to proof start when the logger
+            // isn't attached yet during model building); decide whether to
+            // emit based on using_assertions() *inside* the lambda, when the
+            // logger definitely exists. Guarding on _imp->logger out here
+            // drops the step entirely during model building, losing the
+            // channelling between the proof-only encoding and the actual
+            // variable. See the matching pattern in need_gevar's bound links.
             emit_proof_line_now_or_at_start([v_cond, x_cond](ProofLogger * const logger) {
-                logger->emit_rup_proof_line(WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top);
-                logger->emit_rup_proof_line(WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top);
+                if (logger->get_assertion_level() > AssertionLevel::Links)
+                    return;
+
+                auto assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top);
+                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top);
             });
         }
     }
+
+    // Nothing beyond this point needs to be emmitted at AssertionLevel::Links
+    if (_imp->assertion_level > AssertionLevel::Links)
+        return;
 
     // Reverse direction: see the matching block in need_gevar above.
     if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
@@ -654,11 +675,12 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     _imp->variable_conditions_to_x.emplace(id < v, ! gevar);
 
     // gevar -> bits
-    if (_imp->logger) {
-        _imp->gevars_that_exist[id].emplace(v, visit([&](const auto & id) {
-            return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Top);
-        },
-                                                   id));
+    if (_imp->logger && _imp->assertion_level > AssertionLevel::Definitions) {
+        _imp->gevars_that_exist[id].emplace(v, make_pair(ProofLine{}, ProofLine{})); // Don't output geqvar definitions if using assertions
+    }
+    else if (_imp->logger) {
+        auto def_lines = visit([&](const auto & id) { return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Top); }, id);
+        _imp->gevars_that_exist[id].emplace(v, def_lines);
     }
     else {
         // Label the two halves @i[name][ge<v>][f]/[r] to match cake_pb_cp, but
@@ -686,20 +708,27 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     // is it a bound?
     auto bounds = _imp->integer_variable_definition_bounds.find(id);
 
+    auto fix_bound = [&](bool negated) {
+        if (_imp->logger) {
+            if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+                return;
+
+            ProofRule assert_or_rup = _imp->logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+            auto annotation = AssertionAnnotation{.hint_name = AssertionHintName::InitialBound};
+            visit([&](auto id) { _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i, ProofLevel::Top, annotation); }, id);
+        }
+        else
+            visit([&](auto id) { _imp->model->add_constraint(WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i); }, id);
+    };
+
     // lower?
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first >= v) {
-        if (_imp->logger)
-            visit([&](auto id) { _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * (id >= v) >= 1_i, ProofLevel::Top); }, id);
-        else
-            visit([&](auto id) { _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i); }, id);
+        fix_bound(false);
     }
 
     // upper?
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second < v) {
-        if (_imp->logger)
-            visit([&](auto id) { _imp->logger->emit_rup_proof_line(WPBSum{} + 1_i * ! (id >= v) >= 1_i, ProofLevel::Top); }, id);
-        else
-            visit([&](auto id) { _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i); }, id);
+        fix_bound(true);
     }
 
     auto & other_gevars = _imp->gevars_that_exist.at(id);
@@ -721,15 +750,29 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     };
 
     // implied by the next highest gevar, if there is one?
+    auto link_hint = AssertionAnnotation{.hint_name = AssertionHintName::BoundLink};
     if (higher_gevar != other_gevars.end()) {
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con](ProofLogger * const logger) { logger->emit_rup_proof_line(c, ProofLevel::Top); });
+                emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) { 
+						if (logger->get_assertion_level() > AssertionLevel::Links)
+							return;
+            			ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
-                auto pol = make_pol_chain_line(id >= v, ! (id >= higher_gevar->first));
-                emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                if (_imp->assertion_level > AssertionLevel::Links) {
+                    return;
+                }
+                else if (_imp->assertion_level == AssertionLevel::Links) {
+                    auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
+                    emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
+                }
+                else {
+                    auto pol = make_pol_chain_line(id >= v, ! (id >= higher_gevar->first));
+                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                }
             }}
             .visit(id);
     }
@@ -739,11 +782,24 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con](ProofLogger * const logger) { logger->emit_rup_proof_line(c, ProofLevel::Top); });
+                emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) { 
+						if (logger->get_assertion_level() > AssertionLevel::Links)
+							return;
+            			ProofRule assert_or_rup = logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+						logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint); });
             },
             [&](const SimpleIntegerVariableID & id) {
-                auto pol = make_pol_chain_line(id >= prev(this_gevar)->first, ! (id >= v));
-                emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                if (_imp->assertion_level > AssertionLevel::Links) {
+                    return;
+                }
+                else if (_imp->assertion_level == AssertionLevel::Links) {
+                    auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
+                    emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
+                }
+                else {
+                    auto pol = make_pol_chain_line(id >= prev(this_gevar)->first, ! (id >= v));
+                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                }
             }}
             .visit(id);
     }
@@ -769,12 +825,29 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     // Both lines queued via emit_proof_line_now_or_at_start so they land at
     // the top of the proof, alongside the standard order-encoding chain
     // links, rather than as extra OPB axioms.
+    if (_imp->assertion_level > AssertionLevel::Links)
+        return;
+
     if (auto pid_ptr = std::get_if<ProofOnlySimpleIntegerVariableID>(&id)) {
         auto view_it = _imp->view_proof_only_to_view.find(*pid_ptr);
         if (view_it != _imp->view_proof_only_to_view.end()) {
             const auto & view = view_it->second;
             Integer x_threshold = view.negate_first ? view.then_add - v + 1_i : v - view.then_add;
             need_gevar(view.actual_variable, x_threshold);
+            if (_imp->assertion_level == AssertionLevel::Links) {
+                // Definitions are omitted at this level, instead assert the view links that the
+                // pol lines below would derive.
+                auto v_atom = (*pid_ptr >= v);
+                auto x_atom = (view.actual_variable >= x_threshold);
+                auto x_cond = view.negate_first ? ! x_atom : x_atom;
+                auto d1 = WPBSum{} + 1_i * ! v_atom + 1_i * x_cond >= 1_i;
+                auto d2 = WPBSum{} + 1_i * ! x_cond + 1_i * v_atom >= 1_i;
+                emit_proof_line_now_or_at_start([d1, d2, link_hint](ProofLogger * const logger) {
+                    logger->emit(AssertProofRule{}, d1, ProofLevel::Top, link_hint);
+                    logger->emit(AssertProofRule{}, d2, ProofLevel::Top, link_hint);
+                });
+                return;
+            }
 
             auto v_defs = _imp->gevars_that_exist[id].at(v);
             auto x_defs = _imp->gevars_that_exist[SimpleOrProofOnlyIntegerVariableID{view.actual_variable}].at(x_threshold);
@@ -820,7 +893,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
 
 auto NamesAndIDsTracker::link_immediate_containment(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void
 {
-    if (! _imp->logger)
+    if (! _imp->logger || _imp->logger->get_assertion_level() > AssertionLevel::Links) // Should be unreachable at AssertionLevel::Links anyway
         return;
 
     auto tree_it = _imp->containment_trees.find(id);
@@ -892,11 +965,20 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     _imp->variable_conditions_to_x.emplace(in_range(id, lo, hi), x);
     _imp->variable_conditions_to_x.emplace(not_in_range(id, lo, hi), ! x);
 
-    auto lines = visit([&](const auto & id) {
-        return _imp->logger->emit_red_proof_lines_reifying(
-            WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, in_range(id, lo, hi), ProofLevel::Top);
-    },
-        id);
+    auto will_define = _imp->logger->get_assertion_level() <= AssertionLevel::Links;
+    // Struggling to get clang-format to behave here...
+    auto lines = will_define //
+        ? visit([&](const auto & id) {
+              return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * (id >= lo)) + (1_i * ! (id > hi)) >= 2_i, in_range(id, lo, hi), ProofLevel::Top);
+          },
+              id)
+        : make_pair(ProofLine{}, ProofLine{});
+
+    _imp->invars_that_exist[id].emplace(pair{lo, hi}, lines);
+
+    // No containment tree apparatus needed at higher assertion levels.
+    if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+        return;
 
     // Containment edges let a rejected literal propagate down to the literals a
     // conflict is written over; the order chain alone does not give this. The
@@ -910,8 +992,6 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     }
     link_immediate_containment(id, lo, hi);
     _imp->containment_trees[id].insert(lo, hi);
-
-    _imp->invars_that_exist[id].emplace(pair{lo, hi}, lines);
 }
 
 auto NamesAndIDsTracker::append_cell_literal_to(WPBSum & sum, SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> void
@@ -927,6 +1007,9 @@ auto NamesAndIDsTracker::append_cell_literal_to(WPBSum & sum, SimpleOrProofOnlyI
 
 auto NamesAndIDsTracker::ensure_partition_cut(SimpleOrProofOnlyIntegerVariableID id, Integer p) -> void
 {
+    if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+        return;
+
     auto & boundaries = _imp->interval_partitions.at(id);
     if (boundaries.contains(p))
         return;
@@ -961,6 +1044,9 @@ auto NamesAndIDsTracker::ensure_partition_cut(SimpleOrProofOnlyIntegerVariableID
 
 auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariableID id, Integer request_lo, Integer request_hi) -> void
 {
+    if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+        return;
+
     auto [lb, ub] = _imp->integer_variable_definition_bounds.at(id);
     auto & boundaries = _imp->interval_partitions[id];
     boundaries.insert(lb);
@@ -1024,9 +1110,10 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
     auto [lb, ub] = _imp->integer_variable_definition_bounds.at(id);
     auto span_lo = max(lo, lb), span_hi = min(hi, ub);
 
-    if (span_lo > span_hi) {
+    if (span_lo > span_hi || _imp->assertion_level > AssertionLevel::Links) {
         // Entirely outside: the reification plus the bound axioms already falsify
-        // it, so there is nothing to cover.
+        // it, so there is nothing to cover;
+        // ...OR we are at a higher assertion level that doesn't need covering apparatus in the first place.
         define_plain_invar(id, lo, hi);
         return as_literal();
     }
@@ -1088,13 +1175,20 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
         v_lo, v_hi, name, IntegerVariableProofRepresentation::Bits);
 
     Integer s_coeff = view.negate_first ? -1_i : 1_i;
-    auto [link_le, link_ge] = _imp->model->add_constraint(StringLiteral{"view link"}, StringLiteral{"definitional"},
-        WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add);
+
+    auto will_define = true;              // We do need to define views properly in the model!
+    auto [link_le, link_ge] = will_define //
+        ? _imp->model->add_constraint(StringLiteral{"view link"}, StringLiteral{"definitional"},
+              WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add)
+        : make_pair(ProofLine{}, ProofLine{});
 
     _imp->view_proof_only_vars.emplace(view, v_id);
     _imp->view_proof_only_to_view.emplace(v_id, view);
     _imp->view_link_ids.emplace(v_id, pair{link_le, link_ge});
     _imp->views_of_variable[view.actual_variable].push_back(v_id);
+
+    if (_imp->assertion_level > AssertionLevel::Links) // No further linking needed at higher assertion levels.
+        return v_id;
 
     // Backfill: if X atoms already exist when this view is registered,
     // trigger the matching V atoms now so the V<->X link is emitted for
@@ -1193,6 +1287,8 @@ auto NamesAndIDsTracker::derive_deviewed_form_for(const ProofLine & v_form_line,
     if (view_contributions.empty())
         return;
 
+    if (_imp->assertion_level > AssertionLevel::Links)
+        return;
     // Build the pol expression. For each view contribution:
     //   opb_form_coefficient > 0 (positive V in OPB):  add `|coeff| * link_le`.
     //   opb_form_coefficient < 0 (negative V in OPB):  add `|coeff| * link_ge`.
@@ -1329,6 +1425,28 @@ auto NamesAndIDsTracker::pb_file_string_for(const XLiteral & lit) const -> strin
 auto NamesAndIDsTracker::pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> string
 {
     return pb_file_string_for(xliteral_for(cond));
+}
+
+auto NamesAndIDsTracker::bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> string
+{
+    auto it = _imp->integer_variable_bits_to_size_and_proof_vars.find(var);
+    if (it == _imp->integer_variable_bits_to_size_and_proof_vars.end())
+        throw ProofError("missing bits");
+
+    const auto & [negative_coeff, bits] = it->second;
+
+    bool sign_bit_set = (negative_coeff != 0_i) && (value < 0_i);
+    Integer remainder = sign_bit_set ? value - negative_coeff : value;
+
+    string result;
+    for (const auto & [coeff, lit] : bits) {
+        bool bit_is_one = (coeff < 0_i) ? sign_bit_set : ((remainder / coeff) % 2_i == 1_i);
+        if (! result.empty())
+            result += " ";
+        result += pb_file_string_for(bit_is_one ? lit : ! lit);
+    }
+
+    return result;
 }
 
 auto NamesAndIDsTracker::xliteral_for(const ProofFlag & flag) const -> const XLiteral

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/proofs/reification.hh>
@@ -318,6 +319,11 @@ namespace gcs::innards
          * Return a string form of a raw proof literal, for writing to a model or log.
          */
         [[nodiscard]] auto pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> std::string;
+
+        /**
+         * Return a string form of the exact literals specifying a bit assignment for var == val, an alternative way to witness solutions.
+         */
+        [[nodiscard]] auto bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> std::string;
 
         /**
          * Return the raw proof literal representing a proof flag, for writing to a model or log.

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -207,7 +207,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
     if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
         // soli and no links => have to assert the objective improving constraint
         visit([&](const auto & id) {
-            emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = AssertionHintName::SoliImprove});
+            emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = "soli_improve"});
         },
             optional_minimise_variable_and_value->first);
     else if (optional_minimise_variable_and_value)
@@ -222,7 +222,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             optional_minimise_variable_and_value->first);
     else if (_imp->assertion_level > AssertionLevel::Definitions) {
         // solx and no links => have to assert the blocking constraint
-        emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = AssertionHintName::SolxBlock});
+        emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = "solx_block"});
     }
     // nothing needs done for solx below AssertionLevel::Links
 }
@@ -234,7 +234,7 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     for (const auto & guess : guesses)
         backtrack += 1_i * ! guess;
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-    emit(assert_or_rup, move(backtrack) >= 1_i, ProofLevel::Current, AssertionAnnotation{.hint_name = AssertionHintName::Backtrack});
+    emit(assert_or_rup, move(backtrack) >= 1_i, ProofLevel::Current, AssertionAnnotation{.hint_name = "backtrack"});
 }
 
 auto ProofLogger::end_proof() -> void
@@ -296,7 +296,7 @@ auto ProofLogger::conclude_none() -> void
 }
 
 auto ProofLogger::infer(const Literal & lit, const Justification & why,
-    const ReasonFunction & reason, const optional<AssertionAnnotation> & annotation) -> void
+    const ReasonLiterals & reason, const optional<AssertionAnnotation> & annotation) -> void
 {
     // A range conclusion on a view (folding views into the interval machinery is
     // deferred) or on a plain variable without a bits encoding (no order cuts to
@@ -318,20 +318,15 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
             }
         }
 
-    auto need_lit = [&]() {
-        overloaded{
-            [&](const TrueLiteral &) {},
-            [&](const FalseLiteral &) {},
-            [&]<typename T_>(const VariableConditionFrom<T_> & cond) { names_and_ids_tracker().need_proof_name(cond); }}
-            .visit(simplify_literal(names_and_ids_tracker(), lit));
-    };
-
     if (_imp->assertion_level > AssertionLevel::Inferences)
         return;
 
     if (_imp->assertion_level != AssertionLevel::Off) {
         // At AssertionLevel::Definitions we can assert some inferences and not others (since the needed constraints for the justifications will
         // still be present). At higher levels, we need to assert all inferences.
+        // Explicit-steps justifications are JustifyExplicitly, handled by
+        // infer_explicitly(); this variant only carries the plain ones, so the
+        // annotation is just the one passed in.
         if (! is_literally_true(lit) && ! std::holds_alternative<NoJustificationNeeded>(why)) {
             emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
         }
@@ -339,7 +334,7 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
     }
 
     overloaded{
-        [&]([[maybe_unused]] const JustifyUsingRUP & j) {
+        [&]([[maybe_unused]] const JustifyUsingRUP<NoHint> & j) {
             if (! is_literally_true(lit)) {
                 emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current);
             }
@@ -349,43 +344,14 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
                 emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason);
             }
         },
-        [&](const JustifyExplicitlyOnly & x) {
-            auto t = temporary_proof_level();
-            x.add_proof_steps(reason);
-            forget_proof_level(t);
-        },
-        [&](const JustifyExplicitlyThenRUP & x) {
-            need_lit();
-            auto t = temporary_proof_level();
-            x.add_proof_steps(reason);
-            infer(lit, JustifyUsingRUP{}, reason);
-            forget_proof_level(t);
-        },
         [&](const NoJustificationNeeded &) {
         }}
         .visit(why);
 }
 
-auto ProofLogger::reason_to_lits(const ReasonFunction & reason) -> Reason
-{
-    optional<Reason> reason_literals;
-    if (reason)
-        reason_literals = reason();
-
-    if (reason_literals)
-        names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
-
-    return *reason_literals;
-}
-
 auto ProofLogger::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif) -> WPBSumLE
 {
     return names_and_ids_tracker().reify(ineq, half_reif);
-}
-
-auto ProofLogger::reify(const WPBSumLE & ineq, const ReasonFunction & reason) -> WPBSumLE
-{
-    return names_and_ids_tracker().reify(ineq, reason_to_lits(reason));
 }
 
 auto ProofLogger::emit_proof_line(const string & s, ProofLevel level) -> ProofLine
@@ -460,13 +426,10 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
 
 auto ProofLogger::emit_under_reason(
     const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
-    ProofLevel level, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
+    ProofLevel level, const ReasonLiterals & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
-    optional<Reason> reason_literals;
-    if (reason)
-        reason_literals = reason();
-    if (reason_literals)
-        names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
+    if (! reason.empty())
+        names_and_ids_tracker().need_all_proof_names_in(reason);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
 
@@ -480,8 +443,8 @@ auto ProofLogger::emit_under_reason(
                      .visit(rule)
               << " ";
 
-    if (reason_literals) {
-        emit_inequality_to(names_and_ids_tracker(), reify(ineq, *reason_literals), rule_line);
+    if (! reason.empty()) {
+        emit_inequality_to(names_and_ids_tracker(), reify(ineq, reason), rule_line);
     }
     else {
         emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);
@@ -520,13 +483,13 @@ auto ProofLogger::emit_rup_proof_line(const SumLessThanEqual<Weighted<PseudoBool
     return emit(RUPProofRule{}, ineq, level);
 }
 
-auto ProofLogger::emit_rup_proof_line_under_reason(const ReasonFunction & reason, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
+auto ProofLogger::emit_rup_proof_line_under_reason(const ReasonLiterals & reason, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
     ProofLevel level) -> ProofLine
 {
     return emit_under_reason(RUPProofRule{}, ineq, level, reason);
 }
 
-auto ProofLogger::emit_rup_proof_line_under_reason_then_deview(const ReasonFunction & reason,
+auto ProofLogger::emit_rup_proof_line_under_reason_then_deview(const ReasonLiterals & reason,
     const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> ProofLine
 {
     auto v_form_line = emit_rup_proof_line_under_reason(reason, ineq, level);

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -3,6 +3,7 @@
 #include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/interval_set.hh>
 #include <gcs/innards/proofs/emit_inequality_to.hh>
+#include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
@@ -207,7 +208,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
     if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
         // soli and no links => have to assert the objective improving constraint
         visit([&](const auto & id) {
-            emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = "soli_improve"});
+            emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = hints::SoliImprove::hint_name});
         },
             optional_minimise_variable_and_value->first);
     else if (optional_minimise_variable_and_value)
@@ -222,7 +223,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             optional_minimise_variable_and_value->first);
     else if (_imp->assertion_level > AssertionLevel::Definitions) {
         // solx and no links => have to assert the blocking constraint
-        emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = "solx_block"});
+        emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = hints::SolxBlock::hint_name});
     }
     // nothing needs done for solx below AssertionLevel::Links
 }
@@ -234,7 +235,7 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     for (const auto & guess : guesses)
         backtrack += 1_i * ! guess;
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-    emit(assert_or_rup, move(backtrack) >= 1_i, ProofLevel::Current, AssertionAnnotation{.hint_name = "backtrack"});
+    emit(assert_or_rup, move(backtrack) >= 1_i, ProofLevel::Current, AssertionAnnotation{.hint_name = hints::Backtrack::hint_name});
 }
 
 auto ProofLogger::end_proof() -> void
@@ -408,10 +409,10 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
             }
         },
         [&](const AssertProofRule &) {
-			if (assertion_hint) {
-				rule_line << *assertion_hint;
-	 		}
-			rule_line << ";"; }}
+            if (assertion_hint) {
+                rule_line << *assertion_hint;
+            }
+            rule_line << ";"; }}
         .visit(rule);
 
     auto line = emit_proof_line(rule_line.str(), level);
@@ -452,25 +453,25 @@ auto ProofLogger::emit_under_reason(
 
     overloaded{
         [&](const RUPProofRule & rule) {
-			if(rule.lines) {
-				rule_line << ": ";
-				for (const auto & line : *rule.lines) {
-					rule_line << relative_proof_line(line, _imp->proof_line.number) << " ";
-				}
-				rule_line << " ;";
-			} else {
-				rule_line << ";"; } },
+            if(rule.lines) {
+                rule_line << ": ";
+                for (const auto & line : *rule.lines) {
+                    rule_line << relative_proof_line(line, _imp->proof_line.number) << " ";
+                }
+                rule_line << " ;";
+            } else {
+                rule_line << ";"; } },
         [&](const ImpliesProofRule & rule) { if (rule.line) {
-				rule_line << ": ";
-				rule_line << relative_proof_line(*rule.line, _imp->proof_line.number) << " ";
-				rule_line << " ;";
-			} else { rule_line << ";"; } },
-        [&](const AssertProofRule &) { 
-			if (assertion_hint) {
-				rule_line << *assertion_hint;
-	 		}
+                rule_line << ": ";
+                rule_line << relative_proof_line(*rule.line, _imp->proof_line.number) << " ";
+                rule_line << " ;";
+            } else { rule_line << ";"; } },
+        [&](const AssertProofRule &) {
+            if (assertion_hint) {
+                rule_line << *assertion_hint;
+            }
 
-			rule_line << ";"; }}
+            rule_line << ";"; }}
         .visit(rule);
 
     auto line = emit_proof_line(rule_line.str(), level);

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -1,19 +1,26 @@
 #include <cstdio>
+#include <gcs/expression.hh>
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/interval_set.hh>
 #include <gcs/innards/proofs/emit_inequality_to.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/proof.hh>
 
 #include <cstddef>
 #include <cstdlib>
 #include <deque>
 #include <fstream>
+#include <optional>
 #include <sstream>
 
+#include <variant>
 #include <version>
 #ifdef __cpp_lib_stacktrace
 #include <stacktrace>
@@ -110,6 +117,7 @@ struct ProofLogger::Imp
     string proof_file;
     fstream proof;
     int current_indent = 0;
+    AssertionLevel assertion_level;
 
     Imp(NamesAndIDsTracker & t) :
         tracker(t)
@@ -122,6 +130,7 @@ ProofLogger::ProofLogger(const ProofOptions & proof_options, NamesAndIDsTracker 
 {
     _imp->proof_file = proof_options.proof_file_names.proof_file;
     _imp->proof_lines_by_level.resize(2);
+    _imp->assertion_level = proof_options.assertion_level;
 }
 
 ProofLogger::~ProofLogger() = default;
@@ -167,22 +176,42 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
 
     _imp->proof << (optional_minimise_variable_and_value ? "soli" : "solx");
 
-    for (const auto & [var, val] : all_variables_and_values)
+    WPBSum blocking_sum{};
+
+    for (const auto & [var, val] : all_variables_and_values) {
+        if (! optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
+            blocking_sum += 1_i * (var != val);
+
         overloaded{
             [&](const ConstantIntegerVariableID &) {
             },
             [&](const SimpleIntegerVariableID & var) {
-                _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(var == val);
+                if (_imp->assertion_level > AssertionLevel::Definitions)
+                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(var, val);
+                else
+                    _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(var == val);
             },
             [&](const ViewOfIntegerVariableID & var) {
-                _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(deview(var == val));
+                if (_imp->assertion_level > AssertionLevel::Definitions) {
+                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(*names_and_ids_tracker().find_view(var), val);
+                }
+                else
+                    _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(deview(var == val));
             }}
             .visit(var);
+    }
 
     _imp->proof << ";\n";
     record_proof_line(advance_proof_line_number(), ProofLevel::Top);
 
-    if (optional_minimise_variable_and_value)
+    if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
+        // soli and no links => have to assert the objective improving constraint
+        visit([&](const auto & id) {
+            emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = AssertionHintName::SoliImprove});
+        },
+            optional_minimise_variable_and_value->first);
+    else if (optional_minimise_variable_and_value)
+        // normal soli, emit e line for trimmer
         visit([&](const auto & id) {
             _imp->proof << "e ";
             emit_inequality_to(names_and_ids_tracker(), WPBSum{} + 1_i * id <= optional_minimise_variable_and_value->second - 1_i, _imp->proof);
@@ -191,6 +220,11 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
         },
             optional_minimise_variable_and_value->first);
+    else if (_imp->assertion_level > AssertionLevel::Definitions) {
+        // solx and no links => have to assert the blocking constraint
+        emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = AssertionHintName::SolxBlock});
+    }
+    // nothing needs done for solx below AssertionLevel::Links
 }
 
 auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
@@ -199,7 +233,8 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     WPBSum backtrack;
     for (const auto & guess : guesses)
         backtrack += 1_i * ! guess;
-    emit_rup_proof_line(move(backtrack) >= 1_i, ProofLevel::Current);
+    auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+    emit(assert_or_rup, move(backtrack) >= 1_i, ProofLevel::Current, AssertionAnnotation{.hint_name = AssertionHintName::Backtrack});
 }
 
 auto ProofLogger::end_proof() -> void
@@ -214,8 +249,8 @@ auto ProofLogger::end_proof() -> void
 auto ProofLogger::conclude_unsatisfiable(bool is_optimisation) -> void
 {
     _imp->proof << "% asserting contradiction\n";
-    _imp->proof << "rup >= 1 ;\n";
-    record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+    auto assert_or_rup = _imp->assertion_level >= AssertionLevel::Inferences ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+    emit(assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Top);
     _imp->proof << "output NONE;\n";
     if (is_optimisation)
         _imp->proof << "conclusion BOUNDS INF INF;\n";
@@ -261,7 +296,7 @@ auto ProofLogger::conclude_none() -> void
 }
 
 auto ProofLogger::infer(const Literal & lit, const Justification & why,
-    const ReasonFunction & reason) -> void
+    const ReasonFunction & reason, const optional<AssertionAnnotation> & annotation) -> void
 {
     // A range conclusion on a view (folding views into the interval machinery is
     // deferred) or on a plain variable without a bits encoding (no order cuts to
@@ -291,51 +326,27 @@ auto ProofLogger::infer(const Literal & lit, const Justification & why,
             .visit(simplify_literal(names_and_ids_tracker(), lit));
     };
 
+    if (_imp->assertion_level > AssertionLevel::Inferences)
+        return;
+
+    if (_imp->assertion_level != AssertionLevel::Off) {
+        // At AssertionLevel::Definitions we can assert some inferences and not others (since the needed constraints for the justifications will
+        // still be present). At higher levels, we need to assert all inferences.
+        if (! is_literally_true(lit) && ! std::holds_alternative<NoJustificationNeeded>(why)) {
+            emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
+        }
+        return;
+    }
+
     overloaded{
         [&]([[maybe_unused]] const JustifyUsingRUP & j) {
-            log_stacktrace();
-            need_lit();
-            optional<Reason> reason_literals;
-            if (reason)
-                reason_literals = reason();
-
-            if (reason_literals)
-                names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
-
             if (! is_literally_true(lit)) {
-                WPBSum terms;
-                HalfReifyOnConjunctionOf reif{};
-                if (reason_literals)
-                    reif = *reason_literals;
-
-                terms += 1_i * lit;
-                write_indent();
-                _imp->proof << "rup ";
-                emit_inequality_to(names_and_ids_tracker(), reify(move(terms) >= 1_i, reif), _imp->proof);
-                _imp->proof << ";\n";
-                record_proof_line(advance_proof_line_number(), ProofLevel::Current);
+                emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current);
             }
         },
         [&]([[maybe_unused]] const AssertRatherThanJustifying & j) {
-            log_stacktrace();
-            need_lit();
-            optional<Reason> reason_literals;
-            if (reason)
-                reason_literals = reason();
-
-            HalfReifyOnConjunctionOf reif{};
-            if (reason_literals) {
-                names_and_ids_tracker().need_all_proof_names_in(*reason_literals);
-                reif = *reason_literals;
-            }
             if (! is_literally_true(lit)) {
-                WPBSum terms;
-                terms += 1_i * lit;
-                write_indent();
-                _imp->proof << "a ";
-                emit_inequality_to(names_and_ids_tracker(), reify(move(terms) >= 1_i, reif), _imp->proof);
-                _imp->proof << ";\n";
-                record_proof_line(advance_proof_line_number(), ProofLevel::Current);
+                emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason);
             }
         },
         [&](const JustifyExplicitlyOnly & x) {
@@ -391,7 +402,7 @@ auto ProofLogger::emit_proof_comment(const string & s) -> void
     _imp->proof << "% " << s << '\n';
 }
 
-auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> ProofLine
+auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     log_stacktrace();
@@ -430,14 +441,18 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
                 rule_line << ";";
             }
         },
-        [&](const AssertProofRule &) { rule_line << ";"; }}
+        [&](const AssertProofRule &) {
+			if (assertion_hint) {
+				rule_line << *assertion_hint;
+	 		}
+			rule_line << ";"; }}
         .visit(rule);
 
     auto line = emit_proof_line(rule_line.str(), level);
     // Note: no automatic deview-derivation here. Runtime RUP/red emissions
     // happen many times per propagator inference and per-call deview
     // derivation explodes proof size on tests with many view-using
-    // constraints. Callers that need the deview-form of a runtime-emitted
+    // constraints. Callers that need the deview-form of a runtime-mitted
     // constraint use the explicit `*_then_deview` variant (see
     // `emit_rup_proof_line_under_reason_then_deview`).
     return line;
@@ -445,7 +460,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
 
 auto ProofLogger::emit_under_reason(
     const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
-    ProofLevel level, const ReasonFunction & reason) -> ProofLine
+    ProofLevel level, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
     optional<Reason> reason_literals;
     if (reason)
@@ -487,7 +502,12 @@ auto ProofLogger::emit_under_reason(
 				rule_line << relative_proof_line(*rule.line, _imp->proof_line.number) << " ";
 				rule_line << " ;";
 			} else { rule_line << ";"; } },
-        [&](const AssertProofRule &) { rule_line << ";"; }}
+        [&](const AssertProofRule &) { 
+			if (assertion_hint) {
+				rule_line << *assertion_hint;
+	 		}
+
+			rule_line << ";"; }}
         .visit(rule);
 
     auto line = emit_proof_line(rule_line.str(), level);
@@ -744,4 +764,9 @@ auto ProofLogger::write_indent() -> void
     for (auto _ = _imp->current_indent; _--;) {
         _imp->proof << ' ';
     }
+}
+
+auto ProofLogger::get_assertion_level() -> AssertionLevel
+{
+    return _imp->assertion_level;
 }

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_LOGGER_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_LOGGER_HH
 
+#include <gcs/innards/assertion_hints.hh>
 #include <gcs/innards/justification.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_line.hh>
@@ -14,6 +15,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace gcs::innards
@@ -129,8 +131,9 @@ namespace gcs::innards
          * variable is a single proof line `~[var in lo..hi] >= 1` emitted under the
          * reason, in place of one `var != v` line per removed value; views and
          * direct-only-encoded variables fall back to per-value emission.
+         * Also pass an assertion annotation.
          */
-        auto infer(const Literal & lit, const Justification & why, const ReasonFunction & reason) -> void;
+        auto infer(const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & annotation = std::nullopt) -> void;
 
         /**
          * \brief Return the current <em>active proof level</em> &mdash; the
@@ -244,12 +247,12 @@ namespace gcs::innards
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level) -> ProofLine;
+        auto emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> ProofLine;
 
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &) -> ProofLine;
+        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &, const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> ProofLine;
 
         /**
          * Emit a RUP proof step for the specified expression, not subject to
@@ -326,6 +329,12 @@ namespace gcs::innards
          * Write a number of spaces equal to current_indent.
          */
         auto write_indent() -> void;
+
+        /**
+         * Get the level enum controlling how much of the proof will be asserted
+         * instead of fully justified.
+         */
+        auto get_assertion_level() -> AssertionLevel;
     };
 }
 

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -170,8 +170,8 @@ namespace gcs::innards
          * grab \c t = \c temporary_proof_level(), emit some Temporary
          * lines, then call \c forget_proof_level(<em>t</em>) to delete
          * just those. Using this pattern inside a context that itself
-         * uses Temporary lines (e.g. inside a \c JustifyExplicitlyThenRUP
-         * callback) is unsafe because the helper's forget will also
+         * uses Temporary lines (e.g. inside a \c JustifyExplicitly
+         * <tt>{…, ThenRUP::Yes}</tt> callback) is unsafe because the helper's forget will also
          * delete the surrounding context's Temporary lines &mdash;
          * isolate via \c enter_proof_level instead.
          */

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -133,7 +133,7 @@ namespace gcs::innards
          * direct-only-encoded variables fall back to per-value emission.
          * Also pass an assertion annotation.
          */
-        auto infer(const Literal & lit, const Justification & why, const ReasonFunction & reason, const std::optional<AssertionAnnotation> & annotation = std::nullopt) -> void;
+        auto infer(const Literal & lit, const Justification & why, const ReasonLiterals & reason, const std::optional<AssertionAnnotation> & annotation = std::nullopt) -> void;
 
         /**
          * \brief Return the current <em>active proof level</em> &mdash; the
@@ -218,21 +218,10 @@ namespace gcs::innards
         auto emit_proof_comment(const std::string &) -> void;
 
         /**
-         * Given a reason, return the vector of literals in the conjunction.
-         */
-        auto reason_to_lits(const ReasonFunction & reason) -> Reason;
-
-        /**
          * Given a PB constraint C and a conjunction of literals L, return the native
          * PB constraint encoding L => C
          */
         auto reify(const WPBSumLE &, const HalfReifyOnConjunctionOf &) -> WPBSumLE;
-
-        /**
-         * Given a PB constraint C and a reason R, return the native
-         * PB constraint encoding R => C
-         */
-        auto reify(const WPBSumLE &, const ReasonFunction &) -> WPBSumLE;
 
         /**
          * Get the current proof line ID (i.e. the next one to be used.
@@ -252,7 +241,7 @@ namespace gcs::innards
         /**
          * Emit a proof step, with a specified rule.
          */
-        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonFunction &, const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> ProofLine;
+        auto emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level, const ReasonLiterals &, const std::optional<AssertionAnnotation> & assertion_hint = std::nullopt) -> ProofLine;
 
         /**
          * Emit a RUP proof step for the specified expression, not subject to
@@ -264,7 +253,7 @@ namespace gcs::innards
          * Emit a RUP proof step for the specified expression, subject to a
          * given reason.
          */
-        auto emit_rup_proof_line_under_reason(const ReasonFunction &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level) -> ProofLine;
+        auto emit_rup_proof_line_under_reason(const ReasonLiterals &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level) -> ProofLine;
 
         /**
          * Like `emit_rup_proof_line_under_reason`, but returns the deview-form
@@ -282,7 +271,7 @@ namespace gcs::innards
          * V-form constraint emitted by the RUP step doesn't match those
          * coefficients and the pol cancellation fails.
          */
-        auto emit_rup_proof_line_under_reason_then_deview(const ReasonFunction &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level) -> ProofLine;
+        auto emit_rup_proof_line_under_reason_then_deview(const ReasonLiterals &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level) -> ProofLine;
 
         /**
          * Emit a RED proof step for the specified expression.

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -1,6 +1,6 @@
 #include <gcs/exception.hh>
-#include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
@@ -99,7 +99,7 @@ auto Propagators::define_bound(const State & state, ProofModel * const optional_
         if (optional_model)
             optional_model->add_constraint(constraint_name, sub_rule, WPBSum{} + 1_i * var >= val);
         install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-            inference.infer(logger, var >= val, JustifyUsingRUP{}, NoReason{});
+            inference.infer(logger, var >= val, JustifyUsingRUP{}, NoReason{}, AssertionAnnotation{.hint_name = hints::InitialBound::hint_name});
         });
         return;
     case Upper:
@@ -108,7 +108,7 @@ auto Propagators::define_bound(const State & state, ProofModel * const optional_
         if (optional_model)
             optional_model->add_constraint(constraint_name, sub_rule, WPBSum{} + 1_i * var <= val);
         install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-            inference.infer(logger, var <= val, JustifyUsingRUP{}, NoReason{});
+            inference.infer(logger, var <= val, JustifyUsingRUP{}, NoReason{}, AssertionAnnotation{.hint_name = hints::InitialBound::hint_name});
         });
         return;
     }
@@ -143,15 +143,6 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
 auto Propagators::install_initialiser(InitialisationFunction && f, InitialiserPriority priority) -> void
 {
     _imp->initialisation_functions_by_priority[to_underlying(priority)].emplace_back(move(f));
-}
-
-auto Propagators::install_initial_contradiction(const string &, Justification why, Reason reason, InitialiserPriority priority) -> void
-{
-    install_initialiser(
-        [why = move(why), reason = move(reason)](const State &, auto & inference, ProofLogger * const logger) -> void {
-            inference.contradiction(logger, why, reason);
-        },
-        priority);
 }
 
 auto Propagators::initialise(State & state, ProofLogger * const logger) const -> bool

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -99,7 +99,7 @@ auto Propagators::define_bound(const State & state, ProofModel * const optional_
         if (optional_model)
             optional_model->add_constraint(constraint_name, sub_rule, WPBSum{} + 1_i * var >= val);
         install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-            inference.infer(logger, var >= val, JustifyUsingRUP{}, ReasonFunction{});
+            inference.infer(logger, var >= val, JustifyUsingRUP{}, NoReason{});
         });
         return;
     case Upper:
@@ -108,7 +108,7 @@ auto Propagators::define_bound(const State & state, ProofModel * const optional_
         if (optional_model)
             optional_model->add_constraint(constraint_name, sub_rule, WPBSum{} + 1_i * var <= val);
         install_initialiser([var, val](const State &, auto & inference, ProofLogger * const logger) {
-            inference.infer(logger, var <= val, JustifyUsingRUP{}, ReasonFunction{});
+            inference.infer(logger, var <= val, JustifyUsingRUP{}, NoReason{});
         });
         return;
     }
@@ -145,7 +145,7 @@ auto Propagators::install_initialiser(InitialisationFunction && f, InitialiserPr
     _imp->initialisation_functions_by_priority[to_underlying(priority)].emplace_back(move(f));
 }
 
-auto Propagators::install_initial_contradiction(const string &, Justification why, ReasonFunction reason, InitialiserPriority priority) -> void
+auto Propagators::install_initial_contradiction(const string &, Justification why, Reason reason, InitialiserPriority priority) -> void
 {
     install_initialiser(
         [why = move(why), reason = move(reason)](const State &, auto & inference, ProofLogger * const logger) -> void {
@@ -158,9 +158,16 @@ auto Propagators::initialise(State & state, ProofLogger * const logger) const ->
 {
     for (auto & bucket : _imp->initialisation_functions_by_priority) {
         for (auto & f : bucket) {
-            EagerProofLoggingInferenceTracker inf(state);
             try {
-                f(state, inf, logger);
+                // As in propagate(): with no logger, run the lean tracker.
+                if (logger) {
+                    EagerProofLoggingInferenceTracker inf(state);
+                    f(state, inf, logger);
+                }
+                else {
+                    SimpleInferenceTracker inf(state);
+                    f(state, inf, logger);
+                }
             }
             catch (const TrackedPropagationFailed &) {
                 return false;
@@ -231,46 +238,59 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         _imp->idle_end = orig_idle_end;
     });
 
-    EagerProofLoggingInferenceTracker tracker{state};
-
-    bool contradiction = false;
-    while (! contradiction) {
-        if (0 == _imp->enqueued_end) {
-            for (const auto & [v, inf] : tracker.each_inference())
-                requeue(v, inf);
-            tracker.reset();
-        }
-
-        if (0 == _imp->enqueued_end)
-            break;
-
-        int propagator_id = _imp->queue[--_imp->enqueued_end];
-        try {
-            ++_imp->total_propagations;
-            auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
-            if (tracker.did_anything_since_last_call_by_propagation_queue())
-                ++_imp->effectful_propagations;
-            switch (propagator_state) {
-            case PropagatorState::Enable:
-                break;
-            case PropagatorState::DisableUntilBacktrack:
-                --_imp->idle_end;
-                auto being_swapped_item = _imp->queue[_imp->idle_end];
-                swap(_imp->queue[_imp->enqueued_end], _imp->queue[_imp->idle_end]);
-                swap(_imp->lookup[propagator_id], _imp->lookup[being_swapped_item]);
-                break;
+    // The loop body is identical for either tracker (it only uses the shared base
+    // interface plus the dual-overloaded propagation-function call), so run it on a
+    // generic lambda. With no logger we use the lean SimpleInferenceTracker, whose
+    // proofs-off path carries no reason snapshotting or proof-logging code.
+    auto run = [&](auto & tracker) -> bool {
+        bool contradiction = false;
+        while (! contradiction) {
+            if (0 == _imp->enqueued_end) {
+                for (const auto & [v, inf] : tracker.each_inference())
+                    requeue(v, inf);
+                tracker.reset();
             }
-        }
-        catch (const TrackedPropagationFailed &) {
-            contradiction = true;
-            ++_imp->contradicting_propagations;
+
+            if (0 == _imp->enqueued_end)
+                break;
+
+            int propagator_id = _imp->queue[--_imp->enqueued_end];
+            try {
+                ++_imp->total_propagations;
+                auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
+                if (tracker.did_anything_since_last_call_by_propagation_queue())
+                    ++_imp->effectful_propagations;
+                switch (propagator_state) {
+                case PropagatorState::Enable:
+                    break;
+                case PropagatorState::DisableUntilBacktrack:
+                    --_imp->idle_end;
+                    auto being_swapped_item = _imp->queue[_imp->idle_end];
+                    swap(_imp->queue[_imp->enqueued_end], _imp->queue[_imp->idle_end]);
+                    swap(_imp->lookup[propagator_id], _imp->lookup[being_swapped_item]);
+                    break;
+                }
+            }
+            catch (const TrackedPropagationFailed &) {
+                contradiction = true;
+                ++_imp->contradicting_propagations;
+            }
+
+            if (contradiction || (optional_abort_flag && optional_abort_flag->load()))
+                break;
         }
 
-        if (contradiction || (optional_abort_flag && optional_abort_flag->load()))
-            break;
+        return ! contradiction;
+    };
+
+    if (logger) {
+        EagerProofLoggingInferenceTracker tracker{state};
+        return run(tracker);
     }
-
-    return ! contradiction;
+    else {
+        SimpleInferenceTracker tracker{state};
+        return run(tracker);
+    }
 }
 
 auto Propagators::fill_in_constraint_stats(Stats & stats) const -> void

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -296,11 +296,24 @@ namespace gcs::innards
          * install_initialiser; intended for cases where the OPB encoding
          * emitted by define_proof_model collapses to a trivially-false
          * constraint and we want propagation to detect that up front.
+         *
+         * Templated on the justification type so a RUP justification can carry
+         * a typed assertion hint (JustifyUsingRUP{hints::Foo{owner}}) and the
+         * up-front contradiction names the constraint it came from, exactly as
+         * the constraint's in-search inferences do.
          */
-        auto install_initial_contradiction(const std::string & explain_yourself,
-            Justification why,
+        template <typename Justification_>
+        auto install_initial_contradiction(const std::string &,
+            Justification_ why,
             Reason reason = NoReason{},
-            InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void;
+            InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void
+        {
+            install_initialiser(
+                [why = std::move(why), reason = std::move(reason)](const State &, auto & inference, ProofLogger * const logger) -> void {
+                    inference.contradiction(logger, why, reason);
+                },
+                priority);
+        }
 
         ///@}
 

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -82,7 +83,71 @@ namespace gcs::innards
         }
     };
 
-    using InitialisationFunction = std::function<auto(State &, EagerProofLoggingInferenceTracker &, ProofLogger * const)->void>;
+    // Like PropagationFunction, but for initialisers: a type-erased wrapper that
+    // can be invoked with either inference tracker, so the proofs-off initialiser
+    // pass can use the lean SimpleInferenceTracker too. (A plain std::function
+    // would pin the tracker type to one or the other.)
+    class InitialisationFunctionImplBase
+    {
+    public:
+        virtual ~InitialisationFunctionImplBase() = default;
+
+        InitialisationFunctionImplBase() = default;
+        InitialisationFunctionImplBase(const InitialisationFunctionImplBase &) = delete;
+        InitialisationFunctionImplBase(InitialisationFunctionImplBase &&) = default;
+
+        auto operator=(const InitialisationFunctionImplBase &) -> InitialisationFunctionImplBase & = delete;
+        auto operator=(InitialisationFunctionImplBase &&) -> InitialisationFunctionImplBase & = default;
+
+        virtual auto operator()(State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger) -> void = 0;
+        virtual auto operator()(State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger) -> void = 0;
+    };
+
+    template <typename Func_>
+    class InitialisationFunctionImpl : public InitialisationFunctionImplBase
+    {
+    private:
+        Func_ _f;
+
+    public:
+        InitialisationFunctionImpl(Func_ && f) :
+            _f(std::move(f))
+        {
+        }
+
+        auto operator()(State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger) -> void override
+        {
+            _f(state, tracker, logger);
+        }
+
+        auto operator()(State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger) -> void override
+        {
+            _f(state, tracker, logger);
+        }
+    };
+
+    class InitialisationFunction
+    {
+    private:
+        std::unique_ptr<InitialisationFunctionImplBase> _impl;
+
+    public:
+        template <typename Func_>
+        InitialisationFunction(Func_ && f) :
+            _impl(std::make_unique<InitialisationFunctionImpl<Func_>>(std::move(f)))
+        {
+        }
+
+        auto operator()(State & state, SimpleInferenceTracker & tracker, ProofLogger * const logger) -> void
+        {
+            _impl->operator()(state, tracker, logger);
+        }
+
+        auto operator()(State & state, EagerProofLoggingInferenceTracker & tracker, ProofLogger * const logger) -> void
+        {
+            _impl->operator()(state, tracker, logger);
+        }
+    };
 
     /**
      * \brief Priority for initialisers, controlling the order in which they run.
@@ -227,14 +292,14 @@ namespace gcs::innards
         /**
          * Install an initialiser whose only job is to immediately raise a
          * contradiction with the given Justification (RUP, explicit, or
-         * none) and ReasonFunction. Convenience wrapper around
+         * none) and Reason. Convenience wrapper around
          * install_initialiser; intended for cases where the OPB encoding
          * emitted by define_proof_model collapses to a trivially-false
          * constraint and we want propagation to detect that up front.
          */
         auto install_initial_contradiction(const std::string & explain_yourself,
             Justification why,
-            ReasonFunction reason = ReasonFunction{},
+            Reason reason = NoReason{},
             InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void;
 
         ///@}

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -106,13 +106,13 @@ auto gcs::innards::materialise(const Reason & reason, const State & state) -> Re
     return result;
 }
 
-auto gcs::innards::generic_reason(const State &, const std::vector<IntegerVariableID> & vars,
+auto gcs::innards::generic_reason(const std::vector<IntegerVariableID> & vars,
     const optional<Literal> & extra_lit) -> Reason
 {
     return GenericReasonOver{ReasonVars{vars}, extra_lit};
 }
 
-auto gcs::innards::bounds_reason(const State &, const std::vector<IntegerVariableID> & vars,
+auto gcs::innards::bounds_reason(const std::vector<IntegerVariableID> & vars,
     const optional<Literal> & extra_lit) -> Reason
 {
     return BothBoundsReasonOver{ReasonVars{vars}, extra_lit};

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -1,78 +1,129 @@
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 
+#include <util/overloaded.hh>
+
 using namespace gcs;
 using namespace gcs::innards;
 
-auto gcs::innards::generic_reason(const State & state, const std::vector<IntegerVariableID> & vars,
-    const std::optional<Literal> & extra_lit) -> ReasonFunction
+using std::optional;
+using std::pair;
+
+namespace
 {
-    Reason reason;
-    for (const auto & var : vars) {
-        auto bounds = state.bounds(var);
-        if (bounds.first == bounds.second)
-            reason.push_back(var == bounds.first);
-        else {
-            reason.push_back(var >= bounds.first);
-            reason.push_back(var <= bounds.second);
-            if (state.domain_has_holes(var)) {
-                // Each maximal run of missing values is one range condition;
-                // views take the per-value fallback, since folding views into
-                // the interval machinery is deferred.
-                if (std::holds_alternative<SimpleIntegerVariableID>(var)) {
-                    std::optional<std::pair<Integer, Integer>> run;
-                    auto flush = [&]() {
-                        if (run) {
-                            reason.push_back(not_in_range(var, run->first, run->second));
-                            run.reset();
+    // Walk every value in each variable's domain (lower bound, upper bound, and
+    // any holes), appending the facts to `reason`. This is the materialisation
+    // of GenericReasonOver.
+    auto materialise_generic(const State & state, const std::vector<IntegerVariableID> & vars,
+        const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    {
+        for (const auto & var : vars) {
+            auto bounds = state.bounds(var);
+            if (bounds.first == bounds.second)
+                reason.push_back(var == bounds.first);
+            else {
+                reason.push_back(var >= bounds.first);
+                reason.push_back(var <= bounds.second);
+                if (state.domain_has_holes(var)) {
+                    // Each maximal run of missing values is one range condition;
+                    // views take the per-value fallback, since folding views into
+                    // the interval machinery is deferred.
+                    if (std::holds_alternative<SimpleIntegerVariableID>(var)) {
+                        optional<pair<Integer, Integer>> run;
+                        auto flush = [&]() {
+                            if (run) {
+                                reason.push_back(not_in_range(var, run->first, run->second));
+                                run.reset();
+                            }
+                        };
+                        for (auto v = bounds.first + 1_i; v < bounds.second; ++v) {
+                            if (state.in_domain(var, v))
+                                flush();
+                            else if (run)
+                                run->second = v;
+                            else
+                                run = pair{v, v};
                         }
-                    };
-                    for (auto v = bounds.first + 1_i; v < bounds.second; ++v) {
-                        if (state.in_domain(var, v))
-                            flush();
-                        else if (run)
-                            run->second = v;
-                        else
-                            run = std::pair{v, v};
+                        flush();
                     }
-                    flush();
-                }
-                else {
-                    for (auto v = bounds.first + 1_i; v < bounds.second; ++v)
-                        if (! state.in_domain(var, v))
-                            reason.push_back(var != v);
+                    else {
+                        for (auto v = bounds.first + 1_i; v < bounds.second; ++v)
+                            if (! state.in_domain(var, v))
+                                reason.push_back(var != v);
+                    }
                 }
             }
         }
+        if (extra)
+            reason.push_back(*extra);
     }
-    if (extra_lit)
-        reason.push_back(*extra_lit);
 
-    return [=]() { return reason; };
-}
-
-auto gcs::innards::bounds_reason(const State & state, const std::vector<IntegerVariableID> & vars,
-    const std::optional<Literal> & extra_lit) -> ReasonFunction
-{
-    Reason reason;
-    for (const auto & var : vars) {
-        auto bounds = state.bounds(var);
-        if (bounds.first == bounds.second)
-            reason.push_back(var == bounds.first);
-        else {
-            reason.push_back(var >= bounds.first);
-            reason.push_back(var <= bounds.second);
+    // Walk only the lower and upper bound of each variable. This is the
+    // materialisation of BothBoundsReasonOver.
+    auto materialise_bounds(const State & state, const std::vector<IntegerVariableID> & vars,
+        const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    {
+        for (const auto & var : vars) {
+            auto bounds = state.bounds(var);
+            if (bounds.first == bounds.second)
+                reason.push_back(var == bounds.first);
+            else {
+                reason.push_back(var >= bounds.first);
+                reason.push_back(var <= bounds.second);
+            }
         }
+        if (extra)
+            reason.push_back(*extra);
     }
-    if (extra_lit)
-        reason.push_back(*extra_lit);
 
-    return [=]() { return reason; };
+    // Materialisation of ExactSingleValue: `extra` (if any) first, then `var ==
+    // value` for each variable, where value is the variable's single current
+    // value. The leading-extra order matches the legacy explicit reasons this
+    // replaces, keeping proofs byte-identical. Each var must be instantiated.
+    auto materialise_exact_single_value(const State & state, const std::vector<IntegerVariableID> & vars,
+        const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    {
+        if (extra)
+            reason.push_back(*extra);
+        for (const auto & var : vars)
+            reason.push_back(var == state.optional_single_value(var).value());
+    }
 }
 
-auto innards::singleton_reason(const ProofLiteralOrFlag & lit) -> ReasonFunction
+auto gcs::innards::materialise(const Reason & reason, const State & state) -> ReasonLiterals
 {
-    Reason reason;
-    reason.push_back(lit);
-    return [=]() { return reason; };
+    ReasonLiterals result;
+    reason.visit(overloaded{
+        [&](const NoReason &) {},
+        [&](const ExplicitReason & r) { result = r.literals; },
+        [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, result); },
+        [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, result); },
+        [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, r.extra, result); },
+        [&](const LazyReasonOver & r) { r.fn(state, result); },
+        [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, result); },
+        [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, result); },
+        [&](const NarrowableLazyReasonOver & r) { r.fn(state, result); }});
+    return result;
+}
+
+auto gcs::innards::generic_reason(const State &, const std::vector<IntegerVariableID> & vars,
+    const optional<Literal> & extra_lit) -> Reason
+{
+    return GenericReasonOver{ReasonVars{vars}, extra_lit};
+}
+
+auto gcs::innards::bounds_reason(const State &, const std::vector<IntegerVariableID> & vars,
+    const optional<Literal> & extra_lit) -> Reason
+{
+    return BothBoundsReasonOver{ReasonVars{vars}, extra_lit};
+}
+
+auto gcs::innards::singleton_reason(const ProofLiteralOrFlag & lit) -> Reason
+{
+    return ExplicitReason{ReasonLiterals{lit}};
+}
+
+auto gcs::innards::eager_reason(const Reason & reason, const State & state) -> ReasonLiterals
+{
+    return materialise(reason, state);
 }

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -206,17 +206,16 @@ namespace gcs::innards
      * literal in the reason alongside the variable facts.
      *
      * The domain walk is deferred to materialise(); this just captures the
-     * variable scope. `state` is unused and retained only for call-site
-     * compatibility while the migration is in progress.
+     * variable scope.
      */
-    [[nodiscard]] auto generic_reason(const State & state, const std::vector<IntegerVariableID> & vars,
+    [[nodiscard]] auto generic_reason(const std::vector<IntegerVariableID> & vars,
         const std::optional<Literal> & extra_lit = std::nullopt) -> Reason;
 
     /**
      * \brief Like generic_reason but records only the lower and upper bounds of
      * each variable, omitting any holes in the domain.
      */
-    [[nodiscard]] auto bounds_reason(const State & state, const std::vector<IntegerVariableID> & vars,
+    [[nodiscard]] auto bounds_reason(const std::vector<IntegerVariableID> & vars,
         const std::optional<Literal> & extra_lit = std::nullopt) -> Reason;
 
     [[nodiscard]] auto singleton_reason(const ProofLiteralOrFlag & lit) -> Reason;

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_REASON_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_REASON_HH
 
+#include <gcs/array_param.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/state-fwd.hh>
@@ -10,42 +11,227 @@
 
 #include <functional>
 #include <optional>
+#include <variant>
 #include <vector>
 
 namespace gcs::innards
 {
-    // Reason values are produced eagerly per inference (when proofs are on).
+    // The materialised conjunction of facts a proof line is reified under.
     // Typical sizes are 1 (singleton_reason for reified flags) to a handful
     // (bounds_reason / generic_reason over a small set of variables). Inline
     // capacity 2 keeps the common 1- and 2-element cases off the heap. An
     // interval-shaped fact is stated as an interval: a range condition (see
     // in_range() / not_in_range()) is an ordinary condition, whose proof name
     // is the range ("in") literal.
-    using Reason = gch::small_vector<ProofLiteralOrFlag, 2>;
-    using ReasonFunction = std::function<auto()->Reason>;
+    using ReasonLiterals = gch::small_vector<ProofLiteralOrFlag, 2>;
+
+    // Owned / shared / borrowed handle over the variable scope a reason reasons
+    // about, reusing gcs::ArrayParam (gcs/array_param.hh). "Borrowed" is the
+    // unowned mode: a constraint that always reasons over the same scope passes
+    // `&_vars` and allocates nothing.
+    using ReasonVars = VectorArrayParam<IntegerVariableID>;
+
+    // Escape hatch for the bespoke tail: reads state, appends to `out`.
+    using LazyReasonFn = std::function<auto(const State &, ReasonLiterals & out)->void>;
+
+    /**
+     * \brief A declarative description of a reason: cheap to build, copyable,
+     * and storable. The domain walk that turns it into ReasonLiterals is
+     * deferred to materialise(), so building one off the perf-critical
+     * (proofs-off) path costs nothing but a handle.
+     */
+    struct NoReason
+    {
+    };
+
+    /// Reason given as already-known literals (singletons, fixed lists, eager snapshots).
+    struct ExplicitReason
+    {
+        ReasonLiterals literals;
+    };
+
+    /// Reason recording every value in each variable's domain (bounds + holes), plus an optional extra literal.
+    struct GenericReasonOver
+    {
+        ReasonVars vars;
+        std::optional<Literal> extra;
+    };
+
+    /// Reason recording only the lower and upper bound of each variable, plus an optional extra literal.
+    struct BothBoundsReasonOver
+    {
+        ReasonVars vars;
+        std::optional<Literal> extra;
+    };
+
+    /// Reason recording that each variable in `vars` is fixed to exactly its
+    /// single current value (`var == value`). Equivalent to BothBoundsReasonOver
+    /// for an already-instantiated variable, but it states the equality directly
+    /// and emits `extra` *first*, matching the literal order of the hand-written
+    /// explicit reasons it replaces, so the proof stays byte-identical. Cheap to
+    /// build off the proofs-off path: it captures the (borrowable) variable scope
+    /// and defers reading the value to materialise().
+    struct ExactSingleValue
+    {
+        ReasonVars vars;
+        std::optional<Literal> extra;
+    };
+
+    /// Reason whose literals are computed by a bespoke callback reading state; `vars` records the implicated scope.
+    struct LazyReasonOver
+    {
+        ReasonVars vars;
+        LazyReasonFn fn;
+    };
+
+    // Narrowable counterparts: same payload, different tag. "Narrowable" means
+    // the constraint is content with being handed tightened domains, so the
+    // reason may be re-materialised lazily against whatever (narrower) state is
+    // current later. In eager proof-logging mode they behave identically to
+    // their non-narrowable twins (we always materialise now, against the current
+    // state), so the tag is a no-op until a deferred tracker exists. Default
+    // everything to non-narrowable; settling it per constraint needs a pass with
+    // proof-soundness sign-off.
+    struct NarrowableGenericReasonOver
+    {
+        ReasonVars vars;
+        std::optional<Literal> extra;
+    };
+
+    struct NarrowableBothBoundsReasonOver
+    {
+        ReasonVars vars;
+        std::optional<Literal> extra;
+    };
+
+    struct NarrowableLazyReasonOver
+    {
+        ReasonVars vars;
+        LazyReasonFn fn;
+    };
+
+    /**
+     * \brief A reason for an inference, as a declarative variant.
+     *
+     * Implemented as a thin wrapper over a std::variant so it can also be
+     * implicitly built from a materialised ReasonLiterals (used directly as the
+     * reason). Inspect with visit(); materialise() turns it into ReasonLiterals.
+     */
+    class Reason
+    {
+    public:
+        using Variant = std::variant<
+            NoReason, ExplicitReason,
+            GenericReasonOver, BothBoundsReasonOver, ExactSingleValue, LazyReasonOver,
+            NarrowableGenericReasonOver, NarrowableBothBoundsReasonOver, NarrowableLazyReasonOver>;
+
+        Reason() :
+            _variant(NoReason{})
+        {
+        }
+
+        Reason(NoReason r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(ExplicitReason r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(GenericReasonOver r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(BothBoundsReasonOver r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(ExactSingleValue r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(LazyReasonOver r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(NarrowableGenericReasonOver r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(NarrowableBothBoundsReasonOver r) :
+            _variant(std::move(r))
+        {
+        }
+
+        Reason(NarrowableLazyReasonOver r) :
+            _variant(std::move(r))
+        {
+        }
+
+        /// Materialised literals used verbatim as the reason.
+        Reason(ReasonLiterals literals) :
+            _variant(ExplicitReason{std::move(literals)})
+        {
+        }
+
+        template <typename Visitor_>
+        [[nodiscard]] auto visit(Visitor_ && visitor) const -> decltype(auto)
+        {
+            return std::visit(std::forward<Visitor_>(visitor), _variant);
+        }
+
+    private:
+        Variant _variant;
+    };
+
+    /**
+     * \brief Materialise a reason into its literal conjunction against the given
+     * state. This is the only place a reason walks variable domains; the
+     * caller (a proof-logging inference tracker) does this once it has decided
+     * it needs the literals. Stateless variants ignore `state`.
+     */
+    [[nodiscard]] auto materialise(const Reason & reason, const State & state) -> ReasonLiterals;
 
     /**
      * \brief Build a reason recording every value in each variable's domain
-     * (lower bound, upper bound, and any holes). If `extra_lit` is supplied
-     * it is appended too — handy for reified propagators that want the
-     * reification literal in the reason alongside the variable facts.
+     * (lower bound, upper bound, and any holes). If `extra_lit` is supplied it
+     * is appended too — handy for reified propagators that want the reification
+     * literal in the reason alongside the variable facts.
+     *
+     * The domain walk is deferred to materialise(); this just captures the
+     * variable scope. `state` is unused and retained only for call-site
+     * compatibility while the migration is in progress.
      */
     [[nodiscard]] auto generic_reason(const State & state, const std::vector<IntegerVariableID> & vars,
-        const std::optional<Literal> & extra_lit = std::nullopt) -> ReasonFunction;
+        const std::optional<Literal> & extra_lit = std::nullopt) -> Reason;
 
     /**
-     * \brief Like generic_reason but records only the lower and upper bounds of each
-     * variable, omitting any holes in the domain.
-     *
-     * Suitable for propagators whose inferences depend only on bounds (every
-     * fact consulted is a comparison against `lo` or `hi`). Produces smaller
-     * reasons than generic_reason when domains are wide. The optional
-     * `extra_lit` is appended to the reason when present.
+     * \brief Like generic_reason but records only the lower and upper bounds of
+     * each variable, omitting any holes in the domain.
      */
     [[nodiscard]] auto bounds_reason(const State & state, const std::vector<IntegerVariableID> & vars,
-        const std::optional<Literal> & extra_lit = std::nullopt) -> ReasonFunction;
+        const std::optional<Literal> & extra_lit = std::nullopt) -> Reason;
 
-    [[nodiscard]] auto singleton_reason(const ProofLiteralOrFlag & lit) -> ReasonFunction;
+    [[nodiscard]] auto singleton_reason(const ProofLiteralOrFlag & lit) -> Reason;
+
+    /**
+     * \brief Eagerly materialise a reason into its literal conjunction against
+     * the current state.
+     *
+     * For the handful of proof-only consumers that build a reason and hand it
+     * straight to the ProofLogger (bypassing the inference tracker, which
+     * normally does this conversion). The domain walk happens now, so call this
+     * at the point the old eager `*_reason()` factory would have run. This is
+     * just a convenience spelling of materialise() for those call sites.
+     */
+    [[nodiscard]] auto eager_reason(const Reason & reason, const State & state) -> ReasonLiterals;
 }
 
 #endif

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -1,5 +1,5 @@
+#include <gcs/constraints/extensional_utils.hh>
 #include <gcs/exception.hh>
-#include <gcs/innards/extensional_utils.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/propagators.hh>

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -33,7 +33,7 @@ namespace
         Propagators & propagators, State & state, const optional<Literal> & this_branch_guess,
         ProofLogger * const logger, SimpleIntegerVariableID selector_var_id) -> void
     {
-        if (logger)
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->enter_proof_level(depth + 1);
 
         if (propagators.propagate(this_branch_guess, state, logger)) {
@@ -44,7 +44,7 @@ namespace
                 for (auto & var : vars)
                     tuple.push_back(state(var));
 
-                if (logger) {
+                if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                     logger->emit_proof_comment("new table entry found");
 
                     Integer sel_value(tuples.size());
@@ -79,7 +79,7 @@ namespace
             }
         }
 
-        if (logger) {
+        if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
             logger->enter_proof_level(depth);
             vector<Literal> guesses;
             for (const auto & g : state.guesses())
@@ -98,11 +98,11 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
     initial_state.guess(TrueLiteral{});
 
     auto selector_var_id = initial_state.what_variable_id_will_be_created_next();
-    if (logger)
+    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
         logger->emit_proof_comment("starting autotabulation");
     solve_subproblem(0, tuples, _vars, propagators, initial_state, nullopt, logger, selector_var_id);
 
-    if (logger)
+    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
         logger->emit_proof_comment("creating autotable with " + to_string(tuples.size()) + " entries");
 
     initial_state.backtrack(timestamp);
@@ -115,7 +115,7 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
         throw UnexpectedException{"something went horribly wrong with variable IDs when autotabulating"};
 
     ExtensionalData data{selector, _vars, move(tuples)};
-    if (logger)
+    if (logger && logger->get_assertion_level() == AssertionLevel::Off)
         logger->emit_proof_comment("finished autotabulation");
 
     Triggers triggers;

--- a/gcs/proof.cc
+++ b/gcs/proof.cc
@@ -3,11 +3,69 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/proof.hh>
 
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#include <version>
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+using std::print;
+#else
+#include <fmt/core.h>
+using fmt::print;
+#endif
+
 using namespace gcs;
 using namespace gcs::innards;
 
 using std::make_unique;
+using std::nullopt;
+using std::optional;
 using std::string;
+
+namespace
+{
+    /**
+     * Read an AssertionLevel from the GCS_ASSERTION_LEVEL environment variable, if set.
+     * Accepts either the enum names (case-insensitive) or their numeric values; an
+     * unrecognised value is ignored with a warning.
+     */
+    [[nodiscard]] auto assertion_level_from_env() -> optional<AssertionLevel>
+    {
+        const auto * const env = std::getenv("GCS_ASSERTION_LEVEL");
+        if (! env || ! *env)
+            return nullopt;
+
+        string value{env};
+        if (value == "Off" || value == "off" || value == "0")
+            return AssertionLevel::Off;
+        else if (value == "Definitions" || value == "definitions" || value == "1")
+            return AssertionLevel::Definitions;
+        else if (value == "Links" || value == "links" || value == "2")
+            return AssertionLevel::Links;
+        else if (value == "Inferences" || value == "inferences" || value == "3")
+            return AssertionLevel::Inferences;
+        else if (value == "Backtracking" || value == "backtracking" || value == "4")
+            return AssertionLevel::Backtracking;
+
+        print(stderr, "Ignoring unrecognised GCS_ASSERTION_LEVEL value '{}'\n", value);
+        return nullopt;
+    }
+
+    /**
+     * Apply any environment-variable overrides to a copy of the given ProofOptions.
+     * Environment variables act as defaults only: an option set explicitly in code
+     * takes precedence.
+     */
+    [[nodiscard]] auto with_env_overrides(ProofOptions options) -> ProofOptions
+    {
+        if (! options.assertion_level_set_explicitly)
+            if (auto level = assertion_level_from_env())
+                options.assertion_level = *level;
+        return options;
+    }
+}
 
 ProofFileNames::ProofFileNames(const std::string & s) :
     opb_file(s + ".opb"),
@@ -22,10 +80,8 @@ ProofOptions::ProofOptions(const std::string & f) :
 {
 }
 
-ProofOptions::ProofOptions(const ProofFileNames & f, bool v, bool a) :
-    proof_file_names(f),
-    verbose_names(v),
-    always_use_full_encoding(a)
+ProofOptions::ProofOptions(const ProofFileNames & f) :
+    proof_file_names(f)
 {
 }
 
@@ -44,7 +100,7 @@ struct Proof::Imp
 };
 
 Proof::Proof(const ProofOptions & o) :
-    _imp(make_unique<Imp>(o))
+    _imp(make_unique<Imp>(with_env_overrides(o)))
 {
     _imp->tracker.start_writing_model(model());
 }

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -30,6 +30,19 @@ namespace gcs
     };
 
     /**
+     * \brief Mode setting for annotated assertions. Each option involves successively less
+     * justification.
+     */
+    enum class AssertionLevel
+    {
+        Off = 0,      /// Justify everything; no annotated assertions
+        Definitions,  /// Justify backtracking, links, definitions; assert inferences
+        Links,        /// Justify backtracking; assert inferences & links; omit definitions
+        Inferences,   /// Assert backtracking & inferences; omit links & definitions
+        Backtracking, /// Assert backtracking only; omit everything else
+    };
+
+    /**
      * \brief Options for a Problem telling it how to produce a proof.
      *
      * \sa Problem
@@ -38,12 +51,34 @@ namespace gcs
     struct ProofOptions final
     {
         explicit ProofOptions(const std::string &);
-        explicit ProofOptions(const ProofFileNames &, bool, bool);
+        explicit ProofOptions(const ProofFileNames &);
         ProofOptions(const ProofOptions &) = default;
 
         ProofFileNames proof_file_names;       ///< Filenames for OPB, proof, and mapping files
         bool verbose_names = true;             ///< Use verbose names in proofs?
         bool always_use_full_encoding = false; ///< Always write the full variable encoding to the OPB file
+        AssertionLevel assertion_level = AssertionLevel::Off;
+        bool assertion_level_set_explicitly = false; ///< Was assertion_level set in code (so it overrides the env var)?
+
+        /// Write annotated assertions instead of full justifications.
+        ProofOptions & set_assertion_level(AssertionLevel a = AssertionLevel::Inferences)
+        {
+            assertion_level = a;
+            assertion_level_set_explicitly = true;
+            return *this;
+        }
+        /// Always write the full variable encoding to the OPB file.
+        ProofOptions & enable_full_encoding(bool e = true)
+        {
+            always_use_full_encoding = e;
+            return *this;
+        }
+        /// Set whether to use verbose names in proofs.
+        ProofOptions & set_verbose_names(bool v)
+        {
+            verbose_names = v;
+            return *this;
+        }
     };
 
     class Proof

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -72,7 +72,7 @@ namespace
     auto prove_to_scp(Problem & problem, const std::string & basename) -> std::string
     {
         solve_with(problem, SolveCallbacks{},
-            std::make_optional<ProofOptions>(ProofFileNames{basename}, true, false));
+            std::make_optional<ProofOptions>(ProofFileNames{basename}));
         std::ifstream in{basename + ".scp"};
         std::string scp{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
         for (auto ext : {".opb", ".pbp", ".scp", ".varmap"})

--- a/scp/glasgow_scp_solver.cc
+++ b/scp/glasgow_scp_solver.cc
@@ -104,7 +104,7 @@ auto main(int argc, char * argv[]) -> int
                 return find_all;
             }},
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()}, true, false)
+            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()})
             : nullopt);
 
     if (options_vars.contains("stats"))

--- a/verified_encodings/abs/abs.cc
+++ b/verified_encodings/abs/abs.cc
@@ -94,7 +94,7 @@ auto main(int argc, char * argv[]) -> int
                 return true;
             }},
         options_vars.contains("prove")
-            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()}, true, false)
+            ? make_optional<ProofOptions>(ProofFileNames{options_vars["proof-files-basename"].as<string>()})
             : nullopt);
 
     if (options_vars.contains("stats"))


### PR DESCRIPTION
**Draft — review-ready.** Reasons/infer rework + annotated assertions (#302) + typed per-constraint hints, integrated onto `main` (after the per-constraint directory restructure, #393).

## What this is

The whole reasons/justification body of work as one branch:
- the declarative `Reason` rework + unified `infer` signature + `JustifyExplicitly` / `JustifyUsingRUP` (the core machinery);
- Matthew's annotated-assertions machinery (#302), carried here with his authorship;
- the new **typed per-constraint assertion hints** answering the #378 review.

It is `302-then-347` reconciled onto restructured `main` via a single `git merge` (rename detection followed the #393 moves; the only manual conflicts were `equals.hh` and `disjunctive{,_2d}.cc`).

## The hint design

A typed assertion hint is a small struct in `gcs::innards::hints`, one per constraint, living in `gcs/constraints/<foo>/hints.hh`. It **defaults to emitting only its identity** — `(constraint_id <originator>)`, plus `(subhint <name>)` where the struct names one — via a single generic `hint_sexpr`. It carries **no operand data**: anything re-derivable stays off the wire (the internal proof writer holds it for its own emission). A constraint opts into serialising more by defining its own `hint_sexpr` next to its struct — and that boundary, not the struct's fields, is where an external justifier's data is allowed to be a (possibly strict) subset of the internal data.

Base + derived by inheritance: a base struct carries `originator` + `hint_name` (single source, inherited so siblings can't drift); derived structs add a `subhint_name` and/or held data only where the internal writer distinguishes shapes.

**Reference conversions to look at first:** `abs` (collapses to a single base `hints::Abs{originator}` — the 7 justifier strings gone) and `all_different` (base `AllDifferent` for the forced-value deletions + `AllDifferentHall : AllDifferent` for the GAC Hall shape).

## Scope

- **Every constraint with its own inferences carries a hint** (~32). The minimal ones are just `{originator}` + `hint_name`, threaded into every justification (and through helper functions where the inference lives in one — e.g. circuit's SCC explore chain, sort's Mehlhorn-Thiel propagator, mult_bc's recursive `filter_quotient`).
- The infer family is uniformly hintable: `infer` / `infer_equal` / `infer_not_equal` / `infer_less_than` / `infer_greater_than_or_equal` / `infer_not_in_range` / `infer_all` / `contradiction`, in both `JustifyUsingRUP<Hint>` and `JustifyExplicitly<Emit,Hint>` forms (two overloads — `contradiction` and `infer_not_in_range` — were added to close gaps the rollout exposed).
- Proof-machinery names (`initial_bound`, `bound_link`, `backtrack`, `solx_block`, `soli_improve`) and the s-expr field keys (`constraint_id`, `subhint`) live in `gcs/innards/proofs/hints.hh` — so the whole justifier-facing wire vocabulary is extractable from `gcs::innards::hints` rather than scattered as string literals.

### Deliberate exceptions
- `arithmetic` and `seq_precede_chain` post no inferences of their own (they delegate to Table / ValuePrecede and inherit those hints).
- `table`'s `Table` hint is **infrastructure-only**: Table's propagation runs through the shared *innards* helper `propagate_extensional()`, which can't name a constraint-specific hint without an innards→constraints layering inversion (documented on the struct). When that util is made hint-aware, Table is ready.
- Reification-verdict `JustifyUsingRUP{}` stores and `install_initial_contradiction` sites stay bare — they hold the plain `Justification` variant.

## Verification

Normal-mode (proofs-off) output is **byte-identical** throughout — hints emit only in assertion mode. Release **396/396** + Sanitize (ASan/UBSan) **293/293** at each step; assertion-mode wire spot-checked across the set (`:foo:((constraint_id _N))`, plus `(subhint …)` where applicable).

## History

Rewritten to a clean, logical four-commit series (was the original 62-commit history + the merge + the hint commits). Each commit builds independently (bisectable), and the final tree is byte-identical to the reviewed state:

1. **Annotated assertions** (#302) — *authored by @mmcilree* — `AssertionLevel`, `AssertionAnnotation`, assertion-mode proof logging.
2. **Reasons/infer rework** — declarative `Reason`, unified `infer`, `JustifyExplicitly` / `JustifyUsingRUP`.
3. **Typed per-constraint assertion hints**.
4. **Review cleanup** — lambda hoisting, dead-code removal, hint-header re-split.

@mmcilree's 22 original #302 commits couldn't replay verbatim onto restructured `main` (they collide on the #384-rewritten `disjunctive{,_2d}.cc`), so commit 1 is a faithful squash of them onto restructured `main`, keeping his authorship; the few superseded disjunctive annotations are resolved to the base side and the correct ones land in the later commits.

## Not yet done (intentionally)
- **Assertion-mode e2e** verification needs your VeriPB branch (stock 3.0.2 caps at Definitions), so it isn't in ctest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
