### PR TITLE
Divide/Modulus: cake_pb_cp-conforming proofs for every sign

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -15,6 +15,14 @@ library. For an introduction to *using* the solver, start with the top-level
   the `State` class, the `IntervalSet` domain representation, chronological
   backtracking via epochs, and the inference paths through which propagators
   modify domains. Read first when changing the solver internals.
+- [Variable encodings: state, OPB, and proof](variable-encodings.md) — the map of
+  the ways to bring a variable into existence, along two axes (does it have solver
+  state, and is its encoding asserted in the OPB or introduced inside the proof).
+  A table of every mechanism plus the `register_bits_variable_encoding` primitive
+  they share, why "not in the OPB" is what makes an auxiliary chain-portable
+  against `cake_pb_cp`, and the footguns of a state variable whose bits are
+  introduced in-proof. Read when choosing how to create an auxiliary for a
+  proof-logged constraint.
 - [Implementing a constraint](constraints.md) — the structural pattern every
   constraint follows: class shape, the `install` method, the propagator
   framework, triggers, the inference and justification APIs, OPB encoding

--- a/dev_docs/variable-encodings.md
+++ b/dev_docs/variable-encodings.md
@@ -1,0 +1,119 @@
+# Variable encodings: state, OPB, and proof
+
+There are several ways to bring an integer variable (or a Boolean flag) into
+existence, and they differ along two independent axes: whether the variable has
+**solver state** (a domain that propagation reads and writes) and whether its
+encoding is **asserted in the OPB** (`.opb`) or only **introduced inside the
+proof** (`.pbp`). This document is the map of those mechanisms, so you can pick
+the right one and see that they are complementary rather than duplicated.
+
+For the state side in isolation — the `IntegerVariableID` family, the `State`
+class, epochs — see [state-and-variables.md](state-and-variables.md). This
+document is about the *proof-encoding* side and how it composes with state.
+
+## The mechanisms
+
+| Mechanism (how to create) | User-visible? | Has state? | In OPB? | Usable in PBP? |
+|---|---|---|---|---|
+| `Problem::create_integer_variable` | **Yes** | Yes | Yes (`@i[v][lb/ub]`) | Yes |
+| `State::allocate_integer_variable_with_state` (alone) | No | Yes | No | No¹ |
+| ` … ` + `ProofModel::set_up_integer_variable` | No | Yes | Yes (`@i[v][lb/ub]`) | Yes |
+| ` … ` + `ProofModel::register_state_variable_bits_in_proof` + `ProofLogger::introduce_bits_of` | No | Yes | No | Yes² |
+| `ProofModel::create_proof_only_integer_variable` (`Bits`/`DirectOnly`) | No | No | Yes (unlabelled) | Yes |
+| `ProofModel::create_proof_only_integer_variable` + `CakeBitNaming` | No | No | No | Yes |
+| `ProofModel::create_proof_only_integer_variable_in_proof` + `ProofLogger::introduce_bits_of` | No | No | No | Yes² |
+| `ProofModel::create_proof_flag` / `_reifying` / `_fully_reifying` | No | No | reification only³ | Yes |
+
+¹ A state variable with no proof encoding is fine only if it is *never referenced
+in a proof step* — in particular never narrowed by a logged inference. Give it an
+encoding (one of the two rows below it) the moment it appears in the proof.
+
+² Registered means the bits are *nameable*; the variable only becomes *meaningful*
+once its `introduce_bits_of` (or lazy-atom channel) runs — see "Ordering" below.
+
+³ A bare `create_proof_flag` asserts nothing. `create_proof_flag_reifying` emits
+its reification at a `ProofLevel` (in the PBP); the position/value-indexed
+`create_proof_flag_fully_reifying` emits labelled reification lines to the OPB.
+
+## The two axes, and the one primitive underneath
+
+**Has state?** is set by *who allocates the ID*: `allocate_integer_variable_with_state`
+(and `Problem::create_integer_variable`, which wraps it) mint a
+`SimpleIntegerVariableID` with a domain in `State`; `create_proof_only_*` mint a
+`ProofOnlySimpleIntegerVariableID`, which has no state and exists only for the
+proof.
+
+**In OPB?** is set by *which encoder you call*, and every path shares one private
+primitive:
+
+- `register_bits_variable_encoding(id, lo, hi, name, [cake])` — allocate and name
+  the bit literals and record the bounds, **emit nothing to the OPB**.
+- `set_up_bits_variable_encoding` = `register_bits_variable_encoding` **plus** the
+  `>= lo` / `<= hi` bound lines in the OPB (labelled `@i[name][lb/ub]` for a state
+  variable, unlabelled for a proof-only one).
+
+So "set up" is exactly "register + assert bounds in the OPB". `set_up_integer_variable`,
+`create_proof_only_integer_variable`, `register_state_variable_bits_in_proof`, and
+`create_proof_only_integer_variable_in_proof` are all thin wrappers choosing (a)
+whether to mint a fresh proof-only ID or take an existing state ID, and (b) whether
+to go through `set_up_*` (OPB) or `register_*` alone (in-proof). The `CakeBitNaming`
+overloads are the same register-only path with cake's `x[]/v[]` bit names instead
+of the default `i[name][b]` / `p[index][b]`.
+
+That is why the two "…`_in_proof`" rows and `register_state_variable_bits_in_proof`
+look almost identical: they *are* the same primitive, differing only in the state
+axis. `register_state_variable_bits_in_proof` is the state-backed analogue of
+`create_proof_only_integer_variable_in_proof` — it fills the `(has state, not in
+OPB)` cell that was otherwise empty, not a duplicate of an existing function.
+
+## Why "not in OPB" is a first-class option
+
+The `.pbp` proof is checked against **two** OPBs: our own (workflow 1) and the one
+`cake_pb_cp` re-derives from the `.scp` (workflow 2, the chain — see
+[workflow2_testing.md](workflow2_testing.md)). A proof that references a variable
+only *our* OPB defines will fail against cake's. So any variable that is ours alone
+— internal auxiliaries with no counterpart in cake's encoding — must **not** be an
+OPB axiom; it must be introduced *inside* the proof as a conservative extension
+(`introduce_bits_of`, which defines the variable equal to a linear form in `2m`
+redundancy steps), so the proof stays valid against either OPB. `In OPB = No` is
+what makes a variable **chain-portable**.
+
+For a pure proof helper (a magnitude, a rank, a witness) that is naturally
+`create_proof_only_integer_variable_in_proof`. The wrinkle that motivated
+`register_state_variable_bits_in_proof`: an auxiliary that must *also* drive
+propagation. `Divide`/`Modulus` reuse `mult_bc::propagate`, which reads
+`state.bounds(w)` on the product `w = q·y` — so `w` needs real state — yet cake's
+divide OPB has no `w`, so `w`'s encoding must be in-proof-only. That is the
+`(has state, not in OPB)` cell, and neither `set_up_integer_variable` (state but in
+OPB) nor `create_proof_only_integer_variable_in_proof` (in-proof but no state)
+provides it.
+
+## Footguns for an in-proof-encoded state variable
+
+The two in-proof rows share a rule — the variable is meaningless until introduced
+— and the state-backed one adds a second:
+
+- **Ordering.** `introduce_bits_of` must run *before* any proof step references the
+  variable — and for a state variable, before the first *logged inference narrows
+  it*, because the eager tracker will try to justify that bound change over bits
+  whose meaning is not yet established. Do the introduction in an
+  `install_initialiser` (runs once at proof start, before propagation); see
+  `disjunctive.cc` for the pattern and the shared cache for the returned lines.
+- **Boundary-literal derivability.** A free bit-sum with no OPB bound lines cannot
+  RUP-derive its own `v >= lo` / `v <= hi` boundary literals. If the proof needs
+  them, register the variable's bounds as not-trivially-derivable
+  (`note_bounds_not_trivially_derivable`, as ArgSort's free signed bit-sums do) and
+  derive the bounds once, explicitly, from the introduction.
+
+## Rule of thumb
+
+- User model variable → `Problem::create_integer_variable`.
+- Internal aux that appears in *our* OPB and needs propagation →
+  `allocate_integer_variable_with_state` + `set_up_integer_variable`.
+- Internal aux that must be **chain-portable** and needs propagation →
+  `allocate_integer_variable_with_state` + `register_state_variable_bits_in_proof`,
+  introduced with `introduce_bits_of` in an initialiser.
+- Pure proof helper → `create_proof_only_integer_variable_in_proof` (chain-portable)
+  or `create_proof_only_integer_variable` (asserted in our OPB), `CakeBitNaming` when
+  its bits must match cake's.
+- A proof-only Boolean → `create_proof_flag` and its reifying variants.

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -131,15 +131,19 @@ namespace
         // q*y), mult_bc is told z_is_magnitude so it bounds w by the operand magnitudes.
         //
         // Modulus (use_cake_modulus): the exposed slot is r, and cake leaves the
-        // quotient's magnitude a FREE axis-0 bit-sum with no i[Q] channel. We restrict
-        // to x >= 0 and y >= 1, so q >= 0 too and every sign agrees: q's own in-proof
-        // bits (registered in cake's naming below) ARE that free magnitude, needing no
-        // channel, and r's range/sign come straight off cake's id_*/rng_*/sgn_* rows.
-        // Signed dividends (and, for modulus, a signed divisor) stay on the legacy path.
+        // quotient's magnitude a FREE axis-0 bit-sum with no i[Q] channel. cake always
+        // splits the identity on sign(x): r = x - |q||y| for x >= 0, so |q||y| is a
+        // non-negative magnitude for every sign of y. We restrict to x >= 0 (r is then
+        // non-negative), but allow any-sign divisor: the aux is the quotient magnitude
+        // |q|, the divisor magnitude |y| is a second aux "absy" pinned to |y| by cake's
+        // Yge0/Ylt0 channel, and mult_bc multiplies the two non-negative magnitudes
+        // |q| * |y| = w with no signed reasoning (its quotient filtering divides w by the
+        // non-negative absy, not the signed y). The tabulation recovers sign(x)sign(y)|q|.
+        // Signed dividends (x < 0) stay on the legacy path for now.
         bool plain_operands = optional_model && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var &&
             aout.coeff == 1_i && aout.offset == 0_i;
         bool use_cake_divide = expose_quotient && plain_operands && xlo >= 0_i;
-        bool use_cake_modulus = (! expose_quotient) && plain_operands && xlo >= 0_i && ylo >= 1_i;
+        bool use_cake_modulus = (! expose_quotient) && plain_operands && xlo >= 0_i;
         bool use_cake = use_cake_divide || use_cake_modulus;
 
         // The exposed slot is the user's; the other is an auxiliary, with
@@ -166,12 +170,15 @@ namespace
         else if (use_cake) {
             r = out;
             // cake leaves the quotient a free axis-0 magnitude sized by the dividend's
-            // bit count (q <= x when y >= 1), so its provable range is the bit-implied
-            // [0, 2^n - 1]. Give the state the same range (like divide's product w) and
-            // register its bits in cake's x[id][0_*][bin] naming with no OPB bounds, so
-            // q's own bits ARE the magnitude the bit products multiply.
+            // The aux is the quotient MAGNITUDE |q|, a free axis-0 bit-sum sized by the
+            // dividend's magnitude (|q| <= |x| since |y| >= 1). Its provable range is the
+            // bit-implied [0, 2^n - 1]; give the state that range (like divide's product w)
+            // and register its bits in cake's x[id][0_*][bin] naming with no OPB bounds, so
+            // they ARE the magnitude the bit products multiply. The signed quotient is never
+            // materialised: the propagation is in magnitude space and the tabulation recovers
+            // sign(x)sign(y)|q| for its relation check.
             auto q_bits = 0_i;
-            while (power2(q_bits) <= xhi)
+            while (power2(q_bits) <= mx)
                 q_bits += 1_i;
             auto q_bit_max = power2(q_bits) - 1_i;
             aux = initial_state.allocate_integer_variable_with_state(0_i, q_bit_max);
@@ -349,54 +356,57 @@ namespace
             });
         }
         else if (use_cake) {
-            // Modulus's cake path: the exposed slot is r, the quotient q a free axis-0
-            // magnitude whose bits (registered above) are its own -- no i[Q], no channel,
-            // since q >= 0 means q = |q|. w = q * y (both non-negative) is a product state
-            // variable introduced in the proof; r = x - w comes off cake's id_pos rows and
-            // 0 <= r < |y| off rng_*. The id_neg_*/rng_lo/sgn_* rows are cake's inert
-            // (satisfiable) mirror for x < 0, emitted only to match cake's OPB.
+            // Modulus's cake path: the exposed slot is r; the quotient magnitude |q| (the
+            // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, axis-1 free
+            // magnitude, pinned to |y| by cake's Yge0/Ylt0 channel) multiply to w = |q||y|,
+            // so r = x - w off cake's id_pos rows and 0 <= r < |y| = absy off rng_hi. Both
+            // mult operands are non-negative, so mult_bc needs no signed reasoning and its
+            // quotient filtering divides w by the non-negative absy (dividing by the signed
+            // y would infer a wrong-signed |q|). id_neg_*/rng_lo/sgn_neg are cake's inert
+            // mirror for x < 0, emitted only to match cake's OPB.
             //
-            // The identity stage propagates the exposed r, so r must be the plain underlying
-            // variable *aout.var (r_eff), not any view wrapper: propagating a change through
-            // a view's deviewed bits while the identity spans the wide product w defeats the
-            // reverse unit propagation. The guard's coeff-1/offset-0 restriction makes r_eff
-            // exactly the exposed value, and cake names it i[R] too, so this also matches.
+            // r and the operands are the plain underlying *aout.var / *a*.var, not view
+            // wrappers: the identity stage propagates the exposed r off the wide product w,
+            // and deviewing that defeats the reverse unit propagation.
             auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var, r_eff = *aout.var;
 
             cake_encoding = make_shared<mult_bc::EncodingData>();
             auto & enc = *cake_encoding;
             enc.z_product_ge0_gated = false;
-            enc.z_is_magnitude = false; // q, y >= 0, so w = q * y is the plain product
+            enc.z_is_magnitude = false; // |q|, absy >= 0, so w = |q| * absy is a plain product
 
-            // Axis-1 magnitude channel for y (cake letter "Y"); q needs none, as its own
-            // cake-named bits are the axis-0 magnitude.
-            auto mag_y_ub = max(abs(initial_state.lower_bound(y_eff)), abs(initial_state.upper_bound(y_eff)));
-            auto mag_y = optional_model->create_proof_only_integer_variable(
-                0_i, mag_y_ub, "mod_mag_Y", IntegerVariableProofRepresentation::Bits, CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
+            // absy = |y|: a non-negative magnitude STATE variable (mult_bc's divisor operand
+            // must be a real variable), axis-1 free magnitude bits x[id][1_*][bin], pinned to
+            // |y| by cake's Yge0/Ylt0 channel (below) and propagated by the absy stages.
+            auto absy_bits = 0_i;
+            while (power2(absy_bits) <= may)
+                absy_bits += 1_i;
+            auto absy_bit_max = power2(absy_bits) - 1_i;
+            auto absy = initial_state.allocate_integer_variable_with_state(0_i, absy_bit_max);
+            optional_model->register_state_variable_bits_in_proof(
+                absy, 0_i, absy_bit_max, "aux_modulus_absdivisor" + to_string(absy.index), CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
+
             auto y_ge0 = HalfReifyOnConjunctionOf{y_eff >= 0_i};
             auto y_lt0 = HalfReifyOnConjunctionOf{y_eff < 0_i};
             auto y_pos_ge = optional_model->add_labelled_constraint(
-                label, "Yge0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * mag_y >= 0_i, y_ge0);
+                label, "Yge0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * absy >= 0_i, y_ge0);
             auto y_pos_le = optional_model->add_labelled_constraint(
-                label, "Yge0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * mag_y >= 0_i, y_ge0);
+                label, "Yge0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * absy >= 0_i, y_ge0);
             auto y_neg_ge = optional_model->add_labelled_constraint(
-                label, "Ylt0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * mag_y >= 0_i, y_lt0);
+                label, "Ylt0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * absy >= 0_i, y_lt0);
             auto y_neg_le = optional_model->add_labelled_constraint(
-                label, "Ylt0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * mag_y >= 0_i, y_lt0);
-            enc.channelling_constraints.insert(
-                {y_eff, mult_bc::ChannellingData{y_pos_ge, y_pos_le, y_neg_ge, y_neg_le, true, initial_state.lower_bound(y_eff) < 0_i}});
-            enc.mag_var.insert({y_eff, mag_y});
+                label, "Ylt0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * absy >= 0_i, y_lt0);
 
-            // Bit-product flags x[id][i_j][prod] = q_i ^ mag_y_j and their weighted sum
-            // |q|*|y|. q's axis-0 bits are q_eff's own registered (cake-named) bits.
+            // Bit-product flags x[id][i_j][prod] = |q|_i ^ |y|_j and their weighted sum
+            // |q|*|y|, over the two magnitudes' own free bits (no channel needed).
             auto n1 = optional_model->names_and_ids_tracker().num_bits(q_eff);
-            auto n2 = optional_model->names_and_ids_tracker().num_bits(mag_y);
+            auto n2 = optional_model->names_and_ids_tracker().num_bits(absy);
             auto product_sum = WPBSum{};
             for (Integer i = 0_i; i < n1; ++i) {
                 enc.initial_bit_products.emplace_back();
                 for (Integer j = 0_i; j < n2; ++j) {
                     auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
-                        WPBSum{} + 1_i * ProofBitVariable{q_eff, i, true} + 1_i * ProofBitVariable{mag_y, j, true} >= 2_i);
+                        WPBSum{} + 1_i * ProofBitVariable{q_eff, i, true} + 1_i * ProofBitVariable{absy, j, true} >= 2_i);
                     auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
                     enc.initial_bit_products[i.as_index()].emplace_back(
                         mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
@@ -410,8 +420,8 @@ namespace
             optional_model->add_labelled_constraint(
                 label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
 
-            // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0]) is the active
-            // r = x - w equality; id_neg_* (gated [x<0]) its inert mirror.
+            // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0]) active, id_neg_* the
+            // inert x < 0 mirror.
             auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
             auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
             auto id_pos_ge = optional_model->add_labelled_constraint(
@@ -421,63 +431,62 @@ namespace
             optional_model->add_labelled_constraint(label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xlt0);
             optional_model->add_labelled_constraint(label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xlt0);
 
-            // 0 <= r < |y|: rng_hi (r < |y|, active) and rng_lo (r > -|y|, inert), plus
-            // the r-sign rows (r takes x's sign; sgn_pos trivial, sgn_neg inert here).
-            auto rng_hi = optional_model->add_labelled_constraint(label, "rng_hi", "Modulus", "range", WPBSum{} + -1_i * r_eff + 1_i * mag_y >= 1_i);
-            optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * mag_y >= 1_i);
+            // 0 <= r < |y| = absy: rng_hi (r < absy, active), rng_lo (r > -absy, inert), and
+            // the r-sign rows (r takes x's sign; sgn_pos active, sgn_neg inert here).
+            auto rng_hi = optional_model->add_labelled_constraint(label, "rng_hi", "Modulus", "range", WPBSum{} + -1_i * r_eff + 1_i * absy >= 1_i);
+            optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
             auto sgn_pos = optional_model->add_labelled_constraint(label, "sgn_pos", "Modulus", "sign", WPBSum{} + 1_i * r_eff >= 0_i, xge0);
             optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xlt0);
 
-            // w = |q||y| is a product state variable driving mult_bc, sized to the full
-            // bit-product sum; its bits are introduced in the proof.
+            // w = |q||y| is the product state variable driving mult_bc; its bits are
+            // introduced in the proof.
             auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
             auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
             optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_modulus_product" + to_string(w.index));
-            mult_q = q_eff, mult_y = y_eff, mult_w = w;
+            mult_q = q_eff, mult_y = absy, mult_w = w;
             bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
 
-            // Stages over the underlying operands: the identity r = x - w (two [x>=0]-gated
-            // inequalities off id_pos_*), the range r < |y| (gated [y>=1], off rng_hi + the y
-            // channel), and r >= 0 (gated [x>=0], off sgn_pos) which -- since r takes x's sign
-            // -- prunes a would-be negative remainder when r's domain spans zero. The gates
-            // ride along, discharged by propagate_linear's ThenRUP from x's / y's domains.
-            // Proof lines are filled once w = product is introduced in the initialiser.
+            // Stages: the identity r = x - w (two [x>=0]-gated inequalities off id_pos_*,
+            // lines filled in the initialiser once w = product is introduced); the range
+            // r < absy (off rng_hi, ungated -- absy already carries |y|); r >= 0 (off
+            // sgn_pos, gated [x>=0]); and absy = |y| off the Yge0/Ylt0 channel, split on
+            // sign(y). Only idle/idge need the initialiser; the rest cite an OPB row directly.
             cake_stages = make_shared<vector<LinearStage>>();
             auto [t_idle, m_idle] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * r_eff);
             cake_stages->emplace_back(LinearStage{t_idle, 0_i + m_idle, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
             auto [t_idge, m_idge] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + 1_i * w + 1_i * r_eff);
             cake_stages->emplace_back(LinearStage{t_idge, 0_i + m_idge, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
-            auto [t_rhi, m_rhi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_rhi, m_rhi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff + -1_i * absy);
+            cake_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {rng_hi, nullopt}, nullopt});
             auto [t_slo, m_slo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff);
-            cake_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            cake_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {sgn_pos, nullopt}, optional{x_eff >= 0_i}});
+            // absy = |y|, split on sign(y): each line is the matching Y channel row directly.
+            auto [t_ale, m_ale] = tidy_up_linear(WeightedSum{} + 1_i * absy + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_ale, 0_i + m_ale, false, {y_pos_ge, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_age, m_age] = tidy_up_linear(WeightedSum{} + -1_i * absy + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_age, 0_i + m_age, false, {y_pos_le, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_anle, m_anle] = tidy_up_linear(WeightedSum{} + 1_i * absy + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_anle, 0_i + m_anle, false, {y_neg_le, nullopt}, optional{y_eff < 0_i}});
+            auto [t_ange, m_ange] = tidy_up_linear(WeightedSum{} + -1_i * absy + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_ange, 0_i + m_ange, false, {y_neg_ge, nullopt}, optional{y_eff < 0_i}});
 
-            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le, rng_hi, sgn_pos, y_pos_ge](
-                                                State &, auto &, ProofLogger * const logger) -> void {
-                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                    return;
-                // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
-                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
-                // identity r >= x - w (x - w - r <= 0): id_pos_le (r - x + product >= 0)
-                // + (w >= product). The [x>=0] gate rides along, discharged by x's domain.
-                PolBuilder pb_idle;
-                pb_idle.add(id_pos_le).add(enc->v3_eq_product_lines.first);
-                (*stg)[0].lines = {pb_idle.emit(*logger, ProofLevel::Top), nullopt};
-                // identity r <= x - w (w + r - x <= 0): id_pos_ge (x - product - r >= 0)
-                // + (w <= product).
-                PolBuilder pb_idge;
-                pb_idge.add(id_pos_ge).add(enc->v3_eq_product_lines.second);
-                (*stg)[1].lines = {pb_idge.emit(*logger, ProofLevel::Top), nullopt};
-                // range r < |y| (r - y <= -1, |y|=y): rng_hi (|y| - r >= 1) + Yge0_ge
-                // (y - |y| >= 0); |y| = mag_y cancels, the [y>=0] gate rides along.
-                PolBuilder pb_rhi;
-                pb_rhi.add(rng_hi).add(y_pos_ge);
-                (*stg)[2].lines = {pb_rhi.emit(*logger, ProofLevel::Top), nullopt};
-                // r >= 0 (-r <= 0): straight off sgn_pos, [x>=0] gate discharged by x's domain.
-                PolBuilder pb_slo;
-                pb_slo.add(sgn_pos);
-                (*stg)[3].lines = {pb_slo.emit(*logger, ProofLevel::Top), nullopt};
-            });
+            propagators.install_initialiser(
+                [enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le](State &, auto &, ProofLogger * const logger) -> void {
+                    if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                        return;
+                    // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
+                    enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                    // identity r >= x - w (x - w - r <= 0): id_pos_le (r - x + product >= 0)
+                    // + (w >= product). The [x>=0] gate rides along, discharged by x's domain.
+                    PolBuilder pb_idle;
+                    pb_idle.add(id_pos_le).add(enc->v3_eq_product_lines.first);
+                    (*stg)[0].lines = {pb_idle.emit(*logger, ProofLevel::Top), nullopt};
+                    // identity r <= x - w (w + r - x <= 0): id_pos_ge (x - product - r >= 0)
+                    // + (w <= product).
+                    PolBuilder pb_idge;
+                    pb_idge.add(id_pos_ge).add(enc->v3_eq_product_lines.second);
+                    (*stg)[1].lines = {pb_idge.emit(*logger, ProofLevel::Top), nullopt};
+                });
         }
 
         if (! use_cake && ! needs_mult) {
@@ -650,6 +659,14 @@ namespace
         // q = 0 leaves it anywhere bigger than the remainder. Aliasing
         // spoils the argument, so only distinct slots are claimed (the
         // auxiliary is always fresh).
+        // On the cake modulus path the aux is the quotient MAGNITUDE |q|; recover the signed
+        // quotient sign(x)sign(y)|q| (a magnitude 0 keeps sign 0). Everywhere else the aux is
+        // the signed quotient directly.
+        bool aux_is_magnitude = use_cake_modulus;
+        auto recover_q = [aux_is_magnitude](Integer auxv, Integer xv, Integer yv) -> Integer {
+            return (aux_is_magnitude && ((xv >= 0_i) != (yv >= 0_i))) ? -auxv : auxv;
+        };
+
         vector<DeterminedVariable> determined;
         if (expose_quotient)
             determined.push_back({aux, [ax, ay, aout, px, py, pout](const vector<Integer> & vals) -> optional<Integer> {
@@ -659,34 +676,37 @@ namespace
                                       return xv - qv * yv;
                                   }});
         else if (pout && pout != px && pout != py)
-            determined.push_back({*aout.var, [ax, ay, aout, px, py, paux](const vector<Integer> & vals) -> optional<Integer> {
+            determined.push_back({*aout.var, [ax, ay, aout, px, py, paux, recover_q](const vector<Integer> & vals) -> optional<Integer> {
                                       auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                                       auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
-                                      auto want = xv - vals[paux] * yv;
+                                      auto want = xv - recover_q(vals[paux], xv, yv) * yv;
                                       if ((want - aout.offset) % aout.coeff != 0_i)
                                           return nullopt;
                                       return (want - aout.offset) / aout.coeff;
                                   }});
         if (px && px != py && px != pout)
-            determined.push_back({*ax.var, [ax, ay, aout, py, pout, paux, expose_quotient](const vector<Integer> & vals) -> optional<Integer> {
-                                      auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
-                                      auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                                      auto auxv = vals[paux];
-                                      auto qv = expose_quotient ? outv : auxv;
-                                      auto rv = expose_quotient ? auxv : outv;
-                                      auto want = qv * yv + rv;
-                                      if ((want - ax.offset) % ax.coeff != 0_i)
-                                          return nullopt;
-                                      return (want - ax.offset) / ax.coeff;
-                                  }});
+            determined.push_back(
+                {*ax.var, [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude](const vector<Integer> & vals) -> optional<Integer> {
+                     auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
+                     auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
+                     auto auxv = vals[paux];
+                     // x = q*y + r. On the magnitude path x >= 0 and the quotient's
+                     // sign follows y, so q*y = |q||y|, giving x = |q||y| + r; else
+                     // the aux is the signed quotient directly.
+                     auto want = aux_is_magnitude ? auxv * (yv < 0_i ? -yv : yv) + outv
+                                                  : (expose_quotient ? outv : auxv) * yv + (expose_quotient ? auxv : outv);
+                     if ((want - ax.offset) % ax.coeff != 0_i)
+                         return nullopt;
+                     return (want - ax.offset) / ax.coeff;
+                 }});
 
         if (want_tabulation(level, enum_vars.vars(), determined, initial_state)) {
-            auto accept = [ax, ay, aout, px, py, pout, paux, expose_quotient](const vector<Integer> & vals) -> bool {
+            auto accept = [ax, ay, aout, px, py, pout, paux, expose_quotient, recover_q](const vector<Integer> & vals) -> bool {
                 auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                 auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                 auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
                 auto auxv = vals[paux];
-                auto qv = expose_quotient ? outv : auxv;
+                auto qv = expose_quotient ? outv : recover_q(auxv, xv, yv);
                 auto rv = expose_quotient ? auxv : outv;
                 return is_in_relation(xv, yv, qv, rv);
             };

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -300,7 +300,6 @@ namespace
             cake_encoding = make_shared<mult_bc::EncodingData>();
             auto & enc = *cake_encoding;
             enc.z_product_ge0_gated = false;
-            enc.z_is_magnitude = false; // magq, absy >= 0, so w = magq * absy is a plain product
 
             // magq = |q| (Z channel to the exposed quotient) and absy = |y| (Y channel to the
             // divisor) are the two non-negative mult_bc operands; w = magq * absy.
@@ -405,7 +404,6 @@ namespace
             cake_encoding = make_shared<mult_bc::EncodingData>();
             auto & enc = *cake_encoding;
             enc.z_product_ge0_gated = false;
-            enc.z_is_magnitude = false; // |q|, absy >= 0, so w = |q| * absy is a plain product
 
             // absy = |y| (Y channel to the divisor) is mult_bc's divisor operand; the quotient
             // magnitude q_eff is the free axis-0 aux (no Z channel -- cake leaves it free), so

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -194,16 +194,18 @@ namespace
             q_hi = max({xlo / ylo, xlo / yhi, xhi / ylo, xhi / yhi});
         }
 
-        // cake_pb_cp's divide/modulus encoding: the product |q|*|y| lives only in
-        // bit-product flags feeding the remainder/identity rows, with no w (and, for
-        // divide, no r) in the OPB. We take that path for plain operands, emitting cake's
-        // OPB and introducing the internal handles inside the proof; otherwise the legacy
-        // two's-complement path below. Both directions multiply the two NON-NEGATIVE
-        // magnitudes |q| and |y| into w = |q||y| (mult_bc with no signed reasoning), split
-        // the identity/remainder on sign(x), and recover signed values in the tabulation --
-        // a single magnitude machinery covering every sign of both operands.
+        // The default divide/modulus route emits cake_pb_cp's encoding: the product |q|*|y|
+        // lives only in bit-product flags feeding the remainder/identity rows, with no w (and,
+        // for divide, no r) in the OPB. Plain variable operands take this route (introducing the
+        // internal handles inside the proof); views and constant operands fall back to the
+        // legacy two's-complement path below. The route is chosen on operand SHAPE alone, so the
+        // propagation is the same with or without proofs -- only the proof emission is guarded.
+        // Both directions multiply the two NON-NEGATIVE magnitudes |q| and |y| into w = |q||y|
+        // (mult_bc with no signed reasoning), split the identity/remainder on sign(x), and
+        // recover signed values in the tabulation -- a single magnitude machinery covering
+        // every sign of both operands.
         //
-        // Divide (use_cake_divide): the exposed slot is q. magq = |q| (a state var
+        // Divide (default_divide): the exposed slot is q. magq = |q| (a state var
         // channelled to q by cake's Zge0/Zlt0 channel) and absy = |y| (channelled by
         // Yge0/Ylt0) are the mult operands; cake's rem_* rows range 0 <= x - w < |y| over
         // w and x directly (rem_pos gated [x>=0], rem_neg gated [x<0]), so no remainder is
@@ -212,26 +214,23 @@ namespace
         // propagator. The tabulation enumerates only x, y, q; a rejected leaf pins
         // magq/absy/w by unit propagation from the assigned q, y and the rem rows refute it.
         //
-        // Modulus (use_cake_modulus): the exposed slot is r, and cake leaves the quotient's
+        // Modulus (default_modulus): the exposed slot is r, and cake leaves the quotient's
         // magnitude a FREE axis-0 bit-sum with no i[Q] channel (no Zge0/Zlt0, no sgn_*). The
         // aux is the quotient magnitude |q|; absy = |y| is the second mult operand. cake
         // splits the identity r = x -/+ |q||y| on sign(x), the range/sign rows bound r, and
         // the tabulation recovers the signed quotient sign(x)sign(y)|q|.
-        // Selected on operand SHAPE alone (not whether proofs are on): the cake propagation
-        // runs with or without a proof model, so plain-operand divide/modulus takes this path
-        // in both cases and the legacy two's-complement path is left only for views/constants.
         bool plain_operands = ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var && aout.coeff == 1_i &&
             aout.offset == 0_i;
-        bool use_cake_divide = expose_quotient && plain_operands;
-        bool use_cake_modulus = (! expose_quotient) && plain_operands;
+        bool default_divide = expose_quotient && plain_operands;
+        bool default_modulus = (! expose_quotient) && plain_operands;
 
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
         IntegerVariableID q = 0_c, r = 0_c;
         SimpleIntegerVariableID aux = SimpleIntegerVariableID{0};
-        if (expose_quotient && use_cake_divide) {
+        if (expose_quotient && default_divide) {
             q = out;
-            // The cake divide path materialises no remainder (neither in the OPB nor in the
+            // The default divide path materialises no remainder (neither in the OPB nor in the
             // proof): cake's rem_* rows range x - w directly, so the aux is an inert state
             // slot, never introduced, enumerated, or meaningfully watched.
             aux = initial_state.allocate_integer_variable_with_state(0_i, 0_i);
@@ -248,7 +247,7 @@ namespace
                 optional_model->set_up_integer_variable(aux, r_lo, r_hi, "aux_divide_remainder" + to_string(aux.index), nullopt);
             r = aux;
         }
-        else if (use_cake_modulus) {
+        else if (default_modulus) {
             r = out;
             // The aux is the quotient MAGNITUDE |q|, a free axis-0 bit-sum sized by the
             // dividend's magnitude (|q| <= |x| since |y| >= 1). Its provable range is the
@@ -278,12 +277,12 @@ namespace
 
         auto label = as_string(owner);
 
-        vector<LinearStage> stages;
+        vector<LinearStage> legacy_stages;
         auto add_equality = [&](const WeightedSum & sum, Integer value, const string & role) {
-            add_equality_stage(stages, optional_model, label, sum, value, role);
+            add_equality_stage(legacy_stages, optional_model, label, sum, value, role);
         };
         auto add_le = [&](const WeightedSum & sum, Integer value, const string & role, const optional<IntegerVariableCondition> & gate) {
-            add_le_stage(stages, optional_model, label, sum, value, role, gate);
+            add_le_stage(legacy_stages, optional_model, label, sum, value, role, gate);
         };
 
         // x = q * y + r. With a constant divisor or a constant quotient the
@@ -291,13 +290,13 @@ namespace
         // propagation whenever x and r are known) and multiply directly into
         // it: q * y = w, on plain variables.
         bool needs_mult = ay.var && aq.var;
-        mult_bc::EncodingData encoding;
+        mult_bc::EncodingData legacy_encoding;
         optional<ConstraintStateHandle> bit_products_handle;
         SimpleIntegerVariableID mult_q = aux, mult_y = aux, mult_w = aux; // overwritten when needs_mult
-        shared_ptr<mult_bc::EncodingData> cake_encoding;
-        shared_ptr<vector<LinearStage>> cake_stages;
+        shared_ptr<mult_bc::EncodingData> default_encoding;
+        shared_ptr<vector<LinearStage>> default_stages;
 
-        if (use_cake_divide) {
+        if (default_divide) {
             // Divide, any sign of the dividend. BOTH the x >= 0 and x < 0 remainder rows
             // and w-stages are live, each gated on sign(x) so only the matching regime fires
             // once x is branched. The quotient's sign is pinned off the sgn_* clauses (for
@@ -306,8 +305,8 @@ namespace
             // need a proof-only |x|); the tabulation enumerates only x, y, q.
             auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
 
-            cake_encoding = make_shared<mult_bc::EncodingData>();
-            auto & enc = *cake_encoding;
+            default_encoding = make_shared<mult_bc::EncodingData>();
+            auto & enc = *default_encoding;
             enc.z_product_ge0_gated = false;
 
             // magq = |q| (Z channel to the exposed quotient) and absy = |y| (Y channel to the
@@ -325,21 +324,21 @@ namespace
             // 9/10 = whi split on sign(y)) and the x < 0 w-stages (11 = wlo, 12/13 = whi). Built
             // regardless of proofs; the w-stage lines fuse the rem row with w = product in the
             // initialiser (proofs on only), and the channel lines are nullopt proofs-off.
-            cake_stages = make_shared<vector<LinearStage>>();
-            append_magnitude_stages(*cake_stages, magq, q_eff, zchan, 0_i);
-            append_magnitude_stages(*cake_stages, absy, y_eff, ychan, 1_i);
+            default_stages = make_shared<vector<LinearStage>>();
+            append_magnitude_stages(*default_stages, magq, q_eff, zchan, 0_i);
+            append_magnitude_stages(*default_stages, absy, y_eff, ychan, 1_i);
             auto [t_wlo_p, m_wlo_p] = tidy_up_linear(WeightedSum{} + 1_i * w + -1_i * x_eff);
-            cake_stages->emplace_back(LinearStage{t_wlo_p, 0_i + m_wlo_p, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            default_stages->emplace_back(LinearStage{t_wlo_p, 0_i + m_wlo_p, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
             auto [t_whip_p, m_whip_p] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_whip_p, -1_i + m_whip_p, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
+            default_stages->emplace_back(LinearStage{t_whip_p, -1_i + m_whip_p, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
             auto [t_whin_p, m_whin_p] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_whin_p, -1_i + m_whin_p, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
+            default_stages->emplace_back(LinearStage{t_whin_p, -1_i + m_whin_p, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
             auto [t_wlo_n, m_wlo_n] = tidy_up_linear(WeightedSum{} + 1_i * w + 1_i * x_eff);
-            cake_stages->emplace_back(LinearStage{t_wlo_n, 0_i + m_wlo_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
+            default_stages->emplace_back(LinearStage{t_wlo_n, 0_i + m_wlo_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
             auto [t_whip_n, m_whip_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_whip_n, -1_i + m_whip_n, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
+            default_stages->emplace_back(LinearStage{t_whip_n, -1_i + m_whip_n, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
             auto [t_whin_n, m_whin_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_whin_n, -1_i + m_whin_n, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
+            default_stages->emplace_back(LinearStage{t_whin_n, -1_i + m_whin_n, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
 
             if (optional_model) {
                 auto [product_sum, neg_product] = emit_cake_bit_products(*optional_model, owner, label, magq, absy, enc);
@@ -372,8 +371,8 @@ namespace
                 optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
 
                 propagators.install_initialiser(
-                    [enc = cake_encoding, stg = cake_stages, product_sum, w, rem_pos_lo, rem_pos_hi, rem_neg_hi, rem_neg_lo, y_pos_ge = *ychan.pos_ge,
-                        y_neg_le = *ychan.neg_le](State &, auto &, ProofLogger * const logger) -> void {
+                    [enc = default_encoding, stg = default_stages, product_sum, w, rem_pos_lo, rem_pos_hi, rem_neg_hi, rem_neg_lo,
+                        y_pos_ge = *ychan.pos_ge, y_neg_le = *ychan.neg_le](State &, auto &, ProofLogger * const logger) -> void {
                         if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                             return;
                         enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
@@ -402,8 +401,8 @@ namespace
 
             bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
         }
-        else if (use_cake_modulus) {
-            // Modulus's cake path: the exposed slot is r; the quotient magnitude |q| (the
+        else if (default_modulus) {
+            // The default modulus path: the exposed slot is r; the quotient magnitude |q| (the
             // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, axis-1 free
             // magnitude, pinned to |y| by cake's Yge0/Ylt0 channel) multiply to w = |q||y|.
             // The identity splits on sign(x): r = x - w off id_pos_* (gated [x>=0]) and
@@ -418,8 +417,8 @@ namespace
             // and deviewing that defeats the reverse unit propagation.
             auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var, r_eff = *aout.var;
 
-            cake_encoding = make_shared<mult_bc::EncodingData>();
-            auto & enc = *cake_encoding;
+            default_encoding = make_shared<mult_bc::EncodingData>();
+            auto & enc = *default_encoding;
             enc.z_product_ge0_gated = false;
 
             // absy = |y| (Y channel to the divisor) is mult_bc's divisor operand; the quotient
@@ -436,7 +435,7 @@ namespace
             // The range/sign OPB lines feed their stages below; they exist only proofs-on, so
             // the stages carry nullopt lines (and filter on their terms) proofs-off.
             optional<ProofLine> rng_hi, rng_lo, sgn_pos, sgn_neg;
-            cake_stages = make_shared<vector<LinearStage>>();
+            default_stages = make_shared<vector<LinearStage>>();
 
             if (optional_model) {
                 auto [product_sum, neg_product] = emit_cake_bit_products(*optional_model, owner, label, q_eff, absy, enc);
@@ -469,8 +468,8 @@ namespace
                 // introduced in the proof.
                 optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_modulus_product" + to_string(w.index));
 
-                propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le, id_neg_ge, id_neg_le](
-                                                    State &, auto &, ProofLogger * const logger) -> void {
+                propagators.install_initialiser([enc = default_encoding, stg = default_stages, product_sum, w, id_pos_ge, id_pos_le, id_neg_ge,
+                                                    id_neg_le](State &, auto &, ProofLogger * const logger) -> void {
                     if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
                         return;
                     // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
@@ -501,23 +500,23 @@ namespace
             // Yge0/Ylt0 channel, split on sign(y). Only the identity stages need the initialiser;
             // the rest cite an OPB row directly (nullopt proofs-off).
             auto [t_idle, m_idle] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * r_eff);
-            cake_stages->emplace_back(LinearStage{t_idle, 0_i + m_idle, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            default_stages->emplace_back(LinearStage{t_idle, 0_i + m_idle, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
             auto [t_idge, m_idge] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + 1_i * w + 1_i * r_eff);
-            cake_stages->emplace_back(LinearStage{t_idge, 0_i + m_idge, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            default_stages->emplace_back(LinearStage{t_idge, 0_i + m_idge, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
             auto [t_idle_n, m_idle_n] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + 1_i * w + -1_i * r_eff);
-            cake_stages->emplace_back(LinearStage{t_idle_n, 0_i + m_idle_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
+            default_stages->emplace_back(LinearStage{t_idle_n, 0_i + m_idle_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
             auto [t_idge_n, m_idge_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * r_eff);
-            cake_stages->emplace_back(LinearStage{t_idge_n, 0_i + m_idge_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
+            default_stages->emplace_back(LinearStage{t_idge_n, 0_i + m_idge_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
             auto [t_rhi, m_rhi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff + -1_i * absy);
-            cake_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {rng_hi, nullopt}, nullopt});
+            default_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {rng_hi, nullopt}, nullopt});
             auto [t_rlo, m_rlo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff + -1_i * absy);
-            cake_stages->emplace_back(LinearStage{t_rlo, -1_i + m_rlo, false, {rng_lo, nullopt}, nullopt});
+            default_stages->emplace_back(LinearStage{t_rlo, -1_i + m_rlo, false, {rng_lo, nullopt}, nullopt});
             auto [t_slo, m_slo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff);
-            cake_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {sgn_pos, nullopt}, optional{x_eff >= 0_i}});
+            default_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {sgn_pos, nullopt}, optional{x_eff >= 0_i}});
             auto [t_shi, m_shi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff);
-            cake_stages->emplace_back(LinearStage{t_shi, 0_i + m_shi, false, {sgn_neg, nullopt}, optional{x_eff < 1_i}});
+            default_stages->emplace_back(LinearStage{t_shi, 0_i + m_shi, false, {sgn_neg, nullopt}, optional{x_eff < 1_i}});
             // absy = |y| off the Y channel, split on sign(y).
-            append_magnitude_stages(*cake_stages, absy, y_eff, ychan, 1_i);
+            append_magnitude_stages(*default_stages, absy, y_eff, ychan, 1_i);
 
             bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
         }
@@ -564,8 +563,8 @@ namespace
                     w, w_lo, w_hi, (expose_quotient ? "aux_divide_product" : "aux_modulus_product") + to_string(w.index), nullopt);
 
             if (optional_model)
-                encoding = mult_bc::define_encoding(*optional_model, initial_state, owner, label, q_eff, y_eff, w);
-            bit_products_handle = initial_state.add_persistent_constraint_state(encoding.initial_bit_products);
+                legacy_encoding = mult_bc::define_encoding(*optional_model, initial_state, owner, label, q_eff, y_eff, w);
+            bit_products_handle = initial_state.add_persistent_constraint_state(legacy_encoding.initial_bit_products);
             mult_q = q_eff;
             mult_y = y_eff;
             mult_w = w;
@@ -635,8 +634,8 @@ namespace
         if (plain_operands) {
             propagators.install(
                 owner,
-                [enc = cake_encoding, stg = cake_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y, q = q,
-                    x = x, pin_q_sign = use_cake_divide,
+                [enc = default_encoding, stg = default_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y,
+                    q = q, x = x, pin_q_sign = default_divide,
                     owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     do {
                         if (state.in_domain(y, 0_i))
@@ -679,8 +678,8 @@ namespace
         else
             propagators.install(
                 owner,
-                [stages = stages, needs_mult = needs_mult, encoding = encoding, bit_products_handle = bit_products_handle, mult_q = mult_q,
-                    mult_y = mult_y, mult_w = mult_w, prune_zero = prune_zero, y = y,
+                [stages = legacy_stages, needs_mult = needs_mult, encoding = legacy_encoding, bit_products_handle = bit_products_handle,
+                    mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, prune_zero = prune_zero, y = y,
                     owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     do {
                         if (prune_zero && state.in_domain(y, 0_i))
@@ -705,11 +704,11 @@ namespace
         auto px = ax.var ? optional{enum_vars.position_of(*ax.var)} : nullopt;
         auto py = ay.var ? optional{enum_vars.position_of(*ay.var)} : nullopt;
         auto pout = aout.var ? optional{enum_vars.position_of(*aout.var)} : nullopt;
-        // The cake divide path materialises no remainder in the proof (cake's rem_* rows range
+        // The default divide path materialises no remainder in the proof (cake's rem_* rows range
         // x - w directly, and a rejected (x, y, q) leaf pins magq/absy/w by unit propagation
         // from the assigned q, y so the rem rows refute a wrong remainder), so it enumerates
         // only x, y and q, with no remainder aux and no determined slots.
-        bool no_rem_aux = use_cake_divide;
+        bool no_rem_aux = default_divide;
         std::size_t paux = 0;
         if (! no_rem_aux)
             paux = enum_vars.position_of(aux);
@@ -727,7 +726,7 @@ namespace
         // On the cake modulus path the aux is the quotient MAGNITUDE |q|; recover the signed
         // quotient sign(x)sign(y)|q| (a magnitude 0 keeps sign 0). Everywhere else the aux is
         // the signed quotient directly.
-        bool aux_is_magnitude = use_cake_modulus;
+        bool aux_is_magnitude = default_modulus;
         auto recover_q = [aux_is_magnitude](Integer auxv, Integer xv, Integer yv) -> Integer {
             return (aux_is_magnitude && ((xv >= 0_i) != (yv >= 0_i))) ? -auxv : auxv;
         };
@@ -776,7 +775,7 @@ namespace
                 auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                 auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                 auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                // The cake divide path enumerates no remainder aux: q is the exposed slot and
+                // The default divide path enumerates no remainder aux: q is the exposed slot and
                 // the remainder is derived. Elsewhere the aux is the remainder (legacy Divide)
                 // or the quotient magnitude (Modulus).
                 if (no_rem_aux)

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -117,23 +117,30 @@ namespace
             q_hi = max({xlo / ylo, xlo / yhi, xhi / ylo, xhi / yhi});
         }
 
-        // cake_pb_cp's divide encoding: the product |q|*|y| lives only in bit-product
-        // flags feeding rem_* rows, with no w or r in the OPB. We take that path for
-        // Divide with a non-negative dividend, emitting cake's OPB and introducing w and
-        // r inside the proof; otherwise the legacy two's-complement path below. The
-        // dividend must be non-negative (x >= 0) so that q*y = x - r >= 0 keeps the
-        // product w = |q||y| and remainder r = x - w non-negative (only the pos rem_*
-        // rows and the wlo stage are active). The divisor y and quotient q may take
-        // either sign: make_mag's sign-atom-gated channel converts each to |q|, |y|, the
-        // remainder-hi stage splits on sign(y), and the five sign clauses pin sign(q).
-        // Because w is the magnitude |q||y| (not the signed product q*y), mult_bc is told
-        // z_is_magnitude so it bounds w by the operand magnitudes -- otherwise an
-        // opposite-sign q, y would make it infer a negative bound on the (non-negative) w
-        // and its RUP justification would be unprovable. Signed x -- where r follows x's
-        // sign, needing the neg rem_* rows and neg identity -- is the remaining step and
-        // stays on the legacy path for now.
-        bool use_cake = expose_quotient && optional_model && xlo >= 0_i && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i &&
-            ay.offset == 0_i && aout.var && aout.coeff == 1_i && aout.offset == 0_i;
+        // cake_pb_cp's divide/modulus encoding: the product |q|*|y| lives only in
+        // bit-product flags feeding the remainder/identity rows, with no w (and, for
+        // divide, no r) in the OPB. We take that path for plain operands with a
+        // non-negative dividend, emitting cake's OPB and introducing the internal
+        // handles inside the proof; otherwise the legacy two's-complement path below.
+        //
+        // Divide (use_cake_divide): x >= 0 keeps w = |q||y| and r = x - w non-negative
+        // (only the pos rem_* rows and the wlo stage are active). The divisor y and
+        // quotient q may take either sign: make_mag's sign-atom-gated channel converts
+        // each to |q|, |y|, the remainder-hi stage splits on sign(y), and the five sign
+        // clauses pin sign(q). Because w is the magnitude |q||y| (not the signed product
+        // q*y), mult_bc is told z_is_magnitude so it bounds w by the operand magnitudes.
+        //
+        // Modulus (use_cake_modulus): the exposed slot is r, and cake leaves the
+        // quotient's magnitude a FREE axis-0 bit-sum with no i[Q] channel. We restrict
+        // to x >= 0 and y >= 1, so q >= 0 too and every sign agrees: q's own in-proof
+        // bits (registered in cake's naming below) ARE that free magnitude, needing no
+        // channel, and r's range/sign come straight off cake's id_*/rng_*/sgn_* rows.
+        // Signed dividends (and, for modulus, a signed divisor) stay on the legacy path.
+        bool plain_operands = optional_model && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var &&
+            aout.coeff == 1_i && aout.offset == 0_i;
+        bool use_cake_divide = expose_quotient && plain_operands && xlo >= 0_i;
+        bool use_cake_modulus = (! expose_quotient) && plain_operands && xlo >= 0_i && ylo >= 1_i;
+        bool use_cake = use_cake_divide || use_cake_modulus;
 
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
@@ -155,6 +162,22 @@ namespace
             else if (optional_model)
                 optional_model->register_state_variable_bits_in_proof(aux, r_lo, r_hi_cake, "aux_divide_remainder" + to_string(aux.index));
             r = aux;
+        }
+        else if (use_cake) {
+            r = out;
+            // cake leaves the quotient a free axis-0 magnitude sized by the dividend's
+            // bit count (q <= x when y >= 1), so its provable range is the bit-implied
+            // [0, 2^n - 1]. Give the state the same range (like divide's product w) and
+            // register its bits in cake's x[id][0_*][bin] naming with no OPB bounds, so
+            // q's own bits ARE the magnitude the bit products multiply.
+            auto q_bits = 0_i;
+            while (power2(q_bits) <= xhi)
+                q_bits += 1_i;
+            auto q_bit_max = power2(q_bits) - 1_i;
+            aux = initial_state.allocate_integer_variable_with_state(0_i, q_bit_max);
+            optional_model->register_state_variable_bits_in_proof(
+                aux, 0_i, q_bit_max, "aux_modulus_quotient" + to_string(aux.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
+            q = aux;
         }
         else {
             r = out;
@@ -186,7 +209,7 @@ namespace
         shared_ptr<mult_bc::EncodingData> cake_encoding;
         shared_ptr<vector<LinearStage>> cake_stages;
 
-        if (use_cake) {
+        if (use_cake && expose_quotient) {
             auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
 
             cake_encoding = make_shared<mult_bc::EncodingData>();
@@ -323,6 +346,137 @@ namespace
                 PolBuilder pb_whin;
                 pb_whin.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_lt0_le);
                 (*stg)[2].lines = {pb_whin.emit(*logger, ProofLevel::Top), nullopt};
+            });
+        }
+        else if (use_cake) {
+            // Modulus's cake path: the exposed slot is r, the quotient q a free axis-0
+            // magnitude whose bits (registered above) are its own -- no i[Q], no channel,
+            // since q >= 0 means q = |q|. w = q * y (both non-negative) is a product state
+            // variable introduced in the proof; r = x - w comes off cake's id_pos rows and
+            // 0 <= r < |y| off rng_*. The id_neg_*/rng_lo/sgn_* rows are cake's inert
+            // (satisfiable) mirror for x < 0, emitted only to match cake's OPB.
+            //
+            // The identity stage propagates the exposed r, so r must be the plain underlying
+            // variable *aout.var (r_eff), not any view wrapper: propagating a change through
+            // a view's deviewed bits while the identity spans the wide product w defeats the
+            // reverse unit propagation. The guard's coeff-1/offset-0 restriction makes r_eff
+            // exactly the exposed value, and cake names it i[R] too, so this also matches.
+            auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var, r_eff = *aout.var;
+
+            cake_encoding = make_shared<mult_bc::EncodingData>();
+            auto & enc = *cake_encoding;
+            enc.z_product_ge0_gated = false;
+            enc.z_is_magnitude = false; // q, y >= 0, so w = q * y is the plain product
+
+            // Axis-1 magnitude channel for y (cake letter "Y"); q needs none, as its own
+            // cake-named bits are the axis-0 magnitude.
+            auto mag_y_ub = max(abs(initial_state.lower_bound(y_eff)), abs(initial_state.upper_bound(y_eff)));
+            auto mag_y = optional_model->create_proof_only_integer_variable(
+                0_i, mag_y_ub, "mod_mag_Y", IntegerVariableProofRepresentation::Bits, CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
+            auto y_ge0 = HalfReifyOnConjunctionOf{y_eff >= 0_i};
+            auto y_lt0 = HalfReifyOnConjunctionOf{y_eff < 0_i};
+            auto y_pos_ge = optional_model->add_labelled_constraint(
+                label, "Yge0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * mag_y >= 0_i, y_ge0);
+            auto y_pos_le = optional_model->add_labelled_constraint(
+                label, "Yge0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * mag_y >= 0_i, y_ge0);
+            auto y_neg_ge = optional_model->add_labelled_constraint(
+                label, "Ylt0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * mag_y >= 0_i, y_lt0);
+            auto y_neg_le = optional_model->add_labelled_constraint(
+                label, "Ylt0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * mag_y >= 0_i, y_lt0);
+            enc.channelling_constraints.insert(
+                {y_eff, mult_bc::ChannellingData{y_pos_ge, y_pos_le, y_neg_ge, y_neg_le, true, initial_state.lower_bound(y_eff) < 0_i}});
+            enc.mag_var.insert({y_eff, mag_y});
+
+            // Bit-product flags x[id][i_j][prod] = q_i ^ mag_y_j and their weighted sum
+            // |q|*|y|. q's axis-0 bits are q_eff's own registered (cake-named) bits.
+            auto n1 = optional_model->names_and_ids_tracker().num_bits(q_eff);
+            auto n2 = optional_model->names_and_ids_tracker().num_bits(mag_y);
+            auto product_sum = WPBSum{};
+            for (Integer i = 0_i; i < n1; ++i) {
+                enc.initial_bit_products.emplace_back();
+                for (Integer j = 0_i; j < n2; ++j) {
+                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
+                        WPBSum{} + 1_i * ProofBitVariable{q_eff, i, true} + 1_i * ProofBitVariable{mag_y, j, true} >= 2_i);
+                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
+                    enc.initial_bit_products[i.as_index()].emplace_back(
+                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
+                    product_sum += power2(i + j) * flag;
+                }
+            }
+            auto neg_product = WPBSum{};
+            for (const auto & t : product_sum.terms)
+                neg_product += -t.coefficient * t.variable;
+
+            optional_model->add_labelled_constraint(
+                label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+
+            // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0]) is the active
+            // r = x - w equality; id_neg_* (gated [x<0]) its inert mirror.
+            auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
+            auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
+            auto id_pos_ge = optional_model->add_labelled_constraint(
+                label, "id_pos_ge", "Modulus", "identity", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xge0);
+            auto id_pos_le = optional_model->add_labelled_constraint(
+                label, "id_pos_le", "Modulus", "identity", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xge0);
+            optional_model->add_labelled_constraint(label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xlt0);
+            optional_model->add_labelled_constraint(label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xlt0);
+
+            // 0 <= r < |y|: rng_hi (r < |y|, active) and rng_lo (r > -|y|, inert), plus
+            // the r-sign rows (r takes x's sign; sgn_pos trivial, sgn_neg inert here).
+            auto rng_hi = optional_model->add_labelled_constraint(label, "rng_hi", "Modulus", "range", WPBSum{} + -1_i * r_eff + 1_i * mag_y >= 1_i);
+            optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * mag_y >= 1_i);
+            auto sgn_pos = optional_model->add_labelled_constraint(label, "sgn_pos", "Modulus", "sign", WPBSum{} + 1_i * r_eff >= 0_i, xge0);
+            optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xlt0);
+
+            // w = |q||y| is a product state variable driving mult_bc, sized to the full
+            // bit-product sum; its bits are introduced in the proof.
+            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
+            auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
+            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_modulus_product" + to_string(w.index));
+            mult_q = q_eff, mult_y = y_eff, mult_w = w;
+            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
+
+            // Stages over the underlying operands: the identity r = x - w (two [x>=0]-gated
+            // inequalities off id_pos_*), the range r < |y| (gated [y>=1], off rng_hi + the y
+            // channel), and r >= 0 (gated [x>=0], off sgn_pos) which -- since r takes x's sign
+            // -- prunes a would-be negative remainder when r's domain spans zero. The gates
+            // ride along, discharged by propagate_linear's ThenRUP from x's / y's domains.
+            // Proof lines are filled once w = product is introduced in the initialiser.
+            cake_stages = make_shared<vector<LinearStage>>();
+            auto [t_idle, m_idle] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * r_eff);
+            cake_stages->emplace_back(LinearStage{t_idle, 0_i + m_idle, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            auto [t_idge, m_idge] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + 1_i * w + 1_i * r_eff);
+            cake_stages->emplace_back(LinearStage{t_idge, 0_i + m_idge, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            auto [t_rhi, m_rhi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_slo, m_slo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff);
+            cake_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+
+            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le, rng_hi, sgn_pos, y_pos_ge](
+                                                State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                    return;
+                // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
+                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                // identity r >= x - w (x - w - r <= 0): id_pos_le (r - x + product >= 0)
+                // + (w >= product). The [x>=0] gate rides along, discharged by x's domain.
+                PolBuilder pb_idle;
+                pb_idle.add(id_pos_le).add(enc->v3_eq_product_lines.first);
+                (*stg)[0].lines = {pb_idle.emit(*logger, ProofLevel::Top), nullopt};
+                // identity r <= x - w (w + r - x <= 0): id_pos_ge (x - product - r >= 0)
+                // + (w <= product).
+                PolBuilder pb_idge;
+                pb_idge.add(id_pos_ge).add(enc->v3_eq_product_lines.second);
+                (*stg)[1].lines = {pb_idge.emit(*logger, ProofLevel::Top), nullopt};
+                // range r < |y| (r - y <= -1, |y|=y): rng_hi (|y| - r >= 1) + Yge0_ge
+                // (y - |y| >= 0); |y| = mag_y cancels, the [y>=0] gate rides along.
+                PolBuilder pb_rhi;
+                pb_rhi.add(rng_hi).add(y_pos_ge);
+                (*stg)[2].lines = {pb_rhi.emit(*logger, ProofLevel::Top), nullopt};
+                // r >= 0 (-r <= 0): straight off sgn_pos, [x>=0] gate discharged by x's domain.
+                PolBuilder pb_slo;
+                pb_slo.add(sgn_pos);
+                (*stg)[3].lines = {pb_slo.emit(*logger, ProofLevel::Top), nullopt};
             });
         }
 

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -69,10 +69,14 @@ namespace
     struct CakeMagnitude
     {
         SimpleIntegerVariableID var;
-        ProofLine pos_ge, pos_le, neg_ge, neg_le;
+        Integer num_bits;
+        optional<ProofLine> pos_ge, pos_le, neg_ge, neg_le;
     };
 
-    auto make_cake_magnitude(ProofModel & model, State & state, const ConstraintID & owner, const std::string & label, StringLiteral op,
+    // The magnitude STATE variable and its bit count are allocated unconditionally so the
+    // propagation runs with or without proofs; the channel rows and bit registration are only
+    // emitted when there is a model (proofs on), leaving the channel lines nullopt otherwise.
+    auto make_cake_magnitude(ProofModel * const model, State & state, const ConstraintID & owner, const std::string & label, StringLiteral op,
         SimpleIntegerVariableID v, long long axis, const std::string & letter, const std::string & aux_name) -> CakeMagnitude
     {
         auto mag_ub = max(abs(state.lower_bound(v)), abs(state.upper_bound(v)));
@@ -80,22 +84,25 @@ namespace
         while (power2(bits) <= mag_ub)
             bits += 1_i;
         auto mag = state.allocate_integer_variable_with_state(0_i, power2(bits) - 1_i);
-        model.register_state_variable_bits_in_proof(
+        if (! model)
+            return {mag, bits, nullopt, nullopt, nullopt, nullopt};
+        model->register_state_variable_bits_in_proof(
             mag, 0_i, power2(bits) - 1_i, aux_name + to_string(mag.index), CakeBitNaming{owner, {axis}, "bin", nullopt, false, true});
         auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
         auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
-        return {mag, model.add_labelled_constraint(label, letter + "ge0_ge", op, "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0),
-            model.add_labelled_constraint(label, letter + "ge0_le", op, "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0),
-            model.add_labelled_constraint(label, letter + "lt0_ge", op, "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0),
-            model.add_labelled_constraint(label, letter + "lt0_le", op, "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0)};
+        return {mag, bits,
+            model->add_labelled_constraint(label, letter + "ge0_ge", op, "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0),
+            model->add_labelled_constraint(label, letter + "ge0_le", op, "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0),
+            model->add_labelled_constraint(label, letter + "lt0_ge", op, "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0),
+            model->add_labelled_constraint(label, letter + "lt0_le", op, "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0)};
     }
 
     // The bit-product flags x[id][i_j][prod] = mag_a_i AND mag_b_j and their weighted sum
-    // mag_a * mag_b, appended to enc.initial_bit_products; w_hi is the product's declared max.
+    // mag_a * mag_b, appended to enc.initial_bit_products. Proof-only: the callers compute the
+    // product's declared max w_hi themselves from the magnitudes' bit counts.
     struct CakeBitProducts
     {
         WPBSum product_sum, neg_product;
-        Integer w_hi;
     };
 
     auto emit_cake_bit_products(ProofModel & model, const ConstraintID & owner, const std::string & label, SimpleIntegerVariableID mag_a,
@@ -118,7 +125,7 @@ namespace
         auto neg_product = WPBSum{};
         for (const auto & t : product_sum.terms)
             neg_product += -t.coefficient * t.variable;
-        return {product_sum, neg_product, (power2(n1) - 1_i) * (power2(n2) - 1_i)};
+        return {product_sum, neg_product};
     }
 
     // The four stages pinning mag = |v| in both directions off its cake channel, split on
@@ -210,11 +217,13 @@ namespace
         // aux is the quotient magnitude |q|; absy = |y| is the second mult operand. cake
         // splits the identity r = x -/+ |q||y| on sign(x), the range/sign rows bound r, and
         // the tabulation recovers the signed quotient sign(x)sign(y)|q|.
-        bool plain_operands = optional_model && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var &&
-            aout.coeff == 1_i && aout.offset == 0_i;
+        // Selected on operand SHAPE alone (not whether proofs are on): the cake propagation
+        // runs with or without a proof model, so plain-operand divide/modulus takes this path
+        // in both cases and the legacy two's-complement path is left only for views/constants.
+        bool plain_operands = ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var && aout.coeff == 1_i &&
+            aout.offset == 0_i;
         bool use_cake_divide = expose_quotient && plain_operands;
         bool use_cake_modulus = (! expose_quotient) && plain_operands;
-        bool use_cake = use_cake_divide || use_cake_modulus;
 
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
@@ -239,9 +248,8 @@ namespace
                 optional_model->set_up_integer_variable(aux, r_lo, r_hi, "aux_divide_remainder" + to_string(aux.index), nullopt);
             r = aux;
         }
-        else if (use_cake) {
+        else if (use_cake_modulus) {
             r = out;
-            // cake leaves the quotient a free axis-0 magnitude sized by the dividend's
             // The aux is the quotient MAGNITUDE |q|, a free axis-0 bit-sum sized by the
             // dividend's magnitude (|q| <= |x| since |y| >= 1). Its provable range is the
             // bit-implied [0, 2^n - 1]; give the state that range (like divide's product w)
@@ -254,8 +262,9 @@ namespace
                 q_bits += 1_i;
             auto q_bit_max = power2(q_bits) - 1_i;
             aux = initial_state.allocate_integer_variable_with_state(0_i, q_bit_max);
-            optional_model->register_state_variable_bits_in_proof(
-                aux, 0_i, q_bit_max, "aux_modulus_quotient" + to_string(aux.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
+            if (optional_model)
+                optional_model->register_state_variable_bits_in_proof(
+                    aux, 0_i, q_bit_max, "aux_modulus_quotient" + to_string(aux.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
             q = aux;
         }
         else {
@@ -302,45 +311,20 @@ namespace
             enc.z_product_ge0_gated = false;
 
             // magq = |q| (Z channel to the exposed quotient) and absy = |y| (Y channel to the
-            // divisor) are the two non-negative mult_bc operands; w = magq * absy.
-            auto zchan = make_cake_magnitude(*optional_model, initial_state, owner, label, "Divide", q_eff, 0, "Z", "aux_divide_qmag");
-            auto ychan = make_cake_magnitude(*optional_model, initial_state, owner, label, "Divide", y_eff, 1, "Y", "aux_divide_absdivisor");
+            // divisor) are the two non-negative mult_bc operands; w = magq * absy. The magnitude
+            // state vars and the product's declared max are set regardless of proofs.
+            auto zchan = make_cake_magnitude(optional_model, initial_state, owner, label, "Divide", q_eff, 0, "Z", "aux_divide_qmag");
+            auto ychan = make_cake_magnitude(optional_model, initial_state, owner, label, "Divide", y_eff, 1, "Y", "aux_divide_absdivisor");
             auto magq = zchan.var, absy = ychan.var;
-            auto [product_sum, neg_product, w_hi] = emit_cake_bit_products(*optional_model, owner, label, magq, absy, enc);
-
-            // Both remainder-row sets: 0 <= x - |q||y| < |y| (rem_pos, gated [x>=0]) and
-            // 0 <= -x - |q||y| < |y| (rem_neg, gated [x<1]).
-            auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
-            auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
-            auto rem_pos_lo =
-                optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
-            auto rem_pos_hi = optional_model->add_labelled_constraint(
-                label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xge0);
-            auto rem_neg_hi =
-                optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
-            auto rem_neg_lo = optional_model->add_labelled_constraint(
-                label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xlt0);
-
-            optional_model->add_labelled_constraint(
-                label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i);
-            optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+            auto w_hi = (power2(zchan.num_bits) - 1_i) * (power2(ychan.num_bits) - 1_i);
 
             auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
-            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
             mult_q = magq, mult_y = absy, mult_w = w;
-            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
 
             // Stages: magq (0-3) and absy (4-7) channels, then the x >= 0 w-stages (8 = wlo,
-            // 9/10 = whi split on sign(y)) and the x < 0 w-stages (11 = wlo, 12/13 = whi). The
-            // w-stage lines fuse the rem row with w = product in the initialiser.
+            // 9/10 = whi split on sign(y)) and the x < 0 w-stages (11 = wlo, 12/13 = whi). Built
+            // regardless of proofs; the w-stage lines fuse the rem row with w = product in the
+            // initialiser (proofs on only), and the channel lines are nullopt proofs-off.
             cake_stages = make_shared<vector<LinearStage>>();
             append_magnitude_stages(*cake_stages, magq, q_eff, zchan, 0_i);
             append_magnitude_stages(*cake_stages, absy, y_eff, ychan, 1_i);
@@ -357,35 +341,68 @@ namespace
             auto [t_whin_n, m_whin_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * y_eff);
             cake_stages->emplace_back(LinearStage{t_whin_n, -1_i + m_whin_n, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
 
-            propagators.install_initialiser(
-                [enc = cake_encoding, stg = cake_stages, product_sum, w, rem_pos_lo, rem_pos_hi, rem_neg_hi, rem_neg_lo, y_pos_ge = ychan.pos_ge,
-                    y_neg_le = ychan.neg_le](State &, auto &, ProofLogger * const logger) -> void {
-                    if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                        return;
-                    enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
-                    // x >= 0 w-stages.
-                    PolBuilder pb_wlo_p;
-                    pb_wlo_p.add(rem_pos_lo).add(enc->v3_eq_product_lines.second);
-                    (*stg)[8].lines = {pb_wlo_p.emit(*logger, ProofLevel::Top), nullopt};
-                    PolBuilder pb_whip_p;
-                    pb_whip_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
-                    (*stg)[9].lines = {pb_whip_p.emit(*logger, ProofLevel::Top), nullopt};
-                    PolBuilder pb_whin_p;
-                    pb_whin_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_neg_le);
-                    (*stg)[10].lines = {pb_whin_p.emit(*logger, ProofLevel::Top), nullopt};
-                    // x < 0 w-stages.
-                    PolBuilder pb_wlo_n;
-                    pb_wlo_n.add(rem_neg_hi).add(enc->v3_eq_product_lines.second);
-                    (*stg)[11].lines = {pb_wlo_n.emit(*logger, ProofLevel::Top), nullopt};
-                    PolBuilder pb_whip_n;
-                    pb_whip_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
-                    (*stg)[12].lines = {pb_whip_n.emit(*logger, ProofLevel::Top), nullopt};
-                    PolBuilder pb_whin_n;
-                    pb_whin_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_neg_le);
-                    (*stg)[13].lines = {pb_whin_n.emit(*logger, ProofLevel::Top), nullopt};
-                });
+            if (optional_model) {
+                auto [product_sum, neg_product] = emit_cake_bit_products(*optional_model, owner, label, magq, absy, enc);
+
+                // Both remainder-row sets: 0 <= x - |q||y| < |y| (rem_pos, gated [x>=0]) and
+                // 0 <= -x - |q||y| < |y| (rem_neg, gated [x<1]).
+                auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
+                auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
+                auto rem_pos_lo =
+                    optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
+                auto rem_pos_hi = optional_model->add_labelled_constraint(
+                    label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xge0);
+                auto rem_neg_hi =
+                    optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
+                auto rem_neg_lo = optional_model->add_labelled_constraint(
+                    label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xlt0);
+
+                optional_model->add_labelled_constraint(
+                    label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i);
+                optional_model->add_labelled_constraint(
+                    label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i);
+                optional_model->add_labelled_constraint(
+                    label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i);
+                optional_model->add_labelled_constraint(
+                    label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i);
+                optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i);
+                optional_model->add_labelled_constraint(
+                    label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+
+                optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
+
+                propagators.install_initialiser(
+                    [enc = cake_encoding, stg = cake_stages, product_sum, w, rem_pos_lo, rem_pos_hi, rem_neg_hi, rem_neg_lo, y_pos_ge = *ychan.pos_ge,
+                        y_neg_le = *ychan.neg_le](State &, auto &, ProofLogger * const logger) -> void {
+                        if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                            return;
+                        enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                        // x >= 0 w-stages.
+                        PolBuilder pb_wlo_p;
+                        pb_wlo_p.add(rem_pos_lo).add(enc->v3_eq_product_lines.second);
+                        (*stg)[8].lines = {pb_wlo_p.emit(*logger, ProofLevel::Top), nullopt};
+                        PolBuilder pb_whip_p;
+                        pb_whip_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
+                        (*stg)[9].lines = {pb_whip_p.emit(*logger, ProofLevel::Top), nullopt};
+                        PolBuilder pb_whin_p;
+                        pb_whin_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_neg_le);
+                        (*stg)[10].lines = {pb_whin_p.emit(*logger, ProofLevel::Top), nullopt};
+                        // x < 0 w-stages.
+                        PolBuilder pb_wlo_n;
+                        pb_wlo_n.add(rem_neg_hi).add(enc->v3_eq_product_lines.second);
+                        (*stg)[11].lines = {pb_wlo_n.emit(*logger, ProofLevel::Top), nullopt};
+                        PolBuilder pb_whip_n;
+                        pb_whip_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
+                        (*stg)[12].lines = {pb_whip_n.emit(*logger, ProofLevel::Top), nullopt};
+                        PolBuilder pb_whin_n;
+                        pb_whin_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_neg_le);
+                        (*stg)[13].lines = {pb_whin_n.emit(*logger, ProofLevel::Top), nullopt};
+                    });
+            }
+
+            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
         }
-        else if (use_cake) {
+        else if (use_cake_modulus) {
             // Modulus's cake path: the exposed slot is r; the quotient magnitude |q| (the
             // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, axis-1 free
             // magnitude, pinned to |y| by cake's Yge0/Ylt0 channel) multiply to w = |q||y|.
@@ -407,51 +424,82 @@ namespace
 
             // absy = |y| (Y channel to the divisor) is mult_bc's divisor operand; the quotient
             // magnitude q_eff is the free axis-0 aux (no Z channel -- cake leaves it free), so
-            // w = q_eff * absy over their own bits.
-            auto ychan = make_cake_magnitude(*optional_model, initial_state, owner, label, "Modulus", y_eff, 1, "Y", "aux_modulus_absdivisor");
+            // w = q_eff * absy over their own bits. The magnitude state var, the product's
+            // declared max (q's bit-max times absy's) and w are set regardless of proofs.
+            auto ychan = make_cake_magnitude(optional_model, initial_state, owner, label, "Modulus", y_eff, 1, "Y", "aux_modulus_absdivisor");
             auto absy = ychan.var;
-            auto [product_sum, neg_product, w_hi] = emit_cake_bit_products(*optional_model, owner, label, q_eff, absy, enc);
+            auto w_hi = initial_state.upper_bound(q_eff) * (power2(ychan.num_bits) - 1_i);
 
-            optional_model->add_labelled_constraint(
-                label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
-
-            // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0], r = x - w) and
-            // id_neg_* (gated [x<0], r = x + w -- since for x < 0 the quotient product q*y
-            // has sign(x), i.e. q*y = -w).
-            auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
-            auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
-            auto id_pos_ge = optional_model->add_labelled_constraint(
-                label, "id_pos_ge", "Modulus", "identity", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xge0);
-            auto id_pos_le = optional_model->add_labelled_constraint(
-                label, "id_pos_le", "Modulus", "identity", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xge0);
-            auto id_neg_ge = optional_model->add_labelled_constraint(
-                label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xlt0);
-            auto id_neg_le = optional_model->add_labelled_constraint(
-                label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xlt0);
-
-            // |r| < |y| = absy: rng_hi (r < absy) and rng_lo (r > -absy), plus the r-sign
-            // rows (r takes x's sign; sgn_pos gated [x>=0], sgn_neg gated [x<0]).
-            auto rng_hi = optional_model->add_labelled_constraint(label, "rng_hi", "Modulus", "range", WPBSum{} + -1_i * r_eff + 1_i * absy >= 1_i);
-            auto rng_lo = optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
-            auto sgn_pos = optional_model->add_labelled_constraint(label, "sgn_pos", "Modulus", "sign", WPBSum{} + 1_i * r_eff >= 0_i, xge0);
-            auto sgn_neg = optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xlt0);
-
-            // w = |q||y| is the product state variable driving mult_bc; its bits are
-            // introduced in the proof.
             auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
-            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_modulus_product" + to_string(w.index));
             mult_q = q_eff, mult_y = absy, mult_w = w;
-            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
 
-            // Stages. The identity, split on sign(x): r = x - w gated [x>=0] (idle/idge off
-            // id_pos_*) and r = x + w gated [x<0] (idle_neg/idge_neg off id_neg_*), lines
-            // filled in the initialiser once w = product is introduced. The range 0 <= r <
-            // absy (x>=0) / -absy < r <= 0 (x<0): rng_hi (r < absy) and rng_lo (r > -absy),
-            // both ungated (valid for either sign), plus the r-sign stages sgn_pos (r >= 0
-            // gated [x>=0]) / sgn_neg (r <= 0 gated [x<0]). And absy = |y| off the Yge0/Ylt0
-            // channel, split on sign(y). Only the identity stages need the initialiser; the
-            // rest cite an OPB row directly.
+            // The range/sign OPB lines feed their stages below; they exist only proofs-on, so
+            // the stages carry nullopt lines (and filter on their terms) proofs-off.
+            optional<ProofLine> rng_hi, rng_lo, sgn_pos, sgn_neg;
             cake_stages = make_shared<vector<LinearStage>>();
+
+            if (optional_model) {
+                auto [product_sum, neg_product] = emit_cake_bit_products(*optional_model, owner, label, q_eff, absy, enc);
+
+                optional_model->add_labelled_constraint(
+                    label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+
+                // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0], r = x - w) and
+                // id_neg_* (gated [x<0], r = x + w -- since for x < 0 the quotient product q*y
+                // has sign(x), i.e. q*y = -w).
+                auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
+                auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
+                auto id_pos_ge = optional_model->add_labelled_constraint(
+                    label, "id_pos_ge", "Modulus", "identity", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xge0);
+                auto id_pos_le = optional_model->add_labelled_constraint(
+                    label, "id_pos_le", "Modulus", "identity", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xge0);
+                auto id_neg_ge = optional_model->add_labelled_constraint(
+                    label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xlt0);
+                auto id_neg_le = optional_model->add_labelled_constraint(
+                    label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xlt0);
+
+                // |r| < |y| = absy: rng_hi (r < absy) and rng_lo (r > -absy), plus the r-sign
+                // rows (r takes x's sign; sgn_pos gated [x>=0], sgn_neg gated [x<0]).
+                rng_hi = optional_model->add_labelled_constraint(label, "rng_hi", "Modulus", "range", WPBSum{} + -1_i * r_eff + 1_i * absy >= 1_i);
+                rng_lo = optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
+                sgn_pos = optional_model->add_labelled_constraint(label, "sgn_pos", "Modulus", "sign", WPBSum{} + 1_i * r_eff >= 0_i, xge0);
+                sgn_neg = optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xlt0);
+
+                // w = |q||y| is the product state variable driving mult_bc; its bits are
+                // introduced in the proof.
+                optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_modulus_product" + to_string(w.index));
+
+                propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le, id_neg_ge, id_neg_le](
+                                                    State &, auto &, ProofLogger * const logger) -> void {
+                    if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                        return;
+                    // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
+                    enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                    // x >= 0: r >= x - w (id_pos_le + w >= product); r <= x - w (id_pos_ge + w <= product).
+                    PolBuilder pb_idle;
+                    pb_idle.add(id_pos_le).add(enc->v3_eq_product_lines.first);
+                    (*stg)[0].lines = {pb_idle.emit(*logger, ProofLevel::Top), nullopt};
+                    PolBuilder pb_idge;
+                    pb_idge.add(id_pos_ge).add(enc->v3_eq_product_lines.second);
+                    (*stg)[1].lines = {pb_idge.emit(*logger, ProofLevel::Top), nullopt};
+                    // x < 0: r >= x + w (id_neg_ge + w <= product); r <= x + w (id_neg_le + w >= product).
+                    PolBuilder pb_idle_n;
+                    pb_idle_n.add(id_neg_ge).add(enc->v3_eq_product_lines.second);
+                    (*stg)[2].lines = {pb_idle_n.emit(*logger, ProofLevel::Top), nullopt};
+                    PolBuilder pb_idge_n;
+                    pb_idge_n.add(id_neg_le).add(enc->v3_eq_product_lines.first);
+                    (*stg)[3].lines = {pb_idge_n.emit(*logger, ProofLevel::Top), nullopt};
+                });
+            }
+
+            // Stages (built regardless of proofs). The identity, split on sign(x): r = x - w
+            // gated [x>=0] (idle/idge off id_pos_*) and r = x + w gated [x<0] (idle_neg/idge_neg
+            // off id_neg_*), lines filled in the initialiser once w = product is introduced. The
+            // range 0 <= r < absy (x>=0) / -absy < r <= 0 (x<0): rng_hi (r < absy) and rng_lo
+            // (r > -absy), both ungated (valid for either sign), plus the r-sign stages sgn_pos
+            // (r >= 0 gated [x>=0]) / sgn_neg (r <= 0 gated [x<0]). And absy = |y| off the
+            // Yge0/Ylt0 channel, split on sign(y). Only the identity stages need the initialiser;
+            // the rest cite an OPB row directly (nullopt proofs-off).
             auto [t_idle, m_idle] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * r_eff);
             cake_stages->emplace_back(LinearStage{t_idle, 0_i + m_idle, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
             auto [t_idge, m_idge] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + 1_i * w + 1_i * r_eff);
@@ -471,30 +519,10 @@ namespace
             // absy = |y| off the Y channel, split on sign(y).
             append_magnitude_stages(*cake_stages, absy, y_eff, ychan, 1_i);
 
-            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le, id_neg_ge, id_neg_le](
-                                                State &, auto &, ProofLogger * const logger) -> void {
-                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                    return;
-                // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
-                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
-                // x >= 0: r >= x - w (id_pos_le + w >= product); r <= x - w (id_pos_ge + w <= product).
-                PolBuilder pb_idle;
-                pb_idle.add(id_pos_le).add(enc->v3_eq_product_lines.first);
-                (*stg)[0].lines = {pb_idle.emit(*logger, ProofLevel::Top), nullopt};
-                PolBuilder pb_idge;
-                pb_idge.add(id_pos_ge).add(enc->v3_eq_product_lines.second);
-                (*stg)[1].lines = {pb_idge.emit(*logger, ProofLevel::Top), nullopt};
-                // x < 0: r >= x + w (id_neg_ge + w <= product); r <= x + w (id_neg_le + w >= product).
-                PolBuilder pb_idle_n;
-                pb_idle_n.add(id_neg_ge).add(enc->v3_eq_product_lines.second);
-                (*stg)[2].lines = {pb_idle_n.emit(*logger, ProofLevel::Top), nullopt};
-                PolBuilder pb_idge_n;
-                pb_idge_n.add(id_neg_le).add(enc->v3_eq_product_lines.first);
-                (*stg)[3].lines = {pb_idge_n.emit(*logger, ProofLevel::Top), nullopt};
-            });
+            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
         }
 
-        if (! use_cake && ! needs_mult) {
+        if (! plain_operands && ! needs_mult) {
             // one of d * q + r - x = 0 (constant divisor) or c * y + r - x = 0
             // (Divide with a constant quotient)
             if (! ay.var)
@@ -502,7 +530,7 @@ namespace
             else
                 add_equality(WeightedSum{} + aq.offset * y + 1_i * r + -1_i * x, 0_i, "sum");
         }
-        else if (! use_cake) {
+        else if (! plain_operands) {
             auto y_eff = *ay.var;
             if (ay.coeff != 1_i || ay.offset != 0_i) {
                 auto y_plain = initial_state.allocate_integer_variable_with_state(min(ylo, yhi), max(ylo, yhi));
@@ -550,7 +578,7 @@ namespace
         // slot's range suffices: it is baked into the auxiliary's bounds for
         // Divide, and posted on the user's remainder for Modulus. With a
         // variable divisor, split on the divisor's sign.
-        if (! use_cake) {
+        if (! plain_operands) {
             if (! ay.var) {
                 if (! expose_quotient) {
                     add_le(WeightedSum{} + 1_i * r, rmax, "remhi", nullopt);
@@ -604,7 +632,7 @@ namespace
         triggers.on_bounds = watched;
 
         bool prune_zero = ay.var != nullopt;
-        if (use_cake) {
+        if (plain_operands) {
             propagators.install(
                 owner,
                 [enc = cake_encoding, stg = cake_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y, q = q,

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -119,22 +119,21 @@ namespace
 
         // cake_pb_cp's divide encoding: the product |q|*|y| lives only in bit-product
         // flags feeding rem_* rows, with no w or r in the OPB. We take that path for
-        // plain, fully non-negative Divide (x, y, q all >= 0), emitting cake's OPB and
-        // introducing w and r inside the proof; otherwise the legacy two's-complement
-        // path below. The non-negativity is load-bearing in two ways: x >= 0 keeps the
-        // product w = |q||y| = x - r and the remainder r = x - w non-negative (only the
-        // pos rem_* rows and the wlo stage are then active), and requiring q >= 0
-        // alongside x, y >= 0 means every operand sign agrees, so the sign machinery is
-        // never asked to refute a mismatch. Relaxing any of the three -- signed x, a
-        // zero-spanning or negative divisor, or a quotient free to take the opposite
-        // sign -- exercises the product-sign reconciliation inside introduce_bits_of's
-        // w = |q||y| subproof, whose proofgoal reconciles w's sign against cake's
-        // division sgn_* clauses. That RUP is not yet derivable whenever sign(q) can
-        // differ from sign(x)*sign(y) (e.g. an unsatisfiable q<0 under x, y >= 0); GAC
-        // tabulation hides it for tiny domains but it surfaces under BC / large domains.
-        // Fixing that sign proofgoal is the next step for any signed divide.
-        bool use_cake = expose_quotient && optional_model && xlo >= 0_i && ylo >= 0_i && initial_state.lower_bound(out) >= 0_i && ax.coeff == 1_i &&
-            ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var && aout.coeff == 1_i && aout.offset == 0_i;
+        // Divide with a non-negative dividend, emitting cake's OPB and introducing w and
+        // r inside the proof; otherwise the legacy two's-complement path below. The
+        // dividend must be non-negative (x >= 0) so that q*y = x - r >= 0 keeps the
+        // product w = |q||y| and remainder r = x - w non-negative (only the pos rem_*
+        // rows and the wlo stage are active). The divisor y and quotient q may take
+        // either sign: make_mag's sign-atom-gated channel converts each to |q|, |y|, the
+        // remainder-hi stage splits on sign(y), and the five sign clauses pin sign(q).
+        // Because w is the magnitude |q||y| (not the signed product q*y), mult_bc is told
+        // z_is_magnitude so it bounds w by the operand magnitudes -- otherwise an
+        // opposite-sign q, y would make it infer a negative bound on the (non-negative) w
+        // and its RUP justification would be unprovable. Signed x -- where r follows x's
+        // sign, needing the neg rem_* rows and neg identity -- is the remaining step and
+        // stays on the legacy path for now.
+        bool use_cake = expose_quotient && optional_model && xlo >= 0_i && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i &&
+            ay.offset == 0_i && aout.var && aout.coeff == 1_i && aout.offset == 0_i;
 
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
@@ -193,6 +192,9 @@ namespace
             cake_encoding = make_shared<mult_bc::EncodingData>();
             auto & enc = *cake_encoding;
             enc.z_product_ge0_gated = false;
+            // w is the magnitude |q||y| (not the signed product q*y), so mult_bc bounds
+            // it by the operand magnitudes; see EncodingData::z_is_magnitude.
+            enc.z_is_magnitude = true;
 
             // Operand magnitude channels (cake letters: q -> "Z" axis 0, y -> "Y" axis
             // 1), the bit-product flags x[id][i_j][prod], and their sum |q|*|y|.

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -5,9 +5,6 @@
 #include <gcs/constraints/innards/tabulation.hh>
 #include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/linear/hints.hh>
-#include <gcs/constraints/linear/linear_equality.hh>
-#include <gcs/constraints/linear/linear_greater_than_equal.hh>
-#include <gcs/constraints/linear/linear_less_than_equal.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/constraints/multiply/multiply_bc.hh>
@@ -23,8 +20,6 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_condition.hh>
-
-#include <util/overloaded.hh>
 
 #include <algorithm>
 #include <cstddef>
@@ -65,6 +60,81 @@ namespace
         if (x.raw_value == numeric_limits<long long>::min() && y == -1_i)
             return false;
         return x.raw_value / y.raw_value == q.raw_value && x.raw_value % y.raw_value == r.raw_value;
+    }
+
+    // A non-negative magnitude STATE variable equal to |v|, channelled to v by cake's
+    // <letter>ge0/<letter>lt0 channel (four half-reified rows @c[id][<letter>{ge0,lt0}_{ge,le}])
+    // and carrying axis-<axis> free magnitude bits x[id][<axis>_*][bin]. mult_bc multiplies
+    // these magnitudes, so its operands are always non-negative.
+    struct CakeMagnitude
+    {
+        SimpleIntegerVariableID var;
+        ProofLine pos_ge, pos_le, neg_ge, neg_le;
+    };
+
+    auto make_cake_magnitude(ProofModel & model, State & state, const ConstraintID & owner, const std::string & label, StringLiteral op,
+        SimpleIntegerVariableID v, long long axis, const std::string & letter, const std::string & aux_name) -> CakeMagnitude
+    {
+        auto mag_ub = max(abs(state.lower_bound(v)), abs(state.upper_bound(v)));
+        auto bits = 0_i;
+        while (power2(bits) <= mag_ub)
+            bits += 1_i;
+        auto mag = state.allocate_integer_variable_with_state(0_i, power2(bits) - 1_i);
+        model.register_state_variable_bits_in_proof(
+            mag, 0_i, power2(bits) - 1_i, aux_name + to_string(mag.index), CakeBitNaming{owner, {axis}, "bin", nullopt, false, true});
+        auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
+        auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
+        return {mag, model.add_labelled_constraint(label, letter + "ge0_ge", op, "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0),
+            model.add_labelled_constraint(label, letter + "ge0_le", op, "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0),
+            model.add_labelled_constraint(label, letter + "lt0_ge", op, "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0),
+            model.add_labelled_constraint(label, letter + "lt0_le", op, "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0)};
+    }
+
+    // The bit-product flags x[id][i_j][prod] = mag_a_i AND mag_b_j and their weighted sum
+    // mag_a * mag_b, appended to enc.initial_bit_products; w_hi is the product's declared max.
+    struct CakeBitProducts
+    {
+        WPBSum product_sum, neg_product;
+        Integer w_hi;
+    };
+
+    auto emit_cake_bit_products(ProofModel & model, const ConstraintID & owner, const std::string & label, SimpleIntegerVariableID mag_a,
+        SimpleIntegerVariableID mag_b, mult_bc::EncodingData & enc) -> CakeBitProducts
+    {
+        auto n1 = model.names_and_ids_tracker().num_bits(mag_a);
+        auto n2 = model.names_and_ids_tracker().num_bits(mag_b);
+        auto product_sum = WPBSum{};
+        for (Integer i = 0_i; i < n1; ++i) {
+            enc.initial_bit_products.emplace_back();
+            for (Integer j = 0_i; j < n2; ++j) {
+                auto flag = model.create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
+                    WPBSum{} + 1_i * ProofBitVariable{mag_a, i, true} + 1_i * ProofBitVariable{mag_b, j, true} >= 2_i);
+                auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
+                enc.initial_bit_products[i.as_index()].emplace_back(
+                    mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
+                product_sum += power2(i + j) * flag;
+            }
+        }
+        auto neg_product = WPBSum{};
+        for (const auto & t : product_sum.terms)
+            neg_product += -t.coefficient * t.variable;
+        return {product_sum, neg_product, (power2(n1) - 1_i) * (power2(n2) - 1_i)};
+    }
+
+    // The four stages pinning mag = |v| in both directions off its cake channel, split on
+    // sign(v). pos_threshold gates the non-negative half: 0 when v may be zero (the quotient),
+    // 1 when v is known non-zero (the divisor).
+    auto append_magnitude_stages(std::vector<LinearStage> & stages, SimpleIntegerVariableID mag, SimpleIntegerVariableID v,
+        const CakeMagnitude & chan, Integer pos_threshold) -> void
+    {
+        auto [t_le, m_le] = tidy_up_linear(WeightedSum{} + 1_i * mag + -1_i * v);
+        stages.emplace_back(LinearStage{t_le, 0_i + m_le, false, {chan.pos_ge, nullopt}, optional{v >= pos_threshold}});
+        auto [t_ge, m_ge] = tidy_up_linear(WeightedSum{} + -1_i * mag + 1_i * v);
+        stages.emplace_back(LinearStage{t_ge, 0_i + m_ge, false, {chan.pos_le, nullopt}, optional{v >= pos_threshold}});
+        auto [t_nle, m_nle] = tidy_up_linear(WeightedSum{} + 1_i * mag + 1_i * v);
+        stages.emplace_back(LinearStage{t_nle, 0_i + m_nle, false, {chan.neg_le, nullopt}, optional{v < 0_i}});
+        auto [t_nge, m_nge] = tidy_up_linear(WeightedSum{} + -1_i * mag + -1_i * v);
+        stages.emplace_back(LinearStage{t_nge, 0_i + m_nge, false, {chan.neg_ge, nullopt}, optional{v < 0_i}});
     }
 
     // The shared decomposition: x = q * y + r, |r| < |y|, sign(r) = sign(x)
@@ -119,74 +189,54 @@ namespace
 
         // cake_pb_cp's divide/modulus encoding: the product |q|*|y| lives only in
         // bit-product flags feeding the remainder/identity rows, with no w (and, for
-        // divide, no r) in the OPB. We take that path for plain operands with a
-        // non-negative dividend, emitting cake's OPB and introducing the internal
-        // handles inside the proof; otherwise the legacy two's-complement path below.
+        // divide, no r) in the OPB. We take that path for plain operands, emitting cake's
+        // OPB and introducing the internal handles inside the proof; otherwise the legacy
+        // two's-complement path below. Both directions multiply the two NON-NEGATIVE
+        // magnitudes |q| and |y| into w = |q||y| (mult_bc with no signed reasoning), split
+        // the identity/remainder on sign(x), and recover signed values in the tabulation --
+        // a single magnitude machinery covering every sign of both operands.
         //
-        // Divide (use_cake_divide): x >= 0 keeps w = |q||y| and r = x - w non-negative
-        // (only the pos rem_* rows and the wlo stage are active). The divisor y and
-        // quotient q may take either sign: make_mag's sign-atom-gated channel converts
-        // each to |q|, |y|, the remainder-hi stage splits on sign(y), and the five sign
-        // clauses pin sign(q). Because w is the magnitude |q||y| (not the signed product
-        // q*y), mult_bc is told z_is_magnitude so it bounds w by the operand magnitudes.
+        // Divide (use_cake_divide): the exposed slot is q. magq = |q| (a state var
+        // channelled to q by cake's Zge0/Zlt0 channel) and absy = |y| (channelled by
+        // Yge0/Ylt0) are the mult operands; cake's rem_* rows range 0 <= x - w < |y| over
+        // w and x directly (rem_pos gated [x>=0], rem_neg gated [x<0]), so no remainder is
+        // materialised at all. The magnitude product carries no mult_bc sign_lines, so the
+        // exposed quotient's sign is pinned off the five sgn_* clauses by RUP in the
+        // propagator. The tabulation enumerates only x, y, q; a rejected leaf pins
+        // magq/absy/w by unit propagation from the assigned q, y and the rem rows refute it.
         //
-        // Modulus (use_cake_modulus): the exposed slot is r, and cake leaves the
-        // quotient's magnitude a FREE axis-0 bit-sum with no i[Q] channel. cake splits the
-        // identity on sign(x): r = x - |q||y| for x >= 0, r = x + |q||y| for x < 0, so
-        // |q||y| is a non-negative magnitude for every sign of BOTH operands. The aux is
-        // the quotient magnitude |q|; the divisor magnitude |y| is a second aux "absy"
-        // pinned to |y| by cake's Yge0/Ylt0 channel, and mult_bc multiplies the two
-        // non-negative magnitudes |q| * |y| = w with no signed reasoning (crucially, x is
-        // NOT a mult operand, so x's sign is irrelevant to mult_bc). The identity/range/
-        // sign stages split on sign(x); the tabulation recovers sign(x)sign(y)|q|. Every
-        // plain-operand modulus takes this path.
+        // Modulus (use_cake_modulus): the exposed slot is r, and cake leaves the quotient's
+        // magnitude a FREE axis-0 bit-sum with no i[Q] channel (no Zge0/Zlt0, no sgn_*). The
+        // aux is the quotient magnitude |q|; absy = |y| is the second mult operand. cake
+        // splits the identity r = x -/+ |q||y| on sign(x), the range/sign rows bound r, and
+        // the tabulation recovers the signed quotient sign(x)sign(y)|q|.
         bool plain_operands = optional_model && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var &&
             aout.coeff == 1_i && aout.offset == 0_i;
-        bool use_cake_divide = expose_quotient && plain_operands && xlo >= 0_i;
-        bool use_cake_divide_neg = expose_quotient && plain_operands && xhi < 0_i;
-        bool use_cake_divide_span = expose_quotient && plain_operands && xlo < 0_i && xhi > 0_i;
+        bool use_cake_divide = expose_quotient && plain_operands;
         bool use_cake_modulus = (! expose_quotient) && plain_operands;
-        bool use_cake = use_cake_divide || use_cake_divide_neg || use_cake_divide_span || use_cake_modulus;
+        bool use_cake = use_cake_divide || use_cake_modulus;
 
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
         IntegerVariableID q = 0_c, r = 0_c;
         SimpleIntegerVariableID aux = SimpleIntegerVariableID{0};
-        if (expose_quotient && use_cake_divide_span) {
+        if (expose_quotient && use_cake_divide) {
             q = out;
-            // The spanning-x cake path materialises no remainder (neither in the OPB nor in the
-            // proof); the aux is an inert state slot, never introduced, enumerated, or watched
-            // meaningfully. The rem_* rows range x - w directly.
+            // The cake divide path materialises no remainder (neither in the OPB nor in the
+            // proof): cake's rem_* rows range x - w directly, so the aux is an inert state
+            // slot, never introduced, enumerated, or meaningfully watched.
             aux = initial_state.allocate_integer_variable_with_state(0_i, 0_i);
             r = aux;
         }
-        else if (expose_quotient && use_cake_divide_neg) {
-            q = out;
-            // The dividend is strictly negative, so the remainder r <= 0; the aux is its
-            // MAGNITUDE |r| = |x| - w = -x - w (>= 0), introduced in-proof from -x - w. That
-            // form reaches |x|, so |r|'s bits span [0, max|x|]; the rem_neg rows still pin r
-            // to (-|y|, 0]. The tabulation recovers the signed r = -|r|.
-            auto r_hi_cake = max(rmax, mx);
-            aux = initial_state.allocate_integer_variable_with_state(0_i, r_hi_cake);
-            if (optional_model)
-                optional_model->register_state_variable_bits_in_proof(aux, 0_i, r_hi_cake, "aux_divide_remainder" + to_string(aux.index));
-            r = aux;
-        }
         else if (expose_quotient) {
+            // Legacy divide (views / constant operands): the remainder is a signed auxiliary
+            // in the OPB, pinned by the w + r = x identity.
             q = out;
             auto r_lo = xlo >= 0_i ? 0_i : -rmax;
             auto r_hi = xhi <= 0_i ? 0_i : rmax;
-            // The cake path introduces r = x - w in-proof; the form x - w reaches xhi, so
-            // r's bits must span [0, xhi] for introduce_bits_of's upper proofgoal. Widen
-            // BOTH the solver state and the proof registration to keep the GAC tabulation
-            // (which enumerates the solver range) consistent with the proof bits; the
-            // rem_* rows still pin r to [0, |y|-1].
-            auto r_hi_cake = max(r_hi, xhi);
-            aux = initial_state.allocate_integer_variable_with_state(r_lo, use_cake ? r_hi_cake : r_hi);
-            if (optional_model && ! use_cake)
+            aux = initial_state.allocate_integer_variable_with_state(r_lo, r_hi);
+            if (optional_model)
                 optional_model->set_up_integer_variable(aux, r_lo, r_hi, "aux_divide_remainder" + to_string(aux.index), nullopt);
-            else if (optional_model)
-                optional_model->register_state_variable_bits_in_proof(aux, r_lo, r_hi_cake, "aux_divide_remainder" + to_string(aux.index));
             r = aux;
         }
         else if (use_cake) {
@@ -239,322 +289,7 @@ namespace
         shared_ptr<vector<LinearStage>> cake_stages;
 
         if (use_cake_divide) {
-            auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
-
-            cake_encoding = make_shared<mult_bc::EncodingData>();
-            auto & enc = *cake_encoding;
-            enc.z_product_ge0_gated = false;
-            // w is the magnitude |q||y| (not the signed product q*y), so mult_bc bounds
-            // it by the operand magnitudes; see EncodingData::z_is_magnitude.
-            enc.z_is_magnitude = true;
-
-            // Operand magnitude channels (cake letters: q -> "Z" axis 0, y -> "Y" axis
-            // 1), the bit-product flags x[id][i_j][prod], and their sum |q|*|y|.
-            auto product_sum = WPBSum{};
-            auto make_mag = [&](SimpleIntegerVariableID v, long long axis, const string & letter) -> ProofOnlySimpleIntegerVariableID {
-                auto mag_ub = max(abs(initial_state.lower_bound(v)), abs(initial_state.upper_bound(v)));
-                auto mag = optional_model->create_proof_only_integer_variable(0_i, mag_ub, "div_mag_" + letter,
-                    IntegerVariableProofRepresentation::Bits, CakeBitNaming{owner, {axis}, "bin", nullopt, false, true});
-                auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
-                auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
-                auto pos_ge = optional_model->add_labelled_constraint(
-                    label, letter + "ge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0);
-                auto pos_le = optional_model->add_labelled_constraint(
-                    label, letter + "ge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0);
-                auto neg_ge = optional_model->add_labelled_constraint(
-                    label, letter + "lt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0);
-                auto neg_le = optional_model->add_labelled_constraint(
-                    label, letter + "lt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0);
-                enc.channelling_constraints.insert(
-                    {v, mult_bc::ChannellingData{pos_ge, pos_le, neg_ge, neg_le, true, initial_state.lower_bound(v) < 0_i}});
-                enc.mag_var.insert({v, mag});
-                return mag;
-            };
-            auto mag_z = make_mag(q_eff, 0, "Z");
-            auto mag_y = make_mag(y_eff, 1, "Y");
-            auto n1 = optional_model->names_and_ids_tracker().num_bits(mag_z);
-            auto n2 = optional_model->names_and_ids_tracker().num_bits(mag_y);
-            for (Integer i = 0_i; i < n1; ++i) {
-                enc.initial_bit_products.emplace_back();
-                for (Integer j = 0_i; j < n2; ++j) {
-                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
-                        WPBSum{} + 1_i * ProofBitVariable{mag_z, i, true} + 1_i * ProofBitVariable{mag_y, j, true} >= 2_i);
-                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
-                    enc.initial_bit_products[i.as_index()].emplace_back(
-                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
-                    product_sum += power2(i + j) * flag;
-                }
-            }
-            auto neg_product = WPBSum{};
-            for (const auto & t : product_sum.terms)
-                neg_product += -t.coefficient * t.variable;
-
-            // w = |q||y|: a state variable driving mult_bc::propagate, ranged to hold
-            // the full bit-product sum (the magnitude bits can exceed the operands'
-            // actual maxima, so this is >= q_hi*y_hi). Its bits are introduced in-proof.
-            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
-            auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
-            mult_q = q_eff, mult_y = y_eff, mult_w = w;
-
-            // rem_* : 0 <= x - |q||y| < |y|, split on sign(x). Only the pos rows are
-            // active for non-negative x; |y| is the y magnitude variable mag_y.
-            auto xge0 = HalfReifyOnConjunctionOf{x >= 0_i};
-            auto xlt0 = HalfReifyOnConjunctionOf{x < 1_i};
-            auto rem_pos_lo =
-                optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
-            auto rem_pos_hi = optional_model->add_labelled_constraint(
-                label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * mag_y >= 1_i, xge0);
-            optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
-            optional_model->add_labelled_constraint(label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * mag_y >= 1_i, xlt0);
-
-            // Sign clauses (cake's division orientation over the atoms of x, y, q).
-            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
-                label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i));
-            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
-                label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i));
-            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
-                label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i));
-            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
-                label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i));
-            enc.sign_lines.emplace_back(
-                optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i));
-            optional_model->add_labelled_constraint(
-                label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
-
-            // w = |q||y| is a state variable (drives mult_bc::propagate) whose bits are
-            // introduced inside the proof, so nothing about it is asserted in the OPB.
-            // r is eliminated: cake's rem_* express 0 <= x - w < y directly over w, so r
-            // needs no proof presence (it stays an inert state auxiliary here).
-            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
-            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
-
-            // Stages over w (0 <= x - w < |y|): wlo (w <= x) gated [x>=0]; and the
-            // remainder-hi (x - w <= |y| - 1) split on sign(y) so each stage carries a
-            // single gate -- x-w-y<=-1 gated [y>=1] (|y|=y), x-w+y<=-1 gated [y<0]
-            // (|y|=-y). The stage lines keep rem_*'s [x>=0] gate and the channel's [y
-            // sign] gate; propagate_linear's ThenRUP discharges [x>=0] by unit
-            // propagation (x's domain lb >= 0) and the [y sign] from the stage gate.
-            cake_stages = make_shared<vector<LinearStage>>();
-            auto [t_wlo, m_wlo] = tidy_up_linear(WeightedSum{} + 1_i * w + -1_i * x);
-            cake_stages->emplace_back(LinearStage{t_wlo, 0_i + m_wlo, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
-            auto [t_whip, m_whip] = tidy_up_linear(WeightedSum{} + 1_i * x + -1_i * w + -1_i * y);
-            cake_stages->emplace_back(LinearStage{t_whip, -1_i + m_whip, false, {nullopt, nullopt}, optional{y >= 1_i}});
-            auto [t_whin, m_whin] = tidy_up_linear(WeightedSum{} + 1_i * x + -1_i * w + 1_i * y);
-            cake_stages->emplace_back(LinearStage{t_whin, -1_i + m_whin, false, {nullopt, nullopt}, optional{y < 0_i}});
-
-            auto y_ge0_ge = enc.channelling_constraints.at(y_eff).pos_ge; // y - mag_y >= 0 gated [y>=0]
-            auto y_lt0_le = enc.channelling_constraints.at(y_eff).neg_le; // -y - mag_y >= 0 gated [y<0]
-            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, w_hi, r = aux, x_eff, rem_pos_lo, rem_pos_hi,
-                                                y_ge0_ge, y_lt0_le](State &, auto &, ProofLogger * const logger) -> void {
-                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                    return;
-                // w = |q||y|, introduced as a conservative extension.
-                // v3_eq_product_lines = {w >= product, w <= product}.
-                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
-                // Ungated x - w >= 0 in the DB, so introduce_bits_of(x-w, r) below can
-                // auto-prove r's non-negativity: rem_pos_lo (x - product >= 0, gated
-                // [x>=0], big-M w_hi) + (product >= w) + w_hi*[x>=0] discharges the gate.
-                auto x_ge0 = logger->emit_rup_proof_line(WPBSum{} + 1_i * (x_eff >= 0_i) >= 1_i, ProofLevel::Top);
-                PolBuilder pb_xw;
-                pb_xw.add(rem_pos_lo).add(enc->v3_eq_product_lines.second).add(x_ge0, w_hi);
-                pb_xw.emit(*logger, ProofLevel::Top);
-                // r = x - w, introduced so the tabulation's determined r unit-propagates.
-                logger->introduce_bits_of(WPBSum{} + 1_i * x_eff + -1_i * w, r, ProofLevel::Top);
-                // wlo, [x>=0]-gated (w <= x): rem_pos_lo (x - product >= 0) + (w <= product).
-                PolBuilder pb_wlo;
-                pb_wlo.add(rem_pos_lo).add(enc->v3_eq_product_lines.second);
-                (*stg)[0].lines = {pb_wlo.emit(*logger, ProofLevel::Top), nullopt};
-                // whi_ypos (x - w - y <= -1, |y|=y): rem_pos_hi (product - x + |y| >= 1)
-                // + (w >= product) + Yge0_ge (y - |y| >= 0). |y| = mag_y cancels; the
-                // channel's [y>=0] gate rides along and the stage gates on [y>=1].
-                PolBuilder pb_whip;
-                pb_whip.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_ge0_ge);
-                (*stg)[1].lines = {pb_whip.emit(*logger, ProofLevel::Top), nullopt};
-                // whi_yneg (x - w + y <= -1, |y|=-y): rem_pos_hi + (w >= product)
-                // + Ylt0_le (-y - |y| >= 0). Stage gates on [y<0].
-                PolBuilder pb_whin;
-                pb_whin.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_lt0_le);
-                (*stg)[2].lines = {pb_whin.emit(*logger, ProofLevel::Top), nullopt};
-            });
-        }
-        else if (use_cake_divide_neg) {
-            // Divide with a strictly negative dividend (x < 0). cake's divide OPB is
-            // sign-agnostic -- the rows are identical to the x >= 0 path (the Z/Y magnitude
-            // channels, bit products, both rem_pos and rem_neg, the five sign clauses) -- so
-            // only the propagation differs. Both mult operands are the non-negative
-            // magnitudes magq = |q| (channelled to the exposed quotient) and absy = |y|
-            // (channelled to the divisor), so mult_bc divides w = |q||y| by the non-negative
-            // absy; dividing by the signed divisor was the x < 0 blocker in filter_quotient.
-            // The magnitude product carries no sign_lines, so the exposed quotient's sign is
-            // pinned directly from the sgn_* clauses (below, in the propagator). cake
-            // eliminates the remainder (the rem_neg rows range x - w over w and x directly);
-            // the aux |r| = -x - w is introduced in-proof only for the tabulation.
-            auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
-
-            cake_encoding = make_shared<mult_bc::EncodingData>();
-            auto & enc = *cake_encoding;
-            enc.z_product_ge0_gated = false;
-            enc.z_is_magnitude = false; // magq, absy >= 0, so w = magq * absy is a plain product
-
-            // magq = |q|: a non-negative magnitude STATE variable (mult_bc's operand must be
-            // a real variable), axis-0 free magnitude bits x[id][0_*][bin], channelled to the
-            // exposed quotient q by cake's Zge0/Zlt0 channel and propagated by the magq stages.
-            auto mag_q_ub = max(abs(initial_state.lower_bound(q_eff)), abs(initial_state.upper_bound(q_eff)));
-            auto magq_bits = 0_i;
-            while (power2(magq_bits) <= mag_q_ub)
-                magq_bits += 1_i;
-            auto magq_bit_max = power2(magq_bits) - 1_i;
-            auto magq = initial_state.allocate_integer_variable_with_state(0_i, magq_bit_max);
-            optional_model->register_state_variable_bits_in_proof(
-                magq, 0_i, magq_bit_max, "aux_divide_qmag" + to_string(magq.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
-
-            auto q_ge0 = HalfReifyOnConjunctionOf{q_eff >= 0_i};
-            auto q_lt0 = HalfReifyOnConjunctionOf{q_eff < 0_i};
-            auto q_pos_ge = optional_model->add_labelled_constraint(
-                label, "Zge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + -1_i * magq >= 0_i, q_ge0);
-            auto q_pos_le = optional_model->add_labelled_constraint(
-                label, "Zge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + 1_i * magq >= 0_i, q_ge0);
-            auto q_neg_ge = optional_model->add_labelled_constraint(
-                label, "Zlt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + 1_i * magq >= 0_i, q_lt0);
-            auto q_neg_le = optional_model->add_labelled_constraint(
-                label, "Zlt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + -1_i * magq >= 0_i, q_lt0);
-
-            // absy = |y|: the same non-negative magnitude STATE variable as modulus, axis-1
-            // free magnitude bits x[id][1_*][bin], pinned to |y| by cake's Yge0/Ylt0 channel.
-            auto absy_bits = 0_i;
-            while (power2(absy_bits) <= may)
-                absy_bits += 1_i;
-            auto absy_bit_max = power2(absy_bits) - 1_i;
-            auto absy = initial_state.allocate_integer_variable_with_state(0_i, absy_bit_max);
-            optional_model->register_state_variable_bits_in_proof(
-                absy, 0_i, absy_bit_max, "aux_divide_absdivisor" + to_string(absy.index), CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
-
-            auto y_ge0 = HalfReifyOnConjunctionOf{y_eff >= 0_i};
-            auto y_lt0 = HalfReifyOnConjunctionOf{y_eff < 0_i};
-            auto y_pos_ge = optional_model->add_labelled_constraint(
-                label, "Yge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * absy >= 0_i, y_ge0);
-            auto y_pos_le = optional_model->add_labelled_constraint(
-                label, "Yge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * absy >= 0_i, y_ge0);
-            auto y_neg_ge = optional_model->add_labelled_constraint(
-                label, "Ylt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * absy >= 0_i, y_lt0);
-            auto y_neg_le = optional_model->add_labelled_constraint(
-                label, "Ylt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * absy >= 0_i, y_lt0);
-
-            // Bit-product flags x[id][i_j][prod] = |q|_i ^ |y|_j and their weighted sum
-            // |q|*|y|, over the two magnitudes' own free bits (no channel needed).
-            auto n1 = optional_model->names_and_ids_tracker().num_bits(magq);
-            auto n2 = optional_model->names_and_ids_tracker().num_bits(absy);
-            auto product_sum = WPBSum{};
-            for (Integer i = 0_i; i < n1; ++i) {
-                enc.initial_bit_products.emplace_back();
-                for (Integer j = 0_i; j < n2; ++j) {
-                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
-                        WPBSum{} + 1_i * ProofBitVariable{magq, i, true} + 1_i * ProofBitVariable{absy, j, true} >= 2_i);
-                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
-                    enc.initial_bit_products[i.as_index()].emplace_back(
-                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
-                    product_sum += power2(i + j) * flag;
-                }
-            }
-            auto neg_product = WPBSum{};
-            for (const auto & t : product_sum.terms)
-                neg_product += -t.coefficient * t.variable;
-
-            // rem_* : 0 <= x - |q||y| < |y|, split on sign(x). For x < 0 only the neg rows
-            // are active; both signs are emitted to match cake's sign-agnostic OPB.
-            auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
-            auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
-            optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
-            optional_model->add_labelled_constraint(label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xge0);
-            auto rem_neg_hi =
-                optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
-            auto rem_neg_lo = optional_model->add_labelled_constraint(
-                label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xlt0);
-
-            // Sign clauses (cake's division orientation over the atoms of x, y, q). Unlike the
-            // x >= 0 path these are NOT mult_bc sign_lines (the magnitude product has none);
-            // the propagator pins sign(q) off them directly by RUP.
-            optional_model->add_labelled_constraint(
-                label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i);
-            optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i);
-            optional_model->add_labelled_constraint(
-                label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
-
-            // w = |q||y|: state variable driving mult_bc, ranged to hold the full bit-product
-            // sum; its bits are introduced in-proof.
-            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
-            auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
-            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
-            mult_q = magq, mult_y = absy, mult_w = w;
-            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
-
-            // Stages: magq = |q| and absy = |y| off their sign-split channels (cite the OPB
-            // row directly); the w bounds off the rem_neg rows (0 <= -x - w < |y|, i.e.
-            // w <= -x and -x - w < absy), whose lines fuse rem_neg with w = product in the
-            // initialiser. Indices 0-3 = magq, 4-7 = absy, 8 = wlo, 9/10 = whi (y sign split).
-            cake_stages = make_shared<vector<LinearStage>>();
-            auto [t_zle, m_zle] = tidy_up_linear(WeightedSum{} + 1_i * magq + -1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_zle, 0_i + m_zle, false, {q_pos_ge, nullopt}, optional{q_eff >= 0_i}});
-            auto [t_zge, m_zge] = tidy_up_linear(WeightedSum{} + -1_i * magq + 1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_zge, 0_i + m_zge, false, {q_pos_le, nullopt}, optional{q_eff >= 0_i}});
-            auto [t_znle, m_znle] = tidy_up_linear(WeightedSum{} + 1_i * magq + 1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_znle, 0_i + m_znle, false, {q_neg_le, nullopt}, optional{q_eff < 0_i}});
-            auto [t_znge, m_znge] = tidy_up_linear(WeightedSum{} + -1_i * magq + -1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_znge, 0_i + m_znge, false, {q_neg_ge, nullopt}, optional{q_eff < 0_i}});
-            auto [t_ale, m_ale] = tidy_up_linear(WeightedSum{} + 1_i * absy + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_ale, 0_i + m_ale, false, {y_pos_ge, nullopt}, optional{y_eff >= 1_i}});
-            auto [t_age, m_age] = tidy_up_linear(WeightedSum{} + -1_i * absy + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_age, 0_i + m_age, false, {y_pos_le, nullopt}, optional{y_eff >= 1_i}});
-            auto [t_anle, m_anle] = tidy_up_linear(WeightedSum{} + 1_i * absy + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_anle, 0_i + m_anle, false, {y_neg_le, nullopt}, optional{y_eff < 0_i}});
-            auto [t_ange, m_ange] = tidy_up_linear(WeightedSum{} + -1_i * absy + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_ange, 0_i + m_ange, false, {y_neg_ge, nullopt}, optional{y_eff < 0_i}});
-            auto [t_wlo, m_wlo] = tidy_up_linear(WeightedSum{} + 1_i * w + 1_i * x_eff);
-            cake_stages->emplace_back(LinearStage{t_wlo, 0_i + m_wlo, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
-            auto [t_whip, m_whip] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_whip, -1_i + m_whip, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
-            auto [t_whin, m_whin] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_whin, -1_i + m_whin, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
-
-            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, w_hi, r = aux, x_eff, rem_neg_hi, rem_neg_lo,
-                                                y_pos_ge, y_neg_le](State &, auto &, ProofLogger * const logger) -> void {
-                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                    return;
-                // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
-                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
-                // Ungated -x - w >= 0 so introduce_bits_of(-x - w, |r|) below can auto-prove
-                // |r| >= 0: rem_neg_hi (-product - x >= 0, gated [x<1], big-M) + (product >= w)
-                // + big-M*[x<1] discharges the gate.
-                auto x_lt0 = logger->emit_rup_proof_line(WPBSum{} + 1_i * (x_eff < 1_i) >= 1_i, ProofLevel::Top);
-                PolBuilder pb_xw;
-                pb_xw.add(rem_neg_hi).add(enc->v3_eq_product_lines.second).add(x_lt0, w_hi);
-                pb_xw.emit(*logger, ProofLevel::Top);
-                // |r| = -x - w, introduced so the tabulation's determined |r| unit-propagates.
-                logger->introduce_bits_of(WPBSum{} + -1_i * x_eff + -1_i * w, r, ProofLevel::Top);
-                // wlo (w <= -x): rem_neg_hi (-product - x >= 0) + (w <= product).
-                PolBuilder pb_wlo;
-                pb_wlo.add(rem_neg_hi).add(enc->v3_eq_product_lines.second);
-                (*stg)[8].lines = {pb_wlo.emit(*logger, ProofLevel::Top), nullopt};
-                // whi_ypos (-x - w - y <= -1, |y|=y): rem_neg_lo (product + x + |y| >= 1)
-                // + (w >= product) + Yge0_ge (y - |y| >= 0).
-                PolBuilder pb_whip;
-                pb_whip.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
-                (*stg)[9].lines = {pb_whip.emit(*logger, ProofLevel::Top), nullopt};
-                // whi_yneg (-x - w + y <= -1, |y|=-y): rem_neg_lo + (w >= product) + Ylt0_le.
-                PolBuilder pb_whin;
-                pb_whin.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_neg_le);
-                (*stg)[10].lines = {pb_whin.emit(*logger, ProofLevel::Top), nullopt};
-            });
-        }
-        else if (use_cake_divide_span) {
-            // Divide with a dividend spanning zero (xlo < 0 < xhi). Same cake OPB and magnitude
-            // machinery as the fixed-sign paths, but BOTH the x >= 0 and x < 0 remainder rows
+            // Divide, any sign of the dividend. BOTH the x >= 0 and x < 0 remainder rows
             // and w-stages are live, each gated on sign(x) so only the matching regime fires
             // once x is branched. The quotient's sign is pinned off the sgn_* clauses (for
             // whichever signs of x and y are established). No remainder is materialised: cake's
@@ -567,65 +302,12 @@ namespace
             enc.z_product_ge0_gated = false;
             enc.z_is_magnitude = false; // magq, absy >= 0, so w = magq * absy is a plain product
 
-            // magq = |q|, channelled to the exposed quotient by cake's Zge0/Zlt0 channel.
-            auto mag_q_ub = max(abs(initial_state.lower_bound(q_eff)), abs(initial_state.upper_bound(q_eff)));
-            auto magq_bits = 0_i;
-            while (power2(magq_bits) <= mag_q_ub)
-                magq_bits += 1_i;
-            auto magq_bit_max = power2(magq_bits) - 1_i;
-            auto magq = initial_state.allocate_integer_variable_with_state(0_i, magq_bit_max);
-            optional_model->register_state_variable_bits_in_proof(
-                magq, 0_i, magq_bit_max, "aux_divide_qmag" + to_string(magq.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
-
-            auto q_ge0 = HalfReifyOnConjunctionOf{q_eff >= 0_i};
-            auto q_lt0 = HalfReifyOnConjunctionOf{q_eff < 0_i};
-            auto q_pos_ge = optional_model->add_labelled_constraint(
-                label, "Zge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + -1_i * magq >= 0_i, q_ge0);
-            auto q_pos_le = optional_model->add_labelled_constraint(
-                label, "Zge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + 1_i * magq >= 0_i, q_ge0);
-            auto q_neg_ge = optional_model->add_labelled_constraint(
-                label, "Zlt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + 1_i * magq >= 0_i, q_lt0);
-            auto q_neg_le = optional_model->add_labelled_constraint(
-                label, "Zlt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + -1_i * magq >= 0_i, q_lt0);
-
-            // absy = |y|, channelled to the divisor by cake's Yge0/Ylt0 channel.
-            auto absy_bits = 0_i;
-            while (power2(absy_bits) <= may)
-                absy_bits += 1_i;
-            auto absy_bit_max = power2(absy_bits) - 1_i;
-            auto absy = initial_state.allocate_integer_variable_with_state(0_i, absy_bit_max);
-            optional_model->register_state_variable_bits_in_proof(
-                absy, 0_i, absy_bit_max, "aux_divide_absdivisor" + to_string(absy.index), CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
-
-            auto y_ge0 = HalfReifyOnConjunctionOf{y_eff >= 0_i};
-            auto y_lt0 = HalfReifyOnConjunctionOf{y_eff < 0_i};
-            auto y_pos_ge = optional_model->add_labelled_constraint(
-                label, "Yge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * absy >= 0_i, y_ge0);
-            auto y_pos_le = optional_model->add_labelled_constraint(
-                label, "Yge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * absy >= 0_i, y_ge0);
-            auto y_neg_ge = optional_model->add_labelled_constraint(
-                label, "Ylt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * absy >= 0_i, y_lt0);
-            auto y_neg_le = optional_model->add_labelled_constraint(
-                label, "Ylt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * absy >= 0_i, y_lt0);
-
-            // Bit-product flags and their weighted sum |q| * |y|.
-            auto n1 = optional_model->names_and_ids_tracker().num_bits(magq);
-            auto n2 = optional_model->names_and_ids_tracker().num_bits(absy);
-            auto product_sum = WPBSum{};
-            for (Integer i = 0_i; i < n1; ++i) {
-                enc.initial_bit_products.emplace_back();
-                for (Integer j = 0_i; j < n2; ++j) {
-                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
-                        WPBSum{} + 1_i * ProofBitVariable{magq, i, true} + 1_i * ProofBitVariable{absy, j, true} >= 2_i);
-                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
-                    enc.initial_bit_products[i.as_index()].emplace_back(
-                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
-                    product_sum += power2(i + j) * flag;
-                }
-            }
-            auto neg_product = WPBSum{};
-            for (const auto & t : product_sum.terms)
-                neg_product += -t.coefficient * t.variable;
+            // magq = |q| (Z channel to the exposed quotient) and absy = |y| (Y channel to the
+            // divisor) are the two non-negative mult_bc operands; w = magq * absy.
+            auto zchan = make_cake_magnitude(*optional_model, initial_state, owner, label, "Divide", q_eff, 0, "Z", "aux_divide_qmag");
+            auto ychan = make_cake_magnitude(*optional_model, initial_state, owner, label, "Divide", y_eff, 1, "Y", "aux_divide_absdivisor");
+            auto magq = zchan.var, absy = ychan.var;
+            auto [product_sum, neg_product, w_hi] = emit_cake_bit_products(*optional_model, owner, label, magq, absy, enc);
 
             // Both remainder-row sets: 0 <= x - |q||y| < |y| (rem_pos, gated [x>=0]) and
             // 0 <= -x - |q||y| < |y| (rem_neg, gated [x<1]).
@@ -652,7 +334,6 @@ namespace
             optional_model->add_labelled_constraint(
                 label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
 
-            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
             auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
             optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
             mult_q = magq, mult_y = absy, mult_w = w;
@@ -662,22 +343,8 @@ namespace
             // 9/10 = whi split on sign(y)) and the x < 0 w-stages (11 = wlo, 12/13 = whi). The
             // w-stage lines fuse the rem row with w = product in the initialiser.
             cake_stages = make_shared<vector<LinearStage>>();
-            auto [t_zle, m_zle] = tidy_up_linear(WeightedSum{} + 1_i * magq + -1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_zle, 0_i + m_zle, false, {q_pos_ge, nullopt}, optional{q_eff >= 0_i}});
-            auto [t_zge, m_zge] = tidy_up_linear(WeightedSum{} + -1_i * magq + 1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_zge, 0_i + m_zge, false, {q_pos_le, nullopt}, optional{q_eff >= 0_i}});
-            auto [t_znle, m_znle] = tidy_up_linear(WeightedSum{} + 1_i * magq + 1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_znle, 0_i + m_znle, false, {q_neg_le, nullopt}, optional{q_eff < 0_i}});
-            auto [t_znge, m_znge] = tidy_up_linear(WeightedSum{} + -1_i * magq + -1_i * q_eff);
-            cake_stages->emplace_back(LinearStage{t_znge, 0_i + m_znge, false, {q_neg_ge, nullopt}, optional{q_eff < 0_i}});
-            auto [t_ale, m_ale] = tidy_up_linear(WeightedSum{} + 1_i * absy + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_ale, 0_i + m_ale, false, {y_pos_ge, nullopt}, optional{y_eff >= 1_i}});
-            auto [t_age, m_age] = tidy_up_linear(WeightedSum{} + -1_i * absy + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_age, 0_i + m_age, false, {y_pos_le, nullopt}, optional{y_eff >= 1_i}});
-            auto [t_anle, m_anle] = tidy_up_linear(WeightedSum{} + 1_i * absy + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_anle, 0_i + m_anle, false, {y_neg_le, nullopt}, optional{y_eff < 0_i}});
-            auto [t_ange, m_ange] = tidy_up_linear(WeightedSum{} + -1_i * absy + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_ange, 0_i + m_ange, false, {y_neg_ge, nullopt}, optional{y_eff < 0_i}});
+            append_magnitude_stages(*cake_stages, magq, q_eff, zchan, 0_i);
+            append_magnitude_stages(*cake_stages, absy, y_eff, ychan, 1_i);
             auto [t_wlo_p, m_wlo_p] = tidy_up_linear(WeightedSum{} + 1_i * w + -1_i * x_eff);
             cake_stages->emplace_back(LinearStage{t_wlo_p, 0_i + m_wlo_p, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
             auto [t_whip_p, m_whip_p] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * y_eff);
@@ -691,42 +358,44 @@ namespace
             auto [t_whin_n, m_whin_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * y_eff);
             cake_stages->emplace_back(LinearStage{t_whin_n, -1_i + m_whin_n, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
 
-            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, rem_pos_lo, rem_pos_hi, rem_neg_hi, rem_neg_lo,
-                                                y_pos_ge, y_neg_le](State &, auto &, ProofLogger * const logger) -> void {
-                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                    return;
-                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
-                // x >= 0 w-stages.
-                PolBuilder pb_wlo_p;
-                pb_wlo_p.add(rem_pos_lo).add(enc->v3_eq_product_lines.second);
-                (*stg)[8].lines = {pb_wlo_p.emit(*logger, ProofLevel::Top), nullopt};
-                PolBuilder pb_whip_p;
-                pb_whip_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
-                (*stg)[9].lines = {pb_whip_p.emit(*logger, ProofLevel::Top), nullopt};
-                PolBuilder pb_whin_p;
-                pb_whin_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_neg_le);
-                (*stg)[10].lines = {pb_whin_p.emit(*logger, ProofLevel::Top), nullopt};
-                // x < 0 w-stages.
-                PolBuilder pb_wlo_n;
-                pb_wlo_n.add(rem_neg_hi).add(enc->v3_eq_product_lines.second);
-                (*stg)[11].lines = {pb_wlo_n.emit(*logger, ProofLevel::Top), nullopt};
-                PolBuilder pb_whip_n;
-                pb_whip_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
-                (*stg)[12].lines = {pb_whip_n.emit(*logger, ProofLevel::Top), nullopt};
-                PolBuilder pb_whin_n;
-                pb_whin_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_neg_le);
-                (*stg)[13].lines = {pb_whin_n.emit(*logger, ProofLevel::Top), nullopt};
-            });
+            propagators.install_initialiser(
+                [enc = cake_encoding, stg = cake_stages, product_sum, w, rem_pos_lo, rem_pos_hi, rem_neg_hi, rem_neg_lo, y_pos_ge = ychan.pos_ge,
+                    y_neg_le = ychan.neg_le](State &, auto &, ProofLogger * const logger) -> void {
+                    if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                        return;
+                    enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                    // x >= 0 w-stages.
+                    PolBuilder pb_wlo_p;
+                    pb_wlo_p.add(rem_pos_lo).add(enc->v3_eq_product_lines.second);
+                    (*stg)[8].lines = {pb_wlo_p.emit(*logger, ProofLevel::Top), nullopt};
+                    PolBuilder pb_whip_p;
+                    pb_whip_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
+                    (*stg)[9].lines = {pb_whip_p.emit(*logger, ProofLevel::Top), nullopt};
+                    PolBuilder pb_whin_p;
+                    pb_whin_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_neg_le);
+                    (*stg)[10].lines = {pb_whin_p.emit(*logger, ProofLevel::Top), nullopt};
+                    // x < 0 w-stages.
+                    PolBuilder pb_wlo_n;
+                    pb_wlo_n.add(rem_neg_hi).add(enc->v3_eq_product_lines.second);
+                    (*stg)[11].lines = {pb_wlo_n.emit(*logger, ProofLevel::Top), nullopt};
+                    PolBuilder pb_whip_n;
+                    pb_whip_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
+                    (*stg)[12].lines = {pb_whip_n.emit(*logger, ProofLevel::Top), nullopt};
+                    PolBuilder pb_whin_n;
+                    pb_whin_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_neg_le);
+                    (*stg)[13].lines = {pb_whin_n.emit(*logger, ProofLevel::Top), nullopt};
+                });
         }
         else if (use_cake) {
             // Modulus's cake path: the exposed slot is r; the quotient magnitude |q| (the
             // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, axis-1 free
-            // magnitude, pinned to |y| by cake's Yge0/Ylt0 channel) multiply to w = |q||y|,
-            // so r = x - w off cake's id_pos rows and 0 <= r < |y| = absy off rng_hi. Both
-            // mult operands are non-negative, so mult_bc needs no signed reasoning and its
-            // quotient filtering divides w by the non-negative absy (dividing by the signed
-            // y would infer a wrong-signed |q|). id_neg_*/rng_lo/sgn_neg are cake's inert
-            // mirror for x < 0, emitted only to match cake's OPB.
+            // magnitude, pinned to |y| by cake's Yge0/Ylt0 channel) multiply to w = |q||y|.
+            // The identity splits on sign(x): r = x - w off id_pos_* (gated [x>=0]) and
+            // r = x + w off id_neg_* (gated [x<0], since q*y = -w for x < 0); the range/sign
+            // rows bound 0 <= r < |y| = absy (x>=0) or -|y| < r <= 0 (x<0). Both mult operands
+            // are non-negative, so mult_bc needs no signed reasoning and its quotient filtering
+            // divides w by the non-negative absy (dividing by the signed y would infer a
+            // wrong-signed |q|). Every plain-operand modulus, any sign of x and y, takes this.
             //
             // r and the operands are the plain underlying *aout.var / *a*.var, not view
             // wrappers: the identity stage propagates the exposed r off the wide product w,
@@ -738,47 +407,12 @@ namespace
             enc.z_product_ge0_gated = false;
             enc.z_is_magnitude = false; // |q|, absy >= 0, so w = |q| * absy is a plain product
 
-            // absy = |y|: a non-negative magnitude STATE variable (mult_bc's divisor operand
-            // must be a real variable), axis-1 free magnitude bits x[id][1_*][bin], pinned to
-            // |y| by cake's Yge0/Ylt0 channel (below) and propagated by the absy stages.
-            auto absy_bits = 0_i;
-            while (power2(absy_bits) <= may)
-                absy_bits += 1_i;
-            auto absy_bit_max = power2(absy_bits) - 1_i;
-            auto absy = initial_state.allocate_integer_variable_with_state(0_i, absy_bit_max);
-            optional_model->register_state_variable_bits_in_proof(
-                absy, 0_i, absy_bit_max, "aux_modulus_absdivisor" + to_string(absy.index), CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
-
-            auto y_ge0 = HalfReifyOnConjunctionOf{y_eff >= 0_i};
-            auto y_lt0 = HalfReifyOnConjunctionOf{y_eff < 0_i};
-            auto y_pos_ge = optional_model->add_labelled_constraint(
-                label, "Yge0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * absy >= 0_i, y_ge0);
-            auto y_pos_le = optional_model->add_labelled_constraint(
-                label, "Yge0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * absy >= 0_i, y_ge0);
-            auto y_neg_ge = optional_model->add_labelled_constraint(
-                label, "Ylt0_ge", "Modulus", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * absy >= 0_i, y_lt0);
-            auto y_neg_le = optional_model->add_labelled_constraint(
-                label, "Ylt0_le", "Modulus", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * absy >= 0_i, y_lt0);
-
-            // Bit-product flags x[id][i_j][prod] = |q|_i ^ |y|_j and their weighted sum
-            // |q|*|y|, over the two magnitudes' own free bits (no channel needed).
-            auto n1 = optional_model->names_and_ids_tracker().num_bits(q_eff);
-            auto n2 = optional_model->names_and_ids_tracker().num_bits(absy);
-            auto product_sum = WPBSum{};
-            for (Integer i = 0_i; i < n1; ++i) {
-                enc.initial_bit_products.emplace_back();
-                for (Integer j = 0_i; j < n2; ++j) {
-                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
-                        WPBSum{} + 1_i * ProofBitVariable{q_eff, i, true} + 1_i * ProofBitVariable{absy, j, true} >= 2_i);
-                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
-                    enc.initial_bit_products[i.as_index()].emplace_back(
-                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
-                    product_sum += power2(i + j) * flag;
-                }
-            }
-            auto neg_product = WPBSum{};
-            for (const auto & t : product_sum.terms)
-                neg_product += -t.coefficient * t.variable;
+            // absy = |y| (Y channel to the divisor) is mult_bc's divisor operand; the quotient
+            // magnitude q_eff is the free axis-0 aux (no Z channel -- cake leaves it free), so
+            // w = q_eff * absy over their own bits.
+            auto ychan = make_cake_magnitude(*optional_model, initial_state, owner, label, "Modulus", y_eff, 1, "Y", "aux_modulus_absdivisor");
+            auto absy = ychan.var;
+            auto [product_sum, neg_product, w_hi] = emit_cake_bit_products(*optional_model, owner, label, q_eff, absy, enc);
 
             optional_model->add_labelled_constraint(
                 label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
@@ -806,7 +440,6 @@ namespace
 
             // w = |q||y| is the product state variable driving mult_bc; its bits are
             // introduced in the proof.
-            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
             auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
             optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_modulus_product" + to_string(w.index));
             mult_q = q_eff, mult_y = absy, mult_w = w;
@@ -837,15 +470,8 @@ namespace
             cake_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {sgn_pos, nullopt}, optional{x_eff >= 0_i}});
             auto [t_shi, m_shi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff);
             cake_stages->emplace_back(LinearStage{t_shi, 0_i + m_shi, false, {sgn_neg, nullopt}, optional{x_eff < 1_i}});
-            // absy = |y|, split on sign(y): each line is the matching Y channel row directly.
-            auto [t_ale, m_ale] = tidy_up_linear(WeightedSum{} + 1_i * absy + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_ale, 0_i + m_ale, false, {y_pos_ge, nullopt}, optional{y_eff >= 1_i}});
-            auto [t_age, m_age] = tidy_up_linear(WeightedSum{} + -1_i * absy + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_age, 0_i + m_age, false, {y_pos_le, nullopt}, optional{y_eff >= 1_i}});
-            auto [t_anle, m_anle] = tidy_up_linear(WeightedSum{} + 1_i * absy + 1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_anle, 0_i + m_anle, false, {y_neg_le, nullopt}, optional{y_eff < 0_i}});
-            auto [t_ange, m_ange] = tidy_up_linear(WeightedSum{} + -1_i * absy + -1_i * y_eff);
-            cake_stages->emplace_back(LinearStage{t_ange, 0_i + m_ange, false, {y_neg_ge, nullopt}, optional{y_eff < 0_i}});
+            // absy = |y| off the Y channel, split on sign(y).
+            append_magnitude_stages(*cake_stages, absy, y_eff, ychan, 1_i);
 
             propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le, id_neg_ge, id_neg_le](
                                                 State &, auto &, ProofLogger * const logger) -> void {
@@ -984,7 +610,7 @@ namespace
             propagators.install(
                 owner,
                 [enc = cake_encoding, stg = cake_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y, q = q,
-                    x = x, pin_q_sign = use_cake_divide_neg || use_cake_divide_span,
+                    x = x, pin_q_sign = use_cake_divide,
                     owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     do {
                         if (state.in_domain(y, 0_i))
@@ -1053,11 +679,11 @@ namespace
         auto px = ax.var ? optional{enum_vars.position_of(*ax.var)} : nullopt;
         auto py = ay.var ? optional{enum_vars.position_of(*ay.var)} : nullopt;
         auto pout = aout.var ? optional{enum_vars.position_of(*aout.var)} : nullopt;
-        // The spanning-dividend cake path materialises no remainder in the proof (cake's rem_*
-        // rows range x - w directly, and a rejected (x, y, q) leaf pins magq/absy/w by unit
-        // propagation from the assigned q, y so the rem rows refute a wrong remainder), so it
-        // enumerates only x, y and q, with no remainder aux and no determined slots.
-        bool no_rem_aux = use_cake_divide_span;
+        // The cake divide path materialises no remainder in the proof (cake's rem_* rows range
+        // x - w directly, and a rejected (x, y, q) leaf pins magq/absy/w by unit propagation
+        // from the assigned q, y so the rem rows refute a wrong remainder), so it enumerates
+        // only x, y and q, with no remainder aux and no determined slots.
+        bool no_rem_aux = use_cake_divide;
         std::size_t paux = 0;
         if (! no_rem_aux)
             paux = enum_vars.position_of(aux);
@@ -1079,18 +705,16 @@ namespace
         auto recover_q = [aux_is_magnitude](Integer auxv, Integer xv, Integer yv) -> Integer {
             return (aux_is_magnitude && ((xv >= 0_i) != (yv >= 0_i))) ? -auxv : auxv;
         };
-        // The x < 0 divide path stores the remainder MAGNITUDE |r| in the aux (introduce_bits_of
-        // needs a non-negative target); the signed remainder is r = -|r| (r <= 0 for x < 0).
-        bool divide_r_is_magnitude = use_cake_divide_neg;
 
         vector<DeterminedVariable> determined;
+        // Only the legacy divide path reaches here with a materialised remainder aux (the cake
+        // path sets no_rem_aux); there the aux is the signed remainder r = x - q * y.
         if (expose_quotient && ! no_rem_aux)
-            determined.push_back({aux, [ax, ay, aout, px, py, pout, divide_r_is_magnitude](const vector<Integer> & vals) -> optional<Integer> {
+            determined.push_back({aux, [ax, ay, aout, px, py, pout](const vector<Integer> & vals) -> optional<Integer> {
                                       auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                                       auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                                       auto qv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                                      auto rv = xv - qv * yv;
-                                      return divide_r_is_magnitude ? (rv < 0_i ? -rv : rv) : rv;
+                                      return xv - qv * yv;
                                   }});
         else if (! expose_quotient && pout && pout != px && pout != py)
             determined.push_back({*aout.var, [ax, ay, aout, px, py, paux, recover_q](const vector<Integer> & vals) -> optional<Integer> {
@@ -1108,14 +732,13 @@ namespace
         Integer x_sign = xhi <= 0_i ? -1_i : 1_i;
         if (px && px != py && px != pout && ! no_rem_aux && (! aux_is_magnitude || x_fixed_sign))
             determined.push_back({*ax.var,
-                [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude, divide_r_is_magnitude, x_sign](
-                    const vector<Integer> & vals) -> optional<Integer> {
+                [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude, x_sign](const vector<Integer> & vals) -> optional<Integer> {
                     auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                     auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
                     auto auxv = vals[paux];
-                    // The remainder is the aux for Divide (|r| = -auxv on the x < 0 path) and
-                    // the exposed slot for Modulus; x = q * y + r.
-                    auto rv = expose_quotient ? (divide_r_is_magnitude ? -auxv : auxv) : outv;
+                    // The remainder is the aux for (legacy) Divide and the exposed slot for
+                    // Modulus; x = q * y + r.
+                    auto rv = expose_quotient ? auxv : outv;
                     auto want = aux_is_magnitude ? x_sign * auxv * (yv < 0_i ? -yv : yv) + outv : (expose_quotient ? outv : auxv) * yv + rv;
                     if ((want - ax.offset) % ax.coeff != 0_i)
                         return nullopt;
@@ -1123,19 +746,18 @@ namespace
                 }});
 
         if (want_tabulation(level, enum_vars.vars(), determined, initial_state)) {
-            auto accept = [ax, ay, aout, px, py, pout, paux, no_rem_aux, expose_quotient, divide_r_is_magnitude, recover_q](
-                              const vector<Integer> & vals) -> bool {
+            auto accept = [ax, ay, aout, px, py, pout, paux, no_rem_aux, expose_quotient, recover_q](const vector<Integer> & vals) -> bool {
                 auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                 auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                 auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                // The spanning-x path enumerates no remainder aux: q is the exposed slot and
-                // the remainder is derived. Elsewhere the aux is the remainder (Divide, |r| =
-                // -auxv on the x < 0 path) or the quotient magnitude (Modulus).
+                // The cake divide path enumerates no remainder aux: q is the exposed slot and
+                // the remainder is derived. Elsewhere the aux is the remainder (legacy Divide)
+                // or the quotient magnitude (Modulus).
                 if (no_rem_aux)
                     return is_in_relation(xv, yv, outv, xv - outv * yv);
                 auto auxv = vals[paux];
                 auto qv = expose_quotient ? outv : recover_q(auxv, xv, yv);
-                auto rv = expose_quotient ? (divide_r_is_magnitude ? -auxv : auxv) : outv;
+                auto rv = expose_quotient ? auxv : outv;
                 return is_in_relation(xv, yv, qv, rv);
             };
 

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -131,19 +131,19 @@ namespace
         // q*y), mult_bc is told z_is_magnitude so it bounds w by the operand magnitudes.
         //
         // Modulus (use_cake_modulus): the exposed slot is r, and cake leaves the
-        // quotient's magnitude a FREE axis-0 bit-sum with no i[Q] channel. cake always
-        // splits the identity on sign(x): r = x - |q||y| for x >= 0, so |q||y| is a
-        // non-negative magnitude for every sign of y. We restrict to x >= 0 (r is then
-        // non-negative), but allow any-sign divisor: the aux is the quotient magnitude
-        // |q|, the divisor magnitude |y| is a second aux "absy" pinned to |y| by cake's
-        // Yge0/Ylt0 channel, and mult_bc multiplies the two non-negative magnitudes
-        // |q| * |y| = w with no signed reasoning (its quotient filtering divides w by the
-        // non-negative absy, not the signed y). The tabulation recovers sign(x)sign(y)|q|.
-        // Signed dividends (x < 0) stay on the legacy path for now.
+        // quotient's magnitude a FREE axis-0 bit-sum with no i[Q] channel. cake splits the
+        // identity on sign(x): r = x - |q||y| for x >= 0, r = x + |q||y| for x < 0, so
+        // |q||y| is a non-negative magnitude for every sign of BOTH operands. The aux is
+        // the quotient magnitude |q|; the divisor magnitude |y| is a second aux "absy"
+        // pinned to |y| by cake's Yge0/Ylt0 channel, and mult_bc multiplies the two
+        // non-negative magnitudes |q| * |y| = w with no signed reasoning (crucially, x is
+        // NOT a mult operand, so x's sign is irrelevant to mult_bc). The identity/range/
+        // sign stages split on sign(x); the tabulation recovers sign(x)sign(y)|q|. Every
+        // plain-operand modulus takes this path.
         bool plain_operands = optional_model && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var &&
             aout.coeff == 1_i && aout.offset == 0_i;
         bool use_cake_divide = expose_quotient && plain_operands && xlo >= 0_i;
-        bool use_cake_modulus = (! expose_quotient) && plain_operands && xlo >= 0_i;
+        bool use_cake_modulus = (! expose_quotient) && plain_operands;
         bool use_cake = use_cake_divide || use_cake_modulus;
 
         // The exposed slot is the user's; the other is an auxiliary, with
@@ -420,23 +420,26 @@ namespace
             optional_model->add_labelled_constraint(
                 label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
 
-            // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0]) active, id_neg_* the
-            // inert x < 0 mirror.
+            // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0], r = x - w) and
+            // id_neg_* (gated [x<0], r = x + w -- since for x < 0 the quotient product q*y
+            // has sign(x), i.e. q*y = -w).
             auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
             auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
             auto id_pos_ge = optional_model->add_labelled_constraint(
                 label, "id_pos_ge", "Modulus", "identity", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xge0);
             auto id_pos_le = optional_model->add_labelled_constraint(
                 label, "id_pos_le", "Modulus", "identity", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xge0);
-            optional_model->add_labelled_constraint(label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xlt0);
-            optional_model->add_labelled_constraint(label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xlt0);
+            auto id_neg_ge = optional_model->add_labelled_constraint(
+                label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xlt0);
+            auto id_neg_le = optional_model->add_labelled_constraint(
+                label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xlt0);
 
-            // 0 <= r < |y| = absy: rng_hi (r < absy, active), rng_lo (r > -absy, inert), and
-            // the r-sign rows (r takes x's sign; sgn_pos active, sgn_neg inert here).
+            // |r| < |y| = absy: rng_hi (r < absy) and rng_lo (r > -absy), plus the r-sign
+            // rows (r takes x's sign; sgn_pos gated [x>=0], sgn_neg gated [x<0]).
             auto rng_hi = optional_model->add_labelled_constraint(label, "rng_hi", "Modulus", "range", WPBSum{} + -1_i * r_eff + 1_i * absy >= 1_i);
-            optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
+            auto rng_lo = optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
             auto sgn_pos = optional_model->add_labelled_constraint(label, "sgn_pos", "Modulus", "sign", WPBSum{} + 1_i * r_eff >= 0_i, xge0);
-            optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xlt0);
+            auto sgn_neg = optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xlt0);
 
             // w = |q||y| is the product state variable driving mult_bc; its bits are
             // introduced in the proof.
@@ -446,20 +449,31 @@ namespace
             mult_q = q_eff, mult_y = absy, mult_w = w;
             bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
 
-            // Stages: the identity r = x - w (two [x>=0]-gated inequalities off id_pos_*,
-            // lines filled in the initialiser once w = product is introduced); the range
-            // r < absy (off rng_hi, ungated -- absy already carries |y|); r >= 0 (off
-            // sgn_pos, gated [x>=0]); and absy = |y| off the Yge0/Ylt0 channel, split on
-            // sign(y). Only idle/idge need the initialiser; the rest cite an OPB row directly.
+            // Stages. The identity, split on sign(x): r = x - w gated [x>=0] (idle/idge off
+            // id_pos_*) and r = x + w gated [x<0] (idle_neg/idge_neg off id_neg_*), lines
+            // filled in the initialiser once w = product is introduced. The range 0 <= r <
+            // absy (x>=0) / -absy < r <= 0 (x<0): rng_hi (r < absy) and rng_lo (r > -absy),
+            // both ungated (valid for either sign), plus the r-sign stages sgn_pos (r >= 0
+            // gated [x>=0]) / sgn_neg (r <= 0 gated [x<0]). And absy = |y| off the Yge0/Ylt0
+            // channel, split on sign(y). Only the identity stages need the initialiser; the
+            // rest cite an OPB row directly.
             cake_stages = make_shared<vector<LinearStage>>();
             auto [t_idle, m_idle] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * r_eff);
             cake_stages->emplace_back(LinearStage{t_idle, 0_i + m_idle, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
             auto [t_idge, m_idge] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + 1_i * w + 1_i * r_eff);
             cake_stages->emplace_back(LinearStage{t_idge, 0_i + m_idge, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            auto [t_idle_n, m_idle_n] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + 1_i * w + -1_i * r_eff);
+            cake_stages->emplace_back(LinearStage{t_idle_n, 0_i + m_idle_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
+            auto [t_idge_n, m_idge_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * r_eff);
+            cake_stages->emplace_back(LinearStage{t_idge_n, 0_i + m_idge_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
             auto [t_rhi, m_rhi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff + -1_i * absy);
             cake_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {rng_hi, nullopt}, nullopt});
+            auto [t_rlo, m_rlo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff + -1_i * absy);
+            cake_stages->emplace_back(LinearStage{t_rlo, -1_i + m_rlo, false, {rng_lo, nullopt}, nullopt});
             auto [t_slo, m_slo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff);
             cake_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {sgn_pos, nullopt}, optional{x_eff >= 0_i}});
+            auto [t_shi, m_shi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff);
+            cake_stages->emplace_back(LinearStage{t_shi, 0_i + m_shi, false, {sgn_neg, nullopt}, optional{x_eff < 1_i}});
             // absy = |y|, split on sign(y): each line is the matching Y channel row directly.
             auto [t_ale, m_ale] = tidy_up_linear(WeightedSum{} + 1_i * absy + -1_i * y_eff);
             cake_stages->emplace_back(LinearStage{t_ale, 0_i + m_ale, false, {y_pos_ge, nullopt}, optional{y_eff >= 1_i}});
@@ -470,23 +484,27 @@ namespace
             auto [t_ange, m_ange] = tidy_up_linear(WeightedSum{} + -1_i * absy + -1_i * y_eff);
             cake_stages->emplace_back(LinearStage{t_ange, 0_i + m_ange, false, {y_neg_ge, nullopt}, optional{y_eff < 0_i}});
 
-            propagators.install_initialiser(
-                [enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le](State &, auto &, ProofLogger * const logger) -> void {
-                    if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
-                        return;
-                    // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
-                    enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
-                    // identity r >= x - w (x - w - r <= 0): id_pos_le (r - x + product >= 0)
-                    // + (w >= product). The [x>=0] gate rides along, discharged by x's domain.
-                    PolBuilder pb_idle;
-                    pb_idle.add(id_pos_le).add(enc->v3_eq_product_lines.first);
-                    (*stg)[0].lines = {pb_idle.emit(*logger, ProofLevel::Top), nullopt};
-                    // identity r <= x - w (w + r - x <= 0): id_pos_ge (x - product - r >= 0)
-                    // + (w <= product).
-                    PolBuilder pb_idge;
-                    pb_idge.add(id_pos_ge).add(enc->v3_eq_product_lines.second);
-                    (*stg)[1].lines = {pb_idge.emit(*logger, ProofLevel::Top), nullopt};
-                });
+            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, id_pos_ge, id_pos_le, id_neg_ge, id_neg_le](
+                                                State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                    return;
+                // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
+                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                // x >= 0: r >= x - w (id_pos_le + w >= product); r <= x - w (id_pos_ge + w <= product).
+                PolBuilder pb_idle;
+                pb_idle.add(id_pos_le).add(enc->v3_eq_product_lines.first);
+                (*stg)[0].lines = {pb_idle.emit(*logger, ProofLevel::Top), nullopt};
+                PolBuilder pb_idge;
+                pb_idge.add(id_pos_ge).add(enc->v3_eq_product_lines.second);
+                (*stg)[1].lines = {pb_idge.emit(*logger, ProofLevel::Top), nullopt};
+                // x < 0: r >= x + w (id_neg_ge + w <= product); r <= x + w (id_neg_le + w >= product).
+                PolBuilder pb_idle_n;
+                pb_idle_n.add(id_neg_ge).add(enc->v3_eq_product_lines.second);
+                (*stg)[2].lines = {pb_idle_n.emit(*logger, ProofLevel::Top), nullopt};
+                PolBuilder pb_idge_n;
+                pb_idge_n.add(id_neg_le).add(enc->v3_eq_product_lines.first);
+                (*stg)[3].lines = {pb_idge_n.emit(*logger, ProofLevel::Top), nullopt};
+            });
         }
 
         if (! use_cake && ! needs_mult) {
@@ -684,21 +702,23 @@ namespace
                                           return nullopt;
                                       return (want - aout.offset) / aout.coeff;
                                   }});
-        if (px && px != py && px != pout)
-            determined.push_back(
-                {*ax.var, [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude](const vector<Integer> & vals) -> optional<Integer> {
-                     auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
-                     auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                     auto auxv = vals[paux];
-                     // x = q*y + r. On the magnitude path x >= 0 and the quotient's
-                     // sign follows y, so q*y = |q||y|, giving x = |q||y| + r; else
-                     // the aux is the signed quotient directly.
-                     auto want = aux_is_magnitude ? auxv * (yv < 0_i ? -yv : yv) + outv
-                                                  : (expose_quotient ? outv : auxv) * yv + (expose_quotient ? auxv : outv);
-                     if ((want - ax.offset) % ax.coeff != 0_i)
-                         return nullopt;
-                     return (want - ax.offset) / ax.coeff;
-                 }});
+        // On the magnitude path x is a function of the others only when it has a fixed sign
+        // (for x spanning zero, r = 0 leaves x = +/-|q||y| ambiguous). Its sign then fixes
+        // the product's sign: x = sign(x)|q||y| + r.
+        bool x_fixed_sign = xlo >= 0_i || xhi <= 0_i;
+        Integer x_sign = xhi <= 0_i ? -1_i : 1_i;
+        if (px && px != py && px != pout && (! aux_is_magnitude || x_fixed_sign))
+            determined.push_back({*ax.var,
+                [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude, x_sign](const vector<Integer> & vals) -> optional<Integer> {
+                    auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
+                    auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
+                    auto auxv = vals[paux];
+                    auto want = aux_is_magnitude ? x_sign * auxv * (yv < 0_i ? -yv : yv) + outv
+                                                 : (expose_quotient ? outv : auxv) * yv + (expose_quotient ? auxv : outv);
+                    if ((want - ax.offset) % ax.coeff != 0_i)
+                        return nullopt;
+                    return (want - ax.offset) / ax.coeff;
+                }});
 
         if (want_tabulation(level, enum_vars.vars(), determined, initial_state)) {
             auto accept = [ax, ay, aout, px, py, pout, paux, expose_quotient, recover_q](const vector<Integer> & vals) -> bool {

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -144,14 +144,23 @@ namespace
             aout.coeff == 1_i && aout.offset == 0_i;
         bool use_cake_divide = expose_quotient && plain_operands && xlo >= 0_i;
         bool use_cake_divide_neg = expose_quotient && plain_operands && xhi < 0_i;
+        bool use_cake_divide_span = expose_quotient && plain_operands && xlo < 0_i && xhi > 0_i;
         bool use_cake_modulus = (! expose_quotient) && plain_operands;
-        bool use_cake = use_cake_divide || use_cake_divide_neg || use_cake_modulus;
+        bool use_cake = use_cake_divide || use_cake_divide_neg || use_cake_divide_span || use_cake_modulus;
 
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
         IntegerVariableID q = 0_c, r = 0_c;
         SimpleIntegerVariableID aux = SimpleIntegerVariableID{0};
-        if (expose_quotient && use_cake_divide_neg) {
+        if (expose_quotient && use_cake_divide_span) {
+            q = out;
+            // The spanning-x cake path materialises no remainder (neither in the OPB nor in the
+            // proof); the aux is an inert state slot, never introduced, enumerated, or watched
+            // meaningfully. The rem_* rows range x - w directly.
+            aux = initial_state.allocate_integer_variable_with_state(0_i, 0_i);
+            r = aux;
+        }
+        else if (expose_quotient && use_cake_divide_neg) {
             q = out;
             // The dividend is strictly negative, so the remainder r <= 0; the aux is its
             // MAGNITUDE |r| = |x| - w = -x - w (>= 0), introduced in-proof from -x - w. That
@@ -543,6 +552,172 @@ namespace
                 (*stg)[10].lines = {pb_whin.emit(*logger, ProofLevel::Top), nullopt};
             });
         }
+        else if (use_cake_divide_span) {
+            // Divide with a dividend spanning zero (xlo < 0 < xhi). Same cake OPB and magnitude
+            // machinery as the fixed-sign paths, but BOTH the x >= 0 and x < 0 remainder rows
+            // and w-stages are live, each gated on sign(x) so only the matching regime fires
+            // once x is branched. The quotient's sign is pinned off the sgn_* clauses (for
+            // whichever signs of x and y are established). No remainder is materialised: cake's
+            // rem_* rows range x - w directly, so there is no |r| aux to introduce (which would
+            // need a proof-only |x|); the tabulation enumerates only x, y, q.
+            auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
+
+            cake_encoding = make_shared<mult_bc::EncodingData>();
+            auto & enc = *cake_encoding;
+            enc.z_product_ge0_gated = false;
+            enc.z_is_magnitude = false; // magq, absy >= 0, so w = magq * absy is a plain product
+
+            // magq = |q|, channelled to the exposed quotient by cake's Zge0/Zlt0 channel.
+            auto mag_q_ub = max(abs(initial_state.lower_bound(q_eff)), abs(initial_state.upper_bound(q_eff)));
+            auto magq_bits = 0_i;
+            while (power2(magq_bits) <= mag_q_ub)
+                magq_bits += 1_i;
+            auto magq_bit_max = power2(magq_bits) - 1_i;
+            auto magq = initial_state.allocate_integer_variable_with_state(0_i, magq_bit_max);
+            optional_model->register_state_variable_bits_in_proof(
+                magq, 0_i, magq_bit_max, "aux_divide_qmag" + to_string(magq.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
+
+            auto q_ge0 = HalfReifyOnConjunctionOf{q_eff >= 0_i};
+            auto q_lt0 = HalfReifyOnConjunctionOf{q_eff < 0_i};
+            auto q_pos_ge = optional_model->add_labelled_constraint(
+                label, "Zge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + -1_i * magq >= 0_i, q_ge0);
+            auto q_pos_le = optional_model->add_labelled_constraint(
+                label, "Zge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + 1_i * magq >= 0_i, q_ge0);
+            auto q_neg_ge = optional_model->add_labelled_constraint(
+                label, "Zlt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + 1_i * magq >= 0_i, q_lt0);
+            auto q_neg_le = optional_model->add_labelled_constraint(
+                label, "Zlt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + -1_i * magq >= 0_i, q_lt0);
+
+            // absy = |y|, channelled to the divisor by cake's Yge0/Ylt0 channel.
+            auto absy_bits = 0_i;
+            while (power2(absy_bits) <= may)
+                absy_bits += 1_i;
+            auto absy_bit_max = power2(absy_bits) - 1_i;
+            auto absy = initial_state.allocate_integer_variable_with_state(0_i, absy_bit_max);
+            optional_model->register_state_variable_bits_in_proof(
+                absy, 0_i, absy_bit_max, "aux_divide_absdivisor" + to_string(absy.index), CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
+
+            auto y_ge0 = HalfReifyOnConjunctionOf{y_eff >= 0_i};
+            auto y_lt0 = HalfReifyOnConjunctionOf{y_eff < 0_i};
+            auto y_pos_ge = optional_model->add_labelled_constraint(
+                label, "Yge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * absy >= 0_i, y_ge0);
+            auto y_pos_le = optional_model->add_labelled_constraint(
+                label, "Yge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * absy >= 0_i, y_ge0);
+            auto y_neg_ge = optional_model->add_labelled_constraint(
+                label, "Ylt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * absy >= 0_i, y_lt0);
+            auto y_neg_le = optional_model->add_labelled_constraint(
+                label, "Ylt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * absy >= 0_i, y_lt0);
+
+            // Bit-product flags and their weighted sum |q| * |y|.
+            auto n1 = optional_model->names_and_ids_tracker().num_bits(magq);
+            auto n2 = optional_model->names_and_ids_tracker().num_bits(absy);
+            auto product_sum = WPBSum{};
+            for (Integer i = 0_i; i < n1; ++i) {
+                enc.initial_bit_products.emplace_back();
+                for (Integer j = 0_i; j < n2; ++j) {
+                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
+                        WPBSum{} + 1_i * ProofBitVariable{magq, i, true} + 1_i * ProofBitVariable{absy, j, true} >= 2_i);
+                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
+                    enc.initial_bit_products[i.as_index()].emplace_back(
+                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
+                    product_sum += power2(i + j) * flag;
+                }
+            }
+            auto neg_product = WPBSum{};
+            for (const auto & t : product_sum.terms)
+                neg_product += -t.coefficient * t.variable;
+
+            // Both remainder-row sets: 0 <= x - |q||y| < |y| (rem_pos, gated [x>=0]) and
+            // 0 <= -x - |q||y| < |y| (rem_neg, gated [x<1]).
+            auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
+            auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
+            auto rem_pos_lo =
+                optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
+            auto rem_pos_hi = optional_model->add_labelled_constraint(
+                label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xge0);
+            auto rem_neg_hi =
+                optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
+            auto rem_neg_lo = optional_model->add_labelled_constraint(
+                label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xlt0);
+
+            optional_model->add_labelled_constraint(
+                label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i);
+            optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+
+            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
+            auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
+            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
+            mult_q = magq, mult_y = absy, mult_w = w;
+            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
+
+            // Stages: magq (0-3) and absy (4-7) channels, then the x >= 0 w-stages (8 = wlo,
+            // 9/10 = whi split on sign(y)) and the x < 0 w-stages (11 = wlo, 12/13 = whi). The
+            // w-stage lines fuse the rem row with w = product in the initialiser.
+            cake_stages = make_shared<vector<LinearStage>>();
+            auto [t_zle, m_zle] = tidy_up_linear(WeightedSum{} + 1_i * magq + -1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_zle, 0_i + m_zle, false, {q_pos_ge, nullopt}, optional{q_eff >= 0_i}});
+            auto [t_zge, m_zge] = tidy_up_linear(WeightedSum{} + -1_i * magq + 1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_zge, 0_i + m_zge, false, {q_pos_le, nullopt}, optional{q_eff >= 0_i}});
+            auto [t_znle, m_znle] = tidy_up_linear(WeightedSum{} + 1_i * magq + 1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_znle, 0_i + m_znle, false, {q_neg_le, nullopt}, optional{q_eff < 0_i}});
+            auto [t_znge, m_znge] = tidy_up_linear(WeightedSum{} + -1_i * magq + -1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_znge, 0_i + m_znge, false, {q_neg_ge, nullopt}, optional{q_eff < 0_i}});
+            auto [t_ale, m_ale] = tidy_up_linear(WeightedSum{} + 1_i * absy + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_ale, 0_i + m_ale, false, {y_pos_ge, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_age, m_age] = tidy_up_linear(WeightedSum{} + -1_i * absy + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_age, 0_i + m_age, false, {y_pos_le, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_anle, m_anle] = tidy_up_linear(WeightedSum{} + 1_i * absy + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_anle, 0_i + m_anle, false, {y_neg_le, nullopt}, optional{y_eff < 0_i}});
+            auto [t_ange, m_ange] = tidy_up_linear(WeightedSum{} + -1_i * absy + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_ange, 0_i + m_ange, false, {y_neg_ge, nullopt}, optional{y_eff < 0_i}});
+            auto [t_wlo_p, m_wlo_p] = tidy_up_linear(WeightedSum{} + 1_i * w + -1_i * x_eff);
+            cake_stages->emplace_back(LinearStage{t_wlo_p, 0_i + m_wlo_p, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            auto [t_whip_p, m_whip_p] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_whip_p, -1_i + m_whip_p, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_whin_p, m_whin_p] = tidy_up_linear(WeightedSum{} + 1_i * x_eff + -1_i * w + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_whin_p, -1_i + m_whin_p, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
+            auto [t_wlo_n, m_wlo_n] = tidy_up_linear(WeightedSum{} + 1_i * w + 1_i * x_eff);
+            cake_stages->emplace_back(LinearStage{t_wlo_n, 0_i + m_wlo_n, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
+            auto [t_whip_n, m_whip_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_whip_n, -1_i + m_whip_n, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_whin_n, m_whin_n] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_whin_n, -1_i + m_whin_n, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
+
+            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, rem_pos_lo, rem_pos_hi, rem_neg_hi, rem_neg_lo,
+                                                y_pos_ge, y_neg_le](State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                    return;
+                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                // x >= 0 w-stages.
+                PolBuilder pb_wlo_p;
+                pb_wlo_p.add(rem_pos_lo).add(enc->v3_eq_product_lines.second);
+                (*stg)[8].lines = {pb_wlo_p.emit(*logger, ProofLevel::Top), nullopt};
+                PolBuilder pb_whip_p;
+                pb_whip_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
+                (*stg)[9].lines = {pb_whip_p.emit(*logger, ProofLevel::Top), nullopt};
+                PolBuilder pb_whin_p;
+                pb_whin_p.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_neg_le);
+                (*stg)[10].lines = {pb_whin_p.emit(*logger, ProofLevel::Top), nullopt};
+                // x < 0 w-stages.
+                PolBuilder pb_wlo_n;
+                pb_wlo_n.add(rem_neg_hi).add(enc->v3_eq_product_lines.second);
+                (*stg)[11].lines = {pb_wlo_n.emit(*logger, ProofLevel::Top), nullopt};
+                PolBuilder pb_whip_n;
+                pb_whip_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
+                (*stg)[12].lines = {pb_whip_n.emit(*logger, ProofLevel::Top), nullopt};
+                PolBuilder pb_whin_n;
+                pb_whin_n.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_neg_le);
+                (*stg)[13].lines = {pb_whin_n.emit(*logger, ProofLevel::Top), nullopt};
+            });
+        }
         else if (use_cake) {
             // Modulus's cake path: the exposed slot is r; the quotient magnitude |q| (the
             // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, axis-1 free
@@ -809,21 +984,34 @@ namespace
             propagators.install(
                 owner,
                 [enc = cake_encoding, stg = cake_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y, q = q,
-                    x = x, divide_neg = use_cake_divide_neg,
+                    x = x, pin_q_sign = use_cake_divide_neg || use_cake_divide_span,
                     owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     do {
                         if (state.in_domain(y, 0_i))
                             inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
 
-                        if (divide_neg) {
-                            // x < 0 is fixed on this path, so the quotient's sign follows the
-                            // divisor's: pin it off the sgn_* clauses by RUP (the magnitude
-                            // product dropped mult_bc's sign fusion). sgn_nn: x<0 & y<0 -> q>=0;
-                            // sgn_np: x<0 & y>0 -> q<=0.
-                            if (state.upper_bound(y) < 0_i && state.lower_bound(q) < 0_i)
-                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y < 0_i}});
-                            else if (state.lower_bound(y) > 0_i && state.upper_bound(q) > 0_i)
-                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y >= 1_i}});
+                        if (pin_q_sign) {
+                            // The magnitude product carries no mult_bc sign_lines, so the exposed
+                            // quotient's sign is pinned off the sgn_* clauses by RUP once the signs
+                            // of x and y are both established. sgn_pp: x>0 & y>0 -> q>=0; sgn_pn:
+                            // x>0 & y<0 -> q<=0; sgn_nn: x<0 & y<0 -> q>=0; sgn_np: x<0 & y>0 ->
+                            // q<=0. (On the fixed-negative path only the x<0 rows ever fire.)
+                            if (state.lower_bound(x) >= 1_i) {
+                                if (state.lower_bound(y) >= 1_i && state.lower_bound(q) < 0_i)
+                                    inference.infer(
+                                        logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y >= 1_i}});
+                                else if (state.upper_bound(y) < 0_i && state.upper_bound(q) > 0_i)
+                                    inference.infer(
+                                        logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y < 0_i}});
+                            }
+                            else if (state.upper_bound(x) < 0_i) {
+                                if (state.upper_bound(y) < 0_i && state.lower_bound(q) < 0_i)
+                                    inference.infer(
+                                        logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y < 0_i}});
+                                else if (state.lower_bound(y) >= 1_i && state.upper_bound(q) > 0_i)
+                                    inference.infer(
+                                        logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y >= 1_i}});
+                            }
                         }
 
                         if (! propagate_stages(*stg, state, inference, logger, owner))
@@ -865,7 +1053,14 @@ namespace
         auto px = ax.var ? optional{enum_vars.position_of(*ax.var)} : nullopt;
         auto py = ay.var ? optional{enum_vars.position_of(*ay.var)} : nullopt;
         auto pout = aout.var ? optional{enum_vars.position_of(*aout.var)} : nullopt;
-        auto paux = enum_vars.position_of(aux);
+        // The spanning-dividend cake path materialises no remainder in the proof (cake's rem_*
+        // rows range x - w directly, and a rejected (x, y, q) leaf pins magq/absy/w by unit
+        // propagation from the assigned q, y so the rem rows refute a wrong remainder), so it
+        // enumerates only x, y and q, with no remainder aux and no determined slots.
+        bool no_rem_aux = use_cake_divide_span;
+        std::size_t paux = 0;
+        if (! no_rem_aux)
+            paux = enum_vars.position_of(aux);
 
         // x and r are each a function of the others, pinned by unit
         // propagation forwards through the stages: q and y assigned pin
@@ -889,7 +1084,7 @@ namespace
         bool divide_r_is_magnitude = use_cake_divide_neg;
 
         vector<DeterminedVariable> determined;
-        if (expose_quotient)
+        if (expose_quotient && ! no_rem_aux)
             determined.push_back({aux, [ax, ay, aout, px, py, pout, divide_r_is_magnitude](const vector<Integer> & vals) -> optional<Integer> {
                                       auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                                       auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
@@ -897,7 +1092,7 @@ namespace
                                       auto rv = xv - qv * yv;
                                       return divide_r_is_magnitude ? (rv < 0_i ? -rv : rv) : rv;
                                   }});
-        else if (pout && pout != px && pout != py)
+        else if (! expose_quotient && pout && pout != px && pout != py)
             determined.push_back({*aout.var, [ax, ay, aout, px, py, paux, recover_q](const vector<Integer> & vals) -> optional<Integer> {
                                       auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                                       auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
@@ -911,7 +1106,7 @@ namespace
         // the product's sign: x = sign(x)|q||y| + r.
         bool x_fixed_sign = xlo >= 0_i || xhi <= 0_i;
         Integer x_sign = xhi <= 0_i ? -1_i : 1_i;
-        if (px && px != py && px != pout && (! aux_is_magnitude || x_fixed_sign))
+        if (px && px != py && px != pout && ! no_rem_aux && (! aux_is_magnitude || x_fixed_sign))
             determined.push_back({*ax.var,
                 [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude, divide_r_is_magnitude, x_sign](
                     const vector<Integer> & vals) -> optional<Integer> {
@@ -928,11 +1123,16 @@ namespace
                 }});
 
         if (want_tabulation(level, enum_vars.vars(), determined, initial_state)) {
-            auto accept = [ax, ay, aout, px, py, pout, paux, expose_quotient, divide_r_is_magnitude, recover_q](
+            auto accept = [ax, ay, aout, px, py, pout, paux, no_rem_aux, expose_quotient, divide_r_is_magnitude, recover_q](
                               const vector<Integer> & vals) -> bool {
                 auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                 auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                 auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
+                // The spanning-x path enumerates no remainder aux: q is the exposed slot and
+                // the remainder is derived. Elsewhere the aux is the remainder (Divide, |r| =
+                // -auxv on the x < 0 path) or the quotient magnitude (Modulus).
+                if (no_rem_aux)
+                    return is_in_relation(xv, yv, outv, xv - outv * yv);
                 auto auxv = vals[paux];
                 auto qv = expose_quotient ? outv : recover_q(auxv, xv, yv);
                 auto rv = expose_quotient ? (divide_r_is_magnitude ? -auxv : auxv) : outv;

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -536,7 +536,7 @@ namespace
                     w, w_lo, w_hi, (expose_quotient ? "aux_divide_product" : "aux_modulus_product") + to_string(w.index), nullopt);
 
             if (optional_model)
-                encoding = mult_bc::define_encoding(*optional_model, initial_state, owner, label, "", q_eff, y_eff, w, true);
+                encoding = mult_bc::define_encoding(*optional_model, initial_state, owner, label, q_eff, y_eff, w);
             bit_products_handle = initial_state.add_persistent_constraint_state(encoding.initial_bit_products);
             mult_q = q_eff;
             mult_y = y_eff;

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -13,8 +13,12 @@
 #include <gcs/constraints/multiply/multiply_bc.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
@@ -34,6 +38,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::make_shared;
 using std::make_unique;
 using std::max;
 using std::min;
@@ -41,6 +46,7 @@ using std::move;
 using std::nullopt;
 using std::numeric_limits;
 using std::optional;
+using std::shared_ptr;
 using std::string;
 using std::to_string;
 using std::unique_ptr;
@@ -111,6 +117,19 @@ namespace
             q_hi = max({xlo / ylo, xlo / yhi, xhi / ylo, xhi / yhi});
         }
 
+        // cake_pb_cp's divide encoding: the product |q|*|y| lives only in bit-product
+        // flags feeding rem_* rows, with no w or r in the OPB. We take that path for
+        // plain non-negative Divide (milestone 1), emitting cake's OPB and introducing
+        // w and r inside the proof; otherwise the legacy two's-complement path below.
+        // cake path: plain Divide. The remainder-hi stage splits on sign(y), and the
+        // dividend must be non-negative (x >= 0) so q*y >= 0 keeps the product w =
+        // |q||y| a non-negative magnitude. The stages support signed y/q, but the GAC
+        // tabulation (which references the eliminated aux r) can't be built in-proof,
+        // so signed y/q -- which need GAC on tiny domains -- stay on the legacy path
+        // for now; full signed (signed x, in-proof r, GAC) is the next step.
+        bool use_cake = expose_quotient && optional_model && xlo >= 0_i && ylo >= 0_i && initial_state.lower_bound(out) >= 0_i && ax.coeff == 1_i &&
+            ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var && aout.coeff == 1_i && aout.offset == 0_i;
+
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
         IntegerVariableID q = 0_c, r = 0_c;
@@ -119,9 +138,17 @@ namespace
             q = out;
             auto r_lo = xlo >= 0_i ? 0_i : -rmax;
             auto r_hi = xhi <= 0_i ? 0_i : rmax;
-            aux = initial_state.allocate_integer_variable_with_state(r_lo, r_hi);
-            if (optional_model)
+            // The cake path introduces r = x - w in-proof; the form x - w reaches xhi, so
+            // r's bits must span [0, xhi] for introduce_bits_of's upper proofgoal. Widen
+            // BOTH the solver state and the proof registration to keep the GAC tabulation
+            // (which enumerates the solver range) consistent with the proof bits; the
+            // rem_* rows still pin r to [0, |y|-1].
+            auto r_hi_cake = max(r_hi, xhi);
+            aux = initial_state.allocate_integer_variable_with_state(r_lo, use_cake ? r_hi_cake : r_hi);
+            if (optional_model && ! use_cake)
                 optional_model->set_up_integer_variable(aux, r_lo, r_hi, "aux_divide_remainder" + to_string(aux.index), nullopt);
+            else if (optional_model)
+                optional_model->register_state_variable_bits_in_proof(aux, r_lo, r_hi_cake, "aux_divide_remainder" + to_string(aux.index));
             r = aux;
         }
         else {
@@ -151,8 +178,147 @@ namespace
         mult_bc::EncodingData encoding;
         optional<ConstraintStateHandle> bit_products_handle;
         SimpleIntegerVariableID mult_q = aux, mult_y = aux, mult_w = aux; // overwritten when needs_mult
+        shared_ptr<mult_bc::EncodingData> cake_encoding;
+        shared_ptr<vector<LinearStage>> cake_stages;
 
-        if (! needs_mult) {
+        if (use_cake) {
+            auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
+
+            cake_encoding = make_shared<mult_bc::EncodingData>();
+            auto & enc = *cake_encoding;
+            enc.z_product_ge0_gated = false;
+
+            // Operand magnitude channels (cake letters: q -> "Z" axis 0, y -> "Y" axis
+            // 1), the bit-product flags x[id][i_j][prod], and their sum |q|*|y|.
+            auto product_sum = WPBSum{};
+            auto make_mag = [&](SimpleIntegerVariableID v, long long axis, const string & letter) -> ProofOnlySimpleIntegerVariableID {
+                auto mag_ub = max(abs(initial_state.lower_bound(v)), abs(initial_state.upper_bound(v)));
+                auto mag = optional_model->create_proof_only_integer_variable(0_i, mag_ub, "div_mag_" + letter,
+                    IntegerVariableProofRepresentation::Bits, CakeBitNaming{owner, {axis}, "bin", nullopt, false, true});
+                auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
+                auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
+                auto pos_ge = optional_model->add_labelled_constraint(
+                    label, letter + "ge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0);
+                auto pos_le = optional_model->add_labelled_constraint(
+                    label, letter + "ge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0);
+                auto neg_ge = optional_model->add_labelled_constraint(
+                    label, letter + "lt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0);
+                auto neg_le = optional_model->add_labelled_constraint(
+                    label, letter + "lt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0);
+                enc.channelling_constraints.insert(
+                    {v, mult_bc::ChannellingData{pos_ge, pos_le, neg_ge, neg_le, true, initial_state.lower_bound(v) < 0_i}});
+                enc.mag_var.insert({v, mag});
+                return mag;
+            };
+            auto mag_z = make_mag(q_eff, 0, "Z");
+            auto mag_y = make_mag(y_eff, 1, "Y");
+            auto n1 = optional_model->names_and_ids_tracker().num_bits(mag_z);
+            auto n2 = optional_model->names_and_ids_tracker().num_bits(mag_y);
+            for (Integer i = 0_i; i < n1; ++i) {
+                enc.initial_bit_products.emplace_back();
+                for (Integer j = 0_i; j < n2; ++j) {
+                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
+                        WPBSum{} + 1_i * ProofBitVariable{mag_z, i, true} + 1_i * ProofBitVariable{mag_y, j, true} >= 2_i);
+                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
+                    enc.initial_bit_products[i.as_index()].emplace_back(
+                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
+                    product_sum += power2(i + j) * flag;
+                }
+            }
+            auto neg_product = WPBSum{};
+            for (const auto & t : product_sum.terms)
+                neg_product += -t.coefficient * t.variable;
+
+            // w = |q||y|: a state variable driving mult_bc::propagate, ranged to hold
+            // the full bit-product sum (the magnitude bits can exceed the operands'
+            // actual maxima, so this is >= q_hi*y_hi). Its bits are introduced in-proof.
+            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
+            auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
+            mult_q = q_eff, mult_y = y_eff, mult_w = w;
+
+            // rem_* : 0 <= x - |q||y| < |y|, split on sign(x). Only the pos rows are
+            // active for non-negative x; |y| is the y magnitude variable mag_y.
+            auto xge0 = HalfReifyOnConjunctionOf{x >= 0_i};
+            auto xlt0 = HalfReifyOnConjunctionOf{x < 1_i};
+            auto rem_pos_lo =
+                optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
+            auto rem_pos_hi = optional_model->add_labelled_constraint(
+                label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * mag_y >= 1_i, xge0);
+            optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
+            optional_model->add_labelled_constraint(label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * mag_y >= 1_i, xlt0);
+
+            // Sign clauses (cake's division orientation over the atoms of x, y, q).
+            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
+                label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i));
+            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
+                label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i));
+            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
+                label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i));
+            enc.sign_lines.emplace_back(optional_model->add_labelled_constraint(
+                label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i));
+            enc.sign_lines.emplace_back(
+                optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i));
+            optional_model->add_labelled_constraint(
+                label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+
+            // w = |q||y| is a state variable (drives mult_bc::propagate) whose bits are
+            // introduced inside the proof, so nothing about it is asserted in the OPB.
+            // r is eliminated: cake's rem_* express 0 <= x - w < y directly over w, so r
+            // needs no proof presence (it stays an inert state auxiliary here).
+            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
+            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
+
+            // Stages over w (0 <= x - w < |y|): wlo (w <= x) gated [x>=0]; and the
+            // remainder-hi (x - w <= |y| - 1) split on sign(y) so each stage carries a
+            // single gate -- x-w-y<=-1 gated [y>=1] (|y|=y), x-w+y<=-1 gated [y<0]
+            // (|y|=-y). The stage lines keep rem_*'s [x>=0] gate and the channel's [y
+            // sign] gate; propagate_linear's ThenRUP discharges [x>=0] by unit
+            // propagation (x's domain lb >= 0) and the [y sign] from the stage gate.
+            cake_stages = make_shared<vector<LinearStage>>();
+            auto [t_wlo, m_wlo] = tidy_up_linear(WeightedSum{} + 1_i * w + -1_i * x);
+            cake_stages->emplace_back(LinearStage{t_wlo, 0_i + m_wlo, false, {nullopt, nullopt}, optional{x_eff >= 0_i}});
+            auto [t_whip, m_whip] = tidy_up_linear(WeightedSum{} + 1_i * x + -1_i * w + -1_i * y);
+            cake_stages->emplace_back(LinearStage{t_whip, -1_i + m_whip, false, {nullopt, nullopt}, optional{y >= 1_i}});
+            auto [t_whin, m_whin] = tidy_up_linear(WeightedSum{} + 1_i * x + -1_i * w + 1_i * y);
+            cake_stages->emplace_back(LinearStage{t_whin, -1_i + m_whin, false, {nullopt, nullopt}, optional{y < 0_i}});
+
+            auto y_ge0_ge = enc.channelling_constraints.at(y_eff).pos_ge; // y - mag_y >= 0 gated [y>=0]
+            auto y_lt0_le = enc.channelling_constraints.at(y_eff).neg_le; // -y - mag_y >= 0 gated [y<0]
+            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, w_hi, r = aux, x_eff, rem_pos_lo, rem_pos_hi,
+                                                y_ge0_ge, y_lt0_le](State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                    return;
+                // w = |q||y|, introduced as a conservative extension.
+                // v3_eq_product_lines = {w >= product, w <= product}.
+                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                // Ungated x - w >= 0 in the DB, so introduce_bits_of(x-w, r) below can
+                // auto-prove r's non-negativity: rem_pos_lo (x - product >= 0, gated
+                // [x>=0], big-M w_hi) + (product >= w) + w_hi*[x>=0] discharges the gate.
+                auto x_ge0 = logger->emit_rup_proof_line(WPBSum{} + 1_i * (x_eff >= 0_i) >= 1_i, ProofLevel::Top);
+                PolBuilder pb_xw;
+                pb_xw.add(rem_pos_lo).add(enc->v3_eq_product_lines.second).add(x_ge0, w_hi);
+                pb_xw.emit(*logger, ProofLevel::Top);
+                // r = x - w, introduced so the tabulation's determined r unit-propagates.
+                logger->introduce_bits_of(WPBSum{} + 1_i * x_eff + -1_i * w, r, ProofLevel::Top);
+                // wlo, [x>=0]-gated (w <= x): rem_pos_lo (x - product >= 0) + (w <= product).
+                PolBuilder pb_wlo;
+                pb_wlo.add(rem_pos_lo).add(enc->v3_eq_product_lines.second);
+                (*stg)[0].lines = {pb_wlo.emit(*logger, ProofLevel::Top), nullopt};
+                // whi_ypos (x - w - y <= -1, |y|=y): rem_pos_hi (product - x + |y| >= 1)
+                // + (w >= product) + Yge0_ge (y - |y| >= 0). |y| = mag_y cancels; the
+                // channel's [y>=0] gate rides along and the stage gates on [y>=1].
+                PolBuilder pb_whip;
+                pb_whip.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_ge0_ge);
+                (*stg)[1].lines = {pb_whip.emit(*logger, ProofLevel::Top), nullopt};
+                // whi_yneg (x - w + y <= -1, |y|=-y): rem_pos_hi + (w >= product)
+                // + Ylt0_le (-y - |y| >= 0). Stage gates on [y<0].
+                PolBuilder pb_whin;
+                pb_whin.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_lt0_le);
+                (*stg)[2].lines = {pb_whin.emit(*logger, ProofLevel::Top), nullopt};
+            });
+        }
+
+        if (! use_cake && ! needs_mult) {
             // one of d * q + r - x = 0 (constant divisor) or c * y + r - x = 0
             // (Divide with a constant quotient)
             if (! ay.var)
@@ -160,7 +326,7 @@ namespace
             else
                 add_equality(WeightedSum{} + aq.offset * y + 1_i * r + -1_i * x, 0_i, "sum");
         }
-        else {
+        else if (! use_cake) {
             auto y_eff = *ay.var;
             if (ay.coeff != 1_i || ay.offset != 0_i) {
                 auto y_plain = initial_state.allocate_integer_variable_with_state(min(ylo, yhi), max(ylo, yhi));
@@ -208,38 +374,40 @@ namespace
         // slot's range suffices: it is baked into the auxiliary's bounds for
         // Divide, and posted on the user's remainder for Modulus. With a
         // variable divisor, split on the divisor's sign.
-        if (! ay.var) {
-            if (! expose_quotient) {
-                add_le(WeightedSum{} + 1_i * r, rmax, "remhi", nullopt);
-                add_le(WeightedSum{} + -1_i * r, rmax, "remlo", nullopt);
+        if (! use_cake) {
+            if (! ay.var) {
+                if (! expose_quotient) {
+                    add_le(WeightedSum{} + 1_i * r, rmax, "remhi", nullopt);
+                    add_le(WeightedSum{} + -1_i * r, rmax, "remlo", nullopt);
+                }
             }
-        }
-        else {
-            if (optional_model)
-                optional_model->add_labelled_constraint(
-                    label, "nonzero", "DivideModulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+            else {
+                if (optional_model)
+                    optional_model->add_labelled_constraint(
+                        label, "nonzero", "DivideModulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
 
-            // y >= 1 -> r <= y - 1 and r >= -y + 1
-            add_le(WeightedSum{} + 1_i * r + -1_i * y, -1_i, "rangeposhi", y >= 1_i);
-            add_le(WeightedSum{} + -1_i * r + -1_i * y, -1_i, "rangeposlo", y >= 1_i);
-            // y <= -1 -> r <= -y - 1 and r >= y + 1
-            add_le(WeightedSum{} + 1_i * r + 1_i * y, -1_i, "rangeneghi", y < 0_i);
-            add_le(WeightedSum{} + -1_i * r + 1_i * y, -1_i, "rangeneglo", y < 0_i);
-        }
+                // y >= 1 -> r <= y - 1 and r >= -y + 1
+                add_le(WeightedSum{} + 1_i * r + -1_i * y, -1_i, "rangeposhi", y >= 1_i);
+                add_le(WeightedSum{} + -1_i * r + -1_i * y, -1_i, "rangeposlo", y >= 1_i);
+                // y <= -1 -> r <= -y - 1 and r >= y + 1
+                add_le(WeightedSum{} + 1_i * r + 1_i * y, -1_i, "rangeneghi", y < 0_i);
+                add_le(WeightedSum{} + -1_i * r + 1_i * y, -1_i, "rangeneglo", y < 0_i);
+            }
 
-        // The remainder takes the sign of the dividend, which is what pins
-        // truncation: without it, the identity and |r| < |y| admit both the
-        // truncated and the floored (quotient, remainder) pair when the signs
-        // differ.
-        if (ax.var) {
-            add_le(WeightedSum{} + -1_i * r, 0_i, "signpos", x >= 0_i);
-            add_le(WeightedSum{} + 1_i * r, 0_i, "signneg", x < 1_i);
-        }
-        else {
-            if (ax.offset >= 0_i)
-                add_le(WeightedSum{} + -1_i * r, 0_i, "signpos", nullopt);
-            if (ax.offset <= 0_i)
-                add_le(WeightedSum{} + 1_i * r, 0_i, "signneg", nullopt);
+            // The remainder takes the sign of the dividend, which is what pins
+            // truncation: without it, the identity and |r| < |y| admit both the
+            // truncated and the floored (quotient, remainder) pair when the signs
+            // differ.
+            if (ax.var) {
+                add_le(WeightedSum{} + -1_i * r, 0_i, "signpos", x >= 0_i);
+                add_le(WeightedSum{} + 1_i * r, 0_i, "signneg", x < 1_i);
+            }
+            else {
+                if (ax.offset >= 0_i)
+                    add_le(WeightedSum{} + -1_i * r, 0_i, "signpos", nullopt);
+                if (ax.offset <= 0_i)
+                    add_le(WeightedSum{} + 1_i * r, 0_i, "signneg", nullopt);
+            }
         }
 
         Triggers triggers;
@@ -260,25 +428,45 @@ namespace
         triggers.on_bounds = watched;
 
         bool prune_zero = ay.var != nullopt;
-        propagators.install(
-            owner,
-            [stages = stages, needs_mult = needs_mult, encoding = encoding, bit_products_handle = bit_products_handle, mult_q = mult_q,
-                mult_y = mult_y, mult_w = mult_w, prune_zero = prune_zero, y = y,
-                owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                do {
-                    if (prune_zero && state.in_domain(y, 0_i))
-                        inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
+        if (use_cake) {
+            propagators.install(
+                owner,
+                [enc = cake_encoding, stg = cake_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y,
+                    owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                    do {
+                        if (state.in_domain(y, 0_i))
+                            inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
 
-                    if (! propagate_stages(stages, state, inference, logger, owner))
-                        return PropagatorState::Enable;
+                        if (! propagate_stages(*stg, state, inference, logger, owner))
+                            return PropagatorState::Enable;
 
-                    if (needs_mult)
-                        mult_bc::propagate(mult_q, mult_y, mult_w, state, inference, logger, encoding, *bit_products_handle, owner);
-                } while (inference.did_anything_since_last_call_inside_propagator());
+                        mult_bc::propagate(mult_q, mult_y, mult_w, state, inference, logger, *enc, bph, owner);
+                    } while (inference.did_anything_since_last_call_inside_propagator());
 
-                return PropagatorState::Enable;
-            },
-            triggers);
+                    return PropagatorState::Enable;
+                },
+                triggers);
+        }
+        else
+            propagators.install(
+                owner,
+                [stages = stages, needs_mult = needs_mult, encoding = encoding, bit_products_handle = bit_products_handle, mult_q = mult_q,
+                    mult_y = mult_y, mult_w = mult_w, prune_zero = prune_zero, y = y,
+                    owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                    do {
+                        if (prune_zero && state.in_domain(y, 0_i))
+                            inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
+
+                        if (! propagate_stages(stages, state, inference, logger, owner))
+                            return PropagatorState::Enable;
+
+                        if (needs_mult)
+                            mult_bc::propagate(mult_q, mult_y, mult_w, state, inference, logger, encoding, *bit_products_handle, owner);
+                    } while (inference.did_anything_since_last_call_inside_propagator());
+
+                    return PropagatorState::Enable;
+                },
+                triggers);
 
         // Tabulation for GAC: enumerate the distinct underlying variables and
         // the auxiliary slot, so a complete assignment fixes x, y, q and r and

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -119,14 +119,20 @@ namespace
 
         // cake_pb_cp's divide encoding: the product |q|*|y| lives only in bit-product
         // flags feeding rem_* rows, with no w or r in the OPB. We take that path for
-        // plain non-negative Divide (milestone 1), emitting cake's OPB and introducing
-        // w and r inside the proof; otherwise the legacy two's-complement path below.
-        // cake path: plain Divide. The remainder-hi stage splits on sign(y), and the
-        // dividend must be non-negative (x >= 0) so q*y >= 0 keeps the product w =
-        // |q||y| a non-negative magnitude. The stages support signed y/q, but the GAC
-        // tabulation (which references the eliminated aux r) can't be built in-proof,
-        // so signed y/q -- which need GAC on tiny domains -- stay on the legacy path
-        // for now; full signed (signed x, in-proof r, GAC) is the next step.
+        // plain, fully non-negative Divide (x, y, q all >= 0), emitting cake's OPB and
+        // introducing w and r inside the proof; otherwise the legacy two's-complement
+        // path below. The non-negativity is load-bearing in two ways: x >= 0 keeps the
+        // product w = |q||y| = x - r and the remainder r = x - w non-negative (only the
+        // pos rem_* rows and the wlo stage are then active), and requiring q >= 0
+        // alongside x, y >= 0 means every operand sign agrees, so the sign machinery is
+        // never asked to refute a mismatch. Relaxing any of the three -- signed x, a
+        // zero-spanning or negative divisor, or a quotient free to take the opposite
+        // sign -- exercises the product-sign reconciliation inside introduce_bits_of's
+        // w = |q||y| subproof, whose proofgoal reconciles w's sign against cake's
+        // division sgn_* clauses. That RUP is not yet derivable whenever sign(q) can
+        // differ from sign(x)*sign(y) (e.g. an unsatisfiable q<0 under x, y >= 0); GAC
+        // tabulation hides it for tiny domains but it surfaces under BC / large domains.
+        // Fixing that sign proofgoal is the next step for any signed divide.
         bool use_cake = expose_quotient && optional_model && xlo >= 0_i && ylo >= 0_i && initial_state.lower_bound(out) >= 0_i && ax.coeff == 1_i &&
             ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var && aout.coeff == 1_i && aout.offset == 0_i;
 

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -538,7 +538,7 @@ namespace
                     w, w_lo, w_hi, (expose_quotient ? "aux_divide_product" : "aux_modulus_product") + to_string(w.index), nullopt);
 
             if (optional_model)
-                encoding = mult_bc::define_encoding(*optional_model, initial_state, owner, label, "", q_eff, y_eff, w);
+                encoding = mult_bc::define_encoding(*optional_model, initial_state, owner, label, "", q_eff, y_eff, w, true);
             bit_products_handle = initial_state.add_persistent_constraint_state(encoding.initial_bit_products);
             mult_q = q_eff;
             mult_y = y_eff;

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -143,14 +143,27 @@ namespace
         bool plain_operands = optional_model && ax.coeff == 1_i && ax.offset == 0_i && ay.var && ay.coeff == 1_i && ay.offset == 0_i && aout.var &&
             aout.coeff == 1_i && aout.offset == 0_i;
         bool use_cake_divide = expose_quotient && plain_operands && xlo >= 0_i;
+        bool use_cake_divide_neg = expose_quotient && plain_operands && xhi < 0_i;
         bool use_cake_modulus = (! expose_quotient) && plain_operands;
-        bool use_cake = use_cake_divide || use_cake_modulus;
+        bool use_cake = use_cake_divide || use_cake_divide_neg || use_cake_modulus;
 
         // The exposed slot is the user's; the other is an auxiliary, with
         // bounds tightened by the sign-of-dividend rule where easy.
         IntegerVariableID q = 0_c, r = 0_c;
         SimpleIntegerVariableID aux = SimpleIntegerVariableID{0};
-        if (expose_quotient) {
+        if (expose_quotient && use_cake_divide_neg) {
+            q = out;
+            // The dividend is strictly negative, so the remainder r <= 0; the aux is its
+            // MAGNITUDE |r| = |x| - w = -x - w (>= 0), introduced in-proof from -x - w. That
+            // form reaches |x|, so |r|'s bits span [0, max|x|]; the rem_neg rows still pin r
+            // to (-|y|, 0]. The tabulation recovers the signed r = -|r|.
+            auto r_hi_cake = max(rmax, mx);
+            aux = initial_state.allocate_integer_variable_with_state(0_i, r_hi_cake);
+            if (optional_model)
+                optional_model->register_state_variable_bits_in_proof(aux, 0_i, r_hi_cake, "aux_divide_remainder" + to_string(aux.index));
+            r = aux;
+        }
+        else if (expose_quotient) {
             q = out;
             auto r_lo = xlo >= 0_i ? 0_i : -rmax;
             auto r_hi = xhi <= 0_i ? 0_i : rmax;
@@ -216,7 +229,7 @@ namespace
         shared_ptr<mult_bc::EncodingData> cake_encoding;
         shared_ptr<vector<LinearStage>> cake_stages;
 
-        if (use_cake && expose_quotient) {
+        if (use_cake_divide) {
             auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
 
             cake_encoding = make_shared<mult_bc::EncodingData>();
@@ -353,6 +366,181 @@ namespace
                 PolBuilder pb_whin;
                 pb_whin.add(rem_pos_hi).add(enc->v3_eq_product_lines.first).add(y_lt0_le);
                 (*stg)[2].lines = {pb_whin.emit(*logger, ProofLevel::Top), nullopt};
+            });
+        }
+        else if (use_cake_divide_neg) {
+            // Divide with a strictly negative dividend (x < 0). cake's divide OPB is
+            // sign-agnostic -- the rows are identical to the x >= 0 path (the Z/Y magnitude
+            // channels, bit products, both rem_pos and rem_neg, the five sign clauses) -- so
+            // only the propagation differs. Both mult operands are the non-negative
+            // magnitudes magq = |q| (channelled to the exposed quotient) and absy = |y|
+            // (channelled to the divisor), so mult_bc divides w = |q||y| by the non-negative
+            // absy; dividing by the signed divisor was the x < 0 blocker in filter_quotient.
+            // The magnitude product carries no sign_lines, so the exposed quotient's sign is
+            // pinned directly from the sgn_* clauses (below, in the propagator). cake
+            // eliminates the remainder (the rem_neg rows range x - w over w and x directly);
+            // the aux |r| = -x - w is introduced in-proof only for the tabulation.
+            auto q_eff = *aq.var, y_eff = *ay.var, x_eff = *ax.var;
+
+            cake_encoding = make_shared<mult_bc::EncodingData>();
+            auto & enc = *cake_encoding;
+            enc.z_product_ge0_gated = false;
+            enc.z_is_magnitude = false; // magq, absy >= 0, so w = magq * absy is a plain product
+
+            // magq = |q|: a non-negative magnitude STATE variable (mult_bc's operand must be
+            // a real variable), axis-0 free magnitude bits x[id][0_*][bin], channelled to the
+            // exposed quotient q by cake's Zge0/Zlt0 channel and propagated by the magq stages.
+            auto mag_q_ub = max(abs(initial_state.lower_bound(q_eff)), abs(initial_state.upper_bound(q_eff)));
+            auto magq_bits = 0_i;
+            while (power2(magq_bits) <= mag_q_ub)
+                magq_bits += 1_i;
+            auto magq_bit_max = power2(magq_bits) - 1_i;
+            auto magq = initial_state.allocate_integer_variable_with_state(0_i, magq_bit_max);
+            optional_model->register_state_variable_bits_in_proof(
+                magq, 0_i, magq_bit_max, "aux_divide_qmag" + to_string(magq.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
+
+            auto q_ge0 = HalfReifyOnConjunctionOf{q_eff >= 0_i};
+            auto q_lt0 = HalfReifyOnConjunctionOf{q_eff < 0_i};
+            auto q_pos_ge = optional_model->add_labelled_constraint(
+                label, "Zge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + -1_i * magq >= 0_i, q_ge0);
+            auto q_pos_le = optional_model->add_labelled_constraint(
+                label, "Zge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + 1_i * magq >= 0_i, q_ge0);
+            auto q_neg_ge = optional_model->add_labelled_constraint(
+                label, "Zlt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * q_eff + 1_i * magq >= 0_i, q_lt0);
+            auto q_neg_le = optional_model->add_labelled_constraint(
+                label, "Zlt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * q_eff + -1_i * magq >= 0_i, q_lt0);
+
+            // absy = |y|: the same non-negative magnitude STATE variable as modulus, axis-1
+            // free magnitude bits x[id][1_*][bin], pinned to |y| by cake's Yge0/Ylt0 channel.
+            auto absy_bits = 0_i;
+            while (power2(absy_bits) <= may)
+                absy_bits += 1_i;
+            auto absy_bit_max = power2(absy_bits) - 1_i;
+            auto absy = initial_state.allocate_integer_variable_with_state(0_i, absy_bit_max);
+            optional_model->register_state_variable_bits_in_proof(
+                absy, 0_i, absy_bit_max, "aux_divide_absdivisor" + to_string(absy.index), CakeBitNaming{owner, {1}, "bin", nullopt, false, true});
+
+            auto y_ge0 = HalfReifyOnConjunctionOf{y_eff >= 0_i};
+            auto y_lt0 = HalfReifyOnConjunctionOf{y_eff < 0_i};
+            auto y_pos_ge = optional_model->add_labelled_constraint(
+                label, "Yge0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + -1_i * absy >= 0_i, y_ge0);
+            auto y_pos_le = optional_model->add_labelled_constraint(
+                label, "Yge0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + 1_i * absy >= 0_i, y_ge0);
+            auto y_neg_ge = optional_model->add_labelled_constraint(
+                label, "Ylt0_ge", "Divide", "magnitude channel", WPBSum{} + 1_i * y_eff + 1_i * absy >= 0_i, y_lt0);
+            auto y_neg_le = optional_model->add_labelled_constraint(
+                label, "Ylt0_le", "Divide", "magnitude channel", WPBSum{} + -1_i * y_eff + -1_i * absy >= 0_i, y_lt0);
+
+            // Bit-product flags x[id][i_j][prod] = |q|_i ^ |y|_j and their weighted sum
+            // |q|*|y|, over the two magnitudes' own free bits (no channel needed).
+            auto n1 = optional_model->names_and_ids_tracker().num_bits(magq);
+            auto n2 = optional_model->names_and_ids_tracker().num_bits(absy);
+            auto product_sum = WPBSum{};
+            for (Integer i = 0_i; i < n1; ++i) {
+                enc.initial_bit_products.emplace_back();
+                for (Integer j = 0_i; j < n2; ++j) {
+                    auto flag = optional_model->create_proof_flag_fully_reifying(owner, {i.raw_value, j.raw_value}, "prod",
+                        WPBSum{} + 1_i * ProofBitVariable{magq, i, true} + 1_i * ProofBitVariable{absy, j, true} >= 2_i);
+                    auto base = "x[" + label + "][" + to_string(i.raw_value) + "_" + to_string(j.raw_value) + "][prod]";
+                    enc.initial_bit_products[i.as_index()].emplace_back(
+                        mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
+                    product_sum += power2(i + j) * flag;
+                }
+            }
+            auto neg_product = WPBSum{};
+            for (const auto & t : product_sum.terms)
+                neg_product += -t.coefficient * t.variable;
+
+            // rem_* : 0 <= x - |q||y| < |y|, split on sign(x). For x < 0 only the neg rows
+            // are active; both signs are emitted to match cake's sign-agnostic OPB.
+            auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
+            auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
+            optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
+            optional_model->add_labelled_constraint(label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xge0);
+            auto rem_neg_hi =
+                optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
+            auto rem_neg_lo = optional_model->add_labelled_constraint(
+                label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xlt0);
+
+            // Sign clauses (cake's division orientation over the atoms of x, y, q). Unlike the
+            // x >= 0 path these are NOT mult_bc sign_lines (the magnitude product has none);
+            // the propagator pins sign(q) off them directly by RUP.
+            optional_model->add_labelled_constraint(
+                label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i);
+            optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i);
+            optional_model->add_labelled_constraint(
+                label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+
+            // w = |q||y|: state variable driving mult_bc, ranged to hold the full bit-product
+            // sum; its bits are introduced in-proof.
+            auto w_hi = (power2(n1) - 1_i) * (power2(n2) - 1_i);
+            auto w = initial_state.allocate_integer_variable_with_state(0_i, w_hi);
+            optional_model->register_state_variable_bits_in_proof(w, 0_i, w_hi, "aux_divide_product" + to_string(w.index));
+            mult_q = magq, mult_y = absy, mult_w = w;
+            bit_products_handle = initial_state.add_persistent_constraint_state(enc.initial_bit_products);
+
+            // Stages: magq = |q| and absy = |y| off their sign-split channels (cite the OPB
+            // row directly); the w bounds off the rem_neg rows (0 <= -x - w < |y|, i.e.
+            // w <= -x and -x - w < absy), whose lines fuse rem_neg with w = product in the
+            // initialiser. Indices 0-3 = magq, 4-7 = absy, 8 = wlo, 9/10 = whi (y sign split).
+            cake_stages = make_shared<vector<LinearStage>>();
+            auto [t_zle, m_zle] = tidy_up_linear(WeightedSum{} + 1_i * magq + -1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_zle, 0_i + m_zle, false, {q_pos_ge, nullopt}, optional{q_eff >= 0_i}});
+            auto [t_zge, m_zge] = tidy_up_linear(WeightedSum{} + -1_i * magq + 1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_zge, 0_i + m_zge, false, {q_pos_le, nullopt}, optional{q_eff >= 0_i}});
+            auto [t_znle, m_znle] = tidy_up_linear(WeightedSum{} + 1_i * magq + 1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_znle, 0_i + m_znle, false, {q_neg_le, nullopt}, optional{q_eff < 0_i}});
+            auto [t_znge, m_znge] = tidy_up_linear(WeightedSum{} + -1_i * magq + -1_i * q_eff);
+            cake_stages->emplace_back(LinearStage{t_znge, 0_i + m_znge, false, {q_neg_ge, nullopt}, optional{q_eff < 0_i}});
+            auto [t_ale, m_ale] = tidy_up_linear(WeightedSum{} + 1_i * absy + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_ale, 0_i + m_ale, false, {y_pos_ge, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_age, m_age] = tidy_up_linear(WeightedSum{} + -1_i * absy + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_age, 0_i + m_age, false, {y_pos_le, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_anle, m_anle] = tidy_up_linear(WeightedSum{} + 1_i * absy + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_anle, 0_i + m_anle, false, {y_neg_le, nullopt}, optional{y_eff < 0_i}});
+            auto [t_ange, m_ange] = tidy_up_linear(WeightedSum{} + -1_i * absy + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_ange, 0_i + m_ange, false, {y_neg_ge, nullopt}, optional{y_eff < 0_i}});
+            auto [t_wlo, m_wlo] = tidy_up_linear(WeightedSum{} + 1_i * w + 1_i * x_eff);
+            cake_stages->emplace_back(LinearStage{t_wlo, 0_i + m_wlo, false, {nullopt, nullopt}, optional{x_eff < 1_i}});
+            auto [t_whip, m_whip] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + -1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_whip, -1_i + m_whip, false, {nullopt, nullopt}, optional{y_eff >= 1_i}});
+            auto [t_whin, m_whin] = tidy_up_linear(WeightedSum{} + -1_i * x_eff + -1_i * w + 1_i * y_eff);
+            cake_stages->emplace_back(LinearStage{t_whin, -1_i + m_whin, false, {nullopt, nullopt}, optional{y_eff < 0_i}});
+
+            propagators.install_initialiser([enc = cake_encoding, stg = cake_stages, product_sum, w, w_hi, r = aux, x_eff, rem_neg_hi, rem_neg_lo,
+                                                y_pos_ge, y_neg_le](State &, auto &, ProofLogger * const logger) -> void {
+                if (! logger || logger->get_assertion_level() > AssertionLevel::Off)
+                    return;
+                // w = |q||y|; v3_eq_product_lines = {w >= product, w <= product}.
+                enc->v3_eq_product_lines = logger->introduce_bits_of(product_sum, w, ProofLevel::Top);
+                // Ungated -x - w >= 0 so introduce_bits_of(-x - w, |r|) below can auto-prove
+                // |r| >= 0: rem_neg_hi (-product - x >= 0, gated [x<1], big-M) + (product >= w)
+                // + big-M*[x<1] discharges the gate.
+                auto x_lt0 = logger->emit_rup_proof_line(WPBSum{} + 1_i * (x_eff < 1_i) >= 1_i, ProofLevel::Top);
+                PolBuilder pb_xw;
+                pb_xw.add(rem_neg_hi).add(enc->v3_eq_product_lines.second).add(x_lt0, w_hi);
+                pb_xw.emit(*logger, ProofLevel::Top);
+                // |r| = -x - w, introduced so the tabulation's determined |r| unit-propagates.
+                logger->introduce_bits_of(WPBSum{} + -1_i * x_eff + -1_i * w, r, ProofLevel::Top);
+                // wlo (w <= -x): rem_neg_hi (-product - x >= 0) + (w <= product).
+                PolBuilder pb_wlo;
+                pb_wlo.add(rem_neg_hi).add(enc->v3_eq_product_lines.second);
+                (*stg)[8].lines = {pb_wlo.emit(*logger, ProofLevel::Top), nullopt};
+                // whi_ypos (-x - w - y <= -1, |y|=y): rem_neg_lo (product + x + |y| >= 1)
+                // + (w >= product) + Yge0_ge (y - |y| >= 0).
+                PolBuilder pb_whip;
+                pb_whip.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_pos_ge);
+                (*stg)[9].lines = {pb_whip.emit(*logger, ProofLevel::Top), nullopt};
+                // whi_yneg (-x - w + y <= -1, |y|=-y): rem_neg_lo + (w >= product) + Ylt0_le.
+                PolBuilder pb_whin;
+                pb_whin.add(rem_neg_lo).add(enc->v3_eq_product_lines.first).add(y_neg_le);
+                (*stg)[10].lines = {pb_whin.emit(*logger, ProofLevel::Top), nullopt};
             });
         }
         else if (use_cake) {
@@ -620,11 +808,23 @@ namespace
         if (use_cake) {
             propagators.install(
                 owner,
-                [enc = cake_encoding, stg = cake_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y,
+                [enc = cake_encoding, stg = cake_stages, bph = *bit_products_handle, mult_q = mult_q, mult_y = mult_y, mult_w = mult_w, y = y, q = q,
+                    x = x, divide_neg = use_cake_divide_neg,
                     owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     do {
                         if (state.in_domain(y, 0_i))
                             inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
+
+                        if (divide_neg) {
+                            // x < 0 is fixed on this path, so the quotient's sign follows the
+                            // divisor's: pin it off the sgn_* clauses by RUP (the magnitude
+                            // product dropped mult_bc's sign fusion). sgn_nn: x<0 & y<0 -> q>=0;
+                            // sgn_np: x<0 & y>0 -> q<=0.
+                            if (state.upper_bound(y) < 0_i && state.lower_bound(q) < 0_i)
+                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y < 0_i}});
+                            else if (state.lower_bound(y) > 0_i && state.upper_bound(q) > 0_i)
+                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y >= 1_i}});
+                        }
 
                         if (! propagate_stages(*stg, state, inference, logger, owner))
                             return PropagatorState::Enable;
@@ -684,14 +884,18 @@ namespace
         auto recover_q = [aux_is_magnitude](Integer auxv, Integer xv, Integer yv) -> Integer {
             return (aux_is_magnitude && ((xv >= 0_i) != (yv >= 0_i))) ? -auxv : auxv;
         };
+        // The x < 0 divide path stores the remainder MAGNITUDE |r| in the aux (introduce_bits_of
+        // needs a non-negative target); the signed remainder is r = -|r| (r <= 0 for x < 0).
+        bool divide_r_is_magnitude = use_cake_divide_neg;
 
         vector<DeterminedVariable> determined;
         if (expose_quotient)
-            determined.push_back({aux, [ax, ay, aout, px, py, pout](const vector<Integer> & vals) -> optional<Integer> {
+            determined.push_back({aux, [ax, ay, aout, px, py, pout, divide_r_is_magnitude](const vector<Integer> & vals) -> optional<Integer> {
                                       auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                                       auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                                       auto qv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                                      return xv - qv * yv;
+                                      auto rv = xv - qv * yv;
+                                      return divide_r_is_magnitude ? (rv < 0_i ? -rv : rv) : rv;
                                   }});
         else if (pout && pout != px && pout != py)
             determined.push_back({*aout.var, [ax, ay, aout, px, py, paux, recover_q](const vector<Integer> & vals) -> optional<Integer> {
@@ -709,25 +913,29 @@ namespace
         Integer x_sign = xhi <= 0_i ? -1_i : 1_i;
         if (px && px != py && px != pout && (! aux_is_magnitude || x_fixed_sign))
             determined.push_back({*ax.var,
-                [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude, x_sign](const vector<Integer> & vals) -> optional<Integer> {
+                [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude, divide_r_is_magnitude, x_sign](
+                    const vector<Integer> & vals) -> optional<Integer> {
                     auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                     auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
                     auto auxv = vals[paux];
-                    auto want = aux_is_magnitude ? x_sign * auxv * (yv < 0_i ? -yv : yv) + outv
-                                                 : (expose_quotient ? outv : auxv) * yv + (expose_quotient ? auxv : outv);
+                    // The remainder is the aux for Divide (|r| = -auxv on the x < 0 path) and
+                    // the exposed slot for Modulus; x = q * y + r.
+                    auto rv = expose_quotient ? (divide_r_is_magnitude ? -auxv : auxv) : outv;
+                    auto want = aux_is_magnitude ? x_sign * auxv * (yv < 0_i ? -yv : yv) + outv : (expose_quotient ? outv : auxv) * yv + rv;
                     if ((want - ax.offset) % ax.coeff != 0_i)
                         return nullopt;
                     return (want - ax.offset) / ax.coeff;
                 }});
 
         if (want_tabulation(level, enum_vars.vars(), determined, initial_state)) {
-            auto accept = [ax, ay, aout, px, py, pout, paux, expose_quotient, recover_q](const vector<Integer> & vals) -> bool {
+            auto accept = [ax, ay, aout, px, py, pout, paux, expose_quotient, divide_r_is_magnitude, recover_q](
+                              const vector<Integer> & vals) -> bool {
                 auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                 auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                 auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
                 auto auxv = vals[paux];
                 auto qv = expose_quotient ? outv : recover_q(auxv, xv, yv);
-                auto rv = expose_quotient ? auxv : outv;
+                auto rv = expose_quotient ? (divide_r_is_magnitude ? -auxv : auxv) : outv;
                 return is_in_relation(xv, yv, qv, rv);
             };
 

--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -239,6 +239,15 @@ auto main(int, char *[]) -> int
                 // forced, since the tree is over the Auto threshold.
                 run_divmod_test(proofs, is_div, level, force_gac, {-3, 3}, {-2, 2}, {-3, 3});
 
+                // Strictly negative dividend (x < 0): Divide's cake path works in
+                // magnitude space (|q| * |y| = w) and pins sign(q) off the sign
+                // clauses. The BC level exercises the pure propagation proof (no
+                // tabulation to mask it); the zero-spanning divisor flips sign(q).
+                // GAC-checked only when forced (the tree is over the Auto threshold).
+                run_divmod_test(proofs, is_div, level, force_gac, {-8, -1}, {1, 3}, {-8, 0});
+                run_divmod_test(proofs, is_div, level, force_gac, {-8, -1}, {-3, -1}, {0, 8});
+                run_divmod_test(proofs, is_div, level, force_gac, {-6, -1}, {-3, 3}, {-6, 6});
+
                 // Aliased shapes.
                 run_divmod_alias_test(proofs, is_div, level, ! is_bc, "xxy", {-2, 2}, {-1, 2});
                 run_divmod_alias_test(proofs, is_div, level, force_gac, "xyx", {-2, 2}, {-2, 2});

--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -248,6 +248,13 @@ auto main(int, char *[]) -> int
                 run_divmod_test(proofs, is_div, level, force_gac, {-8, -1}, {-3, -1}, {0, 8});
                 run_divmod_test(proofs, is_div, level, force_gac, {-6, -1}, {-3, 3}, {-6, 6});
 
+                // Dividend spanning zero (xlo < 0 < xhi): both the x >= 0 and x < 0
+                // remainder rows and w-stages are live, gated on sign(x). No remainder
+                // is materialised (the rem rows range x - w directly), so the
+                // tabulation enumerates only x, y, q; BC exercises the propagation proof.
+                run_divmod_test(proofs, is_div, level, force_gac, {-6, 6}, {1, 3}, {-6, 6});
+                run_divmod_test(proofs, is_div, level, force_gac, {-5, 5}, {-3, 3}, {-5, 5});
+
                 // Aliased shapes.
                 run_divmod_alias_test(proofs, is_div, level, ! is_bc, "xxy", {-2, 2}, {-1, 2});
                 run_divmod_alias_test(proofs, is_div, level, force_gac, "xyx", {-2, 2}, {-2, 2});

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -183,7 +183,7 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
     mult_bc::EncodingData encoding;
     optional<pair<optional<ProofLine>, optional<ProofLine>>> copy_lines, fold_lines;
     if (optional_model) {
-        encoding = mult_bc::define_encoding(*optional_model, initial_state, constraint_id(), as_string(constraint_id()), "", u1, m2, *t, true);
+        encoding = mult_bc::define_encoding(*optional_model, initial_state, constraint_id(), as_string(constraint_id()), u1, m2, *t);
 
         auto as_wpb = [](const WeightedSum & ws) {
             WPBSum terms;

--- a/gcs/constraints/multiply/multiply_bc.cc
+++ b/gcs/constraints/multiply/multiply_bc.cc
@@ -1121,14 +1121,32 @@ namespace
     // existing bounds propagator's cutting-planes resolve against cake's flags
     // unchanged: the magnitude variables' bits ARE cake's bin flags. See the cake
     // ENCODING_MULTIPLY spec and dev_docs.
+    // `link`, when set, disambiguates one multiplication of a chain that shares a constraint
+    // id (Power's base^k): it is folded into the cake bit-name index tuples and prepended to
+    // the @c roles as `l<link>_`, so the per-link magnitude/product/sign flags do not clash.
+    // Left nullopt for a single multiplication (Multiply, Divide, Modulus), keeping the names
+    // byte-identical to cake's.
     auto define_encoding_cake(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id, const string & label_id,
-        SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3, mult_bc::EncodingData & result) -> void
+        SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3, mult_bc::EncodingData & result,
+        std::optional<long long> link = std::nullopt) -> void
     {
         auto & bit_products = result.initial_bit_products;
         auto & channelling_constraints = result.channelling_constraints;
         auto & mag_var = result.mag_var;
         auto & sign_lines = result.sign_lines;
         const auto & mbid = label_id;
+
+        // Per-link naming: `lp` prefixes @c roles, `idx` folds the link into a cake bit-name
+        // index tuple, `pidx` into a product-flag name. All no-ops when link is nullopt.
+        auto lp = link ? "l" + std::to_string(*link) + "_" : string{};
+        auto idx = [&](std::vector<long long> t) {
+            if (link)
+                t.insert(t.begin(), *link);
+            return t;
+        };
+        auto pidx = [&](Integer i, Integer j) {
+            return (link ? std::to_string(*link) + "_" : string{}) + std::to_string(i.raw_value) + "_" + std::to_string(j.raw_value);
+        };
 
         // A magnitude variable per operand: a free bit-sum whose bits are named
         // cake's x[id][axis_i][bin] (use_indices_family), channelled to |v| = v
@@ -1137,18 +1155,18 @@ namespace
             // Range [0, max(|lb|, |ub|)] so a signed operand's magnitude has enough
             // bits; for a non-negative operand this is just [0, ub], unchanged.
             auto mag_ub = max(abs(initial_state.lower_bound(v)), abs(initial_state.upper_bound(v)));
-            auto mag = model.create_proof_only_integer_variable(0_i, mag_ub, "mult_mag_" + letter, IntegerVariableProofRepresentation::Bits,
-                CakeBitNaming{constraint_id, {axis}, "bin", nullopt, false, true});
+            auto mag = model.create_proof_only_integer_variable(0_i, mag_ub, "mult_mag_" + lp + letter, IntegerVariableProofRepresentation::Bits,
+                CakeBitNaming{constraint_id, idx({axis}), "bin", nullopt, false, true});
             auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
             auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
             auto pos_ge = model.add_labelled_constraint(
-                mbid, letter + "ge0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0);
+                mbid, lp + letter + "ge0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0);
             auto pos_le = model.add_labelled_constraint(
-                mbid, letter + "ge0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0);
-            auto neg_ge =
-                model.add_labelled_constraint(mbid, letter + "lt0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0);
+                mbid, lp + letter + "ge0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0);
+            auto neg_ge = model.add_labelled_constraint(
+                mbid, lp + letter + "lt0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0);
             auto neg_le = model.add_labelled_constraint(
-                mbid, letter + "lt0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0);
+                mbid, lp + letter + "lt0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0);
             channelling_constraints.insert({v, mult_bc::ChannellingData{pos_ge, pos_le, neg_ge, neg_le, true, initial_state.lower_bound(v) < 0_i}});
             mag_var.insert({v, mag});
             return mag;
@@ -1169,9 +1187,9 @@ namespace
         for (Integer i = 0_i; i < n1; ++i) {
             bit_products.emplace_back();
             for (Integer j = 0_i; j < n2; ++j) {
-                auto flag = model.create_proof_flag_fully_reifying(constraint_id, {i.raw_value, j.raw_value}, "prod",
+                auto flag = model.create_proof_flag_fully_reifying(constraint_id, idx({i.raw_value, j.raw_value}), "prod",
                     WPBSum{} + 1_i * ProofBitVariable{mag1, i, true} + 1_i * ProofBitVariable{mag2, j, true} >= 2_i);
-                auto base = "x[" + mbid + "][" + std::to_string(i.raw_value) + "_" + std::to_string(j.raw_value) + "][prod]";
+                auto base = "x[" + mbid + "][" + pidx(i, j) + "][prod]";
                 bit_products[i.as_index()].emplace_back(
                     mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
                 product_sum += power2(i + j) * flag;
@@ -1186,10 +1204,11 @@ namespace
         auto zlt0 = HalfReifyOnConjunctionOf{v3 < 0_i};
         // Gated on [Z>=0] (byte-matching cake); the product-bound provers discharge
         // the entailed ge0(Z) with the ge0(Z) unit (Z is non-negative here).
-        auto mag_z_ge = model.add_labelled_constraint(mbid, "mag_Zge0_ge", "MultiplyBC", "z = product", neg_product_sum + 1_i * v3 >= 0_i, zge0);
-        auto mag_z_le = model.add_labelled_constraint(mbid, "mag_Zge0_le", "MultiplyBC", "z = product", product_sum + -1_i * v3 >= 0_i, zge0);
-        auto mag_z_neg_ge = model.add_labelled_constraint(mbid, "mag_Zlt0_ge", "MultiplyBC", "z = product", product_sum + 1_i * v3 >= 0_i, zlt0);
-        auto mag_z_neg_le = model.add_labelled_constraint(mbid, "mag_Zlt0_le", "MultiplyBC", "z = product", neg_product_sum + -1_i * v3 >= 0_i, zlt0);
+        auto mag_z_ge = model.add_labelled_constraint(mbid, lp + "mag_Zge0_ge", "MultiplyBC", "z = product", neg_product_sum + 1_i * v3 >= 0_i, zge0);
+        auto mag_z_le = model.add_labelled_constraint(mbid, lp + "mag_Zge0_le", "MultiplyBC", "z = product", product_sum + -1_i * v3 >= 0_i, zge0);
+        auto mag_z_neg_ge = model.add_labelled_constraint(mbid, lp + "mag_Zlt0_ge", "MultiplyBC", "z = product", product_sum + 1_i * v3 >= 0_i, zlt0);
+        auto mag_z_neg_le =
+            model.add_labelled_constraint(mbid, lp + "mag_Zlt0_le", "MultiplyBC", "z = product", neg_product_sum + -1_i * v3 >= 0_i, zlt0);
         result.v3_eq_product_lines = make_pair(mag_z_ge, mag_z_le);
         result.v3_eq_product_lines_neg = make_pair(mag_z_neg_ge, mag_z_neg_le);
         result.z_product_ge0_gated = true;
@@ -1197,140 +1216,30 @@ namespace
         // Sign clauses over reified atoms (all entailed for non-negative operands,
         // but cake always emits them; mirror it so the labels resolve in the chain).
         sign_lines.emplace_back(
-            model.add_labelled_constraint(mbid, "sgn_x0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
+            model.add_labelled_constraint(mbid, lp + "sgn_x0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
         sign_lines.emplace_back(
-            model.add_labelled_constraint(mbid, "sgn_y0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v2 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
+            model.add_labelled_constraint(mbid, lp + "sgn_y0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v2 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
         sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, "sgn_pp", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 < 1_i) + 1_i * (v3 >= 0_i) >= 1_i));
+            mbid, lp + "sgn_pp", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 < 1_i) + 1_i * (v3 >= 0_i) >= 1_i));
         sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, "sgn_nn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
+            mbid, lp + "sgn_nn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
         sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, "sgn_np", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 < 1_i) + 1_i * (v3 < 0_i) >= 1_i));
+            mbid, lp + "sgn_np", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 < 1_i) + 1_i * (v3 < 0_i) >= 1_i));
         sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, "sgn_pn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 < 0_i) >= 1_i));
+            mbid, lp + "sgn_pn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 < 0_i) >= 1_i));
     }
 }
 
 auto gcs::innards::mult_bc::define_encoding(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id,
-    const std::string & label_id, const std::string & role_prefix, SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3,
-    bool allow_cake_scheme) -> EncodingData
+    const std::string & label_id, SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3, std::optional<long long> link)
+    -> EncodingData
 {
+    // cake_pb_cp's multiplication encoding (magnitude bit-product flags, reified sign atoms,
+    // product channelled to |Z|) is the only scheme: it covers signed operands, and the old
+    // two's-complement encoding had no remaining consumer once Power moved onto this. `link`
+    // disambiguates one multiplication of a chain sharing a constraint id (Power's base^k).
     EncodingData result;
-    auto & bit_products = result.initial_bit_products;
-    auto & channelling_constraints = result.channelling_constraints;
-    auto & mag_var = result.mag_var;
-    auto & v3_eq_product_lines = result.v3_eq_product_lines;
-    auto & sign_lines = result.sign_lines;
-    auto * const optional_model = &model;
-
-    // cake_pb_cp's multiplication encoding: fresh magnitude bit-product flags over
-    // x[id][axis_i][bin] flags, reified sign atoms, product channelled to |Z|. Cake
-    // emits all four sign-gated magnitude rows per operand and the six sign clauses,
-    // so this covers signed operands too; the propagator's sign channelling picks
-    // the negative rows via cake's [v>=0] atoms. See dev_docs and the cake
-    // ENCODING_MULTIPLY spec.
-    if (allow_cake_scheme) {
-        define_encoding_cake(model, initial_state, constraint_id, label_id, v1, v2, v3, result);
-        return result;
-    }
-
-    {
-        // PB Encoding
-        auto make_magnitude_representation = [&](SimpleIntegerVariableID & v,
-                                                 const string & name) -> pair<SimpleOrProofOnlyIntegerVariableID, ProofLiteralOrFlag> {
-            auto sign_bit = ProofBitVariable{v, 0_i, true};
-            if (initial_state.lower_bound(v) < 0_i) {
-                auto largest_magnitude = max({abs(initial_state.lower_bound(v)), initial_state.upper_bound(v)});
-
-                auto v_magnitude = optional_model->create_proof_only_integer_variable(
-                    0_i, largest_magnitude, name + "_mag", IntegerVariableProofRepresentation::Bits);
-
-                auto bit_sum_without_neg = WPBSum{};
-                Integer num_bits = optional_model->names_and_ids_tracker().num_bits(v);
-
-                // Skip the neg bit
-                for (Integer pos = 0_i; pos < num_bits - 1_i; pos++)
-                    bit_sum_without_neg += power2(pos) * ProofBitVariable{v, pos + 1_i, true};
-
-                // mult_bc does not chain (cake does not encode multiplication), so
-                // these bit-decomposition defs take invented @c[id][role] labels.
-                const auto & mbid = label_id;
-                auto pos_ge = optional_model->add_labelled_constraint(mbid, "posge_" + name, "MultiplyBC", "magnitude channel",
-                    bit_sum_without_neg + (-1_i * v_magnitude) >= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto pos_le = optional_model->add_labelled_constraint(mbid, "posle_" + name, "MultiplyBC", "magnitude channel",
-                    bit_sum_without_neg + (-1_i * v_magnitude) <= 0_i, HalfReifyOnConjunctionOf{! sign_bit});
-                auto neg_ge = optional_model->add_labelled_constraint(mbid, "negge_" + name, "MultiplyBC", "magnitude channel",
-                    bit_sum_without_neg + (1_i * v_magnitude) >= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
-                auto neg_le = optional_model->add_labelled_constraint(mbid, "negle_" + name, "MultiplyBC", "magnitude channel",
-                    bit_sum_without_neg + (1_i * v_magnitude) <= power2(num_bits - 1_i), HalfReifyOnConjunctionOf{sign_bit});
-
-                channelling_constraints.insert({v, ChannellingData{pos_ge, pos_le, neg_ge, neg_le, false, true}});
-
-                mag_var.insert({v, v_magnitude});
-
-                return make_pair(v_magnitude, sign_bit);
-            }
-            else {
-                return make_pair(v, FalseLiteral{});
-            }
-        };
-        auto [v1_mag, v1_sign] = make_magnitude_representation(v1, role_prefix + "x");
-        auto [v2_mag, v2_sign] = make_magnitude_representation(v2, role_prefix + "y");
-        auto [v3_mag, v3_sign] = make_magnitude_representation(v3, role_prefix + "z");
-
-        const auto & mbid = label_id;
-        auto v1_num_bits = optional_model->names_and_ids_tracker().num_bits(v1_mag);
-        auto v2_num_bits = optional_model->names_and_ids_tracker().num_bits(v2_mag);
-
-        auto bit_product_sum = WPBSum{};
-        for (Integer i = 0_i; i < v1_num_bits; i++) {
-            bit_products.emplace_back();
-            for (Integer j = 0_i; j < v2_num_bits; j++) {
-                auto flag = optional_model->create_proof_flag(format("xy[{}][{}]", i, j));
-
-                auto ijtag = std::to_string(i.raw_value) + "_" + std::to_string(j.raw_value);
-                auto forwards = optional_model->add_labelled_constraint(mbid, role_prefix + "xyfwd_" + ijtag, "MultiplyBC", "bit product",
-                    WPBSum{} + 1_i * ProofBitVariable{v1_mag, i, true} + 1_i * ProofBitVariable{v2_mag, j, true} >= 2_i,
-                    HalfReifyOnConjunctionOf{flag});
-
-                auto backwards = optional_model->add_labelled_constraint(mbid, role_prefix + "xybwd_" + ijtag, "MultiplyBC", "bit product",
-                    WPBSum{} + -1_i * ProofBitVariable{v1_mag, i, true} + -1_i * ProofBitVariable{v2_mag, j, true} >= -1_i,
-                    HalfReifyOnConjunctionOf{! flag});
-
-                bit_products[i.as_index()].emplace_back(BitProductData{flag, forwards, backwards, nullopt, nullopt});
-                bit_product_sum += power2(i + j) * flag;
-            }
-        }
-
-        visit(
-            [&](auto v3_mag) {
-                auto s = optional_model->add_labelled_constraint(mbid, role_prefix + "zprodle", role_prefix + "zprodge", StringLiteral{"MultiplyBC"},
-                    StringLiteral{"z = product"}, bit_product_sum + (-1_i * v3_mag) == 0_i);
-                v3_eq_product_lines = make_pair(s.first, s.second);
-            },
-            v3_mag);
-
-        auto xyss = optional_model->create_proof_flag("xy[s][s]");
-        sign_lines.emplace_back(optional_model->add_labelled_constraint(
-            mbid, role_prefix + "sign_nn", "MultiplyBC", "sign", WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, ! v2_sign}));
-
-        if (mag_var.contains(v1))
-            sign_lines.emplace_back(optional_model->add_labelled_constraint(
-                mbid, role_prefix + "sign_pn", "MultiplyBC", "sign", WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, ! v2_sign}));
-        if (mag_var.contains(v2))
-            sign_lines.emplace_back(optional_model->add_labelled_constraint(
-                mbid, role_prefix + "sign_np", "MultiplyBC", "sign", WPBSum{} + 1_i * xyss >= 1_i, HalfReifyOnConjunctionOf{! v1_sign, v2_sign}));
-        if (mag_var.contains(v1) && mag_var.contains(v2))
-            sign_lines.emplace_back(optional_model->add_labelled_constraint(
-                mbid, role_prefix + "sign_pp", "MultiplyBC", "sign", WPBSum{} + 1_i * ! xyss >= 1_i, HalfReifyOnConjunctionOf{v1_sign, v2_sign}));
-
-        sign_lines.emplace_back(optional_model->add_labelled_constraint(mbid, role_prefix + "sign_v3pos", "MultiplyBC", "sign",
-            WPBSum{} + 1_i * xyss + 1_i * (v1 != 0_i) + 1_i * (v2 != 0_i) >= 3_i, HalfReifyOnConjunctionOf{v3_sign}));
-
-        sign_lines.emplace_back(optional_model->add_labelled_constraint(mbid, role_prefix + "sign_v3neg", "MultiplyBC", "sign",
-            WPBSum{} + 1_i * ! xyss + 1_i * (v1 == 0_i) + 1_i * (v2 == 0_i) >= 1_i, HalfReifyOnConjunctionOf{! v3_sign}));
-    }
-
+    define_encoding_cake(model, initial_state, constraint_id, label_id, v1, v2, v3, result, link);
     return result;
 }
 
@@ -1379,7 +1288,7 @@ auto MultiplyBC::install(Propagators & propagators, State & initial_state, Proof
 
     mult_bc::EncodingData encoding;
     if (optional_model)
-        encoding = mult_bc::define_encoding(*optional_model, initial_state, constraint_id(), as_string(constraint_id()), "", _v1, _v2, _v3, true);
+        encoding = mult_bc::define_encoding(*optional_model, initial_state, constraint_id(), as_string(constraint_id()), _v1, _v2, _v3);
 
     ConstraintStateHandle bit_products_handle = initial_state.add_persistent_constraint_state(encoding.initial_bit_products);
 

--- a/gcs/constraints/multiply/multiply_bc.cc
+++ b/gcs/constraints/multiply/multiply_bc.cc
@@ -989,17 +989,6 @@ namespace
         return {smallest_possible_product, largest_possible_product};
     }
 
-    // When v3 is a magnitude (|v1|*|v2|, e.g. divide's product w) rather than the
-    // signed product, bound it by the operand magnitudes: |v| ranges over
-    // [spans0 ? 0 : min(|lo|,|hi|), max(|lo|,|hi|)]. This never produces a negative
-    // range, so mult_bc does not infer a (false) negative bound on a magnitude v3.
-    auto get_magnitude_product_bounds(Integer x_min, Integer x_max, Integer y_min, Integer y_max) -> pair<Integer, Integer>
-    {
-        auto mag_lo = [](Integer lo, Integer hi) { return (lo < 0_i && hi > 0_i) ? 0_i : min(abs(lo), abs(hi)); };
-        auto mag_hi = [](Integer lo, Integer hi) { return max(abs(lo), abs(hi)); };
-        return {mag_lo(x_min, x_max) * mag_lo(y_min, y_max), mag_hi(x_min, x_max) * mag_hi(y_min, y_max)};
-    }
-
     // Filter variable x where x * y = z based on bounds of y and z
     auto filter_quotient(SimpleIntegerVariableID x_var, SimpleIntegerVariableID y_var, SimpleIntegerVariableID z_var, Integer z_min, Integer z_max,
         Integer y_min, Integer y_max, const State & state, auto & inference,
@@ -1351,12 +1340,7 @@ auto gcs::innards::mult_bc::propagate(SimpleIntegerVariableID v1, SimpleIntegerV
 {
     auto var_bounds = map<IntegerVariableID, pair<Integer, Integer>>{{v1, state.bounds(v1)}, {v2, state.bounds(v2)}, {v3, state.bounds(v3)}};
     auto bounds1 = state.bounds(v1), bounds2 = state.bounds(v2);
-    // A magnitude v3 (|v1|*|v2|, e.g. divide's product w) is bounded by the operand
-    // magnitudes so an opposite-sign operand pair does not yield a negative range that
-    // contradicts the magnitude's own non-negativity; a signed v3 uses the signed range.
-    auto [smallest_product, largest_product] = encoding.z_is_magnitude
-        ? get_magnitude_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second)
-        : get_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second);
+    auto [smallest_product, largest_product] = get_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second);
     auto & bit_products = any_cast<vector<vector<BitProductData>> &>(state.get_persistent_constraint_state(bit_products_handle));
 
     auto justf = [&](const ReasonLiterals & reason) {

--- a/gcs/constraints/multiply/multiply_bc.cc
+++ b/gcs/constraints/multiply/multiply_bc.cc
@@ -1099,8 +1099,8 @@ MultiplyBC::MultiplyBC(const SimpleIntegerVariableID v1, const SimpleIntegerVari
 {
     // Aliased slots are well-defined semantically (squaring, fixed
     // points) but the bit-product proof encoding doesn't tolerate
-    // them: make_magnitude_representation, prove_product_bounds, and
-    // the sign_lines accounting all assume distinct underlying
+    // them: the magnitude channels, prove_product_bounds, and the
+    // sign_lines accounting all assume distinct underlying
     // variables. See GitHub issue for the deeper fix; until then
     // surface as an InvalidProblemDefinitionException so users get
     // an actionable error instead of a proof-verification failure.

--- a/gcs/constraints/multiply/multiply_bc.cc
+++ b/gcs/constraints/multiply/multiply_bc.cc
@@ -823,6 +823,21 @@ namespace
         auto min_x = Integer{x_has_neg ? -(power2(x_bits - 1_i)) : 0_i};
         auto max_x = Integer{x_has_neg ? (power2(x_bits - 1_i)) : power2(x_bits)} - 1_i;
 
+        // The range of x that would violate the bound being proved: x < smallest_quotient (when
+        // proving x >= smallest_quotient) or x > largest_quotient (when proving x <= it),
+        // intersected with x's own bit-encoding range [min_x, max_x].
+        auto x_excl_lower = assume_upper ? min_x : largest_quotient + 1_i;
+        auto x_excl_upper = assume_upper ? smallest_quotient - 1_i : max_x;
+        // When the quotient bound falls outside x's encoding range that intersection is empty:
+        // x can never reach the quotient bound, so the bound is trivially entailed by x's own
+        // bit bounds and needs no product-based derivation -- the caller's RUP line closes
+        // against x's encoding directly. (This arises when filter_quotient reports an
+        // inconsistent quotient range [smallest > largest] on an infeasible node: one of the
+        // two bounds is outside x's encoding and vacuous, the other is genuinely derived, and
+        // the caller's contradiction combines them.)
+        if (x_excl_lower > x_excl_upper)
+            return;
+
         // logger.emit_proof_comment("X bounds for quotient");
         auto upper_x_lit = assume_upper ? x < smallest_quotient : x > largest_quotient;
         auto upper_x_lit_def_line = get_def_line_for_lit(logger, upper_x_lit);
@@ -862,10 +877,11 @@ namespace
             auto [lower, upper] = var_bounds.at(var);
 
             if (var == x) {
-                lower = (assume_upper ? min_x : largest_quotient + 1_i);
-                upper = (! assume_upper ? max_x : smallest_quotient - 1_i);
+                lower = x_excl_lower;
+                upper = x_excl_upper;
             }
 
+            // x's excluded range was already checked non-empty above; y's is its live domain.
             if (lower > upper)
                 throw UnexpectedException{format("var == x is {}, lower is {}, upper is {}, assume_upper is {}, min_x is {}, max_x is {}, "
                                                  "largest_quotient is {}, smallest_quotient is {}",

--- a/gcs/constraints/multiply/multiply_bc.cc
+++ b/gcs/constraints/multiply/multiply_bc.cc
@@ -1129,133 +1129,119 @@ auto MultiplyBC::clone() const -> unique_ptr<Constraint>
     return make_unique<MultiplyBC>(_v1, _v2, _v3);
 }
 
-namespace
-{
-    // cake_pb_cp's multiplication encoding (magnitude bit-products over fresh
-    // x[id][axis_i][bin] flags channelled to |X|, reified sign atoms, product
-    // channelled to |Z|), for non-negative operands. Populates `result` so the
-    // existing bounds propagator's cutting-planes resolve against cake's flags
-    // unchanged: the magnitude variables' bits ARE cake's bin flags. See the cake
-    // ENCODING_MULTIPLY spec and dev_docs.
-    // `link`, when set, disambiguates one multiplication of a chain that shares a constraint
-    // id (Power's base^k): it is folded into the cake bit-name index tuples and prepended to
-    // the @c roles as `l<link>_`, so the per-link magnitude/product/sign flags do not clash.
-    // Left nullopt for a single multiplication (Multiply, Divide, Modulus), keeping the names
-    // byte-identical to cake's.
-    auto define_encoding_cake(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id, const string & label_id,
-        SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3, mult_bc::EncodingData & result,
-        std::optional<long long> link = std::nullopt) -> void
-    {
-        auto & bit_products = result.initial_bit_products;
-        auto & channelling_constraints = result.channelling_constraints;
-        auto & mag_var = result.mag_var;
-        auto & sign_lines = result.sign_lines;
-        const auto & mbid = label_id;
-
-        // Per-link naming: `lp` prefixes @c roles, `idx` folds the link into a cake bit-name
-        // index tuple, `pidx` into a product-flag name. All no-ops when link is nullopt.
-        auto lp = link ? "l" + std::to_string(*link) + "_" : string{};
-        auto idx = [&](std::vector<long long> t) {
-            if (link)
-                t.insert(t.begin(), *link);
-            return t;
-        };
-        auto pidx = [&](Integer i, Integer j) {
-            return (link ? std::to_string(*link) + "_" : string{}) + std::to_string(i.raw_value) + "_" + std::to_string(j.raw_value);
-        };
-
-        // A magnitude variable per operand: a free bit-sum whose bits are named
-        // cake's x[id][axis_i][bin] (use_indices_family), channelled to |v| = v
-        // (non-negative) via cake's four sign-gated rows. axis 0 -> "X", 1 -> "Y".
-        auto make_mag = [&](SimpleIntegerVariableID v, long long axis, const string & letter) -> ProofOnlySimpleIntegerVariableID {
-            // Range [0, max(|lb|, |ub|)] so a signed operand's magnitude has enough
-            // bits; for a non-negative operand this is just [0, ub], unchanged.
-            auto mag_ub = max(abs(initial_state.lower_bound(v)), abs(initial_state.upper_bound(v)));
-            auto mag = model.create_proof_only_integer_variable(0_i, mag_ub, "mult_mag_" + lp + letter, IntegerVariableProofRepresentation::Bits,
-                CakeBitNaming{constraint_id, idx({axis}), "bin", nullopt, false, true});
-            auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
-            auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
-            auto pos_ge = model.add_labelled_constraint(
-                mbid, lp + letter + "ge0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0);
-            auto pos_le = model.add_labelled_constraint(
-                mbid, lp + letter + "ge0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0);
-            auto neg_ge = model.add_labelled_constraint(
-                mbid, lp + letter + "lt0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0);
-            auto neg_le = model.add_labelled_constraint(
-                mbid, lp + letter + "lt0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0);
-            channelling_constraints.insert({v, mult_bc::ChannellingData{pos_ge, pos_le, neg_ge, neg_le, true, initial_state.lower_bound(v) < 0_i}});
-            mag_var.insert({v, mag});
-            return mag;
-        };
-        auto mag1 = make_mag(v1, 0, "X");
-        auto mag2 = make_mag(v2, 1, "Y");
-
-        auto & tracker = model.names_and_ids_tracker();
-        auto n1 = tracker.num_bits(mag1);
-        auto n2 = tracker.num_bits(mag2);
-
-        // Bit products x[id][i_j][prod] <=> binX_i AND binY_j, summed with 2^(i+j).
-        // The two reifying halves carry deterministic labels (create_proof_flag_-
-        // fully_reifying): [r] = flag -> ineq ("forwards"), [f] = ~flag -> ~ineq
-        // ("reverse"); the propagator references them by those labels.
-        auto product_sum = WPBSum{};     // Sum 2^(i+j) prod[i][j]
-        auto neg_product_sum = WPBSum{}; // -Sum 2^(i+j) prod[i][j]
-        for (Integer i = 0_i; i < n1; ++i) {
-            bit_products.emplace_back();
-            for (Integer j = 0_i; j < n2; ++j) {
-                auto flag = model.create_proof_flag_fully_reifying(constraint_id, idx({i.raw_value, j.raw_value}), "prod",
-                    WPBSum{} + 1_i * ProofBitVariable{mag1, i, true} + 1_i * ProofBitVariable{mag2, j, true} >= 2_i);
-                auto base = "x[" + mbid + "][" + pidx(i, j) + "][prod]";
-                bit_products[i.as_index()].emplace_back(
-                    mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
-                product_sum += power2(i + j) * flag;
-                neg_product_sum += -power2(i + j) * flag;
-            }
-        }
-
-        // Channel the product magnitude to |Z| = Z (non-negative), gated on [Z>=0].
-        // The two ge0 halves give Sum(prod) == Z; the propagator uses them as the
-        // z_eq_product pair (.first: Z >= product, .second: Z <= product).
-        auto zge0 = HalfReifyOnConjunctionOf{v3 >= 0_i};
-        auto zlt0 = HalfReifyOnConjunctionOf{v3 < 0_i};
-        // Gated on [Z>=0] (byte-matching cake); the product-bound provers discharge
-        // the entailed ge0(Z) with the ge0(Z) unit (Z is non-negative here).
-        auto mag_z_ge = model.add_labelled_constraint(mbid, lp + "mag_Zge0_ge", "MultiplyBC", "z = product", neg_product_sum + 1_i * v3 >= 0_i, zge0);
-        auto mag_z_le = model.add_labelled_constraint(mbid, lp + "mag_Zge0_le", "MultiplyBC", "z = product", product_sum + -1_i * v3 >= 0_i, zge0);
-        auto mag_z_neg_ge = model.add_labelled_constraint(mbid, lp + "mag_Zlt0_ge", "MultiplyBC", "z = product", product_sum + 1_i * v3 >= 0_i, zlt0);
-        auto mag_z_neg_le =
-            model.add_labelled_constraint(mbid, lp + "mag_Zlt0_le", "MultiplyBC", "z = product", neg_product_sum + -1_i * v3 >= 0_i, zlt0);
-        result.v3_eq_product_lines = make_pair(mag_z_ge, mag_z_le);
-        result.v3_eq_product_lines_neg = make_pair(mag_z_neg_ge, mag_z_neg_le);
-        result.z_product_ge0_gated = true;
-
-        // Sign clauses over reified atoms (all entailed for non-negative operands,
-        // but cake always emits them; mirror it so the labels resolve in the chain).
-        sign_lines.emplace_back(
-            model.add_labelled_constraint(mbid, lp + "sgn_x0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
-        sign_lines.emplace_back(
-            model.add_labelled_constraint(mbid, lp + "sgn_y0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v2 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
-        sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, lp + "sgn_pp", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 < 1_i) + 1_i * (v3 >= 0_i) >= 1_i));
-        sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, lp + "sgn_nn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
-        sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, lp + "sgn_np", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 < 1_i) + 1_i * (v3 < 0_i) >= 1_i));
-        sign_lines.emplace_back(model.add_labelled_constraint(
-            mbid, lp + "sgn_pn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 < 0_i) >= 1_i));
-    }
-}
-
 auto gcs::innards::mult_bc::define_encoding(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id,
     const std::string & label_id, SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3, std::optional<long long> link)
     -> EncodingData
 {
-    // cake_pb_cp's multiplication encoding (magnitude bit-product flags, reified sign atoms,
-    // product channelled to |Z|) is the only scheme: it covers signed operands, and the old
-    // two's-complement encoding had no remaining consumer once Power moved onto this. `link`
-    // disambiguates one multiplication of a chain sharing a constraint id (Power's base^k).
+    // cake_pb_cp's multiplication encoding (magnitude bit-products over fresh x[id][axis_i][bin]
+    // flags channelled to |X|, reified sign atoms, product channelled to |Z|) is the only
+    // scheme: it covers signed operands, and the old two's-complement encoding had no remaining
+    // consumer once Power moved onto this. The magnitude variables' bits ARE cake's bin flags,
+    // so the existing bounds propagator's cutting-planes resolve against them unchanged.
+    // `link`, when set, disambiguates one multiplication of a chain that shares a constraint id
+    // (Power's base^k): it is folded into the cake bit-name index tuples and prepended to the @c
+    // roles as `l<link>_`, so the per-link magnitude/product/sign flags do not clash; left
+    // nullopt for a single multiplication (Multiply, Divide, Modulus), keeping the names byte-
+    // identical to cake's. See the cake ENCODING_MULTIPLY spec and dev_docs.
     EncodingData result;
-    define_encoding_cake(model, initial_state, constraint_id, label_id, v1, v2, v3, result, link);
+    auto & bit_products = result.initial_bit_products;
+    auto & channelling_constraints = result.channelling_constraints;
+    auto & mag_var = result.mag_var;
+    auto & sign_lines = result.sign_lines;
+    const auto & mbid = label_id;
+
+    // Per-link naming: `lp` prefixes @c roles, `idx` folds the link into a cake bit-name
+    // index tuple, `pidx` into a product-flag name. All no-ops when link is nullopt.
+    auto lp = link ? "l" + std::to_string(*link) + "_" : string{};
+    auto idx = [&](std::vector<long long> t) {
+        if (link)
+            t.insert(t.begin(), *link);
+        return t;
+    };
+    auto pidx = [&](Integer i, Integer j) {
+        return (link ? std::to_string(*link) + "_" : string{}) + std::to_string(i.raw_value) + "_" + std::to_string(j.raw_value);
+    };
+
+    // A magnitude variable per operand: a free bit-sum whose bits are named
+    // cake's x[id][axis_i][bin] (use_indices_family), channelled to |v| = v
+    // (non-negative) via cake's four sign-gated rows. axis 0 -> "X", 1 -> "Y".
+    auto make_mag = [&](SimpleIntegerVariableID v, long long axis, const string & letter) -> ProofOnlySimpleIntegerVariableID {
+        // Range [0, max(|lb|, |ub|)] so a signed operand's magnitude has enough
+        // bits; for a non-negative operand this is just [0, ub], unchanged.
+        auto mag_ub = max(abs(initial_state.lower_bound(v)), abs(initial_state.upper_bound(v)));
+        auto mag = model.create_proof_only_integer_variable(0_i, mag_ub, "mult_mag_" + lp + letter, IntegerVariableProofRepresentation::Bits,
+            CakeBitNaming{constraint_id, idx({axis}), "bin", nullopt, false, true});
+        auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
+        auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
+        auto pos_ge = model.add_labelled_constraint(
+            mbid, lp + letter + "ge0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + -1_i * mag >= 0_i, ge0);
+        auto pos_le = model.add_labelled_constraint(
+            mbid, lp + letter + "ge0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + 1_i * mag >= 0_i, ge0);
+        auto neg_ge = model.add_labelled_constraint(
+            mbid, lp + letter + "lt0_ge", "MultiplyBC", "magnitude channel", WPBSum{} + 1_i * v + 1_i * mag >= 0_i, lt0);
+        auto neg_le = model.add_labelled_constraint(
+            mbid, lp + letter + "lt0_le", "MultiplyBC", "magnitude channel", WPBSum{} + -1_i * v + -1_i * mag >= 0_i, lt0);
+        channelling_constraints.insert({v, mult_bc::ChannellingData{pos_ge, pos_le, neg_ge, neg_le, true, initial_state.lower_bound(v) < 0_i}});
+        mag_var.insert({v, mag});
+        return mag;
+    };
+    auto mag1 = make_mag(v1, 0, "X");
+    auto mag2 = make_mag(v2, 1, "Y");
+
+    auto & tracker = model.names_and_ids_tracker();
+    auto n1 = tracker.num_bits(mag1);
+    auto n2 = tracker.num_bits(mag2);
+
+    // Bit products x[id][i_j][prod] <=> binX_i AND binY_j, summed with 2^(i+j).
+    // The two reifying halves carry deterministic labels (create_proof_flag_-
+    // fully_reifying): [r] = flag -> ineq ("forwards"), [f] = ~flag -> ~ineq
+    // ("reverse"); the propagator references them by those labels.
+    auto product_sum = WPBSum{};     // Sum 2^(i+j) prod[i][j]
+    auto neg_product_sum = WPBSum{}; // -Sum 2^(i+j) prod[i][j]
+    for (Integer i = 0_i; i < n1; ++i) {
+        bit_products.emplace_back();
+        for (Integer j = 0_i; j < n2; ++j) {
+            auto flag = model.create_proof_flag_fully_reifying(constraint_id, idx({i.raw_value, j.raw_value}), "prod",
+                WPBSum{} + 1_i * ProofBitVariable{mag1, i, true} + 1_i * ProofBitVariable{mag2, j, true} >= 2_i);
+            auto base = "x[" + mbid + "][" + pidx(i, j) + "][prod]";
+            bit_products[i.as_index()].emplace_back(
+                mult_bc::BitProductData{flag, ProofLineLabel{base + "[r]"}, ProofLineLabel{base + "[f]"}, nullopt, nullopt});
+            product_sum += power2(i + j) * flag;
+            neg_product_sum += -power2(i + j) * flag;
+        }
+    }
+
+    // Channel the product magnitude to |Z| = Z (non-negative), gated on [Z>=0].
+    // The two ge0 halves give Sum(prod) == Z; the propagator uses them as the
+    // z_eq_product pair (.first: Z >= product, .second: Z <= product).
+    auto zge0 = HalfReifyOnConjunctionOf{v3 >= 0_i};
+    auto zlt0 = HalfReifyOnConjunctionOf{v3 < 0_i};
+    // Gated on [Z>=0] (byte-matching cake); the product-bound provers discharge
+    // the entailed ge0(Z) with the ge0(Z) unit (Z is non-negative here).
+    auto mag_z_ge = model.add_labelled_constraint(mbid, lp + "mag_Zge0_ge", "MultiplyBC", "z = product", neg_product_sum + 1_i * v3 >= 0_i, zge0);
+    auto mag_z_le = model.add_labelled_constraint(mbid, lp + "mag_Zge0_le", "MultiplyBC", "z = product", product_sum + -1_i * v3 >= 0_i, zge0);
+    auto mag_z_neg_ge = model.add_labelled_constraint(mbid, lp + "mag_Zlt0_ge", "MultiplyBC", "z = product", product_sum + 1_i * v3 >= 0_i, zlt0);
+    auto mag_z_neg_le =
+        model.add_labelled_constraint(mbid, lp + "mag_Zlt0_le", "MultiplyBC", "z = product", neg_product_sum + -1_i * v3 >= 0_i, zlt0);
+    result.v3_eq_product_lines = make_pair(mag_z_ge, mag_z_le);
+    result.v3_eq_product_lines_neg = make_pair(mag_z_neg_ge, mag_z_neg_le);
+    result.z_product_ge0_gated = true;
+
+    // Sign clauses over reified atoms (all entailed for non-negative operands,
+    // but cake always emits them; mirror it so the labels resolve in the chain).
+    sign_lines.emplace_back(
+        model.add_labelled_constraint(mbid, lp + "sgn_x0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
+    sign_lines.emplace_back(
+        model.add_labelled_constraint(mbid, lp + "sgn_y0", "MultiplyBC", "sign", WPBSum{} + 1_i * (v2 != 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
+    sign_lines.emplace_back(model.add_labelled_constraint(
+        mbid, lp + "sgn_pp", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 < 1_i) + 1_i * (v3 >= 0_i) >= 1_i));
+    sign_lines.emplace_back(model.add_labelled_constraint(
+        mbid, lp + "sgn_nn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 >= 0_i) >= 1_i));
+    sign_lines.emplace_back(model.add_labelled_constraint(
+        mbid, lp + "sgn_np", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 >= 0_i) + 1_i * (v2 < 1_i) + 1_i * (v3 < 0_i) >= 1_i));
+    sign_lines.emplace_back(model.add_labelled_constraint(
+        mbid, lp + "sgn_pn", "MultiplyBC", "sign", WPBSum{} + 1_i * (v1 < 1_i) + 1_i * (v2 >= 0_i) + 1_i * (v3 < 0_i) >= 1_i));
+
     return result;
 }
 

--- a/gcs/constraints/multiply/multiply_bc.cc
+++ b/gcs/constraints/multiply/multiply_bc.cc
@@ -989,6 +989,17 @@ namespace
         return {smallest_possible_product, largest_possible_product};
     }
 
+    // When v3 is a magnitude (|v1|*|v2|, e.g. divide's product w) rather than the
+    // signed product, bound it by the operand magnitudes: |v| ranges over
+    // [spans0 ? 0 : min(|lo|,|hi|), max(|lo|,|hi|)]. This never produces a negative
+    // range, so mult_bc does not infer a (false) negative bound on a magnitude v3.
+    auto get_magnitude_product_bounds(Integer x_min, Integer x_max, Integer y_min, Integer y_max) -> pair<Integer, Integer>
+    {
+        auto mag_lo = [](Integer lo, Integer hi) { return (lo < 0_i && hi > 0_i) ? 0_i : min(abs(lo), abs(hi)); };
+        auto mag_hi = [](Integer lo, Integer hi) { return max(abs(lo), abs(hi)); };
+        return {mag_lo(x_min, x_max) * mag_lo(y_min, y_max), mag_hi(x_min, x_max) * mag_hi(y_min, y_max)};
+    }
+
     // Filter variable x where x * y = z based on bounds of y and z
     auto filter_quotient(SimpleIntegerVariableID x_var, SimpleIntegerVariableID y_var, SimpleIntegerVariableID z_var, Integer z_min, Integer z_max,
         Integer y_min, Integer y_max, const State & state, auto & inference,
@@ -1340,7 +1351,12 @@ auto gcs::innards::mult_bc::propagate(SimpleIntegerVariableID v1, SimpleIntegerV
 {
     auto var_bounds = map<IntegerVariableID, pair<Integer, Integer>>{{v1, state.bounds(v1)}, {v2, state.bounds(v2)}, {v3, state.bounds(v3)}};
     auto bounds1 = state.bounds(v1), bounds2 = state.bounds(v2);
-    auto [smallest_product, largest_product] = get_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second);
+    // A magnitude v3 (|v1|*|v2|, e.g. divide's product w) is bounded by the operand
+    // magnitudes so an opposite-sign operand pair does not yield a negative range that
+    // contradicts the magnitude's own non-negativity; a signed v3 uses the signed range.
+    auto [smallest_product, largest_product] = encoding.z_is_magnitude
+        ? get_magnitude_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second)
+        : get_product_bounds(bounds1.first, bounds1.second, bounds2.first, bounds2.second);
     auto & bit_products = any_cast<vector<vector<BitProductData>> &>(state.get_persistent_constraint_state(bit_products_handle));
 
     auto justf = [&](const ReasonLiterals & reason) {

--- a/gcs/constraints/multiply/multiply_bc.hh
+++ b/gcs/constraints/multiply/multiply_bc.hh
@@ -75,11 +75,6 @@ namespace gcs::innards
             // ungated zprod lines leave z_product_ge0_gated false and _neg empty.
             std::optional<std::pair<ProofLine, ProofLine>> v3_eq_product_lines_neg{};
             bool z_product_ge0_gated = false;
-            // When v3 is a non-negative magnitude |v1|*|v2| (divide/modulus's product w)
-            // rather than the signed product v1*v2, propagate() bounds it by the operand
-            // magnitudes, so an opposite-sign operand pair does not infer a negative
-            // bound that contradicts the magnitude's own non-negativity.
-            bool z_is_magnitude = false;
             std::vector<ProofLine> sign_lines{};
             // Consumed at install time to create the persistent constraint
             // state that propagate() mutates through its handle.

--- a/gcs/constraints/multiply/multiply_bc.hh
+++ b/gcs/constraints/multiply/multiply_bc.hh
@@ -82,19 +82,14 @@ namespace gcs::innards
         };
 
         /**
-         * \brief Emit the magnitude/sign bit-product encoding of
-         * v1 * v2 = v3 into the OPB, labelled `@c[label_id][<role_prefix>...]`.
-         *
-         * The role_prefix keeps roles distinct when one constraint emits
-         * several of these (Power's chains); the emitted lines are byte-for-
-         * byte what MultiplyBC has always produced when it is empty.
+         * \brief Emit cake_pb_cp's magnitude bit-product encoding of v1 * v2 = v3 into the
+         * OPB (the only scheme; it covers signed operands). `link`, when set, disambiguates
+         * one multiplication of a chain sharing a constraint id (Power's base^k), folding it
+         * into the bit-name index tuples and @c roles so the per-link flags do not clash.
          */
-        // allow_cake_scheme opts into cake_pb_cp's magnitude-bit-product encoding
-        // for non-negative operands (Multiply / MultiplyBC); divide/modulus keep the
-        // legacy two's-complement encoding for now. See define_encoding_cake.
         [[nodiscard]] auto define_encoding(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id,
-            const std::string & label_id, const std::string & role_prefix, SimpleIntegerVariableID v1, SimpleIntegerVariableID v2,
-            SimpleIntegerVariableID v3, bool allow_cake_scheme = false) -> EncodingData;
+            const std::string & label_id, SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3,
+            std::optional<long long> link = std::nullopt) -> EncodingData;
 
         /**
          * \brief One pass of bounds consistent multiplication filtering for

--- a/gcs/constraints/multiply/multiply_bc.hh
+++ b/gcs/constraints/multiply/multiply_bc.hh
@@ -75,6 +75,11 @@ namespace gcs::innards
             // ungated zprod lines leave z_product_ge0_gated false and _neg empty.
             std::optional<std::pair<ProofLine, ProofLine>> v3_eq_product_lines_neg{};
             bool z_product_ge0_gated = false;
+            // When v3 is a non-negative magnitude |v1|*|v2| (divide/modulus's product w)
+            // rather than the signed product v1*v2, propagate() bounds it by the operand
+            // magnitudes, so an opposite-sign operand pair does not infer a negative
+            // bound that contradicts the magnitude's own non-negativity.
+            bool z_is_magnitude = false;
             std::vector<ProofLine> sign_lines{};
             // Consumed at install time to create the persistent constraint
             // state that propagate() mutates through its handle.

--- a/gcs/constraints/multiply/multiply_test.cc
+++ b/gcs/constraints/multiply/multiply_test.cc
@@ -246,6 +246,12 @@ auto main(int, char *[]) -> int
         // completeness are still checked, per-node consistency is not.
         run_multiply_test(proofs, consistency::Auto{}, false, {-10, 10}, {-10, 10}, {-100, 100});
         run_multiply_test(proofs, consistency::Auto{}, false, {2, 20}, {-8, 8}, {-160, 160}, {1, 0, 1, 1, 1, 0});
+        // A wide product with a small operand: the quotient estimate for the small operand can
+        // fall outside its bit-encoding, so filter_quotient reports an inconsistent (empty)
+        // quotient range on an infeasible node. Regression for a prove_quotient_bounds crash on
+        // that empty range (the bound is then trivially entailed by the operand's own bounds).
+        run_multiply_test(proofs, consistency::Auto{}, false, {-120, 120}, {-5, 5}, {-620, 620});
+        run_multiply_test(proofs, consistency::Auto{}, false, {-350, 350}, {-3, 3}, {-1100, 1100});
         run_alias_test(proofs, consistency::Auto{}, false, "xxy", {-12, 12}, {0, 144});
         run_constant_test(proofs, consistency::Auto{}, "cv", 7, {-30, 30}, {-210, 210});
 

--- a/gcs/constraints/power/power.cc
+++ b/gcs/constraints/power/power.cc
@@ -113,10 +113,14 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
         ConstraintStateHandle bit_products_handle;
     };
     vector<MultLink> links;
-    auto add_link = [&](const string & prefix, SimpleIntegerVariableID a, SimpleIntegerVariableID b, SimpleIntegerVariableID product) {
+    auto add_link = [&](long long link, SimpleIntegerVariableID a, SimpleIntegerVariableID b, SimpleIntegerVariableID product) {
+        // Each chain link is a signed multiplication encoded with cake's magnitude scheme, the
+        // same one Multiply uses; `link` disambiguates the per-link flags. (cake has no power
+        // encoder, so this self-verifies rather than chain-verifying, but it keeps Power off
+        // mult_bc's legacy encoding.)
         mult_bc::EncodingData encoding;
         if (optional_model)
-            encoding = mult_bc::define_encoding(*optional_model, initial_state, constraint_id(), label, prefix, a, b, product);
+            encoding = mult_bc::define_encoding(*optional_model, initial_state, constraint_id(), label, a, b, product, link);
         auto handle = initial_state.add_persistent_constraint_state(encoding.initial_bit_products);
         links.emplace_back(MultLink{a, b, product, move(encoding), handle});
     };
@@ -219,7 +223,7 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
                     optional_model->set_up_integer_variable(t, lo, hi, "aux_power" + to_string(t.index), nullopt);
             }
 
-            add_link("c" + to_string(i) + "_", prev, other, t);
+            add_link(i, prev, other, t);
 
             if (is_last && ! (result_plain && t == *a3.var))
                 add_equality(WeightedSum{} + 1_i * t + -1_i * _result, 0_i, "resultsum");

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -663,8 +663,8 @@ auto ProofLogger::emit_red_proof_line(const SumLessThanEqual<Weighted<PseudoBool
     return record_proof_line(advance_proof_line_number(), level);
 }
 
-auto ProofLogger::introduce_bits_of(const SumOf<Weighted<PseudoBooleanTerm>> & linear_form, ProofOnlySimpleIntegerVariableID target, ProofLevel level)
-    -> pair<ProofLine, ProofLine>
+auto ProofLogger::introduce_bits_of(
+    const SumOf<Weighted<PseudoBooleanTerm>> & linear_form, SimpleOrProofOnlyIntegerVariableID target, ProofLevel level) -> pair<ProofLine, ProofLine>
 {
     // Wietze Koops's construction: walk target's bits from the top, defining each
     // bit e_k as the reified `running-remainder >= 2^k` via a single red whose

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -319,7 +319,7 @@ namespace gcs::innards
          * two reds --- so the caller can reference the variable's bound-defining
          * lines (e.g. an end = start + length proxy's end_ge / end_le).
          */
-        [[nodiscard]] auto introduce_bits_of(const SumOf<Weighted<PseudoBooleanTerm>> & linear_form, ProofOnlySimpleIntegerVariableID target,
+        [[nodiscard]] auto introduce_bits_of(const SumOf<Weighted<PseudoBooleanTerm>> & linear_form, SimpleOrProofOnlyIntegerVariableID target,
             ProofLevel level) -> std::pair<ProofLine, ProofLine>;
 
         auto create_proof_flag(const std::string &) -> ProofFlag;

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -369,6 +369,14 @@ auto ProofModel::create_proof_only_integer_variable_in_proof(Integer lower, Inte
     return id;
 }
 
+auto ProofModel::register_state_variable_bits_in_proof(const SimpleIntegerVariableID & id, Integer lower, Integer upper, const string & name) -> void
+{
+    // Like create_proof_only_integer_variable_in_proof, but for a variable that is
+    // ALSO state-allocated (so it can drive propagation): register its bits, emit
+    // nothing to the OPB, and leave the caller to introduce its meaning in-proof.
+    register_bits_variable_encoding(id, lower, upper, name);
+}
+
 auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVariableID id, Integer lower, Integer upper, const string & name)
     -> void
 {

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -369,12 +369,14 @@ auto ProofModel::create_proof_only_integer_variable_in_proof(Integer lower, Inte
     return id;
 }
 
-auto ProofModel::register_state_variable_bits_in_proof(const SimpleIntegerVariableID & id, Integer lower, Integer upper, const string & name) -> void
+auto ProofModel::register_state_variable_bits_in_proof(
+    const SimpleIntegerVariableID & id, Integer lower, Integer upper, const string & name, const optional<CakeBitNaming> & bit_naming) -> void
 {
     // Like create_proof_only_integer_variable_in_proof, but for a variable that is
     // ALSO state-allocated (so it can drive propagation): register its bits, emit
-    // nothing to the OPB, and leave the caller to introduce its meaning in-proof.
-    register_bits_variable_encoding(id, lower, upper, name);
+    // nothing to the OPB, and leave the caller to introduce its meaning in-proof. A
+    // CakeBitNaming names the bits in cake's value-flag scheme (modulus's quotient).
+    register_bits_variable_encoding(id, lower, upper, name, bit_naming);
 }
 
 auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVariableID id, Integer lower, Integer upper, const string & name)

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -257,6 +257,19 @@ namespace gcs::innards
          */
         [[nodiscard]] auto create_proof_only_integer_variable_in_proof(Integer, Integer, const std::string &) -> ProofOnlySimpleIntegerVariableID;
 
+        /**
+         * Register a bits encoding for an already-state-allocated integer variable
+         * WITHOUT emitting anything to the OPB, so the caller can define the
+         * variable's meaning inside the proof (ProofLogger::introduce_bits_of).
+         * Unlike set_up_integer_variable (which asserts the bound constraints in the
+         * OPB), this keeps the variable a free bit-sum, so a proof that introduces it
+         * as a conservative extension stays chain-portable against cake_pb_cp's OPB.
+         * The variable keeps its solver state, so it can still drive propagation ---
+         * the combination the pure proof-only
+         * create_proof_only_integer_variable_in_proof cannot provide.
+         */
+        auto register_state_variable_bits_in_proof(const SimpleIntegerVariableID &, Integer, Integer, const std::string &) -> void;
+
         [[nodiscard]] auto create_proof_flag(const std::string & stem) -> ProofFlag;
 
         /**

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -267,8 +267,13 @@ namespace gcs::innards
          * The variable keeps its solver state, so it can still drive propagation ---
          * the combination the pure proof-only
          * create_proof_only_integer_variable_in_proof cannot provide.
+         *
+         * With a CakeBitNaming the bits render in cake_pb_cp's value-flag scheme (as
+         * for create_proof_only_integer_variable): modulus registers its quotient state
+         * variable this way so its bits ARE cake's free axis-0 magnitude x[id][0_*][bin].
          */
-        auto register_state_variable_bits_in_proof(const SimpleIntegerVariableID &, Integer, Integer, const std::string &) -> void;
+        auto register_state_variable_bits_in_proof(
+            const SimpleIntegerVariableID &, Integer, Integer, const std::string &, const std::optional<CakeBitNaming> & = std::nullopt) -> void;
 
         [[nodiscard]] auto create_proof_flag(const std::string & stem) -> ProofFlag;
 

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -558,6 +558,14 @@ add_scp_chain_test(divide_neg_sat         none)
 add_scp_chain_test(divide_neg_yspan_sat   none)
 add_scp_chain_test(divide_neg_negneg_sat  none)
 add_scp_chain_test(divide_neg_unsat       none)
+# A dividend spanning zero (divide_span_*) takes a third cake path: both the x>=0
+# and x<0 remainder rows and w-stages are live (gated on sign(x)), and no remainder
+# is materialised (cake's rem_* rows range x-w directly, and a rejected (x,y,q) leaf
+# refutes off them once magq/absy/w are pinned by the assigned q,y) -- so there is no
+# |r| aux and no proof-only |x|. span_yspan spans BOTH operands; span_unsat has |q| too big.
+add_scp_chain_test(divide_span_sat        none)
+add_scp_chain_test(divide_span_yspan_sat  none)
+add_scp_chain_test(divide_span_unsat      none)
 
 # modulus: the same truncated-division relation exposing r instead of q. cake's
 # modulus OPB leaves the quotient a FREE axis-0 magnitude (no i[Q], no channel):

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -549,3 +549,17 @@ add_scp_chain_test(divide_sat             none)
 add_scp_chain_test(divide_unsat           none)
 add_scp_chain_test(divide_signed_sat      none)
 add_scp_chain_test(divide_signed_unsat    none)
+
+# modulus: the same truncated-division relation exposing r instead of q. cake's
+# modulus OPB leaves the quotient a FREE axis-0 magnitude (no i[Q], no channel):
+# the exposed r reads its identity r = x - |q||y| off the id_pos rows and 0 <= r <
+# |y| off rng_*, while the quotient q is a state variable whose own cake-named bits
+# ARE that magnitude. Only a non-negative dividend with a strictly positive divisor
+# (x >= 0, y >= 1, so q >= 0, r >= 0 -- every sign agrees) takes this path; signed
+# cases stay on the legacy encoding. big_sat widens the bit counts (X[0,20], Y[0,4])
+# and fixedy_sat fixes the divisor so the quotient's bit width is sized by the
+# dividend, not the quotient's range. none, for the same #358 reason as divide.
+add_scp_chain_test(modulus_sat            none)
+add_scp_chain_test(modulus_unsat          none)
+add_scp_chain_test(modulus_big_sat        none)
+add_scp_chain_test(modulus_fixedy_sat     none)

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -542,13 +542,22 @@ add_scp_chain_test(multiply_signed_unsat  none)
 # bound >= 0); the divisor and quotient may take either sign. The signed_sat case
 # has a zero-spanning divisor, and signed_unsat is contradictory (x>0, y>0 forces
 # q>=0 but q<0) -- both exercise the magnitude-bounded product w = |q||y| that
-# lets mult_bc bound the non-negative w without a false negative range. Signed x
-# still uses the legacy encoding. none, not strict, for the same #358 lazy-vs-
-# eager operand-ladder reason as multiply.
+# lets mult_bc bound the non-negative w without a false negative range. A signed
+# (strictly negative) dividend takes a second cake path (divide_neg_*): both mult
+# operands are the non-negative magnitudes |q| and |y|, so mult_bc divides w by the
+# non-negative |y| (dividing by the signed divisor was the x<0 blocker), and the
+# exposed quotient's sign is pinned off the sgn_* clauses directly. The neg_yspan
+# case flips sign(q) with a zero-spanning divisor; neg_negneg forces q>=0; neg_unsat
+# is contradictory. none, not strict, for the same #358 lazy-vs-eager operand-ladder
+# reason as multiply.
 add_scp_chain_test(divide_sat             none)
 add_scp_chain_test(divide_unsat           none)
 add_scp_chain_test(divide_signed_sat      none)
 add_scp_chain_test(divide_signed_unsat    none)
+add_scp_chain_test(divide_neg_sat         none)
+add_scp_chain_test(divide_neg_yspan_sat   none)
+add_scp_chain_test(divide_neg_negneg_sat  none)
+add_scp_chain_test(divide_neg_unsat       none)
 
 # modulus: the same truncated-division relation exposing r instead of q. cake's
 # modulus OPB leaves the quotient a FREE axis-0 magnitude (no i[Q], no channel):

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -560,7 +560,10 @@ add_scp_chain_test(divide_signed_unsat    none)
 # non-negative magnitudes with no signed reasoning; the tabulation recovers the signed
 # quotient. big_sat widens the bit counts and fixedy_sat fixes the divisor. The
 # signed_* cases exercise a fixed-negative / zero-spanning / larger / unsat divisor.
-# none, for the same #358 reason as divide.
+# A signed DIVIDEND (x < 0) works too: x is not a mult operand, so only the identity/
+# range/sign stages mirror (r = x + w and r <= 0 gated [x<0]); signed_dividend / negneg /
+# fully_signed exercise x < 0, both operands negative, and both spanning zero. none, for
+# the same #358 reason as divide.
 add_scp_chain_test(modulus_sat                  none)
 add_scp_chain_test(modulus_unsat                none)
 add_scp_chain_test(modulus_big_sat              none)
@@ -569,3 +572,7 @@ add_scp_chain_test(modulus_signed_divisor_sat   none)
 add_scp_chain_test(modulus_yspan_sat            none)
 add_scp_chain_test(modulus_signed_big_sat       none)
 add_scp_chain_test(modulus_signed_unsat         none)
+add_scp_chain_test(modulus_signed_dividend_sat  none)
+add_scp_chain_test(modulus_fully_signed_sat     none)
+add_scp_chain_test(modulus_negneg_sat           none)
+add_scp_chain_test(modulus_signed_dividend_unsat none)

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -553,13 +553,19 @@ add_scp_chain_test(divide_signed_unsat    none)
 # modulus: the same truncated-division relation exposing r instead of q. cake's
 # modulus OPB leaves the quotient a FREE axis-0 magnitude (no i[Q], no channel):
 # the exposed r reads its identity r = x - |q||y| off the id_pos rows and 0 <= r <
-# |y| off rng_*, while the quotient q is a state variable whose own cake-named bits
-# ARE that magnitude. Only a non-negative dividend with a strictly positive divisor
-# (x >= 0, y >= 1, so q >= 0, r >= 0 -- every sign agrees) takes this path; signed
-# cases stay on the legacy encoding. big_sat widens the bit counts (X[0,20], Y[0,4])
-# and fixedy_sat fixes the divisor so the quotient's bit width is sized by the
-# dividend, not the quotient's range. none, for the same #358 reason as divide.
-add_scp_chain_test(modulus_sat            none)
-add_scp_chain_test(modulus_unsat          none)
-add_scp_chain_test(modulus_big_sat        none)
-add_scp_chain_test(modulus_fixedy_sat     none)
+# |y| off rng_*, while the quotient magnitude |q| is a state variable whose own
+# cake-named bits ARE that magnitude. Requires a non-negative dividend (x >= 0), but
+# ANY-sign divisor: the divisor magnitude |y| is a second magnitude state variable
+# (absy) pinned to |y| by cake's Yge0/Ylt0 channel, so mult_bc multiplies the two
+# non-negative magnitudes with no signed reasoning; the tabulation recovers the signed
+# quotient. big_sat widens the bit counts and fixedy_sat fixes the divisor. The
+# signed_* cases exercise a fixed-negative / zero-spanning / larger / unsat divisor.
+# none, for the same #358 reason as divide.
+add_scp_chain_test(modulus_sat                  none)
+add_scp_chain_test(modulus_unsat                none)
+add_scp_chain_test(modulus_big_sat              none)
+add_scp_chain_test(modulus_fixedy_sat           none)
+add_scp_chain_test(modulus_signed_divisor_sat   none)
+add_scp_chain_test(modulus_yspan_sat            none)
+add_scp_chain_test(modulus_signed_big_sat       none)
+add_scp_chain_test(modulus_signed_unsat         none)

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -538,9 +538,14 @@ add_scp_chain_test(multiply_signed_unsat  none)
 # reified product-bit block, remainder rows gated on sign(x), and the five
 # division sign clauses); the internal product w = |q||y| and remainder r = x - w
 # are proof-only state vars reintroduced in-proof via introduce_bits_of. Only the
-# the fully non-negative case (x, y, q all >= 0) takes this path (the use_cake
-# guard); signed operands exercise a product-sign reconciliation proofgoal that
-# is not yet derivable, so they stay on the legacy encoding. none, not strict,
-# for the same #358 lazy-vs-eager operand-ladder reason as multiply.
+# a non-negative dividend takes this path (the use_cake guard needs x's lower
+# bound >= 0); the divisor and quotient may take either sign. The signed_sat case
+# has a zero-spanning divisor, and signed_unsat is contradictory (x>0, y>0 forces
+# q>=0 but q<0) -- both exercise the magnitude-bounded product w = |q||y| that
+# lets mult_bc bound the non-negative w without a false negative range. Signed x
+# still uses the legacy encoding. none, not strict, for the same #358 lazy-vs-
+# eager operand-ladder reason as multiply.
 add_scp_chain_test(divide_sat             none)
 add_scp_chain_test(divide_unsat           none)
+add_scp_chain_test(divide_signed_sat      none)
+add_scp_chain_test(divide_signed_unsat    none)

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -532,3 +532,14 @@ add_scp_chain_test(multiply_sat           none)
 add_scp_chain_test(multiply_unsat         none)
 add_scp_chain_test(multiply_signed_sat    none)
 add_scp_chain_test(multiply_signed_unsat  none)
+
+# divide: truncated division x = q*y + r, |r| < |y|, sign(r) = sign(x). The
+# proof emits cake's divide OPB (|Q| axis-0 and |Y| axis-1 magnitude channels, a
+# reified product-bit block, remainder rows gated on sign(x), and the five
+# division sign clauses); the internal product w = |q||y| and remainder r = x - w
+# are proof-only state vars reintroduced in-proof via introduce_bits_of. Only the
+# non-negative case takes this path (the use_cake guard needs x, y, q lower
+# bounds >= 0); signed operands still go through the legacy encoding. none, not
+# strict, for the same #358 lazy-vs-eager operand-ladder reason as multiply.
+add_scp_chain_test(divide_sat             none)
+add_scp_chain_test(divide_unsat           none)

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -538,8 +538,9 @@ add_scp_chain_test(multiply_signed_unsat  none)
 # reified product-bit block, remainder rows gated on sign(x), and the five
 # division sign clauses); the internal product w = |q||y| and remainder r = x - w
 # are proof-only state vars reintroduced in-proof via introduce_bits_of. Only the
-# non-negative case takes this path (the use_cake guard needs x, y, q lower
-# bounds >= 0); signed operands still go through the legacy encoding. none, not
-# strict, for the same #358 lazy-vs-eager operand-ladder reason as multiply.
+# the fully non-negative case (x, y, q all >= 0) takes this path (the use_cake
+# guard); signed operands exercise a product-sign reconciliation proofgoal that
+# is not yet derivable, so they stay on the legacy encoding. none, not strict,
+# for the same #358 lazy-vs-eager operand-ladder reason as multiply.
 add_scp_chain_test(divide_sat             none)
 add_scp_chain_test(divide_unsat           none)

--- a/verified_encodings/scp_cases/divide_neg_negneg_sat.scp
+++ b/verified_encodings/scp_cases/divide_neg_negneg_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -12 -1) (Y -3 -1) (Q 0 12) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_neg_sat.scp
+++ b/verified_encodings/scp_cases/divide_neg_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -12 -1) (Y 1 3) (Q -12 0) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_neg_unsat.scp
+++ b/verified_encodings/scp_cases/divide_neg_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X -9 -2) (Y 3 6) (Q 1 5) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_neg_yspan_sat.scp
+++ b/verified_encodings/scp_cases/divide_neg_yspan_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -6 -1) (Y -3 3) (Q -6 6) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_sat.scp
+++ b/verified_encodings/scp_cases/divide_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 6) (Y 1 3) (Q 0 6) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_signed_sat.scp
+++ b/verified_encodings/scp_cases/divide_signed_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 6) (Y -3 3) (Q -6 6) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_signed_unsat.scp
+++ b/verified_encodings/scp_cases/divide_signed_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X 2 9) (Y 3 6) (Q -5 -1) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_span_sat.scp
+++ b/verified_encodings/scp_cases/divide_span_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -4 4) (Y 1 2) (Q -4 4) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_span_unsat.scp
+++ b/verified_encodings/scp_cases/divide_span_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X -5 5) (Y 3 4) (Q 10 20) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_span_yspan_sat.scp
+++ b/verified_encodings/scp_cases/divide_span_yspan_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -4 4) (Y -2 2) (Q -4 4) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/divide_unsat.scp
+++ b/verified_encodings/scp_cases/divide_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X 7 7) (Y 2 2) (Q 4 5) ) ( (_1 divide X Y Q) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_big_sat.scp
+++ b/verified_encodings/scp_cases/modulus_big_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 20) (Y 1 4) (R 0 3) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_fixedy_sat.scp
+++ b/verified_encodings/scp_cases/modulus_fixedy_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 6) (Y 3 3) (R 0 2) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_fully_signed_sat.scp
+++ b/verified_encodings/scp_cases/modulus_fully_signed_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -6 6) (Y -3 3) (R -2 2) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_negneg_sat.scp
+++ b/verified_encodings/scp_cases/modulus_negneg_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -9 -2) (Y -3 -1) (R -2 2) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_sat.scp
+++ b/verified_encodings/scp_cases/modulus_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 6) (Y 1 3) (R 0 2) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_signed_big_sat.scp
+++ b/verified_encodings/scp_cases/modulus_signed_big_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 20) (Y -4 -1) (R -3 3) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_signed_dividend_sat.scp
+++ b/verified_encodings/scp_cases/modulus_signed_dividend_sat.scp
@@ -1,0 +1,1 @@
+( ( (X -6 0) (Y 1 3) (R -2 2) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_signed_dividend_unsat.scp
+++ b/verified_encodings/scp_cases/modulus_signed_dividend_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X -7 -7) (Y 3 3) (R -3 -2) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_signed_divisor_sat.scp
+++ b/verified_encodings/scp_cases/modulus_signed_divisor_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 6) (Y -3 -1) (R -2 2) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_signed_unsat.scp
+++ b/verified_encodings/scp_cases/modulus_signed_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X 7 7) (Y -3 -3) (R 2 3) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_unsat.scp
+++ b/verified_encodings/scp_cases/modulus_unsat.scp
@@ -1,0 +1,1 @@
+( ( (X 7 7) (Y 3 3) (R 2 3) ) ( (_1 modulus X Y R) ) (enumerate) )

--- a/verified_encodings/scp_cases/modulus_yspan_sat.scp
+++ b/verified_encodings/scp_cases/modulus_yspan_sat.scp
@@ -1,0 +1,1 @@
+( ( (X 0 6) (Y -3 3) (R -2 2) ) ( (_1 modulus X Y R) ) (enumerate) )


### PR DESCRIPTION
Makes the solver's `Divide` and `Modulus` proof logging conform to
`cake_pb_cp`'s divide/modulus encoding, so a `.scp` re-derived by
`cake_pb_cp` chain-verifies our proof (workflow 2) for **every sign
combination** of both operands.

### What this achieves
`Divide` and `Modulus` now chain-verify against cake's sign-agnostic OPB for
all signs of the dividend `x`, divisor `y` and quotient `q`:
- non-negative divide and modulus;
- signed divisor / quotient;
- **signed (negative) dividend** — divide and modulus;
- **dividend spanning zero** — divide and modulus.

### How
A single magnitude machinery underlies both directions: the two `mult_bc`
operands are the non-negative magnitudes `|q|` and `|y|` (so `filter_quotient`
never divides by a signed operand — the blocker for `x < 0`), the
identity/remainder splits on `sign(x)`, and the tabulation recovers the signed
values.

- **Divide** (any sign of `x`): both the `x >= 0` and `x < 0` remainder rows
  and w-stages are live, gated on `sign(x)`. The quotient's sign is pinned off
  the `sgn_*` clauses by RUP. **No remainder is materialised** — cake's `rem_*`
  rows range `x - w` directly, and a rejected `(x, y, q)` leaf pins
  `magq/absy/w` by unit propagation from the assigned `q, y`, so the rem rows
  refute a wrong remainder. This avoids needing a proof-only `|x|` (which has
  no linear form) for a spanning dividend.
- **Modulus** (any sign): the exposed slot is `r`; the quotient magnitude is a
  free axis-0 aux, and the identity splits on `sign(x)`.

The four originally-separate cake blocks (divide `x>=0` signed-operand, divide
`x<0`, divide spanning, modulus) are consolidated into two, sharing three local
helpers (`make_cake_magnitude`, `emit_cake_bit_products`,
`append_magnitude_stages`). The final cleanup commit is net **-378 lines** with
no behaviour change.

### The stack
This branch is stacked on **#467** (multiply cake-conform, signed operands),
its base here, and includes the flat-s-expr change from **#468** (cherry-picked
as `Divide/Modulus: flat s-expr shape`). Both are prerequisites; merge them
first (or retarget this PR's base) as suits the intended order.

### Validation
- 23 divide/modulus `.scp` chain tests (workflow-2, verified end-to-end by
  `cake_pb_cp`): non-negative, signed divisor/dividend, zero-spanning divisor
  and dividend, both operands spanning, and unsat cases.
- `divide_modulus_test` caps-off under BC (the pure propagation proof, no
  tabulation masking) across several random seeds.
- Full `ctest` suite green (483/483); multiply / power unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnzpNyXwHCxuPaBoCFM5kn
