### PR TITLE
Circuit: collapse CircuitSCC/CircuitPrevent into one fluent Circuit (#299)

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -726,7 +726,7 @@ correctness work wants the full enumeration check.
     - **Throw `InvalidProblemDefinitionException`** at construction
       when alias has no meaningful semantics, the propagator path is
       unsafe, or the proof encoding can't tolerate it. The Bucket A
-      family — `NotEquals`, `LessThan`, `GreaterThan`, `Circuit*`,
+      family — `NotEquals`, `LessThan`, `GreaterThan`, `Circuit`,
       `Inverse`, `innards::MultiplyBC` (via `Multiply`), `SmartTable` `BinaryEntry` — uses this.
       By convention the check is gated on
       `! is_constant_variable(...)` so two slots pinned to the same

--- a/examples/circuit_random/circuit_random.cc
+++ b/examples/circuit_random/circuit_random.cc
@@ -60,7 +60,16 @@ Stats run_circuit_problem(int n, const vector<vector<long>> & distances, SCCOpti
         }
     }
     auto use_gac_all_different = false;
-    p.post(Circuit{x, use_gac_all_different, options});
+    p.post(Circuit{x}
+            .with_gac_all_different(use_gac_all_different)
+            .with_prune_root(options.prune_root)
+            .with_prune_skip(options.prune_skip)
+            .with_fix_req(options.fix_req)
+            .with_prune_within(options.prune_within)
+            .with_prove_using_dominance(options.prove_using_dominance)
+            .with_enable_comments(options.enable_comments)
+            .with_prove_am1_by_contradiction(options.prove_am1_by_contradiction)
+            .with_short_reasons(options.short_reasons));
 
     // Minimise the distance between any two stops
     auto max_leg = p.create_integer_variable(0_i, 100_i, "max_leg");

