### PR TITLE
Land the element / reason / propagation-queue optimisation stack on main (#398–#406)

### DIFF
--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -439,13 +439,19 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
                 auto infer_bound = [&](Integer relevant_bound, bool ge) {
                     auto lit_to_infer = ge ? (result_var >= relevant_bound) : (result_var <= relevant_bound);
-                    ReasonLiterals reason;
-                    auto idx_reason = materialise(generic_reason(index_vars), state);
-                    reason.insert(reason.end(), idx_reason.begin(), idx_reason.end());
-                    for (const auto & var : considered_vars)
-                        reason.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
-                    reason.push_back(result_var >= current_bounds.first);
-                    reason.push_back(result_var <= current_bounds.second);
+                    // Assemble the reason only when one will be read: this bound
+                    // reason is generic_reason(index_vars) concatenated with the
+                    // captured bound facts, and that concat allocates, so skip it
+                    // entirely during ordinary search.
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals extra;
+                        for (const auto & var : considered_vars)
+                            extra.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
+                        extra.push_back(result_var >= current_bounds.first);
+                        extra.push_back(result_var <= current_bounds.second);
+                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                    }
                     inference.infer(logger, lit_to_infer,
                         JustifyExplicitly{//
                             [&](const ReasonLiterals & reason) {
@@ -471,7 +477,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                 rule_out(rule_out, 0);
                             },
                             ThenRUP::Yes, hints::Element{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 };
 
                 if (lowest_found && *lowest_found > current_bounds.first)
@@ -521,9 +527,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                 collect_supported_values(collect_supported_values, 0);
 
                 for (auto value : still_to_find_support_for.each()) {
-                    ReasonLiterals reason = materialise(generic_reason(index_vars), state);
-                    for (const auto & var : considered_vars)
-                        reason.push_back(var != value);
+                    // index_vars stay a declarative generic_reason, concatenated with
+                    // the per-considered-var literals; assembled only when a reason
+                    // will be read.
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals extra;
+                        for (const auto & var : considered_vars)
+                            extra.push_back(var != value);
+                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                    }
                     inference.infer_not_equal(logger, result_var, value,
                         JustifyExplicitly{//
                             [&](const ReasonLiterals & reason) {
@@ -550,7 +563,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                                 rule_out(rule_out, 0);
                             },
                             ThenRUP::Yes, hints::Element{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 }
 
                 return PropagatorState::Enable;

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -10,6 +10,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/innards/variable_id_utils.hh>
 #include <gcs/integer.hh>
 
 #include <util/enumerate.hh>
@@ -29,6 +30,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace gcs;
@@ -232,6 +234,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         return;
     }
 
+    // Specialise on the index variables' concrete type when they are homogeneous,
+    // so the hot per-element iteration skips the variant deview; mixed scopes fall
+    // back to the general IntegerVariableID path.
+    std::visit([&](const auto & index_vars) { install_propagators_impl(propagators, index_vars); }, as_homogeneous(_index_vars));
+}
+
+template <typename EntryType_, unsigned dimensions_>
+template <typename IndexVec_>
+auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Propagators & propagators, const IndexVec_ & index_vars) -> void
+{
     auto array_has_nonconstants = _array_has_nonconstants;
 
     vector<IntegerVariableID> all_array_vars;
@@ -255,7 +267,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
             collect_array_variables(0);
     }
 
-    for (unsigned fixed_dim = 0; fixed_dim != _index_vars.size(); ++fixed_dim) {
+    for (unsigned fixed_dim = 0; fixed_dim != index_vars.size(); ++fixed_dim) {
         Triggers index_triggers;
         if (array_has_nonconstants) {
             if (_bounds_only)
@@ -269,13 +281,13 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         else
             index_triggers.on_change.emplace_back(_result_var);
 
-        for (const auto & [idx, var] : enumerate(_index_vars))
+        for (const auto & [idx, var] : enumerate(index_vars))
             if (idx != fixed_dim)
                 index_triggers.on_change.emplace_back(var);
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
                 array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // for each index variable, update it to only contain values where
@@ -398,12 +410,12 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         Triggers result_triggers;
         if (array_has_nonconstants)
             result_triggers.on_bounds.insert(result_triggers.on_bounds.end(), all_array_vars.begin(), all_array_vars.end());
-        result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        result_triggers.on_change.insert(result_triggers.on_change.end(), index_vars.begin(), index_vars.end());
         result_triggers.on_bounds.emplace_back(_result_var);
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var,
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // bounds only, so the result variable has to be in the range
@@ -450,7 +462,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                             extra.push_back(ge ? (var >= relevant_bound) : (var <= relevant_bound));
                         extra.push_back(result_var >= current_bounds.first);
                         extra.push_back(result_var <= current_bounds.second);
-                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                        reason = with_extra(generic_reason(vector<IntegerVariableID>{index_vars.begin(), index_vars.end()}), std::move(extra));
                     }
                     inference.infer(logger, lit_to_infer,
                         JustifyExplicitly{//
@@ -494,11 +506,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
         Triggers result_triggers;
         if (array_has_nonconstants)
             result_triggers.on_change.insert(result_triggers.on_change.end(), all_array_vars.begin(), all_array_vars.end());
-        result_triggers.on_change.insert(result_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        result_triggers.on_change.insert(result_triggers.on_change.end(), index_vars.begin(), index_vars.end());
 
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var,
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var,
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // the result variable has to be in the union of possible values
@@ -535,7 +547,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
                         ReasonLiterals extra;
                         for (const auto & var : considered_vars)
                             extra.push_back(var != value);
-                        reason = with_extra(generic_reason(index_vars), std::move(extra));
+                        reason = with_extra(generic_reason(vector<IntegerVariableID>{index_vars.begin(), index_vars.end()}), std::move(extra));
                     }
                     inference.infer_not_equal(logger, result_var, value,
                         JustifyExplicitly{//
@@ -573,11 +585,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators(Propagato
 
     if (array_has_nonconstants) {
         Triggers equality_triggers;
-        equality_triggers.on_change.insert(equality_triggers.on_change.end(), _index_vars.begin(), _index_vars.end());
+        equality_triggers.on_change.insert(equality_triggers.on_change.end(), index_vars.begin(), index_vars.end());
         equality_triggers.on_change.emplace_back(_result_var);
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = _index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // if there's only a single possible array variable left, it can only take values
                 // that are present in the result variable

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -13,6 +13,8 @@
 #include <gcs/innards/variable_id_utils.hh>
 #include <gcs/integer.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <util/enumerate.hh>
 
 #include <version>
@@ -109,7 +111,7 @@ namespace
     }
 
     template <unsigned dims_remaining_, typename T_>
-    auto get_array_var(const vector<size_t> & indices, const T_ & vec, size_t current_index = 0) -> IntegerVariableID
+    auto get_array_var(const auto & indices, const T_ & vec, size_t current_index = 0) -> IntegerVariableID
     {
         if constexpr (1 == dims_remaining_) {
             return as_integer_variable(vec.at(indices.at(current_index)));
@@ -127,7 +129,7 @@ namespace
     // Integer), where it skips the IntegerVariableID variant construction and the
     // State round-trip that get_array_var + state.* would otherwise pay per leaf.
     template <unsigned dims_remaining_, typename T_>
-    auto get_array_value(const vector<size_t> & indices, const T_ & vec, size_t current_index = 0) -> Integer
+    auto get_array_value(const auto & indices, const T_ & vec, size_t current_index = 0) -> Integer
     {
         if constexpr (1 == dims_remaining_) {
             return vec.at(indices.at(current_index));
@@ -213,7 +215,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel
     }
 
     HalfReifyOnConjunctionOf reif;
-    vector<size_t> elem;
+    gch::small_vector<size_t, dimensions_> elem;
 
     function<auto(unsigned)->void> build_implication_constraints = [&](unsigned d) {
         auto s = get_dimension_size<dimensions_>(d, *_array);
@@ -267,7 +269,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
 
     vector<IntegerVariableID> all_array_vars;
     {
-        vector<size_t> elem;
+        gch::small_vector<size_t, dimensions_> elem;
         function<auto(unsigned)->void> collect_array_variables = [&](unsigned d) {
             auto s = get_dimension_size<dimensions_>(d, *_array);
             for (size_t x = 0; x != s; ++x) {
@@ -322,7 +324,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 auto want_reason = inference.want_reasons();
 
                 state.for_each_value_mutable(index_vars.at(fixed_dim), [&](Integer test_val) {
-                    vector<size_t> elem;
+                    gch::small_vector<size_t, dimensions_> elem;
                     vector<IntegerVariableID> explored_vars;
                     if (want_reason)
                         explored_vars.push_back(result_var);
@@ -392,7 +394,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                 [&](const ReasonLiterals & reason) {
                                     // show there's no overlap between array_var and result, for any way the other
                                     // index vars are assigned
-                                    vector<size_t> elem;
+                                    gch::small_vector<size_t, dimensions_> elem;
                                     WPBSum sum_so_far;
                                     auto show_no_support = [&](auto && self, unsigned d) -> void {
                                         // again, we're iterating over every dimension recursively, except for the one where
@@ -459,7 +461,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // bounds only, so the result variable has to be in the range
                 // (rather than the union) of possible values
-                vector<size_t> elem;
+                gch::small_vector<size_t, dimensions_> elem;
                 optional<Integer> lowest_found, highest_found;
                 auto current_bounds = state.bounds(result_var);
                 vector<IntegerVariableID> considered_vars;
@@ -562,7 +564,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // the result variable has to be in the union of possible values
-                vector<size_t> elem;
+                gch::small_vector<size_t, dimensions_> elem;
                 IntervalSet<Integer> still_to_find_support_for = state.copy_of_values(result_var);
                 vector<IntegerVariableID> considered_vars;
                 auto collect_supported_values = [&](auto && self, unsigned d) -> void {
@@ -647,7 +649,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 // if there's only a single possible array variable left, it can only take values
                 // that are present in the result variable
                 bool index_is_fully_defined = true;
-                vector<size_t> elem;
+                gch::small_vector<size_t, dimensions_> elem;
                 ReasonLiterals index_reason;
                 for (const auto & [p, i] : enumerate(index_vars)) {
                     auto v = state.optional_single_value(i);

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -317,11 +317,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 // computing once.
                 auto looking_for = state.copy_of_values(result_var);
                 auto looking_for_bounds = state.bounds(result_var);
+                // explored_vars only feeds the reason; building it is a per-test_val
+                // (no-SBO) allocation, so skip it when no reason will be read.
+                auto want_reason = inference.want_reasons();
 
                 state.for_each_value_mutable(index_vars.at(fixed_dim), [&](Integer test_val) {
                     vector<size_t> elem;
                     vector<IntegerVariableID> explored_vars;
-                    explored_vars.push_back(result_var);
+                    if (want_reason)
+                        explored_vars.push_back(result_var);
                     auto look_for_support = [&](auto && self, unsigned d) -> bool {
                         // we're iterating over every dimension recursively, except for the one where
                         // we're checking support for the fixed test_val.
@@ -343,7 +347,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                 }
                                 else {
                                     auto array_var = get_array_var<dimensions_>(elem, *array);
-                                    if (array_has_nonconstants)
+                                    if (want_reason && array_has_nonconstants)
                                         explored_vars.push_back(array_var);
 
                                     if (bounds_only) {
@@ -368,7 +372,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                         if (d == fixed_dim)
                             return do_it_with(test_val);
                         else {
-                            explored_vars.push_back(index_vars.at(d));
+                            if (want_reason)
+                                explored_vars.push_back(index_vars.at(d));
                             bool support_found = false;
                             state.for_each_value_immutable(index_vars.at(d), [&](Integer x) {
                                 if (do_it_with(x)) {
@@ -431,7 +436,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                     show_no_support(show_no_support, 0);
                                 },
                                 ThenRUP::Yes, hints::Element{owner}},
-                            generic_reason(explored_vars));
+                            want_reason ? generic_reason(explored_vars) : Reason{});
                     }
                 });
 

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -29,6 +29,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -118,6 +119,24 @@ namespace
         }
         else {
             return get_array_var<dims_remaining_ - 1>(indices, vec.at(indices.at(current_index)), current_index + 1);
+        }
+    }
+
+    // Constant-array sibling of get_array_var: fetch the entry's Integer value
+    // directly. Only instantiated for an Integer-valued array (EntryType_ ==
+    // Integer), where it skips the IntegerVariableID variant construction and the
+    // State round-trip that get_array_var + state.* would otherwise pay per leaf.
+    template <unsigned dims_remaining_, typename T_>
+    auto get_array_value(const vector<size_t> & indices, const T_ & vec, size_t current_index = 0) -> Integer
+    {
+        if constexpr (1 == dims_remaining_) {
+            return vec.at(indices.at(current_index));
+        }
+        else if constexpr (0 == dims_remaining_) {
+            throw UnexpectedException{"NDimensionalElement element fetching code is broken"};
+        }
+        else {
+            return get_array_value<dims_remaining_ - 1>(indices, vec.at(indices.at(current_index)), current_index + 1);
         }
     }
 
@@ -309,18 +328,33 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                         auto do_it_with = [&](Integer x) {
                             elem.push_back((x - index_starts.at(d)).as_index());
                             if (elem.size() == dimensions_) {
-                                auto array_var = get_array_var<dimensions_>(elem, *array);
-                                if (array_has_nonconstants)
-                                    explored_vars.push_back(array_var);
-
-                                if (bounds_only) {
-                                    if (state.lower_bound(array_var) >= looking_for_bounds.first &&
-                                        state.upper_bound(array_var) <= looking_for_bounds.second)
-                                        return true;
+                                if constexpr (std::is_same_v<EntryType_, Integer>) {
+                                    // Constant array: test the value directly, skipping the
+                                    // IntegerVariableID construction and the State round-trip.
+                                    auto value = get_array_value<dimensions_>(elem, *array);
+                                    if (bounds_only) {
+                                        if (value >= looking_for_bounds.first && value <= looking_for_bounds.second)
+                                            return true;
+                                    }
+                                    else {
+                                        if (looking_for.contains(value))
+                                            return true;
+                                    }
                                 }
                                 else {
-                                    if (state.domain_intersects_with(array_var, looking_for))
-                                        return true;
+                                    auto array_var = get_array_var<dimensions_>(elem, *array);
+                                    if (array_has_nonconstants)
+                                        explored_vars.push_back(array_var);
+
+                                    if (bounds_only) {
+                                        if (state.lower_bound(array_var) >= looking_for_bounds.first &&
+                                            state.upper_bound(array_var) <= looking_for_bounds.second)
+                                            return true;
+                                    }
+                                    else {
+                                        if (state.domain_intersects_with(array_var, looking_for))
+                                            return true;
+                                    }
                                 }
                             }
                             else {
@@ -431,13 +465,22 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
 
                         elem.push_back((x - index_starts.at(d)).as_index());
                         if (elem.size() == dimensions_) {
-                            auto array_var = get_array_var<dimensions_>(elem, *array);
-                            if (array_has_nonconstants)
-                                considered_vars.push_back(array_var);
-                            auto array_var_bounds = state.bounds(array_var);
-                            if (current_bounds.second >= array_var_bounds.first && current_bounds.first <= array_var_bounds.second) {
-                                lowest_found = lowest_found ? min(*lowest_found, array_var_bounds.first) : array_var_bounds.first;
-                                highest_found = highest_found ? max(*highest_found, array_var_bounds.second) : array_var_bounds.second;
+                            if constexpr (std::is_same_v<EntryType_, Integer>) {
+                                auto value = get_array_value<dimensions_>(elem, *array);
+                                if (current_bounds.second >= value && current_bounds.first <= value) {
+                                    lowest_found = lowest_found ? min(*lowest_found, value) : value;
+                                    highest_found = highest_found ? max(*highest_found, value) : value;
+                                }
+                            }
+                            else {
+                                auto array_var = get_array_var<dimensions_>(elem, *array);
+                                if (array_has_nonconstants)
+                                    considered_vars.push_back(array_var);
+                                auto array_var_bounds = state.bounds(array_var);
+                                if (current_bounds.second >= array_var_bounds.first && current_bounds.first <= array_var_bounds.second) {
+                                    lowest_found = lowest_found ? min(*lowest_found, array_var_bounds.first) : array_var_bounds.first;
+                                    highest_found = highest_found ? max(*highest_found, array_var_bounds.second) : array_var_bounds.second;
+                                }
                             }
                         }
                         else {
@@ -524,10 +567,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
 
                         elem.push_back((x - index_starts.at(d)).as_index());
                         if (elem.size() == dimensions_) {
-                            auto array_var = get_array_var<dimensions_>(elem, *array);
-                            if (array_has_nonconstants)
-                                considered_vars.push_back(array_var);
-                            state.for_each_value_immutable(array_var, [&](Integer v) { still_to_find_support_for.erase(v); });
+                            if constexpr (std::is_same_v<EntryType_, Integer>) {
+                                still_to_find_support_for.erase(get_array_value<dimensions_>(elem, *array));
+                            }
+                            else {
+                                auto array_var = get_array_var<dimensions_>(elem, *array);
+                                if (array_has_nonconstants)
+                                    considered_vars.push_back(array_var);
+                                state.for_each_value_immutable(array_var, [&](Integer v) { still_to_find_support_for.erase(v); });
+                            }
                         }
                         else {
                             self(self, d + 1);

--- a/gcs/constraints/element/element.hh
+++ b/gcs/constraints/element/element.hh
@@ -54,6 +54,14 @@ namespace gcs
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
+        // install_propagators dispatches here on the concrete type of the index
+        // variables (all-Simple / all-View / all-constant, else the mixed
+        // IntegerVariableID vector), so the hot per-element iteration is specialised
+        // at install time rather than branching per call. \p IndexVec_ is one of the
+        // alternatives of innards::as_homogeneous()'s result.
+        template <typename IndexVec_>
+        auto install_propagators_impl(innards::Propagators & propagators, const IndexVec_ & index_vars) -> void;
+
     protected:
         explicit NDimensionalElement(IntegerVariableID result_var, IndexVariables, IndexStarts, Array, bool bounds_only);
 

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -298,12 +298,14 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
                                                 ProofLogger * const logger, const Literal & cond) -> PropagatorState {
         auto value1 = state.optional_single_value(v1);
         if (value1) {
-            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}}, ExactSingleValue{ReasonVars{v1_scope.get()}, cond});
+            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
+                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}));
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
-            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}}, ExactSingleValue{ReasonVars{v2_scope.get()}, cond});
+            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
+                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}));
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;
@@ -324,7 +326,7 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {
-            auto reason = Reason{ExactSingleValue{ReasonVars{v1v2_scope.get()}, std::nullopt}};
+            auto reason = Reason{ExactSingleValue{ReasonVars{v1v2_scope.get()}}};
             if (*value1 == *value2)
                 return reification_verdict::MustHold<EqualsJustification>{
                     .justification = JustifyUsingRUP{hints::Equals{owner}}, //

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -299,13 +299,13 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         auto value1 = state.optional_single_value(v1);
         if (value1) {
             inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
-                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}));
+                inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}) : Reason{});
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
             inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
-                concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}));
+                inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}) : Reason{});
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -181,9 +181,13 @@ auto In::install_propagators(Propagators & propagators) -> void
                     if (supported_by_var)
                         continue;
 
-                    ReasonLiterals reason;
-                    for (const auto & V : var_vals)
-                        reason.emplace_back(V != v);
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals lits;
+                        for (const auto & V : var_vals)
+                            lits.emplace_back(V != v);
+                        reason = ExplicitReason{std::move(lits)};
+                    }
 
                     inference.infer_not_equal(logger, var, v,
                         JustifyExplicitly{//
@@ -193,7 +197,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                                         reason, WPBSum{} + 1_i * ! sel + 1_i * (var != v) >= 1_i, ProofLevel::Temporary);
                             },
                             ThenRUP::Yes, hints::In{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 }
             }
 
@@ -224,12 +228,20 @@ auto In::install_propagators(Propagators & propagators) -> void
                     if (state.in_domain(var, val))
                         continue;
 
-                    ReasonLiterals reason = materialise(generic_reason(vector{var}), state);
-                    for (const auto & [j, V_j] : enumerate(var_vals)) {
-                        if (j == i)
-                            continue;
-                        for (const auto & w : state.each_value_immutable(var))
-                            reason.emplace_back(V_j != w);
+                    // var stays a declarative generic_reason (its domain walk is
+                    // deferred and skipped when no reason is read); only the cross-
+                    // product of supporting-selector literals is the explicit extra,
+                    // and the whole O(var_vals x dom(var)) build is guarded.
+                    Reason reason;
+                    if (inference.want_reasons()) {
+                        ReasonLiterals extra;
+                        for (const auto & [j, V_j] : enumerate(var_vals)) {
+                            if (j == i)
+                                continue;
+                            for (const auto & w : state.each_value_immutable(var))
+                                extra.emplace_back(V_j != w);
+                        }
+                        reason = with_extra(generic_reason(vector{var}), std::move(extra));
                     }
 
                     inference.infer_not_equal(logger, V, val,
@@ -251,7 +263,7 @@ auto In::install_propagators(Propagators & propagators) -> void
                                 }
                             },
                             ThenRUP::Yes, hints::In{owner}},
-                        ExplicitReason{reason});
+                        reason);
                 }
             }
 

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -54,9 +54,15 @@ namespace
         return true;
     }
 
