### PR TITLE
Speed up the non-GAC all_different propagator (VCAllDifferent + circuit)

### DIFF
--- a/examples/ortho_latin/CMakeLists.txt
+++ b/examples/ortho_latin/CMakeLists.txt
@@ -4,4 +4,6 @@ target_link_libraries(ortho_latin PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(ortho_latin PRIVATE cxxopts)
 
-add_test(NAME ortho_latin-5 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:ortho_latin> 5)
+# Pin GAC here: the program now defaults to the non-GAC not-equals encoding, whose
+# full-enumeration proof at this size is far larger than the GAC one this test expects.
+add_test(NAME ortho_latin-5 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:ortho_latin> --all-different gac 5)

--- a/examples/ortho_latin/ortho_latin.cc
+++ b/examples/ortho_latin/ortho_latin.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/arithmetic.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/problem.hh>
@@ -43,16 +44,18 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")                               //
-            ("help", "Display help information")                             //
-            ("prove", "Create a proof")                                      //
-            ("proof-files-basename", "Basename for the .opb and .pbp files", //
-                cxxopts::value<string>()->default_value("ortho_latin"))      //
-            ("stats", "Print solve statistics")                              //
+        options.add_options("Program Options")                                                                       //
+            ("help", "Display help information")                                                                     //
+            ("prove", "Create a proof")                                                                              //
+            ("proof-files-basename", "Basename for the .opb and .pbp files",                                         //
+                cxxopts::value<string>()->default_value("ortho_latin"))                                              //
+            ("stats", "Print solve statistics")                                                                      //
+            ("all-different", "All-different encoding to use: 'gac', 'vc', or 'not-equals' (the not-equals clique)", //
+                cxxopts::value<string>()->default_value("not-equals"))                                               //
             ;
 
-        options.add_options()                                                                    //
-            ("size", "Size of the problem to solve", cxxopts::value<int>()->default_value("88")) //
+        options.add_options()                                                                   //
+            ("size", "Size of the problem to solve", cxxopts::value<int>()->default_value("7")) //
             ("all", "Find all solutions");
 
         options.parse_positional({"size"});
@@ -72,8 +75,27 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
+    const string all_different_mode = options_vars["all-different"].as<string>();
+    if (all_different_mode != "gac" && all_different_mode != "vc" && all_different_mode != "not-equals") {
+        println(cerr, "Error: --all-different must be 'gac', 'vc', or 'not-equals'.");
+        return EXIT_FAILURE;
+    }
+
     Problem p;
     int size = options_vars["size"].as<int>();
+
+    // Post the chosen all-different encoding over the given variables. 'vc' and
+    // 'not-equals' do the same (non-GAC) pruning as each other; 'gac' prunes more.
+    auto post_all_different = [&](const vector<IntegerVariableID> & vars) {
+        if (all_different_mode == "gac")
+            p.post(AllDifferent{vars});
+        else if (all_different_mode == "vc")
+            p.post(VCAllDifferent{vars});
+        else
+            for (unsigned i = 0; i < vars.size(); ++i)
+                for (unsigned j = i + 1; j < vars.size(); ++j)
+                    p.post(NotEquals{vars[i], vars[j]});
+    };
 
     vector<vector<IntegerVariableID>> g1, g2;
     vector<IntegerVariableID> g12;
@@ -99,8 +121,8 @@ auto main(int argc, char * argv[]) -> int
             box1.emplace_back(g1[x][y]);
             box2.emplace_back(g2[x][y]);
         }
-        p.post(AllDifferent{box1});
-        p.post(AllDifferent{box2});
+        post_all_different(box1);
+        post_all_different(box2);
     }
 
     for (int y = 0; y < size; ++y) {
@@ -109,11 +131,11 @@ auto main(int argc, char * argv[]) -> int
             box1.emplace_back(g1[x][y]);
             box2.emplace_back(g2[x][y]);
         }
-        p.post(AllDifferent{box1});
-        p.post(AllDifferent{box2});
+        post_all_different(box1);
+        post_all_different(box2);
     }
 