--- a/examples/circuit_small/circuit_small.cc
+++ b/examples/circuit_small/circuit_small.cc
@@ -79,10 +79,10 @@ auto main(int argc, char * argv[]) -> int
     post_constraints(p, nodes);
 
     if (options_vars["propagator"].as<string>() == "prevent") {
-        p.post(CircuitPrevent{nodes});
+        p.post(Circuit{nodes}.with_algorithm(circuit::Prevent{}));
     }
     else if (options_vars["propagator"].as<string>() == "scc") {
-        p.post(CircuitSCC{nodes});
+        p.post(Circuit{nodes}.with_algorithm(circuit::SCC{}));
     }
     else {
         p.post(Circuit{nodes});

--- a/examples/tour/tour.cc
+++ b/examples/tour/tour.cc
@@ -105,15 +105,13 @@ auto main(int argc, char * argv[]) -> int
     }
 
     if (options_vars["propagator"].as<string>() == "prevent") {
-        p.post(CircuitPrevent{succ, false});
+        p.post(Circuit{succ}.with_algorithm(circuit::Prevent{}));
     }
     else if (options_vars["propagator"].as<string>() == "scc") {
-        SCCOptions options{};
-        options.enable_comments = false;
-        p.post(CircuitSCC{succ, false, options});
+        p.post(Circuit{succ}.with_algorithm(circuit::SCC{}).with_enable_comments(false));
     }
     else {
-        p.post(Circuit{succ, false});
+        p.post(Circuit{succ});
     }
 
     // Minimise the distance between any two stops

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(glasgow_constraint_solver
         constraints/all_equal/all_equal.cc
         constraints/among/among.cc
         constraints/at_most_one/at_most_one.cc
+        constraints/circuit/circuit.cc
         constraints/circuit/circuit_base.cc
         constraints/circuit/circuit_prevent.cc
         constraints/circuit/circuit_scc.cc

--- a/gcs/constraints/circuit.hh
+++ b/gcs/constraints/circuit.hh
@@ -1,12 +1,6 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CIRCUIT_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CIRCUIT_HH
 
-#include <gcs/constraints/circuit/circuit_prevent.hh>
-#include <gcs/constraints/circuit/circuit_scc.hh>
-
-namespace gcs
-{
-    using Circuit = CircuitSCC;
-}
+#include <gcs/constraints/circuit/circuit.hh>
 
 #endif // GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CIRCUIT_HH

--- a/gcs/constraints/circuit/circuit.cc
+++ b/gcs/constraints/circuit/circuit.cc
@@ -1,0 +1,238 @@
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/circuit/circuit.hh>
+#include <gcs/constraints/circuit/circuit_base.hh>
+#include <gcs/constraints/circuit/circuit_prevent.hh>
+#include <gcs/constraints/circuit/circuit_scc.hh>
+#include <gcs/constraints/circuit/hints.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
+
+#include <util/enumerate.hh>
+#include <util/overloaded.hh>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/core.h>
+using fmt::format;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::innards::circuit;
+
+using gcs::circuit::Prevent;
+using gcs::circuit::SCC;
+
+using std::make_unique;
+using std::map;
+using std::optional;
+using std::size_t;
+using std::tie;
+using std::unique_ptr;
+using std::vector;
+
+Circuit::Circuit(vector<IntegerVariableID> succ) : _succ(std::move(succ))
+{
+    // Two slots pinned to the same constant are a valid (if trivially
+    // infeasible) model; only reject true variable aliasing.
+    for (size_t i = 0; i < _succ.size(); ++i) {
+        if (is_constant_variable(_succ[i]))
+            continue;
+        for (size_t j = i + 1; j < _succ.size(); ++j)
+            if (_succ[i] == _succ[j])
+                throw InvalidProblemDefinitionException{"Circuit: successor array contains the same variable handle twice"};
+    }
+}
+
+auto Circuit::with_algorithm(CircuitAlgorithm algorithm) -> Circuit &
+{
+    _algorithm = algorithm;
+    return *this;
+}
+
+auto Circuit::with_gac_all_different(optional<bool> enable) -> Circuit &
+{
+    _gac_all_different = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_prune_root(optional<bool> enable) -> Circuit &
+{
+    _scc_options.prune_root = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_prune_skip(optional<bool> enable) -> Circuit &
+{
+    _scc_options.prune_skip = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_fix_req(optional<bool> enable) -> Circuit &
+{
+    _scc_options.fix_req = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_prune_within(optional<bool> enable) -> Circuit &
+{
+    _scc_options.prune_within = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_prove_using_dominance(optional<bool> enable) -> Circuit &
+{
+    _scc_options.prove_using_dominance = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_enable_comments(optional<bool> enable) -> Circuit &
+{
+    _scc_options.enable_comments = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_prove_am1_by_contradiction(optional<bool> enable) -> Circuit &
+{
+    _scc_options.prove_am1_by_contradiction = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::with_short_reasons(optional<bool> enable) -> Circuit &
+{
+    _scc_options.short_reasons = enable.value_or(true);
+    return *this;
+}
+
+auto Circuit::set_up(Propagators & propagators, State & initial_state, ProofModel * const model) -> PosVarDataMap
+{
+    // Can't have negative values
+    for (const auto & s : _succ)
+        propagators.define_bound(initial_state, model, s, Bound::Lower, 0_i, "Circuit", "successor index range");
+
+    // Can't have too-large values
+    for (const auto & s : _succ)
+        propagators.define_bound(
+            initial_state, model, s, Bound::Upper, Integer(static_cast<long long>(_succ.size() - 1)), "Circuit", "successor index range");
+
+    // Define all different, either gac or non-gac
+    if (_gac_all_different) {
+        AllDifferent all_diff{_succ};
+        std::move(all_diff).install(propagators, initial_state, model);
+    }
+    else {
+        // Still need to define the all different encoding.
+        if (model)
+            define_clique_not_equals_encoding(*model, _constraint_id, _succ);
+    }
+
+    // Define encoding to eliminate sub-cycles
+    PosVarDataMap pos_var_data{};
+
+    if (model) {
+        auto n = static_cast<long long>(_succ.size());
+        // Define encoding to eliminate sub-cycles
+        // Need extra proof variable: pos[i] = j means "the ith node visited in the circuit is the jth var"
+        // WLOG start at node 0, so pos[0] = 0
+        pos_var_data.emplace(0,
+            PosVarData{"p[0]", model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
+                map<long, PosVarLineData>{}});
+        model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
+        // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
+        // cake_pb_cp labels these position relations @c[id][pos_suc_<i>_<j>_le/ge].
+        auto [leq_line, geq_line] = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_0_0_le", "pos_suc_0_0_ge",
+            StringLiteral{"Circuit"}, StringLiteral{"position"}, WPBSum{} == Integer{n - 1}, HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
+
+        pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
+
+        for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
+            pos_var_data.emplace(idx,
+                PosVarData{format("p[{}]", idx),
+                    model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
+                    map<long, PosVarLineData>{}});
+        }
+
+        for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
+            // (succ[0] = i) -> pos[i] - pos[0] = 1
+            tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_0_" + std::to_string(idx) + "_le",
+                "pos_suc_0_" + std::to_string(idx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
+                WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i, HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
+            pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line, geq_line});
+
+            // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
+            tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_" + std::to_string(idx) + "_0_le",
+                "pos_suc_" + std::to_string(idx) + "_0_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
+                WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
+                HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
+            pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
+
+            // (succ[i] = j) -> pos[j] = pos[i] + 1
+            for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
+                tie(leq_line, geq_line) =
+                    model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_le",
+                        "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
+                        WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
+                        HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
+                pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});
+            }
+        }
+    }
+
+    // Infer succ[i] != i at top of search, but no other propagation defined here: use circuit::Prevent or circuit::SCC
+    if (_succ.size() > 1) {
+        propagators.install(
+            constraint_id(),
+            [succ = _succ, owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                for (auto [idx, s] : enumerate(succ)) {
+                    inference.infer_not_equal(
+                        logger, s, Integer(static_cast<long long>(idx)), JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
+                }
+                return PropagatorState::DisableUntilBacktrack;
+            },
+            Triggers{});
+    }
+
+    return pos_var_data;
+}
+
+auto Circuit::install(Propagators & propagators, State & initial_state, ProofModel * const model) && -> void
+{
+    auto pos_var_data = set_up(propagators, initial_state, model);
+
+    overloaded{[&](const SCC &) { install_circuit_scc(propagators, initial_state, constraint_id(), _succ, _scc_options, std::move(pos_var_data)); },
+        [&](const Prevent &) { install_circuit_prevent(propagators, initial_state, constraint_id(), _succ, std::move(pos_var_data)); }}
+        .visit(_algorithm);
+}
+
+auto Circuit::clone() const -> unique_ptr<Constraint>
+{
+    auto cloned = make_unique<Circuit>(_succ);
+    cloned->with_algorithm(_algorithm);
+    cloned->with_gac_all_different(_gac_all_different);
+    cloned->_scc_options = _scc_options;
+    return cloned;
+}
+
+auto Circuit::s_expr(const ProofModel * const model) const -> SExpr
+{
+    auto & tracker = model->names_and_ids_tracker();
+    vector<SExpr> vars;
+    for (const auto & var : _succ)
+        vars.push_back(tracker.s_expr_term_of(var));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("circuit"), SExpr::list(std::move(vars))});
+}

--- a/gcs/constraints/circuit/circuit.hh
+++ b/gcs/constraints/circuit/circuit.hh
@@ -1,0 +1,110 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_CIRCUIT_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_CIRCUIT_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/constraints/circuit/circuit_base.hh>
+#include <gcs/constraints/circuit/circuit_prevent.hh>
+#include <gcs/constraints/circuit/circuit_scc.hh>
+#include <gcs/variable_id.hh>
+
+#include <memory>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace gcs
+{
+    namespace circuit
+    {
+        /**
+         * \brief Propagate Circuit by finding strongly connected components: prune edges that
+         * cannot lie on any Hamiltonian cycle, force required edges, and prevent small cycles.
+         *
+         * This is the default. It propagates more strongly than circuit::Prevent, at a higher
+         * cost per search node.
+         *
+         * \ingroup Constraints
+         */
+        struct SCC final
+        {
+        };
+
+        /**
+         * \brief Propagate Circuit by the cheaper "prevent" method: track the chains formed by
+         * fixed successor edges and forbid (or force) each chain from closing into a short cycle.
+         *
+         * \ingroup Constraints
+         */
+        struct Prevent final
+        {
+        };
+    }
+
+    /**
+     * \brief The propagation algorithms supported by Circuit: circuit::SCC (the stronger default)
+     * or circuit::Prevent (cheaper). Requesting anything else is a compile-time error, and the
+     * choice never changes the constraint's meaning or its proof encoding.
+     *
+     * \ingroup Constraints
+     */
+    using CircuitAlgorithm = std::variant<circuit::SCC, circuit::Prevent>;
+
+    /**
+     * \brief Circuit constraint: requires the variables, representing graph nodes, take values
+     * such that each variable's value is the index of the next node in a single tour visiting
+     * every variable.
+     *
+     * The constructor takes only the successor array; configure propagation with the fluent
+     * setters. Select the algorithm with with_algorithm() (circuit::SCC by default, or
+     * circuit::Prevent). The SCC-only tuning knobs (with_prune_root(), with_prune_skip(), ...)
+     * are no-ops under circuit::Prevent. None of these choices change the constraint's meaning
+     * or the OPB encoding written for proof logging.
+     *
+     * \ingroup Constraints
+     */
+    class Circuit : public Constraint
+    {
+    private:
+        const std::vector<IntegerVariableID> _succ;
+        CircuitAlgorithm _algorithm = circuit::SCC{};
+        bool _gac_all_different = false;
+        SCCOptions _scc_options{};
+
+        auto set_up(innards::Propagators &, innards::State &, innards::ProofModel * const) -> innards::circuit::PosVarDataMap;
+
+    public:
+        explicit Circuit(std::vector<IntegerVariableID> succ);
+
+        /// Select the propagation algorithm: circuit::SCC (the default) or circuit::Prevent.
+        /// The choice selects propagation strength only and never changes the OPB encoding.
+        auto with_algorithm(CircuitAlgorithm algorithm) -> Circuit &;
+
+        /// Enforce all-different over the successors with a full generalised-arc-consistent
+        /// propagator, in addition to the circuit propagation. Off by default (a cheaper
+        /// value-consistent all-different is always applied regardless).
+        auto with_gac_all_different(std::optional<bool> enable = true) -> Circuit &;
+
+        /// SCC-only: prune impossible edges out of the root node. No-op under circuit::Prevent.
+        auto with_prune_root(std::optional<bool> enable = true) -> Circuit &;
+        /// SCC-only: prune edges that would skip over a mandatory subtree. No-op under circuit::Prevent.
+        auto with_prune_skip(std::optional<bool> enable = true) -> Circuit &;
+        /// SCC-only: fix required (back-)edges. No-op under circuit::Prevent.
+        auto with_fix_req(std::optional<bool> enable = true) -> Circuit &;
+        /// SCC-only: prune impossible edges within a subtree. No-op under circuit::Prevent.
+        auto with_prune_within(std::optional<bool> enable = true) -> Circuit &;
+        /// SCC-only: prove pruning by a dominance argument rather than reachability. No-op under circuit::Prevent.
+        auto with_prove_using_dominance(std::optional<bool> enable = true) -> Circuit &;
+        /// SCC-only: emit explanatory proof comments. No-op under circuit::Prevent.
+        auto with_enable_comments(std::optional<bool> enable = true) -> Circuit &;
+        /// SCC-only: prove at-most-one position facts by contradiction. No-op under circuit::Prevent.
+        auto with_prove_am1_by_contradiction(std::optional<bool> enable = true) -> Circuit &;
+        /// SCC-only: reify a short "reason" flag rather than citing the full reason each time. No-op under circuit::Prevent.
+        auto with_short_reasons(std::optional<bool> enable = true) -> Circuit &;
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
+    };
+}
+
+#endif // GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CIRCUIT_CIRCUIT_HH

--- a/gcs/constraints/circuit/circuit_base.cc
+++ b/gcs/constraints/circuit/circuit_base.cc
@@ -1,18 +1,11 @@
-#include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/all_different/vc_all_different.hh>
 #include <gcs/constraints/circuit/circuit_base.hh>
 #include <gcs/constraints/circuit/hints.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
-#include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
-#include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
-#include <gcs/innards/s_expr.hh>
 
-#include <map>
-#include <sstream>
-#include <string>
 #include <util/enumerate.hh>
 #include <utility>
 
@@ -20,9 +13,8 @@
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 #include <format>
-#include <print>
 #else
-#include <fmt/ostream.h>
+#include <fmt/core.h>
 #endif
 
 using namespace gcs;
@@ -30,36 +22,17 @@ using namespace gcs::innards;
 
 using std::cmp_less;
 using std::cmp_not_equal;
-using std::map;
 using std::nullopt;
 using std::optional;
-using std::size_t;
-using std::string;
-using std::stringstream;
 using std::vector;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::format;
-using std::print;
 #else
 using fmt::format;
-using fmt::print;
 #endif
 
 using namespace gcs::innards::circuit;
-
-CircuitBase::CircuitBase(vector<IntegerVariableID> v, const bool g) : _gac_all_different(g), _succ(std::move(v))
-{
-    // Two slots pinned to the same constant are a valid (if trivially
-    // infeasible) model; only reject true variable aliasing.
-    for (size_t i = 0; i < _succ.size(); ++i) {
-        if (is_constant_variable(_succ[i]))
-            continue;
-        for (size_t j = i + 1; j < _succ.size(); ++j)
-            if (_succ[i] == _succ[j])
-                throw InvalidProblemDefinitionException{"Circuit: successor array contains the same variable handle twice"};
-    }
-}
 
 auto gcs::innards::circuit::output_cycle_to_proof(const vector<IntegerVariableID> & succ, const long & start, const long & length,
     const PosVarDataMap & pos_var_data, const State & state, ProofLogger & logger, const optional<Integer> & prevent_idx,
@@ -146,106 +119,6 @@ auto gcs::innards::circuit::prevent_small_cycles(const vector<IntegerVariableID>
             inference.infer(logger, succ[end[i]] == Integer{i}, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
         }
     }
-}
-
-auto CircuitBase::set_up(Propagators & propagators, State & initial_state, ProofModel * const model) -> PosVarDataMap
-{
-    // Can't have negative values
-    for (const auto & s : _succ)
-        propagators.define_bound(initial_state, model, s, Bound::Lower, 0_i, "Circuit", "successor index range");
-
-    // Can't have too-large values
-    for (const auto & s : _succ)
-        propagators.define_bound(
-            initial_state, model, s, Bound::Upper, Integer(static_cast<long long>(_succ.size() - 1)), "Circuit", "successor index range");
-
-    // Define all different, either gac or non-gac
-    if (_gac_all_different) {
-        AllDifferent all_diff{_succ};
-        std::move(all_diff).install(propagators, initial_state, model);
-    }
-    else {
-        // Still need to define the all different encoding.
-        if (model)
-            define_clique_not_equals_encoding(*model, _constraint_id, _succ);
-    }
-
-    // Define encoding to eliminate sub-cycles
-    PosVarDataMap pos_var_data{};
-
-    if (model) {
-        auto n = static_cast<long long>(_succ.size());
-        // Define encoding to eliminate sub-cycles
-        // Need extra proof variable: pos[i] = j means "the ith node visited in the circuit is the jth var"
-        // WLOG start at node 0, so pos[0] = 0
-        pos_var_data.emplace(0,
-            PosVarData{"p[0]", model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
-                map<long, PosVarLineData>{}});
-        model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
-        // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
-        // cake_pb_cp labels these position relations @c[id][pos_suc_<i>_<j>_le/ge].
-        auto [leq_line, geq_line] = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_0_0_le", "pos_suc_0_0_ge",
-            StringLiteral{"Circuit"}, StringLiteral{"position"}, WPBSum{} == Integer{n - 1}, HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
-
-        pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
-
-        for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
-            pos_var_data.emplace(idx,
-                PosVarData{format("p[{}]", idx),
-                    model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
-                    map<long, PosVarLineData>{}});
-        }
-
-        for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
-            // (succ[0] = i) -> pos[i] - pos[0] = 1
-            tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_0_" + std::to_string(idx) + "_le",
-                "pos_suc_0_" + std::to_string(idx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
-                WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i, HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
-            pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line, geq_line});
-
-            // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
-            tie(leq_line, geq_line) = model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_" + std::to_string(idx) + "_0_le",
-                "pos_suc_" + std::to_string(idx) + "_0_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
-                WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
-                HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
-            pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
-
-            // (succ[i] = j) -> pos[j] = pos[i] + 1
-            for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
-                tie(leq_line, geq_line) =
-                    model->add_labelled_constraint(as_string(_constraint_id), "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_le",
-                        "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_ge", StringLiteral{"Circuit"}, StringLiteral{"position"},
-                        WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
-                        HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
-                pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});
-            }
-        }
-    }
-
-    // Infer succ[i] != i at top of search, but no other propagation defined here: use CircuitPrevent or CircuitSCC
-    if (_succ.size() > 1) {
-        propagators.install(
-            constraint_id(),
-            [succ = _succ, owner = constraint_id()](const State &, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                for (auto [idx, s] : enumerate(succ)) {
-                    inference.infer_not_equal(
-                        logger, s, Integer(static_cast<long long>(idx)), JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
-                }
-                return PropagatorState::DisableUntilBacktrack;
-            },
-            Triggers{});
-    }
-
-    return pos_var_data;
-}
-
-auto CircuitBase::s_expr(const innards::ProofModel * const model) const -> SExpr
-{
-    auto & tracker = model->names_and_ids_tracker();
-    vector<SExpr> vars;
-    for (const auto & var : _succ)
-        vars.push_back(tracker.s_expr_term_of(var));
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("circuit"), SExpr::list(std::move(vars))});
 }
 
 template auto gcs::innards::circuit::prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner,

