### PR TITLE
add_constraint→void (2/3): label every per-constraint OPB definition

### DIFF
--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -212,11 +212,11 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 
             // (succ[i] = j) -> pos[j] = pos[i] + 1
             for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
-                tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id),
-                    "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_le",
-                    "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
-                    WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
-                    HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
+                tie(leq_line, geq_line) =
+                    model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_le",
+                        "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
+                        WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
+                        HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
                 pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});
             }
         }

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -183,9 +183,8 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
                 map<long, PosVarLineData>{}});
         model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
         // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
-        // The pos variables are proof-only and cake encodes circuit a different way,
-        // so these position relations cannot be cake-labelled: use the escape hatch.
-        auto [leq_line, geq_line] = model->add_unlabelled_definitional_constraint(
+        // cake_pb_cp labels these position relations @c[id][pos_suc_<i>_<j>_le/ge].
+        auto [leq_line, geq_line] = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_0_0_le", "pos_suc_0_0_ge",
             StringLiteral{"Circuit"}, StringLiteral{"position"}, WPBSum{} == Integer{n - 1}, HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
 
         pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
@@ -199,19 +198,23 @@ auto CircuitBase::set_up(Propagators & propagators, State & initial_state, Proof
 
         for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
             // (succ[0] = i) -> pos[i] - pos[0] = 1
-            tie(leq_line, geq_line) = model->add_unlabelled_definitional_constraint(StringLiteral{"Circuit"}, StringLiteral{"position"},
+            tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_0_" + std::to_string(idx) + "_le",
+                "pos_suc_0_" + std::to_string(idx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
                 WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i, HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
             pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line, geq_line});
 
             // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
-            tie(leq_line, geq_line) = model->add_unlabelled_definitional_constraint(StringLiteral{"Circuit"}, StringLiteral{"position"},
+            tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_" + std::to_string(idx) + "_0_le",
+                "pos_suc_" + std::to_string(idx) + "_0_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
                 WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
                 HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
             pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
 
             // (succ[i] = j) -> pos[j] = pos[i] + 1
             for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
-                tie(leq_line, geq_line) = model->add_unlabelled_definitional_constraint(StringLiteral{"Circuit"}, StringLiteral{"position"},
+                tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id),
+                    "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_le",
+                    "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
                     WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
                     HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
                 pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -194,8 +194,9 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
         std::optional<ProofOnlySimpleIntegerVariableID> end;
         if (use_end) {
             end = model.create_proof_only_integer_variable(0_i, _per_task_t_hi[i] + 1_i, "cumend", IntegerVariableProofRepresentation::Bits);
-            // Proof-only end proxy with no cake equivalent; escape hatch.
-            _end_def_lines[i] = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * *end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
+            // Proof-only end proxy with no cake equivalent: invent a label.
+            _end_def_lines[i] = model.add_labelled_constraint(as_string(_constraint_id), "endge_" + std::to_string(i), "Cumulative", "end >= s + l",
+                WPBSum{} + 1_i * *end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
             model.add_constraint("Cumulative", "end <= s + l", WPBSum{} + 1_i * *end + -1_i * _starts[i] + -1_i * _lengths[i] <= 0_i);
         }
 

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -193,11 +193,12 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
             continue;
         auto end = model.create_proof_only_integer_variable(0_i, _per_task_t_hi[i] + 1_i, "disjend", IntegerVariableProofRepresentation::Bits);
         // The end proxy is a proof-only variable cake does not have (it folds s + l
-        // directly), so these definitions cannot be cake-labelled; use the escape
-        // hatch. (They are only emitted for variable durations, never on the
-        // constant-length chain cases.)
-        _end_ge[i] = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
-        _end_le[i] = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] <= 0_i);
+        // directly), so there is no cake label to match: invent one. (Only emitted
+        // for variable durations, never on the constant-length chain cases.)
+        _end_ge[i] = model.add_labelled_constraint(as_string(_constraint_id), "endge_" + std::to_string(i), "Disjunctive", "end >= s + l",
+            WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] >= 0_i);
+        _end_le[i] = model.add_labelled_constraint(as_string(_constraint_id), "endle_" + std::to_string(i), "Disjunctive", "end <= s + l",
+            WPBSum{} + 1_i * end + -1_i * _starts[i] + -1_i * _lengths[i] <= 0_i);
         _end[i] = end;
     }
 

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -225,10 +225,10 @@ auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
                         optional<ProofOnlySimpleIntegerVariableID> & end_out, optional<ProofLine> & ge_out, optional<ProofLine> & le_out) {
         auto end = model.create_proof_only_integer_variable(0_i, dom_hi, "d2dend", IntegerVariableProofRepresentation::Bits);
         // Proof-only end proxy with no cake equivalent (see Disjunctive): invent a label.
-        ge_out = model.add_labelled_constraint(as_string(_constraint_id), "endge_" + tag, "Disjunctive2D", "end >= pos + size",
-            WPBSum{} + 1_i * end + -1_i * pos + -1_i * size >= 0_i);
-        le_out = model.add_labelled_constraint(as_string(_constraint_id), "endle_" + tag, "Disjunctive2D", "end <= pos + size",
-            WPBSum{} + 1_i * end + -1_i * pos + -1_i * size <= 0_i);
+        ge_out = model.add_labelled_constraint(
+            as_string(_constraint_id), "endge_" + tag, "Disjunctive2D", "end >= pos + size", WPBSum{} + 1_i * end + -1_i * pos + -1_i * size >= 0_i);
+        le_out = model.add_labelled_constraint(
+            as_string(_constraint_id), "endle_" + tag, "Disjunctive2D", "end <= pos + size", WPBSum{} + 1_i * end + -1_i * pos + -1_i * size <= 0_i);
         end_out = end;
     };
     for (auto i : _active_rects) {

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -221,19 +221,21 @@ auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
     _end_x_le.assign(_xs.size(), nullopt);
     _end_y_ge.assign(_xs.size(), nullopt);
     _end_y_le.assign(_xs.size(), nullopt);
-    auto make_end = [&](IntegerVariableID pos, IntegerVariableID size, Integer dom_hi, optional<ProofOnlySimpleIntegerVariableID> & end_out,
-                        optional<ProofLine> & ge_out, optional<ProofLine> & le_out) {
+    auto make_end = [&](const std::string & tag, IntegerVariableID pos, IntegerVariableID size, Integer dom_hi,
+                        optional<ProofOnlySimpleIntegerVariableID> & end_out, optional<ProofLine> & ge_out, optional<ProofLine> & le_out) {
         auto end = model.create_proof_only_integer_variable(0_i, dom_hi, "d2dend", IntegerVariableProofRepresentation::Bits);
-        // Proof-only end proxy with no cake equivalent (see Disjunctive); escape hatch.
-        ge_out = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * pos + -1_i * size >= 0_i);
-        le_out = model.add_unlabelled_definitional_constraint(WPBSum{} + 1_i * end + -1_i * pos + -1_i * size <= 0_i);
+        // Proof-only end proxy with no cake equivalent (see Disjunctive): invent a label.
+        ge_out = model.add_labelled_constraint(as_string(_constraint_id), "endge_" + tag, "Disjunctive2D", "end >= pos + size",
+            WPBSum{} + 1_i * end + -1_i * pos + -1_i * size >= 0_i);
+        le_out = model.add_labelled_constraint(as_string(_constraint_id), "endle_" + tag, "Disjunctive2D", "end <= pos + size",
+            WPBSum{} + 1_i * end + -1_i * pos + -1_i * size <= 0_i);
         end_out = end;
     };
     for (auto i : _active_rects) {
         if (! is_constant_variable(_widths[i]))
-            make_end(_xs[i], _widths[i], _x_hi[i] + 1_i, _end_x[i], _end_x_ge[i], _end_x_le[i]);
+            make_end("x" + std::to_string(i), _xs[i], _widths[i], _x_hi[i] + 1_i, _end_x[i], _end_x_ge[i], _end_x_le[i]);
         if (! is_constant_variable(_heights[i]))
-            make_end(_ys[i], _heights[i], _y_hi[i] + 1_i, _end_y[i], _end_y_ge[i], _end_y_le[i]);
+            make_end("y" + std::to_string(i), _ys[i], _heights[i], _y_hi[i] + 1_i, _end_y[i], _end_y_ge[i], _end_y_le[i]);
     }
 
     // Non-strict mode: a zero-size escape flag per size that can be 0.

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -99,9 +99,9 @@ auto BoundsGlobalCardinality::define_proof_model(ProofModel & model) -> void
         WPBSum sum;
         for (const auto & var : _vars)
             sum += 1_i * (var == value);
-        // cake_pb_cp emits these count equalities unlabelled, so keep them so and
-        // reference by line via the escape hatch.
-        _count_lines.push_back(model.add_unlabelled_definitional_constraint("GCC", "count for value", sum == 1_i * _counts[j]));
+        // cake_pb_cp labels the per-value count equality @c[<id>_<j>][le/ge].
+        _count_lines.push_back(model.add_labelled_constraint(
+            as_string(constraint_id()) + "_" + std::to_string(j), "le", "ge", "GCC", "count for value", sum == 1_i * _counts[j]));
     }
 }
 

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -174,9 +174,9 @@ auto GACGlobalCardinality::define_proof_model(ProofModel & model) -> void
         WPBSum sum;
         for (const auto & var : _vars)
             sum += 1_i * (var == value);
