### PR TITLE
Make the test harness consistency check per-node, fix what it reveals (#413)

### DIFF
--- a/dev_docs/sortedness.md
+++ b/dev_docs/sortedness.md
@@ -39,9 +39,11 @@ permutation and stable variants are NP-hard too. So:
   runs back into the hardness wall and is handled by weaker, costlier passes.
 
 Both constraints run the Mehlhorn-Thiel bounds-consistent propagator (below),
-achieving `bounds(Z)` on the source `x` and the sorted values. `ArgSort`
-additionally runs a channel pass and GAC `all_different` on the permutation `p`
-(see its section). No leaf checker is needed: once `x` is fixed the
+achieving `bounds(Z)` on the source `x` and the sorted values *for the bare
+`Sortedness(x; y)` relation*. `ArgSort` additionally runs a channel pass and GAC
+`all_different` on the permutation `p` (see its section) — but note that the
+stable tie-break makes neither `x` nor `p` fully `bounds(Z)` there; see the
+ArgSort "Caveat (issue #413)" below. No leaf checker is needed: once `x` is fixed the
 achievable-rank-set propagator collapses each element's reachable ranks to its
 single stable rank and prunes `p` to the unique permutation, so a bad `p` is a
 domain wipeout before any leaf.
@@ -132,14 +134,31 @@ the returned `SortednessWitness` (the `before` flags, `pos`, and the `rank_ge`/
     `(x[k] <= U) v before[i][k]` clauses; the inverse channel then closes
     `p[j] != offset+k` by RUP via the case split on `[x[k] >= U+1]`.
 
-**Consistency achieved.** `bounds(Z)` on `x`, `y`, **and `p`**, fully certified.
-The achievable-rank-set propagator gives bounds consistency on `p`: if rank `j`
-is reachable for element `k`, then some `x`-assignment places `k` at rank `j`,
-and that assignment is itself a complete solution with `p[j] = offset + k` — so
-the exact reachable set *is* the BC-supported set. This matches the strength of
-Gecode's `sorted` with permutation variables (Thiel's algorithm), but certified.
-Full GAC on `p` remains NP-hard (rank-feasible but integer-infeasible values can
-survive); that residual is the frontier and is deliberately not pursued.
+**Consistency achieved.** `bounds(Z)` on the internal sorted values `y`, fully
+certified. The achievable-rank-set propagator prunes `p` from each element's
+reachable rank set, every pruning certified.
+
+**Caveat (issue #413): `x` and `p` are NOT bounds(Z) for the *stable* ArgSort.**
+The per-node consistency harness found counterexamples on both. The reused
+Mehlhorn–Thiel propagator is bounds(Z) on `x`/`y` only for the *bare*
+`Sortedness(x; y)` relation, where the permutation is unconstrained (ties
+arbitrary). The stable tie-break that pins a unique `p` makes both sides strictly
+tighter than MT delivers:
+
+- `x` gains strict bounds — `p[j] > p[j+1]` forces `x[p[j]] < x[p[j+1]]`, so a
+  value that could only tie at an extremum is dead (e.g. `p0=1, p1=0` ⇒ `x1<x0`,
+  so `lb(x0)` should rise);
+- `p` gains joint infeasibilities — the achievable-rank set is derived from the
+  `x` intervals but not from the *other* `p` domains, so the "reachable rank ⇒
+  some complete solution places `k` there" argument fails once another `p`
+  position is branched and excludes that solution.
+
+This is exactly the wall Thiel flags: thesis §3.1.4 shows even the *non-stable*
+`SortednessPerm` is not bounds(Z) on `x` or `p` (Lemma 3.1 breaks down), with a
+counterexample; the stable variant is tighter again, and no bounds(Z) algorithm
+for it is known. So `arg_sort_test` checks `x` and `p` at None (enumeration +
+proof only). Full GAC on `p` is NP-hard regardless. Whether to pursue a stronger
+(stable) `x`/`p` propagator is a benchmark-driven open question.
 
 The asymmetry with Sort's witness is deliberate: a proof-only permutation (Sort)
 *forces* the stable-rank construction; a real permutation (ArgSort) channels

--- a/gcs/constraints/all_different/symmetric_all_different_test.cc
+++ b/gcs/constraints/all_different/symmetric_all_different_test.cc
@@ -143,12 +143,20 @@ namespace
         run_symalldiff_test(proofs, true, {{0}}, 0);
         run_symalldiff_test(proofs, true, {{1}}, 1);
 
-        // Small unrestricted: AllDifferent-GAC + Inverse-channeling reaches
-        // full symmetric-alldiff GAC for these.
+        // Two variables: a single off-diagonal pair admits no transitive
+        // chains, so AllDifferent-GAC + Inverse-channeling reaches full
+        // symmetric-alldiff GAC at every node.
         run_symalldiff_test(proofs, true, {{0, 1}, {0, 1}}, 0);
         run_symalldiff_test(proofs, true, {{1, 2}, {1, 2}}, 1);
-        run_symalldiff_test(proofs, true, {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}}, 0);
-        run_symalldiff_test(proofs, true, {{0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}}, 0);
+
+        // Three or more unrestricted variables are GAC at the root but not at
+        // every search node: once branching punches a hole, an assignment can
+        // force a channel (x_i = v => x_v = i) that leaves a third variable with
+        // no remaining value -- an infeasibility only the non-bipartite matching
+        // below detects, not pairwise channeling + bipartite AllDifferent (#413).
+        // Consistency-only (full enumeration + proof), not per-node GAC.
+        run_symalldiff_test(proofs, false, {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}}, 0);
+        run_symalldiff_test(proofs, false, {{0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}}, 0);
 
         // Out-of-range value gets bound-trimmed by Inverse before propagation.
         run_symalldiff_test(proofs, true, {{0, 1, 5}, {0, 1}}, 0);

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -177,10 +177,58 @@ auto Count::install_propagators(Propagators & propagators) -> void
                     inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{hints::Count{owner}}, generic_reason(all_vars));
                 }
                 else {
-                    if ((! lowest_how_many_must) || (how_many_must < *lowest_how_many_must))
-                        lowest_how_many_must = how_many_must;
-                    if ((! highest_how_many_might) || (how_many_might > *highest_how_many_might))
-                        highest_how_many_might = how_many_might;
+                    // [how_many_must, how_many_might] is the range of counts
+                    // achievable for this voi, and every count in it is reachable
+                    // (turn the "might but not must" vars to voi one at a time).
+                    // The two checks above only reject voi when that range lies
+                    // wholly below how_many's lower bound or above its upper bound;
+                    // for true GAC, voi is supported iff some count in the range is
+                    // actually in how_many's domain. If the whole range falls into
+                    // an interior hole of how_many, voi has no support.
+                    bool supported = false;
+                    for (auto c = how_many_must; c <= how_many_might; ++c)
+                        if (state.in_domain(how_many, c)) {
+                            supported = true;
+                            break;
+                        }
+
+                    if (! supported) {
+                        auto justf = [&](const ReasonLiterals & reason) -> void {
+                            // Materialise both conditional count bounds for this
+                            // voi, then value_of_interest != voi follows because
+                            // how_many is pinned into [must, might] while its
+                            // domain (in the reason) excludes that whole range.
+                            //
+                            // Upper bound (value_of_interest == voi => how_many <=
+                            // might): zero the eq flag of every var that cannot be
+                            // voi, exactly as the highest_how_many_might proof
+                            // below does.
+                            for (const auto & [idx, var] : enumerate(vars)) {
+                                if (! state.in_domain(var, voi)) {
+                                    logger->emit_rup_proof_line_under_reason(reason,
+                                        WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (! get<0>(flags[idx])) >= 1_i, ProofLevel::Temporary);
+                                    logger->emit_rup_proof_line_under_reason(
+                                        reason, WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (var != voi) >= 1_i, ProofLevel::Temporary);
+                                }
+                            }
+                            logger->emit_rup_proof_line_under_reason(reason,
+                                WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many < how_many_might + 1_i) >= 1_i, ProofLevel::Temporary);
+                            // Lower bound (value_of_interest == voi => how_many >=
+                            // must): the must vars are fixed to voi, so their eq
+                            // flags propagate on their own (cf. the lowest_must
+                            // proof below).
+                            logger->emit_rup_proof_line_under_reason(reason,
+                                WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= how_many_must) >= 1_i, ProofLevel::Temporary);
+                        };
+                        inference.infer(
+                            logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, generic_reason(all_vars));
+                    }
+                    else {
+                        if ((! lowest_how_many_must) || (how_many_must < *lowest_how_many_must))
+                            lowest_how_many_must = how_many_must;
+                        if ((! highest_how_many_might) || (how_many_might > *highest_how_many_might))
+                            highest_how_many_might = how_many_might;
+                    }
                 }
             }
 

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -290,17 +290,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
 
     for (unsigned fixed_dim = 0; fixed_dim != index_vars.size(); ++fixed_dim) {
         Triggers index_triggers;
-        if (array_has_nonconstants) {
-            if (_bounds_only)
-                index_triggers.on_bounds.insert(index_triggers.on_bounds.end(), all_array_vars.begin(), all_array_vars.end());
-            else
-                index_triggers.on_change.insert(index_triggers.on_change.end(), all_array_vars.begin(), all_array_vars.end());
-        }
+        // The index side is always GAC. bounds_only only weakens the result
+        // propagator (range vs union); the index propagator must therefore watch
+        // the full domains (on_change) and test against result's whole domain, so
+        // that an interior hole in result removes the now-unsupported index value.
+        if (array_has_nonconstants)
+            index_triggers.on_change.insert(index_triggers.on_change.end(), all_array_vars.begin(), all_array_vars.end());
 
-        if (_bounds_only)
-            index_triggers.on_bounds.emplace_back(_result_var);
-        else
-            index_triggers.on_change.emplace_back(_result_var);
+        index_triggers.on_change.emplace_back(_result_var);
 
         for (const auto & [idx, var] : enumerate(index_vars))
             if (idx != fixed_dim)
@@ -309,16 +306,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
         propagators.install(
             constraint_id(),
             [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
-                array_has_nonconstants = array_has_nonconstants, bounds_only = _bounds_only,
+                array_has_nonconstants = array_has_nonconstants,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // for each index variable, update it to only contain values where
                 // there's at least one supporting option. result_var's domain is
                 // not modified by anything inside the loop body (the only infer_*
-                // calls are on index_vars[fixed_dim]), so the looking_for set and
-                // its bounds are constant across iterations and only need
-                // computing once.
+                // calls are on index_vars[fixed_dim]), so the looking_for set is
+                // constant across iterations and only needs computing once.
                 auto looking_for = state.copy_of_values(result_var);
-                auto looking_for_bounds = state.bounds(result_var);
                 // explored_vars only feeds the reason; building it is a per-test_val
                 // (no-SBO) allocation, so skip it when no reason will be read.
                 auto want_reason = inference.want_reasons();
@@ -338,29 +333,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                     // Constant array: test the value directly, skipping the
                                     // IntegerVariableID construction and the State round-trip.
                                     auto value = get_array_value<dimensions_>(elem, *array);
-                                    if (bounds_only) {
-                                        if (value >= looking_for_bounds.first && value <= looking_for_bounds.second)
-                                            return true;
-                                    }
-                                    else {
-                                        if (looking_for.contains(value))
-                                            return true;
-                                    }
+                                    if (looking_for.contains(value))
+                                        return true;
                                 }
                                 else {
                                     auto array_var = get_array_var<dimensions_>(elem, *array);
                                     if (want_reason && array_has_nonconstants)
                                         explored_vars.push_back(array_var);
 
-                                    if (bounds_only) {
-                                        if (state.lower_bound(array_var) >= looking_for_bounds.first &&
-                                            state.upper_bound(array_var) <= looking_for_bounds.second)
-                                            return true;
-                                    }
-                                    else {
-                                        if (state.domain_intersects_with(array_var, looking_for))
-                                            return true;
-                                    }
+                                    if (state.domain_intersects_with(array_var, looking_for))
+                                        return true;
                                 }
                             }
                             else {
@@ -404,16 +386,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
 
                                             if (elem.size() == dimensions_) {
                                                 auto array_var = get_array_var<dimensions_>(elem, *array);
-                                                if (bounds_only && array_has_nonconstants) {
-                                                    throw UnimplementedException{};
-                                                }
-                                                else {
-                                                    state.for_each_value_immutable(array_var, [&](Integer v) {
-                                                        logger->emit_rup_proof_line_under_reason(reason,
-                                                            sum_so_far + 1_i * (index_vars.at(fixed_dim) != test_val) + 1_i * (array_var != v) >= 1_i,
-                                                            ProofLevel::Temporary);
-                                                    });
-                                                }
+                                                state.for_each_value_immutable(array_var, [&](Integer v) {
+                                                    logger->emit_rup_proof_line_under_reason(reason,
+                                                        sum_so_far + 1_i * (index_vars.at(fixed_dim) != test_val) + 1_i * (array_var != v) >= 1_i,
+                                                        ProofLevel::Temporary);
+                                                });
                                             }
                                             else
                                                 self(self, d + 1);

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -176,7 +176,14 @@ auto run_no_overlap_equals_test(bool proofs) -> void
     p.post(EqualsIf{c, 0_c, y == 8_i});
 
     auto proof_name = proofs ? make_optional("equals_test") : nullopt;
-    solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{x, y, z, c});
+    // x, y, z are each GAC (a single EqualsIf is GAC, and c=1 does propagate
+    // x != 4 etc. via the contrapositive). But c is only network-GAC: c=1 is
+    // unsupported at z=1 because x==y combined with *all* the c -> x not in {...}
+    // / c -> y not in {...} implications leaves no common value -- a deduction
+    // across all 13 posted constraints that no individual EqualsIf propagator
+    // can make (GAC of a conjunction != conjunction of GAC). So c is None.
+    solve_for_tests_checking_consistency(p, proof_name, expected, actual,
+        tuple{pair{x, CheckConsistency::GAC}, pair{y, CheckConsistency::GAC}, pair{z, CheckConsistency::GAC}, pair{c, CheckConsistency::None}});
 
     check_results(proof_name, expected, actual);
 }

