### PR TITLE
Circuit: extract SCC/prevent propagators into free functions (#299 prep)

### DIFF
--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -101,15 +101,24 @@ namespace
         }
     }
 
-    auto propagate_circuit_using_prevent(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
-        const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle, const State & state, auto & inference,
-        ProofLogger * const logger) -> void
-    {
-        if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
-            return; // contradiction: the cycle checks below would read junk state; the loop sees contradicted()
-        prevent_small_cycles_incrementally(succ, owner, pos_var_data, chain_handle, state, inference, logger);
-    }
 }
+
+auto gcs::innards::circuit::propagate_circuit_using_prevent(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner,
+    const PosVarDataMap & pos_var_data, const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle,
+    const State & state, auto & inference, ProofLogger * const logger) -> void
+{
+    if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
+        return; // contradiction: the cycle checks below would read junk state; the loop sees contradicted()
+    prevent_small_cycles_incrementally(succ, owner, pos_var_data, chain_handle, state, inference, logger);
+}
+
+template auto gcs::innards::circuit::propagate_circuit_using_prevent(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner,
+    const PosVarDataMap & pos_var_data, const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle,
+    const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger) -> void;
+
+template auto gcs::innards::circuit::propagate_circuit_using_prevent(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner,
+    const PosVarDataMap & pos_var_data, const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle,
+    const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> void;
 
 auto CircuitPrevent::clone() const -> unique_ptr<Constraint>
 {

--- a/gcs/constraints/circuit/circuit_prevent.hh
+++ b/gcs/constraints/circuit/circuit_prevent.hh
@@ -17,4 +17,17 @@ namespace gcs
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
     };
 }
+
+namespace gcs::innards::circuit
+{
+    /**
+     * \brief The "prevent" circuit propagator, shared by CircuitPrevent's install and used by the
+     * collapsed Circuit constraint. Runs the value-consistent all-different, then incrementally folds
+     * newly-fixed edges into chain endpoints to forbid (or force) short cycles. Defined in
+     * circuit_prevent.cc.
+     */
+    auto propagate_circuit_using_prevent(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
+        const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle, const State & state, auto & inference,
+        ProofLogger * const logger) -> void;
+}
 #endif // GLASGOW_CONSTRAINT_SOLVER_CIRCUIT_PREVENT_HH

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -1062,29 +1062,40 @@ namespace
         }
     }
 
-    auto propagate_circuit_using_scc(const State & state, auto & inference, ProofLogger * const logger, const ReasonLiterals & reason,
-        const ConstraintID & owner, const vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
-        const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
-        const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void
-    {
-        auto & pos_var_data = any_cast<PosVarDataMap &>(state.get_persistent_constraint_state(pos_var_data_handle));
-        if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
-            return; // contradiction: the SCC check below would read junk state; the loop sees contradicted()
-        auto proof_data = SCCProofData{pos_var_data, proof_flag_data_handle, pos_alldiff_data_handle};
-        check_sccs(state, inference, logger, reason, owner, succ, scc_options, proof_data);
-        auto & unassigned = any_cast<NonGacAllDifferentUnassigned &>(state.get_constraint_state(unassigned_handle));
-        // Remove any newly assigned vals from unassigned (swap-and-pop; order is irrelevant).
-        for (std::size_t k = 0; k < unassigned.size();) {
-            if (state.optional_single_value(unassigned[k])) {
-                unassigned[k] = unassigned.back();
-                unassigned.pop_back();
-            }
-            else
-                ++k;
-        }
-        prevent_small_cycles(succ, owner, pos_var_data, unassigned_handle, state, inference, logger);
-    }
 }
