### PR TITLE
Eager boundary variable encoding by default (#432 boundary units)

### DIFF
--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -141,12 +141,14 @@ struct NamesAndIDsTracker::Imp
     bool first_varmap_entry = true;
     bool finalised = false;
     bool verbose_names;
+    bool use_compact_boolean_encoding = false;
     AssertionLevel assertion_level = AssertionLevel::Off;
 };
 
 NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) : _imp(make_unique<Imp>())
 {
     _imp->verbose_names = proof_options.verbose_names;
+    _imp->use_compact_boolean_encoding = proof_options.use_compact_boolean_encoding;
     _imp->assertion_level = proof_options.assertion_level;
 
     if (proof_options.proof_file_names.variables_map_file) {
@@ -505,7 +507,14 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         return _imp->model->add_labelled_constraint(eq_base + "[eq" + to_string(v.raw_value) + "][" + role + "]", ineq, reif);
     };
 
-    if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first == v) {
+    // The compact boolean encoding defines an eq atom at a bound using only the
+    // one non-trivial order literal (eq(lower) <=> ~ge(lower+1), since ge(lower)
+    // is always true; eq(upper) <=> ge(upper), since ge(upper+1) is always
+    // false). With it off (the default), every eq atom -- including those at the
+    // bounds -- is the full eq(v) <=> ge(v) & ~ge(v+1), so the trivial ge(lower)
+    // and ge(upper+1) literals are materialised (need_gevar emits and fixes
+    // them), matching cake_pb_cp's eager encoding.
+    if (_imp->use_compact_boolean_encoding && bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.first == v) {
         // it's a lower bound
         if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
             visit(
@@ -527,7 +536,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             ++_imp->model_variables;
         }
     }
-    else if (bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second == v) {
+    else if (_imp->use_compact_boolean_encoding && bounds != _imp->integer_variable_definition_bounds.end() && bounds->second.second == v) {
         // it's an upper bound
         if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
             visit(
@@ -701,21 +710,30 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     auto bounds = _imp->integer_variable_definition_bounds.find(id);
 
     auto fix_bound = [&](bool negated) {
-        if (_imp->logger) {
-            if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
+        // Pin a trivial boundary order literal -- ge(lower) (always true) or
+        // ge(ub+1) (always false) -- in the PROOF, never as an OPB axiom. The fact
+        // is a consequence of the variable's bound constraints, not a definition,
+        // so it does not belong in the OPB; cake_pb_cp likewise derives it rather
+        // than pinning it, so an OPB axiom would make our OPB diverge from cake's,
+        // and -- worse -- a pin re-derived per use does not survive VeriPB's
+        // post-solx enumeration restriction. Emitting it once as a persistent
+        // top-of-proof line (RUP-derivable from the bound constraints, or asserted
+        // at AssertionLevel::Links) keeps the OPB byte-clean and the pin available
+        // throughout both enumeration and refutation. emit_proof_line_now_or_at_start
+        // queues it to proof start when the logger is not yet attached (model
+        // building) and emits it immediately otherwise.
+        emit_proof_line_now_or_at_start([id, v, negated](ProofLogger * const logger) {
+            if (logger->get_assertion_level() > AssertionLevel::Links)
                 return;
-
             ProofRule assert_or_rup =
-                _imp->logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
+                logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
             auto annotation = AssertionAnnotation{.hint_name = hints::InitialBound::hint_name};
             visit(
-                [&](auto id) {
-                    _imp->logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i, ProofLevel::Top, annotation);
+                [&](auto vid) {
+                    logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (vid >= v) : (vid >= v)) >= 1_i, ProofLevel::Top, annotation);
                 },
                 id);
-        }
-        else
-            visit([&](auto id) { _imp->model->add_constraint(WPBSum{} + 1_i * (negated ? ! (id >= v) : (id >= v)) >= 1_i); }, id);
+        });
     };
 
     // lower?

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -54,9 +54,10 @@ namespace gcs
         explicit ProofOptions(const ProofFileNames &);
         ProofOptions(const ProofOptions &) = default;
 
-        ProofFileNames proof_file_names;       ///< Filenames for OPB, proof, and mapping files
-        bool verbose_names = true;             ///< Use verbose names in proofs?
-        bool always_use_full_encoding = false; ///< Always write the full variable encoding to the OPB file
+        ProofFileNames proof_file_names;           ///< Filenames for OPB, proof, and mapping files
+        bool verbose_names = true;                 ///< Use verbose names in proofs?
+        bool always_use_full_encoding = false;     ///< Always write the full variable encoding to the OPB file
+        bool use_compact_boolean_encoding = false; ///< Drop the trivial constant boundary literals (ge_lower, ge_ub+1) from eq-atom definitions
         AssertionLevel assertion_level = AssertionLevel::Off;
         bool assertion_level_set_explicitly = false; ///< Was assertion_level set in code (so it overrides the env var)?
 
@@ -71,6 +72,18 @@ namespace gcs
         ProofOptions & enable_full_encoding(bool e = true)
         {
             always_use_full_encoding = e;
+            return *this;
+        }
+        /// Use the compact boolean encoding: define an eq atom at the variable's
+        /// lower (resp. upper) bound as eq <=> ~ge(v+1) (resp. eq <=> ge(v)),
+        /// dropping the trivially-true ge(lower) and trivially-false ge(ub+1)
+        /// literals. With this off (the default) every eq atom, including those
+        /// at the bounds, is defined as eq <=> ge(v) & ~ge(v+1), so those
+        /// constant boundary literals are materialised -- matching cake_pb_cp's
+        /// eager encoding.
+        ProofOptions & set_compact_boolean_encoding(bool c = true)
+        {
+            use_compact_boolean_encoding = c;
             return *this;
         }
         /// Set whether to use verbose names in proofs.

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -271,17 +271,19 @@ add_scp_chain_test(lex_less_equal_iff_sat     none)
 # keywords (bounds/gac globalcardinality[closed]) over (vars)(values)(counts);
 # the encoding is the per-value count constraint Sum_i (x_i = values[j]) =
 # counts[j] (the closed forms add an at-least-one over the cover values per
-# variable). cake defines the eq/ge literals eagerly, so it chain-verifies but
-# does not byte-match (#358). The open (sat + unsat) and GAC (sat + unsat) cases
-# verify, as does closed enumeration (closed_sat confines 0..2 vars to {0,1}).
-# closed_unsat is omitted: its refutation derives the contradiction through the
-# eq-literal ladder, which is exactly where the lazy-vs-eager encoding (#358)
-# diverges, so that proof shape does not yet line up against cake's OPB.
-add_scp_chain_test(global_cardinality_sat         none)
-add_scp_chain_test(global_cardinality_unsat       none)
-add_scp_chain_test(global_cardinality_closed_sat  none)
-add_scp_chain_test(global_cardinality_gac_sat     none)
-add_scp_chain_test(global_cardinality_gac_unsat   none)
+# variable). cake defines the eq/ge literals eagerly, and so now does the solver
+# (the eager boundary encoding is the default), so the whole family chain-verifies
+# -- the open (sat + unsat), GAC (sat + unsat) and closed (sat + unsat) cases.
+# closed_unsat's refutation derives the contradiction through the boundary
+# eq-literal ladder; it is enabled by the eager default (eq(v) <=> ge(v) & ~ge(v+1)
+# at the bounds too, with ge(lower)/ge(ub+1) pinned as persistent top-of-proof
+# lines), which previously was the lazy-vs-eager divergence that blocked it.
+add_scp_chain_test(global_cardinality_sat          none)
+add_scp_chain_test(global_cardinality_unsat        none)
+add_scp_chain_test(global_cardinality_closed_sat   none)
+add_scp_chain_test(global_cardinality_closed_unsat none)
+add_scp_chain_test(global_cardinality_gac_sat      none)
+add_scp_chain_test(global_cardinality_gac_unsat    none)
 
 # none (chain-only): regular (the sequence of variables is a word accepted by a
 # finite automaton). The writer emits cake's shape -- (vars...) nstates
@@ -433,16 +435,31 @@ add_scp_chain_test(smart_table_unsat      none)
 # sat exempts a value from distinctness (off-diagonal plus the exempt diagonal),
 # unsat is a four-into-three pigeonhole; at_most_one unsat pins two variables to
 # the value; among counts occurrences of a value, unsat demanding more than the
-# candidates can supply. (The sibling precedence globals -- value_precede,
-# seq_precede_chain -- and symmetric_all_different read and round-trip, but their
-# proofs use auxiliary position / structural variables absent from cake's OPB, so
-# they need a structural conform like sort/arg_sort, not just a reader.)
+# candidates can supply. (The sibling precedence globals -- value_precede and
+# seq_precede_chain -- read and round-trip, but their proofs use auxiliary
+# position / structural variables absent from cake's OPB, so they need a
+# structural conform like sort/arg_sort, not just a reader.)
 add_scp_chain_test(all_different_except_sat    none)
 add_scp_chain_test(all_different_except_unsat  none)
 add_scp_chain_test(at_most_one_sat             none)
 add_scp_chain_test(at_most_one_unsat           none)
 add_scp_chain_test(among_sat                   none)
 add_scp_chain_test(among_unsat                 none)
+
+# none (chain-only): symmetric_all_different (the assignment is an involution: if
+# var i takes value start + j then var j takes value start + i). cake's encoder is
+# eager at the value boundaries (eq(0) <=> ge(0) & ~ge(1), defining the always-true
+# ge(0) and always-false ge(ub+1)), and the per-value pairwise-distinctness RUP its
+# enumeration proof cites only collapses once those boundary literals are pinned.
+# With the eager boundary encoding as the default and ge(lower)/ge(ub+1) pinned as
+# persistent top-of-proof lines (so the pin survives VeriPB's post-solx enumeration
+# restriction), both the sat enumeration and the unsat refutation chain-verify.
+# Stays none: the rest of the bit/eq encoding still diverges from cake's labels.
+# sat enumerates the involutions of three elements; unsat is a four-into-three
+# pigeonhole (the involution cannot make four variables pairwise distinct over a
+# three-value domain).
+add_scp_chain_test(symmetric_all_different_sat    none)
+add_scp_chain_test(symmetric_all_different_unsat  none)
 
 # none (chain-only): element_2d -- result = array[i - off_i][j - off_j] over a
 # two-dimensional array. cake reads the array as a list of rows ((row) ...) and

--- a/verified_encodings/scp_cases/global_cardinality_closed_unsat.scp
+++ b/verified_encodings/scp_cases/global_cardinality_closed_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 2) (Y 0 2) (Z 0 2) (CA 2 2) (CB 2 2) ) ( (_1 boundsglobalcardinalityclosed (X Y Z) (0 1) (CA CB)) ) )

