### PR TITLE
Fluent constraint options: linear-equality family (#299)

### DIFF
--- a/examples/crystal_maze/crystal_maze.cc
+++ b/examples/crystal_maze/crystal_maze.cc
@@ -101,8 +101,9 @@ auto main(int argc, char * argv[]) -> int
             p.post(NotEquals{diffs.back(), -1_c});
         }
 
-        p.post(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i,
-            options_vars.contains("gac") ? LinearEqualityConsistency{consistency::Tabulated{}} : LinearEqualityConsistency{consistency::BC{}}});
+        p.post(LinearEquality{WeightedSum{} + 1_i * xs[x1] + -1_i * xs[x2] + -1_i * diffs.back(), 0_i} //
+                .with_consistency(options_vars.contains("gac") ? LinearEqualityConsistency{consistency::Tabulated{}}
+                                                               : LinearEqualityConsistency{consistency::BC{}}));
     }
 
     optional<ProofOptions> proof_options;

--- a/examples/knapsack/knapsack.cc
+++ b/examples/knapsack/knapsack.cc
@@ -77,7 +77,8 @@ auto main(int argc, char * argv[]) -> int
     vector<Integer> profits = {2_i, 4_i, 2_i, 5_i, 4_i, 3_i};
 
     auto oddity = p.create_integer_variable(0_i, 20_i, "oddity");
-    p.post(LinearEquality{WeightedSum{} + 1_i * profit + -2_i * oddity, 1_i, consistency::Tabulated{}});
+    p.post(LinearEquality{WeightedSum{} + 1_i * profit + -2_i * oddity, 1_i} //
+            .with_consistency(consistency::Tabulated{}));
 
     p.post(WeightedSum{} + 1_i * items[5] == 0_i);
 

--- a/examples/odd_even_sum/odd_even_sum.cc
+++ b/examples/odd_even_sum/odd_even_sum.cc
@@ -69,8 +69,10 @@ auto main(int argc, char * argv[]) -> int
     auto d = p.create_integer_variable(0_i, 10_i, "d");
     auto e = p.create_integer_variable(0_i, 2_i, "e");
 
-    p.post(LinearEquality{WeightedSum{} + 2_i * a + 2_i * b + 2_i * c + -2_i * d + 1_i * e, 1_i, consistency::Tabulated{}});
-    p.post(LinearEquality{WeightedSum{} + -2_i * a + 2_i * b + -2_i * c + 2_i * d + 1_i * e, 1_i, consistency::Tabulated{}});
+    p.post(LinearEquality{WeightedSum{} + 2_i * a + 2_i * b + 2_i * c + -2_i * d + 1_i * e, 1_i} //
+            .with_consistency(consistency::Tabulated{}));
+    p.post(LinearEquality{WeightedSum{} + -2_i * a + 2_i * b + -2_i * c + 2_i * d + 1_i * e, 1_i} //
+            .with_consistency(consistency::Tabulated{}));
 
     auto stats = solve(
         p,

--- a/examples/skyscrapers/skyscrapers.cc
+++ b/examples/skyscrapers/skyscrapers.cc
@@ -234,7 +234,8 @@ auto main(int argc, char * argv[]) -> int
                     p.post(EqualsIff{how_many_hidden, constant_variable(0_i), *visible_vars[downwards ? r : c][downwards ? c : r] == 1_i});
                 }
             }
-            p.post(LinearEquality{move(how_many_visible), Integer(target[c]), consistency::Tabulated{}});
+            p.post(LinearEquality{move(how_many_visible), Integer(target[c])} //
+                    .with_consistency(consistency::Tabulated{}));
         }
     };
 

