### PR TITLE
Fluent constraint options: collapse GlobalCardinality Bounds/GAC (#299)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(glasgow_constraint_solver
         constraints/extensional_utils.cc
         constraints/global_cardinality/bounds_global_cardinality.cc
         constraints/global_cardinality/gac_global_cardinality.cc
+        constraints/global_cardinality/global_cardinality.cc
         constraints/global_cardinality/justify.cc
         constraints/in/in.cc
         constraints/increasing/increasing.cc

--- a/gcs/constraints/global_cardinality.hh
+++ b/gcs/constraints/global_cardinality.hh
@@ -1,12 +1,6 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_GLOBAL_CARDINALITY_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_GLOBAL_CARDINALITY_HH
 
-#include <gcs/constraints/global_cardinality/bounds_global_cardinality.hh>
-#include <gcs/constraints/global_cardinality/gac_global_cardinality.hh>
-
-namespace gcs
-{
-    using GlobalCardinality = BoundsGlobalCardinality;
-}
+#include <gcs/constraints/global_cardinality/global_cardinality.hh>
 
 #endif

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.cc
@@ -50,61 +50,6 @@ using std::print;
 using fmt::print;
 #endif
 
-BoundsGlobalCardinality::BoundsGlobalCardinality(vector<IntegerVariableID> vars, vector<Integer> values, vector<IntegerVariableID> counts,
-    bool closed) : _vars(move(vars)), _values(move(values)), _counts(move(counts)), _closed(closed)
-{
-    // The Hall-interval reasoning ranges over contiguous runs of the cover
-    // values, so they (and their count variables) must be in ascending order.
-    vector<std::size_t> order(_values.size());
-    for (std::size_t i = 0; i < order.size(); ++i)
-        order[i] = i;
-    sort(order.begin(), order.end(), [&](std::size_t a, std::size_t b) { return _values[a] < _values[b]; });
-    vector<Integer> sorted_values;
-    vector<IntegerVariableID> sorted_counts;
-    sorted_values.reserve(_values.size());
-    sorted_counts.reserve(_counts.size());
-    for (auto i : order) {
-        sorted_values.push_back(_values[i]);
-        sorted_counts.push_back(_counts[i]);
-    }
-    _values = move(sorted_values);
-    _counts = move(sorted_counts);
-}
-
-auto BoundsGlobalCardinality::clone() const -> unique_ptr<Constraint>
-{
-    return make_unique<BoundsGlobalCardinality>(_vars, _values, _counts, _closed);
-}
-
-auto BoundsGlobalCardinality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model);
-
-    install_propagators(propagators);
-
-    // The closed restriction (every variable takes a cover value) is delegated
-    // to a certified In constraint per variable.
-    if (_closed)
-        for (const auto & var : _vars)
-            In{var, _values}.install(propagators, initial_state, optional_model);
-}
-
-auto BoundsGlobalCardinality::define_proof_model(ProofModel & model) -> void
-{
-    for (const auto & [j, value] : enumerate(_values)) {
-        WPBSum sum;
-        for (const auto & var : _vars)
-            sum += 1_i * (var == value);
-        // cake_pb_cp labels the per-value count equality @c[<id>_<j>][le/ge].
-        _count_lines.push_back(model.add_labelled_constraint(
-            as_string(constraint_id()) + "_" + std::to_string(j), "le", "ge", "GCC", "count for value", sum == 1_i * _counts[j]));
-    }
-}
-
 auto gcs::innards::propagate_bounds_global_cardinality(const vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const vector<Integer> & values, const vector<IntegerVariableID> & counts,
     const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, const vector<IntegerVariableID> & all_vars, const State & state,
@@ -416,40 +361,3 @@ template auto gcs::innards::propagate_bounds_global_cardinality(const std::vecto
     const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts,
     const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
     const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
-
-auto BoundsGlobalCardinality::install_propagators(Propagators & propagators) -> void
-{
-    Triggers triggers;
-    triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
-    triggers.on_bounds.insert(triggers.on_bounds.end(), _counts.begin(), _counts.end());
-
-    vector<IntegerVariableID> all_vars = _vars;
-    all_vars.insert(all_vars.end(), _counts.begin(), _counts.end());
-
-    propagators.install(
-        constraint_id(),
-        [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, count_lines = _count_lines, all_vars = move(all_vars)](
-            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return propagate_bounds_global_cardinality(vars, owner, values, counts, count_lines, all_vars, state, inference, logger);
-        },
-        triggers);
-}
-
-auto BoundsGlobalCardinality::prepare(Propagators &, State &, ProofModel * const) -> bool
-{
-    return true;
-}
-
-auto BoundsGlobalCardinality::s_expr(const ProofModel * const model) const -> SExpr
-{
-    auto & tracker = model->names_and_ids_tracker();
-    vector<SExpr> vars, values, counts;
-    for (const auto & var : _vars)
-        vars.push_back(tracker.s_expr_term_of(var));
-    for (const auto & val : _values)
-        values.push_back(SExpr::atom(val.to_string()));
-    for (const auto & c : _counts)
-        counts.push_back(tracker.s_expr_term_of(c));
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(_closed ? "boundsglobalcardinalityclosed" : "boundsglobalcardinality"),
-        SExpr::list(std::move(vars)), SExpr::list(std::move(values)), SExpr::list(std::move(counts))});
-}

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality.hh
@@ -26,52 +26,6 @@ namespace gcs
             const std::vector<IntegerVariableID> & all_vars, const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState;
     }
 
