### PR TITLE
tsp benchmark: default to the plain Circuit, matching minicp

### DIFF
--- a/minicp_benchmarks/tsp/tsp.cc
+++ b/minicp_benchmarks/tsp/tsp.cc
@@ -30,8 +30,8 @@ auto main(int argc, char * argv[]) -> int
             ("help", "Display help information") //
             ("prove", "Create a proof");
 
-        options.add_options()(
-            "propagator", "Specify which circuit propagation algorithm to use (prevent/scc)", cxxopts::value<string>()->default_value("prevent"));
+        options.add_options()("propagator", "Specify which circuit propagation algorithm to use (circuit/prevent/scc)",
+            cxxopts::value<string>()->default_value("circuit"));
 
         options_vars = options.parse(argc, argv);
     }
@@ -50,8 +50,8 @@ auto main(int argc, char * argv[]) -> int
 
     if (options_vars.contains("propagator")) {
         const string propagator_value = options_vars["propagator"].as<string>();
-        if (propagator_value != "prevent" && propagator_value != "scc") {
-            cerr << "Error: Invalid value for propagator. Use 'scc' or 'prevent'." << endl;
+        if (propagator_value != "prevent" && propagator_value != "scc" && propagator_value != "circuit") {
+            cerr << "Error: Invalid value for propagator. Use 'prevent', 'scc' or 'circuit'." << endl;
             return EXIT_FAILURE;
         }
     }


### PR DESCRIPTION
minicp's TSP benchmark uses a naive "forbid closing a subtour early" circuit propagator, which is our plain `Circuit{succ, false}` — not `CircuitPrevent`. But that branch was unreachable: `--propagator` only accepted `prevent`/`scc` and defaulted to `prevent`, so a bare `tsp` ran a stronger, Glasgow-specific propagator rather than the one we're comparing against.

Accept `circuit` as a third `--propagator` value (wired to the existing plain-`Circuit` branch) and make it the default. `prevent`/`scc` remain available.

On gr17: plain `Circuit` and `scc` both take 1,930,503 recursions; `prevent` takes 4,285,765. `circuit` is the minicp-matching search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)