### PR TITLE
Use VeriPB `cases` rule for selector-style justifications (experimental)

### DIFF
--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -163,15 +163,15 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
                         if (find(excluded.begin(), excluded.end(), v) == excluded.end())
                             non_excluded_values.push_back(v);
                     for (const auto & v : non_excluded_values) {
-                        inf.infer(logger, x != v,
-                            JustifyExplicitly{//
-                                [&logger, x, v, &duplicate_selectors](const ReasonLiterals &) -> void {
-                                    const auto & selector = duplicate_selectors.at(x);
-                                    logger->emit(RUPProofRule{}, WPBSum{} + 1_i * (x != v) + 1_i * selector >= 1_i, ProofLevel::Temporary);
-                                    logger->emit(RUPProofRule{}, WPBSum{} + 1_i * (x != v) + 1_i * (! selector) >= 1_i, ProofLevel::Temporary);
-                                },
-                                ThenRUP::Yes, hints::AllDifferentExcept{owner}},
-                            NoReason{});
+                        // var != v by a complete 2-way case split on the duplicate-pair
+                        // selector: each polarity forces var into the excluded set by RUP.
+                        // The selector is a proof-model flag, so it only exists when
+                        // proving; look it up rather than asserting its presence (with
+                        // proofs off the flags are unused and the map is empty).
+                        std::vector<ProofFlag> case_flags;
+                        if (auto it = duplicate_selectors.find(x); it != duplicate_selectors.end())
+                            case_flags.push_back(it->second);
+                        inf.infer_not_equal(logger, x, v, JustifyUsingCases{std::move(case_flags), hints::AllDifferentExcept{owner}}, NoReason{});
                     }
                 }
             });

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -189,15 +189,10 @@ auto In::install_propagators(Propagators & propagators) -> void
                         reason = ExplicitReason{std::move(lits)};
                     }
 
-                    inference.infer_not_equal(logger, var, v,
-                        JustifyExplicitly{//
-                            [logger, var, v, &selectors](const ReasonLiterals & reason) {
-                                for (const auto & sel : selectors)
-                                    logger->emit_rup_proof_line_under_reason(
-                                        reason, WPBSum{} + 1_i * ! sel + 1_i * (var != v) >= 1_i, ProofLevel::Temporary);
-                            },
-                            ThenRUP::Yes, hints::In{owner}},
-                        reason);
+                    // var != v by case analysis over the source selectors: each selector
+                    // makes var take one source value (none of which is v here), and the
+                    // model's at-least-one selector rules out the all-false case.
+                    inference.infer_not_equal(logger, var, v, JustifyUsingCases{selectors, hints::In{owner}}, reason);
                 }
             }
 

--- a/gcs/constraints/lex/lex.cc
+++ b/gcs/constraints/lex/lex.cc
@@ -112,13 +112,14 @@ namespace
             if (equal_prefix_satisfies)
                 return PropagatorState::DisableUntilBacktrack;
 
-            auto contradiction_proof = [&, n](const ReasonLiterals & r) -> void {
-                if (! logger)
-                    return;
-                for (size_t k = 0; k < n; ++k)
-                    logger->emit_rup_proof_line_under_reason(r, WPBSum{} + 1_i * ! decision_at_flags->at(k) >= 1_i, ProofLevel::Temporary);
-            };
-            inference.contradiction(logger, JustifyExplicitly{contradiction_proof, ThenRUP::Yes, hints::Lex{owner}}, reason);
+            // contradiction by case analysis over the per-position decision selectors:
+            // each individual decision is ruled out here, and the model's at-least-one
+            // (a decision somewhere, or the equal-prefix flag) handles the all-false case.
+            // The selectors are proof-model flags, so only dereference when proving.
+            std::vector<ProofFlag> decision_flags;
+            if (logger)
+                decision_flags = *decision_at_flags;
+            inference.contradiction(logger, JustifyUsingCases{std::move(decision_flags), hints::Lex{owner}}, reason);
         }
 
         auto emit_not_d = [&](const ReasonLiterals & r, size_t k) -> void {

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -128,17 +128,11 @@ auto ArrayMinMax::install_propagators(Propagators & propagators) -> void
                     for (auto & var : vars)
                         reason.emplace_back(var != value);
 
-                    inference.infer_not_equal(logger, result, value,
-                        JustifyExplicitly{//
-                            [logger, result, value, &selectors](const ReasonLiterals & reason) {
-                                // show that none of the selectors work, if we're taking the result to be that value and also
-                                // that the value is missing from all of the vars
-                                for (const auto & sel : selectors)
-                                    logger->emit_rup_proof_line_under_reason(
-                                        reason, WPBSum{} + (1_i * ! sel) + (1_i * (result != value)) >= 1_i, ProofLevel::Temporary);
-                            },
-                            ThenRUP::Yes, hints::MinMax{owner}},
-                        ExplicitReason{reason});
+                    // result != value by case analysis over the selectors: under any single
+                    // selector, result equals that var (which here is missing value), and the
+                    // model's at-least-one selector rules out the all-false case. Each branch
+                    // is RUP; `cases` packages them and the combine into one line.
+                    inference.infer_not_equal(logger, result, value, JustifyUsingCases{selectors, hints::MinMax{owner}}, ExplicitReason{reason});
                 }
             }
 