--- a/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
@@ -86,11 +86,18 @@ auto run_gacgcc_test(bool proofs, const vector<Range> & vars_range, const vector
 
     p.post(GACGlobalCardinality{vars, int_values, counts, closed});
 
-    // This propagator achieves GAC on the assignment variables; the count
-    // variables get the achievable bounds (not checked for consistency here).
+    // Régin's flow makes the assignment variables GAC *relative to the count
+    // bounds*: the network's value capacities are state.bounds(counts[j]), so it
+    // never sees an interior hole in a count domain. Full GAC that respects count
+    // holes is NP-hard (it couples to subset-sum over the counts). Once branching
+    // punches a hole into a count domain, an assignment value can become globally
+    // unsupported solely because some count is forced onto that hole -- invisible
+    // to the bound-based flow (#413). So check the assignment variables at BC,
+    // which treats the counts as intervals and matches what the flow guarantees;
+    // the counts themselves are not checked.
     auto proof_name = proofs ? make_optional("gac_global_cardinality_test") : nullopt;
     solve_for_tests_checking_consistency(
-        p, proof_name, expected, actual, tuple{pair{vars, CheckConsistency::GAC}, pair{counts, CheckConsistency::None}});
+        p, proof_name, expected, actual, tuple{pair{vars, CheckConsistency::BC}, pair{counts, CheckConsistency::None}});
     check_results(proof_name, expected, actual);
 }
 

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -12,6 +12,7 @@
 #include <util/enumerate.hh>
 #include <util/overloaded.hh>
 
