### PR TITLE
tsp benchmark: default back to the prevent propagator (fix #404)

### DIFF
--- a/minicp_benchmarks/tsp/tsp.cc
+++ b/minicp_benchmarks/tsp/tsp.cc
@@ -30,8 +30,8 @@ auto main(int argc, char * argv[]) -> int
             ("help", "Display help information") //
             ("prove", "Create a proof");
 
-        options.add_options()("propagator", "Specify which circuit propagation algorithm to use (circuit/prevent/scc)",
-            cxxopts::value<string>()->default_value("circuit"));
+        options.add_options()(
+            "propagator", "Specify which circuit propagation algorithm to use (prevent/scc)", cxxopts::value<string>()->default_value("prevent"));
 
         options_vars = options.parse(argc, argv);
     }
@@ -50,8 +50,8 @@ auto main(int argc, char * argv[]) -> int
 
     if (options_vars.contains("propagator")) {
         const string propagator_value = options_vars["propagator"].as<string>();
-        if (propagator_value != "prevent" && propagator_value != "scc" && propagator_value != "circuit") {
-            cerr << "Error: Invalid value for propagator. Use 'prevent', 'scc' or 'circuit'." << endl;
+        if (propagator_value != "prevent" && propagator_value != "scc") {
+            cerr << "Error: Invalid value for propagator. Use 'prevent' or 'scc'." << endl;
             return EXIT_FAILURE;
         }
     }
@@ -92,13 +92,10 @@ auto main(int argc, char * argv[]) -> int
     if (options_vars["propagator"].as<string>() == "prevent") {
         p.post(CircuitPrevent{succ, false});
     }
-    else if (options_vars["propagator"].as<string>() == "scc") {
+    else {
         SCCOptions options{};
         options.enable_comments = false;
         p.post(CircuitSCC{succ, false, options});
-    }
-    else {
-        p.post(Circuit{succ, false});
     }
 
     for (unsigned i = 0; i < n; ++i)


### PR DESCRIPTION
#404 changed the tsp default from `prevent` to a new `circuit` option to "match minicp's plain Circuit" — but `Circuit` is aliased to `CircuitSCC` (circuit.hh:9), so `circuit` selects the *strongest* propagator, not the naive one. That made tsp run a stronger-than-minicp propagator (1.93M recursions vs minicp's 5.18M) — winning by a better propagator, which the same-strength minicp comparison is meant to exclude.

Reverts the default to `prevent` (`CircuitPrevent`, the naive subtour-prevention propagator that matches minicp), and drops the misleading `circuit` alias option (leaving prevent/scc). Honest same-strength baseline restored: 4.29M recursions / ~21.6s.