--- a/examples/sudoku/sudoku.cc
+++ b/examples/sudoku/sudoku.cc
@@ -178,13 +178,20 @@ auto main(int argc, char * argv[]) -> int
             for (int r = 0; r < n - 1; ++r)
                 switch (vertical_xvs[c][r]) {
                 case N: break;
-                case V: p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 5_i, consistency::Tabulated{}}); break;
-                case X: p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 10_i, consistency::Tabulated{}}); break;
+                case V:
+                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 5_i} //
+                            .with_consistency(consistency::Tabulated{}));
+                    break;
+                case X:
+                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c], 10_i} //
+                            .with_consistency(consistency::Tabulated{}));
+                    break;
                 case O:
                     auto sum = p.create_integer_variable(0_i, Integer{n * 2});
                     p.post(NotEquals{sum, 5_c});
                     p.post(NotEquals{sum, 10_c});
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c] + -1_i * sum, 0_i, consistency::Tabulated{}});
+                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r + 1][c] + -1_i * sum, 0_i} //
+                            .with_consistency(consistency::Tabulated{}));
                     break;
                 }
 
@@ -192,13 +199,20 @@ auto main(int argc, char * argv[]) -> int
             for (int c = 0; c < n - 1; ++c)
                 switch (horizontal_xvs[r][c]) {
                 case N: break;
-                case V: p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 5_i, consistency::Tabulated{}}); break;
-                case X: p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 10_i, consistency::Tabulated{}}); break;
+                case V:
+                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 5_i} //
+                            .with_consistency(consistency::Tabulated{}));
+                    break;
+                case X:
+                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1], 10_i} //
+                            .with_consistency(consistency::Tabulated{}));
+                    break;
                 case O:
                     auto sum = p.create_integer_variable(0_i, Integer{n * 2});
                     p.post(NotEquals{sum, 5_c});
                     p.post(NotEquals{sum, 10_c});
-                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1] + -1_i * sum, 0_i, consistency::Tabulated{}});
+                    p.post(LinearEquality{WeightedSum{} + 1_i * grid[r][c] + 1_i * grid[r][c + 1] + -1_i * sum, 0_i} //
+                            .with_consistency(consistency::Tabulated{}));
                     break;
                 }
     }

--- a/gcs/consistency.hh
+++ b/gcs/consistency.hh
@@ -7,19 +7,19 @@ namespace gcs
      * \defgroup Consistency Selecting a consistency level or propagation algorithm
      *
      * Some constraints can achieve more than one level of consistency, usually
-     * with stronger levels costing more per search node. Such a constraint's
-     * constructor takes a `std::variant` over tag types naming exactly the
-     * levels it supports, defaulted to a sensible choice, for example
+     * with stronger levels costing more per search node. Such a constraint
+     * exposes a `with_consistency()` fluent setter taking a `std::variant` over
+     * tag types naming exactly the levels it supports, defaulted to a sensible
+     * choice, for example
      *
      * \code{.cc}
-     * problem.post(LinearEquality{sum, 5_i, consistency::Tabulated{}});
+     * problem.post(LinearEquality{sum, 5_i}.with_consistency(consistency::Tabulated{}));
      * \endcode
      *
      * Requesting a level a constraint does not support is a compile-time
-     * error: the constructor signature is the documentation. These tags
-     * select propagation strength only; they never change the constraint's
-     * meaning, and they never change how the constraint is encoded for proof
-     * logging.
+     * error: the setter's signature is the documentation. These tags select
+     * propagation strength only; they never change the constraint's meaning,
+     * and they never change how the constraint is encoded for proof logging.
      */
 
     namespace consistency

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -57,11 +57,21 @@ using std::print;
 using fmt::print;
 #endif
 
-ReifiedLinearEquality::ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition cond, LinearEqualityConsistency level,
-    bool flipped_cond, std::optional<std::size_t> incremental_threshold) :
-    _coeff_vars(move(coeff_vars)), _value(value), _reif_cond(cond), _level(level), _flipped_cond(flipped_cond),
-    _incremental_threshold(incremental_threshold)
+ReifiedLinearEquality::ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition cond, bool flipped_cond) :
+    _coeff_vars(move(coeff_vars)), _value(value), _reif_cond(cond), _flipped_cond(flipped_cond)
 {
+}
+
+auto ReifiedLinearEquality::with_consistency(LinearEqualityConsistency level) -> ReifiedLinearEquality &
+{
+    _level = level;
+    return *this;
+}
+
+auto ReifiedLinearEquality::with_incremental_threshold(std::optional<std::size_t> threshold) -> ReifiedLinearEquality &
+{
+    _incremental_threshold = threshold;
+    return *this;
 }
 
 auto ReifiedLinearEquality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
