### PR TITLE
reified dispatcher: skip the per-call condition test when the verdict is fixed at install

### DIFF
--- a/gcs/constraints/innards/reified_dispatcher.hh
+++ b/gcs/constraints/innards/reified_dispatcher.hh
@@ -127,6 +127,35 @@ namespace gcs::innards
             add_trigger_for(triggers, undecided.cond);
         }
 
+        // If the reification condition is already decided in the root state -- an
+        // unconditional MustHold / MustNotHold, or a reified literal that is already
+        // fixed at install time (as happens with some FlatZinc-generated
+        // constraints) -- then its verdict can never change during search: domains
+        // only shrink from the root, and we never backtrack above it. So install a
+        // propagator that runs the relevant enforce pass directly, with no per-call
+        // test_reification_condition and no verdict visit. It is byte-identical to
+        // the branching path, which would re-derive the same verdict -- and the same
+        // cond literal -- on every call. Only a genuinely Undecided condition needs
+        // the runtime branch below.
+        if (std::holds_alternative<evaluated_reif::MustHold>(initial_evaluated)) {
+            propagators.install(
+                constraint_id,
+                [enforce_constraint_must_hold = std::move(enforce_constraint_must_hold),
+                    cond = std::get<evaluated_reif::MustHold>(initial_evaluated).cond](const State & state, auto & inference,
+                    ProofLogger * const logger) -> PropagatorState { return enforce_constraint_must_hold(state, inference, logger, cond); },
+                triggers);
+            return;
+        }
+        if (std::holds_alternative<evaluated_reif::MustNotHold>(initial_evaluated)) {
+            propagators.install(
+                constraint_id,
+                [enforce_constraint_must_not_hold = std::move(enforce_constraint_must_not_hold),
+                    cond = std::get<evaluated_reif::MustNotHold>(initial_evaluated).cond](const State & state, auto & inference,
+                    ProofLogger * const logger) -> PropagatorState { return enforce_constraint_must_not_hold(state, inference, logger, cond); },
+                triggers);
+            return;
+        }
+
         propagators.install(
             constraint_id,
             [reif_cond, enforce_constraint_must_hold = std::move(enforce_constraint_must_hold),


### PR DESCRIPTION
`install_reified_dispatcher` always installed one propagator that re-evaluated `test_reification_condition` and visited the 4-way verdict on **every** call — even when the reification condition is decided in the root state and so can never change during search (domains only shrink from the root, which is never backtracked above). That covers unconditional `MustHold`/`MustNotHold` constraints (NotEquals, LinearEquality) and reified literals already fixed at install time (common with FlatZinc-generated constraints).

Now key off `initial_evaluated`: when it's `MustHold`/`MustNotHold`, install a propagator that runs the relevant enforce pass directly with the (fixed) cond literal, with no per-call test or verdict visit. Byte-identical to the branching path — which would re-derive the same verdict and cond literal every call — so search and proofs are unchanged; only genuinely `Undecided` conditions keep the runtime branch. Restores an optimisation that predated the reified helper.

Search bit-identical. magic_square 25.3s → 24.0s; n_queens(86) 0.528s → 0.484s (~8%). 133 reified-backed proof-verified tests pass.