### PR TITLE
Fluent constraint options: arithmetic family (#299)

### DIFF
--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -91,7 +91,8 @@ auto main(int argc, char * argv[]) -> int
         // position[i + k] = position[i] + i + 2, tabulated for GAC (this was
         // written for the old PlusGAC, and Auto would fall back to bounds
         // consistency once the positions range over more than ten values)
-        p.post(Plus{position[i + k], constant_variable(Integer{i + 2}), position[i], consistency::Tabulated{}});
+        p.post(Plus{position[i + k], constant_variable(Integer{i + 2}), position[i]} //
+                .with_consistency(consistency::Tabulated{}));
     }
 
     auto stats = solve(

--- a/examples/shikaku/shikaku.cc
+++ b/examples/shikaku/shikaku.cc
@@ -165,7 +165,8 @@ auto main(int argc, char * argv[]) -> int
         // Area = clue, as a (deliberately weak) bounds-consistent product:
         // pinned to BC so that --autotable stays meaningful, since the Auto
         // default would tabulate to GAC at these domain sizes.
-        p.post(Multiply{w, h, area, consistency::BC{}});
+        p.post(Multiply{w, h, area} //
+                .with_consistency(consistency::BC{}));
         // The rectangle covers the clue cell: x + w >= c + 1, y + h >= r + 1.
         p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * x + 1_i * w, Integer{c + 1}});
         p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * y + 1_i * h, Integer{r + 1}});

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -347,14 +347,21 @@ namespace
     }
 }
 
-Divide::Divide(IntegerVariableID x, IntegerVariableID y, IntegerVariableID quotient, DivideConsistency level) :
-    _x(x), _y(y), _quotient(quotient), _level(level)
+Divide::Divide(IntegerVariableID x, IntegerVariableID y, IntegerVariableID quotient) : _x(x), _y(y), _quotient(quotient)
 {
+}
+
+auto Divide::with_consistency(DivideConsistency level) -> Divide &
+{
+    _level = level;
+    return *this;
 }
 
 auto Divide::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Divide>(_x, _y, _quotient, _level);
+    auto cloned = make_unique<Divide>(_x, _y, _quotient);
+    cloned->with_consistency(_level);
+    return cloned;
 }
 
 auto Divide::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
@@ -369,14 +376,21 @@ auto Divide::s_expr(const ProofModel * const model) const -> SExpr
         SExpr::list({tracker.s_expr_term_of(_x), tracker.s_expr_term_of(_y), tracker.s_expr_term_of(_quotient)})});
 }
 
-Modulus::Modulus(IntegerVariableID x, IntegerVariableID y, IntegerVariableID remainder, ModulusConsistency level) :
-    _x(x), _y(y), _remainder(remainder), _level(level)
+Modulus::Modulus(IntegerVariableID x, IntegerVariableID y, IntegerVariableID remainder) : _x(x), _y(y), _remainder(remainder)
 {
+}
+
+auto Modulus::with_consistency(ModulusConsistency level) -> Modulus &
+{
+    _level = level;
+    return *this;
 }
 
 auto Modulus::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Modulus>(_x, _y, _remainder, _level);
+    auto cloned = make_unique<Modulus>(_x, _y, _remainder);
+    cloned->with_consistency(_level);
+    return cloned;
 }
 
 auto Modulus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/divide_modulus/divide_modulus.hh
