### PR TITLE
Fluent constraint options: Disjunctive strict (semantic mode) (#299)

### DIFF
--- a/examples/shikaku/shikaku.cc
+++ b/examples/shikaku/shikaku.cc
@@ -192,7 +192,7 @@ auto main(int argc, char * argv[]) -> int
     }
 
     // No two rectangles overlap (diffn). All sizes are >= 1, so strict.
-    p.post(Disjunctive2D{xs_id, ys_id, ws_id, hs_id, true});
+    p.post(Disjunctive2D{xs_id, ys_id, ws_id, hs_id});
 
     auto n = inst.clues.size();
     auto stats = solve_with(p, //

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -71,8 +71,7 @@ namespace
     }
 }
 
-Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths, bool strict) :
-    _starts(move(starts)), _lengths(move(lengths)), _strict(strict)
+Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths) : _starts(move(starts)), _lengths(move(lengths))
 {
     if (_starts.size() != _lengths.size())
         throw InvalidProblemDefinitionException{"Disjunctive: starts and lengths must have the same size"};
@@ -83,14 +82,21 @@ Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<IntegerVariabl
             throw InvalidProblemDefinitionException{"Disjunctive: lengths must be non-negative"};
 }
 
-Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengths, bool strict) :
-    Disjunctive(move(starts), as_constant_var_ids(lengths), strict)
+Disjunctive::Disjunctive(vector<IntegerVariableID> starts, vector<Integer> lengths) : Disjunctive(move(starts), as_constant_var_ids(lengths))
 {
+}
+
+auto Disjunctive::with_strict(std::optional<bool> strict) -> Disjunctive &
+{
+    _strict = strict.value_or(true);
+    return *this;
 }
 
 auto Disjunctive::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Disjunctive>(_starts, _lengths, _strict);
+    auto cloned = make_unique<Disjunctive>(_starts, _lengths);
+    cloned->with_strict(_strict);
+    return cloned;
 }
 
 auto Disjunctive::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -53,7 +53,7 @@ namespace gcs
     private:
         std::vector<IntegerVariableID> _starts;
         std::vector<IntegerVariableID> _lengths;
-        bool _strict;
+        bool _strict = true;
         std::vector<std::size_t> _active_tasks;
 
         // Length snapshots resolved in prepare(). _length_vals holds the
@@ -109,13 +109,18 @@ namespace gcs
          * \brief General form: durations may be variables or constants
          * (constants pass through as ConstantIntegerVariableID).
          */
-        explicit Disjunctive(std::vector<IntegerVariableID> starts, std::vector<IntegerVariableID> lengths, bool strict = true);
+        explicit Disjunctive(std::vector<IntegerVariableID> starts, std::vector<IntegerVariableID> lengths);
 
         /**
          * \brief Convenience form for constant durations. Delegates to the
          * general constructor.
          */
-        explicit Disjunctive(std::vector<IntegerVariableID> starts, std::vector<Integer> lengths, bool strict = true);
+        explicit Disjunctive(std::vector<IntegerVariableID> starts, std::vector<Integer> lengths);
+
+        /// Whether the tasks are strictly disjunctive (zero-length tasks also may
+        /// not overlap); default true. Takes std::optional<bool> so a runtime flag
+        /// can be passed straight through.
+        auto with_strict(std::optional<bool> strict = true) -> Disjunctive &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/disjunctive/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_test.cc
@@ -94,7 +94,7 @@ namespace
         for (auto l : lengths)
             lengths_i.push_back(Integer{l});
 
-        p.post(Disjunctive{starts, lengths_i, strict});
+        p.post(Disjunctive{starts, lengths_i}.with_strict(strict));
 
         auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_dup") : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{unique_starts});
@@ -138,7 +138,7 @@ namespace
         for (auto l : lengths)
             lengths_i.push_back(Integer{l});
 
-        p.post(Disjunctive{starts, lengths_i, strict});
+        p.post(Disjunctive{starts, lengths_i}.with_strict(strict));
 
         auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_" + view_wrap_config_label(view_cfg)) : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{starts});
@@ -206,7 +206,7 @@ namespace
                 lengths_v.push_back(constant_variable(Integer{length_specs[i].first}));
         }
 
-        p.post(Disjunctive{starts, lengths_v, strict});
+        p.post(Disjunctive{starts, lengths_v}.with_strict(strict));
 
         auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_var") : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{all_vars});
@@ -271,7 +271,7 @@ namespace
                 lengths_v.push_back(constant_variable(Integer{length_specs[i].first}));
         }
 