--- a/verified_encodings/scp_cases/symmetric_all_different_sat.scp
+++ b/verified_encodings/scp_cases/symmetric_all_different_sat.scp
@@ -1,0 +1,1 @@
+( ( (A 0 2) (B 0 2) (C 0 2) ) ( (_1 symmetric_all_different (A B C) 0) ) )

--- a/verified_encodings/scp_cases/symmetric_all_different_unsat.scp
+++ b/verified_encodings/scp_cases/symmetric_all_different_unsat.scp
@@ -1,0 +1,1 @@
+( ( (A 0 2) (B 0 2) (C 0 2) (D 0 2) ) ( (_1 symmetric_all_different (A B C D) 0) ) )


### PR DESCRIPTION
Stacked on #437.

## What

The eq-atom definition at a variable's lower/upper bound used a *compact* form (`eq(lower) ⇔ ~ge(lower+1)`, `eq(upper) ⇔ ge(upper)`) that dropped the trivial constant boundary order literals `ge(lower)` (always true) and `ge(ub+1)` (always false). `cake_pb_cp` defines those literals eagerly, so this lazy-vs-eager divergence (the #432 "boundary units" item) blocked `symmetric_all_different` and `global_cardinality_closed_unsat` from chaining.

This makes the **eager** form (`eq(v) ⇔ ge(v) ∧ ~ge(v+1)` for every value, bounds included) the **default**, gated behind a new `ProofOptions::use_compact_boolean_encoding` flag (**off by default**) so the compact encoding stays available as an option.