-    auto linear_bounds_reason(const auto & coeff_vars, const vector<pair<Integer, Integer>> & bounds, const optional<SimpleIntegerVariableID> & var,
-        bool invert, const optional<Literal> & add_to_reason) -> Reason
+    auto linear_bounds_reason(bool want_reason, const auto & coeff_vars, const vector<pair<Integer, Integer>> & bounds,
+        const optional<SimpleIntegerVariableID> & var, bool invert, const optional<Literal> & add_to_reason) -> Reason
     {
+        // Building this reason is O(coeff_vars) and it is only ever read when proofs
+        // are on (or conflict-directed search wants it), so skip it otherwise -- on a
+        // wide linear constraint that loop runs on every firing during plain search.
+        if (! want_reason)
+            return NoReason{};
+
         ReasonLiterals reason;
         for (const auto & [idx, cv] : enumerate(coeff_vars.terms)) {
             if (var && get_var(cv) != *var) {
@@ -86,7 +92,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else {
@@ -95,7 +101,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
     }
@@ -112,7 +118,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff > 0_i && remainder < 0_i) {
@@ -122,7 +128,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff < 0_i && remainder >= 0_i) {
@@ -131,7 +137,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else if (coeff < 0_i && remainder < 0_i) {
@@ -141,7 +147,7 @@ namespace
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
                 inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
             }
         }
         else
@@ -161,7 +167,8 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
     // by inferring a specific variable has to take a value that it can't
     if (coeff_vars.terms.empty()) {
         if (! (0_i <= value)) {
-            inference.contradiction(logger, JustifyUsingRUP{hint}, linear_bounds_reason(coeff_vars, bounds, nullopt, false, add_to_reason));
+            inference.contradiction(
+                logger, JustifyUsingRUP{hint}, linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, nullopt, false, add_to_reason));
         }
         return PropagatorState::DisableUntilBacktrack;
     }

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -163,13 +163,20 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
             else if (! support_2) {
                 // no, there's only a single var left that has any intersection with result. so, that
                 // variable has to lose any values not present in result.
-                ReasonLiterals reason = materialise(generic_reason(vector{result}), state);
-
-                for (auto & var : vars) {
-                    if (var == *support_1)
-                        continue;
-                    for (const auto & val : state.each_value_immutable(result))
-                        reason.emplace_back(var != val);
+                // generic_reason over result stays declarative; the per-var support
+                // literals are the explicit extra, and the whole O(vars x dom(result))
+                // base is assembled only when a reason will be read.
+                bool want_reason = inference.want_reasons();
+                Reason reason;
+                if (want_reason) {
+                    ReasonLiterals extra;
+                    for (auto & var : vars) {
+                        if (var == *support_1)
+                            continue;
+                        for (const auto & val : state.each_value_immutable(result))
+                            extra.emplace_back(var != val);
+                    }
+                    reason = with_extra(generic_reason(vector{result}), std::move(extra));
                 }
 
                 auto support_1_set = state.copy_of_values(*support_1);
@@ -202,12 +209,8 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                 for (auto [lo, hi] : support_1_set.each_interval_minus(result_set)) {
                     if (both_simple) {
                         // The support reason is the base reason plus the just-excluded
-                        // interval. ExplicitReason holds an immutable snapshot, so the
-                        // justification (which materialises it once per bridge lemma plus
-                        // once for the conclusion) gets a fresh copy each time rather than
-                        // an accumulating literal.
-                        ReasonLiterals support_reason = reason;
-                        support_reason.emplace_back(not_in_range(result, lo, hi));
+                        // interval; with_extra copies the base, so each interval gets a
+                        // fresh reason rather than an accumulating literal.
                         inference.infer_not_in_range(logger, *support_1, lo, hi,
                             JustifyExplicitly{//
                                 [&, lo = lo, hi = hi](const ReasonLiterals & reason) {
@@ -216,7 +219,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                                         *logger, reason, std::get<SimpleIntegerVariableID>(IntegerVariableID{*support_1}), lo, hi, result, lo, hi);
                                 },
                                 ThenRUP::Yes, hints::MinMax{owner}},
-                            ExplicitReason{std::move(support_reason)});
+                            want_reason ? with_extra(reason, ReasonLiterals{not_in_range(result, lo, hi)}) : Reason{});
                     }
                     else
                         for (Integer val = lo; val <= hi; ++val)
@@ -231,7 +234,7 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                                                     WPBSum{} + (1_i * (*support_1 == val)) + (1_i * selectors.at(idx)) >= 1_i, ProofLevel::Temporary);
                                     },
                                     ThenRUP::Yes, hints::MinMax{owner}},
