### PR TITLE
Windows / MSVC support (investigation)

### DIFF
--- a/.github/veripb_smoke/README.md
+++ b/.github/veripb_smoke/README.md
@@ -1,0 +1,17 @@
+# VeriPB smoke fixture
+
+`smoke.opb` / `smoke.pbp` are a small but real proof pair (a reified-equals
+instance, complete enumeration of 8 solutions) captured from `equals_test`.
+Proof checking is deterministic and platform-independent, so these exact bytes
+verify identically everywhere.
+
+They exist so the Windows CI lane (`.github/workflows/windows.yml`) can answer
+"does VeriPB actually verify a proof on Windows?" without first building the
+whole solver and its bash/veripb test harness. Regenerate with:
+
+```
+./build/equals_test        # writes equals_test_dup_equals.{opb,pbp} in CWD
+cp equals_test_dup_equals.opb .github/veripb_smoke/smoke.opb
+cp equals_test_dup_equals.pbp .github/veripb_smoke/smoke.pbp
+veripb .github/veripb_smoke/smoke.opb .github/veripb_smoke/smoke.pbp   # sanity check
+```

--- a/.github/veripb_smoke/smoke.opb
+++ b/.github/veripb_smoke/smoke.opb
@@ -1,0 +1,8 @@
+* #variable= 4 #constraint= 5
+preserved: i[_1][b0] i[_1][b1] i[_1][b2] i[_2][b0] ;
+@i[_1][lb] 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] >= 2 ;
+@i[_1][ub] -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] >= -5 ;
+1 i[_2][b0] >= 0 ;
+* constraint ReifiedEquals equals option
+@c[_1][le] -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] >= 0;
+@c[_1][ge] 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] >= 0;

--- a/.github/veripb_smoke/smoke.pbp
+++ b/.github/veripb_smoke/smoke.pbp
@@ -1,0 +1,97 @@
+pseudo-Boolean proof version 3.0
+% solution
+red 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] 5 ~i[_1][ge5] >= 5 : i[_1][ge5] -> 0;
+red -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] 3 i[_1][ge5] >= -4 : i[_1][ge5] -> 1;
+red 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] 6 ~i[_1][ge6] >= 6 : i[_1][ge6] -> 0;
+red -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] 2 i[_1][ge6] >= -5 : i[_1][ge6] -> 1;
+rup 1 ~i[_1][ge6] >= 1;
+pol -4 -3 + s ;
+red 1 i[_1][ge5] 1 ~i[_1][ge6] 2 ~i[_1][eq5] >= 2 : i[_1][eq5] -> 0;
+red -1 i[_1][ge5] -1 ~i[_1][ge6] 1 i[_1][eq5] >= -1 : i[_1][eq5] -> 1;
+solx i[_1][eq5] i[_2][b0];
+% backtracking
+red 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] 2 ~i[_1][ge2] >= 2 : i[_1][ge2] -> 0;
+red -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] 6 i[_1][ge2] >= -1 : i[_1][ge2] -> 1;
+rup 1 i[_1][ge2] >= 1;
+pol -2 -12 + s ;
+red 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] 3 ~i[_1][ge3] >= 3 : i[_1][ge3] -> 0;
+red -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] 5 i[_1][ge3] >= -2 : i[_1][ge3] -> 1;
+pol -1 -15 + s ;
+pol -6 -3 + s ;
+red 1 i[_1][ge2] 1 ~i[_1][ge3] 2 ~i[_1][eq2] >= 2 : i[_1][eq2] -> 0;
+red -1 i[_1][ge2] -1 ~i[_1][ge3] 1 i[_1][eq2] >= -1 : i[_1][eq2] -> 1;
+red 1 i[_1][ge3] 1 ~i[_1][ge5] 2 ~i[_1][in3_4] >= 2 : i[_1][in3_4] -> 0;
+red -1 i[_1][ge3] -1 ~i[_1][ge5] 1 i[_1][in3_4] >= -1 : i[_1][in3_4] -> 1;
+rup 1 i[_1][eq2] 1 i[_1][in3_4] 1 i[_1][eq5] >= 1;
+rup 1 ~i[_2][b0] 1 i[_1][in3_4] 1 i[_1][eq2] >= 1;
+% solution
+solx i[_1][eq2] i[_2][b0];
+% backtracking
+rup 1 ~i[_2][b0] 1 i[_1][in3_4] 1 ~i[_1][eq2] >= 1;
+% backtracking
+rup 1 ~i[_2][b0] 1 i[_1][in3_4] >= 1;
+del id -4;
+del id -2;
+% solution
+red 1 i[_1][b0] 2 i[_1][b1] 4 i[_1][b2] 4 ~i[_1][ge4] >= 4 : i[_1][ge4] -> 0;
+red -1 i[_1][b0] -2 i[_1][b1] -4 i[_1][b2] 4 i[_1][ge4] >= -3 : i[_1][ge4] -> 1;
+pol -1 -28 + s ;
+pol -15 -3 + s ;
+red 1 i[_1][ge4] 1 ~i[_1][ge5] 2 ~i[_1][eq4] >= 2 : i[_1][eq4] -> 0;
+red -1 i[_1][ge4] -1 ~i[_1][ge5] 1 i[_1][eq4] >= -1 : i[_1][eq4] -> 1;
+rup 1 ~i[_1][eq4] 1 i[_1][in3_4] >= 1;
+red 1 i[_1][ge3] 1 ~i[_1][ge4] 2 ~i[_1][eq3] >= 2 : i[_1][eq3] -> 0;
+red -1 i[_1][ge3] -1 ~i[_1][ge4] 1 i[_1][eq3] >= -1 : i[_1][eq3] -> 1;
+rup 1 ~i[_1][eq3] 1 i[_1][in3_4] >= 1;
+rup 1 ~i[_1][in3_4] 1 i[_1][eq3] 1 i[_1][eq4] >= 1;
+solx i[_1][eq4] i[_2][b0];
+% backtracking
+rup 1 ~i[_2][b0] 1 ~i[_1][in3_4] 1 i[_1][eq3] >= 1;
+% solution
+solx i[_1][eq3] i[_2][b0];
+% backtracking
+rup 1 ~i[_2][b0] 1 ~i[_1][in3_4] 1 ~i[_1][eq3] >= 1;
+% backtracking
+rup 1 ~i[_2][b0] 1 ~i[_1][in3_4] >= 1;
+del id -4;
+del id -2;
+% backtracking
+rup 1 ~i[_2][b0] >= 1;
+del id -18;
+del id -2;
+% solution
+solx i[_1][eq5] ~i[_2][b0];
+% backtracking
+rup 1 i[_2][b0] 1 i[_1][in3_4] 1 i[_1][eq2] >= 1;
+% solution
+solx i[_1][eq2] ~i[_2][b0];
+% backtracking
+rup 1 i[_2][b0] 1 i[_1][in3_4] 1 ~i[_1][eq2] >= 1;
+% backtracking
+rup 1 i[_2][b0] 1 i[_1][in3_4] >= 1;
+del id -4;
+del id -2;
+% solution
+solx i[_1][eq3] ~i[_2][b0];
+% backtracking
+rup 1 i[_2][b0] 1 ~i[_1][in3_4] 1 i[_1][eq4] >= 1;
+% solution
+solx i[_1][eq4] ~i[_2][b0];
+% backtracking
+rup 1 i[_2][b0] 1 ~i[_1][in3_4] 1 ~i[_1][eq4] >= 1;
+% backtracking
+rup 1 i[_2][b0] 1 ~i[_1][in3_4] >= 1;
+del id -4;
+del id -2;
+% backtracking
+rup 1 i[_2][b0] >= 1;
+del id -7;
+del id -2;
+% backtracking
+rup >= 1;
+del id -13;
+del id -2;
+rup >= 1 ;
+output NONE;
+conclusion ENUMERATION_COMPLETE 8 : -1 ;
+end pseudo-Boolean proof;

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,6 +31,23 @@ jobs:
       run: brew install minizincide
       if: startsWith(matrix.os, 'macos')
 
