### PR TITLE
Divide/Modulus: flat s-expr shape, matching cake_pb_cp

### DIFF
--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -372,8 +372,9 @@ auto Divide::install(Propagators & propagators, State & initial_state, ProofMode
 auto Divide::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("divide"),
-        SExpr::list({tracker.s_expr_term_of(_x), tracker.s_expr_term_of(_y), tracker.s_expr_term_of(_quotient)})});
+    // Flat primitive shape `(id divide x y quotient)`, matching cake_pb_cp.
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("divide"), tracker.s_expr_term_of(_x), tracker.s_expr_term_of(_y),
+        tracker.s_expr_term_of(_quotient)});
 }
 
 Modulus::Modulus(IntegerVariableID x, IntegerVariableID y, IntegerVariableID remainder) : _x(x), _y(y), _remainder(remainder)
@@ -401,6 +402,7 @@ auto Modulus::install(Propagators & propagators, State & initial_state, ProofMod
 auto Modulus::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("modulus"),
-        SExpr::list({tracker.s_expr_term_of(_x), tracker.s_expr_term_of(_y), tracker.s_expr_term_of(_remainder)})});
+    // Flat primitive shape `(id modulus x y remainder)`, matching cake_pb_cp.
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("modulus"), tracker.s_expr_term_of(_x), tracker.s_expr_term_of(_y),
+        tracker.s_expr_term_of(_remainder)});
 }

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -809,17 +809,16 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
                 Minus{resolve_variable(variables, terms[2]), resolve_variable(variables, terms[3]), resolve_variable(variables, terms[4])}, label);
         }
         else if (op == "divide" || op == "modulus") {
-            // (label divide (x y quotient)) / (label modulus (x y remainder)):
-            // truncated division, with the divide-by-zero case relational.
-            if (terms.size() != 3)
-                throw ScpReadError{"divide/modulus takes (label " + op + " (x y result))"};
-            auto vars = resolve_variable_list(variables, terms[2], "the divide/modulus variable list");
-            if (vars.size() != 3)
-                throw ScpReadError{op + " takes exactly three variables"};
+            // (label divide x y quotient) / (label modulus x y remainder):
+            // truncated division, with the divide-by-zero case relational. Flat
+            // shape matching cake_pb_cp.
+            if (terms.size() != 5)
+                throw ScpReadError{"divide/modulus takes (label " + op + " x y result)"};
+            auto x = resolve_variable(variables, terms[2]), y = resolve_variable(variables, terms[3]), result = resolve_variable(variables, terms[4]);
             if (op == "divide")
-                post_constraint(problem, Divide{vars[0], vars[1], vars[2]}, label);
+                post_constraint(problem, Divide{x, y, result}, label);
             else
-                post_constraint(problem, Modulus{vars[0], vars[1], vars[2]}, label);
+                post_constraint(problem, Modulus{x, y, result}, label);
         }
         else if (op == "power") {
             // (label power (base exponent result)): base ^ exponent = result,

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -359,7 +359,7 @@ TEST_CASE("read_scp: divide and modulus enumerate correctly")
     auto div_solutions = enumerate(R"(
         (
             ( (X -3 3) (Y -2 2) (Q -3 3) )
-            ( (_1 divide (X Y Q)) )
+            ( (_1 divide X Y Q) )
         ))");
 
     CHECK(! div_solutions.empty());
@@ -372,7 +372,7 @@ TEST_CASE("read_scp: divide and modulus enumerate correctly")
     auto mod_solutions = enumerate(R"(
         (
             ( (X -3 3) (Y -2 2) (R -3 3) )
-            ( (_1 modulus (X Y R)) )
+            ( (_1 modulus X Y R) )
         ))");
 
     CHECK(! mod_solutions.empty());


### PR DESCRIPTION
Write and read `(id divide x y quotient)` / `(id modulus x y remainder)` instead
of the nested `(id divide (x y quotient))`. `cake_pb_cp` rejects the nested form
(`non-linear op expects 3 args: X op Y = Z`) and wants the flat three-argument
shape — the same convention every other primitive already uses, and that
`Multiply` adopted when it conformed to cake.

This is the cake-required **prerequisite** for a future divide/modulus proof
conform, and brings the s-expr shape into line with multiply. It does **not** by
itself make a chain verify: cake's div/mod encoding has no `w = q·y` product
variable and no explicit remainder/quotient auxiliary, whereas GCS materialises
both as real state variables — a larger proof conform that I've deferred pending
a scope decision (see `~/claude/tmp/divmod-cake-conform-assessment.md`).

## Changes
- `Divide::s_expr` / `Modulus::s_expr`: emit the flat shape.
- `scp_reader`: parse the flat 5-term form.
- `scp_reader_test`: divide/modulus enumerate cases use the flat form (the
  write→read→write round-trip case exercises the writer automatically).

## Testing
- `scp_reader_test` (991 assertions) passes.
- `divide_modulus_test` self-verifies (workflow-1 proofs).
- Confirmed `cake_pb_cp` now parses our written divide/modulus scp (previously
  errored on the nested shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)