### PR TITLE
Cumulative: chain-verify variable heights via cake's per-bit cc flags

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -290,14 +290,19 @@ and the pol differently:
   RUP now has `capacity ≤ ub(capacity)` in the reason.
 
 - **Variable heights** linearise the nonlinear product `h_i·active_{i,t}`
-  with a proof-only integer `contrib_{i,t} ∈ [0, ub(h_i)]`, half-reified
-  `active ⇒ contrib = h_i` and `¬active ⇒ contrib = 0`. `C_t` sums
-  `contrib` for variable heights (and `h_i·active` for constant ones, so
-  the all-constant proof is byte-identical). The pol pins
+  over `cake_pb_cp`'s per-bit contribution flags `cc_k = v[id][i_t_k][cc]`
+  (weight `2^k`): `contrib_{i,t} = Σ 2^k·cc_k`, half-reified
+  `active ⇒ contrib = h_i` and `¬active ⇒ contrib = 0` (the flags carry no
+  domain bound of their own — `cle`/`cz` constrain them, exactly as cake
+  does). `C_t` sums `contrib` for variable heights (and `h_i·active` for
+  constant ones, so the all-constant proof is byte-identical). The pol pins
   `contrib_{i,t} ≥ lb(h_i)` (coeff 1) instead of an `active = 1` line
   scaled by the constant height; for the pushed task it deposits
   `contrib_j + lb(h_j)·ext_lit ≥ lb(h_j)`. This is **variable × Boolean**,
-  which is linear — *not* the multiplication frontier.
+  which is linear — *not* the multiplication frontier. Because the `cc`
+  flags are exactly cake's contribution encoding (to VeriPB they are
+  ordinary Booleans, just as the solver's were), the variable-height load
+  reasoning **chain-verifies** (`scp_chain_cumulative_var_height_sat`).
 
 - **Variable durations** rewrite `after_{i,t} ⇔ s_i + l_i ≥ t+1`. The
   pinning `after = 1` then needs the *cross-variable* fact
@@ -342,18 +347,11 @@ combinations.
 - **Energetic reasoning.** Even more set-of-tasks, set-of-intervals.
   No clean OPB witness exists in the current encoding; the proof
   scaffold would need extra auxiliary flags.
-- **Variable-height chain.** Variable *durations* chain-verify, but
-  variable *heights* do not yet: the solver's `contrib_{i,t}` is a
-  bits-encoded proof-only integer, whereas `cake_pb_cp` encodes the
-  contribution as binary `cc` flags, so a `contrib` pin under load
-  pressure references a variable cake's OPB lacks. The fix is the same
-  flavour as the `end` reformulation above (move `contrib`'s definition
-  into the proof and bridge to cake's `cc`), but is separate work; until
-  then `scp_chain_cumulative_var_duration_sat` keeps a constant height.
-
 The current scaffolding (`_before_flags`, `_after_flags`,
-`_active_flags`, `_contrib_vars`, `_end`, `_capacity_lines`) is
+`_active_flags`, `_contrib_flags`, `_end`, `_capacity_lines`) is
 enough for time-table-strength reasoning over variable `d`/`r`/`b` and not
-much more.
+much more. Variable durations and variable heights both chain-verify
+against `cake_pb_cp`; the only remaining divergence is the start/size bit
+*variable* encoding (#358), which is orthogonal.
 
 <!-- vim: set tw=72 spell spelllang=en : -->

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -2,6 +2,8 @@
 #include <gcs/constraints/cumulative/hints.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/power.hh>
+#include <gcs/innards/proofs/bits_encoding.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -55,6 +57,16 @@ namespace
         for (const auto & v : vals)
             result.push_back(constant_variable(v));
         return result;
+    }
+
+    // The variable-height contribution h_i·active is linearised over cake's
+    // per-bit contribution flags cc_k (weight 2^k): contrib = Σ 2^k · cc_k.
+    auto contrib_sum_of(const vector<ProofFlag> & cc) -> WPBSum
+    {
+        WPBSum sum;
+        for (Integer k = 0_i; k.raw_value < static_cast<long long>(cc.size()); ++k)
+            sum += power2(k) * cc[k.raw_value];
+        return sum;
     }
 }
 
