### PR TITLE
Seed propagation with the objective bound, not just the branch guess (#418)

### DIFF
--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -173,8 +173,7 @@ auto Propagators::initialise(State & state, ProofLogger * const logger) const ->
     return true;
 }
 
-auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofLogger * const logger, atomic<bool> * optional_abort_flag) const
-    -> bool
+auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger * const logger, atomic<bool> * optional_abort_flag) const -> bool
 {
     auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) {
         if (v.index < _imp->iv_triggers.size()) {
@@ -192,7 +191,7 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         }
     };
 
-    if (! lit) {
+    if (guesses.empty()) {
         // On the first pass, walk propagators in registration order. The queue runs
         // oldest-first, so push them forwards.
         _imp->queue.resize(_imp->propagation_functions.size());
@@ -207,25 +206,30 @@ auto Propagators::propagate(const optional<Literal> & lit, State & state, ProofL
         _imp->idle_end = _imp->propagation_functions.size();
     }
     else {
+        // Seed the queue from every supplied guess. A propagator already enqueued by an
+        // earlier guess is skipped by the bookkeeping inside requeue, so guesses sharing
+        // a variable do not double-enqueue.
         _imp->enqueued_begin = 0;
         _imp->enqueued_end = 0;
-        overloaded{
-            [&](const TrueLiteral &) {},  //
-            [&](const FalseLiteral &) {}, //
-            [&](const IntegerVariableCondition & cond) {
-                overloaded{
-                    [&](const SimpleIntegerVariableID & var) {
-                        // trigger all propagators on this var, even if we might not actually
-                        // have instantiated it. bit ugly but easier than tracking.
-                        requeue(var, Inference::Instantiated);
-                    },                                                                                                  //
-                    [&](const ConstantIntegerVariableID &) {},                                                          //
-                    [&](const ViewOfIntegerVariableID & var) { requeue(var.actual_variable, Inference::Instantiated); } //
-                }
-                    .visit(cond.var);
-            } //
+        for (const auto & lit : guesses) {
+            overloaded{
+                [&](const TrueLiteral &) {},  //
+                [&](const FalseLiteral &) {}, //
+                [&](const IntegerVariableCondition & cond) {
+                    overloaded{
+                        [&](const SimpleIntegerVariableID & var) {
+                            // trigger all propagators on this var, even if we might not actually
+                            // have instantiated it. bit ugly but easier than tracking.
+                            requeue(var, Inference::Instantiated);
+                        },                                                                                                  //
+                        [&](const ConstantIntegerVariableID &) {},                                                          //
+                        [&](const ViewOfIntegerVariableID & var) { requeue(var.actual_variable, Inference::Instantiated); } //
+                    }
+                        .visit(cond.var);
+                } //
+            }
+                .visit(lit);
         }
-            .visit(*lit);
     }
 
     auto orig_idle_end = _imp->idle_end;

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -330,11 +330,15 @@ namespace gcs::innards
         ///@{
 
         /**
-         * Propagate every constraint, until either a fixed point or a contradiction is reached. If no guess
-         * is supplied, requeue every constraint before we start.
+         * Propagate every constraint, until either a fixed point or a contradiction is reached. Every
+         * supplied guess seeds the propagation queue with the propagators watching its variable; if no
+         * guesses are supplied, requeue every constraint before we start. Pass more than one guess when
+         * several changes were applied to the state before propagating (for example a branch decision
+         * together with a branch-and-bound objective bound), so that propagators watching any of them are
+         * woken.
          */
-        [[nodiscard]] auto propagate(
-            const std::optional<Literal> & guess, State &, ProofLogger * const, std::atomic<bool> * optional_abort_flag = nullptr) const -> bool;
+        [[nodiscard]] auto propagate(const Literals & guesses, State &, ProofLogger * const, std::atomic<bool> * optional_abort_flag = nullptr) const
+            -> bool;
 
         /**
          * Call every initialiser, or until a contradiction is reached.

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -34,7 +34,10 @@ namespace
         if (logger && logger->get_assertion_level() == AssertionLevel::Off)
             logger->enter_proof_level(depth + 1);
 
-        if (propagators.propagate(this_branch_guess, state, logger)) {
+        Literals guesses;
+        if (this_branch_guess)
+            guesses.push_back(*this_branch_guess);
+        if (propagators.propagate(guesses, state, logger)) {
             auto brancher = branch_with(variable_order::dom_then_deg(vars), value_order::smallest_first())(state.current(), propagators);
             auto branch_iter = brancher.begin();
             if (branch_iter == brancher.end()) {

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -40,12 +40,24 @@ namespace
             logger->enter_proof_level(depth + 1);
 
         bool objective_failure = false;
+        Literals guesses;
+        if (this_branch_guess)
+            guesses.push_back(*this_branch_guess);
         if (problem.optional_minimise_variable() && objective_value) {
-            if (state.infer(*problem.optional_minimise_variable() < *objective_value) == Inference::Contradiction)
-                objective_failure = true;
+            auto objective_bound = *problem.optional_minimise_variable() < *objective_value;
+            switch (state.infer(objective_bound)) {
+            case Inference::Contradiction: objective_failure = true; break;
+            case Inference::NoChange: break;
+            // The branch-and-bound bound tightened the objective variable, so seed the queue with
+            // its propagators too. Without this only this_branch_guess seeds the queue, and a
+            // propagator that would react to the new objective bound is not re-run here (issue #418).
+            case Inference::BoundsChanged:
+            case Inference::InteriorValuesChanged:
+            case Inference::Instantiated: guesses.push_back(objective_bound); break;
+            }
         }
 
-        if ((! objective_failure) && propagators.propagate(this_branch_guess, state, logger, optional_abort_flag)) {
+        if ((! objective_failure) && propagators.propagate(guesses, state, logger, optional_abort_flag)) {
             if (optional_abort_flag && optional_abort_flag->load())
                 return false;
 


### PR DESCRIPTION
Closes #418.

## Problem

In branch-and-bound search, `solve_with_state` applies the objective bound `obj < incumbent` to the state with `state.infer()` immediately *before* calling `Propagators::propagate()`. But `propagate()` was only handed the single branch guess to seed its queue, so a propagator watching **only** the objective variable was never woken by the bound change. Whether objective-bound propagation happened at all depended on incidental trigger coverage — i.e. on some other woken propagator happening to be connected to the objective variable.

## Fix

`propagate()` now takes a list of guesses (`Literals`, the codebase's `small_vector<Literal, 2>`, so no per-node heap allocation) instead of a single `optional<Literal>`. `solve_with_state` passes **both** the branch decision and the objective bound (the latter only when the `infer` actually tightened the variable). Each guess seeds the queue with the propagators watching its variable; the existing bookkeeping in `requeue` deduplicates propagators shared between guesses, and an empty list keeps the "requeue everything" root behaviour. `AutoTable`'s solver — the only other caller — builds a one-element list from its optional guess.

This only ever *adds* propagators to the queue, so it cannot remove valid solutions: completeness is preserved by construction, and the fixpoint reached at each node is the same or stronger.

## Effect on search

The objective variable is usually connected to the branch variables through the objective propagator, so most nodes already woke these propagators transitively; the search tree therefore barely changes. But the seeding is now correct **by construction** rather than incidental:

| benchmark (default opts) | recursions before | recursions after | optimum |
|---|---|---|---|
| `minicp_benchmarks/qap` (size 12) | 123333 | 123333 (no change) | 9552 |
| `minicp_benchmarks/tsp` (prevent) | 4285765 | 4285745 (−20) | 2085 |

Notably, with this change tsp's recursion count matches Choco's **exactly**, where before it was extremely close but not identical — consistent with the previous behaviour silently dropping a few objective-bound propagations.

## Validation

- Optima unchanged on both benchmarks; recursion counts deterministic across reruns.
- Full build of all targets + `ctest` (release, default caps): **402/402 passing**, including proof-verified `qap-5`, `auto_table`, and `skyscrapers-5-autotable`.
- Caps-off completeness run (`GCS_TEST_CAP_DEFAULTS=OFF`, full solution enumeration vs reference sets): **402/402 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)