### PR TITLE
PolBuilder: add weaken(), convert the last hand-written pol line (#196)

### DIFF
--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -382,7 +382,11 @@ namespace
                 // Redundance subproof:
                 auto subproofs = make_optional(map<ProofGoal, Subproof>{});
                 auto subproof = [&](ProofLogger & logger) {
-                    logger.emit_proof_line("pol -2 " + logger.names_and_ids_tracker().pb_file_string_for(greater_than_flag) + " w;", ProofLevel::Top);
+                    // Weaken greater_than_flag out of the reverse-reified definition two
+                    // lines back (relative reference -2, passed through unchanged).
+                    PolBuilder weaken_flag;
+                    weaken_flag.add(ProofLineNumber{-2}).weaken(greater_than_flag, logger.names_and_ids_tracker());
+                    weaken_flag.emit(logger, ProofLevel::Top);
                     for (long k = 0; cmp_less(k, ctx.succ.size()); k++) {
                         PolBuilder p_line;
                         // Prove p[i] = k is not possible

--- a/gcs/innards/proofs/pol_builder.cc
+++ b/gcs/innards/proofs/pol_builder.cc
@@ -112,6 +112,12 @@ auto PolBuilder::divide_by(Integer n) -> PolBuilder &
     return *this;
 }
 
+auto PolBuilder::weaken(const ProofFlag & flag, const NamesAndIDsTracker & tracker) -> PolBuilder &
+{
+    _tokens.emplace_back(" " + tracker.pb_file_string_for(flag) + " w");
+    return *this;
+}
+
 auto PolBuilder::empty() const -> bool
 {
     return _empty;

--- a/gcs/innards/proofs/pol_builder.hh
+++ b/gcs/innards/proofs/pol_builder.hh
@@ -171,6 +171,15 @@ namespace gcs::innards
         auto divide_by(Integer n) -> PolBuilder &;
 
         /**
+         * Apply `<flag> w` to the stack top: VeriPB's weaken rule, which
+         * relaxes the running constraint by dropping the term on `flag`. The
+         * flag is resolved to its file-format string via the tracker. (Only a
+         * `ProofFlag` operand is provided, as that is the sole in-tree weaken
+         * site; add further overloads here if another literal kind needs it.)
+         */
+        auto weaken(const ProofFlag & flag, const NamesAndIDsTracker & tracker) -> PolBuilder &;
+
+        /**
          * Has anything been pushed?
          *
          * Callers that conditionally emit (e.g. only when the loop body

--- a/gcs/innards/proofs/pol_builder_test.cc
+++ b/gcs/innards/proofs/pol_builder_test.cc
@@ -98,6 +98,20 @@ TEST_CASE("PolBuilder: reusable across clear")
     CHECK(b.str() == "pol 9 ;");
 }
 
+TEST_CASE("PolBuilder: non-positive line numbers pass through as already-relative references")
+{
+    // circuit_scc.cc weakens a flag out of the constraint two lines back,
+    // referenced relatively as -2 (`pol -2 <flag> w`). relative_proof_line()
+    // treats non-positive numbers as already-relative and leaves them
+    // unchanged, so PolBuilder::add must carry them through verbatim rather
+    // than re-offsetting them. (The `weaken` half needs a tracker to resolve
+    // the flag and is covered end-to-end by the circuit proof's VeriPB check,
+    // as with the other tracker-dependent add overloads.)
+    PolBuilder b;
+    b.add(ProofLineNumber{-2});
+    CHECK(b.str() == "pol -2 ;");
+}
+
 TEST_CASE("PolBuilder: str is non-mutating")
 {
     PolBuilder b;


### PR DESCRIPTION
Closes the final loose end of #196: the codebase had exactly one remaining hand-written `pol` line — the circuit SCC propagator's `pol -2 <flag> w;`, which weakens a greater-than flag out of the reverse-reified definition two lines back. It was left as a `stringstream`-style emit because `PolBuilder` exposed no weaken (`w`) operator.

## Changes

- **`PolBuilder::weaken(const ProofFlag &, const NamesAndIDsTracker &)`** — appends ` <flag> w`, resolving the flag via `pb_file_string_for` (mirroring the existing tracker-dependent `add` overloads). A doc-comment notes only the `ProofFlag` operand is provided, since that is the sole in-tree weaken site.
- **Convert `circuit_scc.cc`** to `PolBuilder`. The relative `-2` reference is carried through `add(ProofLineNumber{-2})`: `relative_proof_line` treats non-positive numbers as already-relative and passes them through unchanged, so the emitted reference is byte-identical. The only difference is the insignificant `w;` → `w ;` spacing, which matches every other PolBuilder-emitted line.
- **Unit test** for the non-positive pass-through (the subtle half of the conversion). The `weaken` wire format is covered end-to-end by the circuit SCC proof's VeriPB check, consistent with how the other tracker-dependent overloads are (not) unit-tested in this file.

## Verification

- `pol_builder_test` passes (new case included).
- All 19 circuit ctests pass, including the cake chain-verify pair `scp_chain_circuit_{sat,unsat}`.
- Confirmed the generated SCC proof now emits `pol -2 f[41][d[5][4]] w ;` (2 occurrences) and VeriPB reports `s VERIFIED UNSATISFIABLE`.

With this, every common `pol` pattern goes through `PolBuilder` and no hand-written `pol` lines remain in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)