### PR TITLE
add_constraint→void (1/3): the labelled-constraint API + void flip

### DIFF
--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -94,7 +94,7 @@ auto Among::define_proof_model(ProofModel & model) -> void
     for (auto & var : _vars)
         for (auto & val : _values_of_interest)
             sum += 1_i * (var == val);
-    _sum_line = model.add_constraint("Among", "how many", sum == 1_i * _how_many);
+    _sum_line = model.add_labelled_constraint(as_string(constraint_id()), "le", "ge", "Among", "how many", sum == 1_i * _how_many);
 }
 
 auto Among::install_propagators(Propagators & propagators) -> void

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -183,7 +183,10 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
                 map<long, PosVarLineData>{}});
         model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
         // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
-        auto [leq_line, geq_line] = model->add_constraint(WPBSum{} == Integer{n - 1}, HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
+        // The pos variables are proof-only and cake encodes circuit a different way,
+        // so these position relations cannot be cake-labelled: use the escape hatch.
+        auto [leq_line, geq_line] = model->add_unlabelled_definitional_constraint(
+            StringLiteral{"Circuit"}, StringLiteral{"position"}, WPBSum{} == Integer{n - 1}, HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
 
         pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
 
@@ -196,19 +199,20 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 
         for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
             // (succ[0] = i) -> pos[i] - pos[0] = 1
-            tie(leq_line, geq_line) = model->add_constraint(
+            tie(leq_line, geq_line) = model->add_unlabelled_definitional_constraint(StringLiteral{"Circuit"}, StringLiteral{"position"},
                 WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i, HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
             pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line, geq_line});
 
             // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
-            tie(leq_line, geq_line) =
-                model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
-                    HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
+            tie(leq_line, geq_line) = model->add_unlabelled_definitional_constraint(StringLiteral{"Circuit"}, StringLiteral{"position"},
+                WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
+                HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
             pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
 
             // (succ[i] = j) -> pos[j] = pos[i] + 1
             for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
-                tie(leq_line, geq_line) = model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
+                tie(leq_line, geq_line) = model->add_unlabelled_definitional_constraint(StringLiteral{"Circuit"}, StringLiteral{"position"},
+                    WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
                     HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
                 pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});
             }

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -194,8 +194,8 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
         std::optional<ProofOnlySimpleIntegerVariableID> end;
         if (use_end) {
             end = model.create_proof_only_integer_variable(0_i, _per_task_t_hi[i] + 1_i, "cumend", IntegerVariableProofRepresentation::Bits);
-            _end_def_lines[i] =
-                model.add_constraint("Cumulative", "end >= s + l", WPBSum{} + 1_i * *end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
+            // Proof-only end proxy with no cake equivalent; escape hatch.
+            _end_def_lines[i] = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * *end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
             model.add_constraint("Cumulative", "end <= s + l", WPBSum{} + 1_i * *end + -1_i * _starts[i] + -1_i * _lengths[i] <= 0_i);
         }
 

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -259,10 +259,14 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
             // variable, move it to the left as a (−1)·capacity term so the
             // constraint stays a single linear inequality with RHS 0.
             std::optional<ProofLine> line;
+            // cake labels its per-time load constraint @c[id][cap_<t>] but indexes
+            // time differently (its global window vs our per-task one), so we cannot
+            // match the label; cumulative chains at `none` via the line reference, so
+            // the escape hatch preserves that.
             if (is_constant_variable(_capacity))
-                line = model.add_constraint("Cumulative", "load at time", load <= _capacity_val);
+                line = model.add_unlabelled_definitional_constraint(load <= _capacity_val);
             else
-                line = model.add_constraint("Cumulative", "load at time", move(load) + -1_i * _capacity <= 0_i);
+                line = model.add_unlabelled_definitional_constraint(move(load) + -1_i * _capacity <= 0_i);
             if (line)
                 _capacity_lines.emplace(t, *line);
         }

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -192,8 +192,12 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
         if (is_constant_variable(_lengths[i]))
             continue;
         auto end = model.create_proof_only_integer_variable(0_i, _per_task_t_hi[i] + 1_i, "disjend", IntegerVariableProofRepresentation::Bits);
-        _end_ge[i] = model.add_constraint("Disjunctive", "end >= s + l", WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
-        _end_le[i] = model.add_constraint("Disjunctive", "end <= s + l", WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] <= 0_i);
+        // The end proxy is a proof-only variable cake does not have (it folds s + l
+        // directly), so these definitions cannot be cake-labelled; use the escape
+        // hatch. (They are only emitted for variable durations, never on the
+        // constant-length chain cases.)
+        _end_ge[i] = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
+        _end_le[i] = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] <= 0_i);
         _end[i] = end;
     }
 
