### PR TITLE
Incremental folding for linear (in)equality propagation

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -216,7 +216,10 @@ if(GCS_BUILD_TESTS)
             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:element_test> ${mode})
     endforeach()
     add_test(NAME equals_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:equals_test>)
-    add_test(NAME linear_constant_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_constant_test>)
+    foreach(linmode incremental stateless)
+        add_test(NAME linear_constant_constraint_${linmode}
+            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_constant_test>)
+    endforeach()
     add_test(NAME sort_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:sort_test>)
     add_test(NAME arg_sort_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:arg_sort_test>)
 
@@ -305,9 +308,15 @@ if(GCS_BUILD_TESTS)
     add_test(NAME inverse_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inverse_test>)
     add_test(NAME knapsack_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:knapsack_test>)
     add_test(NAME lex_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:lex_test>)
+    # Run every linear test in both propagation modes: incremental (threshold 0) and
+    # stateless (a huge threshold). The threshold env is appended below (after the cap
+    # block, so it doesn't clobber it) and is folded into the proof file name by the
+    # test, so the two modes never collide under parallel ctest.
     foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff ne ne_if ne_iff)
-        add_test(NAME linear_constraint_${mode}
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_test> ${mode})
+        foreach(linmode incremental stateless)
+            add_test(NAME linear_constraint_${mode}_${linmode}
+                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_test> ${mode})
+        endforeach()
     endforeach()
     add_test(NAME logical_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:logical_test>)
     add_test(NAME min_max_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:min_max_test>)
@@ -458,4 +467,14 @@ if(GCS_BUILD_TESTS)
         set_tests_properties(${gcs_registered_tests} PROPERTIES ENVIRONMENT
             "GCS_TEST_MAX_SOLUTIONS=${GCS_TEST_MAX_SOLUTIONS};GCS_TEST_MAX_RECURSIONS=${GCS_TEST_MAX_RECURSIONS}")
     endif()
+
+    # Pin the linear incremental threshold per test variant: 0 = always incremental,
+    # a huge value = always stateless, so CI exercises both linear propagation paths.
+    # APPEND so the runtime-cap environment set just above is preserved.
+    foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff ne ne_if ne_iff)
+        set_property(TEST linear_constraint_${mode}_incremental APPEND PROPERTY ENVIRONMENT "GCS_LINEAR_INCREMENTAL_THRESHOLD=0")
+        set_property(TEST linear_constraint_${mode}_stateless APPEND PROPERTY ENVIRONMENT "GCS_LINEAR_INCREMENTAL_THRESHOLD=1000000")
+    endforeach()
+    set_property(TEST linear_constant_constraint_incremental APPEND PROPERTY ENVIRONMENT "GCS_LINEAR_INCREMENTAL_THRESHOLD=0")
+    set_property(TEST linear_constant_constraint_stateless APPEND PROPERTY ENVIRONMENT "GCS_LINEAR_INCREMENTAL_THRESHOLD=1000000")
 endif()

--- a/gcs/constraints/linear/linear_constant_test.cc
+++ b/gcs/constraints/linear/linear_constant_test.cc
@@ -37,6 +37,15 @@ using namespace gcs::test_innards;
 
 namespace
 {
+    // CI runs this test in both propagation modes via GCS_LINEAR_INCREMENTAL_THRESHOLD;
+    // tag the proof file name so the two runs don't clobber each other under parallel ctest.
+    auto threshold_proof_suffix() -> string
+    {
+        if (const char * e = std::getenv("GCS_LINEAR_INCREMENTAL_THRESHOLD"))
+            return string{"_t"} + e;
+        return {};
+    }
+
     // Post `cons` over an otherwise-free x in 0..2; if the constant constraint is
     // satisfiable the free x yields {0,1,2}, otherwise no solutions at all.
     template <typename PostConstraint_>
@@ -55,7 +64,7 @@ namespace
         post(p);
 
         set<tuple<int>> actual;
-        auto proof_name = proofs ? make_optional("linear_constant_test") : nullopt;
+        auto proof_name = proofs ? make_optional("linear_constant_test" + threshold_proof_suffix()) : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{x});
         check_results(proof_name, expected, actual);
     }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -25,8 +25,10 @@
 #include <fmt/ostream.h>
 #endif
 