-                                ExplicitReason{reason});
+                                reason);
                 }
             }
 

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -142,6 +142,19 @@ namespace gcs::innards
 
         auto operator=(const InferenceTrackerBase &) -> InferenceTrackerBase & = delete;
 
+        // Whether a Reason handed to the infer* methods will actually be read.
+        // Today only the proof-materialising tracker consumes reasons; conflict-
+        // directed search (variable weighting / nogood learning) will also want
+        // them, and crucially without a logger -- so this is deliberately keyed on
+        // the tracker's needs, not on whether proofs are being logged. A propagator
+        // whose reason is expensive to assemble (a ConcatReason allocation, a long
+        // extra-literal walk) should guard that assembly on this query, so it
+        // optimises away whenever nothing will read it.
+        [[nodiscard]] auto want_reasons() const -> bool
+        {
+            return Actual_::materialises_reasons;
+        }
+
         auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const Reason & reason,
             const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
         {

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -57,11 +57,17 @@ struct Propagators::Imp
     std::array<vector<InitialisationFunction>, number_of_initialiser_priorities> initialisation_functions_by_priority;
 
     // Every propagation function's index appears exactly once in queue, and lookup[id] always tells
-    // us where that position is. The items from index 0 to enqueued_end - 1 are ready to be
-    // propagated, and the items between enqueued_end and idle_end - 1 do not need to be propagated.
-    // Anything from idle_end onwards is disabled until backtrack.
+    // us where that position is. The ready-to-propagate items are [enqueued_begin, enqueued_end);
+    // we run them oldest-first (FIFO -- empirically far better than a stack, see Schulte & Stuckey,
+    // "Efficient Constraint Propagation Engines"). The items between enqueued_end and idle_end - 1 do
+    // not need to be propagated. Anything from idle_end onwards is disabled until backtrack. Items in
+    // [0, enqueued_begin) have already been propagated this round and become idle again at the next
+    // requeue.
     vector<int> queue, lookup;
-    int enqueued_end = 0, idle_end = 0;
+    int enqueued_begin = 0, enqueued_end = 0, idle_end = 0;
+    // Reused scratch for the disable-until-backtrack propagators of the current round
+    // (see the run loop); a member so it isn't reallocated on every propagate() call.
+    vector<int> to_disable;
 
     unsigned long long total_propagations = 0, effectful_propagations = 0, contradicting_propagations = 0;
     vector<TriggerIDs> iv_triggers;
@@ -187,21 +193,21 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
     };
 
     if (! lit) {
-        // On the first pass, walk propagators in registration order. Our queue runs
-        // backwards, so push them in reverse.
+        // On the first pass, walk propagators in registration order. The queue runs
+        // oldest-first, so push them forwards.
         _imp->queue.resize(_imp->propagation_functions.size());
         _imp->lookup.resize(_imp->propagation_functions.size());
-        unsigned p = 0;
-        for (int i = _imp->propagation_functions.size() - 1; i >= 0; --i) {
-            _imp->queue[p] = i;
-            _imp->lookup[i] = p;
-            ++p;
+        for (unsigned i = 0; i != _imp->propagation_functions.size(); ++i) {
+            _imp->queue[i] = i;
+            _imp->lookup[i] = i;
         }
 
+        _imp->enqueued_begin = 0;
         _imp->enqueued_end = _imp->propagation_functions.size();
         _imp->idle_end = _imp->propagation_functions.size();
     }
     else {
+        _imp->enqueued_begin = 0;
         _imp->enqueued_end = 0;
         overloaded{
             [&](const TrueLiteral &) {},  //
@@ -231,17 +237,36 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
     // proofs-off path carries no reason snapshotting or proof-logging code.
     auto run = [&](auto & tracker) -> bool {
         bool contradiction = false;
+        _imp->to_disable.clear();
         while (! contradiction) {
-            if (0 == _imp->enqueued_end) {
+            if (_imp->enqueued_begin == _imp->enqueued_end) {
+                // The ready queue has drained. Retire any propagators that asked to be
+                // disabled this round -- deferred to here, where the just-propagated
+                // prefix [0, enqueued_begin) and the idle tail form one contiguous
+                // [0, idle_end) block, so each swap-to-disabled has a valid target even
+                // when the idle region emptied mid-round. lookup[] is kept current by
+                // the swaps, so processing order does not matter.
+                for (auto disable_id : _imp->to_disable) {
+                    --_imp->idle_end;
+                    auto being_swapped_item = _imp->queue[_imp->idle_end];
+                    swap(_imp->queue[_imp->lookup[disable_id]], _imp->queue[_imp->idle_end]);
+                    swap(_imp->lookup[disable_id], _imp->lookup[being_swapped_item]);
+                }
+                _imp->to_disable.clear();
+
+                // Fold the propagated prefix back into the idle region and wake the
+                // propagators triggered by this round's inferences.
+                _imp->enqueued_begin = 0;
+                _imp->enqueued_end = 0;
                 for (const auto & [v, inf] : tracker.each_inference())
                     requeue(v, inf);
                 tracker.reset();
             }
 
-            if (0 == _imp->enqueued_end)
+            if (_imp->enqueued_begin == _imp->enqueued_end)
                 break;
 
-            int propagator_id = _imp->queue[--_imp->enqueued_end];
+            int propagator_id = _imp->queue[_imp->enqueued_begin++];
             try {
                 ++_imp->total_propagations;
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
@@ -249,12 +274,7 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
                     ++_imp->effectful_propagations;
                 switch (propagator_state) {
                 case PropagatorState::Enable: break;
-                case PropagatorState::DisableUntilBacktrack:
-                    --_imp->idle_end;
-                    auto being_swapped_item = _imp->queue[_imp->idle_end];
-                    swap(_imp->queue[_imp->enqueued_end], _imp->queue[_imp->idle_end]);
-                    swap(_imp->lookup[propagator_id], _imp->lookup[being_swapped_item]);
-                    break;
+                case PropagatorState::DisableUntilBacktrack: _imp->to_disable.push_back(propagator_id); break;
                 }
             }
             catch (const TrackedPropagationFailed &) {

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -90,20 +90,35 @@ namespace
     }
 }
 
+namespace
+{
+    // Append a reason's literals to `out` (rather than returning a fresh vector),
+    // so a ConcatReason can lay its parts down one after another in order. The
+    // leaf materialise_* helpers and the LazyReasonFn contract already append.
+    auto append_materialised(const Reason & reason, const State & state, ReasonLiterals & out) -> void
+    {
+        reason.visit(overloaded{
+            [&](const NoReason &) {},                                                                            //
+            [&](const ExplicitReason & r) { out.insert(out.end(), r.literals.begin(), r.literals.end()); },      //
+            [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },             //
+            [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); },           //
+            [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, r.extra, out); },   //
+            [&](const LazyReasonOver & r) { r.fn(state, out); },                                                 //
+            [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },   //
+            [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); }, //
+            [&](const NarrowableLazyReasonOver & r) { r.fn(state, out); },                                       //
+            [&](const ConcatReason & r) {
+                for (const auto & part : r.parts)
+                    append_materialised(part, state, out);
+            } //
+        });
+    }
+}
+
 auto gcs::innards::materialise(const Reason & reason, const State & state) -> ReasonLiterals
 {
     ReasonLiterals result;
-    reason.visit(overloaded{
-        [&](const NoReason &) {},                                                                               //
-        [&](const ExplicitReason & r) { result = r.literals; },                                                 //
-        [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, result); },             //
-        [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, result); },           //
-        [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, r.extra, result); },   //
-        [&](const LazyReasonOver & r) { r.fn(state, result); },                                                 //
-        [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, result); },   //
-        [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, result); }, //
-        [&](const NarrowableLazyReasonOver & r) { r.fn(state, result); }                                        //
-    });
+    append_materialised(reason, state, result);
     return result;
 }
 
