### PR TITLE
min_max, in: with_extra + want_reasons guard

### DIFF
--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -10,6 +10,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/innards/variable_id_utils.hh>
 #include <gcs/integer.hh>
 
 #include <util/enumerate.hh>
@@ -29,6 +30,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace gcs;
@@ -232,6 +234,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         return;
     }
 
+    // Specialise on the index variables' concrete type when they are homogeneous,
+    // so the hot per-element iteration skips the variant deview; mixed scopes fall
+    // back to the general IntegerVariableID path.
+    std::visit([&](const auto & index_vars) { install_propagators_impl(propagators, index_vars); }, as_homogeneous(_index_vars));
+}
+
+template <typename EntryType_, unsigned dimensions_>
+template <typename IndexVec_>
+auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Propagators & propagators, const IndexVec_ & index_vars) -> void
+{
     auto array_has_nonconstants = _array_has_nonconstants;
 
     vector<IntegerVariableID> all_array_vars;
@@ -255,7 +267,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             collect_array_variables(0);
     }
 
-    for (unsigned fixed_dim = 0; fixed_dim != _index_vars.size(); ++fixed_dim) {
+    for (unsigned fixed_dim = 0; fixed_dim != index_vars.size(); ++fixed_dim) {
         Triggers index_triggers;
         if (array_has_nonconstants) {
             if (_bounds_only)
@@ -269,13 +281,13 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         else
             index_triggers.on_change.emplace_back(_result_var);
 
-        for (const auto & [idx, var] : enumerate(_index_vars))
+        for (const auto & [idx, var] : enumerate(index_vars))
             if (idx != fixed_dim)
                 index_triggers.on_change.emplace_back(var);
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
                 array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // for each index variable, update it to only contain values where
@@ -398,12 +410,12 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         Triggers result_triggers;
         if (array_has_nonconstants)
             result_triggers.on_bounds.insert(result_triggers.on_bounds.end(), all_array_vars.begin(), all_array_vars.end());
-        result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        result_triggers.on_change.insert(result_triggers.on_change.end(), index_vars.begin(), index_vars.end());
         result_triggers.on_bounds.emplace_back(_result_var);
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var,
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // bounds only, so the result variable has to be in the range
@@ -450,7 +462,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             extra.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
                         extra.push_back(result_var >= current_bounds.first);
                         extra.push_back(result_var <= current_bounds.second);
-                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                        reason = with_extra(generic_reason(vector<IntegerVariableID>{index_vars.begin(), index_vars.end()}), std::move(extra));
                     }
                     inference.infer(logger, lit_to_infer,
                         JustifyExplicitly{//
@@ -494,11 +506,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         Triggers result_triggers;
         if (array_has_nonconstants)
             result_triggers.on_change.insert(result_triggers.on_change.end(), all_array_vars.begin(), all_array_vars.end());
-        result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        result_triggers.on_change.insert(result_triggers.on_change.end(), index_vars.begin(), index_vars.end());
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var,
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // the result variable has to be in the union of possible values
@@ -535,7 +547,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         ReasonLiterals extra;
                         for (const auto & var : considered_vars)
                             extra.push_back(var != value);
-                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                        reason = with_extra(generic_reason(vector<IntegerVariableID>{index_vars.begin(), index_vars.end()}), std::move(extra));
                     }
                     inference.infer_not_equal(logger, result_var, value,
                         JustifyExplicitly{//
@@ -573,11 +585,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
     if (array_has_nonconstants) {
         Triggers equality_triggers;
-        equality_triggers.on_change.insert(equality_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        equality_triggers.on_change.insert(equality_triggers.on_change.end(), index_vars.begin(), index_vars.end());
         equality_triggers.on_change.emplace_back(_result_var);
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // if there's only a single possible array variable left, it can only take values
                 // that are present in the result variable

--- a/gcs/constraints/element/element.hh
+++ b/gcs/constraints/element/element.hh
@@ -54,6 +54,14 @@ namespace gcs
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
+        // install_propagators dispatches here on the concrete type of the index
+        // variables (all-Simple / all-View / all-constant, else the mixed
+        // IntegerVariableID vector), so the hot per-element iteration is specialised
+        // at install time rather than branching per call. \p IndexVec_ is one of the
+        // alternatives of innards::as_homogeneous()'s result.
+        template <typename IndexVec_>
+        auto install_propagators_impl(innards::Propagators & propagators, const IndexVec_ & index_vars) -> void;
+
     protected:
         explicit NDimensionalElement(IntegerVariableID result_var, IndexVariables, IndexStarts, Array, bool bounds_only);
 

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -181,9 +181,13 @@ auto In::install_propagators(Propagators & propagators) -> void
                     if (supported_by_var)
                         continue;
 
-                    ReasonLiterals reason;
-                    for (const auto & V : var_vals)
-                        reason.emplace_back(V != v);
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals lits;
+                        for (const auto & V : var_vals)
+                            lits.emplace_back(V != v);
+                        reason = ExplicitReason{std::move(lits)};
+                    }
 
                     inference.infer_not_equal(logger, var, v,
                         JustifyExplicitly{//
@@ -193,7 +197,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                                         reason, WPBSum{} + 1_i * ! sel + 1_i * (var != v) >= 1_i, ProofLevel::Temporary);
                             },
                             ThenRUP::Yes, hints::In{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 }
             }
 
@@ -224,12 +228,20 @@ auto In::install_propagators(Propagators & propagators) -> void
                     if (state.in_domain(var, val))
                         continue;
 
-                    ReasonLiterals reason = materialise(generic_reason(vector{var}), state);
-                    for (const auto & [j, V_j] : enumerate(var_vals)) {
-                        if (j == i)
-                            continue;
-                        for (const auto & w : state.each_value_immutable(var))
-                            reason.emplace_back(V_j != w);
+                    // var stays a declarative generic_reason (its domain walk is
+                    // deferred and skipped when no reason is read); only the cross-
+                    // product of supporting-selector literals is the explicit extra,
+                    // and the whole O(var_vals x dom(var)) build is guarded.
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals extra;
+                        for (const auto & [j, V_j] : enumerate(var_vals)) {
+                            if (j == i)
+                                continue;
+                            for (const auto & w : state.each_value_immutable(var))
+                                extra.emplace_back(V_j != w);
+                        }
+                        reason = with_extra(generic_reason(vector{var}), std::move(extra));
                     }
 
                     inference.infer_not_equal(logger, V, val,
@@ -251,7 +263,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                                 }
                             },
                             ThenRUP::Yes, hints::In{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 }
             }
 

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -163,13 +163,20 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
             else if (! support_2) {
                 // no, there's only a single var left that has any intersection with result. so, that
                 // variable has to lose any values not present in result.
-                ReasonLiterals reason = materialise(generic_reason(vector{result}), state);
-
-                for (auto & var : vars) {
-                    if (var == *support_1)
-                        continue;
-                    for (const auto & val : state.each_value_immutable(result))
-                        reason.emplace_back(var != val);
+                // generic_reason over result stays declarative; the per-var support
+                // literals are the explicit extra, and the whole O(vars x dom(result))
+                // base is assembled only when a reason will be read.
+                bool want_reason = inference.want_reasons();
+                Reason reason;
+                if (want_reason) {
+                    ReasonLiterals extra;
+                    for (auto & var : vars) {
+                        if (var == *support_1)
+                            continue;
+                        for (const auto & val : state.each_value_immutable(result))
+                            extra.emplace_back(var != val);
+                    }
+                    reason = with_extra(generic_reason(vector{result}), std::move(extra));
                 }
 
                 auto support_1_set = state.copy_of_values(*support_1);
@@ -202,12 +209,8 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                 for (auto [lo, hi] : support_1_set.each_interval_minus(result_set)) {
                     if (both_simple) {
                         // The support reason is the base reason plus the just-excluded
-                        // interval. ExplicitReason holds an immutable snapshot, so the
-                        // justification (which materialises it once per bridge lemma plus
-                        // once for the conclusion) gets a fresh copy each time rather than
-                        // an accumulating literal.
-                        ReasonLiterals support_reason = reason;
-                        support_reason.emplace_back(not_in_range(result, lo, hi));
+                        // interval; with_extra copies the base, so each interval gets a
+                        // fresh reason rather than an accumulating literal.
                         inference.infer_not_in_range(logger, *support_1, lo, hi,
                             JustifyExplicitly{//
                                 [&, lo = lo, hi = hi](const ReasonLiterals & reason) {
@@ -216,7 +219,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                                         *logger, reason, std::get<SimpleIntegerVariableID>(IntegerVariableID{*support_1}), lo, hi, result, lo, hi);
                                 },
                                 ThenRUP::Yes, hints::MinMax{owner}},
-                            ExplicitReason{std::move(support_reason)});
+                            want_reason ? with_extra(reason, ReasonLiterals{not_in_range(result, lo, hi)}) : Reason{});
                     }
                     else
                         for (Integer val = lo; val <= hi; ++val)
@@ -231,7 +234,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                                                     WPBSum{} + (1_i * (*support_1 == val)) + (1_i * selectors.at(idx)) >= 1_i, ProofLevel::Temporary);
                                     },
                                     ThenRUP::Yes, hints::MinMax{owner}},
-                                ExplicitReason{reason});
+                                reason);
                 }
             }
 