+#include <algorithm>
 #include <array>
 #include <cstdlib>
 #include <functional>
@@ -20,6 +21,7 @@
 #include <random>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 #include <version>
@@ -444,8 +446,7 @@ namespace gcs::test_innards
         GAC
     };
 
-    template <typename ResultsSet_>
-    auto consistency_not_achieved(const std::string & which, const ResultsSet_ & expected, const CurrentState & s,
+    inline auto consistency_not_achieved(const std::string & which, const std::unordered_set<long long> & locally_supported, const CurrentState & s,
         const std::vector<IntegerVariableID> & all_vars, const IntegerVariableID & var, Integer val) -> void
     {
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -454,9 +455,11 @@ namespace gcs::test_innards
         using fmt::println;
 #endif
         using std::cerr;
+        std::vector<long long> supported{locally_supported.begin(), locally_supported.end()};
+        std::ranges::sort(supported);
         println(cerr, "{} not achieved in test", which);
-        println(cerr, "expected: {}", expected);
-        println(cerr, "var {} value {} does not occur anywhere in expected", innards::debug_string(var), val);
+        println(cerr, "var {} value {} has no support at the current node", innards::debug_string(var), val);
+        println(cerr, "values of {} that do have a support here: {}", innards::debug_string(var), supported);
         for (const auto & v : all_vars) {
             std::vector<Integer> values;
             for (Integer i : s.each_value(v))
@@ -466,82 +469,102 @@ namespace gcs::test_innards
         throw UnexpectedException{"consistency not achieved"};
     }
 
-    template <typename ResultsSet_, typename Get_>
-    auto check_support(const ResultsSet_ & expected, const CurrentState & s, const std::vector<IntegerVariableID> & all_vars,
-        const IntegerVariableID & var, CheckConsistency consistency, const Get_ & get_from_expected) -> void
+    /**
+     * Is `val` consistent with `var`'s current state for the purposes of being
+     * part of a support at the given consistency level? GAC requires the value
+     * to be present in the live domain; BC (which the solver implements as
+     * bounds(Z)) only requires it to lie within the current [lower, upper]
+     * interval, so a support may legitimately pass through a hole that branching
+     * punched into a partner's domain. Using the right filter per level keeps a
+     * correctly-bounds(Z) partner from triggering a spurious failure when a BC
+     * variable's bound is being checked.
+     */
+    inline auto component_supports(const CurrentState & s, const IntegerVariableID & var, int val, CheckConsistency level) -> bool
     {
-        switch (consistency) {
-        case CheckConsistency::None: return;
-
-        case CheckConsistency::GAC:
-            for (auto val : s.each_value(var)) {
-                bool found_support = false;
-                for (auto & x : expected)
-                    if (get_from_expected(x) == val.raw_value) {
-                        found_support = true;
-                        break;
-                    }
-                if (! found_support)
-                    consistency_not_achieved("gac", expected, s, all_vars, var, val);
-            }
-            return;
-
-        case CheckConsistency::BC:
-            for (const auto & val : std::vector{s.lower_bound(var), s.upper_bound(var)}) {
-                bool found_support = false;
-                for (auto & x : expected)
-                    if (get_from_expected(x) == val.raw_value) {
-                        found_support = true;
-                        break;
-                    }
-                if (! found_support)
-                    consistency_not_achieved("bc", expected, s, all_vars, var, val);
-            }
-            return;
+        switch (level) {
+            using enum CheckConsistency;
+        case None: return true;
+        case GAC: return s.in_domain(var, Integer{val});
+        case BC: return s.lower_bound(var) <= Integer{val} && Integer{val} <= s.upper_bound(var);
         }
-
         throw NonExhaustiveSwitch{};
     }
 
-    template <typename ResultsSet_, typename Get_>
-    auto check_support(const ResultsSet_ & expected, const CurrentState & s, const std::vector<IntegerVariableID> & all_vars,
-        const std::vector<IntegerVariableID> & vars, CheckConsistency consistency, const Get_ & get_from_expected) -> void
+    inline auto component_supports(
+        const CurrentState & s, const std::vector<IntegerVariableID> & vars, const std::vector<int> & vals, CheckConsistency level) -> bool
+    {
+        for (const auto & [idx, var] : enumerate(vars))
+            if (! component_supports(s, var, vals.at(idx), level))
+                return false;
+        return true;
+    }
+
+    /// How many supported-value-set slots a position contributes: one for a
+    /// scalar variable, one per element for a vector position.
+    inline auto support_slot_count(const IntegerVariableID &) -> std::size_t
+    {
+        return 1;
+    }
+
+    inline auto support_slot_count(const std::vector<IntegerVariableID> & vars) -> std::size_t
+    {
+        return vars.size();
+    }
+
+    /// Record an alive tuple's component value(s) into a position's slots.
+    inline auto record_support(std::vector<std::unordered_set<long long>> & slots, int val) -> void
+    {
+        slots.at(0).insert(val);
+    }
+
+    inline auto record_support(std::vector<std::unordered_set<long long>> & slots, const std::vector<int> & vals) -> void
+    {
+        for (const auto & [idx, val] : enumerate(vals))
+            slots.at(idx).insert(val);
+    }
+
+    /**
+     * Check one position against the per-node supported-value sets the caller
+     * built (one pass over `expected`, filtered to tuples alive at this node).
+     * GAC checks every live domain value; BC checks the two bounds.
+     */
+    inline auto check_support(const std::vector<std::unordered_set<long long>> & slots, const CurrentState & s,
+        const std::vector<IntegerVariableID> & all_vars, const IntegerVariableID & var, CheckConsistency consistency) -> void
     {
         switch (consistency) {
-        case CheckConsistency::None: return;
-
-        case CheckConsistency::BC:
-            for (const auto & [the_idx, the_var] : enumerate(vars)) {
-                const auto & idx = the_idx;
-                const auto & var = the_var;
-                for (const auto & val : std::vector{s.lower_bound(var), s.upper_bound(var)}) {
-                    bool found_support = false;
-                    for (auto & x : expected)
-                        if (get_from_expected(x).at(idx) == val.raw_value) {
-                            found_support = true;
-                            break;
-                        }
-                    if (! found_support)
-                        consistency_not_achieved("bc", expected, s, all_vars, var, val);
-                }
-            }
+            using enum CheckConsistency;
+        case None: return;
+        case GAC:
+            for (auto val : s.each_value(var))
+                if (! slots.at(0).contains(val.raw_value))
+                    consistency_not_achieved("gac", slots.at(0), s, all_vars, var, val);
             return;
+        case BC:
+            for (auto val : {s.lower_bound(var), s.upper_bound(var)})
+                if (! slots.at(0).contains(val.raw_value))
+                    consistency_not_achieved("bc", slots.at(0), s, all_vars, var, val);
+            return;
+        }
+        throw NonExhaustiveSwitch{};
+    }
 
-        case CheckConsistency::GAC:
-            for (const auto & [the_idx, the_var] : enumerate(vars)) {
-                const auto & idx = the_idx;
-                const auto & var = the_var;
-                for (auto val : s.each_value(var)) {
-                    bool found_support = false;
-                    for (auto & x : expected)
-                        if (get_from_expected(x).at(idx) == val.raw_value) {
-                            found_support = true;
-                            break;
-                        }
-                    if (! found_support)
-                        consistency_not_achieved("gac", expected, s, all_vars, var, val);
-                }
-            }
+    inline auto check_support(const std::vector<std::unordered_set<long long>> & slots, const CurrentState & s,
+        const std::vector<IntegerVariableID> & all_vars, const std::vector<IntegerVariableID> & vars, CheckConsistency consistency) -> void
+    {
+        switch (consistency) {
+            using enum CheckConsistency;
+        case None: return;
+        case GAC:
+            for (const auto & [idx, var] : enumerate(vars))
+                for (auto val : s.each_value(var))
+                    if (! slots.at(idx).contains(val.raw_value))
+                        consistency_not_achieved("gac", slots.at(idx), s, all_vars, var, val);
+            return;
+        case BC:
+            for (const auto & [idx, var] : enumerate(vars))
+                for (auto val : {s.lower_bound(var), s.upper_bound(var)})
+                    if (! slots.at(idx).contains(val.raw_value))
+                        consistency_not_achieved("bc", slots.at(idx), s, all_vars, var, val);
             return;
         }
 
@@ -565,6 +588,26 @@ namespace gcs::test_innards
         std::vector<IntegerVariableID> all_vars_as_vector;
         [&]<std::size_t... i_>(std::index_sequence<i_...>) { (add_to_all_vars(all_vars_as_vector, std::get<i_>(all_vars).first), ...); }(
             std::index_sequence_for<AllArgs_...>());
+
+        // Which consistency levels are present? Each level needs its own pass
+        // over `expected` with its own "alive at this node" filter (GAC: every
+        // other component in domain; BC: every other component within bounds),
+        // so we skip the pass for an absent level entirely.
+        const bool any_gac = [&]<std::size_t... i_>(std::index_sequence<i_...>) {
+            return ((std::get<i_>(all_vars).second == CheckConsistency::GAC) || ...);
+        }(std::index_sequence_for<AllArgs_...>());
+        const bool any_bc = [&]<std::size_t... i_>(std::index_sequence<i_...>) {
+            return ((std::get<i_>(all_vars).second == CheckConsistency::BC) || ...);
+        }(std::index_sequence_for<AllArgs_...>());
+
+        // Per top-level position, a set of locally supported values per slot
+        // (one slot for a scalar, one per element of a vector position). The
+        // shape is fixed across the search, so size it once and only clear
+        // (keeping capacity) at each node.
+        std::vector<std::vector<std::unordered_set<long long>>> support(sizeof...(AllArgs_));
+        [&]<std::size_t... i_>(std::index_sequence<i_...>) { ((support[i_].resize(support_slot_count(std::get<i_>(all_vars).first))), ...); }(
+            std::index_sequence_for<AllArgs_...>());
+
         solve_for_tests_with_callbacks(
             p, proof_name,
             [&](const CurrentState & s) -> bool {
@@ -572,10 +615,38 @@ namespace gcs::test_innards
                 return true;
             },
             [&](const CurrentState & s) -> bool {
+                for (auto & slots : support)
+                    for (auto & slot : slots)
+                        slot.clear();
+
+                // A tuple is a valid support at `level` only if *every* position
+                // (including None-tagged ones, e.g. a counted array) is alive at
+                // this node under that level's filter.
+                auto tuple_alive = [&](const auto & x, CheckConsistency level) {
+                    return [&]<std::size_t... i_>(std::index_sequence<i_...>) {
+                        return (component_supports(s, std::get<i_>(all_vars).first, std::get<i_>(x), level) && ...);
+                    }(std::index_sequence_for<AllArgs_...>());
+                };
+
+                // One pass over `expected` per level: for each alive tuple,
+                // record the value(s) of every position tagged with that level.
+                auto record_level = [&](CheckConsistency level) {
+                    for (const auto & x : expected) {
+                        if (! tuple_alive(x, level))
+                            continue;
+                        [&]<std::size_t... i_>(std::index_sequence<i_...>) {
+                            ((std::get<i_>(all_vars).second == level ? record_support(support[i_], std::get<i_>(x)) : (void)0), ...);
+                        }(std::index_sequence_for<AllArgs_...>());
+                    }
+                };
+
+                if (any_gac)
+                    record_level(CheckConsistency::GAC);
+                if (any_bc)
+                    record_level(CheckConsistency::BC);
+
                 [&]<std::size_t... i_>(std::index_sequence<i_...>) {
-                    (check_support(expected, s, all_vars_as_vector, std::get<i_>(all_vars).first, std::get<i_>(all_vars).second,
-                         [&](const auto & x) { return std::get<i_>(x); }),
-                        ...);
+                    (check_support(support[i_], s, all_vars_as_vector, std::get<i_>(all_vars).first, std::get<i_>(all_vars).second), ...);
                 }(std::index_sequence_for<AllArgs_...>());
                 return true;
             });

--- a/gcs/constraints/logical/logical.cc
+++ b/gcs/constraints/logical/logical.cc
@@ -73,6 +73,10 @@ namespace
             if (holds_alternative<FalseLiteral>(l))
                 saw_false = true;
         }
+        // Also wake on the reif literal: otherwise fixing full_reif (e.g. by
+        // branching) does not re-run the propagator, so full_reif being forced
+        // true would fail to push the lits true (the GAC gap from #413).
+        add_trigger_for(triggers, full_reif);
 
         if (saw_false) {
             // we saw a false literal, the reif variable must be forced off and

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -238,6 +238,74 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                 }
             }
 
+            // Full GAC on the array variables. The rules above keep every var
+            // within result's bounds and every result value reachable as the
+            // extremum, but a var can still hold an interior value that can be
+            // neither the extremum itself nor sit under an extremum that some
+            // *other* var provides. For Max, value v of var_i is supported iff
+            // either v is itself a feasible result (v in D(result), and every
+            // other var can be <= v, i.e. v >= the largest other lower bound),
+            // or some other var can provide a larger result value (an r in
+            // D(result), r > v, reachable by another var that can also sit at or
+            // above the largest other lower bound). Min is the mirror image.
+            //
+            // Proof of var_i != v: the result-bound rule above already left
+            // D(result) inside [max lower bound, +inf), so every result value r
+            // strictly past v has r >= L_{-i}; by other_extreme's definition no
+            // *other* var can then equal r, and var_i = v can't either, so the
+            // al1 "result is one of the values" selector constraint is violated.
+            // Ruling out every such r forces result onto the wrong side of v,
+            // contradicting result >= var_i (for Max). A pure selector argument,
+            // no cross-variable bound reasoning needed.
+            {
+                vector<IntegerVariableID> scope = vars;
+                scope.push_back(result);
+                for (const auto & [i, var_i] : enumerate(vars)) {
+                    optional<Integer> others_limit; // max: largest other lower bound; min: smallest other upper bound
+                    for (const auto & [k, var_k] : enumerate(vars)) {
+                        if (k == i)
+                            continue;
+                        auto bk = state.bounds(var_k);
+                        auto lim = min ? bk.second : bk.first;
+                        others_limit = ! others_limit ? lim : (min ? std::min(*others_limit, lim) : std::max(*others_limit, lim));
+                    }
+                    optional<Integer> other_extreme; // extremal result value some other var can provide
+                    for (auto r : state.each_value_immutable(result)) {
+                        if (others_limit && (min ? r > *others_limit : r < *others_limit))
+                            continue;
+                        bool other_has = false;
+                        for (const auto & [k, var_k] : enumerate(vars))
+                            if (k != i && state.in_domain(var_k, r)) {
+                                other_has = true;
+                                break;
+                            }
+                        if (other_has)
+                            other_extreme = ! other_extreme ? r : (min ? std::min(*other_extreme, r) : std::max(*other_extreme, r));
+                    }
+                    for (auto v : state.each_value_mutable(var_i)) {
+                        bool supported_as_extreme = state.in_domain(result, v) && (! others_limit || (min ? v <= *others_limit : v >= *others_limit));
+                        bool supported_under_other = other_extreme && (min ? v > *other_extreme : v < *other_extreme);
+                        if (! supported_as_extreme && ! supported_under_other) {
+                            auto justf = [&, var_i = var_i, v = v](const ReasonLiterals & reason) {
+                                for (auto r : state.each_value_immutable(result)) {
+                                    if (min ? r >= v : r <= v)
+                                        continue;
+                                    // if var_i = v and result = r, no var can equal result, breaking al1
+                                    for (std::size_t k = 0; k < vars.size(); ++k)
+                                        logger->emit_rup_proof_line_under_reason(reason,
+                                            WPBSum{} + 1_i * (var_i != v) + 1_i * (result != r) + 1_i * (! selectors.at(k)) >= 1_i,
+                                            ProofLevel::Temporary);
+                                    logger->emit_rup_proof_line_under_reason(
+                                        reason, WPBSum{} + 1_i * (var_i != v) + 1_i * (result != r) >= 1_i, ProofLevel::Temporary);
+                                }
+                            };
+                            inference.infer_not_equal(
+                                logger, var_i, v, JustifyExplicitly{justf, ThenRUP::Yes, hints::MinMax{owner}}, generic_reason(scope));
+                        }
+                    }
+                }
+            }
+
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/sort/arg_sort_test.cc
+++ b/gcs/constraints/sort/arg_sort_test.cc
@@ -87,12 +87,23 @@ namespace
         prob.post(ArgSort{x, p, Integer(offset)});
 
         auto proof_name = proofs ? make_optional("arg_sort_test") : nullopt;
-        // Both x and p are kept bounds(Z)-consistent: x by the reused
-        // Mehlhorn-Thiel propagator, p by the achievable-rank-set propagator plus
-        // GAC all_different. (Full GAC on p is NP-hard, but bounds consistency is
-        // achieved and certified.)
-        solve_for_tests_checking_consistency(
-            prob, proof_name, expected, actual, tuple{std::make_pair(x, CheckConsistency::BC), std::make_pair(p, CheckConsistency::BC)});
+        // Neither x nor p is bounds(Z)-consistent for the *stable* ArgSort, so we
+        // only check full enumeration + the proof here (not per-node consistency).
+        // The reused Mehlhorn-Thiel propagator is bounds(Z) on x and the internal
+        // sorted values, but only for the bare Sortedness(x; y) relation, where
+        // the permutation is unconstrained. The stable tie-break that pins a
+        // unique p makes both sides strictly tighter than MT delivers:
+        //  - x gains strict bounds (p[j] > p[j+1] forces x[p[j]] < x[p[j+1]], so a
+        //    value that could only tie at an extremum is dead);
+        //  - p gains joint infeasibilities -- the achievable-rank-set propagator
+        //    derives each element's ranks from the x intervals but not from the
+        //    *other* p domains, so e.g. fixing one p position can kill another rank
+        //    that the per-element reachable set still admits.
+        // Thiel's thesis sec 3.1.4 shows even the non-stable SortednessPerm is not
+        // bounds(Z) on x or p (Lemma 3.1 breaks down), with a counterexample; the
+        // stable variant is tighter again and no bounds(Z) algorithm for it is
+        // known. So check None on both (#413).
+        solve_for_tests(prob, proof_name, actual, tuple{x, p});
         check_results(proof_name, expected, actual);
     }
 }