+++ b/gcs/constraints/divide_modulus/divide_modulus.hh
@@ -54,10 +54,14 @@ namespace gcs
     {
     private:
         IntegerVariableID _x, _y, _quotient;
-        DivideConsistency _level;
+        DivideConsistency _level = consistency::Auto{};
 
     public:
-        explicit Divide(IntegerVariableID x, IntegerVariableID y, IntegerVariableID quotient, DivideConsistency level = consistency::Auto{});
+        explicit Divide(IntegerVariableID x, IntegerVariableID y, IntegerVariableID quotient);
+
+        /// Select the consistency level; consistency::Auto (the default) tabulates when the
+        /// domains are small. Requesting an unsupported level is a compile-time error.
+        auto with_consistency(DivideConsistency level) -> Divide &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
@@ -81,10 +85,14 @@ namespace gcs
     {
     private:
         IntegerVariableID _x, _y, _remainder;
-        ModulusConsistency _level;
+        ModulusConsistency _level = consistency::Auto{};
 
     public:
-        explicit Modulus(IntegerVariableID x, IntegerVariableID y, IntegerVariableID remainder, ModulusConsistency level = consistency::Auto{});
+        explicit Modulus(IntegerVariableID x, IntegerVariableID y, IntegerVariableID remainder);
+
+        /// Select the consistency level; consistency::Auto (the default) tabulates when the
+        /// domains are small. Requesting an unsupported level is a compile-time error.
+        auto with_consistency(ModulusConsistency level) -> Modulus &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -69,9 +69,9 @@ namespace
         -> void
     {
         if (is_div)
-            p.post(Divide{x, y, out, level});
+            p.post(Divide{x, y, out}.with_consistency(level));
         else
-            p.post(Modulus{x, y, out, level});
+            p.post(Modulus{x, y, out}.with_consistency(level));
     }
 }
 

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -57,14 +57,21 @@ namespace
     }
 }
 
-Multiply::Multiply(IntegerVariableID v1, IntegerVariableID v2, IntegerVariableID result, MultiplyConsistency level) :
-    _v1(v1), _v2(v2), _result(result), _level(level)
+Multiply::Multiply(IntegerVariableID v1, IntegerVariableID v2, IntegerVariableID result) : _v1(v1), _v2(v2), _result(result)
 {
+}
+
+auto Multiply::with_consistency(MultiplyConsistency level) -> Multiply &
+{
+    _level = level;
+    return *this;
 }
 
 auto Multiply::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Multiply>(_v1, _v2, _result, _level);
+    auto cloned = make_unique<Multiply>(_v1, _v2, _result);
+    cloned->with_consistency(_level);
+    return cloned;
 }
 
 auto Multiply::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/multiply/multiply.hh
+++ b/gcs/constraints/multiply/multiply.hh
@@ -53,10 +53,14 @@ namespace gcs
     {
     private:
         IntegerVariableID _v1, _v2, _result;
-        MultiplyConsistency _level;
+        MultiplyConsistency _level = consistency::Auto{};
 
     public:
-        explicit Multiply(IntegerVariableID v1, IntegerVariableID v2, IntegerVariableID result, MultiplyConsistency level = consistency::Auto{});
+        explicit Multiply(IntegerVariableID v1, IntegerVariableID v2, IntegerVariableID result);
+
+        /// Select the consistency level; consistency::Auto (the default) tabulates when the
+        /// domains are small. Requesting an unsupported level is a compile-time error.
+        auto with_consistency(MultiplyConsistency level) -> Multiply &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/multiply/multiply_test.cc
+++ b/gcs/constraints/multiply/multiply_test.cc
@@ -84,7 +84,7 @@ auto run_multiply_test(bool proofs, const MultiplyConsistency & level, bool chec
             result = -result;
         return result + Integer{o};
     };
-    p.post(Multiply{wrap(v1, m1, o1), wrap(v2, m2, o2), wrap(v3, m3, o3), level});
+    p.post(Multiply{wrap(v1, m1, o1), wrap(v2, m2, o2), wrap(v3, m3, o3)}.with_consistency(level));
 
     auto proof_name = proofs ? make_optional("multiply_test") : nullopt;
 
@@ -113,15 +113,15 @@ auto run_alias_test(
     set<tuple<int, int>> expected, actual;
     if (shape == "xxy") {
         build_expected(expected, [](int a, int b) { return a * a == b; }, x_range, y_range);
-        p.post(Multiply{x, x, y, level});
+        p.post(Multiply{x, x, y}.with_consistency(level));
     }
     else if (shape == "xyx") {
         build_expected(expected, [](int a, int b) { return a * b == a; }, x_range, y_range);
-        p.post(Multiply{x, y, x, level});
+        p.post(Multiply{x, y, x}.with_consistency(level));
     }
     else if (shape == "yxx") {
         build_expected(expected, [](int a, int b) { return b * a == a; }, x_range, y_range);
-        p.post(Multiply{y, x, x, level});
+        p.post(Multiply{y, x, x}.with_consistency(level));
     }
     else
         throw UnexpectedException{"unknown alias shape"};
@@ -146,7 +146,7 @@ auto run_all_same_test(bool proofs, const MultiplyConsistency & level, pair<int,
 
     Problem p;
     auto x = p.create_integer_variable(Integer(x_range.first), Integer(x_range.second), "x");
-    p.post(Multiply{x, x, x, level});
+    p.post(Multiply{x, x, x}.with_consistency(level));
 
     set<tuple<int>> expected, actual;
     build_expected(expected, [](int a) { return a * a == a; }, x_range);
@@ -172,15 +172,15 @@ auto run_constant_test(
     set<tuple<int, int>> expected, actual;
     if (shape == "cv") {
         build_expected(expected, [&](int a, int b) { return constant * a == b; }, v_range, r_range);
-        p.post(Multiply{constant_variable(Integer{constant}), v, r, level});
+        p.post(Multiply{constant_variable(Integer{constant}), v, r}.with_consistency(level));
     }
     else if (shape == "vc") {
         build_expected(expected, [&](int a, int b) { return a * constant == b; }, v_range, r_range);
-        p.post(Multiply{v, constant_variable(Integer{constant}), r, level});
+        p.post(Multiply{v, constant_variable(Integer{constant}), r}.with_consistency(level));
     }
     else if (shape == "result") {
         build_expected(expected, [&](int a, int b) { return a * b == constant; }, v_range, r_range);
-        p.post(Multiply{v, r, constant_variable(Integer{constant}), level});
+        p.post(Multiply{v, r, constant_variable(Integer{constant})}.with_consistency(level));
     }
     else
         throw UnexpectedException{"unknown constant shape"};

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -112,14 +112,21 @@ namespace
     }
 }
 
-Minus::Minus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result, MinusConsistency level) :
-    _a(a), _b(b), _result(result), _level(level)
+Minus::Minus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result) : _a(a), _b(b), _result(result)
 {
+}
+
+auto Minus::with_consistency(MinusConsistency level) -> Minus &
+{
+    _level = level;
+    return *this;
 }
 
 auto Minus::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Minus>(_a, _b, _result, _level);