-    /**
-     * \brief The Global Cardinality Constraint, enforced to bounds consistency
-     * via Hall-interval reasoning over the cover values.
-     *
-     * Semantics are as for \ref GlobalCardinality: for each `i`, the number of
-     * variables in `vars` equal to `values[i]` equals the count variable
-     * `counts[i]`; if `closed`, every variable must take a cover value.
-     *
-     * This is a single dedicated propagator. It tightens the count variables
-     * from the must-occur/can-occur counts and
-     * prunes the assignment variables using generalised Hall sets: an interval
-     * of cover values whose total upper capacity is saturated by the variables
-     * confined to it forbids those values elsewhere, and an interval whose total
-     * lower demand exactly matches the variables able to supply it forces those
-     * variables into it. Generalised arc consistency on the count variables is
-     * NP-hard, so only bounds consistency is enforced there.
-     *
-     * The `closed` restriction is delegated to an \ref In constraint per
-     * variable.
-     *
-     * \ingroup Constraints
-     */
-    class BoundsGlobalCardinality : public Constraint
-    {
-    private:
-        std::vector<IntegerVariableID> _vars;
-        std::vector<Integer> _values;
-        std::vector<IntegerVariableID> _counts;
-        bool _closed;
-
-        // Proof lines for each cover value's count constraint
-        // Sum_i (x_i == values[j]) == counts[j], stored as {LE-half, GE-half}.
-        std::vector<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _count_lines;
-
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
-
-    public:
-        explicit BoundsGlobalCardinality(
-            std::vector<IntegerVariableID> vars, std::vector<Integer> values, std::vector<IntegerVariableID> counts, bool closed = false);
-
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-        virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
-    };
 }
 
 #endif

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
@@ -83,7 +83,7 @@ auto run_bgcc_test(bool proofs, const vector<Range> & vars_range, const vector<i
     for (auto & v : values)
         int_values.emplace_back(v);
 
-    p.post(BoundsGlobalCardinality{vars, int_values, counts, closed});
+    p.post(GlobalCardinality{vars, int_values, counts}.with_consistency(consistency::BC{}).with_closed(closed));
 
     // This dedicated propagator claims bounds consistency on both the
     // assignment variables and the count variables.

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.cc
@@ -138,48 +138,6 @@ namespace
     };
 }
 