@@ -230,7 +234,9 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
             for (auto r : {i, j})
                 if (_zero[r])
                     clause_sum += 1_i * *_zero[r];
-            auto clause = model.add_constraint("Disjunctive", "one task must finish first", move(clause_sum) >= 1_i);
+            // cake_pb_cp labels the separation clause @c[id][<i>_<j>sepal1].
+            auto clause = model.add_labelled_constraint(as_string(_constraint_id), std::to_string(i) + "_" + std::to_string(j) + "sepal1",
+                "Disjunctive", "one task must finish first", move(clause_sum) >= 1_i);
             _before_flags.emplace(std::make_pair(i, j), data_ij);
             _before_flags.emplace(std::make_pair(j, i), data_ji);
             _clause_lines.emplace(std::make_pair(i, j), clause);

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -224,8 +224,9 @@ auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
     auto make_end = [&](IntegerVariableID pos, IntegerVariableID size, Integer dom_hi, optional<ProofOnlySimpleIntegerVariableID> & end_out,
                         optional<ProofLine> & ge_out, optional<ProofLine> & le_out) {
         auto end = model.create_proof_only_integer_variable(0_i, dom_hi, "d2dend", IntegerVariableProofRepresentation::Bits);
-        ge_out = model.add_constraint("Disjunctive2D", "end >= pos + size", WPBSum{} + 1_i * end + -1_i * pos + -1_i * size >= 0_i);
-        le_out = model.add_constraint("Disjunctive2D", "end <= pos + size", WPBSum{} + 1_i * end + -1_i * pos + -1_i * size <= 0_i);
+        // Proof-only end proxy with no cake equivalent (see Disjunctive); escape hatch.
+        ge_out = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * pos + -1_i * size >= 0_i);
+        le_out = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * pos + -1_i * size <= 0_i);
         end_out = end;
     };
     for (auto i : _active_rects) {
@@ -264,7 +265,9 @@ auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
                 if (_zero_h[r])
                     clause_sum += 1_i * *_zero_h[r];
             }
-            auto clause = model.add_constraint("Disjunctive2D", "rectangles must be separated on some axis", move(clause_sum) >= 1_i);
+            // cake_pb_cp labels the separation clause @c[id][<i>_<j>sepal1].
+            auto clause = model.add_labelled_constraint(as_string(_constraint_id), std::to_string(i) + "_" + std::to_string(j) + "sepal1",
+                "Disjunctive2D", "rectangles must be separated on some axis", move(clause_sum) >= 1_i);
             _before_x.emplace(make_pair(i, j), bx_ij);
             _before_x.emplace(make_pair(j, i), bx_ji);
             _before_y.emplace(make_pair(i, j), by_ij);

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -99,7 +99,9 @@ auto BoundsGlobalCardinality::define_proof_model(ProofModel & model) -> void
         WPBSum sum;
         for (const auto & var : _vars)
             sum += 1_i * (var == value);
-        _count_lines.push_back(model.add_constraint("GCC", "count for value", sum == 1_i * _counts[j]));
+        // cake_pb_cp emits these count equalities unlabelled, so keep them so and
+        // reference by line via the escape hatch.
+        _count_lines.push_back(model.add_unlabelled_definitional_constraint("GCC", "count for value", sum == 1_i * _counts[j]));
     }
 }
 

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -174,7 +174,9 @@ auto GACGlobalCardinality::define_proof_model(ProofModel & model) -> void
         WPBSum sum;
         for (const auto & var : _vars)
             sum += 1_i * (var == value);
