### PR TITLE
Fluent constraint options: SmartTable + Regular short_reasons (#299)

### DIFF
--- a/examples/regular_random/regular_random.cc
+++ b/examples/regular_random/regular_random.cc
@@ -78,7 +78,8 @@ auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_r
         }
     }
 
-    p.post(Regular{x, num_states, transitions, final_states, short_reasons});
+    p.post(Regular{x, num_states, transitions, final_states} //
+            .with_short_reasons(short_reasons));
 }
 
 auto main(int argc, char * argv[]) -> int

--- a/examples/smart_table_random/smart_table_random.cc
+++ b/examples/smart_table_random/smart_table_random.cc
@@ -276,7 +276,8 @@ auto main(int argc, char * argv[]) -> int
         auto tuple_length = uniform_int_distribution<>(n / 2, n)(rng);
         SmartTuples tuples = random_tuples(tuple_length, vars, rng, display_table, table_as_string);
 
-        p.post(SmartTable{vars, tuples, short_reasons});
+        p.post(SmartTable{vars, tuples} //
+                .with_short_reasons(short_reasons));
 
         auto stats = solve_with(p,                                                           //
             SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return false; }}, //

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -392,8 +392,8 @@ namespace
     }
 }
 
-Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f, bool sr) :
-    _vars(move(v)), _num_states(n), _transitions(t.size()), _final_states(move(f)), _short_reasons(sr), _regex(nullopt)
+Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integer, long>> t, vector<long> f) :
+    _vars(move(v)), _num_states(n), _transitions(t.size()), _final_states(move(f)), _regex(nullopt)
 {
     for (size_t q = 0; q < t.size(); ++q)
         for (const auto & [val, target] : t[q])
@@ -402,8 +402,8 @@ Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integ
     _symbols = symbols_of(_transitions);
 }
 
-Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f, bool sr) :
-    _vars(move(v)), _num_states(n), _transitions(n), _final_states(move(f)), _short_reasons(sr), _regex(nullopt)
+Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> transitions, vector<long> f) :
+    _vars(move(v)), _num_states(n), _transitions(n), _final_states(move(f)), _regex(nullopt)
 {
     for (size_t i = 0; i < transitions.size(); i++)
         for (size_t j = 0; j < transitions[i].size(); j++)
@@ -412,7 +412,7 @@ Regular::Regular(vector<IntegerVariableID> v, long n, vector<vector<long>> trans
     _symbols = symbols_of(_transitions);
 }
 
-Regular::Regular(vector<IntegerVariableID> v, string regex, bool sr) : _vars(move(v)), _num_states(0), _short_reasons(sr), _regex(move(regex))
+Regular::Regular(vector<IntegerVariableID> v, string regex) : _vars(move(v)), _num_states(0), _regex(move(regex))
 {
     // The automaton is compiled from the regex in prepare(), once the
     // variables' domains (and hence the alphabet for "." and "[^...]") are known.
@@ -422,6 +422,12 @@ Regular::Regular(vector<IntegerVariableID> v, long n, vector<unordered_map<Integ
     optional<string> regex) :
     _vars(move(v)), _num_states(n), _transitions(move(t)), _final_states(move(f)), _short_reasons(sr), _regex(move(regex)), _symbols(move(syms))
 {
+}
+
+auto Regular::with_short_reasons(std::optional<bool> short_reasons) -> Regular &
+{
+    _short_reasons = short_reasons.value_or(true);
+    return *this;
 }
 
 auto Regular::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/regular/regular.hh
+++ b/gcs/constraints/regular/regular.hh
@@ -34,7 +34,7 @@ namespace gcs
         long _num_states;
         std::vector<std::unordered_map<Integer, std::set<long>>> _transitions;
         std::vector<long> _final_states;
-        const bool _short_reasons;
+        bool _short_reasons = true;
         const std::optional<std::string> _regex;
         std::vector<Integer> _symbols;
         std::vector<std::vector<innards::ProofFlag>> _state_at_pos_flags;
@@ -52,17 +52,22 @@ namespace gcs
 
     public:
         explicit Regular(std::vector<IntegerVariableID> vars, long num_states, std::vector<std::unordered_map<Integer, long>> transitions,
-            std::vector<long> final_states, bool short_reasons = true);
+            std::vector<long> final_states);
 
-        explicit Regular(std::vector<IntegerVariableID> vars, long num_states, std::vector<std::vector<long>> transitions,
-            std::vector<long> final_states, bool sr = true);
+        explicit Regular(
+            std::vector<IntegerVariableID> vars, long num_states, std::vector<std::vector<long>> transitions, std::vector<long> final_states);
 
         /**
          * \brief Constrain that the sequence of variables matches the given
          * regular expression. The expression is compiled to an NFA over the
          * contiguous min..max range of the variables' domains.
          */
-        explicit Regular(std::vector<IntegerVariableID> vars, std::string regex, bool short_reasons = true);
+        explicit Regular(std::vector<IntegerVariableID> vars, std::string regex);
+
+        /// Whether to use short reasons in the proof log (default true). Takes a
+        /// std::optional<bool> so a runtime flag can be passed directly; nullopt
+        /// or no argument leaves it at true.
+        auto with_short_reasons(std::optional<bool> short_reasons = true) -> Regular &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/smart_table/smart_table.cc
+++ b/gcs/constraints/smart_table/smart_table.cc
@@ -79,7 +79,7 @@ namespace
     }
 }
 
