### PR TITLE
CI: run on pull requests targeting any base branch

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -3,8 +3,9 @@ name: clang-format
 on:
   push:
     branches: [ "main" ]
+  # No base-branch filter here, so PRs onto a feature branch (a stacked PR, not
+  # just onto main) are built and checked too.
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   format:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,8 +3,9 @@ name: CMake
 on:
   push:
     branches: [ "main" ]
+  # No base-branch filter here, so PRs onto a feature branch (a stacked PR, not
+  # just onto main) are built and checked too.
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Both workflows scoped `pull_request` events to `branches: [ "main" ]`, so a **stacked PR** whose base is another feature branch got no CI until it was retargeted to `main` (exactly what happened with #469 in the divide/modulus cake stack). This drops the base-branch filter under `pull_request` in both `cmake.yml` and `clang-format.yml` so every PR is built and checked regardless of its base.

- The `push` trigger stays scoped to `branches: [ "main" ]`, so pushing to an arbitrary branch does **not** spawn a full matrix run on its own — CI runs when a PR exists.
- Trade-off: PRs into throwaway/scratch base branches now also run the matrix (~15 min × several jobs). If that's a concern, a narrower alternative is to keep a filter but enumerate long-lived integration branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)