### PR TITLE
Non-throwing failure path (infer_*_or_stop) + convert hot propagators

### DIFF
--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -49,8 +49,13 @@ using fmt::format;
 using fmt::print;
 #endif
 
+// Returns false if an inference contradicted (the caller must stop and not read
+// state again until backtrack); true if propagation completed. Uses the
+// non-throwing infer_not_equal_or_stop path so a contradiction does not unwind via
+// an exception -- this propagator fails roughly once per node in circuit-style
+// models, so the throw was a large per-node cost.
 auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference,
-    ProofLogger * const logger, const ConstraintID & owner) -> void
+    ProofLogger * const logger, const ConstraintID & owner) -> bool
 {
     auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));
 
@@ -76,16 +81,18 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
         for (auto other : to_propagate) {
             if (other.second == val) {
                 // we're already in a contradicting state
-                inference.infer_not_equal(
-                    logger, var, val, JustifyUsingRUP{hints::AllDifferent{owner}}, ExplicitReason{ReasonLiterals{{other.first == val}}});
+                if (! inference.infer_not_equal_or_stop(
+                        logger, var, val, JustifyUsingRUP{hints::AllDifferent{owner}}, ExplicitReason{ReasonLiterals{{other.first == val}}}))
+                    return false;
             }
         }
 
         while (i != unassigned.end()) {
             auto other = *i;
             if (other != var) {
-                inference.infer_not_equal(
-                    logger, other, val, JustifyUsingRUP{hints::AllDifferent{owner}}, ExplicitReason{ReasonLiterals{{var == val}}});
+                if (! inference.infer_not_equal_or_stop(
+                        logger, other, val, JustifyUsingRUP{hints::AllDifferent{owner}}, ExplicitReason{ReasonLiterals{{var == val}}}))
+                    return false;
                 if (auto other_val = state.optional_single_value(other)) {
                     to_propagate.emplace_back(other, *other_val);
                     unassigned.erase(i++);
@@ -95,6 +102,8 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
             }
         }
     }
+
+    return true;
 }
 
 VCAllDifferent::VCAllDifferent(vector<IntegerVariableID> v) : _vars(move(v))
