### PR TITLE
Use std::optional monadic operations where they read more clearly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,16 @@ Known unavailable in libc++ (clang 21):
 
 Known unavailable in libstdc++ on the GitHub Actions Ubuntu 24.04 runner (GCC 13), which
 we still support:
-- `std::vector::append_range` — use `vec.insert(vec.end(), src.begin(), src.end())` instead
+- `std::vector::append_range` (and the other P1206 `*_range` container members) —
+  `__cpp_lib_containers_ranges` is undefined there. Use
+  `vec.insert(vec.end(), src.begin(), src.end())` instead. Reconfirmed unavailable on the
+  Ubuntu 24.04 lane via CI on 2026-07-03; libc++ (macOS) and GCC 15 both have it.
+
+Confirmed available on **all** supported toolchains (including GCC 13 and macOS libc++),
+verified via CI on 2026-07-03 — prefer them where they read more clearly than a hand-rolled
+`if`/ternary:
+- `std::optional` monadic operations: `.transform()`, `.and_then()`, `.or_else()`, and
+  `.value_or()`.
 
 When adding a new C++23 feature, build with both compilers before committing.
 

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -374,16 +374,16 @@ auto Disjunctive2D::install_propagators(Propagators & propagators) -> void
             // initialiser) as end_*_ge / end_*_le accessors. function-typed so the
             // free/forced-axis dispatch below can select one by axis.
             function<optional<ProofLine>(size_t)> end_x_ge = [&](size_t i) -> optional<ProofLine> {
-                return (*end_x_lines)[i] ? optional<ProofLine>{(*end_x_lines)[i]->first} : nullopt;
+                return (*end_x_lines)[i].transform([](const auto & p) { return p.first; });
             };
             function<optional<ProofLine>(size_t)> end_x_le = [&](size_t i) -> optional<ProofLine> {
-                return (*end_x_lines)[i] ? optional<ProofLine>{(*end_x_lines)[i]->second} : nullopt;
+                return (*end_x_lines)[i].transform([](const auto & p) { return p.second; });
             };
             function<optional<ProofLine>(size_t)> end_y_ge = [&](size_t i) -> optional<ProofLine> {
-                return (*end_y_lines)[i] ? optional<ProofLine>{(*end_y_lines)[i]->first} : nullopt;
+                return (*end_y_lines)[i].transform([](const auto & p) { return p.first; });
             };
             function<optional<ProofLine>(size_t)> end_y_le = [&](size_t i) -> optional<ProofLine> {
-                return (*end_y_lines)[i] ? optional<ProofLine>{(*end_y_lines)[i]->second} : nullopt;
+                return (*end_y_lines)[i].transform([](const auto & p) { return p.second; });
             };
             // Pairwise 2D time-table. The mandatory box of rectangle i is
             //   [ub(x_i), lb(x_i)+lb(w_i)) x [ub(y_i), lb(y_i)+lb(h_i))

--- a/gcs/innards/literal.cc
+++ b/gcs/innards/literal.cc
@@ -98,8 +98,7 @@ auto gcs::innards::is_literally_true_or_false(const Literal & lit) -> optional<b
 
 auto gcs::innards::is_literally_true(const Literal & lit) -> bool
 {
-    auto result = is_literally_true_or_false(lit);
-    return result && *result;
+    return is_literally_true_or_false(lit).value_or(false);
 }
 
 auto gcs::innards::is_literally_false(const Literal & lit) -> bool

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -471,9 +471,7 @@ auto State::optional_single_value(const VarType_ & var) const -> optional<Intege
         },
         [&](const ConstantIntegerVariableID & v) -> optional<Integer> { return make_optional(v.const_value); });
 
-    if (raw)
-        return apply_view(*raw, negate_first, then_add);
-    return nullopt;
+    return raw.transform([negate_first = negate_first, then_add = then_add](Integer v) { return apply_view(v, negate_first, then_add); });
 }
 
 auto State::has_single_value(const IntegerVariableID var) const -> bool

--- a/gcs/problem.cc
+++ b/gcs/problem.cc
@@ -23,7 +23,6 @@ using namespace gcs::innards;
 
 using std::deque;
 using std::generator;
