### PR TITLE
add_constraint→void (3/3): label the variable-encoding core; drop the escape hatch + canary

### DIFF
--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -259,17 +259,17 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
             // Σ heights[i]·active[i,t] ≤ capacity. When the capacity is a
             // variable, move it to the left as a (−1)·capacity term so the
             // constraint stays a single linear inequality with RHS 0.
-            std::optional<ProofLine> line;
-            // cake labels its per-time load constraint @c[id][cap_<t>] but indexes
-            // time differently (its global window vs our per-task one), so we cannot
-            // match the label; cumulative chains at `none` via the line reference, so
-            // the escape hatch preserves that.
-            if (is_constant_variable(_capacity))
-                line = model.add_unlabelled_definitional_constraint(load <= _capacity_val);
-            else
-                line = model.add_unlabelled_definitional_constraint(move(load) + -1_i * _capacity <= 0_i);
-            if (line)
-                _capacity_lines.emplace(t, *line);
+            //
+            // cake_pb_cp labels its per-time load constraint @c[id][cap_<t>], and
+            // its per-task time windowing matches ours, so our load line for time t
+            // is cake's cap line for time t. Emit the same label so the verified
+            // chain references it by name rather than position.
+            auto role = "cap_" + std::to_string(t.raw_value);
+            auto line = is_constant_variable(_capacity)
+                ? model.add_labelled_constraint(as_string(_constraint_id), role, "Cumulative", "load <= capacity", load <= _capacity_val)
+                : model.add_labelled_constraint(
+                      as_string(_constraint_id), role, "Cumulative", "load <= capacity", move(load) + -1_i * _capacity <= 0_i);
+            _capacity_lines.emplace(t, line);
         }
     }
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -494,6 +494,17 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
 
     auto bounds = _imp->integer_variable_definition_bounds.find(id);
     ProofLine forwards_line, reverse_line;