+
+auto gcs::innards::circuit::propagate_circuit_using_scc(const State & state, auto & inference, ProofLogger * const logger,
+    const ReasonLiterals & reason, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
+    const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
+    const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void
+{
+    auto & pos_var_data = any_cast<PosVarDataMap &>(state.get_persistent_constraint_state(pos_var_data_handle));
+    if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
+        return; // contradiction: the SCC check below would read junk state; the loop sees contradicted()
+    auto proof_data = SCCProofData{pos_var_data, proof_flag_data_handle, pos_alldiff_data_handle};
+    check_sccs(state, inference, logger, reason, owner, succ, scc_options, proof_data);
+    auto & unassigned = any_cast<NonGacAllDifferentUnassigned &>(state.get_constraint_state(unassigned_handle));
+    // Remove any newly assigned vals from unassigned (swap-and-pop; order is irrelevant).
+    for (std::size_t k = 0; k < unassigned.size();) {
+        if (state.optional_single_value(unassigned[k])) {
+            unassigned[k] = unassigned.back();
+            unassigned.pop_back();
+        }
+        else
+            ++k;
+    }
+    prevent_small_cycles(succ, owner, pos_var_data, unassigned_handle, state, inference, logger);
+}
+
+template auto gcs::innards::circuit::propagate_circuit_using_scc(const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger,
+    const ReasonLiterals & reason, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
+    const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
+    const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
+
+template auto gcs::innards::circuit::propagate_circuit_using_scc(const State & state, EagerProofLoggingInferenceTracker & inference,
+    ProofLogger * const logger, const ReasonLiterals & reason, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ,
+    const SCCOptions & scc_options, const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
+    const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
 
 CircuitSCC::CircuitSCC(std::vector<IntegerVariableID> var, bool gacAllDifferent, const SCCOptions s) :
     CircuitBase(std::move(var), gacAllDifferent), scc_options(s)

--- a/gcs/constraints/circuit/circuit_scc.hh
+++ b/gcs/constraints/circuit/circuit_scc.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/constraints/circuit/circuit_base.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
 #include <vector>
@@ -31,6 +32,20 @@ namespace gcs
         [[nodiscard]] auto clone() const -> std::unique_ptr<Constraint> override;
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
     };
+}
+
+namespace gcs::innards::circuit
+{
+    /**
+     * \brief The SCC-based circuit propagator, shared by CircuitSCC's install and used by the
+     * collapsed Circuit constraint. Runs the value-consistent all-different, checks strongly
+     * connected components (pruning edges that cannot lie on a Hamiltonian cycle), and prevents
+     * small cycles. Defined in circuit_scc.cc.
+     */
+    auto propagate_circuit_using_scc(const State & state, auto & inference, ProofLogger * const logger, const ReasonLiterals & reason,
+        const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
+        const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
+        const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
 }
 
 #endif // GLASGOW_CONSTRAINT_SOLVER_CIRCUIT_SCC_HH


### PR DESCRIPTION
Pure refactor preparing the Circuit collapse (the last piece of the fluent-options `.with_*()` sweep for #299).

## What

The two circuit propagators were file-local (anonymous-namespace) functions, each called only by its own `install()` lambda:

- `propagate_circuit_using_scc` (`circuit_scc.cc`)
- `propagate_circuit_using_prevent` (`circuit_prevent.cc`)

This PR moves both into `namespace gcs::innards::circuit`, declares them in the matching headers, and explicitly instantiates each for `SimpleInferenceTracker` and `EagerProofLoggingInferenceTracker` — mirroring the existing treatment of `propagate_non_gac_alldifferent` and `prevent_small_cycles`.

Their file-local helpers (`check_sccs`, `prevent_small_cycles_incrementally`, the `SCCProof*` structs, `PreventChainData`) stay in the anonymous namespace — the propagators take only `ConstraintStateHandle`s, so none of that internal state needs to be exposed.

## Why

The follow-up collapse PR merges `CircuitBase` / `CircuitSCC` / `CircuitPrevent` into a single `Circuit` constraint whose `install()` picks a propagator via `.with_algorithm(circuit::SCC{}/Prevent{})`. That merged `install()` lives in its own translation unit and needs to call both propagators, so they can no longer be file-local. Extracting them first keeps that collapse diff small and reviewable.

**No functional change.**

## Testing

- Full `cmake --build` (all targets, GCC 15).
- All 19 `circuit`-matching ctests pass, including `scp_chain_circuit_{sat,unsat}` (cake chain), the `.scp` roundtrip, xcsp, and minizinc.
- `./circuit_test --prove`, `circuit_disconnected_test`, `circuit_prune_root_test` verify under VeriPB (`VERIFIED COMPLETE ENUMERATION` / `VERIFIED UNSATISFIABLE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)