@@ -161,17 +170,18 @@ auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
         constraint_id(),
         [unassigned_handle = _unassigned_handle, owner = constraint_id()](
             const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
-            propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger, owner);
+            if (! propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger, owner))
+                return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::Enable;
         },
         triggers);
 }
 
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
-    SimpleInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> void;
+    SimpleInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> bool;
 
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
-    EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> void;
+    EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> bool;
 
 auto VCAllDifferent::s_expr(const innards::ProofModel * const model) const -> SExpr
 {

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -15,8 +15,8 @@ namespace gcs
 {
     namespace innards
     {
-        auto propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference_tracker,
-            ProofLogger * const logger, const ConstraintID & owner) -> void;
+        [[nodiscard]] auto propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
+            auto & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> bool;
     }
 
     /**

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -64,7 +64,8 @@ namespace
     auto propagate_circuit_using_prevent(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
         const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference, ProofLogger * const logger) -> void
     {
-        propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner);
+        if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
+            return; // contradiction: the cycle checks below would read junk state; the loop sees contradicted()
         check_small_cycles(succ, owner, pos_var_data, state, inference, logger);
         prevent_small_cycles(succ, owner, pos_var_data, unassigned_handle, state, inference, logger);
     }

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -1066,7 +1066,8 @@ namespace
         const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void
     {
         auto & pos_var_data = any_cast<PosVarDataMap &>(state.get_persistent_constraint_state(pos_var_data_handle));
-        propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner);
+        if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
+            return; // contradiction: the SCC check below would read junk state; the loop sees contradicted()
         auto proof_data = SCCProofData{pos_var_data, proof_flag_data_handle, pos_alldiff_data_handle};
         check_sccs(state, inference, logger, reason, owner, succ, scc_options, proof_data);
         auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -159,20 +159,24 @@ auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propa
         auto enforce_constraint_must_hold = [v1 = _v1, v2 = _v2, or_equal = _or_equal, owner = constraint_id()](const State & state, auto & inference,
                                                 ProofLogger * const logger, const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
-            inference.infer_less_than(logger, v1, v2_bounds.second + (or_equal ? 1_i : 0_i), JustifyUsingRUP{hints::Comparison{owner}},
-                ExplicitReason{ReasonLiterals{{cond, v2 <= v2_bounds.second}}});
-            inference.infer_greater_than_or_equal(logger, v2, v1_bounds.first + (or_equal ? 0_i : 1_i), JustifyUsingRUP{hints::Comparison{owner}},
-                ExplicitReason{ReasonLiterals{{cond, v1 >= v1_bounds.first}}});
+            if (! inference.infer_less_than_or_stop(logger, v1, v2_bounds.second + (or_equal ? 1_i : 0_i), JustifyUsingRUP{hints::Comparison{owner}},
+                    ExplicitReason{ReasonLiterals{{cond, v2 <= v2_bounds.second}}}))
+                return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
+            if (! inference.infer_greater_than_or_equal_or_stop(logger, v2, v1_bounds.first + (or_equal ? 0_i : 1_i),
+                    JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v1 >= v1_bounds.first}}}))
+                return PropagatorState::Enable;
             return v1_bounds.second < (v2_bounds.first + (or_equal ? 1_i : 0_i)) ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable;
         };
 
         auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2, or_equal = _or_equal, owner = constraint_id()](const State & state,
                                                     auto & inference, ProofLogger * const logger, const Literal & cond) -> PropagatorState {
             auto v1_bounds = state.bounds(v1), v2_bounds = state.bounds(v2);
-            inference.infer_less_than(logger, v2, v1_bounds.second + (! or_equal ? 1_i : 0_i), JustifyUsingRUP{hints::Comparison{owner}},
-                ExplicitReason{ReasonLiterals{{cond, v1 <= v1_bounds.second}}});
-            inference.infer_greater_than_or_equal(logger, v1, v2_bounds.first + (! or_equal ? 0_i : 1_i), JustifyUsingRUP{hints::Comparison{owner}},
-                ExplicitReason{ReasonLiterals{{cond, v2 >= v2_bounds.first}}});
+            if (! inference.infer_less_than_or_stop(logger, v2, v1_bounds.second + (! or_equal ? 1_i : 0_i),
+                    JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v1 <= v1_bounds.second}}}))
+                return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
+            if (! inference.infer_greater_than_or_equal_or_stop(logger, v1, v2_bounds.first + (! or_equal ? 0_i : 1_i),
+                    JustifyUsingRUP{hints::Comparison{owner}}, ExplicitReason{ReasonLiterals{{cond, v2 >= v2_bounds.first}}}))
+                return PropagatorState::Enable;
             return v2_bounds.second < (v1_bounds.first + (! or_equal ? 1_i : 0_i)) ? PropagatorState::DisableUntilBacktrack : PropagatorState::Enable;
         };
 

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -298,14 +298,16 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
                                                 ProofLogger * const logger, const Literal & cond) -> PropagatorState {
         auto value1 = state.optional_single_value(v1);
         if (value1) {
-            inference.infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
-                inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}) : Reason{});
+            if (! inference.try_to_infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
+                    inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}) : Reason{}))
+                return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
-            inference.infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
-                inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}) : Reason{});
+            if (! inference.try_to_infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
+                    inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}) : Reason{}))
+                return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -298,14 +298,14 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
                                                 ProofLogger * const logger, const Literal & cond) -> PropagatorState {
         auto value1 = state.optional_single_value(v1);
         if (value1) {
-            if (! inference.try_to_infer_not_equal(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
+            if (! inference.infer_not_equal_or_stop(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
                     inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}) : Reason{}))
                 return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
-            if (! inference.try_to_infer_not_equal(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
+            if (! inference.infer_not_equal_or_stop(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
                     inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}) : Reason{}))
                 return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::DisableUntilBacktrack;

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -83,7 +83,7 @@ namespace
 
     // Returns false if the inference contradicted: the caller must stop immediately
     // (it may not read state again until backtrack). Uses the non-throwing
-    // try_to_infer_* path so a failure does not unwind via an exception.
+    // infer_*_or_stop path so a failure does not unwind via an exception.
     [[nodiscard]] auto infer(auto & inference, ProofLogger * const logger, const LinearBounds & bounds, const auto & coeff_vars, int p,
         const SimpleIntegerVariableID & var, Integer remainder, const bool coeff, bool second_constraint_for_equality,
         const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason, const auto & hint)
@@ -94,7 +94,7 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                if (! inference.try_to_infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                if (! inference.infer_less_than_or_stop(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
                         linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
                     return false;
             }
@@ -104,7 +104,7 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                if (! inference.try_to_infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                if (! inference.infer_greater_than_or_equal_or_stop(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
                         linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
                     return false;
             }
@@ -123,7 +123,7 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                if (! inference.try_to_infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                if (! inference.infer_less_than_or_stop(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
                         linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
                     return false;
             }
@@ -134,7 +134,7 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                if (! inference.try_to_infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                if (! inference.infer_less_than_or_stop(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
                         linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
                     return false;
             }
@@ -144,7 +144,7 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                if (! inference.try_to_infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                if (! inference.infer_greater_than_or_equal_or_stop(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
                         linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
                     return false;
             }
@@ -155,7 +155,7 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                if (! inference.try_to_infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                if (! inference.infer_greater_than_or_equal_or_stop(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
                         linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
                     return false;
             }

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -81,18 +81,22 @@ namespace
         return ExplicitReason{reason};
     }
 
-    auto infer(auto & inference, ProofLogger * const logger, const LinearBounds & bounds, const auto & coeff_vars, int p,
+    // Returns false if the inference contradicted: the caller must stop immediately
+    // (it may not read state again until backtrack). Uses the non-throwing
+    // try_to_infer_* path so a failure does not unwind via an exception.
+    [[nodiscard]] auto infer(auto & inference, ProofLogger * const logger, const LinearBounds & bounds, const auto & coeff_vars, int p,
         const SimpleIntegerVariableID & var, Integer remainder, const bool coeff, bool second_constraint_for_equality,
         const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason, const auto & hint)
-        -> void
+        -> bool
     {
         if (coeff) {
             if (bounds[p].second >= (1_i + remainder)) {
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                if (! inference.try_to_infer_less_than(logger, var, 1_i + remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                        linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
+                    return false;
             }
         }
         else {
@@ -100,16 +104,18 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                if (! inference.try_to_infer_greater_than_or_equal(logger, var, -remainder, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                        linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
+                    return false;
             }
         }
+        return true;
     }
 
-    auto infer(auto & inference, ProofLogger * const logger, const LinearBounds & bounds, const auto & coeff_vars, int p,
+    [[nodiscard]] auto infer(auto & inference, ProofLogger * const logger, const LinearBounds & bounds, const auto & coeff_vars, int p,
         const SimpleIntegerVariableID & var, Integer remainder, const Integer coeff, bool second_constraint_for_equality,
         const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line, const optional<Literal> & add_to_reason, const auto & hint)
-        -> void
+        -> bool
     {
         // lots of conditionals to get the rounding right...
         if (coeff > 0_i && remainder >= 0_i) {
@@ -117,8 +123,9 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                if (! inference.try_to_infer_less_than(logger, var, 1_i + remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                        linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
+                    return false;
             }
         }
         else if (coeff > 0_i && remainder < 0_i) {
@@ -127,8 +134,9 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                if (! inference.try_to_infer_less_than(logger, var, 1_i + div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                        linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
+                    return false;
             }
         }
         else if (coeff < 0_i && remainder >= 0_i) {
@@ -136,8 +144,9 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                if (! inference.try_to_infer_greater_than_or_equal(logger, var, remainder / coeff, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                        linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
+                    return false;
             }
         }
         else if (coeff < 0_i && remainder < 0_i) {
@@ -146,12 +155,14 @@ namespace
                 auto justf = [&](const ReasonLiterals &) {
                     justify_linear_bounds(*logger, coeff_vars, bounds, var, second_constraint_for_equality, proof_line.value());
                 };
-                inference.infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
-                    linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason));
+                if (! inference.try_to_infer_greater_than_or_equal(logger, var, div_with_rounding, JustifyExplicitly{justf, ThenRUP::Yes, hint},
+                        linear_bounds_reason(inference.want_reasons(), coeff_vars, bounds, var, second_constraint_for_equality, add_to_reason)))
+                    return false;
             }
         }
         else
             throw UnexpectedException{"uh, trying to divide by zero?"};
+        return true;
     }
 }
 
@@ -199,7 +210,8 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
             lower_without_me = lower_sum - ((get_coeff(cv) >= 0_i) ? (get_coeff(cv) * bounds[p].first) : (get_coeff(cv) * bounds[p].second));
         Integer remainder = value - lower_without_me;
 
-        infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv), false, proof_line, add_to_reason, hint);
+        if (! infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv), false, proof_line, add_to_reason, hint))
+            return PropagatorState::Enable;    // contradiction: stop before reading the (now junk) state
         bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
         if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -236,8 +248,9 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
 
             Integer inv_remainder = -value - inv_lower_without_me;
 
-            infer(inference, logger, bounds, coeff_vars, p, get_var(cv), inv_remainder, negate(get_coeff_or_bool(cv)), true, proof_line,
-                add_to_reason, hint);
+            if (! infer(inference, logger, bounds, coeff_vars, p, get_var(cv), inv_remainder, negate(get_coeff_or_bool(cv)), true, proof_line,
+                    add_to_reason, hint))
+                return PropagatorState::Enable;    // contradiction: stop before reading the (now junk) state
             bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
 
             if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -42,10 +42,13 @@ namespace gcs::innards
         // is rebuilt each call), so it needs no separate reset.
         bool _contradicted = false;
 
+        // do_throw is forwarded to track_impl: true (the default) keeps the throwing
+        // failure path the legacy infer* methods rely on; false is the non-throwing
+        // try_to_infer_* path, which sets _contradicted and returns instead.
         auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason,
-            const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+            const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt, bool do_throw = true) -> void
         {
-            return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason, assertion_hints);
+            return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason, assertion_hints, do_throw);
         }
 
         // Pin a reason's materialisation *timing* so it can be carried across the
@@ -369,6 +372,23 @@ namespace gcs::innards
             return ! _contradicted;
         }
 
+        // Non-throwing counterpart of infer_not_equal on the JustifyUsingRUP path (the
+        // one the reified-equals enforce passes use). On contradiction sets
+        // _contradicted and returns false instead of throwing; [[nodiscard]] forces
+        // the caller to bail.
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        [[nodiscard]] auto try_to_infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyUsingRUP<Hint_> & why,
+            const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> bool
+        {
+            if (_contradicted) [[unlikely]]
+                return false;
+            auto annotation = rup_hint_annotation(logger, why.hint, fallback);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_not_equal(var, value), var != value, JustifyUsingRUP{}, snapshotted, annotation, false);
+            return ! _contradicted;
+        }
+
         template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
         auto infer_not_in_range(ProofLogger * const logger, const VarType_ & var, Integer lo, Integer hi, const JustifyExplicitly<Emit_, Hint_> & why,
             const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
@@ -529,7 +549,7 @@ namespace gcs::innards
         static constexpr bool materialises_reasons = false;
 
         auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const Reason &,
-            const std::optional<AssertionAnnotation> &) -> void
+            const std::optional<AssertionAnnotation> &, bool do_throw = true) -> void
         {
             switch (inf) {
             case Inference::NoChange: break;
@@ -558,7 +578,10 @@ namespace gcs::innards
             [[unlikely]] case Inference::Contradiction:
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
-                throw TrackedPropagationFailed{};
+                _contradicted = true;
+                if (do_throw)
+                    throw TrackedPropagationFailed{};
+                break;
             }
         }
     };
@@ -571,7 +594,7 @@ namespace gcs::innards
         static constexpr bool materialises_reasons = true;
 
         auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason,
-            const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
+            const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt, bool do_throw = true) -> void
         {
             switch (inf) {
             case Inference::NoChange: break;
@@ -612,7 +635,10 @@ namespace gcs::innards
                     logger->infer(lit, just, materialise(reason, _state), assertion_hints);
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
-                throw TrackedPropagationFailed{};
+                _contradicted = true;
+                if (do_throw)
+                    throw TrackedPropagationFailed{};
+                break;
             }
         }
     };

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -36,7 +36,7 @@ namespace gcs::innards
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
         // Set when an inference yields a contradiction on the non-throwing
-        // (try_to_infer_*) path. The throwing infer* methods unwind instead, so
+        // (infer_*_or_stop) path. The throwing infer* methods unwind instead, so
         // this is the signal the propagate loop checks for propagators that opt
         // into the no-throw failure path. Fresh per propagate() call (the tracker
         // is rebuilt each call), so it needs no separate reset.
@@ -44,7 +44,7 @@ namespace gcs::innards
 
         // do_throw is forwarded to track_impl: true (the default) keeps the throwing
         // failure path the legacy infer* methods rely on; false is the non-throwing
-        // try_to_infer_* path, which sets _contradicted and returns instead.
+        // infer_*_or_stop path, which sets _contradicted and returns instead.
         auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason,
             const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt, bool do_throw = true) -> void
         {
@@ -117,7 +117,7 @@ namespace gcs::innards
         // inside infer_explicitly; no std::function is involved.
         // do_throw distinguishes the two failure paths: the throwing infer*
         // methods leave it true (a contradiction unwinds via TrackedPropagationFailed);
-        // the non-throwing try_to_infer_* methods pass false, so a contradiction sets
+        // the non-throwing infer_*_or_stop methods pass false, so a contradiction sets
         // _contradicted and returns normally, and the propagate loop detects it.
         template <typename Emit_, typename Hint_>
         auto track_explicit(ProofLogger * const logger, const Inference inf, const Literal & lit, const JustifyExplicitly<Emit_, Hint_> & why,
@@ -171,7 +171,7 @@ namespace gcs::innards
             return Actual_::materialises_reasons;
         }
 
-        // Whether an inference on the non-throwing try_to_infer_* path has hit a
+        // Whether an inference on the non-throwing infer_*_or_stop path has hit a
         // contradiction this propagate() call. The propagate loop checks this after
         // a propagator returns (for propagators that opt out of throwing on failure).
         [[nodiscard]] auto contradicted() const -> bool
@@ -349,7 +349,7 @@ namespace gcs::innards
         // flow. [[nodiscard]] makes ignoring the verdict a compile error -- the
         // caller must stop (it cannot safely keep reading state after a failure).
         template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
-        [[nodiscard]] auto try_to_infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value,
+        [[nodiscard]] auto infer_less_than_or_stop(ProofLogger * const logger, const VarType_ & var, Integer value,
             const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt)
             -> bool
         {
@@ -361,7 +361,7 @@ namespace gcs::innards
         }
 
         template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
-        [[nodiscard]] auto try_to_infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value,
+        [[nodiscard]] auto infer_greater_than_or_equal_or_stop(ProofLogger * const logger, const VarType_ & var, Integer value,
             const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt)
             -> bool
         {
@@ -372,20 +372,46 @@ namespace gcs::innards
             return ! _contradicted;
         }
 
-        // Non-throwing counterpart of infer_not_equal on the JustifyUsingRUP path (the
-        // one the reified-equals enforce passes use). On contradiction sets
-        // _contradicted and returns false instead of throwing; [[nodiscard]] forces
+        // Non-throwing counterparts on the JustifyUsingRUP path (used by the
+        // reified-equals and comparison enforce passes). On contradiction they set
+        // _contradicted and return false instead of throwing; [[nodiscard]] forces
         // the caller to bail.
         template <IntegerVariableIDLike VarType_, typename Hint_>
             requires(! std::same_as<Hint_, NoHint>)
-        [[nodiscard]] auto try_to_infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyUsingRUP<Hint_> & why,
-            const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> bool
+        [[nodiscard]] auto infer_not_equal_or_stop(ProofLogger * const logger, const VarType_ & var, Integer value,
+            const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> bool
         {
             if (_contradicted) [[unlikely]]
                 return false;
             auto annotation = rup_hint_annotation(logger, why.hint, fallback);
             auto snapshotted = snapshot_reason(logger, reason, _state);
             track(logger, _state.infer_not_equal(var, value), var != value, JustifyUsingRUP{}, snapshotted, annotation, false);
+            return ! _contradicted;
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        [[nodiscard]] auto infer_less_than_or_stop(ProofLogger * const logger, const VarType_ & var, Integer value,
+            const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> bool
+        {
+            if (_contradicted) [[unlikely]]
+                return false;
+            auto annotation = rup_hint_annotation(logger, why.hint, fallback);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_less_than(var, value), var < value, JustifyUsingRUP{}, snapshotted, annotation, false);
+            return ! _contradicted;
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_>
+            requires(! std::same_as<Hint_, NoHint>)
+        [[nodiscard]] auto infer_greater_than_or_equal_or_stop(ProofLogger * const logger, const VarType_ & var, Integer value,
+            const JustifyUsingRUP<Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> bool
+        {
+            if (_contradicted) [[unlikely]]
+                return false;
+            auto annotation = rup_hint_annotation(logger, why.hint, fallback);
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track(logger, _state.infer_greater_than_or_equal(var, value), var >= value, JustifyUsingRUP{}, snapshotted, annotation, false);
             return ! _contradicted;
         }
 

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -35,6 +35,12 @@ namespace gcs::innards
         State & _state;
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
         bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
+        // Set when an inference yields a contradiction on the non-throwing
+        // (try_to_infer_*) path. The throwing infer* methods unwind instead, so
+        // this is the signal the propagate loop checks for propagators that opt
+        // into the no-throw failure path. Fresh per propagate() call (the tracker
+        // is rebuilt each call), so it needs no separate reset.
+        bool _contradicted = false;
 
         auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason,
             const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt) -> void
@@ -106,9 +112,13 @@ namespace gcs::innards
         // Simple, proofs-off tracker never touches them (pay-for-use) and the same
         // body serves both trackers. Dispatch is compile-time overload resolution
         // inside infer_explicitly; no std::function is involved.
+        // do_throw distinguishes the two failure paths: the throwing infer*
+        // methods leave it true (a contradiction unwinds via TrackedPropagationFailed);
+        // the non-throwing try_to_infer_* methods pass false, so a contradiction sets
+        // _contradicted and returns normally, and the propagate loop detects it.
         template <typename Emit_, typename Hint_>
         auto track_explicit(ProofLogger * const logger, const Inference inf, const Literal & lit, const JustifyExplicitly<Emit_, Hint_> & why,
-            const Reason & reason, const std::optional<AssertionAnnotation> & fallback) -> void
+            const Reason & reason, const std::optional<AssertionAnnotation> & fallback, bool do_throw = true) -> void
         {
             switch (inf) {
             case Inference::NoChange: break;
@@ -128,7 +138,10 @@ namespace gcs::innards
                         infer_explicitly(*logger, lit, why.emit, why.then_rup, materialise(reason, _state), why.hint, fallback);
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _did_anything_since_last_call_inside_propagator = true;
-                throw TrackedPropagationFailed{};
+                _contradicted = true;
+                if (do_throw)
+                    throw TrackedPropagationFailed{};
+                break;
             }
         }
 
@@ -153,6 +166,14 @@ namespace gcs::innards
         [[nodiscard]] auto want_reasons() const -> bool
         {
             return Actual_::materialises_reasons;
+        }
+
+        // Whether an inference on the non-throwing try_to_infer_* path has hit a
+        // contradiction this propagate() call. The propagate loop checks this after
+        // a propagator returns (for propagators that opt out of throwing on failure).
+        [[nodiscard]] auto contradicted() const -> bool
+        {
+            return _contradicted;
         }
 
         auto infer(ProofLogger * const logger, const Literal & lit, const Justification & why, const Reason & reason,
@@ -317,6 +338,35 @@ namespace gcs::innards
         {
             auto snapshotted = snapshot_reason(logger, reason, _state);
             track_explicit(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, snapshotted, fallback);
+        }
+
+        // Non-throwing counterparts of the JustifyExplicitly infer_less_than /
+        // infer_greater_than_or_equal: on contradiction they set _contradicted and
+        // return false instead of throwing, so the caller bails up its own control
+        // flow. [[nodiscard]] makes ignoring the verdict a compile error -- the
+        // caller must stop (it cannot safely keep reading state after a failure).
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        [[nodiscard]] auto try_to_infer_less_than(ProofLogger * const logger, const VarType_ & var, Integer value,
+            const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt)
+            -> bool
+        {
+            if (_contradicted) [[unlikely]]
+                return false;
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_less_than(var, value), var < value, why, snapshotted, fallback, false);
+            return ! _contradicted;
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>
+        [[nodiscard]] auto try_to_infer_greater_than_or_equal(ProofLogger * const logger, const VarType_ & var, Integer value,
+            const JustifyExplicitly<Emit_, Hint_> & why, const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt)
+            -> bool
+        {
+            if (_contradicted) [[unlikely]]
+                return false;
+            auto snapshotted = snapshot_reason(logger, reason, _state);
+            track_explicit(logger, _state.infer_greater_than_or_equal(var, value), var >= value, why, snapshotted, fallback, false);
+            return ! _contradicted;
         }
 
         template <IntegerVariableIDLike VarType_, typename Emit_, typename Hint_>

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -270,11 +270,20 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
             try {
                 ++_imp->total_propagations;
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
-                if (tracker.did_anything_since_last_call_by_propagation_queue())
-                    ++_imp->effectful_propagations;
-                switch (propagator_state) {
-                case PropagatorState::Enable: break;
-                case PropagatorState::DisableUntilBacktrack: _imp->to_disable.push_back(propagator_id); break;
+                if (tracker.contradicted()) {
+                    // A propagator that opted into the non-throwing failure path
+                    // (try_to_infer_*) signals contradiction with this flag rather
+                    // than by unwinding; throwing propagators are caught below.
+                    contradiction = true;
+                    ++_imp->contradicting_propagations;
+                }
+                else {
+                    if (tracker.did_anything_since_last_call_by_propagation_queue())
+                        ++_imp->effectful_propagations;
+                    switch (propagator_state) {
+                    case PropagatorState::Enable: break;
+                    case PropagatorState::DisableUntilBacktrack: _imp->to_disable.push_back(propagator_id); break;
+                    }
                 }
             }
             catch (const TrackedPropagationFailed &) {

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -272,7 +272,7 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
                 if (tracker.contradicted()) {
                     // A propagator that opted into the non-throwing failure path
-                    // (try_to_infer_*) signals contradiction with this flag rather
+                    // (infer_*_or_stop) signals contradiction with this flag rather
                     // than by unwinding; throwing propagators are caught below.
                     contradiction = true;
                     ++_imp->contradicting_propagations;


### PR DESCRIPTION
**Rebased onto `main` after #408 + #409 landed** (those two commits — linear small_vector + reified dispatcher — are now in `main`; this PR is just the four non-throwing-path commits). Merged as a single unit; the hybrid throwing/non-throwing path is an intentional migration step (see notes below).

## What

C++ exception throw/unwind for the contradiction signal (`throw TrackedPropagationFailed`) costs ~11–13% of runtime on failure-heavy search (≈1 failure/node). This adds a **non-throwing failure path** alongside the throwing one, and converts the hot, flat propagators to it:

- `inference_tracker.hh`: a `_contradicted` flag + `[[nodiscard]]` `infer_*_or_stop` methods (less_than / greater_than_or_equal / not_equal, on both the JustifyExplicitly and JustifyUsingRUP paths). On contradiction they set the flag and return `false` instead of throwing; a `do_throw` knob on `track`/`track_explicit`/`track_impl` keeps the throwing path for un-converted propagators. The propagate loop checks `tracker.contradicted()` after each propagator **and** still catches the exception — the two coexist (hybrid).
- Converted: **linear**, **equals/reified-equals**, **comparison**, and **non-gac all_different + circuit** (the shared `propagate_non_gac_alldifferent`). Each bails via its own control flow *before* reading post-contradiction (junk) state. `[[nodiscard]]` makes a missing bail a compile error.

## Results (search bit-identical throughout, full proof suites pass)

| benchmark | before | after | note |
|---|---:|---:|---|
| magic_square | 25.5s | 20.0s | linear + reified-equals (+ #409) |
| n_queens (n=88) | 257.7s | 216.6s | NotEquals |
| tsp (prevent) | 21.6s | 19.3s | circuit's all_different |

## Notes for review

- The hybrid is intended as a migration: convert hot flat propagators incrementally; the throwing path + `do_throw` + the `catch` can be retired once everything is converted, at which point `infer_*_or_stop` becomes just `infer_*`.
- AllDifferent (GAC) is deliberately *not* converted — profiling shows its exception cost is ~1%; it's allocation/propagation-bound (`each_value` coroutine), a separate project.
- Allocation/scratch reuse for circuit/non-gac is deferred to their planned incrementality redesign.