-GACGlobalCardinality::GACGlobalCardinality(vector<IntegerVariableID> vars, vector<Integer> values, vector<IntegerVariableID> counts, bool closed) :
-    _vars(move(vars)), _values(move(values)), _counts(move(counts)), _closed(closed)
-{
-}
-
-auto GACGlobalCardinality::clone() const -> unique_ptr<Constraint>
-{
-    return make_unique<GACGlobalCardinality>(_vars, _values, _counts, _closed);
-}
-
-auto GACGlobalCardinality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model);
-
-    install_propagators(propagators);
-
-    if (_closed)
-        for (const auto & var : _vars)
-            In{var, _values}.install(propagators, initial_state, optional_model);
-}
-
-auto GACGlobalCardinality::prepare(Propagators &, State &, ProofModel * const) -> bool
-{
-    return true;
-}
-
-auto GACGlobalCardinality::define_proof_model(ProofModel & model) -> void
-{
-    for (const auto & [j, value] : enumerate(_values)) {
-        WPBSum sum;
-        for (const auto & var : _vars)
-            sum += 1_i * (var == value);
-        // cake_pb_cp labels the per-value count equality @c[<id>_<j>][le/ge].
-        _count_lines.push_back(model.add_labelled_constraint(
-            as_string(constraint_id()) + "_" + std::to_string(j), "le", "ge", "GCC", "count for value", sum == 1_i * _counts[j]));
-    }
-}
-
 auto gcs::innards::propagate_gac_global_cardinality(const vector<IntegerVariableID> & vars, const ConstraintID & owner,
     const vector<Integer> & values, const vector<IntegerVariableID> & counts, bool closed,
     const vector<pair<optional<ProofLine>, optional<ProofLine>>> & count_lines, const vector<IntegerVariableID> & all_vars, const State & state,
@@ -641,35 +599,3 @@ template auto gcs::innards::propagate_gac_global_cardinality(const std::vector<I
     const std::vector<Integer> & values, const std::vector<IntegerVariableID> & counts, bool closed,
     const std::vector<std::pair<std::optional<ProofLine>, std::optional<ProofLine>>> & count_lines, const std::vector<IntegerVariableID> & all_vars,
     const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> PropagatorState;
-
-auto GACGlobalCardinality::install_propagators(Propagators & propagators) -> void
-{
-    Triggers triggers;
-    triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
-    triggers.on_bounds.insert(triggers.on_bounds.end(), _counts.begin(), _counts.end());
-
-    vector<IntegerVariableID> all_vars = _vars;
-    all_vars.insert(all_vars.end(), _counts.begin(), _counts.end());
-
-    propagators.install(
-        constraint_id(),
-        [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, closed = _closed, count_lines = _count_lines,
-            all_vars = move(all_vars)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return propagate_gac_global_cardinality(vars, owner, values, counts, closed, count_lines, all_vars, state, inference, logger);
-        },
-        triggers);
-}
-
-auto GACGlobalCardinality::s_expr(const ProofModel * const model) const -> SExpr
-{
-    auto & tracker = model->names_and_ids_tracker();
-    vector<SExpr> vars, values, counts;
-    for (const auto & var : _vars)
-        vars.push_back(tracker.s_expr_term_of(var));
-    for (const auto & val : _values)
-        values.push_back(SExpr::atom(val.to_string()));
-    for (const auto & c : _counts)
-        counts.push_back(tracker.s_expr_term_of(c));
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(_closed ? "gacglobalcardinalityclosed" : "gacglobalcardinality"),
-        SExpr::list(std::move(vars)), SExpr::list(std::move(values)), SExpr::list(std::move(counts))});
-}

--- a/gcs/constraints/global_cardinality/gac_global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality.hh
@@ -26,48 +26,6 @@ namespace gcs
             const std::vector<IntegerVariableID> & all_vars, const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState;
     }
 