-    p.post(AllDifferent{g12});
+    post_all_different(g12);
 
     // Normal form: first row of each square and first column of first square is 0 1 2 3 ...
     for (int x = 0; x < size; ++x) {

--- a/gcs/constraint_id.hh
+++ b/gcs/constraint_id.hh
@@ -2,6 +2,8 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINT_ID_HH
 
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <variant>
 #include <version>
 
@@ -34,18 +36,30 @@ namespace gcs
 
     struct NamedConstraint final
     {
-        std::string name;
+        // A view into a name string owned elsewhere (the Problem's name pool), so
+        // that ConstraintID stays trivially copyable -- copying it is a memcpy
+        // rather than a std::string copy + the std::variant copy-ctor visit. The
+        // viewed string must outlive every copy of this id; the Problem owns it for
+        // the whole solve. Compared by content, matching the old std::string field.
+        std::string_view name;
         [[nodiscard]] auto operator<=>(const NamedConstraint &) const = default;
         [[nodiscard]] auto as_string() const -> std::string
         {
-            return name;
+            return std::string{name};
         }
     };
 
     // The *identity* of a constraint (`_1`, `_2`, or a caller-given name) -- not
     // its type (`abs`, `all_different`, ...). Kept distinct from "name" because
-    // both readings of that word kept getting confused.
+    // both readings of that word kept getting confused. Trivially copyable (all
+    // three alternatives are), so passing or copying one is just a memcpy.
     using ConstraintID = std::variant<CurrentlyUnnamedConstraint, NumberedConstraint, NamedConstraint>;
+
+    // ConstraintID is copied on the hot path -- every reason/hint a propagator builds
+    // carries one (see e.g. propagate_non_gac_alldifferent). Keep it trivially copyable
+    // so that copy is a memcpy rather than a std::variant copy-ctor visit: in particular
+    // do not give any alternative an owning std::string or other non-trivial member.
+    static_assert(std::is_trivially_copyable_v<ConstraintID>);
 
     [[nodiscard]] auto as_string(const ConstraintID &) -> std::string;
 }

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -78,11 +78,18 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
         to_propagate.pop_back();
         auto i = unassigned.begin();
 
+        // Every removal this fixed (var == val) triggers is justified by the same
+        // single literal, so build that reason once per popped variable rather than
+        // once per inference -- and only when something will read it. Off the proof
+        // and conflict-learning paths want_reasons() is false, the reason is
+        // discarded, and constructing it per inference was ~6% of this benchmark.
+        const auto var_assigned_reason = inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{var == val}}}} : Reason{};
+
         for (auto other : to_propagate) {
             if (other.second == val) {
                 // we're already in a contradicting state
-                if (! inference.infer_not_equal_or_stop(
-                        logger, var, val, JustifyUsingRUP{hints::AllDifferent{owner}}, ExplicitReason{ReasonLiterals{{other.first == val}}}))
+                if (! inference.infer_not_equal_or_stop(logger, var, val, JustifyUsingRUP{hints::AllDifferent{owner}},
+                        inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{other.first == val}}}} : Reason{}))
                     return false;
             }
         }
@@ -90,8 +97,7 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
         while (i != unassigned.end()) {
             auto other = *i;
             if (other != var) {
-                if (! inference.infer_not_equal_or_stop(
-                        logger, other, val, JustifyUsingRUP{hints::AllDifferent{owner}}, ExplicitReason{ReasonLiterals{{var == val}}}))
+                if (! inference.infer_not_equal_or_stop(logger, other, val, JustifyUsingRUP{hints::AllDifferent{owner}}, var_assigned_reason))
                     return false;
                 if (auto other_val = state.optional_single_value(other)) {
                     to_propagate.emplace_back(other, *other_val);

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <list>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -32,7 +31,6 @@ using namespace gcs::innards;
 using std::decay_t;
 using std::function;
 using std::is_same_v;
-using std::list;
 using std::pair;
 using std::string;
 using std::unique_ptr;
@@ -57,7 +55,7 @@ using fmt::print;
 auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference,
     ProofLogger * const logger, const ConstraintID & owner, const std::vector<Reason> * single_value_reasons, unsigned long long reason_base) -> bool
 {
-    auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));
+    auto & unassigned = any_cast<NonGacAllDifferentUnassigned &>(state.get_constraint_state(unassigned_handle));
 
     // The reason every removal cites is "v == val", where v is a variable already
     // fixed to val. When the caller hands us a prebuilt table, look it up by v's own
@@ -75,22 +73,23 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
 
     vector<pair<IntegerVariableID, Integer>> to_propagate;
     {
-        // Collect any newly assigned values
-        for (auto i = unassigned.begin(); i != unassigned.end();) {
-            auto s = *i;
+        // Collect any newly assigned values. Erasing by swap-and-pop (order of
+        // unassigned is irrelevant) keeps this O(1) per removal on a flat container.
+        for (std::size_t k = 0; k < unassigned.size();) {
+            auto s = unassigned[k];
             if (auto val = state.optional_single_value(s)) {
                 to_propagate.emplace_back(s, *val);
-                unassigned.erase(i++);
+                unassigned[k] = unassigned.back();
+                unassigned.pop_back();
             }
             else
-                i++;
+                ++k;
         }
     }
 
     while (! to_propagate.empty()) {
         auto [var, val] = to_propagate.back();
         to_propagate.pop_back();
-        auto i = unassigned.begin();
 
         // The same "var == val" reason justifies every removal this popped variable
         // triggers, so resolve it once here and reuse the reference in the inner loop.
@@ -107,18 +106,21 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
             }
         }
 
-        while (i != unassigned.end()) {
-            auto other = *i;
+        for (std::size_t k = 0; k < unassigned.size();) {
+            auto other = unassigned[k];
+            // var is no longer in unassigned (it was popped into to_propagate), so the
+            // other != var guard from the list version always held; kept for safety.
             if (other != var) {
                 if (! inference.infer_not_equal_or_stop(logger, other, val, JustifyUsingRUP{hints::AllDifferent{owner}}, var_assigned_reason))
                     return false;
                 if (auto other_val = state.optional_single_value(other)) {
                     to_propagate.emplace_back(other, *other_val);
-                    unassigned.erase(i++);
+                    unassigned[k] = unassigned.back();
+                    unassigned.pop_back();
+                    continue;
                 }
-                else
-                    ++i;
             }
+            ++k;
         }
     }
 
@@ -161,7 +163,7 @@ auto VCAllDifferent::prepare(Propagators &, State & initial_state, ProofModel * 
 
     // Keep track of unassigned vars
     // Might want a more centralised way of doing this in future.
-    list<IntegerVariableID> unassigned{};
+    NonGacAllDifferentUnassigned unassigned{};
     for (auto & var : _sanitised_vars)
         if (! initial_state.has_single_value(var))
             unassigned.push_back(var);

--- a/gcs/constraints/all_different/vc_all_different.cc
+++ b/gcs/constraints/all_different/vc_all_different.cc
@@ -55,9 +55,23 @@ using fmt::print;
 // an exception -- this propagator fails roughly once per node in circuit-style
 // models, so the throw was a large per-node cost.
 auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference,
-    ProofLogger * const logger, const ConstraintID & owner) -> bool
+    ProofLogger * const logger, const ConstraintID & owner, const std::vector<Reason> * single_value_reasons, unsigned long long reason_base) -> bool
 {
     auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));
