### PR TITLE
element: install-time homogeneous-type dispatch for hot index iteration

### DIFF
--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -10,6 +10,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/innards/variable_id_utils.hh>
 #include <gcs/integer.hh>
 
 #include <util/enumerate.hh>
@@ -29,6 +30,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace gcs;
@@ -232,6 +234,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         return;
     }
 
+    // Specialise on the index variables' concrete type when they are homogeneous,
+    // so the hot per-element iteration skips the variant deview; mixed scopes fall
+    // back to the general IntegerVariableID path.
+    std::visit([&](const auto & index_vars) { install_propagators_impl(propagators, index_vars); }, as_homogeneous(_index_vars));
+}
+
+template <typename EntryType_, unsigned dimensions_>
+template <typename IndexVec_>
+auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Propagators & propagators, const IndexVec_ & index_vars) -> void
+{
     auto array_has_nonconstants = _array_has_nonconstants;
 
     vector<IntegerVariableID> all_array_vars;
@@ -255,7 +267,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             collect_array_variables(0);
     }
 
-    for (unsigned fixed_dim = 0; fixed_dim != _index_vars.size(); ++fixed_dim) {
+    for (unsigned fixed_dim = 0; fixed_dim != index_vars.size(); ++fixed_dim) {
         Triggers index_triggers;
         if (array_has_nonconstants) {
             if (_bounds_only)
@@ -269,13 +281,13 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         else
             index_triggers.on_change.emplace_back(_result_var);
 
-        for (const auto & [idx, var] : enumerate(_index_vars))
+        for (const auto & [idx, var] : enumerate(index_vars))
             if (idx != fixed_dim)
                 index_triggers.on_change.emplace_back(var);
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
                 array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // for each index variable, update it to only contain values where
@@ -398,12 +410,12 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         Triggers result_triggers;
         if (array_has_nonconstants)
             result_triggers.on_bounds.insert(result_triggers.on_bounds.end(), all_array_vars.begin(), all_array_vars.end());
-        result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        result_triggers.on_change.insert(result_triggers.on_change.end(), index_vars.begin(), index_vars.end());
         result_triggers.on_bounds.emplace_back(_result_var);
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var,
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // bounds only, so the result variable has to be in the range
@@ -450,7 +462,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             extra.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
                         extra.push_back(result_var >= current_bounds.first);
                         extra.push_back(result_var <= current_bounds.second);
-                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                        reason = with_extra(generic_reason(vector<IntegerVariableID>{index_vars.begin(), index_vars.end()}), std::move(extra));
                     }
                     inference.infer(logger, lit_to_infer,
                         JustifyExplicitly{//
@@ -494,11 +506,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         Triggers result_triggers;
         if (array_has_nonconstants)
             result_triggers.on_change.insert(result_triggers.on_change.end(), all_array_vars.begin(), all_array_vars.end());
-        result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        result_triggers.on_change.insert(result_triggers.on_change.end(), index_vars.begin(), index_vars.end());
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var,
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // the result variable has to be in the union of possible values
@@ -535,7 +547,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         ReasonLiterals extra;
                         for (const auto & var : considered_vars)
                             extra.push_back(var != value);
-                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                        reason = with_extra(generic_reason(vector<IntegerVariableID>{index_vars.begin(), index_vars.end()}), std::move(extra));
                     }
                     inference.infer_not_equal(logger, result_var, value,
                         JustifyExplicitly{//
@@ -573,11 +585,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
     if (array_has_nonconstants) {
         Triggers equality_triggers;
-        equality_triggers.on_change.insert(equality_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        equality_triggers.on_change.insert(equality_triggers.on_change.end(), index_vars.begin(), index_vars.end());
         equality_triggers.on_change.emplace_back(_result_var);
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // if there's only a single possible array variable left, it can only take values
                 // that are present in the result variable

--- a/gcs/constraints/element/element.hh
+++ b/gcs/constraints/element/element.hh
@@ -54,6 +54,14 @@ namespace gcs
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
+        // install_propagators dispatches here on the concrete type of the index
+        // variables (all-Simple / all-View / all-constant, else the mixed
+        // IntegerVariableID vector), so the hot per-element iteration is specialised
+        // at install time rather than branching per call. \p IndexVec_ is one of the
+        // alternatives of innards::as_homogeneous()'s result.
+        template <typename IndexVec_>
+        auto install_propagators_impl(innards::Propagators & propagators, const IndexVec_ & index_vars) -> void;
+
     protected:
         explicit NDimensionalElement(IntegerVariableID result_var, IndexVariables, IndexStarts, Array, bool bounds_only);
 

--- a/gcs/innards/variable_id_utils.hh
+++ b/gcs/innards/variable_id_utils.hh
@@ -3,9 +3,13 @@
 
 #include <gcs/variable_id.hh>
 
+#include <algorithm>
 #include <concepts>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -31,6 +35,66 @@ namespace gcs::innards
      */
     template <typename T_>
     concept DirectIntegerVariableIDLike = std::is_convertible_v<T_, DirectIntegerVariableID>;
+
+    /**
+     * \brief The result of as_homogeneous(): a vector specialised to one concrete
+     * IntegerVariableID alternative, or the general mixed vector.
+     *
+     * \ingroup Innards
+     */
+    using HomogeneousIntegerVariables = std::variant<std::vector<SimpleIntegerVariableID>, std::vector<ConstantIntegerVariableID>,
+        std::vector<ViewOfIntegerVariableID>, std::vector<IntegerVariableID>>;
+
+    namespace detail
+    {
+        template <typename T_, typename Container_>
+        [[nodiscard]] auto extract_homogeneous(const Container_ & vars) -> std::vector<T_>
+        {
+            std::vector<T_> result;
+            result.reserve(vars.size());
+            for (const auto & v : vars)
+                result.push_back(std::get<T_>(v));
+            return result;
+        }
+    }
+
+    /**
+     * \brief If every entry of \p vars is the same IntegerVariableID alternative,
+     * return a vector of that concrete type; otherwise return the mixed vector
+     * unchanged.
+     *
+     * Accepts any container of IntegerVariableID (e.g. std::vector or small_vector):
+     * it is templated on the container as a whole, deducing the element type, rather
+     * than taking a template-template parameter -- the latter would not bind to
+     * small_vector, whose signature carries a non-type inline-capacity parameter. The
+     * result is always a std::vector of the concrete type (one install-time
+     * allocation), not a rebind of the input container kind.
+     *
+     * std::visit the result to dispatch a computation onto a single homogeneous
+     * specialisation -- so e.g. per-element domain iteration takes the trivial
+     * same-type path rather than a variant visit -- falling back to the general
+     * IntegerVariableID path only for genuinely mixed scopes. An empty scope yields
+     * the (empty) mixed vector.
+     *
+     * \ingroup Innards
+     */
+    template <typename Container_>
+        requires std::same_as<typename Container_::value_type, IntegerVariableID>
+    [[nodiscard]] auto as_homogeneous(const Container_ & vars) -> HomogeneousIntegerVariables
+    {
+        if (! vars.empty()) {
+            auto first = vars.front().index();
+            if (std::all_of(vars.begin(), vars.end(), [&](const IntegerVariableID & v) { return v.index() == first; }))
+                // Recover the concrete alternative type by visiting the first
+                // entry, rather than mapping raw variant indices to types by hand.
+                return std::visit(
+                    [&](const auto & first_var) -> HomogeneousIntegerVariables {
+                        return detail::extract_homogeneous<std::decay_t<decltype(first_var)>>(vars);
+                    },
+                    vars.front());
+        }
+        return std::vector<IntegerVariableID>(vars.begin(), vars.end());
+    }
 
     /**
      * Convert an IntegerVariableID into a roughly-readable string, for debugging.


### PR DESCRIPTION
Replaces the earlier per-call `simple_index_vars.empty()` branch with a single install-time dispatch on the index variables' concrete type.

### What

Adds `innards::as_homogeneous(container of IntegerVariableID)`, returning a `variant<vector<Simple>, vector<Constant>, vector<View>, vector<IntegerVariableID>>` (aka `HomogeneousIntegerVariables`): when every index variable shares one alternative it yields a vector of that concrete type, otherwise the mixed vector. `install_propagators` `std::visit`-dispatches it once into a templated `install_propagators_impl`, so each propagator body is compiled against the concrete index type.

### Why this beats the per-call branch

The previous design only specialised the `for_each` call site. Visiting at install time specialises the **entire** propagator body on the concrete type, so the compiler optimises the whole hot path — not just the iteration. It also:

- generalises to all-View / all-constant index scopes (not just all-Simple),
- drops the per-call `empty()` check, the `for_each_index_value_*` helper indirection, and the parallel `simple_index_vars` vector,
- moves the dispatch to once-per-install.

### The helper

`as_homogeneous` is a reusable innards utility (likely to recur). The concrete alternative type is recovered by `std::visit`-ing the first entry (`std::decay_t<decltype(...)>`) — no hand-mapped `0/1/2` variant indices, no dependence on `IntegerVariableID`'s member order. It is templated on the container as a whole (deducing `value_type`), so it accepts `std::vector` or `small_vector` alike; a template-template parameter is deliberately avoided, since it can't bind `small_vector`'s non-type inline-capacity parameter. The result is always a `std::vector` specialisation (one install-time allocation).

### Measurements

- qap_12 vs no dispatch: **−16.1%** (the old per-call branch was −6.4%, so **−10.4%** vs that branch).
- Full element stack tip (this + the const-array fast path, alloc reduction, equals guard, FIFO queue): **−9.5%** vs the same stack with the old branch — the mechanism win carries through.

Search bit-identical; `element_test` all modes (var / const / 2d, bare and `--view-position=all`) verify with veripb.