-    /**
-     * \brief The Global Cardinality Constraint, enforced to generalised arc
-     * consistency on the assignment variables via Régin's flow algorithm.
-     *
-     * Semantics are as for \ref GlobalCardinality: for each `i`, the number of
-     * variables in `vars` equal to `values[i]` equals the count variable
-     * `counts[i]`; if `closed`, every variable must take a cover value.
-     *
-     * A value v is removed from a variable x iff no assignment consistent with
-     * the current domains and the cardinality bounds has x = v. This is found
-     * by a feasible flow in the value graph plus a strongly-connected-component
-     * decomposition of its residual. Generalised arc consistency on the count
-     * variables is NP-hard, so only the assignment variables reach GAC; the
-     * count variables get the achievable occurrence bounds.
-     *
-     * The `closed` restriction is delegated to an \ref In constraint per
-     * variable.
-     *
-     * \ingroup Constraints
-     */
-    class GACGlobalCardinality : public Constraint
-    {
-    private:
-        std::vector<IntegerVariableID> _vars;
-        std::vector<Integer> _values;
-        std::vector<IntegerVariableID> _counts;
-        bool _closed;
-
-        std::vector<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _count_lines;
-
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
-
-    public:
-        explicit GACGlobalCardinality(
-            std::vector<IntegerVariableID> vars, std::vector<Integer> values, std::vector<IntegerVariableID> counts, bool closed = false);
-
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-        virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
-    };
 }
 
 #endif

