### PR TITLE
"Last value" optimisation: skip the state copy for the final branch

### DIFF
--- a/dev_docs/benchmarking.md
+++ b/dev_docs/benchmarking.md
@@ -12,25 +12,35 @@ PRs over time.
 
 ## What to run
 
-Eight benchmarks, picked to cover a mix of search-heavy / propagation-heavy
+Eleven benchmarks, picked to cover a mix of search-heavy / propagation-heavy
 workloads, large/holey domains, and runtime ranges. Build with `cmake --preset
-release`; binaries land in `build/`.
+release`; binaries land in `build/`. The wall times below are approximate and
+were taken on a recent build — they have dropped a long way since this set was
+first assembled, as propagator and state-handling work has landed, so re-measure
+your own baseline rather than trusting these absolute numbers.
 
-| Benchmark               | Command                                       | Approx wall time |
-|-------------------------|-----------------------------------------------|------------------|
-| `magic_series_300`      | `./build/magic_series --size=300`             | ~6 s             |
-| `qap_12`                | `./build/qap --size=12`                       | ~7 s             |
-| `langford_11`           | `./build/langford --size=11 --stats`          | ~12 s            |
-| `n_queens_14_all`       | `./build/n_queens --size=14 --all`            | ~18 s            |
-| `ortho_latin_6_all`     | `./build/ortho_latin --size=6 --all --stats`  | ~20 s            |
-| `magic_square_5`        | `./build/magic_square --size=5`               | ~32 s            |
-| `tsp_default`           | `./build/tsp`                                 | ~50 s            |
-| `n_queens_88`           | `./build/n_queens --size=88`                  | ~5 min           |
+| Benchmark                 | Command                                                | Approx wall time |
+|---------------------------|--------------------------------------------------------|------------------|
+| `skyscrapers_7_autotable` | `./build/skyscrapers --instance=7 --autotable --stats` | ~0.2 s           |
+| `qap_12`                  | `./build/qap --size=12`                                | ~1.5 s           |
+| `skeleton_puzzle`         | `./build/skeleton_puzzle --stats`                      | ~3 s             |
+| `magic_series_300`        | `./build/magic_series --size=300`                      | ~4 s             |
+| `langford_11`             | `./build/langford --size=11 --stats`                   | ~9 s             |
+| `tsp_default`             | `./build/tsp`                                          | ~10 s            |
+| `n_queens_14_all`         | `./build/n_queens --size=14 --all`                     | ~11 s            |
+| `ortho_latin_6_all`       | `./build/ortho_latin --size=6 --all --stats`           | ~16 s            |
+| `magic_square_5`          | `./build/magic_square --size=5`                        | ~18 s            |
+| `skyscrapers_7`           | `./build/skyscrapers --instance=7 --stats`             | ~31 s            |
+| `n_queens_88`             | `./build/n_queens --size=88`                           | ~3.5 min         |
 
-The first four cover under-30 s workloads that are quick to iterate on. The
-last four (`ortho_latin` onwards) push out further, with `n_queens_88` being
-the long pole — keep it in the set even though it dominates total runtime,
-because it is the only one that exercises a large search tree at scale.
+`skeleton_puzzle` and `skyscrapers` were added later, while evaluating the
+"last value" search optimisation, to broaden binary-branching coverage and to
+exercise the autotabulation presolve path.
+
+Everything except `n_queens_88` finishes in well under a minute and is quick to
+iterate on; `n_queens_88` is the long pole — keep it in the set even though it
+dominates total runtime, because it is the only one that exercises a large
+search tree at scale.
 
 `magic_series` and `magic_square` are worth keeping for their
 linear-arithmetic-heavy propagation, which the others don't exercise.
@@ -55,6 +65,14 @@ search explores ~6 M nodes — despite the small board.)
 - **`tsp`** has no `--size` argument; it runs a fixed instance with a
   configurable propagator (`--propagator=prevent` is the default; `scc` is
   the alternative).
+- **`skeleton_puzzle`** is a fixed skeleton-multiplication (cryptarithm)
+  instance with no size argument; pass `--stats` to print statistics. It finds
+  its single solution after ~745 k recursions.
+- **`skyscrapers --instance=7`** solves a 7×7 skyscrapers puzzle (~1.2 M
+  recursions). With `--autotable` the autotabulation presolver solves instance 7
+  almost entirely before search (1 recursion, ~0.2 s), so that variant exercises
+  the presolve path rather than the search engine — treat it as a smoke test for
+  autotabulation, not a search-performance signal.
 - **`magic_series` / `magic_square`** print stats by default; the `--stats`
   flag is for the `examples/` binaries only (not the `minicp_benchmarks/`
   ones).
@@ -123,10 +141,13 @@ bench n_queens_88        "n_queens --size=88"
 bench langford_11        "langford --size=11 --stats"
 bench n_queens_14_all    "n_queens --size=14 --all"
 bench ortho_latin_6_all  "ortho_latin --size=6 --all --stats"
+bench skeleton_puzzle    "skeleton_puzzle --stats"
+bench skyscrapers_7      "skyscrapers --instance=7 --stats"
+bench skyscrapers_7_auto "skyscrapers --instance=7 --autotable --stats"
 ```
 