### PR DESCRIPTION
Closes #413.

## The harness bug

`solve_for_tests_checking_consistency` / `_checking_gac` compared each live
domain value against the **global** `expected` solution set, so they only
caught values supported in *no* solution anywhere — a 1-consistency check
wearing a GAC label. It couldn't see a value that is dead at the current node
(a partner lost a value to branching) but feasible elsewhere — exactly the
failure mode of a constraint that is GAC on one variable but weaker on a
partner.

`check_support` is now **per-node**: build per-position supported-value sets
once per node (≤2 passes over `expected`, reused buffers), filtering tuples to
those alive at the current node. Two filters, keyed to the level being checked:

- **GAC** → every other component must be `in_domain`;
- **BC** → every other component within `[lower, upper]` (bounds(Z)), since a
  correctly-bounds(Z) propagator may rely on a support through a branching hole;
  a strict `in_domain` filter there would false-positive.

This is one commit so no intermediate state is red (bisect-safe).

## Constraints it flagged — genuine under-propagation, **fixed** (VeriPB-certified)

| Constraint | Fix |
|---|---|
| **element** | `ElementConstantArray` index was bounds-only; `bounds_only` now weakens only the result side, the index stays GAC |
| **count** | value-of-interest GAC must respect `how_many`'s domain holes, not just its bounds |
| **logical** (And/Or) | propagator never triggered on the reif literal — added the trigger |
| **min_max** | added a full var-GAC pass (a value that can be neither the extremum nor sit under one another var provides is dead) |