@@ -120,6 +135,27 @@ auto gcs::innards::bounds_reason(const std::vector<IntegerVariableID> & vars, co
 auto gcs::innards::singleton_reason(const ProofLiteralOrFlag & lit) -> Reason
 {
     return ExplicitReason{ReasonLiterals{lit}};
+}
+
+auto gcs::innards::with_extra(Reason base, ReasonLiterals extra) -> Reason
+{
+    // Nothing to add: keep the bare (often deferred, allocation-free) base rather
+    // than wrapping it in a heap-backed ConcatReason.
+    if (extra.empty())
+        return base;
+
+    std::vector<Reason> parts;
+    parts.reserve(2);
+    parts.push_back(std::move(base));
+    parts.push_back(ExplicitReason{std::move(extra)});
+    return ConcatReason{std::move(parts)};
+}
+
+auto gcs::innards::with_extra(Reason base, const optional<Literal> & extra) -> Reason
+{
+    if (! extra)
+        return base;
+    return with_extra(std::move(base), ReasonLiterals{*extra});
 }
 
 auto gcs::innards::eager_reason(const Reason & reason, const State & state) -> ReasonLiterals

--- a/gcs/innards/reason.cc
+++ b/gcs/innards/reason.cc
@@ -3,6 +3,8 @@
 
 #include <util/overloaded.hh>
 
+#include <type_traits>
+
 using namespace gcs;
 using namespace gcs::innards;
 
@@ -14,8 +16,7 @@ namespace
     // Walk every value in each variable's domain (lower bound, upper bound, and
     // any holes), appending the facts to `reason`. This is the materialisation
     // of GenericReasonOver.
-    auto materialise_generic(
-        const State & state, const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    auto materialise_generic(const State & state, const std::vector<IntegerVariableID> & vars, ReasonLiterals & reason) -> void
     {
         for (const auto & var : vars) {
             auto bounds = state.bounds(var);
@@ -54,14 +55,11 @@ namespace
                 }
             }
         }
-        if (extra)
-            reason.push_back(*extra);
     }
 
     // Walk only the lower and upper bound of each variable. This is the
     // materialisation of BothBoundsReasonOver.