+    auto cloned = make_unique<Minus>(_a, _b, _result);
+    cloned->with_consistency(_level);
+    return cloned;
 }
 
 auto Minus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/plus_minus/minus.hh
+++ b/gcs/constraints/plus_minus/minus.hh
@@ -28,14 +28,18 @@ namespace gcs
     {
     private:
         IntegerVariableID _a, _b, _result;
-        MinusConsistency _level;
+        MinusConsistency _level = consistency::Auto{};
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
 
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
-        explicit Minus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result, MinusConsistency level = consistency::Auto{});
+        explicit Minus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result);
+
+        /// Select the consistency level; consistency::Auto (the default) tabulates when the
+        /// domains are small. Requesting an unsupported level is a compile-time error.
+        auto with_consistency(MinusConsistency level) -> Minus &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -99,13 +99,21 @@ namespace
     }
 }
 
-Plus::Plus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result, PlusConsistency level) : _a(a), _b(b), _result(result), _level(level)
+Plus::Plus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result) : _a(a), _b(b), _result(result)
 {
+}
+
+auto Plus::with_consistency(PlusConsistency level) -> Plus &
+{
+    _level = level;
+    return *this;
 }
 
 auto Plus::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Plus>(_a, _b, _result, _level);
+    auto cloned = make_unique<Plus>(_a, _b, _result);
+    cloned->with_consistency(_level);
+    return cloned;
 }
 
 auto Plus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/plus_minus/plus.hh