+#include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <type_traits>
 #include <variant>
@@ -54,8 +56,10 @@ using std::print;
 using fmt::print;
 #endif
 
-ReifiedLinearEquality::ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition cond, bool gac, bool flipped_cond) :
-    _coeff_vars(move(coeff_vars)), _value(value), _reif_cond(cond), _gac(gac), _flipped_cond(flipped_cond)
+ReifiedLinearEquality::ReifiedLinearEquality(
+    WeightedSum coeff_vars, Integer value, ReificationCondition cond, bool gac, bool flipped_cond, std::optional<std::size_t> incremental_threshold) :
+    _coeff_vars(move(coeff_vars)), _value(value), _reif_cond(cond), _gac(gac), _flipped_cond(flipped_cond),
+    _incremental_threshold(incremental_threshold)
 {
 }
 
@@ -157,7 +161,7 @@ auto ReifiedLinearEquality::install(Propagators & propagators, State & initial_s
     if (optional_model)
         define_proof_model(*optional_model);
 
-    install_propagators(propagators);
+    install_propagators(propagators, initial_state);
 }
 
 auto ReifiedLinearEquality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
@@ -215,7 +219,7 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
         .visit(_reif_cond);
 }
 
-auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> void
+auto ReifiedLinearEquality::install_propagators(Propagators & propagators, State & initial_state) -> void
 {
     auto [sanitised_cv, modifier] = tidy_up_linear(_coeff_vars);
 
@@ -285,14 +289,34 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> vo
 
                 visit(
                     [&, modifier = modifier](const auto & lin) {
-                        propagators.install(
-                            constraint_id(),
-                            [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond,
-                                owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) {
-                                return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond,
-                                    hints::LinearEquality{owner});
-                            },
-                            triggers);
+                        // Wide enough? Use the incremental propagator (folds instantiated terms
+                        // out), which needs backtrackable constraint state set up here. Otherwise
+                        // the cheaper stateless path, where folding bookkeeping does not pay off.
+                        if (lin.terms.size() >= _incremental_threshold.value_or(default_linear_incremental_threshold())) {
+                            auto active = make_shared<vector<std::size_t>>(lin.terms.size());
+                            for (std::size_t i = 0; i != lin.terms.size(); ++i)
+                                (*active)[i] = i;
+                            auto handle = initial_state.add_constraint_state(LinearIncrementalState{lin.terms.size(), 0_i});
+                            propagators.install(
+                                constraint_id(),
+                                [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond,
+                                    owner = constraint_id(), active = active,
+                                    handle = handle](const State & state, auto & inference, ProofLogger * const logger) {
+                                    return propagate_linear_incremental(lin, value + modifier, state, inference, logger, true, proof_line,
+                                        reason_from_cond, *active, handle, hints::LinearEquality{owner});
+                                },
+                                triggers);
+                        }
+                        else {
+                            propagators.install(
+                                constraint_id(),
+                                [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond,
+                                    owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) {
+                                    return propagate_linear(lin, value + modifier, state, inference, logger, true, proof_line, reason_from_cond,
+                                        hints::LinearEquality{owner});
+                                },
+                                triggers);
+                        }
                     },
                     sanitised_cv);
             }, //
@@ -462,10 +486,11 @@ auto ReifiedLinearEquality::s_expr(const ProofModel * const model) const -> SExp
 
 auto ReifiedLinearEquality::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<ReifiedLinearEquality>(WeightedSum{_coeff_vars}, _value, _reif_cond, _gac, _flipped_cond);
+    return make_unique<ReifiedLinearEquality>(WeightedSum{_coeff_vars}, _value, _reif_cond, _gac, _flipped_cond, _incremental_threshold);
 }
 
-LinearEquality::LinearEquality(WeightedSum coeff_vars, Integer value, bool gac) : ReifiedLinearEquality(coeff_vars, value, reif::MustHold{}, gac)
+LinearEquality::LinearEquality(WeightedSum coeff_vars, Integer value, bool gac, std::optional<std::size_t> incremental_threshold) :
+    ReifiedLinearEquality(coeff_vars, value, reif::MustHold{}, gac, false, incremental_threshold)
 {
 }
 

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -8,6 +8,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/reification.hh>
 