-    auto materialise_bounds(
-        const State & state, const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    auto materialise_bounds(const State & state, const std::vector<IntegerVariableID> & vars, ReasonLiterals & reason) -> void
     {
         for (const auto & var : vars) {
             auto bounds = state.bounds(var);
@@ -72,19 +70,13 @@ namespace
                 reason.push_back(var <= bounds.second);
             }
         }
-        if (extra)
-            reason.push_back(*extra);
     }
 
-    // Materialisation of ExactSingleValue: `extra` (if any) first, then `var ==
-    // value` for each variable, where value is the variable's single current
-    // value. The leading-extra order matches the legacy explicit reasons this
-    // replaces, keeping proofs byte-identical. Each var must be instantiated.
-    auto materialise_exact_single_value(
-        const State & state, const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra, ReasonLiterals & reason) -> void
+    // Materialisation of ExactSingleValue: `var == value` for each variable,
+    // where value is the variable's single current value. Each var must be
+    // instantiated. Leading/extra literals are composed in via concat().
+    auto materialise_exact_single_value(const State & state, const std::vector<IntegerVariableID> & vars, ReasonLiterals & reason) -> void
     {
-        if (extra)
-            reason.push_back(*extra);
         for (const auto & var : vars)
             reason.push_back(var == state.optional_single_value(var).value());
     }