--- a/gcs/innards/variable_id_utils.hh
+++ b/gcs/innards/variable_id_utils.hh
@@ -3,9 +3,13 @@
 
 #include <gcs/variable_id.hh>
 
+#include <algorithm>
 #include <concepts>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -31,6 +35,66 @@ namespace gcs::innards
      */
     template <typename T_>
     concept DirectIntegerVariableIDLike = std::is_convertible_v<T_, DirectIntegerVariableID>;
+
+    /**
+     * \brief The result of as_homogeneous(): a vector specialised to one concrete
+     * IntegerVariableID alternative, or the general mixed vector.
+     *
+     * \ingroup Innards
+     */
+    using HomogeneousIntegerVariables = std::variant<std::vector<SimpleIntegerVariableID>, std::vector<ConstantIntegerVariableID>,
+        std::vector<ViewOfIntegerVariableID>, std::vector<IntegerVariableID>>;
+
+    namespace detail
+    {
+        template <typename T_, typename Container_>
+        [[nodiscard]] auto extract_homogeneous(const Container_ & vars) -> std::vector<T_>
+        {
+            std::vector<T_> result;
+            result.reserve(vars.size());
+            for (const auto & v : vars)
+                result.push_back(std::get<T_>(v));
+            return result;
+        }
+    }
+
+    /**
+     * \brief If every entry of \p vars is the same IntegerVariableID alternative,
+     * return a vector of that concrete type; otherwise return the mixed vector
+     * unchanged.
+     *
+     * Accepts any container of IntegerVariableID (e.g. std::vector or small_vector):
+     * it is templated on the container as a whole, deducing the element type, rather
+     * than taking a template-template parameter -- the latter would not bind to
+     * small_vector, whose signature carries a non-type inline-capacity parameter. The
+     * result is always a std::vector of the concrete type (one install-time
+     * allocation), not a rebind of the input container kind.
+     *
+     * std::visit the result to dispatch a computation onto a single homogeneous
+     * specialisation -- so e.g. per-element domain iteration takes the trivial
+     * same-type path rather than a variant visit -- falling back to the general
+     * IntegerVariableID path only for genuinely mixed scopes. An empty scope yields
+     * the (empty) mixed vector.
+     *
+     * \ingroup Innards
+     */
+    template <typename Container_>
+        requires std::same_as<typename Container_::value_type, IntegerVariableID>
+    [[nodiscard]] auto as_homogeneous(const Container_ & vars) -> HomogeneousIntegerVariables
+    {
+        if (! vars.empty()) {
+            auto first = vars.front().index();
+            if (std::all_of(vars.begin(), vars.end(), [&](const IntegerVariableID & v) { return v.index() == first; }))
+                // Recover the concrete alternative type by visiting the first
+                // entry, rather than mapping raw variant indices to types by hand.
+                return std::visit(
+                    [&](const auto & first_var) -> HomogeneousIntegerVariables {
+                        return detail::extract_homogeneous<std::decay_t<decltype(first_var)>>(vars);
+                    },
+                    vars.front());
+        }
+        return std::vector<IntegerVariableID>(vars.begin(), vars.end());
+    }
 
     /**
      * Convert an IntegerVariableID into a roughly-readable string, for debugging.


### PR DESCRIPTION
Stacked on the retire-`extra` PR. The last two eager "materialise(generic_reason(...)) then push a loop" concat sites, onto the same pattern as Element.

- **in.cc**: the O(`var_vals` × `dom(var)`) cross-product support reason is now declarative + guarded (and its small sibling reason too).
- **min_max.cc**: the O(`vars` × `dom(result)`) base reason (reused across removed intervals) becomes a declarative `with_extra` base, extended per-interval via `with_extra(reason, …)`, under the guard.

Byte-identical (all 81 scp_cases unchanged, incl. array_min/array_max/in_*); min_max_test 88 + in_test 53, zero failures. No benchmark exercises In/MinMax, so the win is by-construction (the O(n²) builds are skipped proofs-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)