### PR TITLE
Incremental folding for reified linear (in)equality enforce paths

### DIFF
--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -367,14 +367,33 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators, State
 
                 visit(
                     [&, modifier = modifier](const auto & sanitised_cv) {
+                        // Only the must-hold branch below is a bounds-sum linear equality that can
+                        // fold incrementally; the must-not-hold branch is a different (not-equals)
+                        // algorithm and the undecided branch only inspects a single residual var, so
+                        // neither uses the fold state. The must-hold state runs (repeatedly) only
+                        // while the condition is decided true in a subtree, backtracks on its own
+                        // handle, and re-folds any terms instantiated while another branch was active.
+                        std::optional<std::pair<std::shared_ptr<vector<std::size_t>>, ConstraintStateHandle>> inc_must_hold;
+                        if (sanitised_cv.terms.size() >= _incremental_threshold.value_or(default_linear_incremental_threshold())) {
+                            auto active = make_shared<vector<std::size_t>>(sanitised_cv.terms.size());
+                            for (std::size_t i = 0; i != sanitised_cv.terms.size(); ++i)
+                                (*active)[i] = i;
+                            auto handle = initial_state.add_constraint_state(LinearIncrementalState{sanitised_cv.terms.size(), 0_i});
+                            inc_must_hold = std::pair{active, handle};
+                        }
+
                         propagators.install(
                             constraint_id(),
                             [sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line,
-                                all_vars = move(all_vars), owner = constraint_id()](const State & state, auto & inference,
+                                all_vars = move(all_vars), owner = constraint_id(),
+                                inc_must_hold = inc_must_hold](const State & state, auto & inference,
                                 ProofLogger * const logger) -> PropagatorState { // This comment is needed to stop clang-format exploding
                                 return overloaded{
                                     [&](const evaluated_reif::MustHold & reif) {
                                         // we now know the condition definitely holds, so it's a linear equality
+                                        if (inc_must_hold)
+                                            return propagate_linear_incremental(sanitised_cv, value, state, inference, logger, true, proof_line,
+                                                reif.cond, *inc_must_hold->first, inc_must_hold->second, hints::LinearEquality{owner});
                                         return propagate_linear(
                                             sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, hints::LinearEquality{owner});
                                     }, //

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -181,19 +181,36 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
             using LinearCondJustification = std::conditional_t<std::is_same_v<CV, NegCV>, JustifyExplicitly<hints::LinearInequalityCond<CV>>,
                 std::variant<JustifyExplicitly<hints::LinearInequalityCond<CV>>, JustifyExplicitly<hints::LinearInequalityCond<NegCV>>>>;
 
-            // Only the unconditional (MustHold) inequality always enforces the same
-            // single propagation, so only then is it sound (and worthwhile) to fold
-            // incrementally. Reified If/Iff (where the dispatcher alternates between the
-            // must-hold and must-not-hold propagations) stay on the stateless path.
-            std::optional<std::pair<std::shared_ptr<std::vector<std::size_t>>, ConstraintStateHandle>> inc_must_hold;
-            if (std::holds_alternative<evaluated_reif::MustHold>(_evaluated_cond) &&
-                sanitised_cv.terms.size() >= _incremental_threshold.value_or(default_linear_incremental_threshold())) {
-                auto active = make_shared<std::vector<std::size_t>>(sanitised_cv.terms.size());
-                for (std::size_t i = 0; i != sanitised_cv.terms.size(); ++i)
+            // Each enforce direction always re-runs the same single propagation while its
+            // verdict holds (the dispatcher keeps it Enabled within a subtree where the
+            // condition is decided one way), so each can fold its own fixed terms away
+            // incrementally. The two directions need independent fold states: within any
+            // one subtree only one direction runs, and each state backtracks on its own
+            // ConstraintStateHandle, so an under-folded state (vars instantiated while the
+            // other direction was active) is still correct -- it just re-folds them on its
+            // next run. Set up a state only for a direction the dispatcher can actually
+            // reach: must-hold for everything but an unconditional must-not-hold; must-not-
+            // hold only for an unconditional must-not-hold or a full Iff (a half-reified
+            // If/NotIf deactivates rather than enforcing the negation).
+            const auto threshold = _incremental_threshold.value_or(default_linear_incremental_threshold());
+            const bool und = std::holds_alternative<evaluated_reif::Undecided>(_evaluated_cond);
+            const bool may_must_hold = std::holds_alternative<evaluated_reif::MustHold>(_evaluated_cond) || und;
+            const bool may_must_not_hold =
+                std::holds_alternative<evaluated_reif::MustNotHold>(_evaluated_cond) || (und && std::holds_alternative<reif::Iff>(_reif_cond));
+
+            auto setup_inc = [&](const auto & cv) -> std::pair<std::shared_ptr<std::vector<std::size_t>>, ConstraintStateHandle> {
+                auto active = make_shared<std::vector<std::size_t>>(cv.terms.size());
+                for (std::size_t i = 0; i != cv.terms.size(); ++i)
                     (*active)[i] = i;
-                auto handle = initial_state.add_constraint_state(LinearIncrementalState{sanitised_cv.terms.size(), 0_i});
-                inc_must_hold = std::pair{active, handle};
-            }
+                auto handle = initial_state.add_constraint_state(LinearIncrementalState{cv.terms.size(), 0_i});
+                return std::pair{active, handle};
+            };
+
+            std::optional<std::pair<std::shared_ptr<std::vector<std::size_t>>, ConstraintStateHandle>> inc_must_hold, inc_must_not_hold;
+            if (may_must_hold && sanitised_cv.terms.size() >= threshold)
+                inc_must_hold = setup_inc(sanitised_cv);
+            if (may_must_not_hold && sanitised_neg_cv.terms.size() >= threshold)
+                inc_must_not_hold = setup_inc(sanitised_neg_cv);
 
             auto enforce_constraint_must_hold = [sanitised_cv, value = _value, modifier = modifier, proof_lines, inc_must_hold](const State & state,
                                                     auto & inference, ProofLogger * const logger, const Literal & cond) -> PropagatorState {
@@ -203,9 +220,12 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
                 return propagate_linear(sanitised_cv, value + modifier, state, inference, logger, false, proof_lines, cond);
             };
 
-            auto enforce_constraint_must_not_hold = [sanitised_neg_cv, value = _value, neg_modifier = neg_modifier, proof_lines_swapped](
-                                                        const State & state, auto & inference, ProofLogger * const logger,
+            auto enforce_constraint_must_not_hold = [sanitised_neg_cv, value = _value, neg_modifier = neg_modifier, proof_lines_swapped,
+                                                        inc_must_not_hold](const State & state, auto & inference, ProofLogger * const logger,
                                                         const Literal & cond) -> PropagatorState {
+                if (inc_must_not_hold)
+                    return propagate_linear_incremental(sanitised_neg_cv, -value + neg_modifier - 1_i, state, inference, logger, false,
+                        proof_lines_swapped, cond, *inc_must_not_hold->first, inc_must_not_hold->second);
                 return propagate_linear(sanitised_neg_cv, -value + neg_modifier - 1_i, state, inference, logger, false, proof_lines_swapped, cond);
             };
 


### PR DESCRIPTION
Stacked on #419 (base = `linear-incremental`).

## What

Extends the incremental folding from #419 (which only covered the unconditional `MustHold` linear (in)equality) to the **enforced paths of the reified constraints**.

- **Inequality `If` / `NotIf` / `Iff`** (and unconditional `MustNotHold`): both `enforce_must_hold` and `enforce_must_not_hold` are plain bounds-sum linear propagations, so each folds its fixed terms away. States are set up only for the directions the dispatcher can actually reach.
- **Equality `Iff`**: the must-hold branch of the undecided dispatcher now folds incrementally. The must-not-hold (not-equals) branch and the single-residual-variable undecided branch are different algorithms and stay stateless.

## Why it's sound

The two enforce directions keep **independent** fold states. Within any one subtree the reification condition is decided one way, so only one direction runs there, and each state backtracks on its own `ConstraintStateHandle`. A state that under-folds (terms instantiated while the other direction, or the undecided branch, was active) is still correct — it simply re-folds those terms on its next run, since folding is purely an optimisation of which terms the propagation walks.

## Testing

- No new template instantiations, no new tests required: the existing both-mode test registration already covers `eq_if`/`eq_iff`/`le_if`/`le_iff`/`ge_if`/`ge_iff`, so the threshold-0 CI runs now exercise the reified incremental paths with full proof verification.
- All 12 linear modes pass at threshold 0 (always incremental) **and** threshold 1000000 (always stateless), with proofs and full enumeration (caps off).
- Separate wide (10-term) reified `Iff` stress test across 5 RHS values: every solution sound, full 2^n enumeration, VeriPB verifies, both incremental and stateless.
- Full `ctest` suite 408/408. GCC + clang-21 both build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)