@@ -98,15 +90,15 @@ namespace
     auto append_materialised(const Reason & reason, const State & state, ReasonLiterals & out) -> void
     {
         reason.visit(overloaded{
-            [&](const NoReason &) {},                                                                            //
-            [&](const ExplicitReason & r) { out.insert(out.end(), r.literals.begin(), r.literals.end()); },      //
-            [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },             //
-            [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); },           //
-            [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, r.extra, out); },   //
-            [&](const LazyReasonOver & r) { r.fn(state, out); },                                                 //
-            [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, r.extra, out); },   //
-            [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, r.extra, out); }, //
-            [&](const NarrowableLazyReasonOver & r) { r.fn(state, out); },                                       //
+            [&](const NoReason &) {},                                                                       //
+            [&](const ExplicitReason & r) { out.insert(out.end(), r.literals.begin(), r.literals.end()); }, //
+            [&](const GenericReasonOver & r) { materialise_generic(state, *r.vars, out); },                 //
+            [&](const BothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, out); },               //
+            [&](const ExactSingleValue & r) { materialise_exact_single_value(state, *r.vars, out); },       //
+            [&](const LazyReasonOver & r) { r.fn(state, out); },                                            //
+            [&](const NarrowableGenericReasonOver & r) { materialise_generic(state, *r.vars, out); },       //
+            [&](const NarrowableBothBoundsReasonOver & r) { materialise_bounds(state, *r.vars, out); },     //
+            [&](const NarrowableLazyReasonOver & r) { r.fn(state, out); },                                  //
             [&](const ConcatReason & r) {
                 for (const auto & part : r.parts)
                     append_materialised(part, state, out);
@@ -124,12 +116,12 @@ auto gcs::innards::materialise(const Reason & reason, const State & state) -> Re
 
 auto gcs::innards::generic_reason(const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra_lit) -> Reason
 {
-    return GenericReasonOver{ReasonVars{vars}, extra_lit};
+    return with_extra(GenericReasonOver{ReasonVars{vars}}, extra_lit);
 }
 
 auto gcs::innards::bounds_reason(const std::vector<IntegerVariableID> & vars, const optional<Literal> & extra_lit) -> Reason
 {
-    return BothBoundsReasonOver{ReasonVars{vars}, extra_lit};
+    return with_extra(BothBoundsReasonOver{ReasonVars{vars}}, extra_lit);
 }
 
 auto gcs::innards::singleton_reason(const ProofLiteralOrFlag & lit) -> Reason
@@ -156,6 +148,22 @@ auto gcs::innards::with_extra(Reason base, const optional<Literal> & extra) -> R
     if (! extra)
         return base;
     return with_extra(std::move(base), ReasonLiterals{*extra});
+}
+
+auto gcs::innards::concat(Reason a, Reason b) -> Reason
+{
+    // NoReason is the identity, so a single real operand stays flat (no
+    // ConcatReason allocation).
+    if (a.visit([](const auto & r) { return std::is_same_v<std::decay_t<decltype(r)>, NoReason>; }))
+        return b;
+    if (b.visit([](const auto & r) { return std::is_same_v<std::decay_t<decltype(r)>, NoReason>; }))
+        return a;
+
+    std::vector<Reason> parts;
+    parts.reserve(2);
+    parts.push_back(std::move(a));
+    parts.push_back(std::move(b));
+    return ConcatReason{std::move(parts)};
 }
 
 auto gcs::innards::eager_reason(const Reason & reason, const State & state) -> ReasonLiterals

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -54,31 +54,28 @@ namespace gcs::innards
         ReasonLiterals literals;
     };
 