@@ -117,7 +129,7 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     // Resolve snapshots used by define_proof_model and the propagator. For a
     // variable length/height, _*_vals[i] is a placeholder 0 (the propagator
     // reads the bound from the state and the proof uses the variable /
-    // _contrib_vars instead); _*_ub[i] is the initial upper bound, used to size
+    // _contrib_flags instead); _*_ub[i] is the initial upper bound, used to size
     // the possible-active window / contrib domain and to filter tasks that can
     // never raise the profile.
     _length_vals.clear();
@@ -173,7 +185,7 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
     _before_flags.assign(_starts.size(), {});
     _after_flags.assign(_starts.size(), {});
     _active_flags.assign(_starts.size(), {});
-    _contrib_vars.assign(_starts.size(), {});
+    _contrib_flags.assign(_starts.size(), {});
     _end.assign(_starts.size(), std::nullopt);
 
     Integer global_lo = 0_i, global_hi = -1_i;
@@ -224,18 +236,25 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
             _active_flags[i].push_back(active);
 
             // For a variable height, the task's load contribution at t is the
-            // product height·active, which is nonlinear. Linearise it with a
-            // proof-only integer contrib in [0, ub(h)]:
+            // product height·active, which is nonlinear. Linearise it over cake's
+            // per-bit contribution flags cc_k (weight 2^k), so contrib = Σ 2^k·cc_k
+            // (same encoding cake_pb_cp emits, so the load reasoning chain-verifies):
             //   active   ⇒ contrib = h   (contrib − h ≥ 0 and ≤ 0)
-            //   ¬active  ⇒ contrib = 0   (contrib ≤ 0; contrib ≥ 0 by domain)
+            //   ¬active  ⇒ contrib = 0   (contrib ≤ 0; cc_k ≥ 0 inherently)
+            // The bit count matches the proof-only bits encoding of [0, ub(h)], and
+            // the flags carry no domain bound of their own (cle/cz constrain them,
+            // exactly as cake does).
             if (! is_constant_variable(_heights[i])) {
-                auto contrib = model.create_proof_only_integer_variable(0_i, _height_ub[i], "cumcontrib", IntegerVariableProofRepresentation::Bits);
-                model.add_constraint(
-                    "Cumulative", "contrib >= h when active", WPBSum{} + 1_i * contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{active});
-                model.add_constraint(
-                    "Cumulative", "contrib <= h when active", WPBSum{} + 1_i * contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{active});
-                model.add_constraint("Cumulative", "contrib = 0 when inactive", WPBSum{} + 1_i * contrib <= 0_i, HalfReifyOnConjunctionOf{! active});
-                _contrib_vars[i].push_back(contrib);
+                auto highest_bit_shift = std::get<0>(get_bits_encoding_coeffs(0_i, _height_ub[i]));
+                std::vector<ProofFlag> cc;
+                for (Integer k = 0_i; k <= highest_bit_shift; ++k)
+                    cc.push_back(model.names_and_ids_tracker().create_proof_flag_values(
+                        _constraint_id, std::vector<long long>{static_cast<long long>(i), t.raw_value, k.raw_value}, "cc"));
+                auto contrib = contrib_sum_of(cc);
+                model.add_constraint("Cumulative", "contrib >= h when active", contrib + -1_i * _heights[i] >= 0_i, HalfReifyOnConjunctionOf{active});
+                model.add_constraint("Cumulative", "contrib <= h when active", contrib + -1_i * _heights[i] <= 0_i, HalfReifyOnConjunctionOf{active});
+                model.add_constraint("Cumulative", "contrib = 0 when inactive", contrib <= 0_i, HalfReifyOnConjunctionOf{! active});
+                _contrib_flags[i].push_back(move(cc));
             }
         }
     }
@@ -250,7 +269,8 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
             if (is_constant_variable(_heights[i]))
                 load += _height_vals[i] * _active_flags[i][idx];
             else