-using std::make_optional;
 using std::make_unique;
 using std::move;
 using std::nullopt;
@@ -134,7 +133,7 @@ auto Problem::create_integer_variable_vector(size_t how_many, Integer lower, Int
     vector<IntegerVariableID> result;
     result.reserve(how_many);
     for (size_t n = 0; n < how_many; ++n)
-        result.push_back(create_integer_variable(lower, upper, name ? make_optional(*name + "[" + to_string(n) + "]") : nullopt));
+        result.push_back(create_integer_variable(lower, upper, name.transform([&](const string & s) { return s + "[" + to_string(n) + "]"; })));
     return result;
 }
 

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -211,7 +211,8 @@ namespace gcs
             template <std::size_t... nn_>
             ArrayInitialisationMagicForProblem(
                 Problem * p, Integer l, Integer u, const std::optional<std::string> & name, std::index_sequence<nn_...>) :
-                result{{p->create_integer_variable(l, u, name ? std::make_optional(*name + "[" + std::to_string(nn_) + "]") : std::nullopt)...}}
+                result{
+                    {p->create_integer_variable(l, u, name.transform([&](const std::string & s) { return s + "[" + std::to_string(nn_) + "]"; }))...}}
             {
             }
         };

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -72,9 +72,7 @@ namespace
                     for (const auto & v : problem.all_normal_variables())
                         vars_and_values.emplace_back(v, state(v));
                     logger->solution(vars_and_values,
-                        problem.optional_minimise_variable()
-                            ? make_optional(pair{*problem.optional_minimise_variable(), state(*problem.optional_minimise_variable())})
-                            : nullopt);
+                        problem.optional_minimise_variable().transform([&](const IntegerVariableID & var) { return pair{var, state(var)}; }));
                 }
 
                 if (problem.optional_minimise_variable())


### PR DESCRIPTION
## What

Adopt C++23's `std::optional` monadic operations (`transform` / `and_then` / `or_else`) and `value_or` at the handful of sites where they replace a hand-rolled `if`/ternary + explicit `make_optional`/`nullopt` with a direct "map the optional" expression:

| Site | Before | After |
|------|--------|-------|
| `State::optional_single_value` | `if (raw) return apply_view(*raw, …); return nullopt;` | `.transform` |
| `is_literally_true` | `result && *result` | `.value_or(false)` |
| `Disjunctive2D` `end_*_ge/le` accessors | `x ? optional{x->first} : nullopt` | `.transform` |
| solve loop objective logging | `min() ? make_optional(pair{*min(), state(*min())}) : nullopt` | `.transform` |
| `Problem::create_integer_variable_vector` / `_n_` | `name ? make_optional(*name + "[…]") : nullopt` | `.transform` |

All conversions are semantically identical — behaviour is unchanged. Removed one now-unused `using std::make_optional;`.

## Why now — availability check

I was holding these back over toolchain support. I pushed a throwaway probe branch (a `static_assert` on the feature-test macros + real usage, compiled on every CI lane) to settle it empirically:

- **`std::optional` monadic ops** (`__cpp_lib_optional >= 202110`): available on **all** supported toolchains, including the Ubuntu 24.04 runner's **GCC 13** and **macOS libc++**. ✅
- **`std::vector::append_range`** (`__cpp_lib_containers_ranges`): **still unavailable** on the Ubuntu 24.04 GCC 13 lane. Deliberately **not** adopted here; `CLAUDE.md` note reconfirmed. ❌ (available on GCC 15 and libc++, so it becomes usable once we drop GCC 13.)

`CLAUDE.md`'s "Compiler and Standard Library Support" section is updated to record both findings.

## Verification

- Builds clean with **GCC 15** and **clang 21**.
- `ctest` **456/456** pass.
- `disjunctive_2d` proofs re-verify via VeriPB (complete enumeration) — the touched accessors feed proof-line generation.
- An optimisation proof (`tutorial_proof`) re-verifies via VeriPB (`VERIFIED BOUNDS 14 <= obj <= 14`) — exercises the solve-loop objective-logging change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)