--- a/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
@@ -84,7 +84,7 @@ auto run_gacgcc_test(bool proofs, const vector<Range> & vars_range, const vector
     for (auto & v : values)
         int_values.emplace_back(v);
 
-    p.post(GACGlobalCardinality{vars, int_values, counts, closed});
+    p.post(GlobalCardinality{vars, int_values, counts}.with_consistency(consistency::GAC{}).with_closed(closed));
 
     // Régin's flow makes the assignment variables GAC *relative to the count
     // bounds*: the network's value capacities are state.bounds(counts[j]), so it

--- a/gcs/constraints/global_cardinality/global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/global_cardinality.cc
@@ -1,0 +1,150 @@
+#include <gcs/constraint.hh>
+#include <gcs/constraints/global_cardinality/global_cardinality.hh>
+#include <gcs/constraints/global_cardinality/hints.hh>
+#include <gcs/constraints/in.hh>
+#include <gcs/expression.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/innards/state.hh>
+
+#include <util/enumerate.hh>
+#include <util/overloaded.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::holds_alternative;
+using std::make_unique;
+using std::move;
+using std::pair;
+using std::unique_ptr;
+using std::vector;
+using std::ranges::sort;
+
+GlobalCardinality::GlobalCardinality(vector<IntegerVariableID> vars, vector<Integer> values, vector<IntegerVariableID> counts) :
+    _vars(move(vars)), _values(move(values)), _counts(move(counts))
+{
+}
+
+auto GlobalCardinality::with_consistency(GlobalCardinalityConsistency level) -> GlobalCardinality &
+{
+    _level = level;
+    return *this;
+}
+
+auto GlobalCardinality::with_closed(std::optional<bool> closed) -> GlobalCardinality &
+{
+    _closed = closed.value_or(true);
+    return *this;
+}
+
+auto GlobalCardinality::sort_cover_values() -> void
+{
+    vector<std::size_t> order(_values.size());
+    for (std::size_t i = 0; i < order.size(); ++i)
+        order[i] = i;
+    sort(order, [&](std::size_t a, std::size_t b) { return _values[a] < _values[b]; });
+    vector<Integer> sorted_values;
+    vector<IntegerVariableID> sorted_counts;
+    sorted_values.reserve(_values.size());
+    sorted_counts.reserve(_counts.size());
+    for (auto i : order) {
+        sorted_values.push_back(_values[i]);
+        sorted_counts.push_back(_counts[i]);
+    }
+    _values = move(sorted_values);
+    _counts = move(sorted_counts);
+}
+
+auto GlobalCardinality::clone() const -> unique_ptr<Constraint>
+{
+    auto cloned = make_unique<GlobalCardinality>(_vars, _values, _counts);
+    cloned->with_consistency(_level).with_closed(_closed);
+    if (holds_alternative<consistency::BC>(_level))
+        cloned->sort_cover_values();
+    return cloned;
+}
+
+auto GlobalCardinality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+
+    // The closed restriction (every variable takes a cover value) is delegated
+    // to a certified In constraint per variable.
+    if (_closed)
+        for (const auto & var : _vars)
+            In{var, _values}.install(propagators, initial_state, optional_model);
+}
+
+auto GlobalCardinality::define_proof_model(ProofModel & model) -> void
+{
+    for (const auto & [j, value] : enumerate(_values)) {
+        WPBSum sum;
+        for (const auto & var : _vars)
+            sum += 1_i * (var == value);
+        // cake_pb_cp labels the per-value count equality @c[<id>_<j>][le/ge].
+        _count_lines.push_back(model.add_labelled_constraint(
+            as_string(constraint_id()) + "_" + std::to_string(j), "le", "ge", "GCC", "count for value", sum == 1_i * _counts[j]));
+    }
+}
+
+auto GlobalCardinality::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    triggers.on_change.insert(triggers.on_change.end(), _vars.begin(), _vars.end());
+    triggers.on_bounds.insert(triggers.on_bounds.end(), _counts.begin(), _counts.end());
+
+    vector<IntegerVariableID> all_vars = _vars;
+    all_vars.insert(all_vars.end(), _counts.begin(), _counts.end());
+
+    overloaded{[&](const consistency::BC &) {
+                   propagators.install(
+                       constraint_id(),
+                       [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, count_lines = _count_lines, all_vars = all_vars](
+                           const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                           return propagate_bounds_global_cardinality(vars, owner, values, counts, count_lines, all_vars, state, inference, logger);
+                       },
+                       triggers);
+               },
+        [&](const consistency::GAC &) {
+            propagators.install(
+                constraint_id(),
+                [vars = _vars, owner = constraint_id(), values = _values, counts = _counts, closed = _closed, count_lines = _count_lines,
+                    all_vars = all_vars](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                    return propagate_gac_global_cardinality(vars, owner, values, counts, closed, count_lines, all_vars, state, inference, logger);
+                },
+                triggers);
+        }}
+        .visit(_level);
+}
+
+auto GlobalCardinality::s_expr(const ProofModel * const model) const -> SExpr
+{
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars, values, counts;
+    for (const auto & var : _vars)
+        vars.push_back(tracker.s_expr_term_of(var));
+    for (const auto & val : _values)
+        values.push_back(SExpr::atom(val.to_string()));
+    for (const auto & c : _counts)
+        counts.push_back(tracker.s_expr_term_of(c));
+    // The term records which propagator ran, matching what cake_pb_cp's parser
+    // and the .scp reader expect (the OPB encoding itself is level-independent).
+    const auto * name = holds_alternative<consistency::GAC>(_level) ? (_closed ? "gacglobalcardinalityclosed" : "gacglobalcardinality")
+                                                                    : (_closed ? "boundsglobalcardinalityclosed" : "boundsglobalcardinality");
+    return SExpr::list(
+        {SExpr::atom(as_string(_constraint_id)), SExpr::atom(name), SExpr::list(move(vars)), SExpr::list(move(values)), SExpr::list(move(counts))});
+}