+
+    // The reason every removal cites is "v == val", where v is a variable already
+    // fixed to val. When the caller hands us a prebuilt table, look it up by v's own
+    // index and return a reference -- no per-inference construction. A view/constant,
+    // or a variable outside the table, falls back to building the reason inline (the
+    // want_reasons() guard still applies there, since that construction is not free).
+    auto reason_for = [&](const IntegerVariableID & v, Integer val, Reason & inline_storage) -> const Reason & {
+        if (single_value_reasons)
+            if (auto s = std::get_if<SimpleIntegerVariableID>(&v))
+                if (auto idx = s->index - reason_base; idx < single_value_reasons->size())
+                    return (*single_value_reasons)[idx];
+        inline_storage = inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{v == val}}}} : Reason{};
+        return inline_storage;
+    };
 
     vector<pair<IntegerVariableID, Integer>> to_propagate;
     {
@@ -78,18 +92,17 @@ auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & 
         to_propagate.pop_back();
         auto i = unassigned.begin();
 
-        // Every removal this fixed (var == val) triggers is justified by the same
-        // single literal, so build that reason once per popped variable rather than
-        // once per inference -- and only when something will read it. Off the proof
-        // and conflict-learning paths want_reasons() is false, the reason is
-        // discarded, and constructing it per inference was ~6% of this benchmark.
-        const auto var_assigned_reason = inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{var == val}}}} : Reason{};
+        // The same "var == val" reason justifies every removal this popped variable
+        // triggers, so resolve it once here and reuse the reference in the inner loop.
+        Reason var_inline_storage;
+        const Reason & var_assigned_reason = reason_for(var, val, var_inline_storage);
 
         for (auto other : to_propagate) {
             if (other.second == val) {
                 // we're already in a contradicting state
-                if (! inference.infer_not_equal_or_stop(logger, var, val, JustifyUsingRUP{hints::AllDifferent{owner}},
-                        inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{{other.first == val}}}} : Reason{}))
+                Reason other_inline_storage;
+                if (! inference.infer_not_equal_or_stop(
+                        logger, var, val, JustifyUsingRUP{hints::AllDifferent{owner}}, reason_for(other.first, val, other_inline_storage)))
                     return false;
             }
         }