--- a/gcs/constraints/smart_table/smart_table.cc
+++ b/gcs/constraints/smart_table/smart_table.cc
@@ -498,12 +498,10 @@ namespace
 
         if (! some_tuple_still_feasible) {
             if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
-                auto justf = [&](const ReasonLiterals & reason) -> void {
-                    for (unsigned int tuple_idx = 0; tuple_idx < tuples.size(); ++tuple_idx) {
-                        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (! pb_selectors[tuple_idx]) >= 1_i, ProofLevel::Temporary);
-                    }
-                };
-                inference.contradiction(logger, JustifyExplicitly{justf, ThenRUP::Yes, hints::SmartTable{owner}}, reason_to_use);
+                // contradiction by case analysis over the tuple selectors: every tuple is
+                // infeasible here, and the model's at-least-one tuple selector forbids the
+                // all-false case.
+                inference.contradiction(logger, JustifyUsingCases{pb_selectors, hints::SmartTable{owner}}, reason_to_use);
                 // if (short_reasons) {
                 //     logger->delete_range(reason_definition_1, reason_definition_2 + 1);
                 // }
@@ -517,13 +515,9 @@ namespace
 
             for (const auto & var : vars) {
                 for (const auto & value : unsupported[var]) {
-                    auto justf = [&](const ReasonLiterals & reason) -> void {
-                        for (unsigned int tuple_idx = 0; tuple_idx < tuples.size(); ++tuple_idx) {
-                            logger->emit_rup_proof_line_under_reason(
-                                reason, WPBSum{} + 1_i * (var != value) + 1_i * (! pb_selectors[tuple_idx]) >= 1_i, ProofLevel::Temporary);
-                        }
-                    };
-                    inference.infer_not_equal(logger, var, value, JustifyExplicitly{justf, ThenRUP::Yes, hints::SmartTable{owner}}, reason_to_use);
+                    // var != value by case analysis over the tuple selectors: no feasible
+                    // tuple assigns var = value, and at-least-one forbids the all-false case.
+                    inference.infer_not_equal(logger, var, value, JustifyUsingCases{pb_selectors, hints::SmartTable{owner}}, reason_to_use);
                 }
             }
             // if (short_reasons) {

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -249,6 +249,48 @@ namespace gcs::innards
             track_explicit(logger, _state.infer_not_equal(var, value), var != value, why, snapshotted, fallback);
         }
 
