### PR TITLE
element: cut per-propagation allocation (explored_vars guard + small_vector elem)

### DIFF
--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -13,6 +13,8 @@
 #include <gcs/innards/variable_id_utils.hh>
 #include <gcs/integer.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <util/enumerate.hh>
 
 #include <version>
@@ -109,7 +111,7 @@ namespace
     }
 
     template <unsigned dims_remaining_, typename T_>
-    auto get_array_var(const vector<size_t> & indices, const T_ & vec, size_t current_index = 0) -> IntegerVariableID
+    auto get_array_var(const auto & indices, const T_ & vec, size_t current_index = 0) -> IntegerVariableID
     {
         if constexpr (1 == dims_remaining_) {
             return as_integer_variable(vec.at(indices.at(current_index)));
@@ -127,7 +129,7 @@ namespace
     // Integer), where it skips the IntegerVariableID variant construction and the
     // State round-trip that get_array_var + state.* would otherwise pay per leaf.
     template <unsigned dims_remaining_, typename T_>
-    auto get_array_value(const vector<size_t> & indices, const T_ & vec, size_t current_index = 0) -> Integer
+    auto get_array_value(const auto & indices, const T_ & vec, size_t current_index = 0) -> Integer
     {
         if constexpr (1 == dims_remaining_) {
             return vec.at(indices.at(current_index));
@@ -213,7 +215,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
     }
 
     HalfReifyOnConjunctionOf reif;
-    vector<size_t> elem;
+    gch::small_vector<size_t, dimensions_> elem;
 
     function<auto(unsigned)->void> build_implication_constraints = [&](unsigned d) {
         auto s = get_dimension_size<dimensions_>(d, *_array);
@@ -267,7 +269,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
 
     vector<IntegerVariableID> all_array_vars;
     {
-        vector<size_t> elem;
+        gch::small_vector<size_t, dimensions_> elem;
         function<auto(unsigned)->void> collect_array_variables = [&](unsigned d) {
             auto s = get_dimension_size<dimensions_>(d, *_array);
             for (size_t x = 0; x != s; ++x) {
@@ -322,7 +324,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 auto want_reason = inference.want_reasons();
 
                 state.for_each_value_mutable(index_vars.at(fixed_dim), [&](Integer test_val) {
-                    vector<size_t> elem;
+                    gch::small_vector<size_t, dimensions_> elem;
                     vector<IntegerVariableID> explored_vars;
                     if (want_reason)
                         explored_vars.push_back(result_var);
@@ -392,7 +394,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                 [&](const ReasonLiterals & reason) {
                                     // show there's no overlap between array_var and result, for any way the other
                                     // index vars are assigned
-                                    vector<size_t> elem;
+                                    gch::small_vector<size_t, dimensions_> elem;
                                     WPBSum sum_so_far;
                                     auto show_no_support = [&](auto && self, unsigned d) -> void {
                                         // again, we're iterating over every dimension recursively, except for the one where
@@ -459,7 +461,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // bounds only, so the result variable has to be in the range
                 // (rather than the union) of possible values
-                vector<size_t> elem;
+                gch::small_vector<size_t, dimensions_> elem;
                 optional<Integer> lowest_found, highest_found;
                 auto current_bounds = state.bounds(result_var);
                 vector<IntegerVariableID> considered_vars;
@@ -562,7 +564,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // the result variable has to be in the union of possible values
-                vector<size_t> elem;
+                gch::small_vector<size_t, dimensions_> elem;
                 IntervalSet<Integer> still_to_find_support_for = state.copy_of_values(result_var);
                 vector<IntegerVariableID> considered_vars;
                 auto collect_supported_values = [&](auto && self, unsigned d) -> void {
@@ -647,7 +649,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 // if there's only a single possible array variable left, it can only take values
                 // that are present in the result variable
                 bool index_is_fully_defined = true;
-                vector<size_t> elem;
+                gch::small_vector<size_t, dimensions_> elem;
                 ReasonLiterals index_reason;
                 for (const auto & [p, i] : enumerate(index_vars)) {
                     auto v = state.optional_single_value(i);

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -317,11 +317,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 // computing once.
                 auto looking_for = state.copy_of_values(result_var);
                 auto looking_for_bounds = state.bounds(result_var);
+                // explored_vars only feeds the reason; building it is a per-test_val
+                // (no-SBO) allocation, so skip it when no reason will be read.
+                auto want_reason = inference.want_reasons();
 
                 state.for_each_value_mutable(index_vars.at(fixed_dim), [&](Integer test_val) {
                     vector<size_t> elem;
                     vector<IntegerVariableID> explored_vars;
-                    explored_vars.push_back(result_var);
+                    if (want_reason)
+                        explored_vars.push_back(result_var);
                     auto look_for_support = [&](auto && self, unsigned d) -> bool {
                         // we're iterating over every dimension recursively, except for the one where
                         // we're checking support for the fixed test_val.
@@ -343,7 +347,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                 }
                                 else {
                                     auto array_var = get_array_var<dimensions_>(elem, *array);
-                                    if (array_has_nonconstants)
+                                    if (want_reason && array_has_nonconstants)
                                         explored_vars.push_back(array_var);
 
                                     if (bounds_only) {
@@ -368,7 +372,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                         if (d == fixed_dim)
                             return do_it_with(test_val);
                         else {
-                            explored_vars.push_back(index_vars.at(d));
+                            if (want_reason)
+                                explored_vars.push_back(index_vars.at(d));
                             bool support_found = false;
                             state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                                 if (do_it_with(x)) {
@@ -431,7 +436,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                     show_no_support(show_no_support, 0);
                                 },
                                 ThenRUP::Yes, hints::Element{owner}},
-                            generic_reason(explored_vars));
+                            want_reason ? generic_reason(explored_vars) : Reason{});
                     }
                 });
 


### PR DESCRIPTION
Stacked on the constant-array fast-path PR (#402). Two allocation cuts in the hot propagators, both byte-identical (all 81 scp_cases unchanged) and search bit-identical.

**1. Guard the GAC `explored_vars` build on `want_reasons()`** — it's a no-SBO `std::vector` allocated per `test_val`, fed to `generic_reason(explored_vars)` even in proofs-off search where the reason is dropped. Same eager-reason waste already fixed for bounds/values, missed here because the reason is a plain `generic_reason`. **qap_12: −12.0%.**

**2. `elem` → `gch::small_vector<size_t, dimensions_>`** — the recursion-index scratch is at most `dimensions_` deep but was a heap `std::vector`; SBO sized to the max depth means it never allocates and push/pop stays in the buffer. `get_array_var`/`get_array_value` take the indices by `const auto &`. **qap_12: −19.5%.**

Both "self-time understated the cost" cases — `emplace_back` read ~5% but the heap traffic was far larger; A/B beats reading self-time.

Cumulative element work on qap_12: 3.23s → **2.10s (−35%)**; vs `main` (6.36s), ~**−67%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)