### PR TITLE
equals: guard the reified must-not-hold reason on want_reasons

### DIFF
--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -299,13 +299,13 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         auto value1 = state.optional_single_value(v1);
         if (value1) {
             inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
-                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}));
+                inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}) : Reason{});
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
             inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
-                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}));
+                inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}) : Reason{});
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;


### PR DESCRIPTION
Fixes a regression introduced by the retire-`extra` PR (#398). Retiring the inline `extra` slot turned the reified-equals must-not-hold reason from a flat `ExactSingleValue{vars, cond}` (no allocation) into `concat(singleton_reason(cond), ExactSingleValue{vars})`, which builds a heap `ConcatReason` **every inference**. magic_series never showed it (its equals fires once then `DisableUntilBacktrack`), but `NotEquals` is a reified equals and n_queens hammers it per node — ~8% in `concat` plus the malloc/free it drives.

Guard the two `concat` constructions on `inference.want_reasons()`, passing `NoReason` in ordinary search.

**n_queens 88: 295.7s → 251.2s (−15.0%)**, search bit-identical (49,339,390 recursions), proofs byte-identical (all 81 scp_cases unchanged), equals_test 284/0.

(Self-time said ~8%; wall-clock says 15% — the allocation drove more than its symbol showed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)