--- a/gcs/constraints/global_cardinality/global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/global_cardinality.hh
@@ -1,0 +1,84 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_GLOBAL_CARDINALITY_GLOBAL_CARDINALITY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_GLOBAL_CARDINALITY_GLOBAL_CARDINALITY_HH
+
+#include <gcs/consistency.hh>
+#include <gcs/constraint.hh>
+#include <gcs/constraints/global_cardinality/bounds_global_cardinality.hh>
+#include <gcs/constraints/global_cardinality/gac_global_cardinality.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief The consistency levels supported by GlobalCardinality: bounds
+     * consistency (the default, Hall-interval reasoning), or generalised arc
+     * consistency (Régin's flow algorithm on the assignment variables; count-GAC
+     * is NP-hard, so the count variables stay bounds-consistent either way).
+     *
+     * \ingroup Consistency
+     */
+    using GlobalCardinalityConsistency = std::variant<consistency::BC, consistency::GAC>;
+
+    /**
+     * \brief The Global Cardinality Constraint: for each `i`, the number of
+     * variables in `vars` equal to `values[i]` equals the count variable
+     * `counts[i]`. With `.with_closed()`, every variable must take a cover value.
+     *
+     * Defaults to bounds consistency; request consistency::GAC for Régin flow.
+     * The two propagators live as free functions in bounds_global_cardinality.cc
+     * and gac_global_cardinality.cc, which this class dispatches between; the
+     * choice selects propagation strength only and never changes the OPB
+     * encoding (the .scp term does record which propagator ran).
+     *
+     * \ingroup Constraints
+     */
+    class GlobalCardinality : public Constraint
+    {
+    private:
+        std::vector<IntegerVariableID> _vars;
+        std::vector<Integer> _values;
+        std::vector<IntegerVariableID> _counts;
+        bool _closed = false;
+        GlobalCardinalityConsistency _level = consistency::BC{};
+
+        // Proof lines for each cover value's count constraint
+        // Sum_i (x_i == values[j]) == counts[j], stored as {LE-half, GE-half}.
+        std::vector<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _count_lines;
+
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+        // The bounds propagator's Hall-interval reasoning ranges over contiguous
+        // runs of the cover values, so under consistency::BC they (and their count
+        // variables) must be in ascending order. Done in clone() rather than a
+        // constructor because the level is chosen post-construction, and both the
+        // stored constraint (which s_expr reads) and its install-time clone (which
+        // define_proof_model reads) must agree.
+        auto sort_cover_values() -> void;
+
+    public:
+        explicit GlobalCardinality(std::vector<IntegerVariableID> vars, std::vector<Integer> values, std::vector<IntegerVariableID> counts);
+
+        /// Select the consistency level: consistency::BC (the default) or
+        /// consistency::GAC. Requesting an unsupported level is a compile-time
+        /// error, and the choice never changes the OPB encoding.
+        auto with_consistency(GlobalCardinalityConsistency level) -> GlobalCardinality &;
+
+        /// Whether the constraint is closed (every variable must take a cover
+        /// value). Takes std::optional<bool> so a runtime flag can be passed
+        /// straight through; nullopt or no argument closes it.
+        auto with_closed(std::optional<bool> closed = true) -> GlobalCardinality &;
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
+    };
+}
+
+#endif

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -699,10 +699,8 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
                 values.push_back(as_integer(v));
             auto counts = resolve_variable_list(variables, terms[4], "the global cardinality count list");
             bool closed = op.ends_with("closed");
-            if (op.starts_with("gac"))
-                post_constraint(problem, GACGlobalCardinality{move(vars), move(values), move(counts), closed}, label);
-            else
-                post_constraint(problem, BoundsGlobalCardinality{move(vars), move(values), move(counts), closed}, label);
+            auto level = op.starts_with("gac") ? GlobalCardinalityConsistency{consistency::GAC{}} : GlobalCardinalityConsistency{consistency::BC{}};
+            post_constraint(problem, GlobalCardinality{move(vars), move(values), move(counts)}.with_consistency(level).with_closed(closed), label);
         }
         else if (op == "increasing" || op == "strictly_increasing" || op == "decreasing" || op == "strictly_decreasing") {
             // The keyword carries the strict / descending flags that IncreasingChain

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -684,7 +684,7 @@ auto main(int argc, char * argv[]) -> int
                 auto cover = arg_as_array_of_integer(data, args, 1);
                 const auto & counts = arg_as_array_of_var(data, args, 2);
                 auto closed = (id == "glasgow_global_cardinality_closed");
-                problem.post(GlobalCardinality{vars, *cover, counts, closed});
+                problem.post(GlobalCardinality{vars, *cover, counts}.with_closed(closed));
             }
             else if (id == "glasgow_increasing_int" || id == "glasgow_increasing_bool") {
                 const auto & vars = arg_as_array_of_var(data, args, 0);

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -650,7 +650,7 @@ namespace
             counts.reserve(occurs.size());
             for (auto o : occurs)
                 counts.emplace_back(constant_variable(Integer{o}));
-            _problem.post(GlobalCardinality{move(vars), gcc_cover(values), move(counts), closed});
+            _problem.post(GlobalCardinality{move(vars), gcc_cover(values), move(counts)}.with_closed(closed));
         }
 
         auto buildConstraintCardinality(string, vector<XVariable *> & x_vars, vector<int> values, vector<XVariable *> & occurs, bool closed)