+
+    // Model-path eq-atom definitions are labelled @<base>[eq<v>][r]/[f] (see
+    // definitional_label_base): @i[name] for a real variable, @po[index] for a
+    // proof-only one, so they are referenced (e.g. in a view's deview-form) by
+    // name rather than line number. A bracket-nesting real-variable name has no
+    // valid label and falls back to the unlabelled definitional form.
+    auto eq_base = definitional_label_base(id);
+    auto add_eq = [&](const char * role, const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & reif) -> ProofLine {
+        return _imp->model->add_labelled_constraint(eq_base + "[eq" + to_string(v.raw_value) + "][" + role + "]", ineq, reif);
+    };
+
     if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first == v) {
         // it's a lower bound
         if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
@@ -509,8 +520,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         else if (! _imp->logger) {
             visit(
                 [&](const auto & id) {
-                    forwards_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
-                    reverse_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
+                    forwards_line = add_eq("r", WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, {{id == v}});
+                    reverse_line = add_eq("f", WPBSum{} + 1_i * (id >= (v + 1_i)) >= 1_i, {{id != v}});
                 },
                 id);
             ++_imp->model_variables;
@@ -531,8 +542,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         else if (! _imp->logger) {
             visit(
                 [&](const auto & id) {
-                    forwards_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
-                    reverse_line = _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
+                    forwards_line = add_eq("r", WPBSum{} + 1_i * (id >= v) >= 1_i, {{id == v}});
+                    reverse_line = add_eq("f", WPBSum{} + 1_i * ! (id >= v) >= 1_i, {{id != v}});
                 },
                 id);
             ++_imp->model_variables;
@@ -552,10 +563,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         else if (! _imp->logger) {
             visit(
                 [&](const auto & id) {
-                    forwards_line =
-                        _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
-                    reverse_line =
-                        _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
+                    forwards_line = add_eq("r", WPBSum{} + 1_i * (id >= v) + 1_i * ! (id > v) >= 2_i, {{id == v}});
+                    reverse_line = add_eq("f", WPBSum{} + 1_i * ! (id >= v) + 1_i * (id > v) >= 1_i, {{id != v}});
                 },
                 id);
             ++_imp->model_variables;
@@ -646,6 +655,13 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
 }
 
+auto NamesAndIDsTracker::definitional_label_base(const SimpleOrProofOnlyIntegerVariableID & id) const -> string
+{
+    return visit(overloaded{[&](const SimpleIntegerVariableID &) -> string { return "i[" + name_of(id) + "]"; },
+                     [&](const ProofOnlySimpleIntegerVariableID & pid) -> string { return "po[" + to_string(pid.index) + "]"; }},
+        id);
+}
+
 auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
 {
     if (_imp->variable_conditions_to_x.contains(id >= v))
@@ -665,23 +681,17 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         _imp->gevars_that_exist[id].emplace(v, def_lines);
     }
     else {
-        // Label the two halves @i[name][ge<v>][f]/[r] to match cake_pb_cp, but
-        // only where it is safe: a real (non-proof-only) variable, a name without
-        // `[` (vector names nest brackets the @label parser rejects), and v >= 0
-        // (a negative v would put a `-` in the role). The first emitted half (the
-        // id>=v reif, carrying ~ge..) is cake's [r]; the second is [f].
-        const auto & name = name_of(id);
-        bool can_label = std::holds_alternative<SimpleIntegerVariableID>(id) && name.find('[') == string::npos && v >= 0_i;
-        string ge_label = can_label ? "i[" + name + "][ge" + to_string(v.raw_value) + "]" : "";
+        // Label the two halves @<base>[ge<v>][r]/[f]: the base is @i[name] for a
+        // real variable (matching cake_pb_cp) or @po[index] for a proof-only one
+        // (cake never sees it). The first emitted half (the id>=v reif, carrying
+        // ~ge..) is cake's [r]; the second is [f]. v may be negative -- veripb
+        // 3.0.2 allows `-` in @labels.
+        string ge_label = definitional_label_base(id) + "[ge" + to_string(v.raw_value) + "]";
         _imp->gevars_that_exist[id].emplace(v,
             visit(
                 [&](const auto & vid) -> pair<ProofLine, ProofLine> {
-                    if (can_label)
-                        return pair{_imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
-                            _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
-                    else
-                        return pair{_imp->model->add_unlabelled_definitional_constraint(WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
-                            _imp->model->add_unlabelled_definitional_constraint(WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
+                    return pair{_imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
+                        _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
                 },
                 id));
         ++_imp->model_variables;

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -87,6 +87,14 @@ namespace gcs::innards
 
         auto emit_proof_line_now_or_at_start(const std::function<auto(ProofLogger * const)->void> &) -> void;
 
+        // The @label base for a variable's encoding definitions (bounds, ge/eq
+        // atom reifications): `i[name]` for a real variable (matching cake_pb_cp,
+        // including vector names like `i[scene[0]]` -- veripb's @label parser
+        // accepts the nested brackets), `po[index]` for a proof-only variable
+        // (which cake never sees, so the invented index-keyed base just has to be
+        // unique -- proof-only names are not). Callers append `[role]`.
+        [[nodiscard]] auto definitional_label_base(const SimpleOrProofOnlyIntegerVariableID & id) const -> std::string;
+
         // Emit containment edges between a newly-introduced literal [lo, hi] and its
         // immediate neighbours in the containment order among the existing range and eq
         // literals on `id`: minimal containers above (self -> parent) and, when self is

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -178,69 +178,6 @@ auto ProofModel::add_constraint(const StringLiteral & constraint_name, const Str
     names_and_ids_tracker().derive_deviewed_form_for(second, eq.lhs, /*le_half=*/false);
 }
 
-auto ProofModel::add_unlabelled_definitional_constraint(const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
-{
-    // Escape hatch: an unlabelled constraint whose line IS referenced later, for
-    // the few proof-internal variable-encoding definitions that cannot be given a
-    // valid @label (proof-only vars, names with `[`, negative offsets, the eq/ge
-    // ladder cake encodes differently). Everything else must use a labelled
-    // variant so it is referenced by name, not line number.
-    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
-    if (half_reif)
-        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
-
-    _imp->opb << "* constraint ? ?\n";
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
-    _imp->opb << ";\n";
-    auto line = advance_constraint_counter();
-    names_and_ids_tracker().derive_deviewed_form_for(line, ineq.lhs, /*le_half=*/true);
-    return line;
-}
-
-auto ProofModel::add_unlabelled_definitional_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq,
-    const optional<HalfReifyOnConjunctionOf> & half_reif) -> pair<ProofLine, ProofLine>
-{
-    // Escape hatch for an equality definition --- see the inequality overload.
-    names_and_ids_tracker().need_all_proof_names_in(eq.lhs);
-    if (half_reif)
-        names_and_ids_tracker().need_all_proof_names_in(*half_reif);
-
-    _imp->opb << "* constraint " << constraint_name.value << ' ' << rule.value << '\n';
-    emit_inequality_to(
-        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
-    _imp->opb << ";\n";
-    auto first = advance_constraint_counter();
-    names_and_ids_tracker().derive_deviewed_form_for(first, eq.lhs, /*le_half=*/true);
-
-    emit_inequality_to(
-        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
-    _imp->opb << ";\n";
-    auto second = advance_constraint_counter();
-    names_and_ids_tracker().derive_deviewed_form_for(second, eq.lhs, /*le_half=*/false);
-
-    return pair{first, second};
-}
-
-auto ProofModel::add_unlabelled_definitional_constraint(const Literals & lits) -> ProofLine
-{
-    // As the no-name add_constraint(Literals) --- a clause, a statically-true
-    // literal making it the trivially-true `sum >= 0` --- but returns the
-    // referenceable line (see the inequality overload).
-    WPBSum sum;
-    bool tautological = false;
-    for (auto & lit : lits) {
-        overloaded{
-            [&](const TrueLiteral &) { tautological = true; },                              //
-            [&](const FalseLiteral &) {},                                                   //
-            [&]<typename T_>(const VariableConditionFrom<T_> & cond) { sum += 1_i * cond; } //
-        }
-            .visit(simplify_literal(names_and_ids_tracker(), lit));
-    }
-    sort(sum.terms);
-    sum.terms.erase(unique(sum.terms).begin(), sum.terms.end());
-    return add_unlabelled_definitional_constraint(move(sum) >= (tautological ? 0_i : 1_i), nullopt);
-}
-
 auto ProofModel::add_labelled_constraint(const string & constraint_id, const string & role_le, const string & role_ge,
     const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq, const optional<HalfReifyOnConjunctionOf> & half_reif)
     -> pair<ProofLine, ProofLine>
@@ -284,7 +221,32 @@ auto ProofModel::add_labelled_constraint(const string & label, const WPBSumLE & 
     emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
     _imp->opb << ";\n";
     advance_constraint_counter();
+    // As the (constraint_id, role) overload: a labelled constraint over a view
+    // still needs its deviewed form, so a proof-only view variable's encoding
+    // definitions are referenced (by label) in deview-form. A no-op when the
+    // inequality mentions no views. emit_inequality_to negates the LE half.
+    names_and_ids_tracker().derive_deviewed_form_for(l, ineq.lhs, /*le_half=*/true);
     return l;
+}
+
+auto ProofModel::add_labelled_constraint(const string & label, const Literals & lits) -> ProofLine
+{
+    // The labelled counterpart of add_constraint(Literals): build the clause's
+    // pseudo-Boolean sum (a statically-true literal collapses it to the
+    // trivially-true `sum >= 0`) and emit it under @label.
+    WPBSum sum;
+    bool tautological = false;
+    for (auto & lit : lits) {
+        overloaded{
+            [&](const TrueLiteral &) { tautological = true; },                              //
+            [&](const FalseLiteral &) {},                                                   //
+            [&]<typename T_>(const VariableConditionFrom<T_> & cond) { sum += 1_i * cond; } //
+        }
+            .visit(simplify_literal(names_and_ids_tracker(), lit));
+    }
+    sort(sum.terms);
+    sum.terms.erase(unique(sum.terms).begin(), sum.terms.end());
+    return add_labelled_constraint(label, move(sum) >= (tautological ? 0_i : 1_i), nullopt);
 }
 
 auto ProofModel::add_labelled_constraint(const string & constraint_id, const string & role, const StringLiteral & constraint_name,
@@ -491,12 +453,11 @@ auto ProofModel::set_up_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableI
     names_and_ids_tracker().track_bits(id, negative_bit_coeff, bits);
     _imp->model_variables += bits.size();
 
-    // @i[name][lb]/[ub] labels match cake_pb_cp, but only for a real variable
-    // with a label-safe name: views / proof-only variables are not in cake's OPB,
-    // and a `[` in the name (e.g. a vector variable box[0]) nests brackets that
-    // veripb's @label parser rejects. The bracket guard is temporary -- nested
-    // brackets are coming in a future cake_pb_cp release.
-    bool labelled = std::holds_alternative<SimpleIntegerVariableID>(id) && name.find('[') == string::npos;
+    // @i[name][lb]/[ub] labels match cake_pb_cp, for a real variable; a vector
+    // name like box[0] is fine (veripb's @label parser accepts the nested
+    // brackets). Proof-only variables are not in cake's OPB, so their bounds stay
+    // unlabelled (nothing references them, and there is no cake label to match).
+    bool labelled = std::holds_alternative<SimpleIntegerVariableID>(id);
 
     // lower bound
     if (labelled)
@@ -616,19 +577,6 @@ auto ProofModel::finalise() -> void
 
         copy(istreambuf_iterator<char>{_imp->opb}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{full_opb});
         _imp->opb = stringstream{};
-
-        // TEMPORARY desync canary (GCS_OPB_DESYNC_PADDING=N): emit N trivially-true
-        // constraints AFTER the real constraints, *without* advancing the
-        // constraint counter, so in workflow-1 self-verify the proof lines sit N
-        // further from the OPB constraints than the proof's relativisation assumed.
-        // Any reference to an OPB constraint by line number then resolves wrong and
-        // the proof fails; @label refs and proof-internal relative refs survive.
-        // Distinct RHS avoids VeriPB deduplicating the padding away.
-        if (const auto * pad = std::getenv("GCS_OPB_DESYNC_PADDING")) {
-            auto n = std::atoi(pad);
-            for (int k = 1; k <= n; ++k)
-                full_opb << ">= -" << k << " ;\n";
-        }
     }
     catch (const ios_base::failure &) {
         throw ProofError{"Error writing opb file to '" + _imp->opb_file + "'"};

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -67,9 +67,8 @@ namespace gcs::innards
 
         /**
          * Add a pseudo-Boolean constraint to a Proof model. Returns void: to
-         * reference the constraint later, add it by @label (add_labelled_constraint)
-         * or, for an unlabellable proof-internal definition, via
-         * add_unlabelled_definitional_constraint --- never by line number.
+         * reference the constraint later, add it by @label (add_labelled_constraint),
+         * never by line number.
          */
         auto add_constraint(const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> void;
 
@@ -97,21 +96,6 @@ namespace gcs::innards
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> void;
 
         /**
-         * \brief Escape hatch: add an unlabelled constraint whose proof line IS
-         * referenced later. Reserved for the few proof-internal variable-encoding
-         * definitions that cannot be given a valid @label (proof-only vars, names
-         * containing `[`, negative offsets, the eq/ge ladder cake encodes its own
-         * way). Everything else must reference constraints by @label, via the
-         * add_labelled_constraint family --- which is why plain add_constraint
-         * returns void.
-         */
-        auto add_unlabelled_definitional_constraint(const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt)
-            -> ProofLine;
-        auto add_unlabelled_definitional_constraint(const StringLiteral & constraint_name, const StringLiteral & rule, const WPBSumEq & eq,
-            const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
-        auto add_unlabelled_definitional_constraint(const Literals & lits) -> ProofLine;
-
-        /**
          * \brief Like add_constraint for an equality, but emits an @label on each
          * half --- \c c[constraint_id][role_le] on the LE half and \c [role_ge]
          * on the GE half --- and returns those labels, so the proof references
@@ -135,6 +119,15 @@ namespace gcs::innards
          */
         auto add_labelled_constraint(
             const std::string & label, const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
+
+        /**
+         * \brief Add a CNF clause under a caller-supplied @label, returning that
+         * label as the ProofLine, so a later proof step references the clause by
+         * name. A clause whose only content is a statically-true literal collapses
+         * to the trivially-true `sum >= 0`. The labelled counterpart of the plain
+         * \c add_constraint(Literals) (which, returning void, cannot be referenced).
+         */
+        auto add_labelled_constraint(const std::string & label, const Literals & lits) -> ProofLine;
 
         /**
          * \brief Like add_constraint for a single inequality, but emits @c[id][role]

--- a/gcs/innards/proofs/proof_model_tautology_test.cc
+++ b/gcs/innards/proofs/proof_model_tautology_test.cc
@@ -7,12 +7,11 @@ using namespace gcs;
 using namespace gcs::innards;
 
 // Issue #264: a clause whose only content is a statically-true literal is a
-// tautology with an empty left-hand side. add_constraint must still emit a
-// trivially-true `>= 0` constraint and return a usable line for it, rather than
-// returning nothing -- which is why no add_constraint overload is optional any
-// more. The emitted constraint must parse in the OPB and stay referenceable from
-// a later proof step, so here we reference its line in a pol step; VeriPB rejects
-// the proof if the line is missing or the empty constraint is malformed.
+// tautology with an empty left-hand side. The proof model must still emit a
+// trivially-true `>= 0` constraint for it, rather than omitting it. The emitted
+// constraint must parse in the OPB and stay referenceable from a later proof
+// step, so here we add it under an @label and reference that label in a pol step;
+// VeriPB rejects the proof if the label is missing or the constraint malformed.
 auto main() -> int
 {
     ProofOptions proof_options{"proof_model_tautology_test"};
@@ -24,7 +23,7 @@ auto main() -> int
     // and does not mention it.
     [[maybe_unused]] auto x = model.create_proof_only_integer_variable(0_i, 10_i, "x", IntegerVariableProofRepresentation::Bits);
 
-    auto tautology_line = model.add_unlabelled_definitional_constraint(Literals{TrueLiteral{}});
+    model.add_labelled_constraint("tautology", Literals{TrueLiteral{}});
 
     model.finalise();
 
@@ -33,10 +32,9 @@ auto main() -> int
     logger.start_proof(model);
     tracker.emit_delayed_proof_steps();
 
-    // The tautology's line must be referenceable: re-deriving it by pol succeeds
-    // only if it was emitted and is well-formed. Reference it relative to the
-    // current line (the only supported way to reference a numeric line).
-    logger.emit_proof_line("pol " + relative_proof_line(tautology_line, logger.get_current_proof_line().number) + " ;", ProofLevel::Current);
+    // The tautology must be referenceable: re-deriving it by pol succeeds only if
+    // it was emitted and is well-formed. Reference it by @label.
+    logger.emit_proof_line("pol @tautology ;", ProofLevel::Current);
 
     logger.conclude_none();
     tracker.finalise();

--- a/gcs/innards/proofs/reification_test.cc
+++ b/gcs/innards/proofs/reification_test.cc
@@ -24,7 +24,9 @@ auto main() -> int
             -2_i * model.create_proof_only_integer_variable(1_i, 10_i, "x", IntegerVariableProofRepresentation::Bits) >=
         4_i;
 
-    model.add_constraint(tracker.reify(constr, HalfReifyOnConjunctionOf{reif}));
+    // Reference the constraint by @label rather than by relative line number, so
+    // the test does not depend on the constraint's position in the OPB.
+    model.add_labelled_constraint("test", tracker.reify(constr, HalfReifyOnConjunctionOf{reif}));
 
     model.finalise();
 
@@ -33,7 +35,9 @@ auto main() -> int
     logger.start_proof(model);
 
     // Check that after saturation, a reification by a false literal is trivially true.
-    logger.emit_proof_line("pol -1 s;", ProofLevel::Current);
+    // The pol references the constraint by @label; the `e` references the pol's own
+    // output (the immediately preceding line), which is a robust proof-internal ref.
+    logger.emit_proof_line("pol @test s;", ProofLevel::Current);
     logger.emit_proof_line("e >= -35 : -1;", ProofLevel::Current);
     logger.conclude_none();
     tracker.finalise();


### PR DESCRIPTION
**Stack 3 of 3** — based on `acrv-2-label-constraint-defs`. Completes the refactor: the escape hatch and canary are removed, and **every referenced OPB constraint is now by `@label`, with no exceptions**.

### Variable-encoding core
New `NamesAndIDsTracker::definitional_label_base` keys each variable's ge/eq atom reifications (and bit-encoding bounds) on a label:
- `i[name]` for a real variable — matches cake; vector names like `i[scene[0]]` are fine (veripb 3.0.2 accepts nested brackets and `-` in labels), so the old bracket/`v>=0` guards are gone;
- `po[index]` for a proof-only variable (unique — their names are not).

The single-label `add_labelled_constraint` now also derives the deviewed form, so a view's proof-only-variable definitions are referenced by label in deview-form. This clears every `*_view_mixed` / arithmetic / mult_bc self-verify case (mult_bc's `get_current_proof_line()` arithmetic was never an OPB ref — it's proof-internal RUP hints).

### Tests
`reification_test` and `proof_model_tautology_test` reference their constraints by `@label`; a labelled `add_labelled_constraint(label, Literals)` overload is the successor to the escape hatch's clause overload.

### Cumulative — and an upstream cake fix
The last holdout was an **upstream `cake_pb_cp` bug**, not a design mismatch. `intnum` is the int→num zig-zag (`2n` for `n≥0`); cake rendered the cumulative cap label via `toString (intnum t)`, double-encoding the time to `cap_<2t>` while the constraint's own variables used real `t`. Fixed upstream (3 one-line sites in `cp_to_ilp_schedulingScript.sml`, proof-neutral), and Cumulative now conforms with `@c[id][cap_<t>]`.

> ⚠️ **Cross-repo dependency:** the `cap_<t>` reference only matches a `cake_pb_cp` built **after** that fix. CI without `cake_pb_cp` degrades to workflow-1 self-verify (passes); running the cumulative chain against a *stale* cake (`cap_<2t>`) will fail until the upstream fix is deployed. Patch to send upstream is ready.

### Removal
With Cumulative converted, nothing needs the escape hatch, so `add_unlabelled_definitional_constraint` and the `GCS_OPB_DESYNC_PADDING` canary are both deleted.

`ctest` **402/402** (incl. all `scp_chain` cake chains against the fixed binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)