### PR TITLE
reason: ConcatReason + with_extra; Element reasons declarative + guarded

### DIFF
--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -439,13 +439,19 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
                 auto infer_bound = [&](Integer relevant_bound, bool ge) {
                     auto lit_to_infer = ge ? (result_var >= relevant_bound) : (result_var <= relevant_bound);
-                    ReasonLiterals reason;
-                    auto idx_reason = materialise(generic_reason(index_vars), state);
-                    reason.insert(reason.end(), idx_reason.begin(), idx_reason.end());
-                    for (const auto & var : considered_vars)
-                        reason.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
-                    reason.push_back(result_var >= current_bounds.first);
-                    reason.push_back(result_var <= current_bounds.second);
+                    // Assemble the reason only when one will be read: this bound
+                    // reason is generic_reason(index_vars) concatenated with the
+                    // captured bound facts, and that concat allocates, so skip it
+                    // entirely during ordinary search.
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals extra;
+                        for (const auto & var : considered_vars)
+                            extra.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
+                        extra.push_back(result_var >= current_bounds.first);
+                        extra.push_back(result_var <= current_bounds.second);
+                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                    }
                     inference.infer(logger, lit_to_infer,
                         JustifyExplicitly{//
                             [&](const ReasonLiterals & reason) {
@@ -471,7 +477,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                 rule_out(rule_out, 0);
                             },
                             ThenRUP::Yes, hints::Element{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 };
 
                 if (lowest_found && *lowest_found > current_bounds.first)
@@ -521,9 +527,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 collect_supported_values(collect_supported_values, 0);
 
                 for (auto value : still_to_find_support_for.each()) {
-                    ReasonLiterals reason = materialise(generic_reason(index_vars), state);
-                    for (const auto & var : considered_vars)
-                        reason.push_back(var != value);
+                    // index_vars stay a declarative generic_reason, concatenated with
+                    // the per-considered-var literals; assembled only when a reason
+                    // will be read.
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals extra;
+                        for (const auto & var : considered_vars)
+                            extra.push_back(var != value);
+                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                    }
                     inference.infer_not_equal(logger, result_var, value,
                         JustifyExplicitly{//
                             [&](const ReasonLiterals & reason) {
@@ -550,7 +563,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                 rule_out(rule_out, 0);
                             },
                             ThenRUP::Yes, hints::Element{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 }
 
                 return PropagatorState::Enable;

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -142,6 +142,19 @@ namespace gcs::innards
 
         auto operator=(const InferenceTrackerBase &) -> InferenceTrackerBase & = delete;
 
+        // Whether a Reason handed to the infer* methods will actually be read.
+        // Today only the proof-materialising tracker consumes reasons; conflict-
+        // directed search (variable weighting / nogood learning) will also want
+        // them, and crucially without a logger -- so this is deliberately keyed on
+        // the tracker's needs, not on whether proofs are being logged. A propagator
+        // whose reason is expensive to assemble (a ConcatReason allocation, a long
+        // extra-literal walk) should guard that assembly on this query, so it
+        // optimises away whenever nothing will read it.
+        [[nodiscard]] auto want_reasons() const -> bool
+        {
+            return Actual_::materialises_reasons;
+        }
+
         auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const Reason & reason,
             const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -90,20 +90,35 @@ namespace
     }
 }
 
+namespace
+{
+    // Append a reason's literals to `out` (rather than returning a fresh vector),
+    // so a ConcatReason can lay its parts down one after another in order. The
+    // leaf materialise_* helpers and the LazyReasonFn contract already append.
+    auto append_materialised(const Reason & reason, const State & state, ReasonLiterals & out) -> void
+    {
+        reason.visit(overloaded{
+            [&](const NoReason &) {},                                                                            //
+            [&](const ExplicitReason & r) { out.insert(out.end(), r.literals.begin(), r.literals.end()); },      //
+            [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },             //
+            [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); },           //
+            [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, r.extra, out); },   //
+            [&](const LazyReasonOver & r) { r.fn(state, out); },                                                 //
+            [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },   //
+            [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); }, //
+            [&](const NarrowableLazyReasonOver & r) { r.fn(state, out); },                                       //
+            [&](const ConcatReason & r) {
+                for (const auto & part : r.parts)
+                    append_materialised(part, state, out);
+            } //
+        });
+    }
+}
+
 auto gcs::innards::materialise(const Reason & reason, const State & state) -> ReasonLiterals
 {
     ReasonLiterals result;
-    reason.visit(overloaded{
-        [&](const NoReason &) {},                                                                               //
-        [&](const ExplicitReason & r) { result = r.literals; },                                                 //
-        [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, result); },             //
-        [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, result); },           //
-        [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, r.extra, result); },   //
-        [&](const LazyReasonOver & r) { r.fn(state, result); },                                                 //
-        [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, result); },   //
-        [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, result); }, //
-        [&](const NarrowableLazyReasonOver & r) { r.fn(state, result); }                                        //
-    });
+    append_materialised(reason, state, result);
     return result;
 }
 