@@ -436,12 +446,12 @@ auto ReifiedLinearEquality::s_expr(const ProofModel * const model) const -> SExp
 
 auto ReifiedLinearEquality::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<ReifiedLinearEquality>(WeightedSum{_coeff_vars}, _value, _reif_cond, _level, _flipped_cond, _incremental_threshold);
+    auto cloned = make_unique<ReifiedLinearEquality>(WeightedSum{_coeff_vars}, _value, _reif_cond, _flipped_cond);
+    cloned->with_consistency(_level).with_incremental_threshold(_incremental_threshold);
+    return cloned;
 }
 
-LinearEquality::LinearEquality(
-    WeightedSum coeff_vars, Integer value, LinearEqualityConsistency level, std::optional<std::size_t> incremental_threshold) :
-    ReifiedLinearEquality(coeff_vars, value, reif::MustHold{}, level, false, incremental_threshold)
+LinearEquality::LinearEquality(WeightedSum coeff_vars, Integer value) : ReifiedLinearEquality(move(coeff_vars), value, reif::MustHold{})
 {
 }
 
@@ -459,27 +469,26 @@ namespace
     }
 }
 
-LinearEqualityIf::LinearEqualityIf(WeightedSum coeff_vars, Integer value, Literal cond, LinearEqualityConsistency level) :
-    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::If>(cond), level)
+LinearEqualityIf::LinearEqualityIf(WeightedSum coeff_vars, Integer value, Literal cond) :
+    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::If>(cond))
 {
 }
 
-LinearEqualityIff::LinearEqualityIff(WeightedSum coeff_vars, Integer value, Literal cond, LinearEqualityConsistency level) :
-    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::Iff>(cond), level)
+LinearEqualityIff::LinearEqualityIff(WeightedSum coeff_vars, Integer value, Literal cond) :
+    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::Iff>(cond))
 {
 }
 
-LinearNotEquals::LinearNotEquals(WeightedSum coeff_vars, Integer value, LinearEqualityConsistency level) :
-    ReifiedLinearEquality(move(coeff_vars), value, reif::MustNotHold{}, level)
+LinearNotEquals::LinearNotEquals(WeightedSum coeff_vars, Integer value) : ReifiedLinearEquality(move(coeff_vars), value, reif::MustNotHold{})
 {
 }
 
-LinearNotEqualsIf::LinearNotEqualsIf(WeightedSum coeff_vars, Integer value, Literal cond, LinearEqualityConsistency level) :
-    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::NotIf>(cond), level)
+LinearNotEqualsIf::LinearNotEqualsIf(WeightedSum coeff_vars, Integer value, Literal cond) :
+    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::NotIf>(cond))
 {
 }
 
-LinearNotEqualsIff::LinearNotEqualsIff(WeightedSum coeff_vars, Integer value, Literal cond, LinearEqualityConsistency level) :
-    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::Iff>(! cond), level, true)
+LinearNotEqualsIff::LinearNotEqualsIff(WeightedSum coeff_vars, Integer value, Literal cond) :
+    ReifiedLinearEquality(move(coeff_vars), value, literal_to_reif<reif::Iff>(! cond), true)
 {
 }

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -43,11 +43,11 @@ namespace gcs
         WeightedSum _coeff_vars;
         Integer _value;
         ReificationCondition _reif_cond;
-        LinearEqualityConsistency _level;
         bool _flipped_cond;
+        LinearEqualityConsistency _level = consistency::BC{};
         // Per-constraint width at/above which to use the incremental propagator; unset
         // means use innards::default_linear_incremental_threshold().