@@ -172,11 +185,37 @@ auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 
+    // Prebuild the per-variable "v == its single value" reason once, indexed by the
+    // variable's own SimpleIntegerVariableID index (offset by reason_base). This is a
+    // deferred ExactSingleValue, so it materialises to v == whatever value v is fixed
+    // to at the point of inference. It is constraint-owned (moved into the propagator
+    // closure), not backtracked: the table never changes during search. Views and
+    // constants get no entry and fall back to inline construction in the propagator.
+    unsigned long long reason_base = 0;
+    vector<Reason> reasons;
+    {
+        auto lo = ~0ull, hi = 0ull;
+        bool any_simple = false;
+        for (const auto & v : _sanitised_vars)
+            if (auto s = std::get_if<SimpleIntegerVariableID>(&v)) {
+                lo = std::min(lo, s->index);
+                hi = std::max(hi, s->index);
+                any_simple = true;
+            }
+        if (any_simple) {
+            reason_base = lo;
+            reasons.resize(hi - lo + 1);
+            for (const auto & v : _sanitised_vars)
+                if (auto s = std::get_if<SimpleIntegerVariableID>(&v))
+                    reasons[s->index - lo] = Reason{ExactSingleValue{ReasonVars{vector<IntegerVariableID>{v}}}};
+        }
+    }
+
     propagators.install(
         constraint_id(),
-        [unassigned_handle = _unassigned_handle, owner = constraint_id()](
+        [unassigned_handle = _unassigned_handle, owner = constraint_id(), reasons = std::move(reasons), reason_base](
             const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
-            if (! propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger, owner))
+            if (! propagate_non_gac_alldifferent(unassigned_handle, state, tracker, logger, owner, reasons.empty() ? nullptr : &reasons, reason_base))
                 return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::Enable;
         },
@@ -184,10 +223,12 @@ auto VCAllDifferent::install_propagators(Propagators & propagators) -> void
 }
 
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
-    SimpleInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> bool;
+    SimpleInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner,
+    const std::vector<Reason> * single_value_reasons, unsigned long long reason_base) -> bool;
 
 template auto gcs::innards::propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