+++ b/gcs/constraints/plus_minus/plus.hh
@@ -36,14 +36,18 @@ namespace gcs
     {
     private:
         IntegerVariableID _a, _b, _result;
-        PlusConsistency _level;
+        PlusConsistency _level = consistency::Auto{};
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
 
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
-        explicit Plus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result, PlusConsistency level = consistency::Auto{});
+        explicit Plus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result);
+
+        /// Select the consistency level; consistency::Auto (the default) tabulates when the
+        /// domains are small. Requesting an unsupported level is a compile-time error.
+        auto with_consistency(PlusConsistency level) -> Plus &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/plus_minus/plus_minus_test.cc
+++ b/gcs/constraints/plus_minus/plus_minus_test.cc
@@ -181,7 +181,7 @@ auto run_tagged_test(bool proofs, const string & proof_suffix, const PlusConsist
     auto v1 = p.create_integer_variable(Integer(v1_range.first), Integer(v1_range.second));
     auto v2 = p.create_integer_variable(Integer(v2_range.first), Integer(v2_range.second));
     auto v3 = p.create_integer_variable(Integer(v3_range.first), Integer(v3_range.second));
-    p.post(Constraint_{v1, v2, v3, level});
+    p.post(Constraint_{v1, v2, v3}.with_consistency(level));
 
     auto proof_name = proofs ? make_optional("plus_minus_test_tagged_" + proof_suffix) : nullopt;
     if (check_gac)

--- a/gcs/constraints/power/power.cc
+++ b/gcs/constraints/power/power.cc
@@ -58,14 +58,21 @@ namespace
     }
 }
 
-Power::Power(IntegerVariableID base, IntegerVariableID exponent, IntegerVariableID result, PowerConsistency level) :
-    _base(base), _exponent(exponent), _result(result), _level(level)
+Power::Power(IntegerVariableID base, IntegerVariableID exponent, IntegerVariableID result) : _base(base), _exponent(exponent), _result(result)
 {
+}
+
+auto Power::with_consistency(PowerConsistency level) -> Power &
+{
+    _level = level;
+    return *this;
 }
 
 auto Power::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Power>(_base, _exponent, _result, _level);
+    auto cloned = make_unique<Power>(_base, _exponent, _result);
+    cloned->with_consistency(_level);
+    return cloned;
 }
 
 auto Power::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/power/power.hh
+++ b/gcs/constraints/power/power.hh
@@ -45,10 +45,14 @@ namespace gcs
     {
     private:
         IntegerVariableID _base, _exponent, _result;
-        PowerConsistency _level;
+        PowerConsistency _level = consistency::Auto{};
 
     public:
-        explicit Power(IntegerVariableID base, IntegerVariableID exponent, IntegerVariableID result, PowerConsistency level = consistency::Auto{});
+        explicit Power(IntegerVariableID base, IntegerVariableID exponent, IntegerVariableID result);
+
+        /// Select the consistency level; consistency::Auto (the default) tabulates when the
+        /// domains are small. Requesting an unsupported level is a compile-time error.
+        auto with_consistency(PowerConsistency level) -> Power &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/power/power_test.cc
+++ b/gcs/constraints/power/power_test.cc
@@ -127,7 +127,7 @@ auto run_power_const_exp_test(bool proofs, const PowerConsistency & level, bool 
             result = -result;
         return result + Integer{o};
     };
-    p.post(Power{wrap(v1, m1, o1), constant_variable(Integer{exp}), wrap(v3, m3, o3), level});
+    p.post(Power{wrap(v1, m1, o1), constant_variable(Integer{exp}), wrap(v3, m3, o3)}.with_consistency(level));
 
     auto proof_name = proofs ? make_optional("power_test") : nullopt;
     if (check_gac)


### PR DESCRIPTION
Second slice of the fluent constraint-options cleanup (#299), following the linear-equality slice (#451).

## What changes

`Plus`, `Minus`, `Multiply`, `Divide`, `Modulus`, `Power` now take **only variables** in their constructors; the consistency level moves to a fluent setter:

```cpp
// before
p.post(Multiply{w, h, area, consistency::BC{}});
// after
p.post(Multiply{w, h, area}.with_consistency(consistency::BC{}));
```

- Each `with_consistency()` takes that constraint's own `std::variant<consistency::Auto, BC, Tabulated>` → unsupported level is a compile error.
- `_level` members default to `consistency::Auto{}`; `clone()` re-applies through the setter.
- Identical shape to #451 (setter returns the concrete type, on the class itself).

## Call sites

Examples `shikaku` and `langford` (with the `//`-forced line break before `.with_consistency()`), and the `multiply`/`divide_modulus`/`power`/`plus_minus` tests.

## Verification

- Full `cmake --build` of **all** targets — clean.
- `ctest -R "plus|minus|multiply|divide|modulus|power|shikaku|langford"` → **13/13**, including the cake chain-verify `scp_chain_plus/minus` tests and the proof-verifying constraint tests.
- clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)