-Total wall time for the full sweep at 3 trials per build is ~50 minutes,
-dominated by `n_queens_88` (~30 minutes alone).
+Total wall time for the full sweep at 3 trials per build is ~30 minutes,
+dominated by `n_queens_88` (~20 minutes alone).
 
 ## What to capture
 

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -628,13 +628,21 @@ auto State::operator()(const IntegerVariableID & i) const -> Integer
     throw VariableDoesNotHaveUniqueValue{"Integer variable " + debug_string(i) + " does not have a unique value"};
 }
 
-auto State::new_epoch(bool subsearch) -> Timestamp
+auto State::new_epoch(bool copy_state, bool subsearch) -> Timestamp
 {
-    _imp->integer_variable_states.push_back(_imp->integer_variable_states.back());
-    _imp->constraint_states.push_back(_imp->constraint_states.back());
+    // The variable and constraint state are only snapshotted when copy_state is set;
+    // otherwise this epoch shares (and mutates) the parent's, and backtrack() leaves it
+    // dirty for the caller to discard. The on_backtracks level is always pushed, so
+    // backtrack hooks stay scoped to their own epoch either way.
+    auto when = _imp->integer_variable_states.size();
+    if (copy_state) {
+        _imp->integer_variable_states.push_back(_imp->integer_variable_states.back());
+        _imp->constraint_states.push_back(_imp->constraint_states.back());
+    }
+    auto how_many_on_backtracks = _imp->on_backtracks.size();
     _imp->on_backtracks.emplace_back();
 
-    return Timestamp{_imp->integer_variable_states.size() - 1, _imp->guesses.size(),
+    return Timestamp{when, how_many_on_backtracks, _imp->guesses.size(),
         subsearch ? make_optional<unsigned long long>(_imp->extra_proof_conditions.size()) : nullopt};
 }
 
@@ -647,7 +655,7 @@ auto State::backtrack(Timestamp t) -> void
         _imp->extra_proof_conditions.erase(
             _imp->extra_proof_conditions.begin() + *t.how_many_extra_proof_conditions, _imp->extra_proof_conditions.end());
 
-    while (_imp->on_backtracks.size() > t.when) {
+    while (_imp->on_backtracks.size() > t.how_many_on_backtracks) {
         for (auto & f : _imp->on_backtracks.back())
             f();
         _imp->on_backtracks.pop_back();

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -38,11 +38,12 @@ namespace gcs::innards
     struct Timestamp
     {
         unsigned long long when;
+        unsigned long long how_many_on_backtracks;
         unsigned long long how_many_guesses;
         std::optional<unsigned long long> how_many_extra_proof_conditions;
 
-        explicit Timestamp(unsigned long long w, unsigned long long g, std::optional<unsigned long long> p) :
-            when(w), how_many_guesses(g), how_many_extra_proof_conditions(p)
+        explicit Timestamp(unsigned long long w, unsigned long long ob, unsigned long long g, std::optional<unsigned long long> p) :
+            when(w), how_many_on_backtracks(ob), how_many_guesses(g), how_many_extra_proof_conditions(p)
         {
         }
     };
@@ -311,9 +312,16 @@ namespace gcs::innards
          * propagated state. If subsearch is true, also clears anything from
          * add_extra_proof_condition() when backtracking.
          *
+         * If copy_state is false, the (potentially expensive) variable and constraint
+         * state is not snapshotted: guesses and inferences made in this epoch mutate the
+         * parent's state in place, and backtracking does not restore it. This is the "last
+         * value" optimisation, only sound for the final child of a node, where the caller's
+         * own backtrack discards the shared state before anything reads it again. The epoch
+         * is still opened, so on_backtrack() hooks remain correctly scoped.
+         *
          * \sa State::guess()
          */
-        [[nodiscard]] auto new_epoch(bool subsearch = false) -> Timestamp;
+        [[nodiscard]] auto new_epoch(bool copy_state = true, bool subsearch = false) -> Timestamp;
 
         /**
          * Backtrack to the specified Timestamp. Behaviour is currently

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -94,7 +94,7 @@ auto AutoTable::run(Problem &, Propagators & propagators, State & initial_state,
 {
     SimpleTuples tuples;
 
-    auto timestamp = initial_state.new_epoch(true);
+    auto timestamp = initial_state.new_epoch(/*copy_state=*/true, /*subsearch=*/true);
     initial_state.guess(TrueLiteral{});
 
     auto selector_var_id = initial_state.what_variable_id_will_be_created_next();

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -93,12 +93,18 @@ namespace
                 if (optional_abort_flag && optional_abort_flag->load())
                     return false;
 
-                auto recurse = [&](const Literal & guess) -> bool {
+                auto recurse = [&](const Literal & guess, bool is_last) -> bool {
                     if (optional_abort_flag && optional_abort_flag->load())
                         return false;
 
                     auto result = true;
-                    auto timestamp = state.new_epoch();
+                    // "Last value" optimisation: the rightmost branch's guess will be undone by
+                    // our caller's backtrack regardless, so its epoch needs no private copy of the
+                    // (expensive) variable and constraint state -- we guess straight into the
+                    // shared parent state, which nothing reads again before the caller backtracks.
+                    // The epoch is still opened, so propagators' disable-until-backtrack hooks stay
+                    // correctly scoped and total propagations are unchanged.
+                    auto timestamp = state.new_epoch(! is_last);
                     state.guess(guess);
                     bool child_contains_solution = false;
                     if (! solve_with_state(depth + 1, stats, problem, propagators, state, guess, callbacks, logger, child_contains_solution,
@@ -114,9 +120,10 @@ namespace
                     return result;
                 };
 
-                for (; branch_iter != branch_generator.end(); ++branch_iter) {
+                while (branch_iter != branch_generator.end()) {
                     auto guess = *branch_iter;
-                    if (! recurse(guess))
+                    ++branch_iter;
+                    if (! recurse(guess, branch_iter == branch_generator.end()))
                         return false;
                 }
             }


### PR DESCRIPTION
Stacked on #422 (base is `fix-418-objective-bound-seeding`); review/merge that first.

## What

A copying solver clones the variable and constraint state for each child of a search node so it can restore on backtrack. The **rightmost** child never needs its own copy: its guess and everything inferred beneath it are discarded by the parent's backtrack anyway, so it can guess straight into the shared parent state. This is the classic "last value" / trailing-vs-copying optimisation, and binary-branching models (all the minicp benchmarks) feel it most.

## How

- `State::new_epoch` gains a `copy_state` flag (default `true`). When `false`, the (expensive) variable/constraint state is **not** snapshotted — the epoch shares and mutates the parent's, and `backtrack()` leaves it dirty for the caller to discard.
- Crucially, the `on_backtracks` level is **still pushed** for a no-copy epoch, so propagators' disable-until-backtrack (`idle_end`) hooks stay scoped to their own epoch exactly as before. This is why total propagations are unchanged — the alternative (skipping `new_epoch` entirely) collapses those hooks into one level and corrupts the disabled-propagator set.
- `Timestamp` now records the `on_backtracks` stack size separately from the variable/constraint state size, since the two stacks no longer grow in lockstep.
- `solve()`'s branch loop passes `copy_state = !is_last`.

## Why it's safe

The epoch structure and the shared state's *values* are identical to the copying version, so the search tree and propagation are unchanged. The shared (dirty) state is only ever read within the rightmost branch's own subtree and is discarded by the caller's backtrack before any sibling sees it.

## Results

Across the minicp benchmarks (default options) plus `skeleton_puzzle`, `ortho_latin 6`, and `skyscrapers 7` (±autotable), **recursions, total/effectful propagations, and solution counts are byte-identical before and after**, with wall-clock lower in every case:

| benchmark | recursions (=) | propagations (=) | time before | time after | Δ |
|---|---|---|---|---|---|
| magic_series (300) | 1193 | 35939832 | 3.98s | 3.91s | −1.8% |
| magic_square (5) | 6042079 | 570891590 | 19.15s | 18.08s | −5.6% |
| n_queens (88) | 49339390 | 6108047866 | 210.2s | 201.2s | −4.3% |
| qap (12) | 123333 | 24700258 | 1.53s | 1.50s | −2.4% |
| tsp (prevent) | 4285745 | 86288408 | 10.98s | 9.87s | **−10.2%** |
| skeleton_puzzle | 745014 | 7499328 | 2.89s | 2.74s | −5.4% |
| ortho_latin (6) | 480383 | 123892702 | 16.11s | 15.78s | −2.0% |
| skyscrapers (7) | 1232741 | 102714905 | 31.82s | 31.34s | −1.5% |
| skyscrapers (7) +autotable | 1 | 334558 | 0.18s | 0.18s | ~0 |

`skyscrapers+autotable` has a single recursion (autotable solves it in presolve), so there's no rightmost branch to save — no change, as expected. Single-run wall-clock, so the ~1.5–2% rows are within noise; the consistent direction and the larger wins (tsp, magic_square, skeleton, n_queens) are the signal.

## Validation

- Full build + `ctest`: **402/402 passing**, proofs included (the no-copy epoch keeps `guesses` correct, so proof output is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)