--- a/gcs/constraints/circuit/circuit_base.hh
+++ b/gcs/constraints/circuit/circuit_base.hh
@@ -58,26 +58,6 @@ namespace gcs::innards::circuit
 
     auto prevent_small_cycles(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
         const ConstraintStateHandle & unassigned_handle, const State & state, auto & inference_tracker, ProofLogger * const logger) -> void;
-
-    /**
-     * \brief Circuit constraint: requires the variables, representing graph nodes, take values
-     * such that each variable's value represents the index of the next node in a tour that visits
-     * all variables.
-     *
-     * \ingroup Constraints
-     */
-    class CircuitBase : public Constraint
-    {
-    protected:
-        const bool _gac_all_different;
-        const std::vector<IntegerVariableID> _succ;
-        virtual auto set_up(innards::Propagators &, innards::State &, ProofModel * const) -> innards::circuit::PosVarDataMap;
-
-    public:
-        explicit CircuitBase(std::vector<IntegerVariableID> var, bool gac_all_different = false);
-        [[nodiscard]] auto clone() const -> std::unique_ptr<Constraint> override = 0;
-        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
-    };
 }
 
 #endif // GLASGOW_CONSTRAINT_SOLVER_CIRCUIT_BASE_HH

--- a/gcs/constraints/circuit/circuit_disconnected_test.cc
+++ b/gcs/constraints/circuit/circuit_disconnected_test.cc
@@ -46,7 +46,7 @@ auto main(int argc, char * argv[]) -> int
     p.post(In{x[6], {5_i, 7_i}});
     p.post(In{x[7], {4_i, 6_i}});
 