+#include <cstddef>
 #include <optional>
 #include <utility>
 
@@ -34,16 +35,21 @@ namespace gcs
         ReificationCondition _reif_cond;
         bool _gac;
         bool _flipped_cond;
+        // Per-constraint width at/above which to use the incremental propagator; unset
+        // means use innards::default_linear_incremental_threshold().
+        std::optional<std::size_t> _incremental_threshold;
         std::optional<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _proof_line;
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
+        // Takes State (unlike the base's Propagators-only hook) because the incremental
+        // equality path registers backtrackable constraint state at install time.
+        auto install_propagators(innards::Propagators &, innards::State &) -> void;
 
     public:
-        explicit ReifiedLinearEquality(
-            WeightedSum coeff_vars, Integer value, ReificationCondition reif_cond, bool gac = false, bool flipped_cond = false);
+        explicit ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition reif_cond, bool gac = false,
+            bool flipped_cond = false, std::optional<std::size_t> incremental_threshold = std::nullopt);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
 
@@ -54,7 +60,8 @@ namespace gcs
     class LinearEquality : public ReifiedLinearEquality
     {
     public:
-        explicit LinearEquality(WeightedSum coeff_vars, Integer value, bool gac = false);
+        explicit LinearEquality(
+            WeightedSum coeff_vars, Integer value, bool gac = false, std::optional<std::size_t> incremental_threshold = std::nullopt);
     };
 
     class LinearEqualityIf : public ReifiedLinearEquality

--- a/gcs/constraints/linear/linear_greater_than_equal.cc
+++ b/gcs/constraints/linear/linear_greater_than_equal.cc
@@ -13,8 +13,8 @@ namespace
     }
 }
 
-LinearGreaterThanEqual::LinearGreaterThanEqual(WeightedSum coeff_vars, Integer value) :
-    ReifiedLinearInequality(move(negate(coeff_vars)), -value, reif::MustHold{})
+LinearGreaterThanEqual::LinearGreaterThanEqual(WeightedSum coeff_vars, Integer value, std::optional<std::size_t> incremental_threshold) :
+    ReifiedLinearInequality(move(negate(coeff_vars)), -value, reif::MustHold{}, incremental_threshold)
 {
 }
 

