### PR TITLE
reason: retire the per-struct `extra` slot; guard linear_bounds_reason

### DIFF
--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -298,12 +298,14 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
                                                 ProofLogger * const logger, const Literal & cond) -> PropagatorState {
         auto value1 = state.optional_single_value(v1);
         if (value1) {
-            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}}, ExactSingleValue{ReasonVars{v1_scope.get()}, cond});
+            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
+                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}));
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
-            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}}, ExactSingleValue{ReasonVars{v2_scope.get()}, cond});
+            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
+                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}));
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;
@@ -324,7 +326,7 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {
-            auto reason = Reason{ExactSingleValue{ReasonVars{v1v2_scope.get()}, std::nullopt}};
+            auto reason = Reason{ExactSingleValue{ReasonVars{v1v2_scope.get()}}};
             if (*value1 == *value2)
                 return reification_verdict::MustHold<EqualsJustification>{
                     .justification = JustifyUsingRUP{hints::Equals{owner}}, //

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -54,9 +54,15 @@ namespace
         return true;
     }
 
-    auto linear_bounds_reason(const auto & coeff_vars, const vector<pair<Integer, Integer>> & bounds, const optional<SimpleIntegerVariableID> & var,
-        bool invert, const optional<Literal> & add_to_reason) -> Reason
+    auto linear_bounds_reason(bool want_reason, const auto & coeff_vars, const vector<pair<Integer, Integer>> & bounds,
+        const optional<SimpleIntegerVariableID> & var, bool invert, const optional<Literal> & add_to_reason) -> Reason
     {
+        // Building this reason is O(coeff_vars) and it is only ever read when proofs
+        // are on (or conflict-directed search wants it), so skip it otherwise -- on a
+        // wide linear constraint that loop runs on every firing during plain search.
+        if (! want_reason)
+            return NoReason{};
+
         ReasonLiterals reason;
         for (const auto & [idx, cv] : enumerate(coeff_vars.terms)) {
             if (var && get_var(cv) != *var) {
@@ -86,7 +92,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else {
@@ -95,7 +101,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
     }
@@ -112,7 +118,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff > 0_i && remainder < 0_i) {
@@ -122,7 +128,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff < 0_i && remainder >= 0_i) {
@@ -131,7 +137,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff < 0_i && remainder < 0_i) {
@@ -141,7 +147,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else
@@ -161,7 +167,8 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
     // by inferring a specific variable has to take a value that it can't
     if (coeff_vars.terms.empty()) {
         if (! (0_i <= value)) {
-            inference.contradiction(logger, JustifyUsingRUP{hint}, linear_bounds_reason(coeff_vars, bounds, nullopt, false, add_to_reason));
+            inference.contradiction(
+                logger, JustifyUsingRUP{hint}, linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, nullopt, false, add_to_reason));
         }
         return PropagatorState::DisableUntilBacktrack;
     }

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -3,6 +3,8 @@
 
 #include <util/overloaded.hh>
 
+#include <type_traits>
+
 using namespace gcs;
 using namespace gcs::innards;
 
@@ -14,8 +16,7 @@ namespace
     // Walk every value in each variable's domain (lower bound, upper bound, and
     // any holes), appending the facts to `reason`. This is the materialisation
     // of GenericReasonOver.
-    auto materialise_generic(
-        const State & state, const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    auto materialise_generic(const State & state, const std::vector<IntegerVariableID> & vars, ReasonLiterals & reason) -> void
     {
         for (const auto & var : vars) {
             auto bounds = state.bounds(var);
@@ -54,14 +55,11 @@ namespace
                 }
             }
         }
-        if (extra)
-            reason.push_back(*extra);
     }
 
     // Walk only the lower and upper bound of each variable. This is the
     // materialisation of BothBoundsReasonOver.
-    auto materialise_bounds(
-        const State & state, const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    auto materialise_bounds(const State & state, const std::vector<IntegerVariableID> & vars, ReasonLiterals & reason) -> void
     {
         for (const auto & var : vars) {
             auto bounds = state.bounds(var);
@@ -72,19 +70,13 @@ namespace
                 reason.push_back(var <= bounds.second);
             }
         }
-        if (extra)
-            reason.push_back(*extra);
     }
 
-    // Materialisation of ExactSingleValue: `extra` (if any) first, then `var ==
-    // value` for each variable, where value is the variable's single current
-    // value. The leading-extra order matches the legacy explicit reasons this
-    // replaces, keeping proofs byte-identical. Each var must be instantiated.
-    auto materialise_exact_single_value(
-        const State & state, const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    // Materialisation of ExactSingleValue: `var == value` for each variable,
+    // where value is the variable's single current value. Each var must be
+    // instantiated. Leading/extra literals are composed in via concat().
+    auto materialise_exact_single_value(const State & state, const std::vector<IntegerVariableID> & vars, ReasonLiterals & reason) -> void
     {
-        if (extra)
-            reason.push_back(*extra);
         for (const auto & var : vars)
             reason.push_back(var == state.optional_single_value(var).value());
     }
@@ -98,15 +90,15 @@ namespace
     auto append_materialised(const Reason & reason, const State & state, ReasonLiterals & out) -> void
     {
         reason.visit(overloaded{
-            [&](const NoReason &) {},                                                                            //
-            [&](const ExplicitReason & r) { out.insert(out.end(), r.literals.begin(), r.literals.end()); },      //
-            [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },             //
-            [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); },           //
-            [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, r.extra, out); },   //
-            [&](const LazyReasonOver & r) { r.fn(state, out); },                                                 //
-            [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },   //
-            [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); }, //
-            [&](const NarrowableLazyReasonOver & r) { r.fn(state, out); },                                       //
+            [&](const NoReason &) {},                                                                       //
+            [&](const ExplicitReason & r) { out.insert(out.end(), r.literals.begin(), r.literals.end()); }, //
+            [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, out); },                 //
+            [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, out); },               //
+            [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, out); },       //
+            [&](const LazyReasonOver & r) { r.fn(state, out); },                                            //
+            [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, out); },       //
+            [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, out); },     //
+            [&](const NarrowableLazyReasonOver & r) { r.fn(state, out); },                                  //
             [&](const ConcatReason & r) {
                 for (const auto & part : r.parts)
                     append_materialised(part, state, out);
@@ -124,12 +116,12 @@ auto gcs::innards::materialise(const Reason & reason, const State & state) -> Re
 
 auto gcs::innards::generic_reason(const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra_lit) -> Reason
 {
-    return GenericReasonOver{ReasonVars{vars}, extra_lit};
+    return with_extra(GenericReasonOver{ReasonVars{vars}}, extra_lit);
 }
 
 auto gcs::innards::bounds_reason(const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra_lit) -> Reason
 {
-    return BothBoundsReasonOver{ReasonVars{vars}, extra_lit};
+    return with_extra(BothBoundsReasonOver{ReasonVars{vars}}, extra_lit);
 }
 
 auto gcs::innards::singleton_reason(const ProofLiteralOrFlag & lit) -> Reason
@@ -156,6 +148,22 @@ auto gcs::innards::with_extra(Reason base, const optional<Literal> & extra) -> R
     if (! extra)
         return base;
     return with_extra(std::move(base), ReasonLiterals{*extra});
+}
+
+auto gcs::innards::concat(Reason a, Reason b) -> Reason
+{
+    // NoReason is the identity, so a single real operand stays flat (no
+    // ConcatReason allocation).
+    if (a.visit([](const auto & r) { return std::is_same_v<std::decay_t<decltype(r)>, NoReason>; }))
+        return b;
+    if (b.visit([](const auto & r) { return std::is_same_v<std::decay_t<decltype(r)>, NoReason>; }))
+        return a;
+
+    std::vector<Reason> parts;
+    parts.reserve(2);
+    parts.push_back(std::move(a));
+    parts.push_back(std::move(b));
+    return ConcatReason{std::move(parts)};
 }
 
 auto gcs::innards::eager_reason(const Reason & reason, const State & state) -> ReasonLiterals

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -54,31 +54,28 @@ namespace gcs::innards
         ReasonLiterals literals;
     };
 