+    - name: Install MiniZinc bundle (Linux)
+      # The Ubuntu runners have no MiniZinc package, so the MiniZinc tests used to
+      # skip there. Download the official bundle (which ships the default gecode
+      # solver the differential tests compare against) and put its bin dir on PATH,
+      # mirroring the macOS brew install above. The bundle's fzn-gecode links Qt/GL
+      # (gecode's Gist is compiled in), so pull in libEGL/libGL for the headless
+      # runner -- without them fzn-gecode fails to load and every test errors.
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get update && sudo apt-get install -y libegl1 libgl1
+        mkdir -p "$HOME/minizinc"
+        curl -fsSL https://github.com/MiniZinc/MiniZincIDE/releases/download/2.9.7/MiniZincIDE-2.9.7-bundle-linux-x86_64.tgz \
+          | tar xz -C "$HOME/minizinc" --strip-components=1
+        mzn="$(find "$HOME/minizinc" -name minizinc -type f | head -1)"
+        dirname "$mzn" >> "$GITHUB_PATH"
+        "$mzn" --version
+
     - name: Configure CMake
       # Turn the constraint-test runtime caps off on the Ubuntu release runners
       # so they do full-enumeration completeness checking; the macOS runners

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,178 @@
+name: Windows (MSVC)
+
+# Builds the solver with Microsoft's compiler and runs the full gcs test suite
+# (Catch2 unit tests + the bash/veripb-verified constraint tests) on Windows,
+# plus the examples, minicp_benchmarks, glasgow_scp_solver and the verified-
+# encoding scp-chain cases (the last self-verify against their own OPB, since
+# cake_pb_cp is not built here). A second job (msvc-frontends) builds the XCSP3,
+# MiniZinc and Python bindings and runs their tests (installing MiniZinc for the
+# differential suite). Does not gate the Linux/macOS checks.
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  msvc:
+    name: windows-2022 / MSVC (library + ctest)
+    runs-on: windows-2022
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Fetch VeriPB
+      run: git clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
+
+    - name: Install VeriPB using cargo
+      # Needed for the proof-verifying constraint tests: the wrapper scripts and
+      # the data-driven tests shell out to veripb, which cargo puts on PATH.
+      run: cargo install --path ./VeriPB
+
+    - name: Configure CMake (Ninja, MSVC)
+      # Ninja (single-config) lets the build keep going past errors so one CI
+      # round surfaces every compile problem rather than stopping at the first
+      # failing translation unit. The configure output reports whether MSVC
+      # supplies <format>/<print>/<generator>/<stacktrace> or the bundled
+      # fallbacks.
+      run: >
+        cmake -S . -B build -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DGCS_ENABLE_XCSP=OFF
+        -DGCS_ENABLE_MINIZINC=OFF
+        -DGCS_ENABLE_EXAMPLES=ON
+        -DGCS_BUILD_TESTS=ON
+
+    - name: Build everything
+      # -k 0: keep going after failures so all errors (and any compiler ICEs) are
+      # reported in a single run.
+      run: cmake --build build -- -k 0
+
+    - name: Test
+      # Full ctest suite: the Catch2 unit tests, the bash-wrapped veripb-verified
+      # constraint tests, and the examples / benchmarks / scp-chain cases (all
+      # add_test COMMANDs invoke bash explicitly on Windows via GCS_BASH). Runtime
+      # caps stay on (default) to bound the data-driven tests. bash comes from Git
+      # for Windows; veripb is on PATH.
+      working-directory: build
+      shell: bash
+      run: ctest --output-on-failure --timeout 300 -j 4
+
+  msvc-frontends:
+    name: windows-2022 / MSVC (XCSP3 + MiniZinc + Python frontends)
+    runs-on: windows-2022
+    # Builds the three modelling frontends with MSVC and runs their tests: the
+    # cached XCSP3 cases (which veripb-verify their proofs), the two hand-written
+    # FlatZinc-JSON cases, and the differential MiniZinc suite (MiniZinc is
+    # installed below). The Python module has no ctest, so for it the job proves the
+    # binding compiles and links on MSVC. libxml2 (needed by the XCSP3 parser) comes
+    # from vcpkg. Kept separate from the library job so a vcpkg or Python-toolchain
+    # hiccup can't mask the main 382/382 baseline.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Set up Python
+      # Provides the interpreter and development headers pybind11 needs for gcspy.
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install libxml2 (vcpkg)
+      # Dynamic x64-windows build: the import library pulls in a self-contained DLL
+      # (it carries zlib/lzma/iconv), so the XCSP3 binding links cleanly; the DLL is
+      # copied next to the built executables below so it is found at load time.
+      run: vcpkg install libxml2:x64-windows
+
+    - name: Fetch VeriPB
+      run: git clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
+
+    - name: Install VeriPB using cargo
+      # The XCSP3 and FlatZinc-JSON test runners shell out to veripb.
+      run: cargo install --path ./VeriPB
+
+    - name: Install MiniZinc bundle
+      # The differential MiniZinc tests need the `minizinc` compiler and its bundled
+      # default solver. Install the official Windows bundle silently (InnoSetup) and
+      # put it on PATH. No Windows-specific solver config is needed: MiniZinc resolves
+      # fzn-glasgow.exe from the PATH the test runner exports, appending .exe itself.
+      shell: pwsh
+      run: |
+        curl.exe -fsSL -o mzn-setup.exe https://github.com/MiniZinc/MiniZincIDE/releases/download/2.9.7/MiniZincIDE-2.9.7-bundled-setup-win64.exe
+        Start-Process -Wait -FilePath .\mzn-setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/DIR=C:\minizinc'
+        $mzn = Get-ChildItem -Path C:\minizinc -Recurse -Filter minizinc.exe | Select-Object -First 1
+        $mzn.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+        & $mzn.FullName --version
+
+    - name: Configure CMake (Ninja, MSVC, vcpkg toolchain)
+      # Derive the toolchain from the vcpkg that installed libxml2 above (the one on
+      # PATH) so both use the same root -- the runner has a second, VS-bundled vcpkg,
+      # and a bare $env: reference inside a folded run: was passed to cmake verbatim.
+      # GCS_BUILD_TESTS=ON is needed for enable_testing()/ctest and for the GCS_BASH
+      # launcher that lets ctest invoke the bash test wrappers on Windows.
+      shell: pwsh
+      run: |
+        $vcpkg = Split-Path (Get-Command vcpkg).Source
+        cmake -S . -B build -G Ninja `
+          -DCMAKE_BUILD_TYPE=Release `
+          -DCMAKE_TOOLCHAIN_FILE="$vcpkg/scripts/buildsystems/vcpkg.cmake" `
+          -DGCS_ENABLE_XCSP=ON `
+          -DGCS_ENABLE_MINIZINC=ON `
+          -DGCS_ENABLE_PYTHON=ON `
+          -DGCS_ENABLE_EXAMPLES=OFF `
+          -DGCS_BUILD_TESTS=ON
+
+    - name: Build the frontends
+      # Only the three frontend targets and their dependencies -- the gcs unit-test
+      # binaries are already built and run by the library job. -k 0 keeps going so
+      # all three report their compile status in a single run.
+      run: cmake --build build --target fzn-glasgow gcspy xcsp_glasgow_constraint_solver -- -k 0
+
+    - name: Deploy libxml2 DLL next to the executables
+      # CMAKE_RUNTIME_OUTPUT_DIRECTORY puts every exe in the build root, which the
+      # Windows loader searches first, so the vcpkg runtime DLLs go there too. Same
+      # vcpkg root as the configure step (the one on PATH that installed libxml2).
+      shell: pwsh
+      run: |
+        $vcpkg = Split-Path (Get-Command vcpkg).Source
+        Copy-Item "$vcpkg/installed/x64-windows/bin/*.dll" -Destination build
+
+    - name: Test the frontends
+      # The XCSP3 cases, the two FlatZinc-JSON cases, and the differential MiniZinc
+      # suite (minizinc is now on PATH). bash is Git for Windows; veripb and minizinc
+      # are on PATH.
+      working-directory: build
+      shell: bash
+      run: ctest --output-on-failure --timeout 300 -j 4 -R 'xcsp_|minizinc-'
+
+  veripb:
+    name: windows-2022 / VeriPB
+    runs-on: windows-2022
+    # Independent of the library build: answers "does VeriPB itself build and
+    # verify a proof on Windows?", which gates whether the bash/veripb test
+    # harness is worth porting. VeriPB 3.x is a Rust tool, so cargo install here
+    # also exercises the MSVC Rust toolchain.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Fetch VeriPB
+      run: git clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
+
+    - name: Install VeriPB using cargo
+      run: cargo install --path ./VeriPB
+
+    - name: Show VeriPB version
+      run: veripb --version
+
+    - name: Verify a real proof (reified equals, 8 solutions)
+      run: veripb .github/veripb_smoke/smoke.opb .github/veripb_smoke/smoke.pbp

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Doxyfile
 *.scp
 # ... except the curated workflow-2 regression cases, which are source, not generated:
 !verified_encodings/scp_cases/*.scp
+# ... and the committed VeriPB smoke fixture used by the Windows CI lane:
+!.github/veripb_smoke/*.opb
+!.github/veripb_smoke/*.pbp
 *~
 XCSP3-CPP-Parser
 generator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,32 +19,42 @@ include(GNUInstallDirs)
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release Debug Sanitize)
+# Multi-config generators (e.g. Visual Studio) leave CMAKE_BUILD_TYPE unset and
+# select the configuration at build time, so there is no cache entry to annotate.
+if(CMAKE_BUILD_TYPE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release Debug Sanitize)
+endif()
 
 # Per-type flags.  These are applied automatically by CMake for the active build type,
-# on top of the always-on flags set below.
-#
-# Release: full optimisation, no sanitizers.  -march=native is added later after the
-#   compiler capability check.  We omit -DNDEBUG deliberately because the codebase does
-#   not use assert(), so it buys nothing while making behaviour harder to reason about.
-set(CMAKE_CXX_FLAGS_RELEASE         "-O3"
-    CACHE STRING "Flags for release builds")
-# Debug: disable optimisation so the debugger can follow every step.
-set(CMAKE_CXX_FLAGS_DEBUG           "-O0"
-    CACHE STRING "Flags for debug builds")
-# Sanitize: light optimisation keeps stack traces readable; -O0 is too slow and hides
-#   inlining bugs.  ASan + UBSan together catch memory errors and undefined behaviour.
-set(CMAKE_CXX_FLAGS_SANITIZE
-    "-O1 -fsanitize=address,undefined -fno-omit-frame-pointer"
-    CACHE STRING "Flags for sanitizer builds (ASan + UBSan)")
-set(CMAKE_EXE_LINKER_FLAGS_SANITIZE    "-fsanitize=address,undefined"
-    CACHE STRING "Linker flags for sanitizer builds")
-set(CMAKE_SHARED_LINKER_FLAGS_SANITIZE "-fsanitize=address,undefined"
-    CACHE STRING "Linker flags for sanitizer builds")
+# on top of the always-on flags set below.  They are GCC/Clang syntax, so on MSVC we
+# leave CMake's own sane per-config defaults (/O2 for Release, /Od /Zi for Debug) in
+# place instead.  The Sanitize configuration is GCC/Clang-only.
+if(NOT MSVC)
+    # Release: full optimisation, no sanitizers.  -march=native is added later after the
+    #   compiler capability check.  We omit -DNDEBUG deliberately because the codebase does
+    #   not use assert(), so it buys nothing while making behaviour harder to reason about.
+    set(CMAKE_CXX_FLAGS_RELEASE         "-O3"
+        CACHE STRING "Flags for release builds")
+    # Debug: disable optimisation so the debugger can follow every step.
+    set(CMAKE_CXX_FLAGS_DEBUG           "-O0"
+        CACHE STRING "Flags for debug builds")
+    # Sanitize: light optimisation keeps stack traces readable; -O0 is too slow and hides
+    #   inlining bugs.  ASan + UBSan together catch memory errors and undefined behaviour.
+    set(CMAKE_CXX_FLAGS_SANITIZE
+        "-O1 -fsanitize=address,undefined -fno-omit-frame-pointer"
+        CACHE STRING "Flags for sanitizer builds (ASan + UBSan)")
+    set(CMAKE_EXE_LINKER_FLAGS_SANITIZE    "-fsanitize=address,undefined"
+        CACHE STRING "Linker flags for sanitizer builds")
+    set(CMAKE_SHARED_LINKER_FLAGS_SANITIZE "-fsanitize=address,undefined"
+        CACHE STRING "Linker flags for sanitizer builds")
+endif()
 
 option(GCS_ENABLE_DOXYGEN "Add a doxygen target to generate the documentation" OFF)
 option(GCS_ENABLE_XCSP "Support for the XCSP modelling language" ${PROJECT_IS_TOP_LEVEL})
 option(GCS_ENABLE_MINIZINC "Support for the MiniZinc modelling language" ${PROJECT_IS_TOP_LEVEL})
+# Off even at top level: unlike the other frontends it needs Python and pybind11.
+# scikit-build (python/pyproject.toml) turns it on explicitly.
+option(GCS_ENABLE_PYTHON "Build the Python bindings (requires Python and pybind11)" OFF)
 option(GCS_ENABLE_EXAMPLES "Build examples" ${PROJECT_IS_TOP_LEVEL})
 option(GCS_BUILD_TESTS "Build GCS tests" ${PROJECT_IS_TOP_LEVEL})
 option(GCS_ENABLE_VIEW_WRAP_SWEEP "Register the view-wrap proof-verification sweep (many tests, most failing today; opt in when working on view proof logging)" OFF)
@@ -80,29 +90,43 @@ CHECK_CXX_COMPILER_FLAG(-Wno-unqualified-std-cast-call COMPILER_SUPPORTS_NO_UNQU
 # Global compile/link options only apply when building as the top-level project.
 # When embedded as a subproject via FetchContent the parent controls these settings.
 if(PROJECT_IS_TOP_LEVEL)
-    add_compile_options(-W)
-    add_compile_options(-Wall)
+    if(MSVC)
+        # MSVC / Visual Studio equivalents of the GCC/Clang flags below. The
+        # -W/-Wall/-g/-pthread/-march flags are all GCC/Clang syntax that MSVC
+        # either rejects or ignores with a D9002 warning, so it needs its own set.
+        add_compile_options(/W3)               # baseline warnings (the GCC/Clang lane uses -Wall)
+        add_compile_options(/EHsc)             # standard C++ exception model
+        add_compile_options(/bigobj)           # heavily-templated TUs exceed the default section count
+        add_compile_options(/utf-8)            # treat sources (and narrow literals) as UTF-8
+        add_compile_options(/Zc:__cplusplus)   # report the real __cplusplus value, not 199711L
+        add_compile_options(/Zc:preprocessor)  # standards-conformant preprocessor
+        # We deliberately use getenv/std::system; silence the CRT "unsafe" deprecations.
+        add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+    else()
+        add_compile_options(-W)
+        add_compile_options(-Wall)
 
-    if(COMPILER_SUPPORTS_NO_RESTRICT)
-        add_compile_options(-Wno-restrict) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
-    endif()
-    if(COMPILER_SUPPORTS_NO_STRINGOP_OVERREAD)
-        add_compile_options(-Wno-stringop-overread) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
-    endif()
-    if(COMPILER_SUPPORTS_NO_UNQUALIFIED_STD_CAST_CALL)
-        add_compile_options(-Wno-unqualified-std-cast-call)
-    endif()
+        if(COMPILER_SUPPORTS_NO_RESTRICT)
+            add_compile_options(-Wno-restrict) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
+        endif()
+        if(COMPILER_SUPPORTS_NO_STRINGOP_OVERREAD)
+            add_compile_options(-Wno-stringop-overread) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
+        endif()
+        if(COMPILER_SUPPORTS_NO_UNQUALIFIED_STD_CAST_CALL)
+            add_compile_options(-Wno-unqualified-std-cast-call)
+        endif()
 
-    # Always include full debug info, even in release builds, so crash reports are useful.
-    add_compile_options(-g)
-    add_compile_options(-g3)
-    add_compile_options(-gdwarf-3)
-    add_compile_options(-pthread)
-    add_link_options(-pthread)
+        # Always include full debug info, even in release builds, so crash reports are useful.
+        add_compile_options(-g)
+        add_compile_options(-g3)
+        add_compile_options(-gdwarf-3)
+        add_compile_options(-pthread)
+        add_link_options(-pthread)
 
-    # Native CPU tuning is worthwhile for release performance but unhelpful for debugging.
-    if(COMPILER_SUPPORTS_MARCH_NATIVE)
-        add_compile_options($<$<CONFIG:Release>:-march=native>)
+        # Native CPU tuning is worthwhile for release performance but unhelpful for debugging.
+        if(COMPILER_SUPPORTS_MARCH_NATIVE)
+            add_compile_options($<$<CONFIG:Release>:-march=native>)
+        endif()
     endif()
 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -110,6 +134,18 @@ endif()
 
 if(GCS_BUILD_TESTS)
     enable_testing()
+    # The test wrappers (run_test_only.bash / run_test_and_verify.bash) are bash
+    # scripts invoked via add_test. On Windows ctest cannot execute a .bash file
+    # through its shebang, so find bash (Git Bash on the GitHub runners) and
+    # invoke it explicitly. On other platforms the shebang works and GCS_BASH
+    # stays empty -- an empty leading COMMAND element expands to no argument, so
+    # those registrations are unchanged. Prepend ${GCS_BASH} to every bash-wrapped
+    # add_test COMMAND.
+    if(WIN32)
+        find_program(GCS_BASH bash REQUIRED)
+    else()
+        set(GCS_BASH "")
+    endif()
 endif()
 
 # FetchContent dependencies declared before the subdirectories that consume them.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Compiling
 **Required:**
 - A C++23 compiler. GCC 13 (Ubuntu 24.04) is the oldest tested; GCC 15 and Clang 21
   are the primary development compilers. Clang on macOS uses libc++ rather than
-  libstdc++, which affects which C++23 features are available natively.
+  libstdc++, which affects which C++23 features are available natively. MSVC (Visual
+  Studio 2022) also works on an experimental basis — see [Platform support](#platform-support).
 - CMake 3.21 or later.
 
 **Fetched automatically by CMake** (no manual installation needed):
@@ -57,6 +58,20 @@ Compiling
   (``minizincide`` via Brew on macOS). The frontend can be disabled with
   ``-DGCS_ENABLE_MINIZINC=OFF``.
 - [Doxygen](https://www.doxygen.nl) — required to generate API documentation.
+
+### Platform support
+
+Linux and macOS are the fully supported platforms and are covered by CI on every
+change.
+
+**Windows support is experimental.** The library, its full test suite, and the XCSP3,
+MiniZinc and Python frontends build with MSVC (Visual Studio 2022) and pass CI on
+`windows-2022`, but the platform is much less exercised than Linux and macOS, so rough
+edges are to be expected. It is best-effort and community-maintained: **bug reports and
+patches are very welcome**. The [`.github/workflows/windows.yml`](.github/workflows/windows.yml)
+lane is the reference for building everything on Windows — notably, libxml2 (for XCSP)
+is supplied via [vcpkg](https://vcpkg.io) and MiniZinc via its official bundle installer,
+and the bash-based test wrappers are run through Git Bash.
 
 ### Build types
 

--- a/examples/auto_table/CMakeLists.txt
+++ b/examples/auto_table/CMakeLists.txt
@@ -3,5 +3,5 @@ target_link_libraries(auto_table PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(auto_table PRIVATE cxxopts)
 
-add_test(NAME auto_table COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:auto_table>)
+add_test(NAME auto_table COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:auto_table>)
 

--- a/examples/cake/CMakeLists.txt
+++ b/examples/cake/CMakeLists.txt
@@ -5,4 +5,4 @@ target_link_libraries(cake PRIVATE glasgow_constraint_solver)
 target_link_libraries(cake PRIVATE cxxopts)
 target_link_libraries(cake PRIVATE gcs_fmt)
 
-add_test(NAME cake COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:cake>)
+add_test(NAME cake COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:cake>)

--- a/examples/circuit_random/CMakeLists.txt
+++ b/examples/circuit_random/CMakeLists.txt
@@ -3,4 +3,4 @@ target_link_libraries(circuit_random PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(circuit_random PRIVATE cxxopts)
 
-add_test(NAME circuit_random COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:circuit_random>)
+add_test(NAME circuit_random COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:circuit_random>)

--- a/examples/circuit_small/CMakeLists.txt
+++ b/examples/circuit_small/CMakeLists.txt
@@ -3,4 +3,4 @@ target_link_libraries(circuit_small PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(circuit_small PRIVATE cxxopts)
 
-add_test(NAME circuit_small COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:circuit_small>)
+add_test(NAME circuit_small COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:circuit_small>)

--- a/examples/colour/CMakeLists.txt
+++ b/examples/colour/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(colour PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(colour PRIVATE cxxopts)
 
-add_test(NAME colour COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:colour>)
+add_test(NAME colour COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:colour>)

--- a/examples/colour/colour.cc
+++ b/examples/colour/colour.cc
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <ranges>
 #include <vector>
 
 #include <cxxopts.hpp>

--- a/examples/crystal_maze/CMakeLists.txt
+++ b/examples/crystal_maze/CMakeLists.txt
@@ -4,8 +4,8 @@ target_link_libraries(crystal_maze PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(crystal_maze PRIVATE cxxopts)
 
-add_test(NAME crystal_maze COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze>)
-add_test(NAME crystal_maze-abs COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze> --abs)
-add_test(NAME crystal_maze-gac COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze> --gac)
-add_test(NAME crystal_maze-abs-gac COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze> --abs --gac)
+add_test(NAME crystal_maze COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze>)
+add_test(NAME crystal_maze-abs COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze> --abs)
+add_test(NAME crystal_maze-gac COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze> --gac)
+add_test(NAME crystal_maze-abs-gac COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:crystal_maze> --abs --gac)
 set_tests_properties(crystal_maze crystal_maze-abs crystal_maze-gac crystal_maze-abs-gac PROPERTIES RESOURCE_LOCK crystal_maze)

--- a/examples/cumulative/CMakeLists.txt
+++ b/examples/cumulative/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(cumulative PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(cumulative PRIVATE cxxopts)
 
-add_test(NAME cumulative COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:cumulative>)
+add_test(NAME cumulative COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:cumulative>)

--- a/examples/cumulative/cumulative.cc
+++ b/examples/cumulative/cumulative.cc
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <ranges>
 #include <vector>
 
 #include <cxxopts.hpp>

--- a/examples/knapsack/CMakeLists.txt
+++ b/examples/knapsack/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(knapsack PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(knapsack PRIVATE cxxopts)
 
-add_test(NAME knapsack COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:knapsack>)
+add_test(NAME knapsack COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:knapsack>)

--- a/examples/knapsack/knapsack.cc
+++ b/examples/knapsack/knapsack.cc
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <ranges>
 #include <vector>
 
 #include <cxxopts.hpp>

--- a/examples/langford/CMakeLists.txt
+++ b/examples/langford/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(langford PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(langford PRIVATE cxxopts)
 
-add_test(NAME langford COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:langford>)
+add_test(NAME langford COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:langford>)

--- a/examples/langford/langford.cc
+++ b/examples/langford/langford.cc
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <ranges>
 #include <vector>
 
 #include <cxxopts.hpp>

--- a/examples/money/CMakeLists.txt
+++ b/examples/money/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(money PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(money PRIVATE cxxopts)
 
-add_test(NAME money COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:money>)
+add_test(NAME money COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:money>)

--- a/examples/multiply_random/CMakeLists.txt
+++ b/examples/multiply_random/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(multiply_random PUBLIC glasgow_constraint_solver)
 target_link_libraries(multiply_random LINK_PUBLIC cxxopts)
 target_link_libraries(multiply_random PRIVATE gcs_fmt)
 
-add_test(NAME multiply_random COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:multiply_random> -- --display_problem --n 50 --stats)
+add_test(NAME multiply_random COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:multiply_random> -- --display_problem --n 50 --stats)

--- a/examples/n_fractions/CMakeLists.txt
+++ b/examples/n_fractions/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(n_fractions PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(n_fractions PRIVATE cxxopts)
 
-add_test(NAME n_fractions COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:n_fractions> --unsat)
+add_test(NAME n_fractions COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:n_fractions> --unsat)

--- a/examples/odd_even_sum/CMakeLists.txt
+++ b/examples/odd_even_sum/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(odd_even_sum PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(odd_even_sum PRIVATE cxxopts)
 
-add_test(NAME odd_even_sum COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:odd_even_sum>)
+add_test(NAME odd_even_sum COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:odd_even_sum>)

--- a/examples/ortho_latin/CMakeLists.txt
+++ b/examples/ortho_latin/CMakeLists.txt
@@ -6,4 +6,4 @@ target_link_libraries(ortho_latin PRIVATE cxxopts)
 
 # Pin GAC here: the program now defaults to the non-GAC not-equals encoding, whose
 # full-enumeration proof at this size is far larger than the GAC one this test expects.
-add_test(NAME ortho_latin-5 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:ortho_latin> --all-different gac 5)
+add_test(NAME ortho_latin-5 COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:ortho_latin> --all-different gac 5)

--- a/examples/random_polynomial/CMakeLists.txt
+++ b/examples/random_polynomial/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(random_polynomial PUBLIC glasgow_constraint_solver)
 target_link_libraries(random_polynomial LINK_PUBLIC cxxopts)
 target_link_libraries(random_polynomial PRIVATE gcs_fmt)
 
-add_test(NAME random_polynomial COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:random_polynomial> -- --display_problem --n 50 --stats)
+add_test(NAME random_polynomial COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:random_polynomial> -- --display_problem --n 50 --stats)

--- a/examples/regex/CMakeLists.txt
+++ b/examples/regex/CMakeLists.txt
@@ -4,8 +4,8 @@ target_link_libraries(regex PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(regex PRIVATE cxxopts)
 
-add_test(NAME regex COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regex>)
-add_test(NAME regex-regex COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regex> --regex)
+add_test(NAME regex COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regex>)
+add_test(NAME regex-regex COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regex> --regex)
 
 # Both runs write the same regex.{opb,pbp} (the proof basename defaults to the
 # binary name), so serialise them rather than racing in a parallel ctest.

--- a/examples/regular_random/CMakeLists.txt
+++ b/examples/regular_random/CMakeLists.txt
@@ -2,6 +2,6 @@ add_executable(regular_random regular_random.cc)
 target_link_libraries(regular_random PRIVATE glasgow_constraint_solver)
 target_link_libraries(regular_random PRIVATE cxxopts)
 
-add_test(NAME regular_random COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regular_random>)
-add_test(NAME regular_random-seeded COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regular_random> --seed -1115540197)
+add_test(NAME regular_random COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regular_random>)
+add_test(NAME regular_random-seeded COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:regular_random> --seed -1115540197)
 set_tests_properties(regular_random regular_random-seeded PROPERTIES RESOURCE_LOCK regular_random)

--- a/examples/regular_random/regular_random.cc
+++ b/examples/regular_random/regular_random.cc
@@ -1,10 +1,11 @@
 #include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/regular.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
 #include <cxxopts.hpp>
 
-#include <gcs/constraints/regular.hh>
+#include <algorithm>
 #include <iostream>
 #include <numeric>
 #include <random>

--- a/examples/rostering/CMakeLists.txt
+++ b/examples/rostering/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(rostering PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(rostering PRIVATE cxxopts)
 
-add_test(NAME rostering COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:rostering>)
+add_test(NAME rostering COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:rostering>)

--- a/examples/shikaku/CMakeLists.txt
+++ b/examples/shikaku/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(shikaku PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(shikaku PRIVATE cxxopts)
 
-add_test(NAME shikaku COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:shikaku>)
+add_test(NAME shikaku COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:shikaku>)

--- a/examples/skyscrapers/CMakeLists.txt
+++ b/examples/skyscrapers/CMakeLists.txt
@@ -4,6 +4,6 @@ target_link_libraries(skyscrapers PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(skyscrapers PRIVATE cxxopts)
 
-add_test(NAME skyscrapers-5 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:skyscrapers> 5)
-add_test(NAME skyscrapers-5-autotable COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:skyscrapers> 5 --autotable)
+add_test(NAME skyscrapers-5 COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:skyscrapers> 5)
+add_test(NAME skyscrapers-5-autotable COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:skyscrapers> 5 --autotable)
 set_tests_properties(skyscrapers-5 skyscrapers-5-autotable PROPERTIES RESOURCE_LOCK skyscrapers)

--- a/examples/smart_table_am1/CMakeLists.txt
+++ b/examples/smart_table_am1/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(smart_table_am1 PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(smart_table_am1 PRIVATE cxxopts)
 
-add_test(NAME smart_table_am1 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_am1>)
+add_test(NAME smart_table_am1 COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_am1>)

--- a/examples/smart_table_lex/CMakeLists.txt
+++ b/examples/smart_table_lex/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(smart_table_lex PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(smart_table_lex PRIVATE cxxopts)
 
-add_test(NAME smart_table_lex COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_lex>)
+add_test(NAME smart_table_lex COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_lex>)

--- a/examples/smart_table_random/CMakeLists.txt
+++ b/examples/smart_table_random/CMakeLists.txt
@@ -3,4 +3,4 @@ target_link_libraries(smart_table_random PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(smart_table_random PRIVATE cxxopts)
 
-add_test(NAME smart_table_random COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_random>)
+add_test(NAME smart_table_random COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_random>)

--- a/examples/smart_table_random/smart_table_random.cc
+++ b/examples/smart_table_random/smart_table_random.cc
@@ -5,6 +5,7 @@
 
 #include <cxxopts.hpp>
 
+#include <algorithm>
 #include <iostream>
 #include <random>
 #include <sstream>

--- a/examples/smart_table_small/CMakeLists.txt
+++ b/examples/smart_table_small/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(smart_table_small PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(smart_table_small PRIVATE cxxopts)
 
-add_test(NAME smart_table_small COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_small>)
+add_test(NAME smart_table_small COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:smart_table_small>)

--- a/examples/sudoku/CMakeLists.txt
+++ b/examples/sudoku/CMakeLists.txt
@@ -4,6 +4,6 @@ target_link_libraries(sudoku PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(sudoku PRIVATE cxxopts)
 
-add_test(NAME sudoku COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:sudoku>)
-add_test(NAME sudoku-xv COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:sudoku> --xv)
+add_test(NAME sudoku COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:sudoku>)
+add_test(NAME sudoku-xv COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:sudoku> --xv)
 set_tests_properties(sudoku sudoku-xv PROPERTIES RESOURCE_LOCK sudoku)

--- a/examples/tables/CMakeLists.txt
+++ b/examples/tables/CMakeLists.txt
@@ -5,5 +5,5 @@ target_link_libraries(tables PRIVATE glasgow_constraint_solver)
 target_link_libraries(tables PRIVATE cxxopts)
 target_link_libraries(tables PRIVATE gcs_fmt)
 
-add_test(NAME tables COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:tables>)
+add_test(NAME tables COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:tables>)
 

--- a/examples/talent/CMakeLists.txt
+++ b/examples/talent/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(talent PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(talent PRIVATE cxxopts)
 
-add_test(NAME talent COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:talent>)
+add_test(NAME talent COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:talent>)

--- a/examples/tour/CMakeLists.txt
+++ b/examples/tour/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(tour PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(tour PRIVATE cxxopts)
 
-add_test(NAME tour COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:tour>)
+add_test(NAME tour COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:tour>)

--- a/examples/tutorial_proof/CMakeLists.txt
+++ b/examples/tutorial_proof/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(tutorial_proof PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(tutorial_proof PRIVATE cxxopts)
 
-add_test(NAME tutorial_proof COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:tutorial_proof>)
+add_test(NAME tutorial_proof COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:tutorial_proof>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -111,8 +111,11 @@ target_include_directories(glasgow_constraint_solver PUBLIC
 # via FetchContent or find_package.
 add_library(GlasgowConstraintSolver::glasgow_constraint_solver ALIAS glasgow_constraint_solver)
 
-if(GCS_COMPILER_HAS_STACKTRACE)
+if(GCS_COMPILER_HAS_STACKTRACE AND NOT MSVC)
     # stacktrace is only used in .cc files, not public headers, so PRIVATE suffices.
+    # stdc++exp is the libstdc++ support library for <stacktrace>/<print>; it is
+    # GCC-specific. MSVC also provides <stacktrace> (so GCS_COMPILER_HAS_STACKTRACE
+    # is true there) but has no such library to link, hence the NOT MSVC guard.
     target_link_libraries(glasgow_constraint_solver PRIVATE stdc++exp)
 endif()
 
@@ -202,39 +205,39 @@ if(GCS_BUILD_TESTS)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
     endforeach()
 
-    add_test(NAME abs_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:abs_test>)
-    add_test(NAME all_different_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_different_test>)
-    add_test(NAME all_different_except_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_different_except_test>)
-    add_test(NAME all_equal_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_equal_test>)
-    add_test(NAME among_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:among_test>)
-    add_test(NAME at_most_one_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:at_most_one_test>)
+    add_test(NAME abs_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:abs_test>)
+    add_test(NAME all_different_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_different_test>)
+    add_test(NAME all_different_except_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_different_except_test>)
+    add_test(NAME all_equal_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:all_equal_test>)
+    add_test(NAME among_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:among_test>)
+    add_test(NAME at_most_one_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:at_most_one_test>)
     foreach(mode ge ge_if ge_iff gt gt_if gt_iff le le_if le_iff lt lt_if lt_iff)
         add_test(NAME comparison_constraint_${mode}
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:comparison_test> ${mode})
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:comparison_test> ${mode})
     endforeach()
-    add_test(NAME count_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:count_test>)
-    add_test(NAME bounds_global_cardinality_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
-    add_test(NAME gac_global_cardinality_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
-    add_test(NAME cumulative_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
+    add_test(NAME count_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:count_test>)
+    add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
+    add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
+    add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
     foreach(mode strict nonstrict)
         add_test(NAME disjunctive_constraint_${mode}
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_test> ${mode})
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_test> ${mode})
     endforeach()
     foreach(mode strict nonstrict)
         add_test(NAME disjunctive_2d_constraint_${mode}
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_2d_test> ${mode})
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_2d_test> ${mode})
     endforeach()
     foreach(mode const const2d var var2d)
         add_test(NAME element_constraint_${mode}
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:element_test> ${mode})
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:element_test> ${mode})
     endforeach()
-    add_test(NAME equals_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:equals_test>)
+    add_test(NAME equals_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:equals_test>)
     foreach(linmode incremental stateless)
         add_test(NAME linear_constant_constraint_${linmode}
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_constant_test>)
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_constant_test>)
     endforeach()
-    add_test(NAME sort_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:sort_test>)
-    add_test(NAME arg_sort_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:arg_sort_test>)
+    add_test(NAME sort_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:sort_test>)
+    add_test(NAME arg_sort_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:arg_sort_test>)
 
     # View-wrap sweep: feeds the constraint each variable as a ViewOfIntegerVariableID
     # (offset / negation / both) instead of a bare SimpleIntegerVariableID. The
@@ -261,17 +264,17 @@ if(GCS_BUILD_TESTS)
     function(add_view_tests test_name target n_positions)
         set(extra_args ${ARGN})
         add_test(NAME ${test_name}_view_mixed
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:${target}>
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:${target}>
             ${extra_args} --view-position=mixed)
         if(GCS_ENABLE_VIEW_WRAP_SWEEP)
             math(EXPR last_position "${n_positions} - 1")
             foreach(wrap RANGE 1 18)
                 add_test(NAME ${test_name}_view_w${wrap}_pall
-                    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:${target}>
+                    COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:${target}>
                     ${extra_args} --view-wrap=${wrap} --view-position=all)
                 foreach(pos RANGE 0 ${last_position})
                     add_test(NAME ${test_name}_view_w${wrap}_p${pos}
-                        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:${target}>
+                        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:${target}>
                         ${extra_args} --view-wrap=${wrap} --view-position=${pos})
                 endforeach()
             endforeach()
@@ -319,11 +322,11 @@ if(GCS_BUILD_TESTS)
     endforeach()
     add_view_tests(cumulative_constraint cumulative_test 4)
     add_view_tests(regular_constraint regular_test 4)
-    add_test(NAME in_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:in_test>)
-    add_test(NAME increasing_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:increasing_test>)
-    add_test(NAME inverse_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inverse_test>)
-    add_test(NAME knapsack_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:knapsack_test>)
-    add_test(NAME lex_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:lex_test>)
+    add_test(NAME in_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:in_test>)
+    add_test(NAME increasing_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:increasing_test>)
+    add_test(NAME inverse_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inverse_test>)
+    add_test(NAME knapsack_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:knapsack_test>)
+    add_test(NAME lex_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:lex_test>)
     # Run every linear test in both propagation modes: incremental (threshold 0) and
     # stateless (a huge threshold). The threshold env is appended below (after the cap
     # block, so it doesn't clobber it) and is folded into the proof file name by the
@@ -331,33 +334,33 @@ if(GCS_BUILD_TESTS)
     foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff ne ne_if ne_iff)
         foreach(linmode incremental stateless)
             add_test(NAME linear_constraint_${mode}_${linmode}
-                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_test> ${mode})
+                COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_test> ${mode})
         endforeach()
     endforeach()
-    add_test(NAME logical_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:logical_test>)
-    add_test(NAME min_max_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:min_max_test>)
-    add_test(NAME divide_modulus_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:divide_modulus_test>)
-    add_test(NAME power_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:power_test>)
-    add_test(NAME multiply_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:multiply_test>)
-    add_test(NAME n_value_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:n_value_test>)
-    add_test(NAME parity_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_test>)
-    add_test(NAME plus_minus_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:plus_minus_test>)
-    add_test(NAME regular_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:regular_test>)
-    add_test(NAME seq_precede_chain_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:seq_precede_chain_test>)
+    add_test(NAME logical_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:logical_test>)
+    add_test(NAME min_max_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:min_max_test>)
+    add_test(NAME divide_modulus_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:divide_modulus_test>)
+    add_test(NAME power_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:power_test>)
+    add_test(NAME multiply_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:multiply_test>)
+    add_test(NAME n_value_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:n_value_test>)
+    add_test(NAME parity_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:parity_test>)
+    add_test(NAME plus_minus_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:plus_minus_test>)
+    add_test(NAME regular_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:regular_test>)
+    add_test(NAME seq_precede_chain_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:seq_precede_chain_test>)
     foreach(mode lex_gt lex_ge lex_lt lex_le
                  lex_gt_fixed lex_ge_fixed lex_lt_fixed lex_le_fixed
                  am1_eq am1_in_set al1_eq al1_in_set
                  mixed_same_var stacked_unary wide_constants degenerate)
         add_test(NAME smart_table_constraint_${mode}
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:smart_table_test> ${mode})
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:smart_table_test> ${mode})
     endforeach()
-    add_test(NAME negative_table_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:negative_table_test>)
-    add_test(NAME symmetric_all_different_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:symmetric_all_different_test>)
-    add_test(NAME table_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:table_test>)
+    add_test(NAME negative_table_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:negative_table_test>)
+    add_test(NAME symmetric_all_different_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:symmetric_all_different_test>)
+    add_test(NAME table_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:table_test>)
     add_test(NAME product_bounds COMMAND $<TARGET_FILE:product_bounds_test>)
-    add_test(NAME product_justify COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:product_justify_test>)
-    add_test(NAME tabulation_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:tabulation_test>)
-    add_test(NAME value_precede_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:value_precede_test>)
+    add_test(NAME product_justify COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:product_justify_test>)
+    add_test(NAME tabulation_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:tabulation_test>)
+    add_test(NAME value_precede_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:value_precede_test>)
 
     # The circuit scenario tests self-verify (they call veripb internally on a
     # view-label-suffixed proof file), so they register with run_test_only.bash
@@ -365,34 +368,34 @@ if(GCS_BUILD_TESTS)
     # registration is the bare (no-view) config.
     add_executable(circuit_disconnected_test constraints/circuit/circuit_disconnected_test.cc)
     target_link_libraries(circuit_disconnected_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME circuit_disconnected COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_disconnected_test>)
+    add_test(NAME circuit_disconnected COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_disconnected_test>)
     add_view_tests(circuit_disconnected circuit_disconnected_test 8)
 
     add_executable(circuit_multiple_sccs_test constraints/circuit/circuit_multiple_sccs_test.cc)
     target_link_libraries(circuit_multiple_sccs_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME circuit_multiple_sccs COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_multiple_sccs_test>)
+    add_test(NAME circuit_multiple_sccs COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_multiple_sccs_test>)
     add_view_tests(circuit_multiple_sccs circuit_multiple_sccs_test 9)
 
     add_executable(circuit_no_backedges_test constraints/circuit/circuit_no_backedges_test.cc)
     target_link_libraries(circuit_no_backedges_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME circuit_no_backedges COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_no_backedges_test>)
+    add_test(NAME circuit_no_backedges COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_no_backedges_test>)
     add_view_tests(circuit_no_backedges circuit_no_backedges_test 8)
 
     add_executable(circuit_prune_root_test constraints/circuit/circuit_prune_root_test.cc)
     target_link_libraries(circuit_prune_root_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME circuit_prune_root COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_prune_root_test>)
+    add_test(NAME circuit_prune_root COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_prune_root_test>)
     add_view_tests(circuit_prune_root circuit_prune_root_test 6)
 
     add_executable(circuit_prune_skip_test constraints/circuit/circuit_prune_skip_test.cc)
     target_link_libraries(circuit_prune_skip_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME circuit_prune_skip COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_prune_skip_test>)
+    add_test(NAME circuit_prune_skip COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_prune_skip_test>)
     add_view_tests(circuit_prune_skip circuit_prune_skip_test 7)
 
     # Data-driven enumerating harness (small full-domain instances), matching
     # the shape of the other constraints' *_test.cc; self-verifies via veripb.
     add_executable(circuit_test constraints/circuit/circuit_test.cc)
     target_link_libraries(circuit_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME circuit_constraint COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_test>)
+    add_test(NAME circuit_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:circuit_test>)
     add_view_tests(circuit_constraint circuit_test 5)
 
     add_executable(circuit_dup_test constraints/circuit/circuit_dup_test.cc)
@@ -401,27 +404,27 @@ if(GCS_BUILD_TESTS)
 
     add_executable(reification_test innards/proofs/reification_test.cc)
     target_link_libraries(reification_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME reification_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:reification_test>)
+    add_test(NAME reification_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:reification_test>)
 
     add_executable(proof_model_tautology_test innards/proofs/proof_model_tautology_test.cc)
     target_link_libraries(proof_model_tautology_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME proof_model_tautology_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:proof_model_tautology_test>)
+    add_test(NAME proof_model_tautology_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:proof_model_tautology_test>)
 
     add_executable(introduce_bits_test innards/proofs/introduce_bits_test.cc)
     target_link_libraries(introduce_bits_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME introduce_bits_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:introduce_bits_test>)
+    add_test(NAME introduce_bits_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:introduce_bits_test>)
 
     add_executable(invar_test innards/proofs/invar_test.cc)
     target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME invar_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)
+    add_test(NAME invar_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)
 
     add_executable(range_branch_test innards/proofs/range_branch_test.cc)
     target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME range_branch_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)
+    add_test(NAME range_branch_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)
 
     add_executable(range_infer_test innards/proofs/range_infer_test.cc)
     target_link_libraries(range_infer_test PRIVATE glasgow_constraint_solver)
-    add_test(NAME range_infer_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_infer_test>)
+    add_test(NAME range_infer_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_infer_test>)
 
     # The range-literal witness suite (dev_docs/range_literals_spec.md §8): each test
     # fails VeriPB within milliseconds if its clause family is removed or weakened.
@@ -429,7 +432,7 @@ if(GCS_BUILD_TESTS)
     foreach(witness w1 w2 w3 w5)
         add_executable(range_witness_${witness}_test innards/proofs/range_witness_${witness}_test.cc)
         target_link_libraries(range_witness_${witness}_test PRIVATE glasgow_constraint_solver)
-        add_test(NAME range_witness_${witness}_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_witness_${witness}_test>)
+        add_test(NAME range_witness_${witness}_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_witness_${witness}_test>)
     endforeach()
 
     add_executable(interval_set_test innards/interval_set_test.cc)

--- a/gcs/constraints/innards/arithmetic_utils.hh
+++ b/gcs/constraints/innards/arithmetic_utils.hh
@@ -43,7 +43,7 @@ namespace gcs::innards
     [[nodiscard]] inline auto product_if_representable(Integer a, Integer b) -> std::optional<Integer>
     {
         long long result;
-        if (__builtin_mul_overflow(a.raw_value, b.raw_value, &result))
+        if (mul_overflows(a.raw_value, b.raw_value, &result))
             return std::nullopt;
         return Integer{result};
     }

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -388,7 +388,14 @@ namespace gcs::test_innards
         // by an immediate re-run, which aborts the solve if it infers anything.
         // Deterministic, at most doubles the cost of claiming runs, and a
         // passing re-run emits nothing, so the proof lanes are unaffected.
+        // MSVC has no POSIX setenv; _putenv_s always overwrites, so mirror the
+        // don't-overwrite (overwrite == 0) semantics with a getenv check.
+#ifdef _WIN32
+        if (! std::getenv("GCS_CHECK_IDEMPOTENT_CLAIMS"))
+            _putenv_s("GCS_CHECK_IDEMPOTENT_CLAIMS", "1");
+#else
         setenv("GCS_CHECK_IDEMPOTENT_CLAIMS", "1", 0);
+#endif
 
         // Apply the optional runtime caps (see env_cap). The wrappers count
         // solutions / internal search nodes and return false to stop the solve

--- a/gcs/constraints/innards/tabulation.cc
+++ b/gcs/constraints/innards/tabulation.cc
@@ -248,7 +248,7 @@ auto gcs::innards::want_tabulation(const std::variant<consistency::Auto, consist
 
             long long size = 1;
             for (const auto & v : enum_vars)
-                if (v != skip && __builtin_mul_overflow(size, initial_state.domain_size(v).raw_value, &size))
+                if (v != skip && mul_overflows(size, initial_state.domain_size(v).raw_value, &size))
                     return false;
             return size <= default_tabulation_threshold();
         }}

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -57,6 +57,99 @@ using std::print;
 using fmt::print;
 #endif
 
+namespace
+{
+    // The "undecided" reification branch of ReifiedLinearEquality::install installs a
+    // propagator whose body is a 4-way overloaded{}.visit nested inside a generic
+    // (auto & inference) lambda that is itself inside a generic (auto & sanitised_cv)
+    // visit lambda. That depth of nested generic lambdas triggers an MSVC internal
+    // compiler error (C1001), so the visitor is hoisted here into a named function
+    // template -- same behaviour, one fewer level of lambda nesting. The capture types
+    // are deduced, so they need not be spelled out at the call site.
+    template <typename SanitisedCV_, typename Cond_, typename ProofLine_, typename AllVars_, typename Owner_, typename IncMustHold_,
+        typename Inference_>
+    auto propagate_reified_linear_equality_when_undecided(const SanitisedCV_ & sanitised_cv, Integer value, const Cond_ & cond,
+        const ProofLine_ & proof_line, const AllVars_ & all_vars, const Owner_ & owner, const IncMustHold_ & inc_must_hold, const State & state,
+        Inference_ & inference, ProofLogger * const logger) -> PropagatorState
+    {
+        return overloaded{
+            [&](const evaluated_reif::MustHold & reif) {
+                // we now know the condition definitely holds, so it's a linear equality
+                if (inc_must_hold)
+                    return propagate_linear_incremental(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond,
+                        *inc_must_hold->first, inc_must_hold->second, hints::LinearEquality{owner});
+                return propagate_linear(sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, hints::LinearEquality{owner});
+            }, //
+            [&](const evaluated_reif::MustNotHold &) {
+                // we now know the condition definitely doesn't hold, so it's a linear not-equals
+                return propagate_linear_not_equals(sanitised_cv, value, state, inference, logger, all_vars, hints::LinearNotEquals{owner});
+            },                                                                                          //
+            [](const evaluated_reif::Deactivated &) { return PropagatorState::DisableUntilBacktrack; }, //
+            [&](const evaluated_reif::Undecided & reif) {
+                // we still don't know whether the condition holds. if we're down to a single unassigned
+                // variable, we might have some information.
+                auto single_unset = sanitised_cv.terms.end();
+                Integer accum = 0_i;
+                for (auto i = sanitised_cv.terms.begin(), i_end = sanitised_cv.terms.end(); i != i_end; ++i) {
+                    auto val = state.optional_single_value(get_var(*i));
+                    if (val)
+                        accum += get_coeff(*i) * *val;
+                    else {
+                        if (single_unset != sanitised_cv.terms.end()) {
+                            // at least two unset variables, do nothing for now
+                            return PropagatorState::Enable;
+                        }
+                        else
+                            single_unset = i;
+                    }
+                }
+
+                if (single_unset == sanitised_cv.terms.end()) {
+                    // every variable is assigned, so we know what the condition must be (if we're fully
+                    // reified)
+                    if (accum == value) {
+                        if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
+                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                        return PropagatorState::DisableUntilBacktrack;
+                    }
+                    else {
+                        if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
+                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                        return PropagatorState::DisableUntilBacktrack;
+                    }
+                }
+                else {
+                    // exactly one thing remaining. perhaps the value that would make the equality
+                    // work doesn't occur in its domain?
+                    Integer residual = value - accum;
+                    if (0_i == residual % get_coeff(*single_unset)) {
+                        Integer would_make_equal = residual / get_coeff(*single_unset);
+                        if (! state.in_domain(get_var(*single_unset), would_make_equal)) {
+                            // no way for the remaining variable to take that value, so the condition
+                            // has to be false
+                            if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
+                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                            return PropagatorState::DisableUntilBacktrack;
+                        }
+                        else {
+                            // could go either way, but this might change as more values are lost
+                            return PropagatorState::Enable;
+                        }
+                    }
+                    else {
+                        // the value that would make the equality work isn't an integer, so the condition
+                        // has to be false
+                        if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
+                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                        return PropagatorState::DisableUntilBacktrack;
+                    }
+                }
+            } //
+        }
+            .visit(test_reification_condition(state, cond));
+    }
+}
+
 ReifiedLinearEquality::ReifiedLinearEquality(WeightedSum coeff_vars, Integer value, ReificationCondition cond, bool flipped_cond) :
     _coeff_vars(move(coeff_vars)), _value(value), _reif_cond(cond), _flipped_cond(flipped_cond)
 {
@@ -325,87 +418,8 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators, State
                                 all_vars = move(all_vars), owner = constraint_id(),
                                 inc_must_hold = inc_must_hold](const State & state, auto & inference,
                                 ProofLogger * const logger) -> PropagatorState { // This comment is needed to stop clang-format exploding
-                                return overloaded{
-                                    [&](const evaluated_reif::MustHold & reif) {
-                                        // we now know the condition definitely holds, so it's a linear equality
-                                        if (inc_must_hold)
-                                            return propagate_linear_incremental(sanitised_cv, value, state, inference, logger, true, proof_line,
-                                                reif.cond, *inc_must_hold->first, inc_must_hold->second, hints::LinearEquality{owner});
-                                        return propagate_linear(
-                                            sanitised_cv, value, state, inference, logger, true, proof_line, reif.cond, hints::LinearEquality{owner});
-                                    }, //
-                                    [&](const evaluated_reif::MustNotHold &) {
-                                        // we now know the condition definitely doesn't hold, so it's a linear not-equals
-                                        return propagate_linear_not_equals(
-                                            sanitised_cv, value, state, inference, logger, all_vars, hints::LinearNotEquals{owner});
-                                    },                                                                                          //
-                                    [](const evaluated_reif::Deactivated &) { return PropagatorState::DisableUntilBacktrack; }, //
-                                    [&](const evaluated_reif::Undecided & reif) {
-                                        // we still don't know whether the condition holds. if we're down to a single unassigned
-                                        // variable, we might have some information.
-                                        auto single_unset = sanitised_cv.terms.end();
-                                        Integer accum = 0_i;
-                                        for (auto i = sanitised_cv.terms.begin(), i_end = sanitised_cv.terms.end(); i != i_end; ++i) {
-                                            auto val = state.optional_single_value(get_var(*i));
-                                            if (val)
-                                                accum += get_coeff(*i) * *val;
-                                            else {
-                                                if (single_unset != sanitised_cv.terms.end()) {
-                                                    // at least two unset variables, do nothing for now
-                                                    return PropagatorState::Enable;
-                                                }
-                                                else
-                                                    single_unset = i;
-                                            }
-                                        }
-
-                                        if (single_unset == sanitised_cv.terms.end()) {
-                                            // every variable is assigned, so we know what the condition must be (if we're fully
-                                            // reified)
-                                            if (accum == value) {
-                                                if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                                                    inference.infer(
-                                                        logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
-                                                return PropagatorState::DisableUntilBacktrack;
-                                            }
-                                            else {
-                                                if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                    inference.infer(
-                                                        logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
-                                                return PropagatorState::DisableUntilBacktrack;
-                                            }
-                                        }
-                                        else {
-                                            // exactly one thing remaining. perhaps the value that would make the equality
-                                            // work doesn't occur in its domain?
-                                            Integer residual = value - accum;
-                                            if (0_i == residual % get_coeff(*single_unset)) {
-                                                Integer would_make_equal = residual / get_coeff(*single_unset);
-                                                if (! state.in_domain(get_var(*single_unset), would_make_equal)) {
-                                                    // no way for the remaining variable to take that value, so the condition
-                                                    // has to be false
-                                                    if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                        inference.infer(
-                                                            logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
-                                                    return PropagatorState::DisableUntilBacktrack;
-                                                }
-                                                else {
-                                                    // could go either way, but this might change as more values are lost
-                                                    return PropagatorState::Enable;
-                                                }
-                                            }
-                                            else {
-                                                // the value that would make the equality work isn't an integer, so the condition
-                                                // has to be false
-                                                if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                                    inference.infer(
-                                                        logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
-                                                return PropagatorState::DisableUntilBacktrack;
-                                            }
-                                        }
-                                    } //
-                                }
-                                    .visit(test_reification_condition(state, cond));
+                                return propagate_reified_linear_equality_when_undecided(
+                                    sanitised_cv, value, cond, proof_line, all_vars, owner, inc_must_hold, state, inference, logger);
                             },
                             triggers);
                     },

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -109,7 +109,7 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
                                 skipped = true;
                                 continue;
                             }
-                            if (__builtin_mul_overflow(size, d.raw_value, &size))
+                            if (mul_overflows(size, d.raw_value, &size))
                                 return consistency::BC{};
                         }
                         if (size <= default_tabulation_threshold())

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -190,7 +190,7 @@ auto Minus::install(Propagators & propagators, State & initial_state, ProofModel
             auto bv = pb ? ab.coeff * vals[*pb] + ab.offset : ab.offset;
             auto cv = pc ? ac.coeff * vals[*pc] + ac.offset : ac.offset;
             long long sum;
-            if (__builtin_sub_overflow(av.raw_value, bv.raw_value, &sum))
+            if (sub_overflows(av.raw_value, bv.raw_value, &sum))
                 return false;
             return sum == cv.raw_value;
         };

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -180,7 +180,7 @@ auto Plus::install(Propagators & propagators, State & initial_state, ProofModel 
             auto bv = pb ? ab.coeff * vals[*pb] + ab.offset : ab.offset;
             auto cv = pc ? ac.coeff * vals[*pc] + ac.offset : ac.offset;
             long long sum;
-            if (__builtin_add_overflow(av.raw_value, bv.raw_value, &sum))
+            if (add_overflows(av.raw_value, bv.raw_value, &sum))
                 return false;
             return sum == cv.raw_value;
         };

--- a/gcs/constraints/power/power_test.cc
+++ b/gcs/constraints/power/power_test.cc
@@ -64,7 +64,7 @@ namespace
         long long r = 1;
         for (long long i = 0; i < b; ++i) {
             long long next;
-            if (__builtin_mul_overflow(r, a, &next))
+            if (innards::mul_overflows(r, a, &next))
                 return false;
             r = next;
         }

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -16,6 +16,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <type_traits>
 #include <utility>
 #include <variant>
 #include <version>
@@ -164,6 +165,122 @@ auto NegativeTable::define_proof_model(ProofModel & model) -> void
 namespace
 {
     constexpr size_t no_watch = std::numeric_limits<size_t>::max();
+
+    // The negative-table initialiser body, hoisted out of the generic
+    // visit(auto && tuples) lambda for the same MSVC-C1001 reason as
+    // propagate_negative_table below (a nested lambda inside a generic-on-inference
+    // lambda inside a generic lambda makes MSVC emit an internal compiler error).
+    template <typename Vars_, typename Tuples_, typename Watches_, typename Owner_, typename Inference_>
+    auto initialise_negative_table_watches(const Vars_ & vars, const Tuples_ & tuples, const Watches_ & watches, const Owner_ & owner,
+        const State & state, Inference_ & inference, ProofLogger * const logger) -> void
+    {
+        const auto & tuple_data = depointinate(tuples);
+        watches->reserve(tuple_data.size());
+
+        for (size_t ti = 0; ti < tuple_data.size(); ++ti) {
+            const auto & t = tuple_data[ti];
+
+            auto find_unbroken = [&](size_t skip) -> optional<size_t> {
+                for (size_t p = 0; p < vars.size(); ++p) {
+                    if (p == skip)
+                        continue;
+                    if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
+                        return p;
+                }
+                return nullopt;
+            };
+
+            auto w1 = find_unbroken(no_watch);
+            if (! w1) {
+                inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+            }
+
+            auto w2 = find_unbroken(*w1);
+            if (! w2) {
+                // Unit clause: vars[*w1] != t[*w1] is the only possibly-true
+                // disjunct, so it must hold.
+                inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                // Mark the tuple as already handled — both watches at the same
+                // position will read as broken on every subsequent fire, and
+                // any rescue search will discover the inference is now redundant.
+                watches->emplace_back(*w1, *w1);
+            }
+            else {
+                watches->emplace_back(*w1, *w2);
+            }
+        }
+    }
+
+    // The negative-table propagator body, hoisted out of the generic
+    // visit(auto && tuples) lambda in install_propagators. Keeping this much logic
+    // inside that generic lambda (which itself contains the generic-on-inference
+    // propagator lambda, which in turn nests further lambdas) makes MSVC emit an
+    // internal compiler error (C1001); a named function template compiles cleanly.
+    // Capture types are deduced. See the same treatment in linear_equality.cc.
+    template <typename Vars_, typename Tuples_, typename Watches_, typename Owner_, typename Inference_>
+    auto propagate_negative_table(const Vars_ & vars, const Tuples_ & tuples, const Watches_ & watches, const Owner_ & owner, const State & state,
+        Inference_ & inference, ProofLogger * const logger) -> PropagatorState
+    {
+        const auto & tuple_data = depointinate(tuples);
+        using Tuple = std::remove_cvref_t<decltype(tuple_data[0])>;
+
+        auto is_broken = [&](const Tuple & t, size_t p) -> bool { return state.test_literal(vars[p] == t[p]) == LiteralIs::DefinitelyTrue; };
+
+        auto find_unbroken = [&](const Tuple & t, size_t skip1, size_t skip2) -> optional<size_t> {
+            for (size_t p = 0; p < vars.size(); ++p) {
+                if (p == skip1 || p == skip2)
+                    continue;
+                if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
+                    return p;
+            }
+            return nullopt;
+        };
+
+        for (size_t ti = 0; ti < tuple_data.size(); ++ti) {
+            auto & w = (*watches)[ti];
+            const auto & t = tuple_data[ti];
+
+            bool b1 = is_broken(t, w.first);
+            bool b2 = is_broken(t, w.second);
+
+            if (! b1 && ! b2)
+                continue;
+
+            if (b1 && b2) {
+                auto new1 = find_unbroken(t, no_watch, no_watch);
+                if (! new1) {
+                    inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                }
+                auto new2 = find_unbroken(t, *new1, no_watch);
+                if (! new2) {
+                    inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                }
+                else {
+                    w.first = *new1;
+                    w.second = *new2;
+                }
+            }
+            else if (b1) {
+                auto new1 = find_unbroken(t, w.second, no_watch);
+                if (! new1) {
+                    inference.infer(logger, vars[w.second] != t[w.second], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                }
+                else {
+                    w.first = *new1;
+                }
+            }
+            else {
+                auto new2 = find_unbroken(t, w.first, no_watch);
+                if (! new2) {
+                    inference.infer(logger, vars[w.first] != t[w.first], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                }
+                else {
+                    w.second = *new2;
+                }
+            }
+        }
+        return PropagatorState::Enable;
+    }
 }
 
 auto NegativeTable::install_propagators(Propagators & propagators) -> void
@@ -187,109 +304,14 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
             // to TrueLiteral, which tests as DefinitelyTrue).
             propagators.install_initialiser([vars = _vars, tuples = tuples, watches = watches, owner = constraint_id()](
                                                 const State & state, auto & inference, ProofLogger * const logger) -> void {
-                const auto & tuple_data = depointinate(tuples);
-                watches->reserve(tuple_data.size());
-
-                for (size_t ti = 0; ti < tuple_data.size(); ++ti) {
-                    const auto & t = tuple_data[ti];
-
-                    auto find_unbroken = [&](size_t skip) -> optional<size_t> {
-                        for (size_t p = 0; p < vars.size(); ++p) {
-                            if (p == skip)
-                                continue;
-                            if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
-                                return p;
-                        }
-                        return nullopt;
-                    };
-
-                    auto w1 = find_unbroken(no_watch);
-                    if (! w1) {
-                        inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
-                    }
-
-                    auto w2 = find_unbroken(*w1);
-                    if (! w2) {
-                        // Unit clause: vars[*w1] != t[*w1] is the only possibly-true
-                        // disjunct, so it must hold.
-                        inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
-                        // Mark the tuple as already handled — both watches at the same
-                        // position will read as broken on every subsequent fire, and
-                        // any rescue search will discover the inference is now redundant.
-                        watches->emplace_back(*w1, *w1);
-                    }
-                    else {
-                        watches->emplace_back(*w1, *w2);
-                    }
-                }
+                initialise_negative_table_watches(vars, tuples, watches, owner, state, inference, logger);
             });
 
             propagators.install(
                 constraint_id(),
                 [vars = move(_vars), tuples = move(tuples), watches = watches, owner = constraint_id()](
                     const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                    const auto & tuple_data = depointinate(tuples);
-
-                    auto is_broken = [&](const auto & t, size_t p) -> bool {
-                        return state.test_literal(vars[p] == t[p]) == LiteralIs::DefinitelyTrue;
-                    };
-
-                    auto find_unbroken = [&](const auto & t, size_t skip1, size_t skip2) -> optional<size_t> {
-                        for (size_t p = 0; p < vars.size(); ++p) {
-                            if (p == skip1 || p == skip2)
-                                continue;
-                            if (state.test_literal(vars[p] == t[p]) != LiteralIs::DefinitelyTrue)
-                                return p;
-                        }
-                        return nullopt;
-                    };
-
-                    for (size_t ti = 0; ti < tuple_data.size(); ++ti) {
-                        auto & w = (*watches)[ti];
-                        const auto & t = tuple_data[ti];
-
-                        bool b1 = is_broken(t, w.first);
-                        bool b2 = is_broken(t, w.second);
-
-                        if (! b1 && ! b2)
-                            continue;
-
-                        if (b1 && b2) {
-                            auto new1 = find_unbroken(t, no_watch, no_watch);
-                            if (! new1) {
-                                inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
-                            }
-                            auto new2 = find_unbroken(t, *new1, no_watch);
-                            if (! new2) {
-                                inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
-                            }
-                            else {
-                                w.first = *new1;
-                                w.second = *new2;
-                            }
-                        }
-                        else if (b1) {
-                            auto new1 = find_unbroken(t, w.second, no_watch);
-                            if (! new1) {
-                                inference.infer(
-                                    logger, vars[w.second] != t[w.second], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
-                            }
-                            else {
-                                w.first = *new1;
-                            }
-                        }
-                        else {
-                            auto new2 = find_unbroken(t, w.first, no_watch);
-                            if (! new2) {
-                                inference.infer(
-                                    logger, vars[w.first] != t[w.first], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
-                            }
-                            else {
-                                w.second = *new2;
-                            }
-                        }
-                    }
-                    return PropagatorState::Enable;
+                    return propagate_negative_table(vars, tuples, watches, owner, state, inference, logger);
                 },
                 triggers);
         },

--- a/gcs/innards/idempotent_claim_checker_test.cc
+++ b/gcs/innards/idempotent_claim_checker_test.cc
@@ -20,7 +20,12 @@ namespace
 {
     auto enable_checker() -> void
     {
+        // MSVC has no POSIX setenv; _putenv_s matches the overwrite == 1 semantics.
+#ifdef _WIN32
+        _putenv_s("GCS_CHECK_IDEMPOTENT_CLAIMS", "1");
+#else
         setenv("GCS_CHECK_IDEMPOTENT_CLAIMS", "1", 1);
+#endif
     }
 }
 

--- a/gcs/innards/integer_overflow.hh
+++ b/gcs/innards/integer_overflow.hh
@@ -3,6 +3,9 @@
 
 #include <gcs/exception.hh>
 
+#include <limits>
+#include <type_traits>
+
 namespace gcs::innards
 {
     /**
@@ -18,6 +21,98 @@ namespace gcs::innards
 
     [[noreturn]] auto throw_integer_overflow(const char * op, long long a, long long b) -> void;
     [[noreturn]] auto throw_integer_overflow(const char * op, long long a) -> void;
+
+    // Portable checked arithmetic. Each of these mirrors the semantics of the
+    // GCC / Clang __builtin_{add,sub,mul}_overflow builtins: the function
+    // returns true if the operation overflows the range of Int_, and otherwise
+    // stores the mathematically-correct result in *out and returns false. On
+    // GCC and Clang they forward to the builtins; MSVC has no equivalent, so a
+    // branch-based checked fallback is used there. The fallback is written to be
+    // free of any signed overflow (which would itself be undefined behaviour):
+    // every intermediate is proven in range before it is computed.
+#if defined(__has_builtin)
+#define GCS_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define GCS_HAS_BUILTIN(x) 0
+#endif
+
+    template <typename Int_>
+    [[nodiscard]] constexpr auto add_overflows(Int_ a, Int_ b, Int_ * out) -> bool
+    {
+        static_assert(std::is_integral_v<Int_>);
+#if GCS_HAS_BUILTIN(__builtin_add_overflow)
+        return __builtin_add_overflow(a, b, out);
+#else
+        constexpr auto max = std::numeric_limits<Int_>::max();
+        constexpr auto min = std::numeric_limits<Int_>::min();
+        if (b >= Int_{0}) {
+            if (a > max - b)
+                return true;
+        }
+        else if (a < min - b)
+            return true;
+        *out = static_cast<Int_>(a + b);
+        return false;
+#endif
+    }
+
+    template <typename Int_>
+    [[nodiscard]] constexpr auto sub_overflows(Int_ a, Int_ b, Int_ * out) -> bool
+    {
+        static_assert(std::is_integral_v<Int_>);
+#if GCS_HAS_BUILTIN(__builtin_sub_overflow)
+        return __builtin_sub_overflow(a, b, out);
+#else
+        constexpr auto max = std::numeric_limits<Int_>::max();
+        constexpr auto min = std::numeric_limits<Int_>::min();
+        if (b >= Int_{0}) {
+            if (a < min + b)
+                return true;
+        }
+        else if (a > max + b)
+            return true;
+        *out = static_cast<Int_>(a - b);
+        return false;
+#endif
+    }
+
+    template <typename Int_>
+    [[nodiscard]] constexpr auto mul_overflows(Int_ a, Int_ b, Int_ * out) -> bool
+    {
+        static_assert(std::is_integral_v<Int_>);
+#if GCS_HAS_BUILTIN(__builtin_mul_overflow)
+        return __builtin_mul_overflow(a, b, out);
+#else
+        constexpr auto max = std::numeric_limits<Int_>::max();
+        if constexpr (std::is_signed_v<Int_>) {
+            constexpr auto min = std::numeric_limits<Int_>::min();
+            // Classic CERT INT32-C division-based check: every division below has
+            // a non-zero divisor whose sign keeps the quotient in range.
+            if (a > Int_{0}) {
+                if (b > Int_{0}) {
+                    if (a > max / b)
+                        return true;
+                }
+                else if (b < min / a)
+                    return true;
+            }
+            else {
+                if (b > Int_{0}) {
+                    if (a < min / b)
+                        return true;
+                }
+                else if (a != Int_{0} && b < max / a)
+                    return true;
+            }
+        }
+        else if (a != Int_{0} && b > max / a)
+            return true;
+        *out = static_cast<Int_>(a * b);
+        return false;
+#endif
+    }
+
+#undef GCS_HAS_BUILTIN
 }
 
 #endif

--- a/gcs/innards/power.cc
+++ b/gcs/innards/power.cc
@@ -42,11 +42,11 @@ auto gcs::innards::checked_integer_power(Integer base, Integer exp) -> optional<
     long long e = exp.raw_value;
     while (e > 0) {
         if (e & 1)
-            if (__builtin_mul_overflow(result, b, &result))
+            if (mul_overflows(result, b, &result))
                 return nullopt;
         e >>= 1;
         if (e > 0)
-            if (__builtin_mul_overflow(b, b, &b))
+            if (mul_overflows(b, b, &b))
                 return nullopt;
     }
     return Integer{result};

--- a/gcs/integer.hh
+++ b/gcs/integer.hh
@@ -121,14 +121,14 @@ namespace gcs
     [[nodiscard]] constexpr inline auto operator+(Integer a, Integer b) -> Integer
     {
         long long r;
-        if (__builtin_add_overflow(a.raw_value, b.raw_value, &r))
+        if (innards::add_overflows(a.raw_value, b.raw_value, &r))
             innards::throw_integer_overflow("+", a.raw_value, b.raw_value);
         return Integer{r};
     }
 
     constexpr inline auto operator+=(Integer & a, Integer b) -> Integer &
     {
-        if (__builtin_add_overflow(a.raw_value, b.raw_value, &a.raw_value))
+        if (innards::add_overflows(a.raw_value, b.raw_value, &a.raw_value))
             innards::throw_integer_overflow("+=", a.raw_value, b.raw_value);
         return a;
     }
@@ -136,14 +136,14 @@ namespace gcs
     [[nodiscard]] constexpr inline auto operator-(Integer a, Integer b) -> Integer
     {
         long long r;
-        if (__builtin_sub_overflow(a.raw_value, b.raw_value, &r))
+        if (innards::sub_overflows(a.raw_value, b.raw_value, &r))
             innards::throw_integer_overflow("-", a.raw_value, b.raw_value);
         return Integer{r};
     }
 
     constexpr inline auto operator-=(Integer & a, Integer b) -> Integer &
     {
-        if (__builtin_sub_overflow(a.raw_value, b.raw_value, &a.raw_value))
+        if (innards::sub_overflows(a.raw_value, b.raw_value, &a.raw_value))
             innards::throw_integer_overflow("-=", a.raw_value, b.raw_value);
         return a;
     }
@@ -151,7 +151,7 @@ namespace gcs
     [[nodiscard]] constexpr inline auto operator*(Integer a, Integer b) -> Integer
     {
         long long r;
-        if (__builtin_mul_overflow(a.raw_value, b.raw_value, &r))
+        if (innards::mul_overflows(a.raw_value, b.raw_value, &r))
             innards::throw_integer_overflow("*", a.raw_value, b.raw_value);
         return Integer{r};
     }

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <memory>
 #include <random>
+#include <ranges>
 
 using std::generator;
 using std::make_shared;

--- a/minicp_benchmarks/magic_series/CMakeLists.txt
+++ b/minicp_benchmarks/magic_series/CMakeLists.txt
@@ -3,4 +3,4 @@ target_link_libraries(magic_series PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(magic_series PRIVATE cxxopts)
 
-add_test(NAME magic_series-10 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:magic_series> 10)
+add_test(NAME magic_series-10 COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:magic_series> 10)

--- a/minicp_benchmarks/magic_square/CMakeLists.txt
+++ b/minicp_benchmarks/magic_square/CMakeLists.txt
@@ -3,4 +3,4 @@ target_link_libraries(magic_square PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(magic_square PRIVATE cxxopts)
 
-add_test(NAME magic_square-3 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:magic_square> 3)
+add_test(NAME magic_square-3 COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:magic_square> 3)

--- a/minicp_benchmarks/n_queens/CMakeLists.txt
+++ b/minicp_benchmarks/n_queens/CMakeLists.txt
@@ -3,4 +3,4 @@ target_link_libraries(n_queens PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(n_queens PRIVATE cxxopts)
 
-add_test(NAME n_queens-all-10 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:n_queens> --all 10)
+add_test(NAME n_queens-all-10 COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:n_queens> --all 10)

--- a/minicp_benchmarks/qap/CMakeLists.txt
+++ b/minicp_benchmarks/qap/CMakeLists.txt
@@ -3,4 +3,4 @@ target_link_libraries(qap PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(qap PRIVATE cxxopts)
 
-add_test(NAME qap-5 COMMAND ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:qap> 5)
+add_test(NAME qap-5 COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:qap> 5)

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -1,209 +1,209 @@
 add_executable(fzn-glasgow fzn_glasgow.cc)
 target_link_libraries(fzn-glasgow PRIVATE glasgow_constraint_solver cxxopts gcs_fmt nlohmann_json::nlohmann_json)
 
-add_test(NAME minizinc-abs COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ abs true true)
+add_test(NAME minizinc-abs COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ abs true true)
 set_tests_properties(minizinc-abs PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-alldifferentexcept COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ alldifferentexcept true true)
+add_test(NAME minizinc-alldifferentexcept COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ alldifferentexcept true true)
 set_tests_properties(minizinc-alldifferentexcept PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-alldifferentexceptzero COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ alldifferentexceptzero true true)
+add_test(NAME minizinc-alldifferentexceptzero COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ alldifferentexceptzero true true)
 set_tests_properties(minizinc-alldifferentexceptzero PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-among COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ amongtest true true)
+add_test(NAME minizinc-among COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ amongtest true true)
 set_tests_properties(minizinc-among PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-arraybooland COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arraybooland true true)
+add_test(NAME minizinc-arraybooland COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arraybooland true true)
 set_tests_properties(minizinc-arraybooland PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-arrayboolxor COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayboolxor true true)
+add_test(NAME minizinc-arrayboolxor COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayboolxor true true)
 set_tests_properties(minizinc-arrayboolxor PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-arrayint COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayint true true)
+add_test(NAME minizinc-arrayint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayint true true)
 set_tests_properties(minizinc-arrayint PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-arrayintminmax COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayintminmax false true)
+add_test(NAME minizinc-arrayintminmax COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayintminmax false true)
 set_tests_properties(minizinc-arrayintminmax PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-arrayvar COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayvar true true)
+add_test(NAME minizinc-arrayvar COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ arrayvar true true)
 set_tests_properties(minizinc-arrayvar PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-aust COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ aust true true)
+add_test(NAME minizinc-aust COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ aust true true)
 set_tests_properties(minizinc-aust PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-boolxor COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ boolxor true true)
+add_test(NAME minizinc-boolxor COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ boolxor true true)
 set_tests_properties(minizinc-boolxor PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-cake COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cake false true)
+add_test(NAME minizinc-cake COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cake false true)
 set_tests_properties(minizinc-cake PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-circuit COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ circuittest true true)
+add_test(NAME minizinc-circuit COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ circuittest true true)
 set_tests_properties(minizinc-circuit PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-count COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ counttest true true)
+add_test(NAME minizinc-count COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ counttest true true)
 set_tests_properties(minizinc-count PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-cumulative COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativetest false true)
+add_test(NAME minizinc-cumulative COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativetest false true)
 set_tests_properties(minizinc-cumulative PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-cumulative-mode COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativemodetest true true)
+add_test(NAME minizinc-cumulative-mode COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativemodetest true true)
 set_tests_properties(minizinc-cumulative-mode PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-disjunctive COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivetest true true)
+add_test(NAME minizinc-disjunctive COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivetest true true)
 set_tests_properties(minizinc-disjunctive PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-disjunctivestrict COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivestricttest true true)
+add_test(NAME minizinc-disjunctivestrict COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivestricttest true true)
 set_tests_properties(minizinc-disjunctivestrict PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-disjunctive-var COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivevartest true true)
+add_test(NAME minizinc-disjunctive-var COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivevartest true true)
 set_tests_properties(minizinc-disjunctive-var PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-disjunctive-var-nonstrict COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivevarnonstricttest true true)
+add_test(NAME minizinc-disjunctive-var-nonstrict COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivevarnonstricttest true true)
 set_tests_properties(minizinc-disjunctive-var-nonstrict PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-diffn COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ diffntest true true)
+add_test(NAME minizinc-diffn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ diffntest true true)
 set_tests_properties(minizinc-diffn PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-diffn-rotate COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ diffnrotatetest true true)
+add_test(NAME minizinc-diffn-rotate COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ diffnrotatetest true true)
 set_tests_properties(minizinc-diffn-rotate PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-diffn-nonstrict COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ diffnnonstricttest true true)
+add_test(NAME minizinc-diffn-nonstrict COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ diffnnonstricttest true true)
 set_tests_properties(minizinc-diffn-nonstrict PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-countops COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ countops true true)
+add_test(NAME minizinc-countops COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ countops true true)
 set_tests_properties(minizinc-countops PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-crystalmaze COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ crystalmaze true true)
+add_test(NAME minizinc-crystalmaze COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ crystalmaze true true)
 set_tests_properties(minizinc-crystalmaze PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-decreasing COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ decreasing true true)
+add_test(NAME minizinc-decreasing COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ decreasing true true)
 set_tests_properties(minizinc-decreasing PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-disjointdomain COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjointdomain true true)
+add_test(NAME minizinc-disjointdomain COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjointdomain true true)
 set_tests_properties(minizinc-disjointdomain PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-div COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ div true true)
+add_test(NAME minizinc-div COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ div true true)
 set_tests_properties(minizinc-div PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-equals COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ equals false true)
+add_test(NAME minizinc-equals COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ equals false true)
 set_tests_properties(minizinc-equals PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-equalsreif COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ equalsreif true true)
+add_test(NAME minizinc-equalsreif COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ equalsreif true true)
 set_tests_properties(minizinc-equalsreif PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-globalcardinality COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ globalcardinality true true)
+add_test(NAME minizinc-globalcardinality COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ globalcardinality true true)
 set_tests_properties(minizinc-globalcardinality PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-globalcardinalityclosed COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ globalcardinalityclosed true true)
+add_test(NAME minizinc-globalcardinalityclosed COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ globalcardinalityclosed true true)
 set_tests_properties(minizinc-globalcardinalityclosed PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-globalcardinalitylowup COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ globalcardinalitylowup true true)
+add_test(NAME minizinc-globalcardinalitylowup COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ globalcardinalitylowup true true)
 set_tests_properties(minizinc-globalcardinalitylowup PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-increasing COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ increasing true true)
+add_test(NAME minizinc-increasing COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ increasing true true)
 set_tests_properties(minizinc-increasing PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-inverses COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ inverses true true)
+add_test(NAME minizinc-inverses COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ inverses true true)
 set_tests_properties(minizinc-inverses PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-knapsack COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ knapsacktest false true)
+add_test(NAME minizinc-knapsack COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ knapsacktest false true)
 set_tests_properties(minizinc-knapsack PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lessthans COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lessthans true true)
+add_test(NAME minizinc-lessthans COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lessthans true true)
 set_tests_properties(minizinc-lessthans PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexbool COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexbool true true)
+add_test(NAME minizinc-lexbool COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexbool true true)
 set_tests_properties(minizinc-lexbool PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexgequnequal COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexgequnequal true true)
+add_test(NAME minizinc-lexgequnequal COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexgequnequal true true)
 set_tests_properties(minizinc-lexgequnequal PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexgtunequal COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexgtunequal true true)
+add_test(NAME minizinc-lexgtunequal COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexgtunequal true true)
 set_tests_properties(minizinc-lexgtunequal PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexlequnequal COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexlequnequal true true)
+add_test(NAME minizinc-lexlequnequal COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexlequnequal true true)
 set_tests_properties(minizinc-lexlequnequal PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexless COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexless true true)
+add_test(NAME minizinc-lexless COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexless true true)
 set_tests_properties(minizinc-lexless PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexlesseq COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexlesseq true true)
+add_test(NAME minizinc-lexlesseq COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexlesseq true true)
 set_tests_properties(minizinc-lexlesseq PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexltunequal COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexltunequal true true)
+add_test(NAME minizinc-lexltunequal COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexltunequal true true)
 set_tests_properties(minizinc-lexltunequal PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-lexreif COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexreif true true)
+add_test(NAME minizinc-lexreif COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ lexreif true true)
 set_tests_properties(minizinc-lexreif PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-allequal COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ allequaltest true true)
+add_test(NAME minizinc-allequal COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ allequaltest true true)
 set_tests_properties(minizinc-allequal PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-member COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ membertest true true)
+add_test(NAME minizinc-member COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ membertest true true)
 set_tests_properties(minizinc-member PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-minmax COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ minmax false true)
+add_test(NAME minizinc-minmax COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ minmax false true)
 set_tests_properties(minizinc-minmax PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-notequalsreif COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ notequalsreif true true)
+add_test(NAME minizinc-notequalsreif COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ notequalsreif true true)
 set_tests_properties(minizinc-notequalsreif PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-nvalue COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ nvaluetest true true)
+add_test(NAME minizinc-nvalue COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ nvaluetest true true)
 set_tests_properties(minizinc-nvalue PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-regex COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ regex true true)
+add_test(NAME minizinc-regex COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ regex true true)
 set_tests_properties(minizinc-regex PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-nurses COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ nurses true false)
+add_test(NAME minizinc-nurses COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ nurses true false)
 set_tests_properties(minizinc-nurses PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-seqprecedechain COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ seqprecedechain true true)
+add_test(NAME minizinc-seqprecedechain COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ seqprecedechain true true)
 set_tests_properties(minizinc-seqprecedechain PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-setinreif COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ setinreif true true)
+add_test(NAME minizinc-setinreif COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ setinreif true true)
 set_tests_properties(minizinc-setinreif PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-sets COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ sets true true)
+add_test(NAME minizinc-sets COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ sets true true)
 set_tests_properties(minizinc-sets PROPERTIES SKIP_RETURN_CODE 66)
 
 # Empty-set set_in / set_in_reif: MiniZinc folds `x in {}` to false before it
 # reaches the solver, so these feed hand-written JSON FlatZinc to fzn-glasgow
 # directly to exercise the empty-set frontend guards.
-add_test(NAME minizinc-emptysetin COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in)
-add_test(NAME minizinc-emptysetinreif COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in_reif)
+add_test(NAME minizinc-emptysetin COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in)
+add_test(NAME minizinc-emptysetinreif COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in_reif)
 
-add_test(NAME minizinc-small COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ small true true)
+add_test(NAME minizinc-small COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ small true true)
 set_tests_properties(minizinc-small PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-sort COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ sorttest true true)
+add_test(NAME minizinc-sort COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ sorttest true true)
 set_tests_properties(minizinc-sort PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-argsort COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ argsorttest true true)
+add_test(NAME minizinc-argsort COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ argsorttest true true)
 set_tests_properties(minizinc-argsort PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-strictlydecreasing COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ strictlydecreasing true true)
+add_test(NAME minizinc-strictlydecreasing COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ strictlydecreasing true true)
 set_tests_properties(minizinc-strictlydecreasing PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-strictlyincreasing COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ strictlyincreasing true true)
+add_test(NAME minizinc-strictlyincreasing COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ strictlyincreasing true true)
 set_tests_properties(minizinc-strictlyincreasing PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-symmetricalldifferent COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ symmetricalldifferent true true)
+add_test(NAME minizinc-symmetricalldifferent COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ symmetricalldifferent true true)
 set_tests_properties(minizinc-symmetricalldifferent PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-tablebool COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ tablebool true true)
+add_test(NAME minizinc-tablebool COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ tablebool true true)
 set_tests_properties(minizinc-tablebool PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-tableint COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ tableint true true)
+add_test(NAME minizinc-tableint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ tableint true true)
 set_tests_properties(minizinc-tableint PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-times COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ times true true)
+add_test(NAME minizinc-times COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ times true true)
 set_tests_properties(minizinc-times PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-tsp COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ tsp false true)
+add_test(NAME minizinc-tsp COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ tsp false true)
 set_tests_properties(minizinc-tsp PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-valueprecede COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ valueprecede true true)
+add_test(NAME minizinc-valueprecede COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ valueprecede true true)
 set_tests_properties(minizinc-valueprecede PROPERTIES SKIP_RETURN_CODE 66)
 
-add_test(NAME minizinc-valueprecedechain COMMAND ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ valueprecedechain true true)
+add_test(NAME minizinc-valueprecedechain COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ valueprecedechain true true)
 set_tests_properties(minizinc-valueprecedechain PROPERTIES SKIP_RETURN_CODE 66)

--- a/minizinc/run_minizinc_test.bash
+++ b/minizinc/run_minizinc_test.bash
@@ -24,7 +24,16 @@ if ! command -v minizinc ; then
     exit 66
 fi
 
-minizinc --solver "$minizincdir/glasgow-for-tests.msc" --fzn "$testname.fzn" -a "$minizincdir/tests/$testname.mzn" | tee "$testname.glasgow.out" || exit 1
+# MiniZinc resolves the solver executable named in the .msc; a bare name relying on
+# PATH is not enough on Windows (it is not found / spawned as .exe), so generate a
+# config pointing at the absolute path of the built solver ($1, which already
+# carries the .exe suffix on Windows) with an absolute mznlib. Same result on Unix.
+solver_msc="$testname.glasgow.msc"
+sed -e "s|\"executable\": \"fzn-glasgow\"|\"executable\": \"$1\"|" \
+    -e "s|\"mznlib\": \"mznlib\"|\"mznlib\": \"$minizincdir/mznlib\"|" \
+    "$minizincdir/glasgow-for-tests.msc" > "$solver_msc"
+
+minizinc --solver "$solver_msc" --fzn "$testname.fzn" -a "$minizincdir/tests/$testname.mzn" | tee "$testname.glasgow.out" || exit 1
 minizinc -a "$minizincdir/tests/$testname.mzn" | tee "$testname.default.out" || exit 2
 
 if [[ "$enumeration" == "true" ]] ; then
@@ -50,7 +59,7 @@ else
 fi
 
 if [[ "$doproofs" == "true" ]] && veripb --help >/dev/null ; then
-    minizinc --solver "$minizincdir/glasgow-for-tests.msc" -a "$minizincdir/tests/$testname.mzn" --prove "$testname" | tee "$testname.glasgow.out" || exit 7
+    minizinc --solver "$solver_msc" -a "$minizincdir/tests/$testname.mzn" --prove "$testname" | tee "$testname.glasgow.out" || exit 7
     if ! veripb "$testname.opb" "$testname.pbp" ; then
         echo "Rerunning last 100 lines of proof verification in trace mode..."
         echo '$ ' veripb --trace "$(readlink -f "$testname.opb")" "$(readlink -f "$testname.pbp")"

--- a/python/gcspy.cc
+++ b/python/gcspy.cc
@@ -453,7 +453,7 @@ auto Python::post_global_cardinality(
     int_values.reserve(values.size());
     for (auto v : values)
         int_values.emplace_back(v);
-    p.post(GlobalCardinality(get_vars(var_ids), move(int_values), get_vars(count_ids), closed));
+    p.post(GlobalCardinality(get_vars(var_ids), move(int_values), get_vars(count_ids)).with_closed(closed));
 }
 
 auto Python::post_element(const string & var_id, const string & index_id, const vector<string> & var_ids) -> void

--- a/python/gcspy.hh
+++ b/python/gcspy.hh
@@ -1,10 +1,16 @@
 #ifndef GCS_API_HH
 #define GCS_API_HH
+#include <atomic>
+#include <csignal>
 #include <deque>
+#include <functional>
 #include <gcs/gcs.hh>
+#include <optional>
 #include <pybind11/pybind11.h>
+#include <sstream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 using namespace gcs;
 
 using std::string;

--- a/run_test_and_verify.bash
+++ b/run_test_and_verify.bash
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 prog=$1
-progname=$(basename $prog )
+progname=$(basename "$prog")
+# On Windows the target file ends in .exe, but the test binaries name their proof
+# files after the plain stem (e.g. ProofOptions{"range_witness_w1_test"}), so strip
+# the suffix to find name.opb / name.pbp rather than name.exe.opb.
+progname=${progname%.exe}
 shift
 
 export PATH=$HOME/.cargo/bin:$PATH

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -12,7 +12,7 @@ set(_scp_chain_runner ${CMAKE_CURRENT_SOURCE_DIR}/../run_scp_chain.bash)
 # add_scp_chain_test(<case> <opbdiff-mode>)  -- mode: strict | aux | none
 function(add_scp_chain_test case mode)
     add_test(NAME scp_chain_${case}
-        COMMAND ${_scp_chain_runner} $<TARGET_FILE:glasgow_scp_solver>
+        COMMAND ${GCS_BASH} ${_scp_chain_runner} $<TARGET_FILE:glasgow_scp_solver>
             ${CMAKE_CURRENT_SOURCE_DIR}/${case}.scp ${mode})
     set_tests_properties(scp_chain_${case} PROPERTIES SKIP_RETURN_CODE 77)
 endfunction()

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(xcsp_glasgow_constraint_solver PRIVATE
 # missing, the test skips (ctest exit code 66) rather than failing.
 function(add_xcsp_test name)
     add_test(NAME xcsp_${name}
-        COMMAND ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash
+        COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash
             $<TARGET_FILE:xcsp_glasgow_constraint_solver>
             ${CMAKE_SOURCE_DIR}/xcsp/tests/
             ${name})

--- a/xcsp/run_xcsp_test.bash
+++ b/xcsp/run_xcsp_test.bash
@@ -39,19 +39,29 @@ fi
 
 echo "writing output to $testname.out"
 
+# Normalise line endings before comparing: on Windows the solver's stdout arrives
+# CRLF (cout is in text mode) and git may check the LF-committed caches out as CRLF
+# too, so strip CR from both the captured output and the cached expectations.
 if [[ $mode == enumerate ]]; then
     $prog --prove --all "$testsdir/$testname.xml" > "$testname.out" || exit 1
+    tr -d '\r' < "$testname.out" > "$testname.out.nocr" && mv -f "$testname.out.nocr" "$testname.out"
 
     actualfile="$testname.sols.actual"
     grep '^ENUMSOL: ' "$testname.out" | sed 's/^ENUMSOL: //' | sort > "$actualfile"
 
-    if ! diff -u "$sols_cache" "$actualfile"; then
+    expectedfile="$testname.sols.expected"
+    tr -d '\r' < "$sols_cache" > "$expectedfile"
+
+    if ! diff -u "$expectedfile" "$actualfile"; then
         echo "solution set differs from cached expected" >&2
+        echo "--- od -c expected (first lines) ---" >&2; od -c "$expectedfile" | head -4 >&2
+        echo "--- od -c actual   (first lines) ---" >&2; od -c "$actualfile" | head -4 >&2
         exit 2
     fi
-    rm -f "$actualfile"
+    rm -f "$actualfile" "$expectedfile"
 else
     $prog --prove "$testsdir/$testname.xml" > "$testname.out" || exit 1
+    tr -d '\r' < "$testname.out" > "$testname.out.nocr" && mv -f "$testname.out.nocr" "$testname.out"
 
     if ! grep -q '^s OPTIMUM FOUND$' "$testname.out"; then
         echo "expected 's OPTIMUM FOUND' in solver output" >&2
@@ -59,7 +69,7 @@ else
     fi
 
     actual_opt=$(grep '^o ' "$testname.out" | tail -1 | awk '{print $2}')
-    expected_opt=$(cat "$opt_cache")
+    expected_opt=$(tr -d '\r' < "$opt_cache")
     if [[ "$actual_opt" != "$expected_opt" ]]; then
         echo "optimum mismatch: gcs=$actual_opt, expected=$expected_opt" >&2
         exit 3


### PR DESCRIPTION
**Draft for review** — adds Windows / MSVC support for the core solver. Opened as a draft; the Linux/macOS lanes are untouched and stay green.

## Result (all green on the `windows-2022 / MSVC` CI lane)
- Core library compiles and links with MSVC.
- **Full `gcs` ctest suite passes: 188/188** — Catch2 unit tests *and* the bash/veripb-verified constraint & proof tests.
- VeriPB builds from Rust source and verifies proofs on Windows.

For a codebase with no prior Windows awareness this was a contained set of changes; the C++ itself was already very portable (no POSIX headers, no `__int128`, `std::chrono` timing, standard threading). Recent MSVC supplies `<format>`/`<print>`/`<generator>`/`<stacktrace>` natively.

## What's here
- **Portable overflow shim** (`gcs/innards/integer_overflow.hh`): `add/sub/mul_overflows` replace the GCC/Clang-only `__builtin_*_overflow`; they forward to the builtins on GCC/Clang and use a constexpr checked-arithmetic fallback on MSVC.
- **CMake**: MSVC branch for compiler flags; `stdc++exp` linked only when `NOT MSVC`; no `CMAKE_BUILD_TYPE` annotation under multi-config generators; a `GCS_BASH` launcher so `add_test` invokes the wrapper scripts through bash on Windows (empty, hence a no-op, elsewhere).
- **`#include <ranges>`** in `search_heuristics.cc` (MSVC isn't transitively inclusive).
- **Two MSVC C1001 internal compiler errors** worked around (`linear_equality.cc`, `negative_table.cc`): MSVC chokes on *generic* lambdas (`const auto &`) nested inside the generic-on-inference propagator lambdas, so the affected visitor/propagator bodies are hoisted into named function templates. Behaviour-preserving (solves stay sound; proofs still VeriPB-VERIFIED).
- **`run_test_and_verify.bash`**: strip a trailing `.exe` from the proof basename so veripb finds `name.opb`, not `name.exe.opb`.
- **CI**: a `Windows (MSVC)` workflow (Ninja + `msvc-dev-cmd`) that builds and runs the full `gcs` suite, plus a small VeriPB-on-Windows check.

## Not included (future opt-in)
XCSP / MiniZinc / Python frontends and the examples stay off on Windows — they pull in extra native dependencies (libxml2, MiniZinc) and have behavioural gaps (`signal(SIGTERM)` is never delivered on Windows; `system("... >/dev/null")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)