--- a/gcs/constraints/linear/linear_greater_than_equal.hh
+++ b/gcs/constraints/linear/linear_greater_than_equal.hh
@@ -16,7 +16,7 @@ namespace gcs
     class LinearGreaterThanEqual : public ReifiedLinearInequality
     {
     public:
-        explicit LinearGreaterThanEqual(WeightedSum coeff_vars, Integer value);
+        explicit LinearGreaterThanEqual(WeightedSum coeff_vars, Integer value, std::optional<std::size_t> incremental_threshold = std::nullopt);
     };
 
     /**

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -21,15 +21,20 @@
 #include <fmt/ostream.h>
 #endif
 
+#include <memory>
+#include <optional>
 #include <sstream>
+#include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
 using std::make_pair;
+using std::make_shared;
 using std::nullopt;
 using std::optional;
 using std::pair;
+using std::shared_ptr;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -42,14 +47,15 @@ using std::print;
 using fmt::print;
 #endif
 
-ReifiedLinearInequality::ReifiedLinearInequality(WeightedSum coeff_vars, Integer value, ReificationCondition cond) :
-    _coeff_vars(move(coeff_vars)), _value(value), _reif_cond(cond)
+ReifiedLinearInequality::ReifiedLinearInequality(
+    WeightedSum coeff_vars, Integer value, ReificationCondition cond, std::optional<std::size_t> incremental_threshold) :
+    _coeff_vars(move(coeff_vars)), _value(value), _reif_cond(cond), _incremental_threshold(incremental_threshold)
 {
 }
 
 auto ReifiedLinearInequality::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<ReifiedLinearInequality>(WeightedSum{_coeff_vars}, _value, _reif_cond);
+    return make_unique<ReifiedLinearInequality>(WeightedSum{_coeff_vars}, _value, _reif_cond, _incremental_threshold);
 }
 
 namespace
@@ -91,7 +97,7 @@ auto ReifiedLinearInequality::install(Propagators & propagators, State & initial
     if (optional_model)
         define_proof_model(*optional_model);
 
-    install_propagators(propagators);
+    install_propagators(propagators, initial_state);
 }
 
 auto ReifiedLinearInequality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
@@ -132,7 +138,7 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
         .visit(_reif_cond);
 }
 
-auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> void
+auto ReifiedLinearInequality::install_propagators(Propagators & propagators, State & initial_state) -> void
 {
     auto proof_lines = _proof_lines;
     auto proof_lines_swapped = pair{_proof_lines.second, _proof_lines.first};
@@ -167,8 +173,25 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
             using LinearCondJustification = std::conditional_t<std::is_same_v<CV, NegCV>, JustifyExplicitly<hints::LinearInequalityCond<CV>>,
                 std::variant<JustifyExplicitly<hints::LinearInequalityCond<CV>>, JustifyExplicitly<hints::LinearInequalityCond<NegCV>>>>;
 
-            auto enforce_constraint_must_hold = [sanitised_cv, value = _value, modifier = modifier, proof_lines](const State & state,
+            // Only the unconditional (MustHold) inequality always enforces the same
+            // single propagation, so only then is it sound (and worthwhile) to fold
+            // incrementally. Reified If/Iff (where the dispatcher alternates between the
+            // must-hold and must-not-hold propagations) stay on the stateless path.
+            std::optional<std::pair<std::shared_ptr<std::vector<std::size_t>>, ConstraintStateHandle>> inc_must_hold;
+            if (std::holds_alternative<evaluated_reif::MustHold>(_evaluated_cond) &&
+                sanitised_cv.terms.size() >= _incremental_threshold.value_or(default_linear_incremental_threshold())) {
+                auto active = make_shared<std::vector<std::size_t>>(sanitised_cv.terms.size());
+                for (std::size_t i = 0; i != sanitised_cv.terms.size(); ++i)
+                    (*active)[i] = i;
+                auto handle = initial_state.add_constraint_state(LinearIncrementalState{sanitised_cv.terms.size(), 0_i});
+                inc_must_hold = std::pair{active, handle};
+            }
+
+            auto enforce_constraint_must_hold = [sanitised_cv, value = _value, modifier = modifier, proof_lines, inc_must_hold](const State & state,
                                                     auto & inference, ProofLogger * const logger, const Literal & cond) -> PropagatorState {
+                if (inc_must_hold)
+                    return propagate_linear_incremental(sanitised_cv, value + modifier, state, inference, logger, false, proof_lines, cond,
+                        *inc_must_hold->first, inc_must_hold->second);
                 return propagate_linear(sanitised_cv, value + modifier, state, inference, logger, false, proof_lines, cond);
             };
 

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -9,6 +9,7 @@
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/reification.hh>
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -32,13 +33,19 @@ namespace gcs
         ReificationCondition _reif_cond;
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _proof_lines;
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
+        // Per-constraint width at/above which to use the incremental propagator; unset
+        // means use innards::default_linear_incremental_threshold().
+        std::optional<std::size_t> _incremental_threshold;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
+        // Takes State (unlike the base's Propagators-only hook) because the incremental
+        // must-hold path registers backtrackable constraint state at install time.
+        auto install_propagators(innards::Propagators &, innards::State &) -> void;
 
     public:
-        explicit ReifiedLinearInequality(WeightedSum coeff_vars, Integer value, ReificationCondition cond);
+        explicit ReifiedLinearInequality(
+            WeightedSum coeff_vars, Integer value, ReificationCondition cond, std::optional<std::size_t> incremental_threshold = std::nullopt);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/linear/linear_less_than_equal.cc
+++ b/gcs/constraints/linear/linear_less_than_equal.cc
@@ -3,7 +3,8 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-LinearLessThanEqual::LinearLessThanEqual(WeightedSum coeff_vars, Integer value) : ReifiedLinearInequality(move(coeff_vars), value, reif::MustHold{})
+LinearLessThanEqual::LinearLessThanEqual(WeightedSum coeff_vars, Integer value, std::optional<std::size_t> incremental_threshold) :
+    ReifiedLinearInequality(move(coeff_vars), value, reif::MustHold{}, incremental_threshold)
 {
 }
 

--- a/gcs/constraints/linear/linear_less_than_equal.hh
+++ b/gcs/constraints/linear/linear_less_than_equal.hh
@@ -16,7 +16,7 @@ namespace gcs
     class LinearLessThanEqual : public ReifiedLinearInequality
     {
     public:
-        explicit LinearLessThanEqual(WeightedSum coeff_vars, Integer value);
+        explicit LinearLessThanEqual(WeightedSum coeff_vars, Integer value, std::optional<std::size_t> incremental_threshold = std::nullopt);
     };
 
     /**

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -40,6 +40,19 @@ using fmt::println;
 using namespace gcs;
 using namespace gcs::test_innards;
 
+namespace
+{
+    // CI runs this test in both propagation modes (incremental / stateless) by setting
+    // GCS_LINEAR_INCREMENTAL_THRESHOLD; tag the proof file names with it so the two
+    // runs don't clobber each other's .opb/.pbp under parallel ctest.
+    auto threshold_proof_suffix() -> string
+    {
+        if (const char * e = std::getenv("GCS_LINEAR_INCREMENTAL_THRESHOLD"))
+            return string{"_t"} + e;
+        return {};
+    }
+}
+
 template <typename Constraint_>
 auto run_linear_test(bool proofs, const string & mode, const ViewWrapConfig & view_cfg, pair<int, int> v1_range, pair<int, int> v2_range,
     pair<int, int> v3_range, const vector<pair<vector<int>, int>> & ineqs, const std::function<auto(int, int)->bool> & compare) -> void
@@ -73,7 +86,8 @@ auto run_linear_test(bool proofs, const string & mode, const ViewWrapConfig & vi
         p.post(Constraint_{c, Integer{value}});
     }
 
-    auto proof_name = proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+    auto proof_name =
+        proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg) + threshold_proof_suffix()) : nullopt;
 
     if ((! is_same_v<Constraint_, LinearEquality>) && 1 == ineqs.size())
         solve_for_tests_checking_consistency(
@@ -117,7 +131,8 @@ auto run_linear_test_gac(bool proofs, const string & mode, const ViewWrapConfig 
         p.post(Constraint_{c, Integer{value}, true});
     }
 
-    auto proof_name = proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+    auto proof_name =
+        proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg) + threshold_proof_suffix()) : nullopt;
 
     if (1 == ineqs.size())
         solve_for_tests_checking_consistency(p, proof_name, expected, actual,
@@ -170,7 +185,8 @@ auto run_linear_reif_test(bool full_reif, bool proofs, const string & mode, cons
             p.post(Constraint_{c, Integer{value}, v4 == 1_i});
         }
 
-        auto proof_name = proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+        auto proof_name =
+            proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg) + threshold_proof_suffix()) : nullopt;
 
         if ((! is_same_v<Constraint_, LinearEqualityIff>) && (! is_same_v<Constraint_, LinearEqualityIf>) &&
             (! is_same_v<Constraint_, LinearNotEqualsIf>) && (! is_same_v<Constraint_, LinearNotEqualsIff>) && 1 == ineqs.size())
@@ -215,7 +231,7 @@ auto run_dup_linear_test(bool proofs, const string & mode, pair<int, int> a_rang
     c += Integer{coeffs_a_then_b.at(2)} * b;
     p.post(Constraint_{c, Integer{rhs}});
 
-    auto proof_name = proofs ? make_optional("linear_equality_test_" + mode + "_dup") : nullopt;
+    auto proof_name = proofs ? make_optional("linear_equality_test_" + mode + "_dup" + threshold_proof_suffix()) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{a, b});
     check_results(proof_name, expected, actual);
 }

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -11,9 +11,12 @@
 
 #include <util/enumerate.hh>
 
+#include <any>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 using std::is_same_v;
 using std::nullopt;
@@ -290,6 +293,148 @@ GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<PositiveOrNegative<SimpleIntegerVariableI
 GCS_INSTANTIATE_PROPAGATE_LINEAR(SumOf<SimpleIntegerVariableID>, EagerProofLoggingInferenceTracker, NoHint);
 
 #undef GCS_INSTANTIATE_PROPAGATE_LINEAR
+
+auto gcs::innards::default_linear_incremental_threshold() -> std::size_t
+{
+    static const std::size_t threshold = []() -> std::size_t {
+        if (const char * e = std::getenv("GCS_LINEAR_INCREMENTAL_THRESHOLD"))
+            return std::strtoull(e, nullptr, 10);
+        return 8; // default: use the incremental path for constraints with >= 8 terms
+    }();
+    return threshold;
+}
+
+template <typename Hint_>
+auto gcs::innards::propagate_linear_incremental(const auto & coeff_vars, Integer value, const State & state, auto & inference,
+    ProofLogger * const logger, bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line,
+    const optional<Literal> & add_to_reason, std::vector<std::size_t> & active, ConstraintStateHandle state_handle, const Hint_ & hint)
+    -> PropagatorState
+{
+    // The empty (all-coefficients-cancelled) constraint has no terms to fold; defer to
+    // the stateless propagator, which handles the constant-only feasibility check.
+    if (coeff_vars.terms.empty())
+        return propagate_linear(coeff_vars, value, state, inference, logger, equality, proof_line, add_to_reason, hint);
+
+    auto & st = std::any_cast<LinearIncrementalState &>(state.get_constraint_state(state_handle));
+    const auto n = coeff_vars.terms.size();
+    const bool want = inference.want_reasons();
+
+    // Per-tier contributions, specialised exactly as the stateless propagate_linear is,
+    // so the inferences (and hence the search tree) are identical -- min for the <= half,
+    // -(max) for the >= (inverse) half.
+    auto min_contrib = [](const auto & cv, const pair<Integer, Integer> & b) -> Integer {
+        using CV = std::decay_t<decltype(cv)>;
+        if constexpr (is_same_v<CV, SimpleIntegerVariableID>)
+            return b.first;
+        else if constexpr (is_same_v<CV, PositiveOrNegative<SimpleIntegerVariableID>>)
+            return cv.positive ? b.first : -b.second;
+        else {
+            auto c = get_coeff(cv);
+            return (c >= 0_i) ? (c * b.first) : (c * b.second);
+        }
+    };
+    auto inv_contrib = [](const auto & cv, const pair<Integer, Integer> & b) -> Integer {
+        using CV = std::decay_t<decltype(cv)>;
+        if constexpr (is_same_v<CV, SimpleIntegerVariableID>)
+            return -b.second;
+        else if constexpr (is_same_v<CV, PositiveOrNegative<SimpleIntegerVariableID>>)
+            return cv.positive ? -b.second : b.first;
+        else {
+            auto c = get_coeff(cv);
+            return (c >= 0_i) ? -(c * b.second) : -(c * b.first);
+        }
+    };
+
+    // Active terms' bounds are always needed; fixed terms' bounds only when a reason or
+    // justification will actually read them (proofs / conflict learning).
+    LinearBounds bounds;
+    bounds.resize(n, pair{0_i, 0_i});
+    for (std::size_t k = 0; k != st.n_active; ++k)
+        bounds[active[k]] = state.bounds(get_var(coeff_vars.terms[active[k]]));
+    if (want)
+        for (std::size_t k = st.n_active; k != n; ++k)
+            bounds[active[k]] = state.bounds(get_var(coeff_vars.terms[active[k]]));
+
+    // Forward (<=): coeff_p * x_p <= value - (lower_sum - contrib_p).
+    Integer lower_sum = st.fixed_lower;
+    for (std::size_t k = 0; k != st.n_active; ++k)
+        lower_sum += min_contrib(coeff_vars.terms[active[k]], bounds[active[k]]);
+
+    for (std::size_t k = 0; k != st.n_active; ++k) {
+        auto p = active[k];
+        const auto & cv = coeff_vars.terms[p];
+        Integer lower_without_me = lower_sum - min_contrib(cv, bounds[p]);
+        Integer remainder = value - lower_without_me;
+        if (! infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv), false, proof_line, add_to_reason, hint))
+            return PropagatorState::Enable;
+        bounds[p] = state.bounds(get_var(cv));
+        lower_sum = lower_without_me + min_contrib(cv, bounds[p]);
+    }
+
+    if (equality) {
+        // Backward (>=): mirror of the forward pass on the inverse sum.
+        Integer inv_lower_sum = -st.fixed_lower;
+        for (std::size_t k = 0; k != st.n_active; ++k)
+            inv_lower_sum += inv_contrib(coeff_vars.terms[active[k]], bounds[active[k]]);
+
+        for (std::size_t k = 0; k != st.n_active; ++k) {
+            auto p = active[k];
+            const auto & cv = coeff_vars.terms[p];
+            Integer inv_lower_without_me = inv_lower_sum - inv_contrib(cv, bounds[p]);
+            Integer inv_remainder = -value - inv_lower_without_me;
+            if (! infer(inference, logger, bounds, coeff_vars, p, get_var(cv), inv_remainder, negate(get_coeff_or_bool(cv)), true, proof_line,
+                    add_to_reason, hint))
+                return PropagatorState::Enable;
+            bounds[p] = state.bounds(get_var(cv));
+            inv_lower_sum = inv_lower_without_me + inv_contrib(cv, bounds[p]);
+        }
+    }
+
+    // Fold any newly-instantiated active terms out of the active set, but ALWAYS keep at
+    // least one term active: with everything folded, a fully-fixed but violated
+    // assignment would be left unchecked (the loops above wouldn't run). Keeping one
+    // active means the standard loop still verifies the (in)equality at a leaf, and
+    // contradicts via the ordinary per-variable justification. The permutation is
+    // persistent (never restored on backtrack); only n_active and fixed_lower are
+    // backtracked, which is sound because the loops above are order-independent.
+    for (std::size_t k = 0; k != st.n_active && st.n_active > 1;) {
+        auto p = active[k];
+        if (auto v = state.optional_single_value(get_var(coeff_vars.terms[p]))) {
+            st.fixed_lower += get_coeff(coeff_vars.terms[p]) * *v;
+            --st.n_active;
+            std::swap(active[k], active[st.n_active]);
+        }
+        else
+            ++k;
+    }
+
+    return PropagatorState::Enable;
+}
+
+// One instantiation per (coeff vector, tracker, hint): hints::LinearEquality for the
+// equality MustHold path, NoHint for the inequality must-hold path.
+#define GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(CoeffVars, Tracker, Hint)                                                                       \
+    template auto gcs::innards::propagate_linear_incremental(const CoeffVars & coeff_vars, Integer value, const State & state, Tracker &,            \
+        ProofLogger * const logger, bool equality, const optional<pair<optional<ProofLine>, optional<ProofLine>>> & proof_line,                      \
+        const optional<Literal> & add_to_reason, std::vector<std::size_t> & active, ConstraintStateHandle state_handle, const Hint & hint)           \
+        -> PropagatorState
+
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<Weighted<SimpleIntegerVariableID>>, SimpleInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, SimpleInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<SimpleIntegerVariableID>, SimpleInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<Weighted<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(
+    SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, hints::LinearEquality);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<SimpleIntegerVariableID>, EagerProofLoggingInferenceTracker, hints::LinearEquality);
+
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<Weighted<SimpleIntegerVariableID>>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<SimpleIntegerVariableID>, SimpleInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<Weighted<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<PositiveOrNegative<SimpleIntegerVariableID>>, EagerProofLoggingInferenceTracker, NoHint);
+GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL(SumOf<SimpleIntegerVariableID>, EagerProofLoggingInferenceTracker, NoHint);
+
+#undef GCS_INSTANTIATE_PROPAGATE_LINEAR_INCREMENTAL
 
 template <typename Hint_>
 auto gcs::innards::propagate_linear_not_equals(const auto & coeff_vars, Integer value, const State & state, auto & inference,

--- a/gcs/constraints/linear/propagate.hh
+++ b/gcs/constraints/linear/propagate.hh
@@ -8,9 +8,11 @@
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/propagators-fwd.hh>
-#include <gcs/innards/state-fwd.hh>
+#include <gcs/innards/state.hh>
 
+#include <cstddef>
 #include <optional>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -23,6 +25,47 @@ namespace gcs::innards
     auto propagate_linear(const auto & terms, Integer, const State &, auto & inference_tracker, ProofLogger * const logger, bool equality,
         const std::optional<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & proof_line, const std::optional<Literal> & add_to_reason,
         const Hint_ & hint = {}) -> PropagatorState;
+
+    /**
+     * \brief Backtrackable state for the incremental linear propagator: the count of
+     * not-yet-instantiated ("active") terms, and the summed contribution of the
+     * instantiated ("fixed") ones (a fixed term contributes coeff*value to the lower
+     * sum, and -coeff*value to the inverse/upper sum).
+     *
+     * \ingroup Innards
+     */
+    struct LinearIncrementalState
+    {
+        std::size_t n_active;
+        Integer fixed_lower;
+    };
+
+    /**
+     * \brief The default minimum number of terms at and above which a linear
+     * (in)equality uses the incremental propagator, used when a constraint is posted
+     * without an explicit threshold. A wide threshold keeps narrow constraints on the
+     * cheaper stateless path, where the incremental bookkeeping does not pay off.
+     *
+     * The per-constraint threshold (a constructor argument on the linear constraints)
+     * is the intended interface; this default is overridable via the
+     * GCS_LINEAR_INCREMENTAL_THRESHOLD environment variable, which is how the test
+     * suite sweeps both code paths (threshold 0 = always incremental, a huge value =
+     * always stateless).
+     */
+    [[nodiscard]] auto default_linear_incremental_threshold() -> std::size_t;
+
+    /**
+     * \brief Incremental variant of propagate_linear: folds instantiated terms out of
+     * the active set so each firing only walks the still-unassigned terms. `active`
+     * is a persistent (non-backtracked) permutation of term indices, mutated in place;
+     * `state_handle` refers to a LinearIncrementalState added via add_constraint_state.
+     *
+     * \ingroup Innards
+     */
+    template <typename Hint_ = NoHint>
+    auto propagate_linear_incremental(const auto & terms, Integer, const State &, auto & inference_tracker, ProofLogger * const logger, bool equality,
+        const std::optional<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & proof_line, const std::optional<Literal> & add_to_reason,
+        std::vector<std::size_t> & active, ConstraintStateHandle state_handle, const Hint_ & hint = {}) -> PropagatorState;
 
     /**
      * \brief Propagate a not-equals


### PR DESCRIPTION
## What

Adds an **incremental** variant of `propagate_linear` that folds instantiated terms out of an active set, so each firing only walks the still-unassigned terms instead of recomputing over all of them. It is a wall-clock win on *wide* linear constraints, with **byte-identical search trees** and **unchanged proofs**.

It is opt-in per constraint via a size threshold — a constructor argument on `LinearEquality` / `LinearLessThanEqual` / `LinearGreaterThanEqual`, defaulting to `default_linear_incremental_threshold()` (8, overridable via `GCS_LINEAR_INCREMENTAL_THRESHOLD`). Below the threshold, narrow constraints stay on the cheaper stateless path, where the folding bookkeeping doesn't pay off.

## Performance (Release, solve time, identical recursions)

| benchmark | shape | stateless | +incremental |
|---|---|---:|---:|
| magic_series 300 | wide, shallow | 6.47s | 5.22s (**−19%**) |
| synthetic deep+wide (eq + ≤) | wide, deep | 17.5s | 11.4s (**−35%**) |
| magic_square 5 | narrow (n=5 < threshold) | — | unchanged |
| qap 12 / tsp | element/circuit-dominated | — | flat |

No regressions: the threshold keeps narrow constraints on the stateless path.

## Details

- **Scope:** the incremental path is used only for *unconditional* (`MustHold`) linear `==`, `<=`, `>=`. Reified `If`/`Iff` stay stateless, since the reified dispatcher alternates between the must-hold and must-not-hold propagations.
- The backtrackable state is a small POD `{n_active, fixed_lower}` registered via `add_constraint_state`, plus a persistent (non-backtracked) permutation of term indices. The per-firing arithmetic and proof emission **reuse the existing stateless code**, so the inferences are identical.
- At least one term is always kept active, so a fully-fixed but violated leaf is still caught by the ordinary per-variable justification (no new proof path needed).

## Testing

- `linear_test` and `linear_constant_test` now run in **both modes** in CI (threshold 0 = always incremental, 1000000 = always stateless). The threshold is folded into the proof file name so the two runs never clobber each other's `.opb`/`.pbp` under parallel ctest.
- Full `ctest` passes at threshold 0 and at 1000000 (every linear-using test, with proofs); `linear_test` eq/le/ge verify full enumeration under VeriPB with incremental forced on.
- Builds clean under GCC 15.2 and clang 21; ASan/UBSan clean with incremental forced on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
