### PR TITLE
Fluent constraint options: Element family (#299)

### DIFF
--- a/gcs/constraints/element/element.hh
+++ b/gcs/constraints/element/element.hh
@@ -2,10 +2,12 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_ELEMENT_ELEMENT_HH
 
 #include <gcs/array_param.hh>
+#include <gcs/consistency.hh>
 #include <gcs/constraint.hh>
 #include <gcs/variable_id.hh>
 
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace gcs
@@ -27,6 +29,15 @@ namespace gcs
             using Type = std::vector<typename MakeNDVector<E_, n_ - 1>::Type>;
         };
     }
+
+    /**
+     * \brief The consistency levels supported by the Element family: generalised
+     * arc consistency, or bounds consistency. The variable-array forms (Element,
+     * Element2D) default to GAC; the constant-array forms default to BC.
+     *
+     * \ingroup Consistency
+     */
+    using ElementConsistency = std::variant<consistency::GAC, consistency::BC>;
 
     template <typename EntryType_, unsigned dimensions_>
     class NDimensionalElement : public Constraint
@@ -66,6 +77,15 @@ namespace gcs
         explicit NDimensionalElement(IntegerVariableID result_var, IndexVariables, IndexStarts, Array, bool bounds_only);
 
     public:
+        /// Select the consistency level: consistency::GAC or consistency::BC.
+        /// This selects propagation strength only and never changes the OPB
+        /// encoding. Requesting any other level is a compile-time error.
+        auto with_consistency(ElementConsistency level) -> NDimensionalElement &
+        {
+            _bounds_only = std::holds_alternative<consistency::BC>(level);
+            return *this;
+        }
+
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
@@ -74,13 +94,13 @@ namespace gcs
     class Element : public NDimensionalElement<IntegerVariableID, 1>
     {
     public:
-        explicit Element(IntegerVariableID var, IntegerVariableID zero_idx, Array array, bool bounds_only = false) :
-            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, std::move(array), bounds_only)
+        explicit Element(IntegerVariableID var, IntegerVariableID zero_idx, Array array) :
+            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, std::move(array), false)
         {
         }
 
-        explicit Element(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array array, bool bounds_only = false) :
-            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, std::move(array), bounds_only)
+        explicit Element(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array array) :
+            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, std::move(array), false)
         {
         }
     };
@@ -88,14 +108,13 @@ namespace gcs
     class Element2D : public NDimensionalElement<IntegerVariableID, 2>
     {
     public:
-        explicit Element2D(IntegerVariableID var, IntegerVariableID zero_idx_1, IntegerVariableID zero_idx_2, Array array, bool bounds_only = false) :
-            NDimensionalElement(var, {{zero_idx_1, zero_idx_2}}, {{0_i, 0_i}}, std::move(array), bounds_only)
+        explicit Element2D(IntegerVariableID var, IntegerVariableID zero_idx_1, IntegerVariableID zero_idx_2, Array array) :
+            NDimensionalElement(var, {{zero_idx_1, zero_idx_2}}, {{0_i, 0_i}}, std::move(array), false)
         {
         }
 
-        explicit Element2D(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx1, std::pair<IntegerVariableID, Integer> idx2, Array array,
-            bool bounds_only = false) :
-            NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, std::move(array), bounds_only)
+        explicit Element2D(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx1, std::pair<IntegerVariableID, Integer> idx2,
+            Array array) : NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, std::move(array), false)
         {
         }
     };
@@ -103,13 +122,13 @@ namespace gcs
     class ElementConstantArray : public NDimensionalElement<Integer, 1>
     {
     public:
-        explicit ElementConstantArray(IntegerVariableID var, IntegerVariableID zero_idx, Array array, bool bounds_only = true) :
-            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, std::move(array), bounds_only)
+        explicit ElementConstantArray(IntegerVariableID var, IntegerVariableID zero_idx, Array array) :
+            NDimensionalElement(var, {{zero_idx}}, {{0_i}}, std::move(array), true)
         {
         }
 