-                load += 1_i * _contrib_vars[i][idx];
+                for (Integer k = 0_i; k.raw_value < static_cast<long long>(_contrib_flags[i][idx].size()); ++k)
+                    load += power2(k) * _contrib_flags[i][idx][k.raw_value];
             any = true;
         }
         if (any) {
@@ -332,7 +352,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         constraint_id(),
         [starts = move(_starts), lengths_var = move(_lengths), heights_var = move(_heights), capacity_var = _capacity,
             active_tasks = move(_active_tasks), before_flags = move(_before_flags), after_flags = move(_after_flags),
-            active_flags = move(_active_flags), contrib_vars = move(_contrib_vars), ends = move(_end), end_lines,
+            active_flags = move(_active_flags), contrib_flags = move(_contrib_flags), ends = move(_end), end_lines,
             capacity_lines = move(_capacity_lines), per_task_t_lo = move(_per_task_t_lo),
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // The capacity may be a variable: the load profile is infeasible
@@ -344,7 +364,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
             // A height may be a variable: a task's *guaranteed* contribution to
             // the load is its smallest still-allowed height, lb(h_i). For a
             // constant height lb(h_i) is just its value. Variable heights' bounds
-            // are part of every reason, and the proof uses contrib_vars.
+            // are part of every reason, and the proof uses the cc flags.
             auto hlb = [&](size_t i) { return state.lower_bound(heights_var[i]); };
             auto h_is_var = [&](size_t i) { return ! is_constant_variable(heights_var[i]); };
 
@@ -405,7 +425,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                 if (! h_is_var(i))
                     return {active_line, hlb(i)};
                 auto contrib_line =
-                    logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * contrib_vars[i][fi] >= hlb(i), ProofLevel::Temporary);
+                    logger->emit_rup_proof_line_under_reason(reason, contrib_sum_of(contrib_flags[i][fi]) >= hlb(i), ProofLevel::Temporary);
                 return {contrib_line, 1_i};
             };
 
@@ -430,7 +450,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                 if (! h_is_var(j_idx))
                     return {active_line, hlb(j_idx)};
                 auto contrib_line = logger->emit_rup_proof_line_under_reason(
-                    reason, WPBSum{} + 1_i * contrib_vars[j_idx][fj] + hlb(j_idx) * ext_lit >= hlb(j_idx), ProofLevel::Temporary);
+                    reason, contrib_sum_of(contrib_flags[j_idx][fj]) + hlb(j_idx) * ext_lit >= hlb(j_idx), ProofLevel::Temporary);
                 return {contrib_line, 1_i};
             };
 

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -45,7 +45,7 @@ namespace gcs
         IntegerVariableID _capacity;
         // Snapshots resolved in prepare(). For each of lengths and heights,
         // _*_vals holds the constant value for a constant argument (and 0 for a
-        // variable one, where the variable / _contrib_vars is used instead) and
+        // variable one, where the variable / _contrib_flags is used instead) and
         // _*_ub holds the initial upper bound (used to size the possible-active
         // window / contrib domain and to filter tasks that can never load).
         std::vector<Integer> _length_vals;
@@ -63,9 +63,11 @@ namespace gcs
         std::vector<std::vector<innards::ProofFlag>> _after_flags;
         std::vector<std::vector<innards::ProofFlag>> _active_flags;
         // Per (variable-height task, t) load contribution contrib = h·active,
-        // a proof-only integer in [0, ub(h)]. Empty inner vector for tasks
-        // whose height is constant (those use h·active directly in C_t).
-        std::vector<std::vector<innards::ProofOnlySimpleIntegerVariableID>> _contrib_vars;
+        // linearised over cake's per-bit contribution flags v[id][i_t_k][cc]
+        // (weight 2^k), so contrib = Σ 2^k·cc_k. Indexed [task][t_idx][bit];
+        // empty middle vector for tasks whose height is constant (those use
+        // h·active directly in C_t).
+        std::vector<std::vector<std::vector<innards::ProofFlag>>> _contrib_flags;
         // For a task whose start AND length both vary, a proof-only end = s + l
         // introduced INSIDE the proof (a conservative extension, with no OPB
         // encoding): cake reifies `after` on s + l directly, so end has no cake

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -343,18 +343,20 @@ add_scp_chain_test(disjunctive2d_var_sat  none)
 # propagator change (it holds the flag handles, whose names the rename updates).
 # Stays none: the start / size bit encodings still diverge from cake's eager
 # variable encoding (#358). sat enumerates the placements that keep every slot
