### PR TITLE
GlobalCardinality: extract propagators into free functions (#299 prep)

### DIFF
--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -105,6 +105,318 @@ auto BoundsGlobalCardinality::define_proof_model(ProofModel & model) -> void
     }
 }
 
+auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVariableID> & vars, const ConstraintID & owner,
+    const vector<Integer> & values, const vector<IntegerVariableID> & counts,
+    const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, const vector<IntegerVariableID> & all_vars, const State & state,
+    auto & inference, ProofLogger * const logger) -> PropagatorState
+{
+    auto m = values.size();
+
+    // Part 1: per-value (singleton Hall) reasoning, with real RUP
+    // justifications. For each cover value this gives the count variable
+    // its must-occur lower bound and can-occur upper bound, removes a
+    // value whose upper capacity is saturated by the variables fixed to
+    // it, and forces the variables into a value whose lower demand can
+    // only just be met.
+    for (const auto & [j, value] : enumerate(values)) {
+        ReasonLiterals fixed_eq;  // var == value, for variables fixed to value
+        ReasonLiterals absent_ne; // var != value, for variables without value
+        Integer must = 0_i, can = 0_i;
+        for (const auto & var : vars) {
+            if (state.in_domain(var, value)) {
+                ++can;
+                if (state.has_single_value(var)) {
+                    ++must;
+                    fixed_eq.emplace_back(var == value);
+                }
+            }
+            else
+                absent_ne.emplace_back(var != value);
+        }
+
+        auto [lb_j, ub_j] = state.bounds(counts[j]);
+
+        // c_j >= must: the fixed variables alone force the count up.
+        if (must > lb_j)
+            inference.infer(logger, counts[j] >= must, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{fixed_eq});
+
+        // c_j <= can: only the variables that can still take value may
+        // contribute to the count.
+        if (can < ub_j)
+            inference.infer(logger, counts[j] <= can, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{absent_ne});
+
+        // Saturated capacity: if as many variables are already fixed to
+        // value as the count's upper bound allows, no other variable may
+        // take it.
+        if (must == ub_j) {
+            ReasonLiterals sat = fixed_eq;
+            sat.emplace_back(counts[j] <= ub_j);
+            for (const auto & var : vars)
+                if (state.in_domain(var, value) && ! state.has_single_value(var))
+                    inference.infer(logger, var != value, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{sat});
+        }
+
+        // Just-met demand: if only `can` variables can take value and the
+        // count's lower bound needs all of them, each is forced to value.
+        if (can == lb_j && can > 0_i) {
+            ReasonLiterals force = absent_ne;
+            force.emplace_back(counts[j] >= lb_j);
+            for (const auto & var : vars)
+                if (state.in_domain(var, value) && ! state.has_single_value(var))
+                    for (const auto & w : state.each_value_mutable(var))
+                        if (w != value)
+                            inference.infer(logger, var != w, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{force});
+        }
+    }
+
+    // Part 2: multi-value Hall intervals over contiguous runs of the
+    // (sorted, distinct) cover values. This is the genuine cross-value
+    // strengthening beyond per-value reasoning: count-variable bound
+    // tightening, variable-domain pruning in both Hall directions, and
+    // infeasibility. All have real pol justifications.
+    for (std::size_t a = 0; a < m; ++a) {
+        set<Integer> hall;
+        Integer cap = 0_i, demand = 0_i;
+        hall.insert(values[a]);
+        {
+            auto [c_lo, c_hi] = state.bounds(counts[a]);
+            cap += c_hi;
+            demand += c_lo;
+        }
+        for (std::size_t b = a + 1; b < m; ++b) {
+            hall.insert(values[b]);
+            auto [c_lo, c_hi] = state.bounds(counts[b]);
+            cap += c_hi;
+            demand += c_lo;
+
+            auto domain_subset_of_hall = [&](const IntegerVariableID & var) -> bool {
+                for (const auto & val : state.each_value_immutable(var))
+                    if (! hall.contains(val))
+                        return false;
+                return true;
+            };
+            auto domain_meets_hall = [&](const IntegerVariableID & var) -> bool {
+                for (const auto & val : hall)
+                    if (state.in_domain(var, val))
+                        return true;
+                return false;
+            };
+
+            vector<IntegerVariableID> confined, potential;
+            for (const auto & var : vars) {
+                if (domain_subset_of_hall(var))
+                    confined.push_back(var);
+                if (domain_meets_hall(var))
+                    potential.push_back(var);
+            }
+            auto confined_count = Integer(confined.size());
+            auto potential_count = Integer(potential.size());
+
+            // The capacity aggregate: summing the per-value count upper
+            // lines (Sum_i x_{i=v} <= c_v), the count upper bounds
+            // (c_v <= ub_v), and an at-least-one over the hall set for
+            // each confined variable yields
+            //   Sum_{i not confined, v in H} x_{i=v} <= cap - confined.
+            // When confined == cap this is <= 0, RUP-closing each removal;
+            // when confined > cap it is already contradictory. Passing a
+            // `keep` index suppresses that value's c_v <= ub_v step so its
+            // count variable survives uncancelled, which RUP-closes the
+            // count lower bound c_keep >= confined - (cap - ub_keep).
+            auto emit_capacity_pol = [&, a = a, b = b](optional<std::size_t> keep) {
+                auto & tracker = logger->names_and_ids_tracker();
+                PolBuilder pb;
+                for (std::size_t v = a; v <= b; ++v) {
+                    pb.add(*count_lines[v].first);
+                    // A constant count already folds its bound into the
+                    // count line; only a real variable needs c_v <= ub_v.
+                    if (keep != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                        pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
+                }
+                for (const auto & var : confined)
+                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
+                pb.emit(*logger, ProofLevel::Temporary);
+            };
+
+            auto capacity_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> ReasonLiterals {
+                ReasonLiterals r;
+                for (const auto & var : confined) {
+                    auto [v_lo, v_hi] = state.bounds(var);
+                    for (Integer s = v_lo; s <= v_hi; ++s)
+                        if (! hall.contains(s) && ! state.in_domain(var, s))
+                            r.emplace_back(var != s);
+                    r.emplace_back(var >= v_lo);
+                    r.emplace_back(var <= v_hi);
+                }
+                for (std::size_t v = a; v <= b; ++v)
+                    if (exclude != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                        r.emplace_back(counts[v] <= state.bounds(counts[v]).second);
+                return r;
+            };
+
+            // The per-value capacity lines Sum_i x_{i=v} <= ub_v and
+            // Sum_i x_{i=v} >= lb_v. Each is a direct consequence of the
+            // count line (Sum_i x_{i=v} = c_v) and the count bound, but
+            // combining them in a pol is blocked because the count line
+            // carries c_v in its bit encoding while the bound is an
+            // order-encoding atom (and is vacuous at the bit-width
+            // boundary). These two true facts are asserted; everything
+            // built on top of them is real, so the surrounding Hall
+            // combinatorics is genuinely checked.
+            auto demand_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> ReasonLiterals {
+                ReasonLiterals r;
+                for (const auto & var : vars)
+                    if (! domain_meets_hall(var))
+                        for (const auto & val : hall)
+                            r.emplace_back(var != val);
+                for (std::size_t v = a; v <= b; ++v)
+                    if (exclude != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                        r.emplace_back(counts[v] >= state.bounds(counts[v]).first);
+                return r;
+            };
+
+            for (std::size_t j = a; j <= b; ++j) {
+                auto [lb_j, ub_j] = state.bounds(counts[j]);
+                auto lower = confined_count - (cap - ub_j);
+                if (lower > lb_j)
+                    // For each v != j sum the count line LE_v with the
+                    // defining implication of c_v <= ub_v (add_for_literal,
+                    // which resolves the order-encoded bound against
+                    // BinEnc(c_v) so the bits cancel, leaving Sum_i x_{i=v}
+                    // <= ub_v reified by the gevar). Add an at-least-one
+                    // over H per confined variable and the j count line
+                    // LE_j; this yields c_j - Sum_{i not confined} x >= L.
+                    // The final RUP closes c_j >= L; its reason supplies
+                    // c_v <= ub_v (v != j), discharging the gevars.
+                    inference.infer(logger, counts[j] >= lower,
+                        JustifyExplicitly{//
+                            [&, a = a, b = b, j = j](const ReasonLiterals &) {
+                                auto & tracker = logger->names_and_ids_tracker();
+                                PolBuilder pb;
+                                for (std::size_t v = a; v <= b; ++v)
+                                    if (v != j) {
+                                        pb.add(*count_lines[v].first);
+                                        if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                                            pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
+                                    }
+                                for (const auto & var : confined)
+                                    pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
+                                pb.add(*count_lines[j].first);
+                                pb.emit(*logger, ProofLevel::Temporary);
+                            },
+                            ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                        LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = capacity_reason(j); }});
+                auto upper = potential_count - (demand - lb_j);
+                if (upper < ub_j)
+                    // Dual: at-most-one over H per potential variable, the
+                    // count lines GE_v with the defining implication of
+                    // c_v >= lb_v for v != j, and the j count line GE_j;
+                    // RUP-closes c_j <= U, the reason discharging the gevars.
+                    inference.infer(logger, counts[j] <= upper,
+                        JustifyExplicitly{//
+                            [&, a = a, b = b, j = j](const ReasonLiterals &) {
+                                auto & tracker = logger->names_and_ids_tracker();
+                                PolBuilder pb;
+                                for (const auto & var : potential) {
+                                    vector<IntegerVariableCondition> atoms;
+                                    for (const auto & val : hall)
+                                        atoms.push_back(var == val);
+                                    pb.add(recover_am1<IntegerVariableCondition>(*logger, ProofLevel::Temporary, atoms,
+                                        [&](const IntegerVariableCondition & p, const IntegerVariableCondition & q) {
+                                            return logger->emit(RUPProofRule{}, WPBSum{} + 1_i * ! p + 1_i * ! q >= 1_i, ProofLevel::Temporary);
+                                        }));
+                                }
+                                for (std::size_t v = a; v <= b; ++v)
+                                    if (v != j) {
+                                        pb.add(*count_lines[v].second);
+                                        if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                                            pb.add_for_literal(tracker, counts[v] >= state.bounds(counts[v]).first);
+                                    }
+                                pb.add(*count_lines[j].second);
+                                pb.emit(*logger, ProofLevel::Temporary);
+                            },
+                            ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                        LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = demand_reason(j); }});
+            }
+
+            if (confined_count > cap) {
+                inference.contradiction(logger,
+                    JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                    LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
+            }
+            else if (confined_count == cap) {
+                for (const auto & var : vars) {
+                    if (domain_subset_of_hall(var))
+                        continue;
+                    for (const auto & val : hall)
+                        if (state.in_domain(var, val))
+                            inference.infer(logger, var != val,
+                                JustifyExplicitly{
+                                    [&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                                LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
+                }
+            }
+
+            // The demand aggregate (dual of the capacity one): summing
+            // the per-value count lower lines (Sum_i x_{i=v} >= c_v), the
+            // count lower bounds (c_v >= lb_v), and an at-most-one over
+            // the hall set for each potential variable yields
+            //   Sum_{i not potential, v in H} x_{i=v} >= demand - potential.
+            // When demand > potential this is contradictory; when
+            // demand == potential, giving one potential variable an
+            // at-most-one over H u {w} instead RUP-closes its removal of
+            // the outside value w.
+            auto emit_demand_pol = [&, a = a, b = b](optional<IntegerVariableID> kvar, Integer kw) {
+                auto & tracker = logger->names_and_ids_tracker();
+                PolBuilder pb;
+                for (std::size_t v = a; v <= b; ++v) {
+                    pb.add(*count_lines[v].second);
+                    if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
+                        pb.add_for_literal(tracker, counts[v] >= state.bounds(counts[v]).first);
+                }
+                for (const auto & var : potential) {
+                    vector<IntegerVariableCondition> atoms;
+                    for (const auto & val : hall)
+                        atoms.push_back(var == val);
+                    if (kvar == optional<IntegerVariableID>{var})
+                        atoms.push_back(var == kw);
+                    pb.add(recover_am1<IntegerVariableCondition>(
+                        *logger, ProofLevel::Temporary, atoms, [&](const IntegerVariableCondition & p, const IntegerVariableCondition & q) {
+                            return logger->emit(RUPProofRule{}, WPBSum{} + 1_i * ! p + 1_i * ! q >= 1_i, ProofLevel::Temporary);
+                        }));
+                }
+                pb.emit(*logger, ProofLevel::Temporary);
+            };
+
+            if (potential_count < demand) {
+                inference.contradiction(logger,
+                    JustifyExplicitly{[&](const ReasonLiterals &) { emit_demand_pol(nullopt, 0_i); }, ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                    LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
+            }
+            else if (potential_count == demand) {
+                for (const auto & var : potential)
+                    for (const auto & val : state.each_value_mutable(var))
+                        if (! hall.contains(val))
+                            inference.infer(logger, var != val,
+                                JustifyExplicitly{[&, var = var, val = val](const ReasonLiterals &) { emit_demand_pol(var, val); }, ThenRUP::Yes,
+                                    hints::GlobalCardinality{owner}},
+                                LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
+            }
+        }
+    }
+
+    return PropagatorState::Enable;
+}
+
+template auto gcs::innards::propagate_bounds_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
+    const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
+    const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+
+template auto gcs::innards::propagate_bounds_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
+    const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
+    const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+
 auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
@@ -118,304 +430,7 @@ auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> 
         constraint_id(),
         [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, count_lines = _count_lines, all_vars = move(all_vars)](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            auto m = values.size();
-
-            // Part 1: per-value (singleton Hall) reasoning, with real RUP
-            // justifications. For each cover value this gives the count variable
-            // its must-occur lower bound and can-occur upper bound, removes a
-            // value whose upper capacity is saturated by the variables fixed to
-            // it, and forces the variables into a value whose lower demand can
-            // only just be met.
-            for (const auto & [j, value] : enumerate(values)) {
-                ReasonLiterals fixed_eq;  // var == value, for variables fixed to value
-                ReasonLiterals absent_ne; // var != value, for variables without value
-                Integer must = 0_i, can = 0_i;
-                for (const auto & var : vars) {
-                    if (state.in_domain(var, value)) {
-                        ++can;
-                        if (state.has_single_value(var)) {
-                            ++must;
-                            fixed_eq.emplace_back(var == value);
-                        }
-                    }
-                    else
-                        absent_ne.emplace_back(var != value);
-                }
-
-                auto [lb_j, ub_j] = state.bounds(counts[j]);
-
-                // c_j >= must: the fixed variables alone force the count up.
-                if (must > lb_j)
-                    inference.infer(logger, counts[j] >= must, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{fixed_eq});
-
-                // c_j <= can: only the variables that can still take value may
-                // contribute to the count.
-                if (can < ub_j)
-                    inference.infer(logger, counts[j] <= can, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{absent_ne});
-
-                // Saturated capacity: if as many variables are already fixed to
-                // value as the count's upper bound allows, no other variable may
-                // take it.
-                if (must == ub_j) {
-                    ReasonLiterals sat = fixed_eq;
-                    sat.emplace_back(counts[j] <= ub_j);
-                    for (const auto & var : vars)
-                        if (state.in_domain(var, value) && ! state.has_single_value(var))
-                            inference.infer(logger, var != value, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{sat});
-                }
-
-                // Just-met demand: if only `can` variables can take value and the
-                // count's lower bound needs all of them, each is forced to value.
-                if (can == lb_j && can > 0_i) {
-                    ReasonLiterals force = absent_ne;
-                    force.emplace_back(counts[j] >= lb_j);
-                    for (const auto & var : vars)
-                        if (state.in_domain(var, value) && ! state.has_single_value(var))
-                            for (const auto & w : state.each_value_mutable(var))
-                                if (w != value)
-                                    inference.infer(logger, var != w, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{force});
-                }
-            }
-
-            // Part 2: multi-value Hall intervals over contiguous runs of the
-            // (sorted, distinct) cover values. This is the genuine cross-value
-            // strengthening beyond per-value reasoning: count-variable bound
-            // tightening, variable-domain pruning in both Hall directions, and
-            // infeasibility. All have real pol justifications.
-            for (std::size_t a = 0; a < m; ++a) {
-                set<Integer> hall;
-                Integer cap = 0_i, demand = 0_i;
-                hall.insert(values[a]);
-                {
-                    auto [c_lo, c_hi] = state.bounds(counts[a]);
-                    cap += c_hi;
-                    demand += c_lo;
-                }
-                for (std::size_t b = a + 1; b < m; ++b) {
-                    hall.insert(values[b]);
-                    auto [c_lo, c_hi] = state.bounds(counts[b]);
-                    cap += c_hi;
-                    demand += c_lo;
-
-                    auto domain_subset_of_hall = [&](const IntegerVariableID & var) -> bool {
-                        for (const auto & val : state.each_value_immutable(var))
-                            if (! hall.contains(val))
-                                return false;
-                        return true;
-                    };
-                    auto domain_meets_hall = [&](const IntegerVariableID & var) -> bool {
-                        for (const auto & val : hall)
-                            if (state.in_domain(var, val))
-                                return true;
-                        return false;
-                    };
-
-                    vector<IntegerVariableID> confined, potential;
-                    for (const auto & var : vars) {
-                        if (domain_subset_of_hall(var))
-                            confined.push_back(var);
-                        if (domain_meets_hall(var))
-                            potential.push_back(var);
-                    }
-                    auto confined_count = Integer(confined.size());
-                    auto potential_count = Integer(potential.size());
-
-                    // The capacity aggregate: summing the per-value count upper
-                    // lines (Sum_i x_{i=v} <= c_v), the count upper bounds
-                    // (c_v <= ub_v), and an at-least-one over the hall set for
-                    // each confined variable yields
-                    //   Sum_{i not confined, v in H} x_{i=v} <= cap - confined.
-                    // When confined == cap this is <= 0, RUP-closing each removal;
-                    // when confined > cap it is already contradictory. Passing a
-                    // `keep` index suppresses that value's c_v <= ub_v step so its
-                    // count variable survives uncancelled, which RUP-closes the
-                    // count lower bound c_keep >= confined - (cap - ub_keep).
-                    auto emit_capacity_pol = [&, a = a, b = b](optional<std::size_t> keep) {
-                        auto & tracker = logger->names_and_ids_tracker();
-                        PolBuilder pb;
-                        for (std::size_t v = a; v <= b; ++v) {
-                            pb.add(*count_lines[v].first);
-                            // A constant count already folds its bound into the
-                            // count line; only a real variable needs c_v <= ub_v.
-                            if (keep != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
-                        }
-                        for (const auto & var : confined)
-                            pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
-                        pb.emit(*logger, ProofLevel::Temporary);
-                    };
-
-                    auto capacity_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> ReasonLiterals {
-                        ReasonLiterals r;
-                        for (const auto & var : confined) {
-                            auto [v_lo, v_hi] = state.bounds(var);
-                            for (Integer s = v_lo; s <= v_hi; ++s)
-                                if (! hall.contains(s) && ! state.in_domain(var, s))
-                                    r.emplace_back(var != s);
-                            r.emplace_back(var >= v_lo);
-                            r.emplace_back(var <= v_hi);
-                        }
-                        for (std::size_t v = a; v <= b; ++v)
-                            if (exclude != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                r.emplace_back(counts[v] <= state.bounds(counts[v]).second);
-                        return r;
-                    };
-
-                    // The per-value capacity lines Sum_i x_{i=v} <= ub_v and
-                    // Sum_i x_{i=v} >= lb_v. Each is a direct consequence of the
-                    // count line (Sum_i x_{i=v} = c_v) and the count bound, but
-                    // combining them in a pol is blocked because the count line
-                    // carries c_v in its bit encoding while the bound is an
-                    // order-encoding atom (and is vacuous at the bit-width
-                    // boundary). These two true facts are asserted; everything
-                    // built on top of them is real, so the surrounding Hall
-                    // combinatorics is genuinely checked.
-                    auto demand_reason = [&, a = a, b = b](optional<std::size_t> exclude) -> ReasonLiterals {
-                        ReasonLiterals r;
-                        for (const auto & var : vars)
-                            if (! domain_meets_hall(var))
-                                for (const auto & val : hall)
-                                    r.emplace_back(var != val);
-                        for (std::size_t v = a; v <= b; ++v)
-                            if (exclude != optional<std::size_t>{v} && ! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                r.emplace_back(counts[v] >= state.bounds(counts[v]).first);
-                        return r;
-                    };
-
-                    for (std::size_t j = a; j <= b; ++j) {
-                        auto [lb_j, ub_j] = state.bounds(counts[j]);
-                        auto lower = confined_count - (cap - ub_j);
-                        if (lower > lb_j)
-                            // For each v != j sum the count line LE_v with the
-                            // defining implication of c_v <= ub_v (add_for_literal,
-                            // which resolves the order-encoded bound against
-                            // BinEnc(c_v) so the bits cancel, leaving Sum_i x_{i=v}
-                            // <= ub_v reified by the gevar). Add an at-least-one
-                            // over H per confined variable and the j count line
-                            // LE_j; this yields c_j - Sum_{i not confined} x >= L.
-                            // The final RUP closes c_j >= L; its reason supplies
-                            // c_v <= ub_v (v != j), discharging the gevars.
-                            inference.infer(logger, counts[j] >= lower,
-                                JustifyExplicitly{//
-                                    [&, a = a, b = b, j = j](const ReasonLiterals &) {
-                                        auto & tracker = logger->names_and_ids_tracker();
-                                        PolBuilder pb;
-                                        for (std::size_t v = a; v <= b; ++v)
-                                            if (v != j) {
-                                                pb.add(*count_lines[v].first);
-                                                if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                                    pb.add_for_literal(tracker, counts[v] <= state.bounds(counts[v]).second);
-                                            }
-                                        for (const auto & var : confined)
-                                            pb.add(tracker.need_constraint_saying_variable_takes_at_least_one_value(var));
-                                        pb.add(*count_lines[j].first);
-                                        pb.emit(*logger, ProofLevel::Temporary);
-                                    },
-                                    ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                                LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = capacity_reason(j); }});
-                        auto upper = potential_count - (demand - lb_j);
-                        if (upper < ub_j)
-                            // Dual: at-most-one over H per potential variable, the
-                            // count lines GE_v with the defining implication of
-                            // c_v >= lb_v for v != j, and the j count line GE_j;
-                            // RUP-closes c_j <= U, the reason discharging the gevars.
-                            inference.infer(logger, counts[j] <= upper,
-                                JustifyExplicitly{//
-                                    [&, a = a, b = b, j = j](const ReasonLiterals &) {
-                                        auto & tracker = logger->names_and_ids_tracker();
-                                        PolBuilder pb;
-                                        for (const auto & var : potential) {
-                                            vector<IntegerVariableCondition> atoms;
-                                            for (const auto & val : hall)
-                                                atoms.push_back(var == val);
-                                            pb.add(recover_am1<IntegerVariableCondition>(*logger, ProofLevel::Temporary, atoms,
-                                                [&](const IntegerVariableCondition & p, const IntegerVariableCondition & q) {
-                                                    return logger->emit(
-                                                        RUPProofRule{}, WPBSum{} + 1_i * ! p + 1_i * ! q >= 1_i, ProofLevel::Temporary);
-                                                }));
-                                        }
-                                        for (std::size_t v = a; v <= b; ++v)
-                                            if (v != j) {
-                                                pb.add(*count_lines[v].second);
-                                                if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                                    pb.add_for_literal(tracker, counts[v] >= state.bounds(counts[v]).first);
-                                            }
-                                        pb.add(*count_lines[j].second);
-                                        pb.emit(*logger, ProofLevel::Temporary);
-                                    },
-                                    ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                                LazyReasonOver{vars, [&, j = j](const State &, ReasonLiterals & out) { out = demand_reason(j); }});
-                    }
-
-                    if (confined_count > cap) {
-                        inference.contradiction(logger,
-                            JustifyExplicitly{
-                                [&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                            LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
-                    }
-                    else if (confined_count == cap) {
-                        for (const auto & var : vars) {
-                            if (domain_subset_of_hall(var))
-                                continue;
-                            for (const auto & val : hall)
-                                if (state.in_domain(var, val))
-                                    inference.infer(logger, var != val,
-                                        JustifyExplicitly{[&](const ReasonLiterals &) { emit_capacity_pol(nullopt); }, ThenRUP::Yes,
-                                            hints::GlobalCardinality{owner}},
-                                        LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = capacity_reason(nullopt); }});
-                        }
-                    }
-
-                    // The demand aggregate (dual of the capacity one): summing
-                    // the per-value count lower lines (Sum_i x_{i=v} >= c_v), the
-                    // count lower bounds (c_v >= lb_v), and an at-most-one over
-                    // the hall set for each potential variable yields
-                    //   Sum_{i not potential, v in H} x_{i=v} >= demand - potential.
-                    // When demand > potential this is contradictory; when
-                    // demand == potential, giving one potential variable an
-                    // at-most-one over H u {w} instead RUP-closes its removal of
-                    // the outside value w.
-                    auto emit_demand_pol = [&, a = a, b = b](optional<IntegerVariableID> kvar, Integer kw) {
-                        auto & tracker = logger->names_and_ids_tracker();
-                        PolBuilder pb;
-                        for (std::size_t v = a; v <= b; ++v) {
-                            pb.add(*count_lines[v].second);
-                            if (! holds_alternative<ConstantIntegerVariableID>(counts[v]))
-                                pb.add_for_literal(tracker, counts[v] >= state.bounds(counts[v]).first);
-                        }
-                        for (const auto & var : potential) {
-                            vector<IntegerVariableCondition> atoms;
-                            for (const auto & val : hall)
-                                atoms.push_back(var == val);
-                            if (kvar == optional<IntegerVariableID>{var})
-                                atoms.push_back(var == kw);
-                            pb.add(recover_am1<IntegerVariableCondition>(
-                                *logger, ProofLevel::Temporary, atoms, [&](const IntegerVariableCondition & p, const IntegerVariableCondition & q) {
-                                    return logger->emit(RUPProofRule{}, WPBSum{} + 1_i * ! p + 1_i * ! q >= 1_i, ProofLevel::Temporary);
-                                }));
-                        }
-                        pb.emit(*logger, ProofLevel::Temporary);
-                    };
-
-                    if (potential_count < demand) {
-                        inference.contradiction(logger,
-                            JustifyExplicitly{
-                                [&](const ReasonLiterals &) { emit_demand_pol(nullopt, 0_i); }, ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                            LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
-                    }
-                    else if (potential_count == demand) {
-                        for (const auto & var : potential)
-                            for (const auto & val : state.each_value_mutable(var))
-                                if (! hall.contains(val))
-                                    inference.infer(logger, var != val,
-                                        JustifyExplicitly{[&, var = var, val = val](const ReasonLiterals &) { emit_demand_pol(var, val); },
-                                            ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                                        LazyReasonOver{vars, [&](const State &, ReasonLiterals & out) { out = demand_reason(nullopt); }});
-                    }
-                }
-            }
-
-            return PropagatorState::Enable;
+            return propagate_bounds_global_cardinality(vars, owner, values, counts, count_lines, all_vars, state, inference, logger);
         },
         triggers);
 }

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
@@ -12,6 +13,19 @@
 
 namespace gcs
 {
+    namespace innards
+    {
+        /**
+         * \brief The bounds-consistency GlobalCardinality propagator, extracted from
+         * BoundsGlobalCardinality's install_propagators so the forthcoming merged
+         * GlobalCardinality can dispatch to it. Behaviour is unchanged.
+         */
+        [[nodiscard]] auto propagate_bounds_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
+            const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
+            const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines,
+            const std::vector<IntegerVariableID> & all_vars, const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState;
+    }
+
     /**
      * \brief The Global Cardinality Constraint, enforced to bounds consistency
      * via Hall-interval reasoning over the cover values.

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -180,6 +180,468 @@ auto GACGlobalCardinality::define_proof_model(ProofModel & model) -> void
     }
 }
 
+auto gcs::innards::propagate_gac_global_cardinality(const vector<IntegerVariableID> & vars, const ConstraintID & owner,
+    const vector<Integer> & values, const vector<IntegerVariableID> & counts, bool closed,
+    const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, const vector<IntegerVariableID> & all_vars, const State & state,
+    auto & inference, ProofLogger * const logger) -> PropagatorState
+{
+    auto m = values.size();
+    auto n = vars.size();
+
+    // Per-value count bounds: keep the count variables pinned to the
+    // must-occur..can-occur range (so they are determined at a leaf).
+    // These are the certified per-value RUP steps from the BC propagator.
+    for (const auto & [j, value] : enumerate(values)) {
+        ReasonLiterals fixed_eq, absent_ne;
+        Integer must = 0_i, can = 0_i;
+        for (const auto & var : vars) {
+            if (state.in_domain(var, value)) {
+                ++can;
+                if (state.has_single_value(var)) {
+                    ++must;
+                    fixed_eq.emplace_back(var == value);
+                }
+            }
+            else
+                absent_ne.emplace_back(var != value);
+        }
+        auto [lb_j, ub_j] = state.bounds(counts[j]);
+        if (must > lb_j)
+            inference.infer(logger, counts[j] >= must, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{fixed_eq});
+        if (can < ub_j)
+            inference.infer(logger, counts[j] <= can, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{absent_ne});
+    }
+
+    // Build Régin's value graph as a flow network and find a feasible
+    // flow with lower bounds. Every variable must be assigned (var->T is
+    // [1,1]); in the open case a dummy value of capacity [0,n] absorbs
+    // the variables that take a non-cover value. Node layout: 0 = source,
+    // 1 = sink, 2+j = value j, 2+m = dummy value, 2+m+1+i = variable i,
+    // then a super source/sink for the lower-bound reduction.
+    auto S = 0, T = 1;
+    auto value_node = [&](std::size_t j) { return 2 + static_cast<int>(j); };
+    auto dummy_node = 2 + static_cast<int>(m);
+    auto var_node = [&](std::size_t i) { return 2 + static_cast<int>(m) + 1 + static_cast<int>(i); };
+    auto base_nodes = 2 + static_cast<int>(m) + 1 + static_cast<int>(n);
+    auto SS = base_nodes, TT = base_nodes + 1;
+    MaxFlow mf(base_nodes + 2);
+
+    set<Integer> cover(values.begin(), values.end());
+    long long inf = static_cast<long long>(n) + 1;
+
+    // Original edges with lower bounds, recorded so we can recover the
+    // feasible flow and build the residual.
+    struct OrigEdge
+    {
+        int from, to;
+        long long lo, hi;
+        int u, k; // location of the reduced (hi - lo) edge in mf.g
+    };
+    vector<OrigEdge> orig;
+    vector<long long> excess(base_nodes + 2, 0);
+
+    auto add_orig = [&](int u, int v, long long lo, long long hi) {
+        auto [a, k] = mf.add_edge(u, v, hi - lo);
+        orig.push_back(OrigEdge{u, v, lo, hi, a, k});
+        excess[v] += lo;
+        excess[u] -= lo;
+    };
+
+    // value->var assignment edges; remember which OrigEdge each is.
+    vector<vector<int>> assign_edge(m, vector<int>(n, -1));
+    for (const auto & [j, value] : enumerate(values)) {
+        auto [c_lo, c_hi] = state.bounds(counts[j]);
+        if (c_lo < 0_i)
+            c_lo = 0_i;
+        add_orig(S, value_node(j), c_lo.raw_value, c_hi.raw_value);
+        for (std::size_t i = 0; i < n; ++i)
+            if (state.in_domain(vars[i], value)) {
+                assign_edge[j][i] = static_cast<int>(orig.size());
+                add_orig(value_node(j), var_node(i), 0, 1);
+            }
+    }
+    vector<int> dummy_edge(n, -1);
+    if (! closed) {
+        add_orig(S, dummy_node, 0, inf);
+        for (std::size_t i = 0; i < n; ++i) {
+            bool has_non_cover = false;
+            for (const auto & val : state.each_value_immutable(vars[i]))
+                if (! cover.contains(val)) {
+                    has_non_cover = true;
+                    break;
+                }
+            if (has_non_cover) {
+                dummy_edge[i] = static_cast<int>(orig.size());
+                add_orig(dummy_node, var_node(i), 0, 1);
+            }
+        }
+    }
+    for (std::size_t i = 0; i < n; ++i)
+        add_orig(var_node(i), T, 1, 1);
+    add_orig(T, S, 0, inf);
+
+    // Lower-bound reduction: balance the excess through SS/TT.
+    long long need = 0;
+    for (int node = 0; node < base_nodes; ++node) {
+        if (excess[node] > 0) {
+            mf.add_edge(SS, node, excess[node]);
+            need += excess[node];
+        }
+        else if (excess[node] < 0)
+            mf.add_edge(node, TT, -excess[node]);
+    }
+
+    auto feasible = (mf.max_flow(SS, TT) == need);
+
+    // Flow on each original edge (the partial flow when infeasible).
+    vector<long long> flow(orig.size());
+    for (const auto & [idx, e] : enumerate(orig))
+        flow[idx] = e.lo + mf.flow_on(e.u, e.k);
+
+    if (! feasible) {
+        // A variable the flow could not assign (no incoming assignment)
+        // witnesses a capacity-driven Hall violator: grow a set of
+        // variables confined to cover values whose total upper capacity
+        // is too small. (Demand-driven infeasibility -- too much lower
+        // demand for the suppliers -- is still asserted.)
+        int unmatched = -1;
+        for (std::size_t i = 0; i < n && unmatched < 0; ++i) {
+            long long in = 0;
+            for (std::size_t j = 0; j < m; ++j)
+                if (assign_edge[j][i] >= 0)
+                    in += flow[assign_edge[j][i]];
+            if (dummy_edge[i] >= 0)
+                in += flow[dummy_edge[i]];
+            if (in == 0)
+                unmatched = static_cast<int>(i);
+        }
+
+        vector<std::size_t> cut_values;
+        vector<IntegerVariableID> confined;
+        if (unmatched >= 0) {
+            vector<std::uint8_t> hv_var(n, 0), hv_val(m, 0);
+            hv_var[unmatched] = 1;
+            bool grew = true;
+            while (grew) {
+                grew = false;
+                for (std::size_t j = 0; j < m; ++j) {
+                    if (hv_val[j])
+                        continue;
+                    bool in_neighbourhood = false;
+                    for (std::size_t i = 0; i < n; ++i)
+                        if (hv_var[i] && state.in_domain(vars[i], values[j])) {
+                            in_neighbourhood = true;
+                            break;
+                        }
+                    if (! in_neighbourhood)
+                        continue;
+                    hv_val[j] = 1;
+                    grew = true;
+                    for (std::size_t i = 0; i < n; ++i)
+                        if (assign_edge[j][i] >= 0 && flow[assign_edge[j][i]] == 1)
+                            hv_var[i] = 1;
+                }
+            }
+            for (std::size_t j = 0; j < m; ++j)
+                if (hv_val[j])
+                    cut_values.push_back(j);
+            // Confine to the variables that can only take cut values.
+            set<Integer> hall;
+            for (auto j : cut_values)
+                hall.insert(values[j]);
+            Integer cap = 0_i;
+            for (auto j : cut_values)
+                cap += state.bounds(counts[j]).second;
+            for (std::size_t i = 0; i < n; ++i) {
+                bool subset = true;
+                for (const auto & val : state.each_value_immutable(vars[i]))
+                    if (! hall.contains(val)) {
+                        subset = false;
+                        break;
+                    }
+                if (subset)
+                    confined.push_back(vars[i]);
+            }
+            if (Integer(confined.size()) <= cap) {
+                cut_values.clear();
+                confined.clear();
+            }
+        }
+
+        // Demand-driven Hall violator (dual of the capacity one): grow
+        // from an under-supplied value a set of cover values whose total
+        // lower demand exceeds the variables that can supply them.
+        vector<std::size_t> demand_cut;
+        vector<IntegerVariableID> suppliers;
+        if (cut_values.empty()) {
+            int under = -1;
+            for (std::size_t j = 0; j < m && under < 0; ++j) {
+                long long assigned = 0;
+                for (std::size_t i = 0; i < n; ++i)
+                    if (assign_edge[j][i] >= 0)
+                        assigned += flow[assign_edge[j][i]];
+                if (assigned < state.bounds(counts[j]).first.raw_value)
+                    under = static_cast<int>(j);
+            }
+            if (under >= 0) {
+                vector<std::uint8_t> hv_val(m, 0), hv_var(n, 0);
+                hv_val[under] = 1;
+                bool grew = true;
+                while (grew) {
+                    grew = false;
+                    for (std::size_t i = 0; i < n; ++i) {
+                        if (hv_var[i])
+                            continue;
+                        bool meets = false;
+                        for (std::size_t j = 0; j < m; ++j)
+                            if (hv_val[j] && state.in_domain(vars[i], values[j])) {
+                                meets = true;
+                                break;
+                            }
+                        if (! meets)
+                            continue;
+                        hv_var[i] = 1;
+                        grew = true;
+                        for (std::size_t j = 0; j < m; ++j)
+                            if (! hv_val[j] && assign_edge[j][i] >= 0 && flow[assign_edge[j][i]] == 1)
+                                hv_val[j] = 1;
+                    }
+                }
+                Integer demand = 0_i;
+                for (std::size_t j = 0; j < m; ++j)
+                    if (hv_val[j]) {
+                        demand_cut.push_back(j);
+                        demand += state.bounds(counts[j]).first;
+                    }
+                for (std::size_t i = 0; i < n; ++i)
+                    if (hv_var[i])
+                        suppliers.push_back(vars[i]);
+                if (Integer(suppliers.size()) >= demand) {
+                    demand_cut.clear();
+                    suppliers.clear();
+                }
+            }
+        }
+
+        if (! cut_values.empty())
+            inference.contradiction(logger,
+                JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
+                                      emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
+                                  },
+                    ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) {
+                                   out = gcc_capacity_reason(state, values, counts, cut_values, confined);
+                               }});
+        else if (! demand_cut.empty())
+            inference.contradiction(logger,
+                JustifyExplicitly{//
+                    [&, demand_cut, suppliers](const ReasonLiterals &) {
+                        emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, demand_cut, suppliers, nullopt, nullopt);
+                    },
+                    ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                LazyReasonOver{vars, [&, demand_cut, suppliers](const State &, ReasonLiterals & out) {
+                                   out = gcc_demand_reason(state, vars, values, counts, demand_cut, suppliers);
+                               }});
+        else if (closed && unmatched >= 0)
+            // A closed variable with no cover value left: the per-variable
+            // In constraint certifies this, so leave it to that rather
+            // than raise an unjustified contradiction here.
+            return PropagatorState::Enable;
+        else
+            // An infeasible flow has either an unassignable variable
+            // (capacity Hall violator) or an under-supplied value (demand
+            // Hall violator), so one of the branches above should have
+            // fired. Reaching here means the violator search missed it:
+            // fail loudly rather than emit an unjustified contradiction.
+            throw UnexpectedException{"global cardinality: infeasible flow with no Hall violator found"};
+        return PropagatorState::Enable;
+    }
+
+    vector<vector<int>> radj(base_nodes);
+    for (const auto & [idx, e] : enumerate(orig)) {
+        if (flow[idx] < e.hi)
+            radj[e.from].push_back(e.to);
+        if (flow[idx] > e.lo)
+            radj[e.to].push_back(e.from);
+    }
+
+    // Tarjan strongly-connected components of the residual.
+    vector<int> index(base_nodes, 0), low(base_nodes, 0), comp(base_nodes, -1);
+    vector<std::uint8_t> on_stack(base_nodes, 0);
+    vector<int> stk;
+    int next_index = 1, n_comp = 0;
+    function<void(int)> scc = [&](int v) {
+        index[v] = low[v] = next_index++;
+        stk.push_back(v);
+        on_stack[v] = 1;
+        for (auto w : radj[v]) {
+            if (index[w] == 0) {
+                scc(w);
+                low[v] = min(low[v], low[w]);
+            }
+            else if (on_stack[w])
+                low[v] = min(low[v], index[w]);
+        }
+        if (low[v] == index[v]) {
+            int w;
+            do {
+                w = stk.back();
+                stk.pop_back();
+                on_stack[w] = 0;
+                comp[w] = n_comp;
+            } while (w != v);
+            ++n_comp;
+        }
+    };
+    for (int v = 0; v < base_nodes; ++v)
+        if (index[v] == 0)
+            scc(v);
+
+    // Residual reachability from a node (for extracting the proof cut).
+    auto reachable_from = [&](int start) {
+        vector<std::uint8_t> seen(base_nodes, 0);
+        vector<int> q{start};
+        seen[start] = 1;
+        for (std::size_t h = 0; h < q.size(); ++h)
+            for (auto w : radj[q[h]])
+                if (! seen[w]) {
+                    seen[w] = 1;
+                    q.push_back(w);
+                }
+        return seen;
+    };
+
+    auto value_index = [&](Integer val) -> int {
+        for (std::size_t v = 0; v < m; ++v)
+            if (values[v] == val)
+                return static_cast<int>(v);
+        return -1;
+    };
+
+    // An assignment edge value j -> var i that carries no flow and
+    // crosses two components has no support: prune it, justified by the
+    // cut reachable from the variable. If the source is in that cut the
+    // pruning is capacity-driven (the values *outside* the cut are full);
+    // otherwise it is demand-driven (the values *inside* the cut are at
+    // their lower bound).
+    for (const auto & [j, value] : enumerate(values))
+        for (std::size_t i = 0; i < n; ++i) {
+            auto ei = assign_edge[j][i];
+            if (ei < 0)
+                continue;
+            if (! (flow[ei] == 0 && comp[value_node(j)] != comp[var_node(i)]))
+                continue;
+
+            auto seen = reachable_from(var_node(i));
+            if (seen[S]) {
+                // Capacity cut: full cover values are those not reachable.
+                vector<std::size_t> cut_values;
+                for (std::size_t v = 0; v < m; ++v)
+                    if (! seen[value_node(v)])
+                        cut_values.push_back(v);
+                vector<IntegerVariableID> confined;
+                for (std::size_t k = 0; k < n; ++k) {
+                    bool subset = true;
+                    for (const auto & val : state.each_value_immutable(vars[k])) {
+                        auto vi = value_index(val);
+                        if (vi < 0 || seen[value_node(static_cast<std::size_t>(vi))]) {
+                            subset = false;
+                            break;
+                        }
+                    }
+                    if (subset)
+                        confined.push_back(vars[k]);
+                }
+                inference.infer(logger, vars[i] != value,
+                    JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
+                                          emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
+                                      },
+                        ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                    LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) {
+                                       out = gcc_capacity_reason(state, values, counts, cut_values, confined);
+                                   }});
+            }
+            else {
+                // Demand cut: cover values inside the cut are at their lower bound.
+                vector<std::size_t> cut_values;
+                for (std::size_t v = 0; v < m; ++v)
+                    if (seen[value_node(v)])
+                        cut_values.push_back(v);
+                // The at-most-ones must cover every variable that can take
+                // a cut value, matching the reason's exclusions.
+                vector<IntegerVariableID> potential;
+                for (std::size_t k = 0; k < n; ++k) {
+                    bool meets = false;
+                    for (auto v : cut_values)
+                        if (state.in_domain(vars[k], values[v])) {
+                            meets = true;
+                            break;
+                        }
+                    if (meets)
+                        potential.push_back(vars[k]);
+                }
+                inference.infer(logger, vars[i] != value,
+                    JustifyExplicitly{//
+                        [&, cut_values, potential, value = value, i = i](const ReasonLiterals &) {
+                            emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], value);
+                        },
+                        ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                    LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) {
+                                       out = gcc_demand_reason(state, vars, values, counts, cut_values, potential);
+                                   }});
+            }
+        }
+
+    // Likewise the dummy edge: if a variable cannot route through the
+    // dummy value, it cannot take any non-cover value. This is always a
+    // demand cut (the cover values' lower bounds force the variable in),
+    // so the source is not in the cut reachable from it.
+    for (std::size_t i = 0; i < n; ++i) {
+        auto ei = dummy_edge[i];
+        if (! (ei >= 0 && flow[ei] == 0 && comp[dummy_node] != comp[var_node(i)]))
+            continue;
+        auto seen = reachable_from(var_node(i));
+        vector<std::size_t> cut_values;
+        for (std::size_t v = 0; v < m; ++v)
+            if (seen[value_node(v)])
+                cut_values.push_back(v);
+        vector<IntegerVariableID> potential;
+        for (std::size_t k = 0; k < n; ++k) {
+            bool meets = false;
+            for (auto v : cut_values)
+                if (state.in_domain(vars[k], values[v])) {
+                    meets = true;
+                    break;
+                }
+            if (meets)
+                potential.push_back(vars[k]);
+        }
+        for (const auto & val : state.each_value_mutable(vars[i]))
+            if (! cover.contains(val))
+                inference.infer(logger, vars[i] != val,
+                    JustifyExplicitly{//
+                        [&, cut_values, potential, val = val, i = i](const ReasonLiterals &) {
+                            emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], val);
+                        },
+                        ThenRUP::Yes, hints::GlobalCardinality{owner}},
+                    LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) {
+                                       out = gcc_demand_reason(state, vars, values, counts, cut_values, potential);
+                                   }});
+    }
+
+    return PropagatorState::Enable;
+}
+
+template auto gcs::innards::propagate_gac_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
+    const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts, bool closed,
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
+    const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+
+template auto gcs::innards::propagate_gac_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
+    const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts, bool closed,
+    const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
+    const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
+
 auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> void
 {
     Triggers triggers;
@@ -193,451 +655,7 @@ auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> voi
         constraint_id(),
         [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, closed = _closed, count_lines = _count_lines,
             all_vars = move(all_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            auto m = values.size();
-            auto n = vars.size();
-
-            // Per-value count bounds: keep the count variables pinned to the
-            // must-occur..can-occur range (so they are determined at a leaf).
-            // These are the certified per-value RUP steps from the BC propagator.
-            for (const auto & [j, value] : enumerate(values)) {
-                ReasonLiterals fixed_eq, absent_ne;
-                Integer must = 0_i, can = 0_i;
-                for (const auto & var : vars) {
-                    if (state.in_domain(var, value)) {
-                        ++can;
-                        if (state.has_single_value(var)) {
-                            ++must;
-                            fixed_eq.emplace_back(var == value);
-                        }
-                    }
-                    else
-                        absent_ne.emplace_back(var != value);
-                }
-                auto [lb_j, ub_j] = state.bounds(counts[j]);
-                if (must > lb_j)
-                    inference.infer(logger, counts[j] >= must, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{fixed_eq});
-                if (can < ub_j)
-                    inference.infer(logger, counts[j] <= can, JustifyUsingRUP{hints::GlobalCardinality{owner}}, ExplicitReason{absent_ne});
-            }
-
-            // Build Régin's value graph as a flow network and find a feasible
-            // flow with lower bounds. Every variable must be assigned (var->T is
-            // [1,1]); in the open case a dummy value of capacity [0,n] absorbs
-            // the variables that take a non-cover value. Node layout: 0 = source,
-            // 1 = sink, 2+j = value j, 2+m = dummy value, 2+m+1+i = variable i,
-            // then a super source/sink for the lower-bound reduction.
-            auto S = 0, T = 1;
-            auto value_node = [&](std::size_t j) { return 2 + static_cast<int>(j); };
-            auto dummy_node = 2 + static_cast<int>(m);
-            auto var_node = [&](std::size_t i) { return 2 + static_cast<int>(m) + 1 + static_cast<int>(i); };
-            auto base_nodes = 2 + static_cast<int>(m) + 1 + static_cast<int>(n);
-            auto SS = base_nodes, TT = base_nodes + 1;
-            MaxFlow mf(base_nodes + 2);
-
-            set<Integer> cover(values.begin(), values.end());
-            long long inf = static_cast<long long>(n) + 1;
-
-            // Original edges with lower bounds, recorded so we can recover the
-            // feasible flow and build the residual.
-            struct OrigEdge
-            {
-                int from, to;
-                long long lo, hi;
-                int u, k; // location of the reduced (hi - lo) edge in mf.g
-            };
-            vector<OrigEdge> orig;
-            vector<long long> excess(base_nodes + 2, 0);
-
-            auto add_orig = [&](int u, int v, long long lo, long long hi) {
-                auto [a, k] = mf.add_edge(u, v, hi - lo);
-                orig.push_back(OrigEdge{u, v, lo, hi, a, k});
-                excess[v] += lo;
-                excess[u] -= lo;
-            };
-
-            // value->var assignment edges; remember which OrigEdge each is.
-            vector<vector<int>> assign_edge(m, vector<int>(n, -1));
-            for (const auto & [j, value] : enumerate(values)) {
-                auto [c_lo, c_hi] = state.bounds(counts[j]);
-                if (c_lo < 0_i)
-                    c_lo = 0_i;
-                add_orig(S, value_node(j), c_lo.raw_value, c_hi.raw_value);
-                for (std::size_t i = 0; i < n; ++i)
-                    if (state.in_domain(vars[i], value)) {
-                        assign_edge[j][i] = static_cast<int>(orig.size());
-                        add_orig(value_node(j), var_node(i), 0, 1);
-                    }
-            }
-            vector<int> dummy_edge(n, -1);
-            if (! closed) {
-                add_orig(S, dummy_node, 0, inf);
-                for (std::size_t i = 0; i < n; ++i) {
-                    bool has_non_cover = false;
-                    for (const auto & val : state.each_value_immutable(vars[i]))
-                        if (! cover.contains(val)) {
-                            has_non_cover = true;
-                            break;
-                        }
-                    if (has_non_cover) {
-                        dummy_edge[i] = static_cast<int>(orig.size());
-                        add_orig(dummy_node, var_node(i), 0, 1);
-                    }
-                }
-            }
-            for (std::size_t i = 0; i < n; ++i)
-                add_orig(var_node(i), T, 1, 1);
-            add_orig(T, S, 0, inf);
-
-            // Lower-bound reduction: balance the excess through SS/TT.
-            long long need = 0;
-            for (int node = 0; node < base_nodes; ++node) {
-                if (excess[node] > 0) {
-                    mf.add_edge(SS, node, excess[node]);
-                    need += excess[node];
-                }
-                else if (excess[node] < 0)
-                    mf.add_edge(node, TT, -excess[node]);
-            }
-
-            auto feasible = (mf.max_flow(SS, TT) == need);
-
-            // Flow on each original edge (the partial flow when infeasible).
-            vector<long long> flow(orig.size());
-            for (const auto & [idx, e] : enumerate(orig))
-                flow[idx] = e.lo + mf.flow_on(e.u, e.k);
-
-            if (! feasible) {
-                // A variable the flow could not assign (no incoming assignment)
-                // witnesses a capacity-driven Hall violator: grow a set of
-                // variables confined to cover values whose total upper capacity
-                // is too small. (Demand-driven infeasibility -- too much lower
-                // demand for the suppliers -- is still asserted.)
-                int unmatched = -1;
-                for (std::size_t i = 0; i < n && unmatched < 0; ++i) {
-                    long long in = 0;
-                    for (std::size_t j = 0; j < m; ++j)
-                        if (assign_edge[j][i] >= 0)
-                            in += flow[assign_edge[j][i]];
-                    if (dummy_edge[i] >= 0)
-                        in += flow[dummy_edge[i]];
-                    if (in == 0)
-                        unmatched = static_cast<int>(i);
-                }
-
-                vector<std::size_t> cut_values;
-                vector<IntegerVariableID> confined;
-                if (unmatched >= 0) {
-                    vector<std::uint8_t> hv_var(n, 0), hv_val(m, 0);
-                    hv_var[unmatched] = 1;
-                    bool grew = true;
-                    while (grew) {
-                        grew = false;
-                        for (std::size_t j = 0; j < m; ++j) {
-                            if (hv_val[j])
-                                continue;
-                            bool in_neighbourhood = false;
-                            for (std::size_t i = 0; i < n; ++i)
-                                if (hv_var[i] && state.in_domain(vars[i], values[j])) {
-                                    in_neighbourhood = true;
-                                    break;
-                                }
-                            if (! in_neighbourhood)
-                                continue;
-                            hv_val[j] = 1;
-                            grew = true;
-                            for (std::size_t i = 0; i < n; ++i)
-                                if (assign_edge[j][i] >= 0 && flow[assign_edge[j][i]] == 1)
-                                    hv_var[i] = 1;
-                        }
-                    }
-                    for (std::size_t j = 0; j < m; ++j)
-                        if (hv_val[j])
-                            cut_values.push_back(j);
-                    // Confine to the variables that can only take cut values.
-                    set<Integer> hall;
-                    for (auto j : cut_values)
-                        hall.insert(values[j]);
-                    Integer cap = 0_i;
-                    for (auto j : cut_values)
-                        cap += state.bounds(counts[j]).second;
-                    for (std::size_t i = 0; i < n; ++i) {
-                        bool subset = true;
-                        for (const auto & val : state.each_value_immutable(vars[i]))
-                            if (! hall.contains(val)) {
-                                subset = false;
-                                break;
-                            }
-                        if (subset)
-                            confined.push_back(vars[i]);
-                    }
-                    if (Integer(confined.size()) <= cap) {
-                        cut_values.clear();
-                        confined.clear();
-                    }
-                }
-
-                // Demand-driven Hall violator (dual of the capacity one): grow
-                // from an under-supplied value a set of cover values whose total
-                // lower demand exceeds the variables that can supply them.
-                vector<std::size_t> demand_cut;
-                vector<IntegerVariableID> suppliers;
-                if (cut_values.empty()) {
-                    int under = -1;
-                    for (std::size_t j = 0; j < m && under < 0; ++j) {
-                        long long assigned = 0;
-                        for (std::size_t i = 0; i < n; ++i)
-                            if (assign_edge[j][i] >= 0)
-                                assigned += flow[assign_edge[j][i]];
-                        if (assigned < state.bounds(counts[j]).first.raw_value)
-                            under = static_cast<int>(j);
-                    }
-                    if (under >= 0) {
-                        vector<std::uint8_t> hv_val(m, 0), hv_var(n, 0);
-                        hv_val[under] = 1;
-                        bool grew = true;
-                        while (grew) {
-                            grew = false;
-                            for (std::size_t i = 0; i < n; ++i) {
-                                if (hv_var[i])
-                                    continue;
-                                bool meets = false;
-                                for (std::size_t j = 0; j < m; ++j)
-                                    if (hv_val[j] && state.in_domain(vars[i], values[j])) {
-                                        meets = true;
-                                        break;
-                                    }
-                                if (! meets)
-                                    continue;
-                                hv_var[i] = 1;
-                                grew = true;
-                                for (std::size_t j = 0; j < m; ++j)
-                                    if (! hv_val[j] && assign_edge[j][i] >= 0 && flow[assign_edge[j][i]] == 1)
-                                        hv_val[j] = 1;
-                            }
-                        }
-                        Integer demand = 0_i;
-                        for (std::size_t j = 0; j < m; ++j)
-                            if (hv_val[j]) {
-                                demand_cut.push_back(j);
-                                demand += state.bounds(counts[j]).first;
-                            }
-                        for (std::size_t i = 0; i < n; ++i)
-                            if (hv_var[i])
-                                suppliers.push_back(vars[i]);
-                        if (Integer(suppliers.size()) >= demand) {
-                            demand_cut.clear();
-                            suppliers.clear();
-                        }
-                    }
-                }
-
-                if (! cut_values.empty())
-                    inference.contradiction(logger,
-                        JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
-                                              emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
-                                          },
-                            ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                        LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) {
-                                           out = gcc_capacity_reason(state, values, counts, cut_values, confined);
-                                       }});
-                else if (! demand_cut.empty())
-                    inference.contradiction(logger,
-                        JustifyExplicitly{//
-                            [&, demand_cut, suppliers](const ReasonLiterals &) {
-                                emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, demand_cut, suppliers, nullopt, nullopt);
-                            },
-                            ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                        LazyReasonOver{vars, [&, demand_cut, suppliers](const State &, ReasonLiterals & out) {
-                                           out = gcc_demand_reason(state, vars, values, counts, demand_cut, suppliers);
-                                       }});
-                else if (closed && unmatched >= 0)
-                    // A closed variable with no cover value left: the per-variable
-                    // In constraint certifies this, so leave it to that rather
-                    // than raise an unjustified contradiction here.
-                    return PropagatorState::Enable;
-                else
-                    // An infeasible flow has either an unassignable variable
-                    // (capacity Hall violator) or an under-supplied value (demand
-                    // Hall violator), so one of the branches above should have
-                    // fired. Reaching here means the violator search missed it:
-                    // fail loudly rather than emit an unjustified contradiction.
-                    throw UnexpectedException{"global cardinality: infeasible flow with no Hall violator found"};
-                return PropagatorState::Enable;
-            }
-
-            vector<vector<int>> radj(base_nodes);
-            for (const auto & [idx, e] : enumerate(orig)) {
-                if (flow[idx] < e.hi)
-                    radj[e.from].push_back(e.to);
-                if (flow[idx] > e.lo)
-                    radj[e.to].push_back(e.from);
-            }
-
-            // Tarjan strongly-connected components of the residual.
-            vector<int> index(base_nodes, 0), low(base_nodes, 0), comp(base_nodes, -1);
-            vector<std::uint8_t> on_stack(base_nodes, 0);
-            vector<int> stk;
-            int next_index = 1, n_comp = 0;
-            function<void(int)> scc = [&](int v) {
-                index[v] = low[v] = next_index++;
-                stk.push_back(v);
-                on_stack[v] = 1;
-                for (auto w : radj[v]) {
-                    if (index[w] == 0) {
-                        scc(w);
-                        low[v] = min(low[v], low[w]);
-                    }
-                    else if (on_stack[w])
-                        low[v] = min(low[v], index[w]);
-                }
-                if (low[v] == index[v]) {
-                    int w;
-                    do {
-                        w = stk.back();
-                        stk.pop_back();
-                        on_stack[w] = 0;
-                        comp[w] = n_comp;
-                    } while (w != v);
-                    ++n_comp;
-                }
-            };
-            for (int v = 0; v < base_nodes; ++v)
-                if (index[v] == 0)
-                    scc(v);
-
-            // Residual reachability from a node (for extracting the proof cut).
-            auto reachable_from = [&](int start) {
-                vector<std::uint8_t> seen(base_nodes, 0);
-                vector<int> q{start};
-                seen[start] = 1;
-                for (std::size_t h = 0; h < q.size(); ++h)
-                    for (auto w : radj[q[h]])
-                        if (! seen[w]) {
-                            seen[w] = 1;
-                            q.push_back(w);
-                        }
-                return seen;
-            };
-
-            auto value_index = [&](Integer val) -> int {
-                for (std::size_t v = 0; v < m; ++v)
-                    if (values[v] == val)
-                        return static_cast<int>(v);
-                return -1;
-            };
-
-            // An assignment edge value j -> var i that carries no flow and
-            // crosses two components has no support: prune it, justified by the
-            // cut reachable from the variable. If the source is in that cut the
-            // pruning is capacity-driven (the values *outside* the cut are full);
-            // otherwise it is demand-driven (the values *inside* the cut are at
-            // their lower bound).
-            for (const auto & [j, value] : enumerate(values))
-                for (std::size_t i = 0; i < n; ++i) {
-                    auto ei = assign_edge[j][i];
-                    if (ei < 0)
-                        continue;
-                    if (! (flow[ei] == 0 && comp[value_node(j)] != comp[var_node(i)]))
-                        continue;
-
-                    auto seen = reachable_from(var_node(i));
-                    if (seen[S]) {
-                        // Capacity cut: full cover values are those not reachable.
-                        vector<std::size_t> cut_values;
-                        for (std::size_t v = 0; v < m; ++v)
-                            if (! seen[value_node(v)])
-                                cut_values.push_back(v);
-                        vector<IntegerVariableID> confined;
-                        for (std::size_t k = 0; k < n; ++k) {
-                            bool subset = true;
-                            for (const auto & val : state.each_value_immutable(vars[k])) {
-                                auto vi = value_index(val);
-                                if (vi < 0 || seen[value_node(static_cast<std::size_t>(vi))]) {
-                                    subset = false;
-                                    break;
-                                }
-                            }
-                            if (subset)
-                                confined.push_back(vars[k]);
-                        }
-                        inference.infer(logger, vars[i] != value,
-                            JustifyExplicitly{[&, cut_values, confined](const ReasonLiterals &) {
-                                                  emit_gcc_capacity_pol(*logger, state, vars, values, counts, count_lines, cut_values, confined);
-                                              },
-                                ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                            LazyReasonOver{vars, [&, cut_values, confined](const State &, ReasonLiterals & out) {
-                                               out = gcc_capacity_reason(state, values, counts, cut_values, confined);
-                                           }});
-                    }
-                    else {
-                        // Demand cut: cover values inside the cut are at their lower bound.
-                        vector<std::size_t> cut_values;
-                        for (std::size_t v = 0; v < m; ++v)
-                            if (seen[value_node(v)])
-                                cut_values.push_back(v);
-                        // The at-most-ones must cover every variable that can take
-                        // a cut value, matching the reason's exclusions.
-                        vector<IntegerVariableID> potential;
-                        for (std::size_t k = 0; k < n; ++k) {
-                            bool meets = false;
-                            for (auto v : cut_values)
-                                if (state.in_domain(vars[k], values[v])) {
-                                    meets = true;
-                                    break;
-                                }
-                            if (meets)
-                                potential.push_back(vars[k]);
-                        }
-                        inference.infer(logger, vars[i] != value,
-                            JustifyExplicitly{//
-                                [&, cut_values, potential, value = value, i = i](const ReasonLiterals &) {
-                                    emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], value);
-                                },
-                                ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                            LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) {
-                                               out = gcc_demand_reason(state, vars, values, counts, cut_values, potential);
-                                           }});
-                    }
-                }
-
-            // Likewise the dummy edge: if a variable cannot route through the
-            // dummy value, it cannot take any non-cover value. This is always a
-            // demand cut (the cover values' lower bounds force the variable in),
-            // so the source is not in the cut reachable from it.
-            for (std::size_t i = 0; i < n; ++i) {
-                auto ei = dummy_edge[i];
-                if (! (ei >= 0 && flow[ei] == 0 && comp[dummy_node] != comp[var_node(i)]))
-                    continue;
-                auto seen = reachable_from(var_node(i));
-                vector<std::size_t> cut_values;
-                for (std::size_t v = 0; v < m; ++v)
-                    if (seen[value_node(v)])
-                        cut_values.push_back(v);
-                vector<IntegerVariableID> potential;
-                for (std::size_t k = 0; k < n; ++k) {
-                    bool meets = false;
-                    for (auto v : cut_values)
-                        if (state.in_domain(vars[k], values[v])) {
-                            meets = true;
-                            break;
-                        }
-                    if (meets)
-                        potential.push_back(vars[k]);
-                }
-                for (const auto & val : state.each_value_mutable(vars[i]))
-                    if (! cover.contains(val))
-                        inference.infer(logger, vars[i] != val,
-                            JustifyExplicitly{//
-                                [&, cut_values, potential, val = val, i = i](const ReasonLiterals &) {
-                                    emit_gcc_demand_pol(*logger, state, vars, values, counts, count_lines, cut_values, potential, vars[i], val);
-                                },
-                                ThenRUP::Yes, hints::GlobalCardinality{owner}},
-                            LazyReasonOver{vars, [&, cut_values, potential](const State &, ReasonLiterals & out) {
-                                               out = gcc_demand_reason(state, vars, values, counts, cut_values, potential);
-                                           }});
-            }
-
-            return PropagatorState::Enable;
+            return propagate_gac_global_cardinality(vars, owner, values, counts, closed, count_lines, all_vars, state, inference, logger);
         },
         triggers);
 }

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/propagators-fwd.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
@@ -12,6 +13,19 @@
 
 namespace gcs
 {
+    namespace innards
+    {
+        /**
+         * \brief The GAC GlobalCardinality propagator (Régin flow), extracted from
+         * GACGlobalCardinality's install_propagators so the forthcoming merged
+         * GlobalCardinality can dispatch to it. Behaviour is unchanged.
+         */
+        [[nodiscard]] auto propagate_gac_global_cardinality(const std::vector<IntegerVariableID> & vars, const ConstraintID & owner,
+            const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts, bool closed,
+            const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines,
+            const std::vector<IntegerVariableID> & all_vars, const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState;
+    }
+
     /**
      * \brief The Global Cardinality Constraint, enforced to generalised arc
      * consistency on the assignment variables via Régin's flow algorithm.


### PR DESCRIPTION
**Pure, behaviour-preserving refactor** — the safe first step toward collapsing GlobalCardinality's Bounds/GAC variants (as agreed, since a direct merge would relocate proof-sensitive code).

## What changes

`BoundsGlobalCardinality` and `GACGlobalCardinality` each carried their whole propagator as a ~300–500 line inline lambda inside `install_propagators`. This lifts each into a free function in `gcs::innards`:

- `propagate_bounds_global_cardinality(...)`
- `propagate_gac_global_cardinality(...)`

declared in the respective headers and explicitly instantiated for both inference trackers — the **same shape as `propagate_gac_all_different`**. `install_propagators` now just sets up the triggers/captures and calls the function. **The lambda bodies are moved verbatim (only re-indented); no logic changes**, so this is safe to land on its own.

This gives the forthcoming merged `GlobalCardinality` something to dispatch to (the AllDifferent pattern), without relocating proof-sensitive code during the collapse itself.

## Verification (as requested — including cake)

- Full `cmake --build` of all targets — clean.
- `ctest -R "global_cardinality|gcc|scp|xcsp|minizinc"` → **15/15**, including **all six** cake chain-verify tests `scp_chain_global_cardinality_{,closed_,gac_}{sat,unsat}`, the `.scp` roundtrip (`scp_reader_test`), and the minizinc/xcsp frontends.
- Explicit proof runs: `bounds_global_cardinality_test --prove` = **VERIFIED** (12 sols), `gac_global_cardinality_test --prove` = **VERIFIED** (9 sols).
- clang-format 21 clean.

No public API change; `GlobalCardinality`/`GACGlobalCardinality`/`BoundsGlobalCardinality` are untouched at the call-site level. The collapse (merge into one type + `.with_consistency()` + `.with_closed()`) is a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)