-    EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> bool;
+    EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger, const ConstraintID & owner,
+    const std::vector<Reason> * single_value_reasons, unsigned long long reason_base) -> bool;
 
 auto VCAllDifferent::s_expr(const innards::ProofModel * const model) const -> SExpr
 {

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/inference_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
 #include <optional>
@@ -15,8 +16,14 @@ namespace gcs
 {
     namespace innards
     {
+        // single_value_reasons, when non-null, is a constraint-owned (not backtracked)
+        // table of prebuilt "v == its single value" reasons, indexed by the variable's
+        // SimpleIntegerVariableID index minus reason_base, so the hot loops hand back a
+        // reference instead of constructing a reason. Variables with no entry (views /
+        // constants, or an out-of-range index) fall back to building the reason inline.
         [[nodiscard]] auto propagate_non_gac_alldifferent(const ConstraintStateHandle & unassigned_handle, const State & state,
-            auto & inference_tracker, ProofLogger * const logger, const ConstraintID & owner) -> bool;
+            auto & inference_tracker, ProofLogger * const logger, const ConstraintID & owner,
+            const std::vector<Reason> * single_value_reasons = nullptr, unsigned long long reason_base = 0) -> bool;
     }
 
     /**

--- a/gcs/constraints/all_different/vc_all_different.hh
+++ b/gcs/constraints/all_different/vc_all_different.hh
@@ -16,6 +16,14 @@ namespace gcs
 {
     namespace innards
     {
+        // The not-yet-assigned variables tracked as backtrackable constraint state by
+        // the non-GAC all_different propagator (and circuit, which shares it). Order is
+        // not significant: the propagators may permute it (swap-and-pop erase), so it is
+        // a flat contiguous container rather than a list, to keep the per-search-node
+        // backtracking copy of the constraint state cheap (one allocation + memcpy, or
+        // none at all, instead of a heap node per element).
+        using NonGacAllDifferentUnassigned = std::vector<IntegerVariableID>;
+
         // single_value_reasons, when non-null, is a constraint-owned (not backtracked)
         // table of prebuilt "v == its single value" reasons, indexed by the variable's
         // SimpleIntegerVariableID index minus reason_base, so the hot loops hand back a

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -10,7 +10,6 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 
-#include <list>
 #include <map>
 #include <sstream>
 #include <string>
@@ -31,7 +30,6 @@ using namespace gcs::innards;
 
 using std::cmp_less;
 using std::cmp_not_equal;
-using std::list;
 using std::map;
 using std::nullopt;
 using std::optional;
@@ -104,7 +102,7 @@ auto gcs::innards::circuit::prevent_small_cycles(const vector<IntegerVariableID>
     const PosVarDataMap & pos_var_data, const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference,
     ProofLogger * const logger) -> void
 {
-    auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));
+    auto & unassigned = any_cast<NonGacAllDifferentUnassigned &>(state.get_constraint_state(unassigned_handle));
     auto n = succ.size();
     auto end = vector<long>(n, -1);
     auto known_ends = vector<long>{};

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -6,16 +6,16 @@
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/propagators.hh>
 
-#include <util/enumerate.hh>
-
+#include <any>
 #include <map>
 #include <utility>
+#include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 using namespace gcs::innards::circuit;
 
-using std::cmp_less;
+using std::any_cast;
 using std::map;
 using std::size_t;
 using std::stringstream;
@@ -24,48 +24,90 @@ using std::vector;
 
 namespace
 {
-    auto check_small_cycles(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
-        const State & state, auto & inference, ProofLogger * const logger) -> void
+    // Incremental "prevent" state: the fixed successor edges partition the nodes into
+    // simple paths (chains). For each node we record the chain it belongs to by its
+    // endpoints. These are maintained in O(1) as edges are fixed and restored on
+    // backtrack (held as backtrackable constraint state), rather than recomputed from
+    // scratch each call. orig[v] is valid when v is a chain *end*, dest[v]/len[v] when
+    // v is a chain *start* -- which is exactly how they are queried below.
+    struct PreventChainData
     {
-        auto n = succ.size();
-        auto checked = vector<bool>(n, false);
+        std::vector<long> orig;      // start node of the chain ending at this node
+        std::vector<long> dest;      // end node of the chain starting at this node
+        std::vector<long> len;       // number of fixed edges in the chain starting at this node
+        std::vector<long> unspliced; // node indices whose fixed successor edge is not yet folded in
+    };
 
-        for (auto [idx, var] : enumerate(succ)) {
-            if (checked[idx])
-                continue;
-            checked[idx] = true;
-            if (auto val = state.optional_single_value(var)) {
-                auto j0 = (*val).raw_value;
-                if (state.has_single_value(succ[j0])) {
-                    auto cycle_length = 0;
-                    auto j = j0;
-                    do {
-                        j = state.optional_single_value(succ[j])->raw_value;
-                        checked[j] = true;
-                        cycle_length++;
-                        if (j == j0) {
-                            if (cmp_less(cycle_length, n)) {
-                                if (logger && logger->get_assertion_level() == AssertionLevel::Off)
-                                    output_cycle_to_proof(succ, j0, cycle_length, pos_var_data, state, *logger);
-                                inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
-                            }
+    // Fold every newly-fixed edge into the chain endpoints and make the same inferences
+    // the from-scratch prevent_small_cycles would: forbid a short chain from closing
+    // (succ[end] != start), force the full chain to close (succ[end] == start), and
+    // contradict if a sub-cycle has actually closed. Each edge is processed once, in
+    // O(1); the outer loop re-runs only because forcing an edge fixes a new one.
+    auto prevent_small_cycles_incrementally(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
+        const ConstraintStateHandle & chain_handle, const State & state, auto & inference, ProofLogger * const logger) -> void
+    {
+        auto & chain = any_cast<PreventChainData &>(state.get_constraint_state(chain_handle));
+        auto n = static_cast<long>(succ.size());
 
-                            else
-                                break;
-                        }
-                    } while (state.has_single_value(succ[j]));
+        bool progress = true;
+        while (progress) {
+            progress = false;
+            for (std::size_t k = 0; k < chain.unspliced.size();) {
+                auto i = chain.unspliced[k];
+                auto val = state.optional_single_value(succ[i]);
+                if (! val) {
+                    ++k;
+                    continue;
+                }
+
+                // Edge i -> j is fixed; remove i from the unspliced set (swap-and-pop)
+                // and fold it in. i was a chain end (its successor had been unfixed);
+                // by all-different j had no predecessor, so j is a chain start.
+                auto j = val->raw_value;
+                chain.unspliced[k] = chain.unspliced.back();
+                chain.unspliced.pop_back();
+                progress = true;
+
+                auto o = chain.orig[i];
+                if (j == o) {
+                    // This edge closes the chain o..i into a cycle of len[o] + 1 edges.
+                    if (chain.len[o] + 1 < n) {
+                        if (logger && logger->get_assertion_level() == AssertionLevel::Off)
+                            output_cycle_to_proof(succ, o, chain.len[o] + 1, pos_var_data, state, *logger);
+                        inference.contradiction(logger, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
+                    }
+                    // else: the final edge of the full Hamiltonian cycle -- nothing to infer.
+                }
+                else {
+                    // Splice chain (o..i) and chain (j..d) into (o..d).
+                    auto d = chain.dest[j];
+                    auto new_len = chain.len[o] + 1 + chain.len[j];
+                    chain.dest[o] = d;
+                    chain.orig[d] = o;
+                    chain.len[o] = new_len;
+                    if (new_len < n - 1) {
+                        auto justf = [&](const ReasonLiterals &) {
+                            output_cycle_to_proof(succ, o, new_len, pos_var_data, state, *logger, Integer{d}, Integer{o});
+                        };
+                        inference.infer(
+                            logger, succ[d] != Integer{o}, JustifyExplicitly{justf, ThenRUP::Yes, hints::Circuit{owner}}, generic_reason(succ));
+                    }
+                    else {
+                        // The chain spans every node; it must close to complete the tour.
+                        inference.infer(logger, succ[d] == Integer{o}, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
+                    }
                 }
             }
         }
     }
 
     auto propagate_circuit_using_prevent(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
-        const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference, ProofLogger * const logger) -> void
+        const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle, const State & state, auto & inference,
+        ProofLogger * const logger) -> void
     {
         if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
             return; // contradiction: the cycle checks below would read junk state; the loop sees contradicted()
-        check_small_cycles(succ, owner, pos_var_data, state, inference, logger);
-        prevent_small_cycles(succ, owner, pos_var_data, unassigned_handle, state, inference, logger);
+        prevent_small_cycles_incrementally(succ, owner, pos_var_data, chain_handle, state, inference, logger);
     }
 }
 
@@ -83,15 +125,30 @@ auto CircuitPrevent::install(innards::Propagators & propagators, innards::State 
     }
     auto unassigned_handle = initial_state.add_constraint_state(unassigned);
 
+    // Backtrackable chain endpoints for the incremental small-cycle prevention. Each
+    // node starts as its own length-zero chain; edges fold in as successors are fixed.
+    auto num_nodes = _succ.size();
+    PreventChainData chain;
+    chain.orig.resize(num_nodes);
+    chain.dest.resize(num_nodes);
+    chain.len.assign(num_nodes, 0);
+    chain.unspliced.resize(num_nodes);
+    for (size_t i = 0; i < num_nodes; ++i) {
+        chain.orig[i] = static_cast<long>(i);
+        chain.dest[i] = static_cast<long>(i);
+        chain.unspliced[i] = static_cast<long>(i);
+    }
+    auto chain_handle = initial_state.add_constraint_state(std::move(chain));
+
     auto pos_var_data = CircuitBase::set_up(propagators, initial_state, model);
 
     Triggers triggers;
     triggers.on_instantiated = {_succ.begin(), _succ.end()};
     propagators.install(
         constraint_id(),
-        [succ = _succ, owner = constraint_id(), pvd = pos_var_data, unassigned_handle = unassigned_handle](
+        [succ = _succ, owner = constraint_id(), pvd = pos_var_data, unassigned_handle = unassigned_handle, chain_handle = chain_handle](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_circuit_using_prevent(succ, owner, pvd, unassigned_handle, state, inference, logger);
+            propagate_circuit_using_prevent(succ, owner, pvd, unassigned_handle, chain_handle, state, inference, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -8,7 +8,6 @@
 
 #include <util/enumerate.hh>
 
-#include <list>
 #include <map>
 #include <utility>
 
@@ -17,7 +16,6 @@ using namespace gcs::innards;
 using namespace gcs::innards::circuit;
 
 using std::cmp_less;
-using std::list;
 using std::map;
 using std::size_t;
 using std::stringstream;
@@ -79,7 +77,7 @@ auto CircuitPrevent::clone() const -> unique_ptr<Constraint>
 auto CircuitPrevent::install(innards::Propagators & propagators, innards::State & initial_state, innards::ProofModel * const model) && -> void
 {
     // Keep track of unassigned vars
-    list<IntegerVariableID> unassigned{};
+    NonGacAllDifferentUnassigned unassigned{};
     for (auto v : _succ) {
         unassigned.emplace_back(v);
     }

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -10,7 +10,6 @@
 #include <gcs/proof.hh>
 #include <util/enumerate.hh>
 
-#include <list>
 #include <map>
 #include <random>
 #include <set>
@@ -32,7 +31,6 @@ using fmt::format;
 using std::cmp_less;
 using std::cmp_less_equal;
 using std::cmp_not_equal;
-using std::list;
 using std::make_optional;
 using std::map;
 using std::min;
@@ -1070,14 +1068,15 @@ namespace
             return; // contradiction: the SCC check below would read junk state; the loop sees contradicted()
         auto proof_data = SCCProofData{pos_var_data, proof_flag_data_handle, pos_alldiff_data_handle};
         check_sccs(state, inference, logger, reason, owner, succ, scc_options, proof_data);
-        auto & unassigned = any_cast<list<IntegerVariableID> &>(state.get_constraint_state(unassigned_handle));
-        // Remove any newly assigned vals from unassigned
-        auto it = unassigned.begin();
-        while (it != unassigned.end()) {
-            if (state.optional_single_value(*it))
-                it = unassigned.erase(it);
+        auto & unassigned = any_cast<NonGacAllDifferentUnassigned &>(state.get_constraint_state(unassigned_handle));
+        // Remove any newly assigned vals from unassigned (swap-and-pop; order is irrelevant).
+        for (std::size_t k = 0; k < unassigned.size();) {
+            if (state.optional_single_value(unassigned[k])) {
+                unassigned[k] = unassigned.back();
+                unassigned.pop_back();
+            }
             else
-                ++it;
+                ++k;
         }
         prevent_small_cycles(succ, owner, pos_var_data, unassigned_handle, state, inference, logger);
     }
@@ -1098,7 +1097,7 @@ auto CircuitSCC::install(Propagators & propagators, State & initial_state, Proof
     auto pos_var_data = CircuitBase::set_up(propagators, initial_state, model);
 
     // Keep track of unassigned vars
-    list<IntegerVariableID> unassigned{};
+    NonGacAllDifferentUnassigned unassigned{};
     for (auto v : _succ) {
         unassigned.emplace_back(v);
     }

--- a/gcs/constraints/circuit/circuit_test.cc
+++ b/gcs/constraints/circuit/circuit_test.cc
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <set>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -58,10 +59,17 @@ auto is_single_circuit(const vector<int> & succ) -> bool
     return cur == 0 && count == n;
 }
 
-auto run_circuit_test(bool proofs, const ViewWrapConfig & view_cfg, int n) -> void
+enum struct CircuitPropagator
+{
+    scc,
+    prevent
+};
+
+auto run_circuit_test(bool proofs, const ViewWrapConfig & view_cfg, int n, CircuitPropagator propagator) -> void
 {
     auto wraps = wraps_for_positions(view_cfg, n);
-    print(cerr, "circuit [{}] n={}{}", view_wrap_config_label(view_cfg), n, proofs ? " with proofs:" : ":");
+    auto prop_label = propagator == CircuitPropagator::prevent ? "prevent" : "scc";
+    print(cerr, "circuit/{} [{}] n={}{}", prop_label, view_wrap_config_label(view_cfg), n, proofs ? " with proofs:" : ":");
     cerr << flush;
 
     vector<pair<int, int>> domains(static_cast<std::size_t>(n), pair{0, n - 1});
@@ -74,9 +82,12 @@ auto run_circuit_test(bool proofs, const ViewWrapConfig & view_cfg, int n) -> vo
     vector<IntegerVariableID> succ;
     for (int i = 0; i < n; ++i)
         succ.push_back(create_integer_variable_or_constant_with_view(p, pair{0, n - 1}, wraps.at(static_cast<std::size_t>(i))));
-    p.post(Circuit{succ});
+    if (propagator == CircuitPropagator::prevent)
+        p.post(CircuitPrevent{succ, false});
+    else
+        p.post(Circuit{succ});
 
-    auto proof_name = proofs ? make_optional("circuit_test_" + view_wrap_config_label(view_cfg)) : nullopt;
+    auto proof_name = proofs ? make_optional("circuit_test_" + std::string{prop_label} + "_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{succ});
     check_results(proof_name, expected, actual);
 }
@@ -95,15 +106,17 @@ auto main(int argc, char * argv[]) -> int
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
-        for (int n : {3, 4, 5})
-            run_circuit_test(proofs, view_cfg, n);
-        // Degenerate minimal circuits (issue #254): n=1 is a single self-loop
-        // (the canonical minimal circuit), n=2 the unique 2-cycle. Run only in
-        // the bare configuration; the view sweep targets the larger instances
-        // and its positions can exceed these tiny n.
-        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
-            run_circuit_test(proofs, view_cfg, 1);
-            run_circuit_test(proofs, view_cfg, 2);
+        for (auto propagator : {CircuitPropagator::scc, CircuitPropagator::prevent}) {
+            for (int n : {3, 4, 5})
+                run_circuit_test(proofs, view_cfg, n, propagator);
+            // Degenerate minimal circuits (issue #254): n=1 is a single self-loop
+            // (the canonical minimal circuit), n=2 the unique 2-cycle. Run only in
+            // the bare configuration; the view sweep targets the larger instances
+            // and its positions can exceed these tiny n.
+            if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+                run_circuit_test(proofs, view_cfg, 1, propagator);
+                run_circuit_test(proofs, view_cfg, 2, propagator);
+            }
         }
     }
 

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -90,11 +90,15 @@ auto Problem::check_name(const string & name) -> const string &
     if (! stack.empty())
         throw NamingError{"Unbalanced brackets in variable name '" + name + "'"};
 
-    // The name is valid, but check for duplicates
-    if (! _imp->names.insert(name).second)
+    // The name is valid, but check for duplicates. Return a reference to the
+    // interned copy in _imp->names (whose elements have stable addresses for the
+    // set's lifetime) rather than to the caller's argument, so that a NamedConstraint
+    // can hold a string_view into it that stays valid for the whole solve.
+    auto [it, inserted] = _imp->names.insert(name);
+    if (! inserted)
         throw NamingError{"Duplicate variable name '" + name + "'"};
 
-    return name;
+    return *it;
 }
 
 auto Problem::create_integer_variable(Integer lower, Integer upper, const optional<string> & name) -> SimpleIntegerVariableID

--- a/minicp_benchmarks/magic_square/magic_square.cc
+++ b/minicp_benchmarks/magic_square/magic_square.cc
@@ -1,6 +1,7 @@
 /* vim : set sw = 4 sts = 4 et foldmethod = syntax : */
 
 #include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/problem.hh>
@@ -22,6 +23,7 @@ using std::endl;
 using std::ifstream;
 using std::make_optional;
 using std::nullopt;
+using std::string;
 using std::vector;
 
 auto main(int argc, char * argv[]) -> int
@@ -30,10 +32,11 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
-            ("all-different", "Use AllDifferent rather than inequalities");
+        options.add_options("Program Options")                                                                       //
+            ("help", "Display help information")                                                                     //
+            ("prove", "Create a proof")                                                                              //
+            ("all-different", "All-different encoding to use: 'gac', 'vc', or 'not-equals' (the not-equals clique)", //
+                cxxopts::value<string>()->default_value("not-equals"));
 
         options.add_options()("size", "Size of the problem to solve", cxxopts::value<int>()->default_value("5"));
 
@@ -52,6 +55,12 @@ auto main(int argc, char * argv[]) -> int
         cout << endl;
         cout << options.help() << endl;
         return EXIT_SUCCESS;
+    }
+
+    const string all_different_mode = options_vars["all-different"].as<string>();
+    if (all_different_mode != "gac" && all_different_mode != "vc" && all_different_mode != "not-equals") {
+        cerr << "Error: --all-different must be 'gac', 'vc', or 'not-equals'." << endl;
+        return EXIT_FAILURE;
     }
 
     cout << "Replicating the MiniCP Magic Square benchmark." << endl;