## Constraints whose declared consistency is genuinely unachievable — **re-tagged** (enumeration + proof still verify)

| Constraint | Why | New tag |
|---|---|---|
| **symmetric_all_different** | full involution-GAC needs non-bipartite matching; achieves neither GAC nor BC | None (size ≥ 3) |
| **gac_global_cardinality** | Régin's flow is GAC relative to count *bounds*; respecting count holes is NP-hard | BC |
| **equals** (no-overlap network) | only `c` is network-GAC (GAC-of-a-conjunction); `x,y,z` stay GAC | `c` → None |
| **arg_sort** | bounds(Z) on `x`/`p` for the *stable* argsort isn't in the literature (Thiel thesis §3.1.4: even non-stable `SortednessPerm` isn't bounds(Z) on `x`/`p`) | None |

`dev_docs/sortedness.md`'s "bounds(Z) on x, y, and p, fully certified" claim is
corrected accordingly.

## Verification

Full `ctest` with caps **off** (`GCS_TEST_CAP_DEFAULTS=OFF`, full enumeration +
VeriPB): **100% tests passed, 0 failed of 395**. Every newly-fixed propagator
verifies clean with proofs; the re-tagged tests still run full enumeration and
proof checking. All changed sources are clang-format-21 clean.

The four re-tagged constraints are candidates for stronger (benchmark-driven)
propagation later; none is a regression — the propagators are unchanged there,
only the test's consistency claim was corrected to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