-# within capacity (cumulative_var_sat uses variable heights, exercising the
-# contribution path); unsat forces more load into a slot than the capacity allows.
+# within capacity; unsat forces more load into a slot than the capacity allows.
+# Variable heights: the load contribution h_i*active is linearised over cake's
+# per-bit contribution flags v[id][i_t_k][cc] (weight 2^k), the same encoding cake
+# emits, so the contribution reasoning is also a naming conform (no bits-integer of
+# our own). cumulative_var_height_sat drives enough load to pin those contributions.
 # cumulative_var_duration_sat exercises variable durations (both start and length
 # vary). cake reifies after on s + l directly; the solver introduces a proof-only
 # end = s + l as a conservative extension (introduce_bits_of, no OPB axiom) purely
 # to give its propagator a single-variable after pin, bridged to cake's two-variable
 # after by a per-(task,time) `end >= t+1 -> after` lemma the initialiser emits. So
-# the chain has no end axiom to resolve. (Variable heights additionally diverge in
-# the contribution encoding -- cake's binary cc flags vs the solver's bits-integer
-# contrib -- so cumulative_var_duration_sat keeps a constant height; that gap is
-# separate, see dev_docs.)
-add_scp_chain_test(cumulative_sat            none)
-add_scp_chain_test(cumulative_var_sat        none)
+# the chain has no end axiom to resolve. Stays none: the start / size bit encodings
+# still diverge from cake's eager variable encoding (#358).
+add_scp_chain_test(cumulative_sat              none)
+add_scp_chain_test(cumulative_var_sat          none)
+add_scp_chain_test(cumulative_var_height_sat   none)
 add_scp_chain_test(cumulative_var_duration_sat none)
-add_scp_chain_test(cumulative_unsat          none)
+add_scp_chain_test(cumulative_unsat            none)

--- a/verified_encodings/scp_cases/cumulative_var_height_sat.scp
+++ b/verified_encodings/scp_cases/cumulative_var_height_sat.scp
@@ -1,0 +1,1 @@
+( ( (S0 0 3) (S1 0 3) (H0 1 2) (H1 1 2) ) ( (_1 cumulative (S0 S1) (1 1) (H0 H1) 2) ) (enumerate) )


### PR DESCRIPTION
Stacked on #433 (→ #428). Retarget down the stack as each base merges.

## What
Makes **variable-height** cumulative chain-verify against `cake_pb_cp`. Variable durations (#433) and constant-everything already chained; variable heights were the last time-table gap.

## Why it didn't chain
The variable-height contribution `h_i·active` was linearised with a proof-only **integer** `contrib` (bits `p[N_cumcontrib][bk]`). cake encodes the same contribution as **per-bit flags** `v[id][i_t_k][cc]` (weight `2^k`). The constraints are byte-identical with `contrib ↔ Σ 2^k·cc_k` (`cge`/`cle`/`cz` and the per-time `cap_t` line), but a `contrib` pin under load pressure referenced the solver's `p[...]` bits — which cake's OPB lacks — so the chain failed.

## The fix (a naming conform)
To VeriPB, the solver's contrib bits and cake's `cc` flags are *both just Booleans in PB constraints*, so this is the same kind of naming conform that `before`/`after`/`active` were — **no bridge lemma** needed (unlike the variable-duration `end`). Build `contrib` over flags named with cake's value-index `{i,t,k}` via `create_proof_flag_values(…, "cc")`, sized by `get_bits_encoding_coeffs(0, ub(h))`, and use `Σ 2^k·cc_k` everywhere the integer appeared (the three reified definitions, the load sum, and the `pin_contributor`/`pin_pushed` RUP lines). The flags carry no domain bound of their own — `cle`/`cz` constrain them, exactly as cake does.

## Verification
- New `scp_chain_cumulative_var_height_sat` (drives enough load to pin contributions) passes the full chain; variable height, variable duration, and the two **combined** all verify end-to-end against cake.
- `cumulative_test` self-verify and the propagator behaviour are unchanged.
- Full suite **407/407**, no regressions.

With this, cumulative is fully chain-verifying for variable durations/heights/capacities; the only remaining divergence is the start/size *variable* bit encoding (#358), which is orthogonal to every constraint.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