-        // cake_pb_cp emits these count equalities unlabelled, so keep them so and
-        // reference by line via the escape hatch.
-        _count_lines.push_back(model.add_unlabelled_definitional_constraint("GCC", "count for value", sum == 1_i * _counts[j]));
+        // cake_pb_cp labels the per-value count equality @c[<id>_<j>][le/ge].
+        _count_lines.push_back(model.add_labelled_constraint(
+            as_string(constraint_id()) + "_" + std::to_string(j), "le", "ge", "GCC", "count for value", sum == 1_i * _counts[j]));
     }
 }
 

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -190,10 +190,10 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
                 HalfReifyOnConjunctionOf{{! neflag}});
         }, //
         [&](const reif::If & cond) {
-            // The reified (if/iff) linear equalities are not chain-verified; reference
-            // them by line via the escape hatch.
-            _proof_line = model.add_unlabelled_definitional_constraint(
-                "ReifiedLinearEquality", "unconditional sum", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            // The reified (if/iff) linear equalities are not chain-verified, so an
+            // invented @c[id][le/ge] label is fine.
+            _proof_line = model.add_labelled_constraint(as_string(constraint_id()), "le", "ge", "ReifiedLinearEquality", "unconditional sum",
+                terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
         }, //
         [&](const reif::NotIf & cond) {
             // condition is definitely false, the flag implies either greater or less
@@ -203,8 +203,8 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
         }, //
         [&](const reif::Iff & cond) {
             // condition unknown, the condition implies it is neither greater nor less
-            _proof_line = model.add_unlabelled_definitional_constraint(
-                "ReifiedLinearEquality", "equals option", terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
+            _proof_line = model.add_labelled_constraint(as_string(constraint_id()), "le", "ge", "ReifiedLinearEquality", "equals option",
+                terms == _value, HalfReifyOnConjunctionOf{{cond.cond}});
 
             auto gtflag = model.create_proof_flag("lineqgt");
             model.add_constraint("ReifiedLinearEquality", "greater option", terms >= _value + 1_i, HalfReifyOnConjunctionOf{{gtflag}});

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -108,20 +108,33 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
 
     overloaded{
         [&](const reif::MustHold &) {
-            // cake_pb_cp emits the unconditional inequality unlabelled, so keep it
-            // unlabelled and reference it by line via the escape hatch.
-            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value), nullopt};
-        },                                                                                                                                     //
-        [&](const reif::MustNotHold &) { _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms >= _value + 1_i), nullopt}; }, //
+            // cake_pb_cp labels the unconditional inequality @c[<id>] (no role).
+            auto ineq = terms <= _value;
+            auto line = model.add_labelled_constraint("c[" + as_string(constraint_id()) + "]", ineq);
+            model.names_and_ids_tracker().derive_deviewed_form_for(line, ineq.lhs, /*le_half=*/true);
+            _proof_lines = pair{line, nullopt};
+        }, //
+        [&](const reif::MustNotHold &) {
+            auto ineq = terms >= _value + 1_i;
+            auto line = model.add_labelled_constraint("c[" + as_string(constraint_id()) + "]", ineq);
+            model.names_and_ids_tracker().derive_deviewed_form_for(line, ineq.lhs, /*le_half=*/true);
+            _proof_lines = pair{line, nullopt};
+        }, //
         [&](const reif::If & cond) {
-            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "lt", "ReifiedLinearInequality", "less than option",
+                                    terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
+                nullopt};
         }, //
         [&](const reif::NotIf & cond) {
-            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "ltn", "ReifiedLinearInequality", "less than option",
+                                    terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
+                nullopt};
         }, //
         [&](const reif::Iff & cond) {
-            _proof_lines = pair{model.add_unlabelled_definitional_constraint(terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
-                model.add_unlabelled_definitional_constraint(terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
+            _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "lt", "ReifiedLinearInequality", "less than option",
+                                    terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
+                model.add_labelled_constraint(as_string(constraint_id()), "gt", "ReifiedLinearInequality", "greater than option",
+                    terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
         } //
     }
         .visit(_reif_cond);

--- a/gcs/constraints/mult_bc/mult_bc.cc
+++ b/gcs/constraints/mult_bc/mult_bc.cc
@@ -1084,13 +1084,16 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
                 for (Integer pos = 0_i; pos < num_bits - 1_i; pos++)
                     bit_sum_without_neg += power2(pos) * ProofBitVariable{v, pos + 1_i, true};
 
-                auto pos_ge = optional_model->add_unlabelled_definitional_constraint(
+                // mult_bc does not chain (cake does not encode multiplication), so
+                // these bit-decomposition defs take invented @c[id][role] labels.
+                auto mbid = as_string(constraint_id());
+                auto pos_ge = optional_model->add_labelled_constraint(mbid, "posge_" + name, "MultBC", "magnitude channel",
                     bit_sum_without_neg + (-1_i * v_magnitude) >= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto pos_le = optional_model->add_unlabelled_definitional_constraint(
+                auto pos_le = optional_model->add_labelled_constraint(mbid, "posle_" + name, "MultBC", "magnitude channel",
                     bit_sum_without_neg + (-1_i * v_magnitude) <= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto neg_ge = optional_model->add_unlabelled_definitional_constraint(
+                auto neg_ge = optional_model->add_labelled_constraint(mbid, "negge_" + name, "MultBC", "magnitude channel",
                     bit_sum_without_neg + (1_i * v_magnitude) >= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
-                auto neg_le = optional_model->add_unlabelled_definitional_constraint(
+                auto neg_le = optional_model->add_labelled_constraint(mbid, "negle_" + name, "MultBC", "magnitude channel",
                     bit_sum_without_neg + (1_i * v_magnitude) <= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
 
                 channelling_constraints.insert({v, ChannellingData{pos_ge, pos_le, neg_ge, neg_le}});
@@ -1107,6 +1110,7 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
         auto [v2_mag, v2_sign] = make_magnitude_representation(_v2, "y");
         auto [v3_mag, v3_sign] = make_magnitude_representation(_v3, "z");
 
+        auto mbid = as_string(constraint_id());
         auto v1_num_bits = optional_model->names_and_ids_tracker().num_bits(v1_mag);
         auto v2_num_bits = optional_model->names_and_ids_tracker().num_bits(v2_mag);
 
@@ -1116,11 +1120,12 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
             for (Integer j = 0_i; j < v2_num_bits; j++) {
                 auto flag = optional_model->create_proof_flag(format("xy[{}][{}]", i, j));
 
-                auto forwards = optional_model->add_unlabelled_definitional_constraint(
+                auto ijtag = std::to_string(i.raw_value) + "_" + std::to_string(j.raw_value);
+                auto forwards = optional_model->add_labelled_constraint(mbid, "xyfwd_" + ijtag, "MultBC", "bit product",
                     WPBSum{} + 1_i * ProofBitVariable{v1_mag, i, true} + 1_i * ProofBitVariable{v2_mag, j, true} >= 2_i,
                     HalfReifyOnConjunctionOf{flag});
 
-                auto backwards = optional_model->add_unlabelled_definitional_constraint(
+                auto backwards = optional_model->add_labelled_constraint(mbid, "xybwd_" + ijtag, "MultBC", "bit product",
                     WPBSum{} + -1_i * ProofBitVariable{v1_mag, i, true} + -1_i * ProofBitVariable{v2_mag, j, true} >= -1_i,
                     HalfReifyOnConjunctionOf{! flag});
 
@@ -1131,30 +1136,30 @@ auto MultBC::install(Propagators & propagators, State & initial_state, ProofMode
 
         visit(
             [&](auto v3_mag) {
-                auto s = optional_model->add_unlabelled_definitional_constraint(
-                    StringLiteral{"MultBC"}, StringLiteral{"z = product"}, bit_product_sum + (-1_i * v3_mag) == 0_i);
+                auto s = optional_model->add_labelled_constraint(
+                    mbid, "zprodle", "zprodge", StringLiteral{"MultBC"}, StringLiteral{"z = product"}, bit_product_sum + (-1_i * v3_mag) == 0_i);
                 v3_eq_product_lines = make_pair(s.first, s.second);
             },
             v3_mag);
 
         auto xyss = optional_model->create_proof_flag("xy[s][s]");
-        sign_lines.emplace_back(
-            optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, ! v2_sign}));
+        sign_lines.emplace_back(optional_model->add_labelled_constraint(
+            mbid, "sign_nn", "MultBC", "sign", WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, ! v2_sign}));
 
         if (mag_var.contains(_v1))
-            sign_lines.emplace_back(
-                optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, ! v2_sign}));
+            sign_lines.emplace_back(optional_model->add_labelled_constraint(
+                mbid, "sign_pn", "MultBC", "sign", WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, ! v2_sign}));
         if (mag_var.contains(_v2))
-            sign_lines.emplace_back(
-                optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, v2_sign}));
+            sign_lines.emplace_back(optional_model->add_labelled_constraint(
+                mbid, "sign_np", "MultBC", "sign", WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, v2_sign}));
         if (mag_var.contains(_v1) && mag_var.contains(_v2))
-            sign_lines.emplace_back(
-                optional_model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, v2_sign}));
+            sign_lines.emplace_back(optional_model->add_labelled_constraint(
+                mbid, "sign_pp", "MultBC", "sign", WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, v2_sign}));
 
-        sign_lines.emplace_back(optional_model->add_unlabelled_definitional_constraint(
+        sign_lines.emplace_back(optional_model->add_labelled_constraint(mbid, "sign_v3pos", "MultBC", "sign",
             WPBSum{} + 1_i * xyss + 1_i * (_v1 != 0_i) + 1_i * (_v2 != 0_i) >= 3_i, HalfReifyOnConjunctionOf{v3_sign}));
 
-        sign_lines.emplace_back(optional_model->add_unlabelled_definitional_constraint(
+        sign_lines.emplace_back(optional_model->add_labelled_constraint(mbid, "sign_v3neg", "MultBC", "sign",
             WPBSum{} + 1_i * ! xyss + 1_i * (_v1 == 0_i) + 1_i * (_v2 == 0_i) >= 1_i, HalfReifyOnConjunctionOf{! v3_sign}));
     }
 

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -141,7 +141,11 @@ auto gcs::innards::define_sortedness_proof_model(ProofModel & model, const vecto
         for (size_t ip = 0; ip < n; ++ip)
             if (ip != i)
                 rank += -1_i * w.before[ip][i];
-        auto [le, ge] = model.add_unlabelled_definitional_constraint("Sort", "pos is stable rank", move(rank) == 0_i);
+        // Sort does not chain (cake encodes it differently), so an invented label
+        // keyed on the position variable is fine; this is a free function with no
+        // constraint id, so the pos variable's index gives the unique key.
+        auto [le, ge] = model.add_labelled_constraint(
+            "sort_pos_" + std::to_string(i), "rankle", "rankge", "Sort", "pos is stable rank", move(rank) == 0_i);
         w.rank_ge.push_back(ge);
         w.rank_le.push_back(le);
     }

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -144,8 +144,8 @@ auto gcs::innards::define_sortedness_proof_model(ProofModel & model, const vecto
         // Sort does not chain (cake encodes it differently), so an invented label
         // keyed on the position variable is fine; this is a free function with no
         // constraint id, so the pos variable's index gives the unique key.
-        auto [le, ge] = model.add_labelled_constraint(
-            "sort_pos_" + std::to_string(i), "rankle", "rankge", "Sort", "pos is stable rank", move(rank) == 0_i);
+        auto [le, ge] =
+            model.add_labelled_constraint("sort_pos_" + std::to_string(i), "rankle", "rankge", "Sort", "pos is stable rank", move(rank) == 0_i);
         w.rank_ge.push_back(ge);
         w.rank_le.push_back(le);
     }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1168,9 +1168,11 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
 
     Integer s_coeff = view.negate_first ? -1_i : 1_i;
 
-    // Views must be defined properly in the model.
-    auto [link_le, link_ge] = _imp->model->add_unlabelled_definitional_constraint(
-        StringLiteral{"view link"}, StringLiteral{"definitional"}, WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add);
+    // Views must be defined properly in the model. Cake has no view variables, so
+    // there is no cake label to match: invent one named after the view, referenced
+    // by label rather than line number.
+    auto [link_le, link_ge] = _imp->model->add_labelled_constraint(name, "viewle", "viewge", StringLiteral{"view link"},
+        StringLiteral{"definitional"}, WPBSum{} + 1_i * v_id + (-s_coeff) * view.actual_variable == view.then_add);
 
     _imp->view_proof_only_vars.emplace(view, v_id);
     _imp->view_proof_only_to_view.emplace(v_id, view);

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -616,6 +616,19 @@ auto ProofModel::finalise() -> void
 
         copy(istreambuf_iterator<char>{_imp->opb}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{full_opb});
         _imp->opb = stringstream{};
+
+        // TEMPORARY desync canary (GCS_OPB_DESYNC_PADDING=N): emit N trivially-true
+        // constraints AFTER the real constraints, *without* advancing the
+        // constraint counter, so in workflow-1 self-verify the proof lines sit N
+        // further from the OPB constraints than the proof's relativisation assumed.
+        // Any reference to an OPB constraint by line number then resolves wrong and
+        // the proof fails; @label refs and proof-internal relative refs survive.
+        // Distinct RHS avoids VeriPB deduplicating the padding away.
+        if (const auto * pad = std::getenv("GCS_OPB_DESYNC_PADDING")) {
+            auto n = std::atoi(pad);
+            for (int k = 1; k <= n; ++k)
+                full_opb << ">= -" << k << " ;\n";
+        }
     }
     catch (const ios_base::failure &) {
         throw ProofError{"Error writing opb file to '" + _imp->opb_file + "'"};


### PR DESCRIPTION
**Stack 2 of 3** — based on `acrv-1-void-and-api`.

Moves every per-constraint OPB definition off line numbers and onto `@label`s, matching `cake_pb_cp` where it labels the constraint and inventing a `@c[id][role]` label where it does not:

- view-link def; linear (`c[id]` + reified `c[id][le/ge]`); GCC count (`c[id_j][le/ge]`); circuit position (`c[id][pos_suc_i_j_le/ge]`) — cake-matched, chains verify;
- disjunctive/2d/cumulative *end* proxies + sort rank + mult_bc bit-decomposition — invented labels (proof-only, no cake counterpart).

Adds a temporary `GCS_OPB_DESYNC_PADDING` **desync canary** (env-gated, harmless when unset) that pads the OPB to make any surviving line-number reference resolve wrong in self-verify — the audit instrument for completeness. Removed in 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)