-        std::optional<std::size_t> _incremental_threshold;
+        std::optional<std::size_t> _incremental_threshold = std::nullopt;
         std::optional<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _proof_line;
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
 
@@ -58,9 +58,23 @@ namespace gcs
         auto install_propagators(innards::Propagators &, innards::State &) -> void;
 
     public:
-        explicit ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition reif_cond,
-            LinearEqualityConsistency level = consistency::BC{}, bool flipped_cond = false,
-            std::optional<std::size_t> incremental_threshold = std::nullopt);
+        // flipped_cond is internal reification plumbing, set by the derived NotEqualsIff
+        // form; it is not user configuration. Propagation strength and the incremental
+        // threshold are chosen after construction via with_consistency() and
+        // with_incremental_threshold().
+        explicit ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition reif_cond, bool flipped_cond = false);
+
+        /**
+         * \brief Select the consistency level: bounds consistency (the default) or
+         * consistency::Tabulated. Requesting any other level is a compile-time error.
+         */
+        auto with_consistency(LinearEqualityConsistency level) -> ReifiedLinearEquality &;
+
+        /**
+         * \brief Set the per-constraint scope width at or above which the incremental
+         * (fixed-term-folding) propagator is used; unset means the solver default.
+         */
+        auto with_incremental_threshold(std::optional<std::size_t> threshold) -> ReifiedLinearEquality &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
 
@@ -71,39 +85,37 @@ namespace gcs
     class LinearEquality : public ReifiedLinearEquality
     {
     public:
-        explicit LinearEquality(WeightedSum coeff_vars, Integer value, LinearEqualityConsistency level = consistency::BC{},
-            std::optional<std::size_t> incremental_threshold = std::nullopt);
+        explicit LinearEquality(WeightedSum coeff_vars, Integer value);
     };
 
     class LinearEqualityIf : public ReifiedLinearEquality
     {
     public:
-        explicit LinearEqualityIf(WeightedSum coeff_vars, Integer value, innards::Literal cond, LinearEqualityConsistency level = consistency::BC{});
+        explicit LinearEqualityIf(WeightedSum coeff_vars, Integer value, innards::Literal cond);
     };
 
     class LinearEqualityIff : public ReifiedLinearEquality
     {
     public:
-        explicit LinearEqualityIff(WeightedSum coeff_vars, Integer value, innards::Literal cond, LinearEqualityConsistency level = consistency::BC{});
+        explicit LinearEqualityIff(WeightedSum coeff_vars, Integer value, innards::Literal cond);
     };
 
     class LinearNotEquals : public ReifiedLinearEquality
     {
     public:
-        explicit LinearNotEquals(WeightedSum coeff_vars, Integer value, LinearEqualityConsistency level = consistency::BC{});
+        explicit LinearNotEquals(WeightedSum coeff_vars, Integer value);
     };
 
     class LinearNotEqualsIf : public ReifiedLinearEquality
     {
     public:
-        explicit LinearNotEqualsIf(WeightedSum coeff_vars, Integer value, innards::Literal cond, LinearEqualityConsistency level = consistency::BC{});
+        explicit LinearNotEqualsIf(WeightedSum coeff_vars, Integer value, innards::Literal cond);
     };
 
     class LinearNotEqualsIff : public ReifiedLinearEquality
     {
     public:
-        explicit LinearNotEqualsIff(
-            WeightedSum coeff_vars, Integer value, innards::Literal cond, LinearEqualityConsistency level = consistency::BC{});
+        explicit LinearNotEqualsIff(WeightedSum coeff_vars, Integer value, innards::Literal cond);
     };
 }
 

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -128,7 +128,7 @@ auto run_linear_test_gac(bool proofs, const string & mode, const ViewWrapConfig 
         for (const auto & [idx, coeff] : enumerate(linear))
             if (coeff != 0)
                 c += Integer{coeff} * vs[idx];
-        p.post(Constraint_{c, Integer{value}, consistency::Tabulated{}});
+        p.post(Constraint_{c, Integer{value}}.with_consistency(consistency::Tabulated{}));
     }
 
     auto proof_name =
