### PR TITLE
Cake-named free-bit-sum proof-only integer variables (#432)

### DIFF
--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1641,24 +1641,19 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(ProofFlag flag) -> XLiteral
     return allocate_flag_xliteral(flag, format("f[{}][{}]", flag.index, name_of(flag)));
 }
 
-auto NamesAndIDsTracker::allocate_xliteral_meaning_negative_bit_of(SimpleOrProofOnlyIntegerVariableID id, Integer power) -> XLiteral
+auto NamesAndIDsTracker::allocate_xliteral_meaning_negative_bit_of(
+    SimpleOrProofOnlyIntegerVariableID id, Integer power, const optional<string> & name_override) -> XLiteral
 {
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
-        overloaded{
-            [&](const SimpleIntegerVariableID & id) -> void {
-                string name = format("i[{}][sign]", name_of(id));
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
-            }, //
-            [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
-                string name = format("p[{}_{}][sign]", id.index, name_of(id));
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
-            } //
-        }
-            .visit(id);
+        string name = name_override
+            ? *name_override
+            : visit(overloaded{[&](const SimpleIntegerVariableID & id) { return format("i[{}][sign]", name_of(id)); },
+                        [&](const ProofOnlySimpleIntegerVariableID & id) { return format("p[{}_{}][sign]", id.index, name_of(id)); }},
+                  id);
+        _imp->xlits_to_verbose_names.emplace(result, name);
+        _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
     }
 
     if (_imp->variables_map_file) {
@@ -1689,24 +1684,22 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning_negative_bit_of(SimpleOrProof
     return result;
 }
 
-auto NamesAndIDsTracker::allocate_xliteral_meaning_bit_of(SimpleOrProofOnlyIntegerVariableID id, Integer power) -> XLiteral
+auto NamesAndIDsTracker::allocate_xliteral_meaning_bit_of(
+    SimpleOrProofOnlyIntegerVariableID id, Integer power, const optional<string> & name_override) -> XLiteral
 {
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
-        overloaded{
-            [&](const SimpleIntegerVariableID & id) -> void {
-                string name = format("i[{}][b{}]", name_of(id), power);
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
-            }, //
-            [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
-                string name = format("p[{}_{}][b{}]", id.index, name_of(id), power);
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
-            } //
-        }
-            .visit(id);
+        // name_override lets a proof-only variable's bits be named in a caller-chosen
+        // scheme (cake_pb_cp's value flags) rather than the default p[index_name][b];
+        // the literal is still the variable's bit, only named.
+        string name = name_override
+            ? *name_override
+            : visit(overloaded{[&](const SimpleIntegerVariableID & id) { return format("i[{}][b{}]", name_of(id), power); },
+                        [&](const ProofOnlySimpleIntegerVariableID & id) { return format("p[{}_{}][b{}]", id.index, name_of(id), power); }},
+                  id);
+        _imp->xlits_to_verbose_names.emplace(result, name);
+        _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
     }
 
     if (_imp->variables_map_file) {

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -487,12 +487,14 @@ namespace gcs::innards
         /**
          * Allocate an XLiteral with the given semantic meaning.
          */
-        [[nodiscard]] auto allocate_xliteral_meaning_negative_bit_of(SimpleOrProofOnlyIntegerVariableID flag, Integer power) -> XLiteral;
+        [[nodiscard]] auto allocate_xliteral_meaning_negative_bit_of(
+            SimpleOrProofOnlyIntegerVariableID flag, Integer power, const std::optional<std::string> & name_override = std::nullopt) -> XLiteral;
 
         /**
          * Allocate an XLiteral with the given semantic meaning.
          */
-        [[nodiscard]] auto allocate_xliteral_meaning_bit_of(SimpleOrProofOnlyIntegerVariableID flag, Integer power) -> XLiteral;
+        [[nodiscard]] auto allocate_xliteral_meaning_bit_of(
+            SimpleOrProofOnlyIntegerVariableID flag, Integer power, const std::optional<std::string> & name_override = std::nullopt) -> XLiteral;
 
         /**
          * Track a human-readable name for a variable.

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -336,10 +336,17 @@ auto ProofModel::names_and_ids_tracker() const -> const NamesAndIDsTracker &
     return _imp->tracker;
 }
 
-auto ProofModel::create_proof_only_integer_variable(Integer lower, Integer upper, const string & name, const IntegerVariableProofRepresentation rep)
-    -> ProofOnlySimpleIntegerVariableID
+auto ProofModel::create_proof_only_integer_variable(Integer lower, Integer upper, const string & name, const IntegerVariableProofRepresentation rep,
+    const optional<CakeBitNaming> & bit_naming) -> ProofOnlySimpleIntegerVariableID
 {
     ProofOnlySimpleIntegerVariableID id{_imp->proof_only_integer_variable_nr++};
+    if (bit_naming) {
+        // cake names its position/rank/value auxiliaries as free bit-sums with no
+        // bound constraints in the OPB; register the (cake-named) bits only, so the
+        // variable's eq/ge atoms are introduced lazily in the proof when first used.
+        register_bits_variable_encoding(id, lower, upper, name, bit_naming);
+        return id;
+    }
     switch (rep) {
     case IntegerVariableProofRepresentation::DirectOnly: set_up_direct_only_variable_encoding(id, lower, upper, name); break;
     case IntegerVariableProofRepresentation::Bits: set_up_bits_variable_encoding(id, lower, upper, name); break;
@@ -453,7 +460,8 @@ auto ProofModel::set_up_integer_variable(
     }
 }
 
-auto ProofModel::register_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableID id, Integer lower, Integer upper, const string & name) -> void
+auto ProofModel::register_bits_variable_encoding(
+    SimpleOrProofOnlyIntegerVariableID id, Integer lower, Integer upper, const string & name, const optional<CakeBitNaming> & bit_naming) -> void
 {
     // The "register" half of a bits encoding: allocate and name the bit literals
     // and record the bounds, but emit nothing to the OPB. set_up_bits_variable_encoding
@@ -462,15 +470,40 @@ auto ProofModel::register_bits_variable_encoding(SimpleOrProofOnlyIntegerVariabl
     // (e.g. via ProofLogger::introduce_bits_of) rather than asserted in the model.
     auto [highest_bit_shift, highest_bit_coeff, negative_bit_coeff] = get_bits_encoding_coeffs(lower, upper);
     vector<pair<Integer, XLiteral>> bits;
+    auto & tracker = names_and_ids_tracker();
+    tracker.track_variable_name(id, name);
 
-    names_and_ids_tracker().track_variable_name(id, name);
-    if (0_i != negative_bit_coeff)
-        bits.emplace_back(negative_bit_coeff, names_and_ids_tracker().allocate_xliteral_meaning_negative_bit_of(id, negative_bit_coeff));
-    for (Integer b = 0_i; b <= highest_bit_shift; ++b)
-        bits.emplace_back(power2(b), names_and_ids_tracker().allocate_xliteral_meaning_bit_of(id, Integer{b}));
+    // With a CakeBitNaming, a bit is named v[id][values...][annotation] (as
+    // create_proof_flag_values would); the value bits carry the bit number as the
+    // final index and the sign bit does not. Without one, name_override is nullopt
+    // and the tracker uses the default p[index_name][b] names.
+    auto cake_bit_name = [&](const vector<long long> & values, const string & annotation) -> optional<string> {
+        if (! bit_naming)
+            return nullopt;
+        string s = "v[" + as_string(bit_naming->id) + "][";
+        for (size_t k = 0; k < values.size(); ++k)
+            s += (k != 0 ? "_" : "") + std::to_string(values[k]);
+        return s + "][" + annotation + "]";
+    };
 
-    names_and_ids_tracker().track_bits(id, negative_bit_coeff, bits);
-    names_and_ids_tracker().track_bounds(id, lower, upper);
+    if (0_i != negative_bit_coeff) {
+        if (bit_naming && ! bit_naming->sign_annotation)
+            throw ProofError{"a signed cake-named proof-only variable needs a sign annotation to name its sign bit"};
+        auto sign_name = bit_naming ? cake_bit_name(bit_naming->indices, *bit_naming->sign_annotation) : nullopt;
+        bits.emplace_back(negative_bit_coeff, tracker.allocate_xliteral_meaning_negative_bit_of(id, negative_bit_coeff, sign_name));
+    }
+    for (Integer b = 0_i; b <= highest_bit_shift; ++b) {
+        optional<string> value_name;
+        if (bit_naming) {
+            auto values = bit_naming->indices;
+            values.push_back(b.raw_value);
+            value_name = cake_bit_name(values, bit_naming->value_annotation);
+        }
+        bits.emplace_back(power2(b), tracker.allocate_xliteral_meaning_bit_of(id, Integer{b}, value_name));
+    }
+
+    tracker.track_bits(id, negative_bit_coeff, bits);
+    tracker.track_bounds(id, lower, upper);
 }
 
 auto ProofModel::set_up_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableID id, Integer lower, Integer upper, const string & name) -> void

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -27,6 +27,24 @@ namespace gcs::innards
         char const * value;
     };
 
+    /**
+     * \brief How to name a proof-only integer variable's bit literals to match
+     * cake_pb_cp's value-flag scheme, instead of the default `p[index_name][b]`:
+     * value bit b becomes `v[id][indices..._b][value_annotation]` and a
+     * two's-complement variable's sign bit becomes `v[id][indices...][sign_annotation]`
+     * (required when the range is negative). The bits are still the variable's bits;
+     * only their names change. Passing one to create_proof_only_integer_variable also
+     * makes the variable a free bit-sum (no OPB bound lines), matching how cake encodes
+     * these auxiliaries. Mirrors NamesAndIDsTracker::create_proof_flag_values.
+     */
+    struct CakeBitNaming
+    {
+        ConstraintID id;
+        std::vector<long long> indices;
+        std::string value_annotation;
+        std::optional<std::string> sign_annotation;
+    };
+
     class ProofModel
     {
     private:
@@ -44,8 +62,10 @@ namespace gcs::innards
         // Register a bits encoding (allocate/name the bit literals, track bounds)
         // without emitting anything to the OPB. The shared "register" half of
         // set_up_bits_variable_encoding and create_proof_only_integer_variable_in_proof;
-        // the registered bits are then readable via the tracker's each_bit.
-        auto register_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
+        // the registered bits are then readable via the tracker's each_bit. With a
+        // CakeBitNaming the bit literals are named in cake's value-flag scheme.
+        auto register_bits_variable_encoding(
+            SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &, const std::optional<CakeBitNaming> & = std::nullopt) -> void;
 
         auto set_up_bits_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
 
@@ -200,9 +220,16 @@ namespace gcs::innards
 
         /**
          * Create a variable ID that is used only in proof definitions, not state.
+         *
+         * With a CakeBitNaming, the variable's bits are named in cake_pb_cp's
+         * value-flag scheme (see CakeBitNaming) and nothing is emitted to the OPB
+         * (the variable is a free bit-sum, matching how cake encodes such an
+         * auxiliary); its eq/ge atoms are then introduced lazily in the proof when
+         * first used. Without one, the encoding (with OPB bound constraints) is
+         * written as usual under the default `p[index_name][b]` names.
          */
-        [[nodiscard]] auto create_proof_only_integer_variable(Integer, Integer, const std::string &, const IntegerVariableProofRepresentation enc)
-            -> ProofOnlySimpleIntegerVariableID;
+        [[nodiscard]] auto create_proof_only_integer_variable(Integer, Integer, const std::string &, const IntegerVariableProofRepresentation enc,
+            const std::optional<CakeBitNaming> & = std::nullopt) -> ProofOnlySimpleIntegerVariableID;
 
         /**
          * Create a bits-encoded proof-only variable whose encoding is NOT emitted


### PR DESCRIPTION
Extracts the `CakeBitNaming` primitive so it sits **below** its first users (value_precede, sort, arg_sort) instead of being introduced mid-stack. This is the base of the reworked verified-encoding stack: #439 (value_precede), #441 (sort), and #442 (arg_sort) all build on it.

### What it adds

A proof-only integer variable can now be created with a `CakeBitNaming`: its bits are named in cake_pb_cp's value-flag scheme (`v[id][indices..._b][annot]`, with an optional sign annotation) instead of the default `p[index_name][b]`, and it is registered as a **free bit-sum with no OPB bound lines** — so its eq/ge atoms are introduced lazily in the proof on first use. That's exactly how cake encodes its position/rank/value auxiliaries, letting a constraint reason over a real `ProofOnlySimpleIntegerVariableID` whose bits line up with cake's, instead of hand-rolling the bits as separate flags.

- `CakeBitNaming` struct + `create_proof_only_integer_variable` overload (`proof_model.{hh,cc}`);
- `register_bits_variable_encoding` free-bit-sum path (`proof_model.cc`);
- `name_override` on `allocate_xliteral_meaning_bit_of` / `allocate_xliteral_meaning_negative_bit_of` (`names_and_ids_tracker.{hh,cc}`).

### Notes

- **No functional change on its own** — the primitive is unused until the constraints above adopt it; the full suite is unchanged (`ctest` 453/453).
- This code was originally introduced inside the sort conform (#441); it's been pulled out to the bottom of the stack so value_precede (#439) can build its `pos[v]` on it too rather than faking a proof-only integer variable out of flags. #441 is correspondingly slimmed to just its sort usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pevHBYXbX3o1LeHEyH3WR