-    p.post(CircuitSCC{x});
+    p.post(Circuit{x}.with_algorithm(circuit::SCC{}));
 
     bool proofs = can_run_veripb();
     auto proof_name = proofs ? make_optional("circuit_disconnected_test_" + view_wrap_config_label(view_cfg)) : nullopt;

--- a/gcs/constraints/circuit/circuit_dup_test.cc
+++ b/gcs/constraints/circuit/circuit_dup_test.cc
@@ -11,16 +11,17 @@ using std::cerr;
 
 namespace
 {
-    template <typename Constraint_>
-    auto expect_throw_on_dup(const char * which) -> bool
+    auto expect_throw_on_dup(CircuitAlgorithm algorithm, const char * which) -> bool
     {
         // Circuit's successor array must be all-different; aliasing two
         // slots to the same variable handle is trivially infeasible. We
         // reject at construction so users don't wait for search to UNSAT.
+        // The rejection is in the constructor, so it fires whichever
+        // algorithm is later selected.
         Problem p;
         auto x = p.create_integer_variable_vector(4, 0_i, 3_i);
         try {
-            p.post(Constraint_{{x[0], x[1], x[2], x[1]}});
+            p.post(Circuit{{x[0], x[1], x[2], x[1]}}.with_algorithm(algorithm));
         }
         catch (const InvalidProblemDefinitionException &) {
             return true;
@@ -33,7 +34,7 @@ namespace
 auto main(int, char *[]) -> int
 {
     bool ok = true;
-    ok &= expect_throw_on_dup<CircuitSCC>("CircuitSCC");
-    ok &= expect_throw_on_dup<CircuitPrevent>("CircuitPrevent");
+    ok &= expect_throw_on_dup(circuit::SCC{}, "circuit::SCC");
+    ok &= expect_throw_on_dup(circuit::Prevent{}, "circuit::Prevent");
     return ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/gcs/constraints/circuit/circuit_multiple_sccs_test.cc
+++ b/gcs/constraints/circuit/circuit_multiple_sccs_test.cc
@@ -50,7 +50,7 @@ auto main(int argc, char * argv[]) -> int
 
     post_constraints(p, nodes);
 
-    p.post(CircuitSCC{nodes});
+    p.post(Circuit{nodes}.with_algorithm(circuit::SCC{}));
 
     bool proofs = can_run_veripb();
     auto proof_name = proofs ? make_optional("circuit_multiple_sccs_test_" + view_wrap_config_label(view_cfg)) : nullopt;

--- a/gcs/constraints/circuit/circuit_no_backedges_test.cc
+++ b/gcs/constraints/circuit/circuit_no_backedges_test.cc
@@ -62,12 +62,7 @@ auto main(int argc, char * argv[]) -> int
 
     post_constraints(p, nodes);
 
-    SCCOptions scc_options;
-    scc_options.fix_req = true;
-    scc_options.prune_root = false;
-    scc_options.prune_within = false;
-    scc_options.prune_skip = false;
-    p.post(CircuitSCC{nodes, false, scc_options});
+    p.post(Circuit{nodes}.with_algorithm(circuit::SCC{}).with_fix_req(true).with_prune_root(false).with_prune_within(false).with_prune_skip(false));
 
     bool proofs = can_run_veripb();
     auto proof_name = proofs ? make_optional("circuit_no_backedges_test_" + view_wrap_config_label(view_cfg)) : nullopt;

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -7,7 +7,6 @@
 #include <gcs/innards/propagators.hh>
 
 #include <any>
-#include <map>
 #include <utility>
 #include <vector>
 
@@ -16,10 +15,7 @@ using namespace gcs::innards;
 using namespace gcs::innards::circuit;
 
 using std::any_cast;
-using std::map;
 using std::size_t;
-using std::stringstream;
-using std::unique_ptr;
 using std::vector;
 
 namespace
@@ -120,23 +116,19 @@ template auto gcs::innards::circuit::propagate_circuit_using_prevent(const std::
     const PosVarDataMap & pos_var_data, const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle,
     const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> void;
 
-auto CircuitPrevent::clone() const -> unique_ptr<Constraint>
-{
-    return make_unique<CircuitPrevent>(_succ, _gac_all_different);
-}
-
-auto CircuitPrevent::install(innards::Propagators & propagators, innards::State & initial_state, innards::ProofModel * const model) && -> void
+auto gcs::innards::circuit::install_circuit_prevent(Propagators & propagators, State & initial_state, const ConstraintID & owner,
+    const vector<IntegerVariableID> & succ, PosVarDataMap pos_var_data) -> void
 {
     // Keep track of unassigned vars
     NonGacAllDifferentUnassigned unassigned{};
-    for (auto v : _succ) {
+    for (auto v : succ) {
         unassigned.emplace_back(v);
     }
     auto unassigned_handle = initial_state.add_constraint_state(unassigned);
 
     // Backtrackable chain endpoints for the incremental small-cycle prevention. Each
     // node starts as its own length-zero chain; edges fold in as successors are fixed.
-    auto num_nodes = _succ.size();
+    auto num_nodes = succ.size();
     PreventChainData chain;
     chain.orig.resize(num_nodes);
     chain.dest.resize(num_nodes);
@@ -149,13 +141,11 @@ auto CircuitPrevent::install(innards::Propagators & propagators, innards::State 
     }
     auto chain_handle = initial_state.add_constraint_state(std::move(chain));
 
-    auto pos_var_data = CircuitBase::set_up(propagators, initial_state, model);
-
     Triggers triggers;
-    triggers.on_instantiated = {_succ.begin(), _succ.end()};
+    triggers.on_instantiated = {succ.begin(), succ.end()};
     propagators.install(
-        constraint_id(),
-        [succ = _succ, owner = constraint_id(), pvd = pos_var_data, unassigned_handle = unassigned_handle, chain_handle = chain_handle](
+        owner,
+        [succ, owner, pvd = std::move(pos_var_data), unassigned_handle = unassigned_handle, chain_handle = chain_handle](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             propagate_circuit_using_prevent(succ, owner, pvd, unassigned_handle, chain_handle, state, inference, logger);
             return PropagatorState::Enable;

--- a/gcs/constraints/circuit/circuit_prevent.hh
+++ b/gcs/constraints/circuit/circuit_prevent.hh
@@ -3,31 +3,25 @@
 
 #include <gcs/constraints/circuit/circuit_base.hh>
 
-namespace gcs
-{
-    /**
-     * Circuit constraint that propagates by identifying chains and removing the head of each chain from the domain of
-     * the tail "preventing" small cycles.
-     */
-    class CircuitPrevent : public innards::circuit::CircuitBase
-    {
-    public:
-        using CircuitBase::CircuitBase;
-        [[nodiscard]] auto clone() const -> std::unique_ptr<Constraint> override;
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-    };
-}
-
 namespace gcs::innards::circuit
 {
     /**
-     * \brief The "prevent" circuit propagator, shared by CircuitPrevent's install and used by the
-     * collapsed Circuit constraint. Runs the value-consistent all-different, then incrementally folds
-     * newly-fixed edges into chain endpoints to forbid (or force) short cycles. Defined in
-     * circuit_prevent.cc.
+     * \brief The "prevent" circuit propagator, used by the Circuit constraint when the
+     * circuit::Prevent algorithm is selected. Runs the value-consistent all-different, then
+     * incrementally folds newly-fixed edges into chain endpoints to forbid (or force) short
+     * cycles. Defined in circuit_prevent.cc.
      */
     auto propagate_circuit_using_prevent(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
         const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle, const State & state, auto & inference,
         ProofLogger * const logger) -> void;
+
+    /**
+     * \brief Set up the backtrackable state for the "prevent" circuit propagator (unassigned set
+     * plus the incremental chain endpoints) and install it, given the position-variable proof data
+     * already produced by Circuit::set_up. Called from Circuit::install when the circuit::Prevent
+     * algorithm is selected. Defined in circuit_prevent.cc.
+     */
+    auto install_circuit_prevent(Propagators & propagators, State & initial_state, const ConstraintID & owner,
+        const std::vector<IntegerVariableID> & succ, PosVarDataMap pos_var_data) -> void;
 }
 #endif // GLASGOW_CONSTRAINT_SOLVER_CIRCUIT_PREVENT_HH

--- a/gcs/constraints/circuit/circuit_prune_root_test.cc
+++ b/gcs/constraints/circuit/circuit_prune_root_test.cc
@@ -47,7 +47,7 @@ auto main(int argc, char * argv[]) -> int
 
     post_constraints(p, nodes);
 
-    p.post(CircuitSCC{nodes});
+    p.post(Circuit{nodes}.with_algorithm(circuit::SCC{}));
 
     bool proofs = can_run_veripb();
     auto proof_name = proofs ? make_optional("circuit_prune_root_test_" + view_wrap_config_label(view_cfg)) : nullopt;

--- a/gcs/constraints/circuit/circuit_prune_skip_test.cc
+++ b/gcs/constraints/circuit/circuit_prune_skip_test.cc
@@ -50,12 +50,7 @@ auto main(int argc, char * argv[]) -> int
 
     post_constraints(p, nodes);
 
-    SCCOptions scc_options;
-    scc_options.fix_req = false;
-    scc_options.prune_root = false;
-    scc_options.prune_within = false;
-    scc_options.prune_skip = true;
-    p.post(CircuitSCC{nodes, false, scc_options});
+    p.post(Circuit{nodes}.with_algorithm(circuit::SCC{}).with_fix_req(false).with_prune_root(false).with_prune_within(false).with_prune_skip(true));
 
     bool proofs = can_run_veripb();
     auto proof_name = proofs ? make_optional("circuit_prune_skip_test_" + view_wrap_config_label(view_cfg)) : nullopt;

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -41,7 +41,6 @@ using std::pair;
 using std::set;
 using std::string;
 using std::stringstream;
-using std::unique_ptr;
 using std::vector;
 
 using namespace gcs;
@@ -1097,35 +1096,24 @@ template auto gcs::innards::circuit::propagate_circuit_using_scc(const State & s
     const SCCOptions & scc_options, const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
     const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
 
-CircuitSCC::CircuitSCC(std::vector<IntegerVariableID> var, bool gacAllDifferent, const SCCOptions s) :
-    CircuitBase(std::move(var), gacAllDifferent), scc_options(s)
+auto gcs::innards::circuit::install_circuit_scc(Propagators & propagators, State & initial_state, const ConstraintID & owner,
+    const vector<IntegerVariableID> & succ, const SCCOptions & scc_options, PosVarDataMap pos_var_data) -> void
 {
-}
-
-auto CircuitSCC::clone() const -> unique_ptr<Constraint>
-{
-    return make_unique<CircuitSCC>(_succ, _gac_all_different, scc_options);
-}
-
-auto CircuitSCC::install(Propagators & propagators, State & initial_state, ProofModel * const model) && -> void
-{
-    auto pos_var_data = CircuitBase::set_up(propagators, initial_state, model);
-
     // Keep track of unassigned vars
     NonGacAllDifferentUnassigned unassigned{};
-    for (auto v : _succ) {
+    for (auto v : succ) {
         unassigned.emplace_back(v);
     }
-    auto pos_var_data_handle = initial_state.add_persistent_constraint_state(pos_var_data);
+    auto pos_var_data_handle = initial_state.add_persistent_constraint_state(std::move(pos_var_data));
     auto unassigned_handle = initial_state.add_constraint_state(unassigned);
     auto proof_flag_data_handle = initial_state.add_persistent_constraint_state(map<long, ShiftedPosDataMaps>{});
     auto pos_alldiff_data_handle = initial_state.add_persistent_constraint_state(PosAllDiffData{});
 
     Triggers triggers;
-    triggers.on_change = {_succ.begin(), _succ.end()};
+    triggers.on_change = {succ.begin(), succ.end()};
     propagators.install(
-        constraint_id(),
-        [succ = _succ, owner = constraint_id(), pos_var_data_handle = pos_var_data_handle, proof_flag_data_handle = proof_flag_data_handle,
+        owner,
+        [succ, owner, pos_var_data_handle = pos_var_data_handle, proof_flag_data_handle = proof_flag_data_handle,
             pos_alldiff_data_handle = pos_alldiff_data_handle, unassigned_handle = unassigned_handle,
             options = scc_options](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             ReasonLiterals reason = eager_reason(generic_reason(succ), state);

--- a/gcs/constraints/circuit/circuit_scc.hh
+++ b/gcs/constraints/circuit/circuit_scc.hh
@@ -10,6 +10,10 @@
 
 namespace gcs
 {
+    /**
+     * \brief SCC-only tuning knobs for the Circuit constraint, set through Circuit's
+     * with_prune_root()/with_prune_skip()/... fluent setters.
+     */
     struct SCCOptions
     {
         bool prune_root = true;
@@ -21,31 +25,28 @@ namespace gcs
         bool prove_am1_by_contradiction = true;
         bool short_reasons = true;
     };
-
-    class CircuitSCC : public innards::circuit::CircuitBase
-    {
-    protected:
-        const SCCOptions scc_options;
-
-    public:
-        explicit CircuitSCC(std::vector<IntegerVariableID> var, bool gac_all_different = false, SCCOptions scc_options = SCCOptions{});
-        [[nodiscard]] auto clone() const -> std::unique_ptr<Constraint> override;
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-    };
 }
 
 namespace gcs::innards::circuit
 {
     /**
-     * \brief The SCC-based circuit propagator, shared by CircuitSCC's install and used by the
-     * collapsed Circuit constraint. Runs the value-consistent all-different, checks strongly
-     * connected components (pruning edges that cannot lie on a Hamiltonian cycle), and prevents
-     * small cycles. Defined in circuit_scc.cc.
+     * \brief The SCC-based circuit propagator, used by the Circuit constraint when the
+     * circuit::SCC algorithm is selected. Runs the value-consistent all-different, checks
+     * strongly connected components (pruning edges that cannot lie on a Hamiltonian cycle),
+     * and prevents small cycles. Defined in circuit_scc.cc.
      */
     auto propagate_circuit_using_scc(const State & state, auto & inference, ProofLogger * const logger, const ReasonLiterals & reason,
         const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
         const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
         const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
+
+    /**
+     * \brief Set up the backtrackable state for the SCC circuit propagator and install it, given
+     * the position-variable proof data already produced by Circuit::set_up. Called from
+     * Circuit::install when the circuit::SCC algorithm is selected. Defined in circuit_scc.cc.
+     */
+    auto install_circuit_scc(Propagators & propagators, State & initial_state, const ConstraintID & owner,
+        const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options, PosVarDataMap pos_var_data) -> void;
 }
 
 #endif // GLASGOW_CONSTRAINT_SOLVER_CIRCUIT_SCC_HH

--- a/gcs/constraints/circuit/circuit_test.cc
+++ b/gcs/constraints/circuit/circuit_test.cc
@@ -83,9 +83,9 @@ auto run_circuit_test(bool proofs, const ViewWrapConfig & view_cfg, int n, Circu
     for (int i = 0; i < n; ++i)
         succ.push_back(create_integer_variable_or_constant_with_view(p, pair{0, n - 1}, wraps.at(static_cast<std::size_t>(i))));
     if (propagator == CircuitPropagator::prevent)
-        p.post(CircuitPrevent{succ, false});
+        p.post(Circuit{succ}.with_algorithm(circuit::Prevent{}));
     else
-        p.post(Circuit{succ});
+        p.post(Circuit{succ}.with_algorithm(circuit::SCC{}));
 
     auto proof_name = proofs ? make_optional("circuit_test_" + std::string{prop_label} + "_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{succ});

--- a/minicp_benchmarks/tsp/tsp.cc
+++ b/minicp_benchmarks/tsp/tsp.cc
@@ -90,12 +90,10 @@ auto main(int argc, char * argv[]) -> int
     auto dist = p.create_integer_variable_vector(n, 0_i, 745_i);
 
     if (options_vars["propagator"].as<string>() == "prevent") {
-        p.post(CircuitPrevent{succ, false});
+        p.post(Circuit{succ}.with_algorithm(circuit::Prevent{}));
     }
     else {
-        SCCOptions options{};
-        options.enable_comments = false;
-        p.post(CircuitSCC{succ, false, options});
+        p.post(Circuit{succ}.with_algorithm(circuit::SCC{}).with_enable_comments(false));
     }
 
     for (unsigned i = 0; i < n; ++i)


### PR DESCRIPTION
The last constraint in the fluent `.with_*()` sweep for #299. **Stacked on #459** (the propagator extraction) — review/merge that first.

## What

Previously `Circuit` was a `using`-alias for `CircuitSCC`, one of two sibling classes (`CircuitSCC`, `CircuitPrevent`) deriving from an abstract `CircuitBase`. The propagation algorithm was chosen by the class name, and SCC tuning was passed as a ctor `SCCOptions` struct.

This PR collapses the three classes into a single concrete `Circuit` whose constructor takes only the successor array. Everything else is fluent:

```cpp
problem.post(Circuit{succ}
    .with_algorithm(circuit::Prevent{})   // or circuit::SCC{} (the default)
    .with_gac_all_different()
    .with_enable_comments(false));
```

- `circuit::SCC{}` / `circuit::Prevent{}` are new algorithm tags (a `std::variant<>` `CircuitAlgorithm`), selected with `.with_algorithm()`. SCC is the default, matching the old `Circuit = CircuitSCC` alias. Requesting an unsupported tag is a compile-time error. These are an *algorithm* choice, not a consistency level, so they get their own tags rather than reusing `consistency::`.
- The eight `SCCOptions` fields become eight `.with_*(std::optional<bool>)` setters, documented as no-ops under `circuit::Prevent`. `.with_gac_all_different()` replaces the old ctor bool.
- `Circuit::install()` runs the shared `set_up()` (bounds + all-different encoding + sub-cycle position encoding, moved here from `CircuitBase`), then dispatches on the algorithm tag to `install_circuit_scc` / `install_circuit_prevent`. Those two install helpers keep each algorithm's backtrackable-state setup — and the prevent chain struct — encapsulated in their own translation units, so **nothing new is exposed** beyond the two helper signatures.
- `s_expr()` is unchanged for both algorithms (always emits `"circuit"`), so the cake `.scp` chain reads the same term. `CircuitBase` is gone; `circuit_base.{hh,cc}` now hold just the shared proof-data structs and helper free functions.

## No functional change

The SCC and Prevent proofs (`.opb` **and** `.pbp`) are **byte-identical** to pre-collapse `main` for `circuit_test`'s instances (checked against an `origin/main` worktree).

## Testing

- Full `cmake --build` (all targets, GCC 15), full `ctest` suite **456/456**.
- All 19 `circuit` ctests pass, including `scp_chain_circuit_{sat,unsat}` (cake chain), the `.scp` roundtrip, xcsp, and minizinc.
- `./circuit_test`, `circuit_disconnected_test`, `circuit_prune_root_test`, `circuit_prune_skip_test`, `circuit_no_backedges_test`, `circuit_multiple_sccs_test` all verify under VeriPB.

## Users updated

The fzn/xcsp frontends and `scp_reader` keep `Circuit{vars}` unchanged; the examples, the tsp benchmark, and the circuit tests move to the fluent setters. The dup test now parameterises over the algorithm tag instead of the class type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)