-        _count_lines.push_back(model.add_constraint("GCC", "count for value", sum == 1_i * _counts[j]));
+        // cake_pb_cp emits these count equalities unlabelled, so keep them so and
+        // reference by line via the escape hatch.
+        _count_lines.push_back(model.add_unlabelled_definitional_constraint("GCC", "count for value", sum == 1_i * _counts[j]));
     }
 }
 

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -612,8 +612,8 @@ auto Knapsack::define_proof_model(ProofModel & model) -> void
         WPBSum sum_eq;
         for (const auto & [idx, v] : enumerate(_vars))
             sum_eq += cc.at(idx) * v;
-        auto [eq1, eq2] = model.add_labelled_constraint(
-            as_string(constraint_id()), "le" + std::to_string(cc_idx), "ge" + std::to_string(cc_idx), "Knapsack", "totals", sum_eq == 1_i * _totals.at(cc_idx));
+        auto [eq1, eq2] = model.add_labelled_constraint(as_string(constraint_id()), "le" + std::to_string(cc_idx), "ge" + std::to_string(cc_idx),
+            "Knapsack", "totals", sum_eq == 1_i * _totals.at(cc_idx));
         _eqns_lines.emplace_back(eq1, eq2);
     }
 }

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -612,7 +612,8 @@ auto Knapsack::define_proof_model(ProofModel & model) -> void
         WPBSum sum_eq;
         for (const auto & [idx, v] : enumerate(_vars))
             sum_eq += cc.at(idx) * v;