@@ -120,6 +135,27 @@ auto gcs::innards::bounds_reason(const std::vector<IntegerVariableID> & vars, co
 auto gcs::innards::singleton_reason(const ProofLiteralOrFlag & lit) -> Reason
 {
     return ExplicitReason{ReasonLiterals{lit}};
+}
+
+auto gcs::innards::with_extra(Reason base, ReasonLiterals extra) -> Reason
+{
+    // Nothing to add: keep the bare (often deferred, allocation-free) base rather
+    // than wrapping it in a heap-backed ConcatReason.
+    if (extra.empty())
+        return base;
+
+    std::vector<Reason> parts;
+    parts.reserve(2);
+    parts.push_back(std::move(base));
+    parts.push_back(ExplicitReason{std::move(extra)});
+    return ConcatReason{std::move(parts)};
+}
+
+auto gcs::innards::with_extra(Reason base, const optional<Literal> & extra) -> Reason
+{
+    if (! extra)
+        return base;
+    return with_extra(std::move(base), ReasonLiterals{*extra});
 }
 
 auto gcs::innards::eager_reason(const Reason & reason, const State & state) -> ReasonLiterals

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -34,6 +34,10 @@ namespace gcs::innards
     // Escape hatch for the bespoke tail: reads state, appends to `out`.
     using LazyReasonFn = std::function<auto(const State &, ReasonLiterals & out)->void>;
 
+    // Forward declaration so ConcatReason can hold a list of sub-reasons (Reason
+    // is self-referential, so the parts live behind std::vector's indirection).
+    class Reason;
+
     /**
      * \brief A declarative description of a reason: cheap to build, copyable,
      * and storable. The domain walk that turns it into ReasonLiterals is
@@ -111,6 +115,21 @@ namespace gcs::innards
     };
 
     /**
+     * \brief Concatenation of sub-reasons: materialises to each part's literals
+     * in order (part order == literal order).
+     *
+     * This is the composable alternative to a per-reason `extra` slot. The parts
+     * are heap-indirected because Reason is self-referential, so building one is
+     * not free -- prefer the with_extra() helper, which degrades to the bare base
+     * reason when there is nothing to add, keeping the common case a flat,
+     * allocation-free reason.
+     */
+    struct ConcatReason
+    {
+        std::vector<Reason> parts;
+    };
+
+    /**
      * \brief A reason for an inference, as a declarative variant.
      *
      * Implemented as a thin wrapper over a std::variant so it can also be
@@ -121,7 +140,7 @@ namespace gcs::innards
     {
     public:
         using Variant = std::variant<NoReason, ExplicitReason, GenericReasonOver, BothBoundsReasonOver, ExactSingleValue, LazyReasonOver,
-            NarrowableGenericReasonOver, NarrowableBothBoundsReasonOver, NarrowableLazyReasonOver>;
+            NarrowableGenericReasonOver, NarrowableBothBoundsReasonOver, NarrowableLazyReasonOver, ConcatReason>;
 
         Reason() : _variant(NoReason{})
         {
@@ -160,6 +179,10 @@ namespace gcs::innards
         }
 
         Reason(NarrowableLazyReasonOver r) : _variant(std::move(r))
+        {
+        }
+
+        Reason(ConcatReason r) : _variant(std::move(r))
         {
         }
 
@@ -204,6 +227,20 @@ namespace gcs::innards
     [[nodiscard]] auto bounds_reason(const std::vector<IntegerVariableID> & vars, const std::optional<Literal> & extra_lit = std::nullopt) -> Reason;
 
     [[nodiscard]] auto singleton_reason(const ProofLiteralOrFlag & lit) -> Reason;
+
+    /**
+     * \brief Compose a base reason with extra literals that materialise *after*
+     * the base's, via a ConcatReason. This is the convenience spelling for the
+     * recurring "structured reason over some variables, plus a handful of
+     * specific literals" shape (Element, MinMax, In, …).
+     *
+     * Degrades to \p base unchanged when there is nothing to add, so the common
+     * (no-extra) path stays a flat, allocation-free reason rather than paying for
+     * a ConcatReason. The \c optional overload is the drop-in for the many sites
+     * that already hold an `optional<Literal>` extra.
+     */
+    [[nodiscard]] auto with_extra(Reason base, ReasonLiterals extra) -> Reason;
+    [[nodiscard]] auto with_extra(Reason base, const std::optional<Literal> & extra) -> Reason;
 
     /**
      * \brief Eagerly materialise a reason into its literal conjunction against


### PR DESCRIPTION
Stacked on #221 (`prototype/for-each-value`).

Adds a composable `ConcatReason{vector<Reason>}` + `with_extra(base, extra)` helper (degrades to the bare base when empty), and `InferenceTrackerBase::want_reasons()` (true iff the tracker will read the reason — keyed on the tracker, not on `logger`, so conflict-directed search can flip it on later).

Element's bounds/values propagators stop eagerly `materialise()`-ing `generic_reason(index_vars)`: the generic part stays declarative, the captured literals become the explicit extra, and assembly is guarded on `want_reasons()`.

**Measured (qap_12, vs the for_each_value baseline):** eager 3.85s → guarded `ConcatReason` 3.22s (**−16.5%**). Search bit-identical; element_test (all four modes) + scp_chain_element_{sat,unsat} verify byte-identically.

`ConcatReason` *unguarded* was only −9.8% (its parts are heap-indirected because `Reason` is self-referential, so the never-empty bounds reason allocates every inference) — hence the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)