@@ -243,7 +243,7 @@ auto run_linear_reif_test_gac(bool full_reif, bool proofs, const string & mode, 
             for (const auto & [idx, coeff] : enumerate(linear))
                 if (coeff != 0)
                     c += Integer{coeff} * vs[idx];
-            p.post(Constraint_{c, Integer{value}, v4 == 1_i, consistency::Tabulated{}});
+            p.post(Constraint_{c, Integer{value}, v4 == 1_i}.with_consistency(consistency::Tabulated{}));
         }
 
         auto proof_name =

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -111,7 +111,8 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
                     tidied);
             }}.visit(_level);
 
-        LinearEquality resolved{move(sum), value, linear_level};
+        LinearEquality resolved{move(sum), value};
+        resolved.with_consistency(linear_level);
         resolved.set_constraint_id(constraint_id());
         move(resolved).install(propagators, initial_state, optional_model);
         return;

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -315,7 +315,8 @@ namespace
 
         // Equality family: lin_equals* and lin_not_equals*.
         auto [cond, flipped_cond] = equality_reification(op.starts_with("lin_not_equals"), iff, half, variables, terms[2]);
-        post_constraint(problem, ReifiedLinearEquality{std::move(coeff_vars), value, cond, consistency::BC{}, flipped_cond}, label);
+        // Consistency isn't recorded in the .scp; reconstruct with the default (BC).
+        post_constraint(problem, ReifiedLinearEquality{std::move(coeff_vars), value, cond, flipped_cond}, label);
     }
 
     // The equals family: (label <equals|not_equals>[_if|_iff] [(cond)] v1 v2),


### PR DESCRIPTION
**First slice of the fluent constraint-options cleanup** (tracking #299). This establishes the pattern on one family so the shape can be reviewed before rolling it across the rest.

## What changes

Per the agreed direction, constraint constructors should take **only variables and data**; configuration moves to fluent `.with_*()` setters. For the linear-equality family:

```cpp
// before
p.post(LinearEquality{sum, 5_i, consistency::Tabulated{}});
// after
p.post(LinearEquality{sum, 5_i}.with_consistency(consistency::Tabulated{}));
```

- `ReifiedLinearEquality` gains `with_consistency(LinearEqualityConsistency)` and `with_incremental_threshold(std::optional<std::size_t>)`; the `level`/`incremental_threshold` constructor parameters are removed from it and all six derived classes (`LinearEquality`, `LinearEqualityIf/Iff`, `LinearNotEquals`, `LinearNotEqualsIf/Iff`).
- **Compile-time safety preserved:** `with_consistency()` takes the family's own `std::variant<consistency::BC, consistency::Tabulated>`, so requesting an unsupported level is still a compile error — this is why reversing #299's constructor-arg choice costs nothing on safety.
- `clone()` rebuilds through the setters (as suggested for clone in the design discussion).
- `flipped_cond` stays an internal base-constructor parameter — it's reification plumbing, not user configuration (#299 scoped it out).
- `consistency.hh`'s group doc updated to describe the setter instead of the constructor arg.

## Note on #299

This deliberately **reverses the constructor-`std::variant` decision recorded in #299** in favour of the fluent setter, keeping the same compile-time guarantees. The remaining families (arithmetic, Element, SmartTable/Regular, and the collapsing type-families AllDifferent/GlobalCardinality/Circuit) follow in subsequent PRs. I'll update the #299 write-up once the mechanism is agreed here.

## Migrated call sites

`sudoku`, `skyscrapers`, `odd_even_sum`, `knapsack`, the internal `Multiply` single-operand delegation, `scp_reader` reconstruction, and `linear_test`.

## Verification

- `ctest -R "linear|scp|multiply"` → **168/168**, including the cake chain-verify `scp_chain_*` tests.
- `odd_even_sum --prove` → `VERIFIED COMPLETE ENUMERATION`; `sudoku`/`skyscrapers`/`knapsack` solve.
- clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)