-    /// Reason recording every value in each variable's domain (bounds + holes), plus an optional extra literal.
+    /// Reason recording every value in each variable's domain (bounds + holes).
+    /// Compose with with_extra() / concat() to add specific literals.
     struct GenericReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
-    /// Reason recording only the lower and upper bound of each variable, plus an optional extra literal.
+    /// Reason recording only the lower and upper bound of each variable.
+    /// Compose with with_extra() / concat() to add specific literals.
     struct BothBoundsReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     /// Reason recording that each variable in `vars` is fixed to exactly its
     /// single current value (`var == value`). Equivalent to BothBoundsReasonOver
-    /// for an already-instantiated variable, but it states the equality directly
-    /// and emits `extra` *first*, matching the literal order of the hand-written
-    /// explicit reasons it replaces, so the proof stays byte-identical. Cheap to
-    /// build off the proofs-off path: it captures the (borrowable) variable scope
-    /// and defers reading the value to materialise().
+    /// for an already-instantiated variable, but states the equality directly.
+    /// Cheap to build off the proofs-off path: it captures the (borrowable)
+    /// variable scope and defers reading the value to materialise().
     struct ExactSingleValue
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     /// Reason whose literals are computed by a bespoke callback reading state; `vars` records the implicated scope.
@@ -99,13 +96,11 @@ namespace gcs::innards
     struct NarrowableGenericReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     struct NarrowableBothBoundsReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     struct NarrowableLazyReasonOver
@@ -241,6 +236,14 @@ namespace gcs::innards
      */
     [[nodiscard]] auto with_extra(Reason base, ReasonLiterals extra) -> Reason;
     [[nodiscard]] auto with_extra(Reason base, const std::optional<Literal> & extra) -> Reason;
+
+    /**
+     * \brief Concatenate two reasons: \p a's literals materialise first, then
+     * \p b's. NoReason is the identity (so concat degrades to the other operand).
+     * Use when the parts are themselves structured reasons and the order matters
+     * (e.g. a leading condition literal ahead of an ExactSingleValue).
+     */
+    [[nodiscard]] auto concat(Reason a, Reason b) -> Reason;
 
     /**
      * \brief Eagerly materialise a reason into its literal conjunction against


### PR DESCRIPTION
Stacked on the ConcatReason PR.

**Retire `extra`:** `GenericReasonOver`/`BothBoundsReasonOver`/`ExactSingleValue` (+ Narrowable twins) each carried an `optional<Literal> extra` — a one-literal concat bolted onto every reason type, with `materialise_*` hand-coding first-vs-last ordering. That's exactly what `ConcatReason` generalises. The structs are now pure "facts over these vars"; `generic_reason`/`bounds_reason` keep their signatures but route through `with_extra`; `ExactSingleValue`'s leading-condition becomes explicit via a new `concat(a,b)`. Byte-identical by construction — **all 81 scp_cases proofs unchanged**; equals_test 284 / arg_sort_test 23 / sort_test 29, zero failures.

**linear guard:** `linear_bounds_reason` built an O(coeff_vars) reason on every firing, handed straight to `infer_*`, unguarded. Guarded on `want_reasons()`. **magic_series 300: 7.06s → 6.25s (−11.5%)**, search bit-identical, proofs still byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)