### PR TITLE
propagators: requeue oldest-first so the queue is properly FIFO

### DIFF
--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -539,10 +539,15 @@ namespace gcs::innards
                 infer(logger, lit, why, snapshotted, fallback);
         }
 
+        // Yields this round's inferences in the order they were made (oldest first). The
+        // propagation queue replays them to wake the next round's propagators, so this order
+        // is the order in which a variable's changes re-trigger its propagators: oldest-first
+        // keeps that requeue properly FIFO (matching the FIFO drain), rather than the reverse
+        // (newest-first) order, which made the requeue effectively LIFO within a round.
         auto each_inference() const -> std::generator<std::pair<SimpleIntegerVariableID, Inference>>
         {
             return [](const auto & inferences) -> std::generator<std::pair<SimpleIntegerVariableID, Inference>> {
-                for (const auto & [var, inf] : inferences | std::ranges::views::reverse)
+                for (const auto & [var, inf] : inferences)
                     co_yield std::pair{var, inf};
             }(_inferences);
         }

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -255,7 +255,9 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
                 _imp->to_disable.clear();
 
                 // Fold the propagated prefix back into the idle region and wake the
-                // propagators triggered by this round's inferences.
+                // propagators triggered by this round's inferences. each_inference() yields
+                // oldest-first, so propagators are requeued in the order their triggers
+                // occurred -- keeping the queue properly FIFO (the drain is already FIFO).
                 _imp->enqueued_begin = 0;
                 _imp->enqueued_end = 0;
                 for (const auto & [v, inf] : tracker.each_inference())


### PR DESCRIPTION
## What

Replay each propagation round's inferences **oldest-first** when requeueing, so the
propagation queue is properly FIFO.

`each_inference()` (gcs/innards/inference_tracker.hh) previously yielded the round's
inferences in **reverse** (newest-first). The round-boundary requeue in
`Propagators::propagate` replays them to wake the next round's propagators, so that reverse
order meant propagators were re-woken **newest-trigger-first** — effectively LIFO *within* a
round, even though ba41ef04 had already made the queue *drain* FIFO. This makes the requeue
order match the drain: a variable's changes re-trigger its propagators in the order they
occurred.

## Why

Schulte & Stuckey ("Efficient Constraint Propagation Engines", TOPLAS 2008), already cited in
ba41ef04, show FIFO comprehensively beats LIFO for propagation. That commit fixed the drain but
left the requeue replay reverse; this finishes the job.

The change is **confluent-safe**: propagation reaches the same fixpoint regardless of the order
in which propagators run, so the search tree is unchanged — only the *work* to reach each
node's fixpoint changes. Verified empirically: `recursions` **and** `contradicting-propagations`
are byte-identical before/after on tsp, magic_square and ortho_latin; tsp's gr17 optimum is
unchanged (2085); the full test suite passes under VeriPB.

## Results (Release -O3)

| benchmark | before | after | |
|---|---:|---:|---|
| tsp (gr17, prevent) | 19.31s | 17.66s | **−8.6%** (fewer total propagations to reach the same fixpoints) |
| magic_square 5 | — | — | flat |
| ortho_latin 6 | — | — | flat |

(On the `vc-all-different-speedup` branch, where CircuitPrevent is cheaper per call, the same
change is −11.6% on tsp; it composes with that work.)

## Change

One-line behavioural change (drop `| std::ranges::views::reverse` from `each_inference()`),
plus clarifying comments. `each_inference()` has a single caller (the requeue).

## Related

A separate, riskier requeue idea (per-propagator idempotence / skip self-requeue) is written up in #416 for later exploration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