@@ -77,9 +86,13 @@ auto main(int argc, char * argv[]) -> int
     }
 
     // As far as I can tell, the statistics reported in the paper only make
-    // sense for non-GAC all-different.
-    if (options_vars.contains("all-different")) {
+    // sense for non-GAC all-different (the 'vc' or 'not-equals' encodings,
+    // which do the same pruning as each other).
+    if (all_different_mode == "gac") {
         p.post(AllDifferent{grid_flat});
+    }
+    else if (all_different_mode == "vc") {
+        p.post(VCAllDifferent{grid_flat});
     }
     else {
         for (unsigned x = 0; x < grid_flat.size(); ++x)


### PR DESCRIPTION
Makes the non-GAC all_different propagator (`propagate_non_gac_alldifferent`, shared by `VCAllDifferent` and `circuit`) faster, driven by profiling three benchmarks. Each step keeps the search **bit-identical** (recursions unchanged) and proofs verifying.

Cumulative on `magic_square --all-different vc 5`: **14.5s → 12.1s (~17%)**.

## Commits

1. **examples: select gac/vc/not-equals all-different in magic_square + ortho_latin** — benchmark plumbing. `magic_square` and `ortho_latin` gain `--all-different {gac|vc|not-equals}` (default `not-equals`); `ortho_latin`'s default size drops from 88 to 7 (the `ortho_latin-5` ctest is pinned to `--all-different gac` to keep its proof the GAC one). No engine change.

2. **guard the non-GAC reason on want_reasons, build once per fixed var** — the propagator built an `ExplicitReason` per not-equal inference even with proofs off (it is *not* DCE'd). Build it once per popped variable and only when `inference.want_reasons()`. ~6% on magic_square vc.

3. **prebuilt per-variable reason table** — a constraint-owned (not backtracked) table of deferred `ExactSingleValue` reasons, indexed **by variable** (`SimpleIntegerVariableID` index), moved into the propagator closure. The hot loop hands back a reference; no per-inference construction, no `want_reasons` branch on that path. Views/constants + circuit fall back to inline construction. This is the form needed once wdeg / conflict generation makes `want_reasons()` ~always true.

4. **track unassigned vars in a vector, not a std::list** — the backtrackable `unassigned` set is copied per search node; as a `std::list` that is one heap-node allocation **per element**. A flat `vector` (swap-and-pop erase; order is irrelevant) copies in one allocation. Shared `NonGacAllDifferentUnassigned` alias across all_different + circuit. **~8% on magic_square vc** — the biggest single win. (A `small_vector` was measured and ties `vector`: `ConstraintState` is a `std::any` whose ~8-byte SBO can't hold any vector-sized object, so the inline buffer never avoids an allocation.)

5. **constraint_id: make ConstraintID trivially copyable** — `NamedConstraint` holds a `std::string_view` into the Problem's name pool instead of an owning `std::string`, so the variant (copied per inference inside every reason/hint) is trivially copyable — a memcpy, not a variant copy-ctor visit. `check_name` already interned names into a stable set; it now returns the interned reference. `as_string` stays a free function, so the ~40 proof call sites are untouched. ~3% on magic_square vc; `static_assert` locks the invariant in.

## Verification
- Search bit-identical at every step (recursions and contradicting-propagation counts unchanged; total/effectful counts shift only where the unassigned set is permuted, which is benign).
- Proofs verify throughout: the all_different + circuit suites, `magic_square vc --prove`, and a directly-checked **named** constraint rendering correctly in the OPB (`@c[my_abs_name][...]`, veripb VERIFIED).
- Full tree builds clean (GCC).