-        p.post(Disjunctive{starts, lengths_v, strict});
+        p.post(Disjunctive{starts, lengths_v}.with_strict(strict));
 
         auto proof_name = proofs ? make_optional("disjunctive_test_" + mode + "_cstart") : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{all_vars});

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -71,7 +71,7 @@ namespace
 }
 
 Disjunctive2D::Disjunctive2D(vector<IntegerVariableID> xs, vector<IntegerVariableID> ys, vector<IntegerVariableID> widths,
-    vector<IntegerVariableID> heights, bool strict) : _xs(move(xs)), _ys(move(ys)), _widths(move(widths)), _heights(move(heights)), _strict(strict)
+    vector<IntegerVariableID> heights) : _xs(move(xs)), _ys(move(ys)), _widths(move(widths)), _heights(move(heights))
 {
     if (_xs.size() != _ys.size() || _xs.size() != _widths.size() || _xs.size() != _heights.size())
         throw InvalidProblemDefinitionException{"Disjunctive2D: xs, ys, widths, heights must have the same size"};
@@ -85,14 +85,22 @@ Disjunctive2D::Disjunctive2D(vector<IntegerVariableID> xs, vector<IntegerVariabl
             throw InvalidProblemDefinitionException{"Disjunctive2D: heights must be non-negative"};
 }
 
-Disjunctive2D::Disjunctive2D(vector<IntegerVariableID> xs, vector<IntegerVariableID> ys, vector<Integer> widths, vector<Integer> heights,
-    bool strict) : Disjunctive2D(move(xs), move(ys), as_constant_var_ids(widths), as_constant_var_ids(heights), strict)
+Disjunctive2D::Disjunctive2D(vector<IntegerVariableID> xs, vector<IntegerVariableID> ys, vector<Integer> widths, vector<Integer> heights) :
+    Disjunctive2D(move(xs), move(ys), as_constant_var_ids(widths), as_constant_var_ids(heights))
 {
+}
+
+auto Disjunctive2D::with_strict(std::optional<bool> strict) -> Disjunctive2D &
+{
+    _strict = strict.value_or(true);
+    return *this;
 }
 
 auto Disjunctive2D::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Disjunctive2D>(_xs, _ys, _widths, _heights, _strict);
+    auto cloned = make_unique<Disjunctive2D>(_xs, _ys, _widths, _heights);
+    cloned->with_strict(_strict);
+    return cloned;
 }
 
 auto Disjunctive2D::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
@@ -52,7 +52,7 @@ namespace gcs
         std::vector<IntegerVariableID> _ys;
         std::vector<IntegerVariableID> _widths;
         std::vector<IntegerVariableID> _heights;
-        bool _strict;
+        bool _strict = true;
         std::vector<std::size_t> _active_rects;
 
         // Size snapshots resolved in prepare(). _*_vals holds the constant
@@ -111,14 +111,19 @@ namespace gcs
          * (constants pass through as ConstantIntegerVariableID).
          */
         explicit Disjunctive2D(std::vector<IntegerVariableID> xs, std::vector<IntegerVariableID> ys, std::vector<IntegerVariableID> widths,
-            std::vector<IntegerVariableID> heights, bool strict = true);
+            std::vector<IntegerVariableID> heights);
 
         /**
          * \brief Convenience form for constant rectangle sizes. Delegates to
          * the general constructor.
          */
-        explicit Disjunctive2D(std::vector<IntegerVariableID> xs, std::vector<IntegerVariableID> ys, std::vector<Integer> widths,
-            std::vector<Integer> heights, bool strict = true);
+        explicit Disjunctive2D(
+            std::vector<IntegerVariableID> xs, std::vector<IntegerVariableID> ys, std::vector<Integer> widths, std::vector<Integer> heights);
+
+        /// Whether the rectangles are strictly disjunctive (zero-area rectangles
+        /// also may not overlap); default true. Takes std::optional<bool> so a
+        /// runtime flag can be passed straight through.
+        auto with_strict(std::optional<bool> strict = true) -> Disjunctive2D &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
@@ -104,7 +104,7 @@ namespace
         for (auto h : heights)
             heights_i.push_back(Integer{h});
 
-        p.post(Disjunctive2D{xs, ys, widths_i, heights_i, strict});
+        p.post(Disjunctive2D{xs, ys, widths_i, heights_i}.with_strict(strict));
 
         auto proof_name = proofs ? make_optional("disjunctive_2d_test_" + mode + "_" + tag) : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{all_vars});