@@ -659,7 +659,7 @@ namespace
             if (values.size() != occurs.size())
                 report_unsupported("cardinality", "values/occurs size mismatch");
             auto vars = need_variables(x_vars);
-            _problem.post(GlobalCardinality{move(vars), gcc_cover(values), need_variables(occurs), closed});
+            _problem.post(GlobalCardinality{move(vars), gcc_cover(values), need_variables(occurs)}.with_closed(closed));
         }
 
         auto buildConstraintCardinality(string, vector<XVariable *> & x_vars, vector<int> values, vector<XInterval> & occurs, bool closed)
@@ -673,7 +673,7 @@ namespace
             for (size_t i = 0; i != occurs.size(); ++i)
                 counts.emplace_back(
                     _problem.create_integer_variable(Integer{occurs[i].min}, Integer{occurs[i].max}, "gccoccurs" + std::to_string(i)));
-            _problem.post(GlobalCardinality{move(vars), gcc_cover(values), move(counts), closed});
+            _problem.post(GlobalCardinality{move(vars), gcc_cover(values), move(counts)}.with_closed(closed));
         }
 
         auto buildConstraintIntension(string, Tree * tree) -> void override


### PR DESCRIPTION
Second type-family collapse. **Stacked on #457** (the propagator extraction) — review that first; this PR's diff is just the collapse. **Left open for your review** (hard break: `BoundsGlobalCardinality`/`GACGlobalCardinality` deleted).

## What changes

The two classes had byte-identical `define_proof_model`; only the propagator (and the `.scp` term) differed. They collapse into one `GlobalCardinality` that dispatches — via `with_consistency(std::variant<consistency::BC, consistency::GAC>)` — to the free functions extracted in #457. `closed` moves to `with_closed(std::optional<bool>)`:

```cpp
p.post(GlobalCardinality{vars, values, counts});                        // BC (default)
p.post(GlobalCardinality{vars, values, counts}.with_consistency(consistency::GAC{}).with_closed());
```

## Two GCC-specific subtleties (both handled)

1. **`s_expr` differs by level** (`boundsglobalcardinality` vs `gacglobalcardinality`, +`closed`), which cake's parser reads — so the merged `s_expr` branches on the level. `define_proof_model` is level-independent (identical), as required.
2. **The bounds propagator needs sorted cover values** (Hall runs). Since the level is chosen *after* construction, the sort happens in **`clone()` for BC** — so both the stored constraint (read by `s_expr`) and its install-time clone (read by `define_proof_model`) stay sorted and consistent. GAC is untouched (no functional change).

## Users updated

Top-level alias, `scp_reader`, the two test files (now parameterised by consistency level rather than class type), and the **fzn/xcsp frontends** (`closed` → `.with_closed(closed)`).

## Verification

- Full `cmake --build` of all targets — clean.
- `ctest` over global_cardinality/gcc/scp/xcsp/minizinc → **134/134**, including **all six** cake `scp_chain_global_cardinality_{,closed_,gac_}{sat,unsat}`, the `.scp` roundtrip, and the frontends.
- Explicit proofs `VERIFIED` for both levels.
- clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)