-        auto [eq1, eq2] = model.add_constraint(sum_eq == 1_i * _totals.at(cc_idx));
+        auto [eq1, eq2] = model.add_labelled_constraint(
+            as_string(constraint_id()), "le" + std::to_string(cc_idx), "ge" + std::to_string(cc_idx), "Knapsack", "totals", sum_eq == 1_i * _totals.at(cc_idx));
         _eqns_lines.emplace_back(eq1, eq2);
     }
 }

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -190,7 +190,10 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
                 HalfReifyOnConjunctionOf{{! neflag}});
         }, //
         [&](const reif::If & cond) {
-            _proof_line = model.add_constraint("ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            // The reified (if/iff) linear equalities are not chain-verified; reference
+            // them by line via the escape hatch.
+            _proof_line = model.add_unlabelled_definitional_constraint(
+                "ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
         }, //
         [&](const reif::NotIf & cond) {
             // condition is definitely false, the flag implies either greater or less
@@ -200,7 +203,7 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
         }, //
         [&](const reif::Iff & cond) {
             // condition unknown, the condition implies it is neither greater nor less
-            _proof_line = model.add_constraint("ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_unlabelled_definitional_constraint("ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
 
             auto gtflag = model.create_proof_flag("lineqgt");
             model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -203,7 +203,8 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
         }, //
         [&](const reif::Iff & cond) {
             // condition unknown, the condition implies it is neither greater nor less
-            _proof_line = model.add_unlabelled_definitional_constraint("ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_unlabelled_definitional_constraint(
+                "ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
 
             auto gtflag = model.create_proof_flag("lineqgt");
             model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -111,23 +111,17 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
             // cake_pb_cp emits the unconditional inequality unlabelled, so keep it
             // unlabelled and reference it by line via the escape hatch.
             _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value), nullopt};
-        }, //
-        [&](const reif::MustNotHold &) {
-            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms >= _value + 1_i), nullopt};
-        }, //
+        },                                                                                                                                     //
+        [&](const reif::MustNotHold &) { _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms >= _value + 1_i), nullopt}; }, //
         [&](const reif::If & cond) {
-            _proof_lines = pair{
-                model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         }, //
         [&](const reif::NotIf & cond) {
-            _proof_lines =
-                pair{model.add_constraint("ReifiedLinearInequality", "greater than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
-                    nullopt};
+            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         }, //
         [&](const reif::Iff & cond) {
-            _proof_lines = pair{
-                model.add_constraint("ReifiedLinearInequality", "less than option", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
-                model.add_constraint("ReifiedLinearInequality", "greater than option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
+            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
+                model.add_unlabelled_definitional_constraint(terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
         } //
     }
         .visit(_reif_cond);

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -108,11 +108,12 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
 
     overloaded{
         [&](const reif::MustHold &) {
-            _proof_lines = pair{model.add_constraint("ReifiedLinearInequality", "unconditional less than", terms <= _value, nullopt), nullopt};
+            // cake_pb_cp emits the unconditional inequality unlabelled, so keep it
+            // unlabelled and reference it by line via the escape hatch.
+            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value), nullopt};
         }, //
         [&](const reif::MustNotHold &) {
-            _proof_lines =
-                pair{model.add_constraint("ReifiedLinearInequality", "unconditional greater than", terms >= _value + 1_i, nullopt), nullopt};
+            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms >= _value + 1_i), nullopt};
         }, //
         [&](const reif::If & cond) {
             _proof_lines = pair{

--- a/gcs/constraints/mult_bc/mult_bc.cc
+++ b/gcs/constraints/mult_bc/mult_bc.cc
@@ -1084,11 +1084,13 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
                 for (Integer pos = 0_i; pos < num_bits - 1_i; pos++)
                     bit_sum_without_neg += power2(pos) * ProofBitVariable{v, pos + 1_i, true};
 
-                auto pos_ge = optional_model->add_constraint(bit_sum_without_neg + (-1_i * v_magnitude) >= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto pos_le = optional_model->add_constraint(bit_sum_without_neg + (-1_i * v_magnitude) <= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto neg_ge = optional_model->add_constraint(
+                auto pos_ge = optional_model->add_unlabelled_definitional_constraint(
+                    bit_sum_without_neg + (-1_i * v_magnitude) >= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
+                auto pos_le = optional_model->add_unlabelled_definitional_constraint(
+                    bit_sum_without_neg + (-1_i * v_magnitude) <= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
+                auto neg_ge = optional_model->add_unlabelled_definitional_constraint(
                     bit_sum_without_neg + (1_i * v_magnitude) >= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
-                auto neg_le = optional_model->add_constraint(
+                auto neg_le = optional_model->add_unlabelled_definitional_constraint(
                     bit_sum_without_neg + (1_i * v_magnitude) <= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
 
                 channelling_constraints.insert({v, ChannellingData{pos_ge, pos_le, neg_ge, neg_le}});
@@ -1114,11 +1116,11 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
             for (Integer j = 0_i; j < v2_num_bits; j++) {
                 auto flag = optional_model->create_proof_flag(format("xy[{}][{}]", i, j));
 
-                auto forwards = optional_model->add_constraint(
+                auto forwards = optional_model->add_unlabelled_definitional_constraint(
                     WPBSum{} + 1_i * ProofBitVariable{v1_mag, i, true} + 1_i * ProofBitVariable{v2_mag, j, true} >= 2_i,
                     HalfReifyOnConjunctionOf{flag});
 
-                auto backwards = optional_model->add_constraint(
+                auto backwards = optional_model->add_unlabelled_definitional_constraint(
                     WPBSum{} + -1_i * ProofBitVariable{v1_mag, i, true} + -1_i * ProofBitVariable{v2_mag, j, true} >= -1_i,
                     HalfReifyOnConjunctionOf{! flag});
 
@@ -1129,7 +1131,8 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
 
         visit(
             [&](auto v3_mag) {
-                auto s = optional_model->add_constraint(bit_product_sum + (-1_i * v3_mag) == 0_i);
+                auto s = optional_model->add_unlabelled_definitional_constraint(
+                    StringLiteral{"MultBC"}, StringLiteral{"z = product"}, bit_product_sum + (-1_i * v3_mag) == 0_i);
                 v3_eq_product_lines = make_pair(s.first, s.second);
             },
             v3_mag);

--- a/gcs/constraints/mult_bc/mult_bc.cc
+++ b/gcs/constraints/mult_bc/mult_bc.cc
@@ -1138,19 +1138,23 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
             v3_mag);
 
         auto xyss = optional_model->create_proof_flag("xy[s][s]");
-        sign_lines.emplace_back(optional_model->add_constraint(WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, ! v2_sign}));
+        sign_lines.emplace_back(
+            optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, ! v2_sign}));
 
         if (mag_var.contains(_v1))
-            sign_lines.emplace_back(optional_model->add_constraint(WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, ! v2_sign}));
+            sign_lines.emplace_back(
+                optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, ! v2_sign}));
         if (mag_var.contains(_v2))
-            sign_lines.emplace_back(optional_model->add_constraint(WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, v2_sign}));
+            sign_lines.emplace_back(
+                optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, v2_sign}));
         if (mag_var.contains(_v1) && mag_var.contains(_v2))
-            sign_lines.emplace_back(optional_model->add_constraint(WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, v2_sign}));
+            sign_lines.emplace_back(
+                optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, v2_sign}));
 
-        sign_lines.emplace_back(optional_model->add_constraint(
+        sign_lines.emplace_back(optional_model->add_unlabelled_definitional_constraint(
             WPBSum{} + 1_i * xyss + 1_i * (_v1 != 0_i) + 1_i * (_v2 != 0_i) >= 3_i, HalfReifyOnConjunctionOf{v3_sign}));
 
-        sign_lines.emplace_back(optional_model->add_constraint(
+        sign_lines.emplace_back(optional_model->add_unlabelled_definitional_constraint(
             WPBSum{} + 1_i * ! xyss + 1_i * (_v1 == 0_i) + 1_i * (_v2 == 0_i) >= 1_i, HalfReifyOnConjunctionOf{! v3_sign}));
     }
 

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -141,7 +141,7 @@ auto gcs::innards::define_sortedness_proof_model(ProofModel & model, const vecto
         for (size_t ip = 0; ip < n; ++ip)
             if (ip != i)
                 rank += -1_i * w.before[ip][i];
-        auto [le, ge] = model.add_constraint("Sort", "pos is stable rank", move(rank) == 0_i);
+        auto [le, ge] = model.add_unlabelled_definitional_constraint("Sort", "pos is stable rank", move(rank) == 0_i);
         w.rank_ge.push_back(ge);
         w.rank_le.push_back(le);
     }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -552,8 +552,10 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         else if (! _imp->logger) {
             visit(
                 [&](const auto & id) {
-                    forwards_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
-                    reverse_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
+                    forwards_line =
+                        _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
+                    reverse_line =
+                        _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
                 },
                 id);
             ++_imp->model_variables;

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -509,8 +509,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         else if (! _imp->logger) {
             visit(
                 [&](const auto & id) {
-                    forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
-                    reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
+                    forwards_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
+                    reverse_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
                 },
                 id);
             ++_imp->model_variables;
@@ -531,8 +531,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         else if (! _imp->logger) {
             visit(
                 [&](const auto & id) {
-                    forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
-                    reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
+                    forwards_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
+                    reverse_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
                 },
                 id);
             ++_imp->model_variables;
@@ -552,8 +552,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         else if (! _imp->logger) {
             visit(
                 [&](const auto & id) {
-                    forwards_line = _imp->model->add_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
-                    reverse_line = _imp->model->add_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
+                    forwards_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
+                    reverse_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
                 },
                 id);
             ++_imp->model_variables;
@@ -678,8 +678,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                         return pair{_imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
                             _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
                     else
-                        return pair{_imp->model->add_constraint(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
-                            _imp->model->add_constraint(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
+                        return pair{_imp->model->add_unlabelled_definitional_constraint(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
+                            _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
                 },
                 id));
         ++_imp->model_variables;
@@ -1167,7 +1167,7 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
     Integer s_coeff = view.negate_first ? -1_i : 1_i;
 
     // Views must be defined properly in the model.
-    auto [link_le, link_ge] = _imp->model->add_constraint(
+    auto [link_le, link_ge] = _imp->model->add_unlabelled_definitional_constraint(
         StringLiteral{"view link"}, StringLiteral{"definitional"}, WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add);
 
     _imp->view_proof_only_vars.emplace(view, v_id);

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -102,15 +102,13 @@ auto ProofModel::emit_constraint_label(const string & constraint_id, const strin
     return ProofLineLabel{"c[" + constraint_id + "]" + (role.empty() ? "" : "[" + role + "]")};
 }
 
-auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> ProofLine
+auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> void
 {
     WPBSum sum;
 
     // A clause containing a statically-true literal is a tautology. It
     // constrains nothing, but we still emit it as a trivially-true `sum >= 0`
-    // rather than omitting it, so there is always a line to return and the
-    // constraint counter stays in step. This is why no add_constraint overload
-    // returns optional any more (issue #264); a tautology was the only source.
+    // rather than omitting it, so the constraint counter stays in step.
     bool tautological = false;
     for (auto & lit : lits) {
         overloaded{
@@ -127,16 +125,16 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     // remove duplicates
     sum.terms.erase(unique(sum.terms).begin(), sum.terms.end());
 
-    return add_constraint(constraint_name, rule, move(sum) >= (tautological ? 0_i : 1_i), nullopt);
+    add_constraint(constraint_name, rule, move(sum) >= (tautological ? 0_i : 1_i), nullopt);
 }
 
-auto ProofModel::add_constraint(const Literals & lits) -> ProofLine
+auto ProofModel::add_constraint(const Literals & lits) -> void
 {
-    return add_constraint("?", "?", lits);
+    add_constraint("?", "?", lits);
 }
 
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumLE & ineq,
-    const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
+    const optional<HalfReifyOnConjunctionOf> & half_reif) -> void
 {
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     if (half_reif)
@@ -148,16 +146,15 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     auto line = advance_constraint_counter();
     // emit_inequality_to negates the LE inequality to land in PB >= form.
     names_and_ids_tracker().derive_deviewed_form_for(line, ineq.lhs, /*le_half=*/true);
-    return line;
 }
 
-auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
+auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> void
 {
-    return add_constraint("?", "?", ineq, half_reif);
+    add_constraint("?", "?", ineq, half_reif);
 }
 
 auto ProofModel::add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq,
-    const optional<HalfReifyOnConjunctionOf> & half_reif) -> pair<ProofLine, ProofLine>
+    const optional<HalfReifyOnConjunctionOf> & half_reif) -> void
 {
     names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
     if (half_reif)
@@ -179,8 +176,6 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     // emit_inequality_to negates it again, so OPB-form coefficients match
     // the input WPBSum.
     names_and_ids_tracker().derive_deviewed_form_for(second, eq.lhs, /*le_half=*/false);
-
-    return pair{first, second};
 }
 
 auto ProofModel::add_unlabelled_definitional_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
@@ -310,9 +305,9 @@ auto ProofModel::add_labelled_constraint(const string & constraint_id, const str
     return label;
 }
 
-auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> pair<ProofLine, ProofLine>
+auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> void
 {
-    return add_constraint("?", "?", eq, half_reif);
+    add_constraint("?", "?", eq, half_reif);
 }
 
 auto ProofModel::add_two_way_reified_constraint(

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -226,6 +226,26 @@ auto ProofModel::add_unlabelled_definitional_constraint(const StringLiteral & co
     return pair{first, second};
 }
 
+auto ProofModel::add_unlabelled_definitional_constraint(const Literals & lits) -> ProofLine
+{
+    // As the no-name add_constraint(Literals) --- a clause, a statically-true
+    // literal making it the trivially-true `sum >= 0` --- but returns the
+    // referenceable line (see the inequality overload).
+    WPBSum sum;
+    bool tautological = false;
+    for (auto & lit : lits) {
+        overloaded{
+            [&](const TrueLiteral &) { tautological = true; },                              //
+            [&](const FalseLiteral &) {},                                                   //
+            [&]<typename T_>(const VariableConditionFrom<T_> & cond) { sum += 1_i * cond; } //
+        }
+            .visit(simplify_literal(names_and_ids_tracker(), lit));
+    }
+    sort(sum.terms);
+    sum.terms.erase(unique(sum.terms).begin(), sum.terms.end());
+    return add_unlabelled_definitional_constraint(move(sum) >= (tautological ? 0_i : 1_i), nullopt);
+}
+
 auto ProofModel::add_labelled_constraint(const string & constraint_id, const string & role_le, const string & role_ge,
     const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<ProofLine, ProofLine>

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -255,8 +255,21 @@ auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnC
 auto ProofModel::add_two_way_reified_constraint(
     const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumLE & ineq, const ProofFlag & flag) -> pair<ProofLine, ProofLine>
 {
-    auto forward = add_constraint(constraint_name, rule, ineq, HalfReifyOnConjunctionOf{{flag}});
-    auto reverse = add_constraint(constraint_name, rule, negate_inequality(ineq), HalfReifyOnConjunctionOf{{! flag}});
+    // Emit both halves under labels derived from the flag's own name --- base[r]
+    // is the forward half (flag -> ineq), base[f] the reverse (~flag -> ~ineq) ---
+    // so callers reference the halves by @label, never by line number, and for a
+    // cake-named flag (x[id][..] / v[id][..]) the labels match cake_pb_cp. Mirrors
+    // the manual labelling in create_proof_flag_fully_reifying(ConstraintID, ...).
+    // Use the flag's full PB rendering (e.g. f[3][sort_before] or x[id][i_j][bf]),
+    // not name_of, whose plain-flag form is the bare stem and would collide across
+    // flags sharing it.
+    auto base = names_and_ids_tracker().pb_file_string_for(flag);
+    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
+    auto forward = add_labelled_constraint(base + "[r]", ineq, HalfReifyOnConjunctionOf{{flag}});
+    names_and_ids_tracker().derive_deviewed_form_for(forward, ineq.lhs, /*le_half=*/true);
+    auto reverse_ineq = negate_inequality(ineq);
+    auto reverse = add_labelled_constraint(base + "[f]", reverse_ineq, HalfReifyOnConjunctionOf{{! flag}});
+    names_and_ids_tracker().derive_deviewed_form_for(reverse, reverse_ineq.lhs, /*le_half=*/true);
     return {forward, reverse};
 }
 

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -183,6 +183,49 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     return pair{first, second};
 }
 
+auto ProofModel::add_unlabelled_definitional_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
+{
+    // Escape hatch: an unlabelled constraint whose line IS referenced later, for
+    // the few proof-internal variable-encoding definitions that cannot be given a
+    // valid @label (proof-only vars, names with `[`, negative offsets, the eq/ge
+    // ladder cake encodes differently). Everything else must use a labelled
+    // variant so it is referenced by name, not line number.
+    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    _imp->opb << "* constraint ? ?\n";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
+    _imp->opb << ";\n";
+    auto line = advance_constraint_counter();
+    names_and_ids_tracker().derive_deviewed_form_for(line, ineq.lhs, /*le_half=*/true);
+    return line;
+}
+
+auto ProofModel::add_unlabelled_definitional_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq,
+    const optional<HalfReifyOnConjunctionOf> & half_reif) -> pair<ProofLine, ProofLine>
+{
+    // Escape hatch for an equality definition --- see the inequality overload.
+    names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
+    if (half_reif)
+        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
+
+    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
+    emit_inequality_to(
+        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+    auto first = advance_constraint_counter();
+    names_and_ids_tracker().derive_deviewed_form_for(first, eq.lhs, /*le_half=*/true);
+
+    emit_inequality_to(
+        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
+    _imp->opb << ";\n";
+    auto second = advance_constraint_counter();
+    names_and_ids_tracker().derive_deviewed_form_for(second, eq.lhs, /*le_half=*/false);
+
+    return pair{first, second};
+}
+
 auto ProofModel::add_labelled_constraint(const string & constraint_id, const string & role_le, const string & role_ge,
     const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<ProofLine, ProofLine>

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -66,41 +66,35 @@ namespace gcs::innards
         ///@{
 
         /**
-         * Add a pseudo-Boolean constraint to a Proof model.
+         * Add a pseudo-Boolean constraint to a Proof model. Returns void: to
+         * reference the constraint later, add it by @label (add_labelled_constraint)
+         * or, for an unlabellable proof-internal definition, via
+         * add_unlabelled_definitional_constraint --- never by line number.
          */
-        auto add_constraint(const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
+        auto add_constraint(const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> void;
 
         /**
-         * Add a pair of pseudo-Boolean constraints representing an equality to a Proof model.
-         *
-         * Returns `{LE-half, GE-half}` — i.e. `{ line for lhs <= rhs,
-         * line for lhs >= rhs }`. Callers binding the result with
-         * structured bindings should mirror that order; getting it wrong
-         * has previously led to per-call `pol` steps referencing the
-         * wrong half of the equation.
+         * Add a pair of pseudo-Boolean constraints representing an equality to a
+         * Proof model. Returns void --- see the inequality overload above.
          */
-        auto add_constraint(const WPBSumEq & eq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt)
-            -> std::pair<ProofLine, ProofLine>;
+        auto add_constraint(const WPBSumEq & eq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> void;
 
         /**
          * Add a CNF definition to a Proof model.
          */
-        auto add_constraint(const Literals & lits) -> ProofLine;
+        auto add_constraint(const Literals & lits) -> void;
 
         /**
          * Add a pseudo-Boolean constraint to a Proof model.
          */
         auto add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumLE & ineq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> void;
 
         /**
          * Add a pair of pseudo-Boolean constraints representing an equality to a Proof model.
-         *
-         * Returns `{LE-half, GE-half}` — see the no-name overload above
-         * for the rationale.
          */
         auto add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> void;
 
         /**
          * \brief Escape hatch: add an unlabelled constraint whose proof line IS
@@ -153,7 +147,7 @@ namespace gcs::innards
         /**
          * Add a CNF definition to a Proof model.
          */
-        auto add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> ProofLine;
+        auto add_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const Literals & lits) -> void;
 
         /**
          * \brief Encode `flag ⇔ ineq` in OPB by emitting both halves of the equivalence:

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -115,6 +115,7 @@ namespace gcs::innards
             -> ProofLine;
         auto add_unlabelled_definitional_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq,
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
+        auto add_unlabelled_definitional_constraint(const Literals & lits) -> ProofLine;
 
         /**
          * \brief Like add_constraint for an equality, but emits an @label on each

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -103,6 +103,20 @@ namespace gcs::innards
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
 
         /**
+         * \brief Escape hatch: add an unlabelled constraint whose proof line IS
+         * referenced later. Reserved for the few proof-internal variable-encoding
+         * definitions that cannot be given a valid @label (proof-only vars, names
+         * containing `[`, negative offsets, the eq/ge ladder cake encodes its own
+         * way). Everything else must reference constraints by @label, via the
+         * add_labelled_constraint family --- which is why plain add_constraint
+         * returns void.
+         */
+        auto add_unlabelled_definitional_constraint(const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt)
+            -> ProofLine;
+        auto add_unlabelled_definitional_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq,
+            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
+
+        /**
          * \brief Like add_constraint for an equality, but emits an @label on each
          * half --- \c c[constraint_id][role_le] on the LE half and \c [role_ge]
          * on the GE half --- and returns those labels, so the proof references

--- a/gcs/innards/proofs/proof_model_tautology_test.cc
+++ b/gcs/innards/proofs/proof_model_tautology_test.cc
@@ -24,7 +24,7 @@ auto main() -> int
     // and does not mention it.
     [[maybe_unused]] auto x = model.create_proof_only_integer_variable(0_i, 10_i, "x", IntegerVariableProofRepresentation::Bits);
 
-    auto tautology_line = model.add_constraint(Literals{TrueLiteral{}});
+    auto tautology_line = model.add_unlabelled_definitional_constraint(Literals{TrueLiteral{}});
 
     model.finalise();
 


### PR DESCRIPTION
**Stack 1 of 3** — base for `acrv-2-label-constraint-defs` → `acrv-3-deep-core`.

Establishes the invariant that **a reference into the OPB must be by `@label`, never by relative line number** (a relative line ref only resolves if our OPB and `cake_pb_cp`'s re-derived OPB are structurally aligned — a coincidence that broke sort/arg_sort, see #358-class issues).

- `ProofModel::add_constraint` returns **void**, so anything wanting to reference a constraint later must use a labelled variant (`add_labelled_constraint`) — the type system is the primary guard.
- `add_two_way_reified_constraint` emits both halves under `@<flag>[r]`/`[f]`.
- A transitional `add_unlabelled_definitional_constraint` escape hatch keeps the build green while callers are converted incrementally (removed in 3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)