@@ -167,7 +167,7 @@ namespace
         for (auto h : heights)
             heights_i.push_back(Integer{h});
 
-        p.post(Disjunctive2D{xs, ys, widths_i, heights_i, strict});
+        p.post(Disjunctive2D{xs, ys, widths_i, heights_i}.with_strict(strict));
 
         auto proof_name = proofs ? make_optional("disjunctive_2d_test_" + mode + "_dup") : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{all_vars});
@@ -251,7 +251,7 @@ namespace
         for (size_t i = 0; i < n; ++i)
             heights.push_back(make(h_specs[i], hvar[i]));
 
-        p.post(Disjunctive2D{xs, ys, widths, heights, strict});
+        p.post(Disjunctive2D{xs, ys, widths, heights}.with_strict(strict));
 
         auto proof_name = proofs ? make_optional("disjunctive_2d_test_" + mode + "_var_" + tag) : nullopt;
         solve_for_tests(p, proof_name, actual, tuple{all_vars});

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -856,7 +856,8 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
                 throw ScpReadError{"disjunctive is (label " + op + " (starts...) (lengths...))"};
             post_constraint(problem,
                 Disjunctive{resolve_variable_list(variables, terms[2], "the disjunctive start list"),
-                    resolve_variable_list(variables, terms[3], "the disjunctive length list"), op.ends_with("_strict")},
+                    resolve_variable_list(variables, terms[3], "the disjunctive length list")}
+                    .with_strict(op.ends_with("_strict")),
                 label);
         }
         else if (op == "disjunctive2d" || op == "disjunctive2d_strict") {
@@ -870,7 +871,8 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
                 Disjunctive2D{resolve_variable_list(variables, terms[2], "the disjunctive2d x list"),
                     resolve_variable_list(variables, terms[3], "the disjunctive2d y list"),
                     resolve_variable_list(variables, terms[4], "the disjunctive2d width list"),
-                    resolve_variable_list(variables, terms[5], "the disjunctive2d height list"), op.ends_with("_strict")},
+                    resolve_variable_list(variables, terms[5], "the disjunctive2d height list")}
+                    .with_strict(op.ends_with("_strict")),
                 label);
         }
         else if (op == "cumulative") {

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -628,10 +628,12 @@ TEST_CASE("read_scp: regular, disjunctive, disjunctive2d and cumulative survive 
     auto y1 = original.create_integer_variable(0_i, 3_i, "Y1");
     original.post(Regular{std::vector<IntegerVariableID>{x0, x1}, 2,
         std::vector<std::unordered_map<Integer, long>>{{{0_i, 0}, {1_i, 1}}, {{0_i, 1}, {1_i, 0}}}, std::vector<long>{0}});
-    original.post(Disjunctive{std::vector<IntegerVariableID>{s0, s1}, std::vector<Integer>{2_i, 2_i}});        // strict -> disjunctive_strict
-    original.post(Disjunctive{std::vector<IntegerVariableID>{s0, s1}, std::vector<Integer>{2_i, 2_i}, false}); // non-strict -> disjunctive
+    original.post(Disjunctive{std::vector<IntegerVariableID>{s0, s1}, std::vector<Integer>{2_i, 2_i}}); // strict -> disjunctive_strict
+    original.post(
+        Disjunctive{std::vector<IntegerVariableID>{s0, s1}, std::vector<Integer>{2_i, 2_i}}.with_strict(false)); // non-strict -> disjunctive
     original.post(Disjunctive2D{std::vector<IntegerVariableID>{s0, s1}, std::vector<IntegerVariableID>{y0, y1}, std::vector<Integer>{2_i, 2_i},
-        std::vector<Integer>{2_i, 2_i}, false});
+        std::vector<Integer>{2_i, 2_i}}
+            .with_strict(false));
     original.post(Cumulative{std::vector<IntegerVariableID>{s0, s1}, std::vector<Integer>{2_i, 2_i}, std::vector<Integer>{1_i, 1_i}, 2_i});
     auto scp_a = prove_to_scp(original, "scp_reader_regdisj_a");
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -669,7 +669,7 @@ auto main(int argc, char * argv[]) -> int
                 const auto & starts = arg_as_array_of_var(data, args, 0);
                 const auto & lengths = arg_as_array_of_var(data, args, 1);
                 auto strict = (id == "glasgow_disjunctive_strict");