-SmartTable::SmartTable(vector<IntegerVariableID> v, SmartTuples t, bool s) : _vars(move(v)), _tuples(move(t)), _short_reasons(s)
+SmartTable::SmartTable(vector<IntegerVariableID> v, SmartTuples t) : _vars(move(v)), _tuples(move(t))
 {
     // Aliased BinaryEntry endpoints break build_forests: both ends
     // hash to the same `deview` key, so adjacent_edges holds the entry
@@ -767,9 +767,17 @@ auto consolidate_unary_entries(State & state, vector<SmartEntry> tuple) -> vecto
     return new_tuple;
 }
 
+auto SmartTable::with_short_reasons(std::optional<bool> short_reasons) -> SmartTable &
+{
+    _short_reasons = short_reasons.value_or(true);
+    return *this;
+}
+
 auto SmartTable::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<SmartTable>(_vars, _tuples, _short_reasons);
+    auto cloned = make_unique<SmartTable>(_vars, _tuples);
+    cloned->with_short_reasons(_short_reasons);
+    return cloned;
 }
 
 auto SmartTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/smart_table/smart_table.hh
+++ b/gcs/constraints/smart_table/smart_table.hh
@@ -5,6 +5,8 @@
 #include <gcs/extensional.hh>
 #include <gcs/variable_id.hh>
 
+#include <optional>
+
 namespace gcs
 {
     namespace innards
@@ -64,10 +66,16 @@ namespace gcs
     private:
         const std::vector<IntegerVariableID> _vars;
         SmartTuples _tuples;
-        bool _short_reasons;
+        bool _short_reasons = true;
 
     public:
-        explicit SmartTable(std::vector<IntegerVariableID> vars, SmartTuples tuples, bool short_reasons = true);
+        explicit SmartTable(std::vector<IntegerVariableID> vars, SmartTuples tuples);
+
+        /// Whether to use short reasons in the proof log (default true). Takes a
+        /// std::optional<bool> so a runtime flag (e.g. command_line.has("...")) can
+        /// be passed directly; std::nullopt or no argument leaves it at true.
+        auto with_short_reasons(std::optional<bool> short_reasons = true) -> SmartTable &;
+
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
 


### PR DESCRIPTION
Fourth slice of the fluent constraint-options cleanup (#299).

## What changes

The `short_reasons` proof-logging knob moves off the constructors onto a fluent setter on both `SmartTable` and `Regular`:

```cpp
p.post(SmartTable{vars, tuples}.with_short_reasons(cmd.has("sr")));
p.post(Regular{vars, regex}.with_short_reasons(false));
```

- `with_short_reasons(std::optional<bool> = true)` — takes `optional<bool>` per the requested `.with_blah(command_line.has_option("blah"))` ergonomic; `nullopt`/no-arg leaves it at `true`.
- **Fixes the `sr` vs `short_reasons` drift**: the two `Regular` overloads previously disagreed on the parameter name; both now use the setter, so the drift is gone.
- `Regular::_short_reasons` is de-`const`ed so the setter can write it; the private clone ctor keeps carrying the value internally.
- Proof knob kept as its own setter (separate from `.with_consistency()`), per the #299 note that reason-length is a proof-output policy, not a consistency level.

## Call sites

Only `smart_table_random` and `regular_random` passed the flag (both from a runtime `short_reasons` variable) — migrated with the `//`-forced break.

## Verification

- Full `cmake --build` of all targets — clean.
- `ctest -R "smart_table|regular|regex"` → **36/36**, including the proof-verifying SmartTable tests and the `minizinc-regex` frontend test.
- clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)