## The key enabler

`need_gevar`'s `fix_bound` now **always emits the boundary pin** (`ge(lower) = 1`, `ge(ub+1) = 0`) **as a persistent top-of-proof line, never as an OPB axiom**:

- That fact is a *consequence* of the variable's bound constraints, not a definition, so it never belonged in the OPB (cf. the opb-definitional-not-consequences rule); cake derives it the same way. Keeping it out of the OPB keeps our OPB byte-clean against cake's.
- Emitting it as a persistent **core** unit makes it survive VeriPB's post-`solx` enumeration restriction. Without that, the enumeration cases (`element`/`circuit`/`regular`) regress, because their per-value RUP steps need the boundary literal pinned, not re-derived from bits per use.

## Re-enabled chain cases (`none`)

- `symmetric_all_different_sat` + `symmetric_all_different_unsat`
- `global_cardinality_closed_unsat`

Comments corrected accordingly (the stale "symmetric needs a structural conform like sort/arg_sort" note is gone).

## Validation

`ctest` **443/443** caps-off (full enumeration). Strict byte-match chain cases unaffected.

## Note

The compact path is now exercised by no test (it's the old default, gated behind the off-by-default flag). It's deliberately divergent from cake's eager OPB, so the scp/cake chain isn't the vehicle for it; left unexercised for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)