-    /// Reason recording every value in each variable's domain (bounds + holes), plus an optional extra literal.
+    /// Reason recording every value in each variable's domain (bounds + holes).
+    /// Compose with with_extra() / concat() to add specific literals.
     struct GenericReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
-    /// Reason recording only the lower and upper bound of each variable, plus an optional extra literal.
+    /// Reason recording only the lower and upper bound of each variable.
+    /// Compose with with_extra() / concat() to add specific literals.
     struct BothBoundsReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     /// Reason recording that each variable in `vars` is fixed to exactly its
     /// single current value (`var == value`). Equivalent to BothBoundsReasonOver
-    /// for an already-instantiated variable, but it states the equality directly
-    /// and emits `extra` *first*, matching the literal order of the hand-written
-    /// explicit reasons it replaces, so the proof stays byte-identical. Cheap to
-    /// build off the proofs-off path: it captures the (borrowable) variable scope
-    /// and defers reading the value to materialise().
+    /// for an already-instantiated variable, but states the equality directly.
+    /// Cheap to build off the proofs-off path: it captures the (borrowable)
+    /// variable scope and defers reading the value to materialise().
     struct ExactSingleValue
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     /// Reason whose literals are computed by a bespoke callback reading state; `vars` records the implicated scope.
@@ -99,13 +96,11 @@ namespace gcs::innards
     struct NarrowableGenericReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     struct NarrowableBothBoundsReasonOver
     {
         ReasonVars vars;
-        std::optional<Literal> extra;
     };
 
     struct NarrowableLazyReasonOver
@@ -241,6 +236,14 @@ namespace gcs::innards
      */
     [[nodiscard]] auto with_extra(Reason base, ReasonLiterals extra) -> Reason;
     [[nodiscard]] auto with_extra(Reason base, const std::optional<Literal> & extra) -> Reason;
+
+    /**
+     * \brief Concatenate two reasons: \p a's literals materialise first, then
+     * \p b's. NoReason is the identity (so concat degrades to the other operand).
+     * Use when the parts are themselves structured reasons and the order matters
+     * (e.g. a leading condition literal ahead of an ExactSingleValue).
+     */
+    [[nodiscard]] auto concat(Reason a, Reason b) -> Reason;
 
     /**
      * \brief Eagerly materialise a reason into its literal conjunction against

--- a/gcs/innards/reason.hh
+++ b/gcs/innards/reason.hh
@@ -34,6 +34,10 @@ namespace gcs::innards
     // Escape hatch for the bespoke tail: reads state, appends to `out`.
     using LazyReasonFn = std::function<auto(const State &, ReasonLiterals & out)->void>;
 
+    // Forward declaration so ConcatReason can hold a list of sub-reasons (Reason
+    // is self-referential, so the parts live behind std::vector's indirection).
+    class Reason;
+
     /**
      * \brief A declarative description of a reason: cheap to build, copyable,
      * and storable. The domain walk that turns it into ReasonLiterals is
@@ -111,6 +115,21 @@ namespace gcs::innards
     };
 
     /**
+     * \brief Concatenation of sub-reasons: materialises to each part's literals
+     * in order (part order == literal order).
+     *
+     * This is the composable alternative to a per-reason `extra` slot. The parts
+     * are heap-indirected because Reason is self-referential, so building one is
+     * not free -- prefer the with_extra() helper, which degrades to the bare base
+     * reason when there is nothing to add, keeping the common case a flat,
+     * allocation-free reason.
+     */
+    struct ConcatReason
+    {
+        std::vector<Reason> parts;
+    };
+
+    /**
      * \brief A reason for an inference, as a declarative variant.
      *
      * Implemented as a thin wrapper over a std::variant so it can also be
@@ -121,7 +140,7 @@ namespace gcs::innards
     {
     public:
         using Variant = std::variant<NoReason, ExplicitReason, GenericReasonOver, BothBoundsReasonOver, ExactSingleValue, LazyReasonOver,
-            NarrowableGenericReasonOver, NarrowableBothBoundsReasonOver, NarrowableLazyReasonOver>;
+            NarrowableGenericReasonOver, NarrowableBothBoundsReasonOver, NarrowableLazyReasonOver, ConcatReason>;
 
         Reason() : _variant(NoReason{})
         {
@@ -160,6 +179,10 @@ namespace gcs::innards
         }
 
         Reason(NarrowableLazyReasonOver r) : _variant(std::move(r))
+        {
+        }
+
+        Reason(ConcatReason r) : _variant(std::move(r))
         {
         }
 
@@ -204,6 +227,20 @@ namespace gcs::innards
     [[nodiscard]] auto bounds_reason(const std::vector<IntegerVariableID> & vars, const std::optional<Literal> & extra_lit = std::nullopt) -> Reason;
 
     [[nodiscard]] auto singleton_reason(const ProofLiteralOrFlag & lit) -> Reason;
+
+    /**
+     * \brief Compose a base reason with extra literals that materialise *after*
+     * the base's, via a ConcatReason. This is the convenience spelling for the
+     * recurring "structured reason over some variables, plus a handful of
+     * specific literals" shape (Element, MinMax, In, …).
+     *
+     * Degrades to \p base unchanged when there is nothing to add, so the common
+     * (no-extra) path stays a flat, allocation-free reason rather than paying for
+     * a ConcatReason. The \c optional overload is the drop-in for the many sites
+     * that already hold an `optional<Literal>` extra.
+     */
+    [[nodiscard]] auto with_extra(Reason base, ReasonLiterals extra) -> Reason;
+    [[nodiscard]] auto with_extra(Reason base, const std::optional<Literal> & extra) -> Reason;
 
     /**
      * \brief Eagerly materialise a reason into its literal conjunction against

--- a/gcs/innards/variable_id_utils.hh
+++ b/gcs/innards/variable_id_utils.hh
@@ -3,9 +3,13 @@
 
 #include <gcs/variable_id.hh>
 
+#include <algorithm>
 #include <concepts>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -31,6 +35,66 @@ namespace gcs::innards
      */
     template <typename T_>
     concept DirectIntegerVariableIDLike = std::is_convertible_v<T_, DirectIntegerVariableID>;
