### PR TITLE
Docs: record the #299 fluent-options resolution (consistency.hh + constraints.md)

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -77,22 +77,29 @@ gcs/constraints/all_different/*_test.cc                tests
 ```
 
 Here the umbrella `gcs/constraints/<family>.hh` `#include`s every
-variant's header and may add a `using AllDifferent = GACAllDifferent;`
-style alias to name the default implementation. `gcs/gcs.hh` then only
-needs the umbrella, not each variant.
+variant's header. `gcs/gcs.hh` then only needs the umbrella, not each
+variant.
 
-Newer constraints select behaviour with the `gcs/consistency.hh` tag
-types instead of separate public variant classes (issue #299): the
-constructor takes a `std::variant` over exactly the levels it supports,
-defaulted sensibly, as in `Multiply{x, y, z, consistency::Tabulated{}}`. `consistency::GAC`
-names a genuine algorithm that achieves the level; a constraint that can
-only get there by enumerating a table takes `consistency::Tabulated`, so
-the very different cost model is visible in the signature. The
-arithmetic family (`Multiply`, `Divide`, `Modulus`, `Power`, `Plus`,
-`Minus`) also accepts `consistency::Auto`, which tabulates the relation
-for GAC when the domains involved are small (see
+Constraints that offer more than one consistency level or propagation
+algorithm select it with a fluent `.with_*()` setter and the
+`gcs/consistency.hh` tag types, not a constructor argument or a separate
+public class (issue #299): the constructor takes only variables and data,
+and the setter takes a `std::variant` over exactly the levels the
+constraint supports, so requesting an unsupported one is a compile-time
+error, as in
+`problem.post(Multiply{x, y, z}.with_consistency(consistency::Tabulated{}))`.
+`consistency::GAC` names a genuine algorithm that achieves the level; a
+constraint that can only get there by enumerating a table takes
+`consistency::Tabulated`, so the very different cost model is visible in
+the signature. The arithmetic family (`Multiply`, `Divide`, `Modulus`,
+`Power`, `Plus`, `Minus`) also accepts `consistency::Auto`, which
+tabulates the relation for GAC when the domains involved are small (see
 `gcs/constraints/innards/tabulation.hh`); the tag never changes the OPB
-encoding, since the table is derived in-proof.
+encoding, since the table is derived in-proof. Families that used to
+expose several public classes behind a `using` alias — `AllDifferent`,
+`GlobalCardinality`, `Circuit` — are now a single class each, the choice
+moved onto the setter (`.with_consistency()`, or `.with_algorithm()` for
+`Circuit`'s `circuit::SCC`/`circuit::Prevent`).
 
 A compound constraint should emit one flat `@c[id][role]` OPB block and
 install one propagator, reusing the exposed machinery (`mult_bc::

--- a/gcs/consistency.hh
+++ b/gcs/consistency.hh
@@ -20,6 +20,14 @@ namespace gcs
      * error: the setter's signature is the documentation. These tags select
      * propagation strength only; they never change the constraint's meaning,
      * and they never change how the constraint is encoded for proof logging.
+     *
+     * A few constraints choose between genuine *algorithms* that are not
+     * ordered by strength (so a consistency level would be the wrong
+     * vocabulary). They follow the same shape with their own tag family and a
+     * sibling setter — for example `Circuit` selects `circuit::SCC` (the
+     * default) or `circuit::Prevent` via `with_algorithm()`. As with the
+     * consistency tags, the choice is propagation-only and never changes the
+     * encoding.
      */
 
     namespace consistency
@@ -93,9 +101,9 @@ namespace gcs
          * enforced, but no stronger reasoning is carried out.
          *
          * This is the weakest level, and usually the cheapest per search node.
-         * No constraint accepts it yet: it is here for when the AllDifferent
-         * family (whose fastest propagator is exactly this) migrates onto
-         * consistency tags in issue #299.
+         * AllDifferent takes it (`AllDifferent{vars}.with_consistency(consistency::VC{})`)
+         * to select its value-consistent propagator, which only removes a fixed
+         * variable's value from the other variables' domains.
          *
          * \ingroup Consistency
          */


### PR DESCRIPTION
Documentation follow-up to the #299 fluent-options sweep (now code-complete). Brings the docs in line with the shipped `.with_consistency()` / `.with_algorithm()` API.

- **`gcs/consistency.hh`**: drops the stale "No constraint accepts VC yet … migrates … in issue #299" note on `consistency::VC` (AllDifferent takes it now as its value-consistent level), and adds a note to the group doc about the sibling *algorithm*-tag pattern for choices that aren't ordered by strength (`Circuit`'s `circuit::SCC` / `circuit::Prevent` via `with_algorithm()`).
- **`dev_docs/constraints.md`**: the selection mechanism is a fluent setter, not a constructor argument — fixes the `Multiply{x, y, z, consistency::Tabulated{}}` example to `Multiply{x, y, z}.with_consistency(consistency::Tabulated{})`, and notes that the `AllDifferent` / `GlobalCardinality` / `Circuit` families are a single class each now rather than a `using` alias over several public variant classes.

Docs only — no code change; library still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)