-                problem.post(Disjunctive{starts, lengths, strict});
+                problem.post(Disjunctive{starts, lengths}.with_strict(strict));
             }
             else if (id == "glasgow_diffn" || id == "glasgow_diffn_nonstrict") {
                 const auto & xs = arg_as_array_of_var(data, args, 0);
@@ -677,7 +677,7 @@ auto main(int argc, char * argv[]) -> int
                 const auto & widths = arg_as_array_of_var(data, args, 2);
                 const auto & heights = arg_as_array_of_var(data, args, 3);
                 auto strict = (id == "glasgow_diffn");
-                problem.post(Disjunctive2D{xs, ys, widths, heights, strict});
+                problem.post(Disjunctive2D{xs, ys, widths, heights}.with_strict(strict));
             }
             else if (id == "glasgow_global_cardinality" || id == "glasgow_global_cardinality_closed") {
                 const auto & vars = arg_as_array_of_var(data, args, 0);

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -445,13 +445,13 @@ namespace
             vector<Integer> lengths_i;
             for (auto l : lengths)
                 lengths_i.push_back(Integer{l});
-            _problem.post(Disjunctive{starts, lengths_i, ! zeroIgnored});
+            _problem.post(Disjunctive{starts, lengths_i}.with_strict(! zeroIgnored));
         }
 
         auto buildConstraintNoOverlap(string, vector<XVariable *> & origins, vector<XVariable *> & lengths, bool zeroIgnored) -> void override
         {
             // 1D noOverlap with variable lengths.
-            _problem.post(Disjunctive{need_variables(origins), need_variables(lengths), ! zeroIgnored});
+            _problem.post(Disjunctive{need_variables(origins), need_variables(lengths)}.with_strict(! zeroIgnored));
         }
 
         auto buildConstraintNoOverlap(string, vector<vector<XVariable *>> & origins, vector<vector<int>> & lengths, bool zeroIgnored) -> void override
@@ -469,7 +469,7 @@ namespace
                 widths.push_back(Integer{lengths[r][0]});
                 heights.push_back(Integer{lengths[r][1]});
             }
-            _problem.post(Disjunctive2D{xs, ys, widths, heights, ! zeroIgnored});
+            _problem.post(Disjunctive2D{xs, ys, widths, heights}.with_strict(! zeroIgnored));
         }
 
         auto buildConstraintNoOverlap(string, vector<vector<XVariable *>> & origins, vector<vector<XVariable *>> & lengths, bool zeroIgnored)
@@ -487,7 +487,7 @@ namespace
                 widths.push_back(need_variable(lengths[r][0]->id));
                 heights.push_back(need_variable(lengths[r][1]->id));
             }
-            _problem.post(Disjunctive2D{xs, ys, widths, heights, ! zeroIgnored});
+            _problem.post(Disjunctive2D{xs, ys, widths, heights}.with_strict(! zeroIgnored));
         }
 
         // Shared backend for every cumulative shape: lengths and heights are


### PR DESCRIPTION
Fifth slice of the fluent constraint-options cleanup (#299) — the semantic mode flag.

**Left open for review** (the other five slices are merged): this one touches the frontends and the `.scp` roundtrip, and `strict` is a *semantic* flag rather than a consistency level, so it's worth a look.

## What changes

Per the decision to make semantic modes fluent for readability, the `strict` bool moves off the `Disjunctive`/`Disjunctive2D` constructors onto a setter:

```cpp
p.post(Disjunctive{starts, lengths}.with_strict(false));
p.post(Disjunctive2D{xs, ys, ws, hs}.with_strict(! zeroIgnored));
```

- `with_strict(std::optional<bool> = true)` — runtime flag passes straight through; `nullopt`/no-arg leaves it strict.
- `strict` genuinely changes the constraint's meaning and its `s_expr` name (`disjunctive` vs `disjunctive_strict`), so it stays its own setter (not folded into `.with_consistency()`). Because `with_strict()` runs before `install()`, `define_proof_model` and `s_expr` still see the right value.
- `clone()` re-applies via the setter.

## Call sites

`disjunctive`/`disjunctive_2d` tests, the **fzn and xcsp frontends** (xcsp maps `! zeroIgnored`), `scp_reader` reconstruction (`op.ends_with("_strict")`), `scp_reader_test`, and `shikaku` (dropped a redundant `true`).

## Verification

- Full `cmake --build` of all targets — clean.
- `ctest -R "disjunctive|shikaku|scp"` → **19/19**: both strict *and* non-strict modes, cake chain-verify `scp_chain_disjunctive*`, the `.scp` roundtrip (`scp_reader_test`), and the `minizinc-*` and xcsp frontend tests.
- clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)