+
+    /**
+     * \brief The result of as_homogeneous(): a vector specialised to one concrete
+     * IntegerVariableID alternative, or the general mixed vector.
+     *
+     * \ingroup Innards
+     */
+    using HomogeneousIntegerVariables = std::variant<std::vector<SimpleIntegerVariableID>, std::vector<ConstantIntegerVariableID>,
+        std::vector<ViewOfIntegerVariableID>, std::vector<IntegerVariableID>>;
+
+    namespace detail
+    {
+        template <typename T_, typename Container_>
+        [[nodiscard]] auto extract_homogeneous(const Container_ & vars) -> std::vector<T_>
+        {
+            std::vector<T_> result;
+            result.reserve(vars.size());
+            for (const auto & v : vars)
+                result.push_back(std::get<T_>(v));
+            return result;
+        }
+    }
+
+    /**
+     * \brief If every entry of \p vars is the same IntegerVariableID alternative,
+     * return a vector of that concrete type; otherwise return the mixed vector
+     * unchanged.
+     *
+     * Accepts any container of IntegerVariableID (e.g. std::vector or small_vector):
+     * it is templated on the container as a whole, deducing the element type, rather
+     * than taking a template-template parameter -- the latter would not bind to
+     * small_vector, whose signature carries a non-type inline-capacity parameter. The
+     * result is always a std::vector of the concrete type (one install-time
+     * allocation), not a rebind of the input container kind.
+     *
+     * std::visit the result to dispatch a computation onto a single homogeneous
+     * specialisation -- so e.g. per-element domain iteration takes the trivial
+     * same-type path rather than a variant visit -- falling back to the general
+     * IntegerVariableID path only for genuinely mixed scopes. An empty scope yields
+     * the (empty) mixed vector.
+     *
+     * \ingroup Innards
+     */
+    template <typename Container_>
+        requires std::same_as<typename Container_::value_type, IntegerVariableID>
+    [[nodiscard]] auto as_homogeneous(const Container_ & vars) -> HomogeneousIntegerVariables
+    {
+        if (! vars.empty()) {
+            auto first = vars.front().index();
+            if (std::all_of(vars.begin(), vars.end(), [&](const IntegerVariableID & v) { return v.index() == first; }))
+                // Recover the concrete alternative type by visiting the first
+                // entry, rather than mapping raw variant indices to types by hand.
+                return std::visit(
+                    [&](const auto & first_var) -> HomogeneousIntegerVariables {
+                        return detail::extract_homogeneous<std::decay_t<decltype(first_var)>>(vars);
+                    },
+                    vars.front());
+        }
+        return std::vector<IntegerVariableID>(vars.begin(), vars.end());
+    }
 
     /**
      * Convert an IntegerVariableID into a roughly-readable string, for debugging.


### PR DESCRIPTION
The #398–#406 stack was merged via the GitHub button while each PR was based on its **parent feature branch** rather than `main`, so the merges cascaded down the feature-branch chain and never reached `main`. This branch re-lands the whole stack cleanly on current `main`.

It is a clean rebase of the ten optimisation commits onto `main` (`git rebase --onto main 60198101`): the foundation (`for_each_value`) is byte-identical to main's already-merged version and the only main-side delta since the fork (#404 tsp default) is orthogonal, so there were no conflicts. The optimisation content is byte-identical to the reviewed-and-merged commits (verified: diff vs the merged tip is only tsp.cc/#404).

Commits (bottom → top):
- `reason: add ConcatReason + with_extra; use in Element (guarded)`
- `reason: retire the per-struct extra slot in favour of concat()` (#398)
- `linear: skip linear_bounds_reason when no reason is wanted`
- `min_max, in: with_extra + want_reasons guard for the concat reasons` (#399)
- `element: install-time homogeneous-type dispatch via as_homogeneous` (#401)
- `element: constant-array value fast path in the hot propagators` (#402)
- `element: guard the GAC explored_vars build on want_reasons` (#403)
- `element: use a small_vector for the recursion-index scratch (elem)` (#403)
- `equals: guard the reified must-not-hold reason on want_reasons` (#405)
- `propagators: run the propagation queue FIFO instead of LIFO` (#406)

Supersedes the wrongly-based merges of #401–#406 and folds in #398/#399.

### Verification
- Clean rebase onto current `main`; full tree builds (GCC).
- `element_test` (all modes incl. view sweep) and `equals_test` pass with veripb.
- minicp benchmarks vs pre-stack `main` — recursions identical (search unchanged), every benchmark faster: qap −69% vs target, tsp −23% vs baseline, magic_square −10%, n_queens −2%, magic_series beats target. No regression.