### PR TITLE
linear: keep the per-firing bounds snapshot off the heap (small_vector)

### DIFF
--- a/gcs/constraints/linear/justify.cc
+++ b/gcs/constraints/linear/justify.cc
@@ -10,9 +10,8 @@ using namespace gcs::innards;
 
 using std::optional;
 using std::pair;
-using std::vector;
 
-auto gcs::innards::justify_linear_bounds(ProofLogger & logger, const auto & coeff_vars, const vector<pair<Integer, Integer>> & bounds,
+auto gcs::innards::justify_linear_bounds(ProofLogger & logger, const auto & coeff_vars, const LinearBounds & bounds,
     const SimpleIntegerVariableID & change_var, bool second_constraint_for_equality, pair<optional<ProofLine>, optional<ProofLine>> proof_lines)
     -> void
 {
@@ -46,13 +45,13 @@ auto gcs::innards::justify_linear_bounds(ProofLogger & logger, const auto & coef
 }
 
 template auto gcs::innards::justify_linear_bounds(ProofLogger & logger, const SumOf<Weighted<SimpleIntegerVariableID>> & coeff_vars,
-    const vector<pair<Integer, Integer>> & bounds, const SimpleIntegerVariableID & change_var, bool second_constraint_for_equality,
+    const LinearBounds & bounds, const SimpleIntegerVariableID & change_var, bool second_constraint_for_equality,
     pair<optional<ProofLine>, optional<ProofLine>> proof_line) -> void;
 
 template auto gcs::innards::justify_linear_bounds(ProofLogger & logger, const SumOf<PositiveOrNegative<SimpleIntegerVariableID>> & coeff_vars,
-    const vector<pair<Integer, Integer>> & bounds, const SimpleIntegerVariableID & change_var, bool second_constraint_for_equality,
+    const LinearBounds & bounds, const SimpleIntegerVariableID & change_var, bool second_constraint_for_equality,
     pair<optional<ProofLine>, optional<ProofLine>> proof_line) -> void;
 
 template auto gcs::innards::justify_linear_bounds(ProofLogger & logger, const SumOf<SimpleIntegerVariableID> & coeff_vars,
-    const vector<pair<Integer, Integer>> & bounds, const SimpleIntegerVariableID & change_var, bool second_constraint_for_equality,
+    const LinearBounds & bounds, const SimpleIntegerVariableID & change_var, bool second_constraint_for_equality,
     pair<optional<ProofLine>, optional<ProofLine>> proof_line) -> void;

--- a/gcs/constraints/linear/justify.hh
+++ b/gcs/constraints/linear/justify.hh
@@ -6,13 +6,19 @@
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
+#include <gch/small_vector.hpp>
+
 #include <optional>
 #include <utility>
-#include <vector>
 
 namespace gcs::innards
 {
-    auto justify_linear_bounds(ProofLogger & logger, const auto & coeff_vars, const std::vector<std::pair<Integer, Integer>> & bounds,
+    // The per-variable (lower, upper) snapshot a linear propagation works over.
+    // Rebuilt on every firing, so it keeps the common small-arity case in inline
+    // storage to stay off the heap; wider constraints spill to the heap as usual.
+    using LinearBounds = gch::small_vector<std::pair<Integer, Integer>, 8>;
+
+    auto justify_linear_bounds(ProofLogger & logger, const auto & coeff_vars, const LinearBounds & bounds,
         const SimpleIntegerVariableID & which_var_is_changing, bool use_second_constraint_for_equality,
         std::pair<std::optional<ProofLine>, std::optional<ProofLine>> proof_lines) -> void;
 }

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -54,8 +54,8 @@ namespace
         return true;
     }
 
-    auto linear_bounds_reason(bool want_reason, const auto & coeff_vars, const vector<pair<Integer, Integer>> & bounds,
-        const optional<SimpleIntegerVariableID> & var, bool invert, const optional<Literal> & add_to_reason) -> Reason
+    auto linear_bounds_reason(bool want_reason, const auto & coeff_vars, const LinearBounds & bounds, const optional<SimpleIntegerVariableID> & var,
+        bool invert, const optional<Literal> & add_to_reason) -> Reason
     {
         // Building this reason is O(coeff_vars) and it is only ever read when proofs
         // are on (or conflict-directed search wants it), so skip it otherwise -- on a
@@ -81,7 +81,7 @@ namespace
         return ExplicitReason{reason};
     }
 
-    auto infer(auto & inference, ProofLogger * const logger, const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars, int p,
+    auto infer(auto & inference, ProofLogger * const logger, const LinearBounds & bounds, const auto & coeff_vars, int p,
         const SimpleIntegerVariableID & var, Integer remainder, const bool coeff, bool second_constraint_for_equality,
         const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason, const auto & hint)
         -> void
@@ -106,7 +106,7 @@ namespace
         }
     }
 
-    auto infer(auto & inference, ProofLogger * const logger, const vector<pair<Integer, Integer>> & bounds, const auto & coeff_vars, int p,
+    auto infer(auto & inference, ProofLogger * const logger, const LinearBounds & bounds, const auto & coeff_vars, int p,
         const SimpleIntegerVariableID & var, Integer remainder, const Integer coeff, bool second_constraint_for_equality,
         const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason, const auto & hint)
         -> void
@@ -160,7 +160,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
     bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason,
     const Hint_ & hint) -> PropagatorState
 {
-    vector<pair<Integer, Integer>> bounds;
+    LinearBounds bounds;
     bounds.reserve(coeff_vars.terms.size());
 
     // need to check the empty sum case somewhere, because we only get a contradiction


### PR DESCRIPTION
`propagate_linear` rebuilds a `vector<pair<Integer,Integer>>` of the term bounds on every firing, so a narrow constraint heap-allocates and frees a tiny buffer per propagation. Switch it to a `small_vector` with inline capacity 8 (new `LinearBounds` alias in justify.hh), so common small-arity constraints stay inline; wide ones spill to the heap as before.

Threaded through the `justify_linear_bounds` proof path too. Search bit-identical; ~1% on magic_square. All linear/equals proof-verified tests pass.