### PR TITLE
Add a shareable clang-format pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Reject a commit whose staged C++ is not clang-formatted, mirroring the
+# clang-format CI job (.github/workflows/clang-format.yml). The vendored
+# XCSP3-CPP-Parser is excluded, as in CI.
+#
+# Bypass once with:  git commit --no-verify
+#
+set -uo pipefail
+
+# clang-format 21 matches CI (the workflow pins 21.1.8); formatting output
+# differs between major releases, so prefer an explicitly-versioned binary.
+fmt=$(command -v clang-format-21 || command -v clang-format) || {
+    echo "pre-commit: clang-format not found on PATH; skipping format check" >&2
+    exit 0
+}
+
+# Staged, added/copied/modified .cc/.hh files, minus the vendored parser.
+files=$(git diff --cached --name-only --diff-filter=ACM -- '*.cc' '*.hh' | grep -v '^XCSP3-CPP-Parser/')
+[ -z "$files" ] && exit 0
+
+bad=""
+while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    # Compare the *staged* blob (":$f") against its formatted form, so partial
+    # staging is checked correctly rather than whatever is in the working tree.
+    if ! diff -q <(git show ":$f") <(git show ":$f" | "$fmt" --assume-filename="$f") >/dev/null 2>&1; then
+        bad="${bad}${f}"$'\n'
+    fi
+done <<< "$files"
+
+if [ -n "$bad" ]; then
+    ver=$("$fmt" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    echo "✗ clang-format ${ver:-?}: these staged files are not formatted:" >&2
+    printf '    %s\n' $bad >&2
+    echo >&2
+    printf '  fix:   %s -i %s && git add %s\n' "$fmt" "$(echo $bad)" "$(echo $bad)" >&2
+    echo "  skip:  git commit --no-verify" >&2
+    exit 1
+fi
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,9 @@ releases). Format the whole tree with:
 ```shell
 git ls-files '*.cc' '*.hh' | grep -v '^XCSP3-CPP-Parser/' | xargs clang-format -i
 ```
-The `clang-format` CI workflow enforces this on every push and pull request.
+The `clang-format` CI workflow enforces this on every push and pull request. To
+catch violations before CI, enable the tracked pre-commit hook once per clone
+with `git config core.hooksPath .githooks` (see CONTRIBUTING.md).
 
 ## Compiler and Standard Library Support
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,18 @@ The `clang-format` CI workflow runs `clang-format --dry-run --Werror` over the
 same files on every push and pull request, so an unformatted contribution will
 fail the check.
 
+To catch this locally before CI does, a `pre-commit` hook that runs the same
+check over the staged C++ is tracked in `.githooks/`. Enable it once per clone:
+
+```shell
+git config core.hooksPath .githooks
+```
+
+It rejects a commit whose staged files are not formatted, printing the exact
+`clang-format -i` command to fix them; `git commit --no-verify` bypasses it for
+a one-off. The hook uses `clang-format-21` if present, otherwise `clang-format`,
+so install version 21 (CI pins 21.1.8) for results that match CI.
+
 Developer Documentation
 =======================
 


### PR DESCRIPTION
A tracked `pre-commit` hook (`.githooks/pre-commit`) that runs the CI `clang-format --dry-run --Werror` check over **staged** C++ and rejects an unformatted commit, printing the exact `clang-format -i` fix. Catches formatting locally before it reaches CI.

- **Reject, never auto-rewrite** — it tells you what to fix rather than silently reformatting staged content.
- Checks the staged *blob* (so partial staging is handled correctly) and excludes `XCSP3-CPP-Parser/`, exactly as CI does.
- Prefers `clang-format-21`, falls back to `clang-format`; `git commit --no-verify` bypasses it.

Tracked in `.githooks/` (rather than `.git/hooks/`, which isn't shareable) so the whole team can opt in once per clone:

```shell
git config core.hooksPath .githooks
```

Documented in `CONTRIBUTING.md` (Code Formatting) and `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)