+        // A JustifyUsingCases inference is justified by VeriPB's `cases` rule: the
+        // inferred literal is derived directly by case analysis over the given
+        // proof flags. Each overload builds the one-line emitter and reuses the
+        // JustifyExplicitly path (ThenRUP::No, since the cases line concludes the
+        // inference itself), so state changes and proofs-off behaviour are shared.
+        template <typename Hint_ = NoHint>
+        auto infer(ProofLogger * const logger, const Literal & lit, const JustifyUsingCases<Hint_> & why, const Reason & reason,
+            const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer(logger, lit,
+                JustifyExplicitly{[logger, lit, flags = why.case_flags](const ReasonLiterals & r) {
+                                      logger->emit_cases_proof_line_under_reason(r, WPBSum{} + 1_i * lit >= 1_i, flags, ProofLevel::Current);
+                                  },
+                    ThenRUP::No, why.hint},
+                reason, fallback);
+        }
+
+        template <IntegerVariableIDLike VarType_, typename Hint_ = NoHint>
+        auto infer_not_equal(ProofLogger * const logger, const VarType_ & var, Integer value, const JustifyUsingCases<Hint_> & why,
+            const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            infer_not_equal(logger, var, value,
+                JustifyExplicitly{[logger, var, value, flags = why.case_flags](const ReasonLiterals & r) {
+                                      logger->emit_cases_proof_line_under_reason(
+                                          r, WPBSum{} + 1_i * (var != value) >= 1_i, flags, ProofLevel::Current);
+                                  },
+                    ThenRUP::No, why.hint},
+                reason, fallback);
+        }
+
+        template <typename Hint_ = NoHint>
+        [[noreturn]] auto contradiction(ProofLogger * const logger, const JustifyUsingCases<Hint_> & why, const Reason & reason,
+            const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
+        {
+            contradiction(logger,
+                JustifyExplicitly{[logger, flags = why.case_flags](const ReasonLiterals & r) {
+                                      logger->emit_cases_proof_line_under_reason(r, WPBSum{} >= 1_i, flags, ProofLevel::Current);
+                                  },
+                    ThenRUP::No, why.hint},
+                reason, fallback);
+        }
+
         // A JustifyUsingRUP carrying a typed hint is a RUP inference (no explicit
         // steps) that wants a typed assertion hint. Each overload below turns the
         // hint into an annotation (only when something will be asserted — Off mode

--- a/gcs/innards/justification.hh
+++ b/gcs/innards/justification.hh
@@ -70,8 +70,10 @@ namespace gcs::innards
      * carrying a typed assertion hint exactly as JustifyUsingRUP does. In Off
      * proof mode nothing is emitted.
      *
-     * Each branch must be RUP — this suits "exactly one selector holds" reasoning,
-     * not cross-variable cutting-planes case splits (use JustifyExplicitly there).
+     * Each branch must be automatically provable (trivial, in-database, RUP, or
+     * implied by a database constraint) — this suits "exactly one selector holds"
+     * reasoning, not cross-variable cutting-planes case splits (use
+     * JustifyExplicitly there).
      *
      * \ingroup Innards
      * \sa JustifyUsingRUP

--- a/gcs/innards/justification.hh
+++ b/gcs/innards/justification.hh
@@ -5,10 +5,12 @@
 #include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/reason.hh>
 
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -54,6 +56,37 @@ namespace gcs::innards
 
     template <typename Hint_>
     JustifyUsingRUP(Hint_) -> JustifyUsingRUP<Hint_>;
+
+    /**
+     * \brief Specify that an inference is justified by case analysis over a set
+     * of proof flags, using VeriPB's `cases` rule.
+     *
+     * The mirror of JustifyUsingRUP for selector-style reasoning: the inferred
+     * literal follows because, under each \c case_flag, it holds by RUP, and the
+     * model's at-least-one constraint over those flags rules out the all-false
+     * case. The inference-tracker overloads turn this into a single
+     * `emit_cases_proof_line_under_reason` for the inferred literal (so it is a
+     * direct, persistent derivation, not temporary steps plus a RUP), optionally
+     * carrying a typed assertion hint exactly as JustifyUsingRUP does. In Off
+     * proof mode nothing is emitted.
+     *
+     * Each branch must be RUP — this suits "exactly one selector holds" reasoning,
+     * not cross-variable cutting-planes case splits (use JustifyExplicitly there).
+     *
+     * \ingroup Innards
+     * \sa JustifyUsingRUP
+     */
+    template <typename Hint_ = NoHint>
+    struct JustifyUsingCases
+    {
+        std::vector<ProofFlag> case_flags;
+        [[no_unique_address]] Hint_ hint{};
+    };
+
+    JustifyUsingCases(std::vector<ProofFlag>) -> JustifyUsingCases<NoHint>;
+
+    template <typename Hint_>
+    JustifyUsingCases(std::vector<ProofFlag>, Hint_) -> JustifyUsingCases<Hint_>;
 
     /**
      * \brief Specify that an inference will be asserted rather than justified.

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -507,6 +507,12 @@ auto ProofLogger::emit_rup_proof_line_under_reason(
 auto ProofLogger::emit_cases_proof_line_under_reason(const ReasonLiterals & reason_in, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
     const std::vector<ProofFlag> & case_flags, ProofLevel level) -> ProofLine
 {
+    // A case analysis over zero cases just asserts that the conclusion is
+    // autoprovable, which for our clause conclusions means RUP, so emit the
+    // plain RUP step (which VeriPB's cases elaboration currently can't).
+    if (case_flags.empty())
+        return emit_rup_proof_line_under_reason(reason_in, ineq, level);
+
     // De-duplicate the reason: a constraint over duplicate variables (e.g.
     // min(x, x, y)) yields repeated reason literals, which reify into repeated
     // terms; VeriPB sums their coefficients, turning what is logically a clause

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -15,6 +15,7 @@
 #include <gcs/innards/state.hh>
 #include <gcs/proof.hh>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <deque>
@@ -501,6 +502,39 @@ auto ProofLogger::emit_rup_proof_line_under_reason(
     const ReasonLiterals & reason, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> ProofLine
 {
     return emit_under_reason(RUPProofRule{}, ineq, level, reason);
+}
+
+auto ProofLogger::emit_cases_proof_line_under_reason(const ReasonLiterals & reason_in, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
+    const std::vector<ProofFlag> & case_flags, ProofLevel level) -> ProofLine
+{
+    // De-duplicate the reason: a constraint over duplicate variables (e.g.
+    // min(x, x, y)) yields repeated reason literals, which reify into repeated
+    // terms; VeriPB sums their coefficients, turning what is logically a clause
+    // into a coefficient->1 pseudo-Boolean constraint, and `cases` only accepts
+    // clause targets. The repeated literal is redundant, so dropping it is sound
+    // and keeps the emitted conclusion a clause.
+    ReasonLiterals reason;
+    for (const auto & lit : reason_in)
+        if (std::find(reason.begin(), reason.end(), lit) == reason.end())
+            reason.push_back(lit);
+
+    if (! reason.empty())
+        names_and_ids_tracker().need_all_proof_names_in(reason);
+    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
+
+    log_stacktrace();
+    stringstream rule_line;
+    rule_line << "cases ";
+    if (! reason.empty())
+        emit_inequality_to(names_and_ids_tracker(), reify(ineq, reason), rule_line);
+    else
+        emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);
+    rule_line << ": ";
+    for (const auto & flag : case_flags)
+        rule_line << names_and_ids_tracker().pb_file_string_for(flag) << " ";
+    rule_line << ";";
+
+    return emit_proof_line(rule_line.str(), level);
 }
 
 auto ProofLogger::emit_rup_proof_line_under_reason_then_deview(

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -510,9 +510,11 @@ auto ProofLogger::emit_cases_proof_line_under_reason(const ReasonLiterals & reas
     // De-duplicate the reason: a constraint over duplicate variables (e.g.
     // min(x, x, y)) yields repeated reason literals, which reify into repeated
     // terms; VeriPB sums their coefficients, turning what is logically a clause
-    // into a coefficient->1 pseudo-Boolean constraint, and `cases` only accepts
-    // clause targets. The repeated literal is redundant, so dropping it is sound
-    // and keeps the emitted conclusion a clause.
+    // into a coefficient->2 pseudo-Boolean constraint. `cases` now accepts
+    // general PB targets, but the clause is the constraint we actually want to
+    // derive, and non-clausal targets exercise VeriPB's known-buggy elaboration
+    // path. The repeated literal is redundant, so dropping it is sound and
+    // keeps the emitted conclusion a clause.
     ReasonLiterals reason;
     for (const auto & lit : reason_in)
         if (std::find(reason.begin(), reason.end(), lit) == reason.end())
@@ -529,10 +531,11 @@ auto ProofLogger::emit_cases_proof_line_under_reason(const ReasonLiterals & reas
         emit_inequality_to(names_and_ids_tracker(), reify(ineq, reason), rule_line);
     else
         emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);
-    rule_line << ": ";
+    // the case list is bare variables, not literals: a case split over ~f is
+    // the same split as over f, and VeriPB's grammar rejects the negation
     for (const auto & flag : case_flags)
-        rule_line << names_and_ids_tracker().pb_file_string_for(flag) << " ";
-    rule_line << ";";
+        rule_line << " " << names_and_ids_tracker().pb_file_string_for(flag.positive ? flag : ! flag);
+    rule_line << " ;";
 
     return emit_proof_line(rule_line.str(), level);
 }

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -266,8 +266,9 @@ namespace gcs::innards
          * Emit a `cases` proof step deriving the specified expression by case
          * analysis over `case_flags`, subject to a given reason. VeriPB verifies
          * that, for every assignment to the case flags, the (reason-reified)
-         * conclusion follows by RUP, then expands this to plain RUP lines during
-         * elaboration. Each branch must be RUP, so this suits selector-style
+         * conclusion is trivial, in the database, RUP, or implied by a database
+         * constraint, then expands this to plain lines during elaboration. Each
+         * branch must be automatically provable, so this suits selector-style
          * "exactly one of these flags holds" reasoning, not cross-variable
          * cutting-planes case splits.
          */

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -263,6 +263,18 @@ namespace gcs::innards
             -> ProofLine;
 
         /**
+         * Emit a `cases` proof step deriving the specified expression by case
+         * analysis over `case_flags`, subject to a given reason. VeriPB verifies
+         * that, for every assignment to the case flags, the (reason-reified)
+         * conclusion follows by RUP, then expands this to plain RUP lines during
+         * elaboration. Each branch must be RUP, so this suits selector-style
+         * "exactly one of these flags holds" reasoning, not cross-variable
+         * cutting-planes case splits.
+         */
+        auto emit_cases_proof_line_under_reason(const ReasonLiterals &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &,
+            const std::vector<ProofFlag> & case_flags, ProofLevel level) -> ProofLine;
+
+        /**
          * Like `emit_rup_proof_line_under_reason`, but returns the deview-form
          * line of the just-emitted RUP rather than the V-form line itself.
          *


### PR DESCRIPTION
## Summary

Adds a justification path that uses VeriPB's proposed **`cases`** rule (derive a
target by case analysis over a small set of literals) and converts five
selector-style propagator justifications to it, replacing hand-rolled
per-selector RUP loops with a single proof line.

> [!WARNING]
> **Experimental / draft.** These proofs only verify with a VeriPB build that
> implements the `cases` rule (branch `cases-rule` in our veripb-dev checkout).
> The released `veripb` rejects `cases`, so **CI will be red** until/unless the
> rule lands upstream. This PR is to evaluate the solver-side ergonomics and to
> gather evidence for proposing the rule to the VeriPB authors.

## What `cases` is

`cases <constraint> : <case literals> ;` asks the checker to verify the target
by considering each assignment to the case literals: every branch must hold by
RUP (or be trivial / in the DB), after which the target is safe. It elaborates
to plain `rup`/`deld` lines, so it adds nothing to the trusted base — the
elaborated kernel proofs are accepted by the formally-verified `cake_pb`.

## Framework (reusable, +121 LOC)

- `ProofLogger::emit_cases_proof_line_under_reason` — emits `cases <C reified
  under reason> : <flags> ;`. De-duplicates the reason so duplicate-variable
  instances (e.g. `min(x, x, y)`) still render a clause (which `cases` requires).
- `JustifyUsingCases<Hint>` — mirrors `JustifyUsingRUP`. Inference-tracker
  overloads (`infer` / `infer_not_equal` / `contradiction`) build the one-line
  emitter and reuse the `JustifyExplicitly` path (`ThenRUP::No`), so state
  changes and proofs-off behaviour are shared and nothing is emitted with proofs
  off. Call sites become one-liners.

## Conversions

Each is the same shape — "at-most/exactly-one selector holds; under each the
conclusion is RUP; the model's at-least-one rules out all-false" (or a complete
2-way split):

| Constraint | Inference | Case literals |
|---|---|---|
| `min_max` | result ∉ ⋃ vars | per-value selectors |
| `in` | var unsupported by any source | source selectors |
| `all_different_except` | duplicate forced into excluded set | duplicate-pair selector (2-way) |
| `smart_table` | no-feasible-tuple contradiction + per-value filter | tuple selectors |
| `lex` | equal-prefix-cannot-satisfy contradiction | per-position decision selectors |

`lex`'s other sites (tighten / force-strict / scaffold) mix `prefix_equal`
bounds and `infer_all`, so they keep their explicit justifications.

Note: selector vectors are proof-model-only, so they're copied/dereferenced
only when a logger is present (`.find` not `.at`).

## Evidence

- **Breadth:** five distinct global constraints were independently hand-rolling
  this pattern.
- **Source-proof compression:** each `cases` line replaces *(#selectors + 1)*
  manual RUP/scaffold lines — sampled min_max 57 → 228, smart_table 39 → 234
  (~4.5× in those regions).
- **Soundness/composability:** verified with a `cases`-aware VeriPB across
  min_max/in/all_different_except/smart_table/lex; elaborated kernel proofs pass
  `cake_pb` (e.g. a min_max proof: 37 source lines → 69-line pure rup/deld kernel
  proof → `cake_pb: s VERIFIED`).
- **Not a universal hammer:** only fits when each branch is RUP. `abs` etc. are
  *not* candidates (their branches need cross-variable cutting-planes).

## Reproducing

Build the `cases`-aware VeriPB, put it first on `PATH`, then run e.g.
`./build/min_max_test --prove` (the test binary self-verifies via the `veripb`
on `PATH`).