-        explicit ElementConstantArray(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array array, bool bounds_only = true) :
-            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, std::move(array), bounds_only)
+        explicit ElementConstantArray(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx, Array array) :
+            NDimensionalElement(var, {{idx.first}}, {{idx.second}}, std::move(array), true)
         {
         }
     };
@@ -117,14 +136,13 @@ namespace gcs
     class Element2DConstantArray : public NDimensionalElement<Integer, 2>
     {
     public:
-        explicit Element2DConstantArray(IntegerVariableID var, IntegerVariableID idx1, IntegerVariableID idx2, Array array, bool bounds_only = true) :
-            NDimensionalElement(var, {{idx1, idx2}}, {{0_i, 0_i}}, std::move(array), bounds_only)
+        explicit Element2DConstantArray(IntegerVariableID var, IntegerVariableID idx1, IntegerVariableID idx2, Array array) :
+            NDimensionalElement(var, {{idx1, idx2}}, {{0_i, 0_i}}, std::move(array), true)
         {
         }
 
         explicit Element2DConstantArray(IntegerVariableID var, std::pair<IntegerVariableID, Integer> idx1, std::pair<IntegerVariableID, Integer> idx2,
-            Array array, bool bounds_only = true) :
-            NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, std::move(array), bounds_only)
+            Array array) : NDimensionalElement(var, {{idx1.first, idx2.first}}, {{idx1.second, idx2.second}}, std::move(array), true)
         {
         }
     };

--- a/gcs/constraints/element/element_test.cc
+++ b/gcs/constraints/element/element_test.cc
@@ -69,7 +69,9 @@ auto run_element_test(bool proofs, const string & mode, const ViewWrapConfig & v
     vector<IntegerVariableID> array;
     for (const auto & r : array_range)
         array.push_back(create_integer_variable_or_constant_with_view(p, r, wraps.at(array.size() + 2)));
-    p.post(Element{var, idx, &array});
+    // GAC is Element's default; setting it explicitly drives the with_consistency
+    // setter end-to-end while keeping the checking_gac assertion valid.
+    p.post(Element{var, idx, &array}.with_consistency(consistency::GAC{}));
 
     auto proof_name = proofs ? make_optional("element_test_" + mode + "_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{var, idx, array});


### PR DESCRIPTION
Third slice of the fluent constraint-options cleanup (#299), after linear (#451) and arithmetic (#452).

## What changes

The Element family's `bounds_only` bool becomes a consistency choice:

```cpp
// before
p.post(Element{var, idx, &array, /*bounds_only=*/true});
// after
p.post(Element{var, idx, &array}.with_consistency(consistency::BC{}));
```

- `with_consistency()` takes `ElementConsistency = std::variant<consistency::GAC, consistency::BC>` → unsupported level is a compile error.
- `bounds_only` only affects the propagator, never `define_proof_model`, so the "consistency never changes the OPB encoding" rule holds.
- **Behaviour-preserving:** the per-type defaults are kept — `Element`/`Element2D` default to GAC, `ElementConstantArray`/`Element2DConstantArray` to BC. Each wrapper passes its own default to the protected base ctor (mirroring how linear keeps `flipped_cond` internal). No call site anywhere passed `bounds_only` explicitly, so nothing else changes.
- The `element_test` var path now drives `with_consistency(consistency::GAC{})` end-to-end (a no-op vs the default, so the `checking_gac` assertion stays valid).

## ⚠️ Query for review (not addressed here)

The catalogue flagged the **default flip** as a footgun: `Element` defaults to GAC but `ElementConstantArray` defaults to BC, so same-looking calls propagate differently. I've **preserved** that flip because unifying the defaults is a *functional* change, out of scope for this API-cleanup pass. If you'd like the defaults unified (e.g. everything GAC by default), that's a small separate PR — flag it and I'll do it.

## Verification

- Full `cmake --build` of all targets — clean.
- `ctest -R element` → 12/12, including cake chain-verify `scp_chain_element*`.
- clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)