### PR TITLE
Match cake's clash-free labels for knapsack and global_cardinality

### DIFF
--- a/gcs/constraints/global_cardinality/global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/global_cardinality.cc
@@ -95,9 +95,11 @@ auto GlobalCardinality::define_proof_model(ProofModel & model) -> void
         WPBSum sum;
         for (const auto & var : _vars)
             sum += 1_i * (var == value);
-        // cake_pb_cp labels the per-value count equality @c[<id>_<j>][le/ge].
+        // cake_pb_cp labels the per-value count equality @c[<id>][<j>_le]/[<j>_ge]:
+        // the value index lives in the annotation tag, not the constraint name (a
+        // name-embedded index could collide with a sibling constraint's name).
         _count_lines.push_back(model.add_labelled_constraint(
-            as_string(constraint_id()) + "_" + std::to_string(j), "le", "ge", "GCC", "count for value", sum == 1_i * _counts[j]));
+            as_string(constraint_id()), std::to_string(j) + "_le", std::to_string(j) + "_ge", "GCC", "count for value", sum == 1_i * _counts[j]));
     }
 }
 

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -612,12 +612,13 @@ auto Knapsack::define_proof_model(ProofModel & model) -> void
         WPBSum sum_eq;
         for (const auto & [idx, v] : enumerate(_vars))
             sum_eq += cc.at(idx) * v;
-        // cake_pb_cp emits each row's totals equality under its own constraint id
-        // `name ^ row` (@c[_1<row>][le]/[ge]), not a row-indexed role on a single id
-        // (@c[_1][le<row>]); match that so the propagator's pol steps, which cite
-        // these lines by label, resolve against cake's OPB. The bodies are identical.
-        auto [eq1, eq2] = model.add_labelled_constraint(
-            as_string(constraint_id()) + std::to_string(cc_idx), "le", "ge", "Knapsack", "totals", sum_eq == 1_i * _totals.at(cc_idx));
+        // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
+        // the row index lives in the annotation tag, not the constraint name (a
+        // name-embedded row could collide with a sibling constraint's name). Match
+        // that so the propagator's pol steps, which cite these lines by label,
+        // resolve against cake's OPB. The bodies are identical.
+        auto [eq1, eq2] = model.add_labelled_constraint(as_string(constraint_id()), std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge",
+            "Knapsack", "totals", sum_eq == 1_i * _totals.at(cc_idx));
         _eqns_lines.emplace_back(eq1, eq2);
     }
 }


### PR DESCRIPTION
Following the CakePB meeting: cake_pb_cp fixed non-unique `@`-annotations by
moving the row/value index out of the synthesized constraint *name* and into
the annotation *tag* — `@c[<id>][<idx>_le]` / `@c[<id>][<idx>_ge]` — so a
name-embedded index can no longer collide with a sibling constraint's name
(see `LABEL_CLASH_FIXES.md` items 6–7).

Two of our constraints cite these lines by label in their proofs, so they broke
against the new cake binary:

- **knapsack** — was `@c[<id><row>][le]` (row concatenated onto the name);
  now `@c[<id>][<row>_le]`/`[<row>_ge]`.
- **global_cardinality** — was `@c[<id>_<j>][le]`; now `@c[<id>][<j>_le]`/`[<j>_ge]`.

Both are pure label-string changes in `define_proof_model`; the constraint
bodies and propagators are unchanged (the propagators cite these lines through
the returned `ProofLine` handles, not by reconstructing the strings).

The other five renamed constraints in the doc (lex, value_precede /
seq_precede_chain, symmetric_all_different, reified lex, element_2d) did **not**
cite the renamed labels in their proofs, so they were unaffected.

### Verification
- Full `scp_chain` suite: **125/125** pass against the new cake binary
  (`fix duplication in label names`, `2ef10e5`).
- Workflow-1 self-verify (proofs against our own OPB) pass:
  `knapsack_test`, `bounds_global_cardinality_test`, `gac_global_cardinality_test`.
- The affected chain cases — knapsack sat/unsat and global_cardinality
  closed_unsat / gac_sat / gac_unsat — were failing before this change
  (`label @c[...] is not assigned to a constraint ID`) and now verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)