### PR TITLE
Per-run propagator idempotence claims (EnableButIdempotent) + wave-1 adopters

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -214,6 +214,23 @@ on backtrack to a level above where it was disabled. Don't return
 *right now* — the propagator will be triggered again as soon as a
 domain changes.
 
+In between the two sits `PropagatorState::EnableButIdempotent`: the
+propagator stays registered, but this run reached its own fixpoint —
+re-running it immediately, against the domains exactly as this run
+left them, would infer nothing and not contradict — so the propagation
+queue skips re-waking it from its own inferences (changes made by
+other propagators wake it as usual). The claim is per-run, and only
+correct for algorithms that process all their internal cascades in one
+call *and* whose scope has no two positions aliasing the same
+underlying variable; `Propagators::install` detects aliased trigger
+scopes (including through views) and silently ignores claims from such
+propagators, which relies on claiming propagators registering triggers
+1:1 with their scope positions. A wrong claim silently under-propagates
+or is unsound, so every adoption needs an audit note, and the test
+harness sets `GCS_CHECK_IDEMPOTENT_CLAIMS` to re-run every honoured
+claim and abort if it infers anything. When in doubt, return `Enable`:
+the only cost is a possible wasted no-op run.
+
 ### Triggers
 
 Three trigger kinds, applied to specific variables:

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -464,6 +464,14 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(state_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME state_test COMMAND $<TARGET_FILE:state_test>)
 
+    add_executable(propagators_test innards/propagators_test.cc)
+    target_link_libraries(propagators_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME propagators_test COMMAND $<TARGET_FILE:propagators_test>)
+
+    add_executable(idempotent_claim_checker_test innards/idempotent_claim_checker_test.cc)
+    target_link_libraries(idempotent_claim_checker_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME idempotent_claim_checker_test COMMAND $<TARGET_FILE:idempotent_claim_checker_test>)
+
     add_executable(linear_utils_test constraints/linear/utils_test.cc)
     target_link_libraries(linear_utils_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME linear_utils_test COMMAND $<TARGET_FILE:linear_utils_test>)

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -151,7 +151,17 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
                     if (! propagate_non_gac_alldifferent(
                             unassigned_handle, state, tracker, logger, owner, reasons.empty() ? nullptr : &reasons, reason_base))
                         return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
-                    return PropagatorState::Enable;
+                    // Idempotent: the to_propagate worklist re-checks
+                    // optional_single_value after every removal and processes the
+                    // whole cascade in this call, so at return no variable left in
+                    // unassigned is single-valued and a re-run collects nothing.
+                    // Duplicate scope variables never reach here (prepare rejects
+                    // them), and triggers are 1:1 with the scope, so view aliasing
+                    // is caught by the install-time downgrade. The claim is this
+                    // call site's, deliberately not the shared helper's: circuit
+                    // wraps the same helper in propagators that do more work in
+                    // the same run and must not claim.
+                    return PropagatorState::EnableButIdempotent;
                 },
                 triggers);
         }}

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -113,7 +113,16 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
                     constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                     propagate_gac_all_different(
                         constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), state, inference, logger);
-                    return PropagatorState::Enable;
+                    // Idempotent: one call prunes to the GAC closure. The
+                    // matching and SCCs are built from an entry snapshot, and
+                    // what survives is exactly the union of maximum matchings,
+                    // so a re-run deletes nothing (every remaining edge is in
+                    // some maximum matching) and a matching still exists (no
+                    // contradiction). Duplicate scope variables never reach here
+                    // (prepare rejects them), and triggers are 1:1 with the
+                    // scope, so view aliasing is caught by the install-time
+                    // downgrade.
+                    return PropagatorState::EnableButIdempotent;
                 },
                 triggers);
         },

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -39,9 +39,13 @@ namespace
     // (succ[end] != start), force the full chain to close (succ[end] == start), and
     // contradict if a sub-cycle has actually closed. Each edge is processed once, in
     // O(1); the outer loop re-runs only because forcing an edge fixes a new one.
+    // Returns whether any successor became single-valued along the way -- the one
+    // event whose alldifferent consequences this pass does not handle itself, so the
+    // caller knows whether another alldifferent pass is needed.
     auto prevent_small_cycles_incrementally(const vector<IntegerVariableID> & succ, const ConstraintID & owner, const PosVarDataMap & pos_var_data,
-        const ConstraintStateHandle & chain_handle, const State & state, auto & inference, ProofLogger * const logger) -> void
+        const ConstraintStateHandle & chain_handle, const State & state, auto & inference, ProofLogger * const logger) -> bool
     {
+        bool fixed_a_successor = false;
         auto & chain = any_cast<PreventChainData &>(state.get_constraint_state(chain_handle));
         auto n = static_cast<long>(succ.size());
 
@@ -87,14 +91,19 @@ namespace
                         };
                         inference.infer(
                             logger, succ[d] != Integer{o}, JustifyExplicitly{justf, ThenRUP::Yes, hints::Circuit{owner}}, generic_reason(succ));
+                        if (state.optional_single_value(succ[d]))
+                            fixed_a_successor = true;
                     }
                     else {
                         // The chain spans every node; it must close to complete the tour.
                         inference.infer(logger, succ[d] == Integer{o}, JustifyUsingRUP{hints::Circuit{owner}}, generic_reason(succ));
+                        fixed_a_successor = true;
                     }
                 }
             }
         }
+
+        return fixed_a_successor;
     }
 
 }
@@ -103,9 +112,21 @@ auto gcs::innards::circuit::propagate_circuit_using_prevent(const std::vector<In
     const PosVarDataMap & pos_var_data, const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle,
     const State & state, auto & inference, ProofLogger * const logger) -> void
 {
-    if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
-        return; // contradiction: the cycle checks below would read junk state; the loop sees contradicted()
-    prevent_small_cycles_incrementally(succ, owner, pos_var_data, chain_handle, state, inference, logger);
+    // Each phase runs its own internal cascade to quiescence, but they feed
+    // each other: a small-cycle prevention (succ[end] != start) or a forced
+    // closing (succ[end] == start) can fix a successor, whose alldifferent
+    // consequences -- and any chain work those fixings cascade into -- used
+    // to be caught only by the self-requeue. Alternate the phases until the
+    // prevention pass stops fixing successors (mere removals need no
+    // alldifferent attention, so the common run still makes exactly one pass
+    // of each), so a single call reaches this propagator's own fixpoint and
+    // the caller can claim idempotence.
+    while (true) {
+        if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
+            return; // contradiction: the cycle checks below would read junk state; the loop sees contradicted()
+        if (! prevent_small_cycles_incrementally(succ, owner, pos_var_data, chain_handle, state, inference, logger))
+            return;
+    }
 }
 
 template auto gcs::innards::circuit::propagate_circuit_using_prevent(const std::vector<IntegerVariableID> & succ, const ConstraintID & owner,
@@ -148,7 +169,17 @@ auto gcs::innards::circuit::install_circuit_prevent(Propagators & propagators, S
         [succ, owner, pvd = std::move(pos_var_data), unassigned_handle = unassigned_handle, chain_handle = chain_handle](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             propagate_circuit_using_prevent(succ, owner, pvd, unassigned_handle, chain_handle, state, inference, logger);
-            return PropagatorState::Enable;
+            // Idempotent: propagate_circuit_using_prevent alternates its
+            // alldifferent and small-cycle passes until the latter stops
+            // inferring, so at return no unassigned successor is
+            // single-valued and every fixed edge is folded into its chain
+            // with the closing inference made -- a re-run finds nothing.
+            // (This was the propagator whose skipped self-requeue made the
+            // global-skip prototype unsound on tsp; the alternation is what
+            // makes the claim honest.) Triggers are 1:1 with the scope, so
+            // view aliasing is caught by the install-time downgrade, and the
+            // Circuit constructor rejects repeated variable handles outright.
+            return PropagatorState::EnableButIdempotent;
         },
         triggers);
 }

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -16,6 +16,7 @@
 #include <gch/small_vector.hpp>
 
 #include <util/enumerate.hh>
+#include <util/overloaded.hh>
 
 #include <version>
 
@@ -47,6 +48,8 @@ using std::string;
 using std::stringstream;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::adjacent_find;
+using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -284,8 +287,40 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 elem.pop_back();
             }
         };
-        if (array_has_nonconstants)
+        // A variable-entried array's variables are needed for the aliasing
+        // check below even when they are all root-fixed; the trigger sets
+        // still guard on array_has_nonconstants.
+        if constexpr (std::is_same_v<EntryType_, IntegerVariableID>)
             collect_array_variables(0);
+    }
+
+    // The idempotence claims below must de-alias their own scope: the index
+    // propagators deliberately do not watch the variable they write (before
+    // claims existed, a self-wake was pure waste), so Propagators::install's
+    // trigger-scope downgrade cannot see aliasing that involves the written
+    // variable. If any two scope positions share an underlying variable --
+    // result also an index (the *_dup_xx tests), an index repeated, result or
+    // an index inside the array -- a claiming propagator's snapshot of its
+    // read side can be invalidated by its own writes, so no propagator of
+    // this constraint claims.
+    bool scope_has_aliasing = false;
+    {
+        vector<unsigned long long> underlying;
+        auto add_underlying = [&](const IntegerVariableID & v) {
+            overloaded{
+                [&](const SimpleIntegerVariableID & sv) { underlying.push_back(sv.index); },                 //
+                [&](const ViewOfIntegerVariableID & vv) { underlying.push_back(vv.actual_variable.index); }, //
+                [&](const ConstantIntegerVariableID &) {}                                                    //
+            }
+                .visit(v);
+        };
+        add_underlying(_result_var);
+        for (const auto & v : index_vars)
+            add_underlying(v);
+        for (const auto & v : all_array_vars)
+            add_underlying(v);
+        sort(underlying);
+        scope_has_aliasing = adjacent_find(underlying) != underlying.end();
     }
 
     for (unsigned fixed_dim = 0; fixed_dim != index_vars.size(); ++fixed_dim) {
@@ -306,7 +341,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
         propagators.install(
             constraint_id(),
             [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, fixed_dim = fixed_dim,
-                array_has_nonconstants = array_has_nonconstants,
+                array_has_nonconstants = array_has_nonconstants, scope_has_aliasing = scope_has_aliasing,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // for each index variable, update it to only contain values where
                 // there's at least one supporting option. result_var's domain is
@@ -419,7 +454,15 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                     }
                 });
 
-                return PropagatorState::Enable;
+                // Idempotent when the scope has no aliasing: this run writes
+                // only index_vars[fixed_dim], and no support test reads it (a
+                // value's support depends on result, the other index
+                // variables, and the array only), so at return every
+                // remaining value's support is intact and a re-run removes
+                // nothing. The engine's trigger downgrade cannot stand in for
+                // the scope_has_aliasing guard here, because the written
+                // variable is deliberately absent from the triggers.
+                return scope_has_aliasing ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
             },
             index_triggers);
     }
@@ -525,6 +568,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 if (highest_found && *highest_found < current_bounds.second)
                     infer_bound(*highest_found, false);
 
+                // Deliberately not EnableButIdempotent: this propagator reads
+                // and writes result's bounds, and a bound write that snaps
+                // past a hole tightens the range the next run filters array
+                // entries against, which can exclude the entries that
+                // supported the old bounds and so licence a strictly tighter
+                // inference on an immediate re-run (result {0,3,6,10} against
+                // entries {2,5,9} first infers [2,9], snapping to [3,6], and
+                // only a re-run gets >= 5 from the sole surviving entry).
                 return PropagatorState::Enable;
             },
             result_triggers);
@@ -538,7 +589,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
         propagators.install(
             constraint_id(),
             [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var,
-                array_has_nonconstants = array_has_nonconstants,
+                array_has_nonconstants = array_has_nonconstants, scope_has_aliasing = scope_has_aliasing,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // the result variable has to be in the union of possible values
                 gch::small_vector<size_t, dimensions_> elem;
@@ -610,7 +661,14 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                         reason);
                 }
 
-                return PropagatorState::Enable;
+                // Idempotent when the scope has no aliasing: this run writes
+                // only result, whose values play no part in the supported-set
+                // computation (that reads the index variables and the array
+                // only), so the values that survive are exactly the supported
+                // ones and a re-run removes nothing. Value removals are
+                // exact, so there is no snapping hazard, unlike the bounds
+                // variant above.
+                return scope_has_aliasing ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
             },
             result_triggers);
     }
@@ -621,8 +679,8 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
         equality_triggers.on_change.emplace_back(_result_var);
         propagators.install(
             constraint_id(),
-            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, owner = constraint_id()](
-                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            [array = _array, index_vars = index_vars, index_starts = _index_starts, result_var = _result_var, scope_has_aliasing = scope_has_aliasing,
+                owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // if there's only a single possible array variable left, it can only take values
                 // that are present in the result variable
                 bool index_is_fully_defined = true;
@@ -643,7 +701,16 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                     enforce_equality(logger, result_var, array_var, state, inference, index_reason, owner);
                 }
 
-                return PropagatorState::Enable;
+                // Idempotent when the scope has no aliasing: a run that did
+                // nothing (index not fully defined) trivially so; otherwise
+                // the run writes only result and the selected array variable,
+                // which enforce_equality leaves with equal domains -- the
+                // holey path prunes both sides' symmetric difference from
+                // entry snapshots, the hole-free path intersects bounds
+                // exactly (no snapping without holes) -- so a re-run finds
+                // nothing left to remove, and its single-value shortcut can
+                // only re-infer an equality that already holds (NoChange).
+                return scope_has_aliasing ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
             },
             equality_triggers);
     }

--- a/gcs/constraints/extensional_utils.cc
+++ b/gcs/constraints/extensional_utils.cc
@@ -117,7 +117,18 @@ auto gcs::innards::propagate_extensional(
         },
         table.tuples);
 
-    return PropagatorState::Enable;
+    // Idempotent when the vars are distinct: this call prunes to the closure.
+    // A value survives the support pass only if some still-selectable tuple
+    // matches it, and a selectable tuple's own entries are therefore all still
+    // in domain (wildcards match everything), so a re-run finds every
+    // selectable tuple still feasible and every remaining value still
+    // supported. A repeated variable breaks exactly this self-witnessing (a
+    // tuple can be feasible per-position yet killed by a removal at the other
+    // occurrence, noticed only on the next run) -- that is the motivating case
+    // for the install-time downgrade, which every caller's 1:1 triggers make
+    // detectable. The claim rides the shared helper because, unlike the
+    // non-GAC alldifferent helper, every caller's run is exactly this call.
+    return PropagatorState::EnableButIdempotent;
 }
 
 // One instantiation per (inference tracker, hint) pair actually used: NoHint for

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -361,6 +361,13 @@ namespace gcs::test_innards
     auto solve_for_tests_with_callbacks(
         Problem & p, const std::optional<std::string> & proof_name, const SolutionCallback_ & f, const TraceCallback_ & t) -> void
     {
+        // Every constraint test runs with the idempotence claim checker on:
+        // each honoured PropagatorState::EnableButIdempotent claim is verified
+        // by an immediate re-run, which aborts the solve if it infers anything.
+        // Deterministic, at most doubles the cost of claiming runs, and a
+        // passing re-run emits nothing, so the proof lanes are unaffected.
+        setenv("GCS_CHECK_IDEMPOTENT_CLAIMS", "1", 0);
+
         // Apply the optional runtime caps (see env_cap). The wrappers count
         // solutions / internal search nodes and return false to stop the solve
         // once a cap is reached; `f` and `t` and these counters all outlive the

--- a/gcs/constraints/innards/reified_dispatcher.hh
+++ b/gcs/constraints/innards/reified_dispatcher.hh
@@ -162,10 +162,21 @@ namespace gcs::innards
                 enforce_constraint_must_not_hold = std::move(enforce_constraint_must_not_hold),
                 infer_cond_when_undecided = std::move(infer_cond_when_undecided)](
                 const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                // An enforce pass may claim idempotence (EnableButIdempotent),
+                // but this runtime dispatch does not forward the claim: a
+                // re-run of the dispatcher also re-tests the reification
+                // condition, and nobody has audited that interplay yet. The
+                // install-time decided paths above forward claims unchanged,
+                // since there the run is exactly the enforce call.
+                auto without_any_idempotency_claim = [](PropagatorState s) {
+                    return s == PropagatorState::EnableButIdempotent ? PropagatorState::Enable : s;
+                };
                 return overloaded{
-                    [&](const evaluated_reif::MustHold & reif) { return enforce_constraint_must_hold(state, inference, logger, reif.cond); }, //
+                    [&](const evaluated_reif::MustHold & reif) {
+                        return without_any_idempotency_claim(enforce_constraint_must_hold(state, inference, logger, reif.cond));
+                    }, //
                     [&](const evaluated_reif::MustNotHold & reif) {
-                        return enforce_constraint_must_not_hold(state, inference, logger, reif.cond);
+                        return without_any_idempotency_claim(enforce_constraint_must_not_hold(state, inference, logger, reif.cond));
                     }, //
                     [&](const evaluated_reif::Undecided & reif) {
                         // The verdict's justification type varies per constraint

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -166,8 +166,13 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
         },
         sanitised_cv);
 
+    // Trigger on the sanitised terms, not the user's: tidy_up_linear coalesces
+    // repeats and resolves views (2a + 3a -> 5a), and these deduplicated
+    // underlying variables are the propagator's actual read/write scope. The
+    // user's raw terms would register a repeated variable twice and spuriously
+    // trip the idempotence-claim downgrade.
     Triggers triggers;
-    for (auto & [_, v] : _coeff_vars.terms)
+    for (const auto & v : vars)
         triggers.on_bounds.push_back(v);
 
     visit(

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -187,47 +187,85 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
         return PropagatorState::DisableUntilBacktrack;
     }
 
-    Integer lower_sum{0};
-    for (const auto & cv : coeff_vars.terms) {
-        const auto & var = get_var(cv);
-        bounds.push_back(state.bounds(var));
-        if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
-            lower_sum += bounds.back().first;
-        else if constexpr (is_same_v<decltype(cv), const pair<bool, SimpleIntegerVariableID> &>)
-            lower_sum += (cv.first ? bounds.back().first : -bounds.back().second);
-        else {
-            auto coeff = get_coeff(cv);
-            lower_sum += (coeff >= 0_i) ? (coeff * bounds.back().first) : (coeff * bounds.back().second);
+    for (const auto & cv : coeff_vars.terms)
+        bounds.push_back(state.bounds(get_var(cv)));
+
+    // lower_sum, the least value the (forward) sum can take, from each term's
+    // min contribution. It is invariant within a forward sweep -- the sweep
+    // writes only upper bounds of positive-coefficient terms and lower bounds
+    // of negative ones, neither of which feeds lower_sum -- so one recompute at
+    // the top of each sweep from the current bounds is exact, and picks up any
+    // tightening a previous inverse sweep made.
+    auto compute_lower_sum = [&]() -> Integer {
+        Integer s{0};
+        for (unsigned i = 0, e = coeff_vars.terms.size(); i != e; ++i) {
+            const auto & cv = coeff_vars.terms[i];
+            if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
+                s += bounds[i].first;
+            else if constexpr (is_same_v<decltype(cv), const pair<bool, SimpleIntegerVariableID> &>)
+                s += (cv.first ? bounds[i].first : -bounds[i].second);
+            else {
+                auto coeff = get_coeff(cv);
+                s += (coeff >= 0_i) ? (coeff * bounds[i].first) : (coeff * bounds[i].second);
+            }
         }
-    }
+        return s;
+    };
 
-    for (unsigned p = 0, p_end = coeff_vars.terms.size(); p != p_end; ++p) {
-        const auto & cv = coeff_vars.terms[p];
+    // The forward (sum <= value) sweep reaches the <= fixpoint in one pass and is
+    // idempotent on its own: a positive-coefficient term is only ever written on
+    // its upper bound and only ever read (via lower_sum) on its lower, and vice
+    // versa for negative coefficients, so reads and writes are disjoint per
+    // variable and no write -- not even one that snaps past a hole, since removing
+    // values above a bound cannot raise a minimum -- can re-enable a guard.
+    //
+    // An equality additionally runs the inverse (sum >= value) sweep, which reads
+    // exactly the upper bounds the forward sweep wrote and writes the lower bounds
+    // it read: a closed loop, so the inverse can tighten a bound that lets the
+    // forward tighten further. We therefore alternate the two sweeps until neither
+    // infers anything, reaching the propagator's own fixpoint in a single call, so
+    // it can claim idempotence. Previously the equality left that alternation to
+    // the propagation queue's self-requeue (a full re-dispatch, re-reading every
+    // bound, per fwd<->inv exchange); the internal loop keeps the bounds snapshot
+    // warm and reaches the identical fixpoint (propagators are monotone).
+    // Per-sweep change detection lets the loop stop the moment a sweep is clean,
+    // rather than always paying one confirming double-sweep: after a clean
+    // forward the inverse's inputs (the forward's upper bounds) are unchanged
+    // from last time, and after a clean inverse the forward's inputs (the
+    // inverse's lower bounds) are, so either clean sweep proves the fixpoint. We
+    // detect change with the tracker's non-destructive inference count rather
+    // than did_anything_since_last_call_inside_propagator(), because that flag
+    // is shared with the propagate_stages callers (multiply/divide/power run
+    // their own do-while on it across all stages), so clearing it here would
+    // corrupt their loop.
+    for (bool first = true;; first = false) {
+        auto inferences_before_forward = inference.count_inferences();
 
-        Integer lower_without_me{0_i};
-        if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
-            lower_without_me = lower_sum - bounds[p].first;
-        else if constexpr (is_same_v<decltype(cv), const pair<bool, SimpleIntegerVariableID> &>)
-            lower_without_me = lower_sum - (cv.first ? bounds[p].first : -bounds[p].second);
-        else
-            lower_without_me = lower_sum - ((get_coeff(cv) >= 0_i) ? (get_coeff(cv) * bounds[p].first) : (get_coeff(cv) * bounds[p].second));
-        Integer remainder = value - lower_without_me;
+        Integer lower_sum = compute_lower_sum();
+        for (unsigned p = 0, p_end = coeff_vars.terms.size(); p != p_end; ++p) {
+            const auto & cv = coeff_vars.terms[p];
 
-        if (! infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv), false, proof_line, add_to_reason, hint))
-            return PropagatorState::Enable;    // contradiction: stop before reading the (now junk) state
-        bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
+            Integer lower_without_me{0_i};
+            if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
+                lower_without_me = lower_sum - bounds[p].first;
+            else if constexpr (is_same_v<decltype(cv), const pair<bool, SimpleIntegerVariableID> &>)
+                lower_without_me = lower_sum - (cv.first ? bounds[p].first : -bounds[p].second);
+            else
+                lower_without_me = lower_sum - ((get_coeff(cv) >= 0_i) ? (get_coeff(cv) * bounds[p].first) : (get_coeff(cv) * bounds[p].second));
+            Integer remainder = value - lower_without_me;
 
-        if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
-            lower_sum = lower_without_me + bounds[p].first;
-        else if constexpr (is_same_v<decltype(cv), const pair<bool, SimpleIntegerVariableID> &>) {
-            lower_sum = lower_without_me + (cv.first ? bounds[p].first : -bounds[p].second);
+            if (! infer(
+                    inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv), false, proof_line, add_to_reason, hint))
+                return PropagatorState::Enable;    // contradiction: stop before reading the (now junk) state
+            bounds[p] = state.bounds(get_var(cv)); // might be tighter than expected if we had holes
         }
-        else {
-            lower_sum = lower_without_me + ((get_coeff(cv) >= 0_i) ? (get_coeff(cv) * bounds[p].first) : (get_coeff(cv) * bounds[p].second));
-        }
-    }
 
-    if (equality) {
+        // A clean forward sweep after the first iteration means the inverse's
+        // last output fed the forward nothing new; the fixpoint is reached.
+        if (! equality || (! first && inference.count_inferences() == inferences_before_forward))
+            break;
+
+        auto inferences_before_inverse = inference.count_inferences();
         Integer inv_lower_sum{0};
         for (const auto & [idx, cv] : enumerate(coeff_vars.terms)) {
             if constexpr (is_same_v<decltype(cv), const SimpleIntegerVariableID &>)
@@ -264,19 +302,14 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
                 inv_lower_sum =
                     inv_lower_without_me + ((-get_coeff(cv) >= 0_i) ? (-get_coeff(cv) * bounds[p].first) : (-get_coeff(cv) * bounds[p].second));
         }
+
+        // A clean inverse sweep means the forward's last output fed the inverse
+        // nothing new; the fixpoint is reached.
+        if (inference.count_inferences() == inferences_before_inverse)
+            break;
     }
 
-    // The pure inequality pass is idempotent: a positive-coefficient term is
-    // only ever written on its upper bound and only ever read (via lower_sum)
-    // on its lower, and vice versa for negative coefficients, so reads and
-    // writes are disjoint per variable and no write -- not even one that
-    // snaps past a hole, since removing values above a bound cannot raise a
-    // minimum -- can re-enable an inference guard. The equality's inverted
-    // second pass reads exactly the bounds the first pass wrote (a closed
-    // read/write loop), so a re-run there can infer more and it must not
-    // claim. Callers whose runs do more than this one call (the runtime
-    // reified dispatch, propagate_stages) do not forward the claim.
-    return equality ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
+    return PropagatorState::EnableButIdempotent;
 }
 
 // Two hint instantiations per (coeff-vector type, tracker): hints::LinearEquality
@@ -365,23 +398,40 @@ auto gcs::innards::propagate_linear_incremental(const auto & coeff_vars, Integer
         for (std::size_t k = st.n_active; k != n; ++k)
             bounds[active[k]] = state.bounds(get_var(coeff_vars.terms[active[k]]));
 
-    // Forward (<=): coeff_p * x_p <= value - (lower_sum - contrib_p).
-    Integer lower_sum = st.fixed_lower;
-    for (std::size_t k = 0; k != st.n_active; ++k)
-        lower_sum += min_contrib(coeff_vars.terms[active[k]], bounds[active[k]]);
+    // Alternate the forward (<=) and inverse (>=) sweeps over the active terms
+    // to the equality's own fixpoint in a single call, so it can claim
+    // idempotence -- see propagate_linear for the read/write reasoning (the
+    // inverse writes the lower bounds the forward reads, so it can feed a
+    // further forward tightening) and the same non-destructive change detection
+    // (the shared did_anything flag belongs to the propagate_stages callers).
+    // lower_sum / inv_lower_sum are invariant within a sweep, so each is
+    // recomputed at the sweep top from the current active-term bounds plus the
+    // folded fixed_lower. An inequality does a single forward sweep, as before.
+    for (bool first = true;; first = false) {
+        auto inferences_before_forward = inference.count_inferences();
 
-    for (std::size_t k = 0; k != st.n_active; ++k) {
-        auto p = active[k];
-        const auto & cv = coeff_vars.terms[p];
-        Integer lower_without_me = lower_sum - min_contrib(cv, bounds[p]);
-        Integer remainder = value - lower_without_me;
-        if (! infer(inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv), false, proof_line, add_to_reason, hint))
-            return PropagatorState::Enable;
-        bounds[p] = state.bounds(get_var(cv));
-        lower_sum = lower_without_me + min_contrib(cv, bounds[p]);
-    }
+        // Forward (<=): coeff_p * x_p <= value - (lower_sum - contrib_p).
+        Integer lower_sum = st.fixed_lower;
+        for (std::size_t k = 0; k != st.n_active; ++k)
+            lower_sum += min_contrib(coeff_vars.terms[active[k]], bounds[active[k]]);
 
-    if (equality) {
+        for (std::size_t k = 0; k != st.n_active; ++k) {
+            auto p = active[k];
+            const auto & cv = coeff_vars.terms[p];
+            Integer lower_without_me = lower_sum - min_contrib(cv, bounds[p]);
+            Integer remainder = value - lower_without_me;
+            if (! infer(
+                    inference, logger, bounds, coeff_vars, p, get_var(cv), remainder, get_coeff_or_bool(cv), false, proof_line, add_to_reason, hint))
+                return PropagatorState::Enable;
+            bounds[p] = state.bounds(get_var(cv));
+            lower_sum = lower_without_me + min_contrib(cv, bounds[p]);
+        }
+
+        if (! equality || (! first && inference.count_inferences() == inferences_before_forward))
+            break;
+
+        auto inferences_before_inverse = inference.count_inferences();
+
         // Backward (>=): mirror of the forward pass on the inverse sum.
         Integer inv_lower_sum = -st.fixed_lower;
         for (std::size_t k = 0; k != st.n_active; ++k)
@@ -398,6 +448,9 @@ auto gcs::innards::propagate_linear_incremental(const auto & coeff_vars, Integer
             bounds[p] = state.bounds(get_var(cv));
             inv_lower_sum = inv_lower_without_me + inv_contrib(cv, bounds[p]);
         }
+
+        if (inference.count_inferences() == inferences_before_inverse)
+            break;
     }
 
     // Fold any newly-instantiated active terms out of the active set, but ALWAYS keep at
@@ -418,12 +471,13 @@ auto gcs::innards::propagate_linear_incremental(const auto & coeff_vars, Integer
             ++k;
     }
 
-    // The inequality claim carries over from propagate_linear: the read/write
-    // analysis there is per-tier-of-term, and the fold above is internal
-    // bookkeeping, not inference -- it moves a fixed term's contribution from
-    // the active sum into fixed_lower without changing the total, so a re-run
-    // computes the same remainders and every guard stays false.
-    return equality ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
+    // Idempotent for both equality and inequality: the sweeps above ran to the
+    // fixpoint, and the fold is internal bookkeeping, not inference -- it moves a
+    // fixed term's contribution from the active sum into fixed_lower without
+    // changing the total, so an immediate re-run computes the same remainders
+    // (over the smaller active set plus the larger fixed_lower) and every guard
+    // stays false.
+    return PropagatorState::EnableButIdempotent;
 }
 
 // One instantiation per (coeff vector, tracker, hint): hints::LinearEquality for the

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -266,7 +266,17 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
         }
     }
 
-    return PropagatorState::Enable;
+    // The pure inequality pass is idempotent: a positive-coefficient term is
+    // only ever written on its upper bound and only ever read (via lower_sum)
+    // on its lower, and vice versa for negative coefficients, so reads and
+    // writes are disjoint per variable and no write -- not even one that
+    // snaps past a hole, since removing values above a bound cannot raise a
+    // minimum -- can re-enable an inference guard. The equality's inverted
+    // second pass reads exactly the bounds the first pass wrote (a closed
+    // read/write loop), so a re-run there can infer more and it must not
+    // claim. Callers whose runs do more than this one call (the runtime
+    // reified dispatch, propagate_stages) do not forward the claim.
+    return equality ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
 }
 
 // Two hint instantiations per (coeff-vector type, tracker): hints::LinearEquality
@@ -408,7 +418,12 @@ auto gcs::innards::propagate_linear_incremental(const auto & coeff_vars, Integer
             ++k;
     }
 
-    return PropagatorState::Enable;
+    // The inequality claim carries over from propagate_linear: the read/write
+    // analysis there is per-tier-of-term, and the fold above is internal
+    // bookkeeping, not inference -- it moves a fixed term's contribution from
+    // the active sum into fixed_lower without changing the total, so a re-run
+    // computes the same remainders and every guard stays false.
+    return equality ? PropagatorState::Enable : PropagatorState::EnableButIdempotent;
 }
 
 // One instantiation per (coeff vector, tracker, hint): hints::LinearEquality for the

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -64,10 +64,6 @@ namespace
     auto propagate_minus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result, const State & state, auto & inference,
         ProofLogger * const logger, const pair<optional<ProofLine>, optional<ProofLine>> & sum_line, const ConstraintID & owner) -> PropagatorState
     {
-        auto a_vals = state.bounds(a);
-        auto b_vals = state.bounds(b);
-        auto result_vals = state.bounds(result);
-
         enum class Conclude
         {
             GE,
@@ -79,36 +75,54 @@ namespace
             return JustifyExplicitly{hints::Minus{owner, sum_line_value}, ThenRUP::Yes};
         };
 
-        // Conclude side picked so the OPB sum_line half contributes the same
-        // sign on the variable being bounded as the reasons do, leaving the
-        // inferred literal after cancellation. sum_line.first is the "a - b ≤ c"
-        // half (-a + b + c >= 0); sum_line.second is "a - b ≥ c" (a - b - c >= 0).
+        // a - b = result is a unit-coefficient linear equality, so one snapshot pass
+        // of the six bound inferences is already the fixpoint unless a written bound
+        // snaps across a hole, which the other two variables then pick up only on a
+        // fresh snapshot; alternate the pass to quiescence to reach the fixpoint in one
+        // call and claim idempotence (see propagate_plus for the full argument). Change
+        // is detected with the non-destructive inference count; a contradicting infer
+        // throws straight out of the loop.
+        while (true) {
+            auto before = inference.count_inferences();
 
-        // min(result) = min(a) - max(b);
-        inference.infer(logger, result >= a_vals.first - b_vals.second, justify(Conclude::LE),
-            ExplicitReason{ReasonLiterals{a >= a_vals.first, b <= b_vals.second}});
+            auto a_vals = state.bounds(a);
+            auto b_vals = state.bounds(b);
+            auto result_vals = state.bounds(result);
 
-        // max(result) = max(a) - min(b);
-        inference.infer(logger, result <= a_vals.second - b_vals.first, justify(Conclude::GE),
-            ExplicitReason{ReasonLiterals{a <= a_vals.second, b >= b_vals.first}});
+            // Conclude side picked so the OPB sum_line half contributes the same
+            // sign on the variable being bounded as the reasons do, leaving the
+            // inferred literal after cancellation. sum_line.first is the "a - b ≤ c"
+            // half (-a + b + c >= 0); sum_line.second is "a - b ≥ c" (a - b - c >= 0).
 
-        // min(a) = min(result) + min(b);
-        inference.infer(logger, a >= result_vals.first + b_vals.first, justify(Conclude::GE),
-            ExplicitReason{ReasonLiterals{result >= result_vals.first, b >= b_vals.first}});
+            // min(result) = min(a) - max(b);
+            inference.infer(logger, result >= a_vals.first - b_vals.second, justify(Conclude::LE),
+                ExplicitReason{ReasonLiterals{a >= a_vals.first, b <= b_vals.second}});
 
-        // max(a) = max(result) + max(b);
-        inference.infer(logger, a <= result_vals.second + b_vals.second, justify(Conclude::LE),
-            ExplicitReason{ReasonLiterals{result <= result_vals.second, b <= b_vals.second}});
+            // max(result) = max(a) - min(b);
+            inference.infer(logger, result <= a_vals.second - b_vals.first, justify(Conclude::GE),
+                ExplicitReason{ReasonLiterals{a <= a_vals.second, b >= b_vals.first}});
 
-        // min(b) = min(a) - max(result);
-        inference.infer(logger, b >= a_vals.first - result_vals.second, justify(Conclude::LE),
-            ExplicitReason{ReasonLiterals{a >= a_vals.first, result <= result_vals.second}});
+            // min(a) = min(result) + min(b);
+            inference.infer(logger, a >= result_vals.first + b_vals.first, justify(Conclude::GE),
+                ExplicitReason{ReasonLiterals{result >= result_vals.first, b >= b_vals.first}});
 
-        // max(b) = max(a) - min(result);
-        inference.infer(logger, b <= a_vals.second - result_vals.first, justify(Conclude::GE),
-            ExplicitReason{ReasonLiterals{a <= a_vals.second, result >= result_vals.first}});
+            // max(a) = max(result) + max(b);
+            inference.infer(logger, a <= result_vals.second + b_vals.second, justify(Conclude::LE),
+                ExplicitReason{ReasonLiterals{result <= result_vals.second, b <= b_vals.second}});
 
-        return PropagatorState::Enable;
+            // min(b) = min(a) - max(result);
+            inference.infer(logger, b >= a_vals.first - result_vals.second, justify(Conclude::LE),
+                ExplicitReason{ReasonLiterals{a >= a_vals.first, result <= result_vals.second}});
+
+            // max(b) = max(a) - min(result);
+            inference.infer(logger, b <= a_vals.second - result_vals.first, justify(Conclude::GE),
+                ExplicitReason{ReasonLiterals{a <= a_vals.second, result >= result_vals.first}});
+
+            if (inference.count_inferences() == before)
+                break;
+        }
+
+        return PropagatorState::EnableButIdempotent;
     }
 }
 

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -56,10 +56,6 @@ namespace
     auto propagate_plus(IntegerVariableID a, IntegerVariableID b, IntegerVariableID result, const State & state, auto & inference,
         ProofLogger * const logger, const pair<optional<ProofLine>, optional<ProofLine>> & sum_line, const ConstraintID & owner) -> PropagatorState
     {
-        auto a_vals = state.bounds(a);
-        auto b_vals = state.bounds(b);
-        auto result_vals = state.bounds(result);
-
         enum class Conclude
         {
             GE,
@@ -71,31 +67,52 @@ namespace
             return JustifyExplicitly{hints::Plus{owner, sum_line_value}, ThenRUP::Yes};
         };
 
-        // min(result) = min(a) + min(b);
-        inference.infer(logger, result >= a_vals.first + b_vals.first, justify(Conclude::LE),
-            ExplicitReason{ReasonLiterals{a >= a_vals.first, b >= b_vals.first}});
+        // result = a + b is a unit-coefficient linear equality, so a single snapshot
+        // pass of the six bound inferences is already the bounds fixpoint -- unless a
+        // written bound snaps across a hole in its own domain, which is the only way
+        // the reads-of-a-just-written-bound below fail to cancel (see propagate_linear
+        // for the same argument). A snap is picked up only by the other two variables,
+        // and only on a fresh snapshot, so alternate the pass until nothing fires:
+        // that reaches this propagator's own fixpoint in one call, so it can claim
+        // idempotence. The common (no-snap) case is one pass plus a cheap no-op check.
+        // Change is detected with the non-destructive inference count; a contradicting
+        // infer throws, unwinding straight out of the loop.
+        while (true) {
+            auto before = inference.count_inferences();
 
-        // max(result) = max(a) + max(b);
-        inference.infer(logger, result <= a_vals.second + b_vals.second, justify(Conclude::GE),
-            ExplicitReason{ReasonLiterals{a <= a_vals.second, b <= b_vals.second}});
+            auto a_vals = state.bounds(a);
+            auto b_vals = state.bounds(b);
+            auto result_vals = state.bounds(result);
 
-        // min(a) = min(result) - max(b);
-        inference.infer(logger, a >= result_vals.first - b_vals.second, justify(Conclude::GE),
-            ExplicitReason{ReasonLiterals{result >= result_vals.first, b <= b_vals.second}});
+            // min(result) = min(a) + min(b);
+            inference.infer(logger, result >= a_vals.first + b_vals.first, justify(Conclude::LE),
+                ExplicitReason{ReasonLiterals{a >= a_vals.first, b >= b_vals.first}});
 
-        // max(a) = max(result) - min(b);
-        inference.infer(logger, a <= result_vals.second - b_vals.first, justify(Conclude::LE),
-            ExplicitReason{ReasonLiterals{result <= result_vals.second, b >= b_vals.first}});
+            // max(result) = max(a) + max(b);
+            inference.infer(logger, result <= a_vals.second + b_vals.second, justify(Conclude::GE),
+                ExplicitReason{ReasonLiterals{a <= a_vals.second, b <= b_vals.second}});
 
-        // min(b) = min(result) - max(a);
-        inference.infer(logger, b >= result_vals.first - a_vals.second, justify(Conclude::GE),
-            ExplicitReason{ReasonLiterals{result >= result_vals.first, a <= a_vals.second}});
+            // min(a) = min(result) - max(b);
+            inference.infer(logger, a >= result_vals.first - b_vals.second, justify(Conclude::GE),
+                ExplicitReason{ReasonLiterals{result >= result_vals.first, b <= b_vals.second}});
 
-        // max(b) = max(result) - min(a);
-        inference.infer(logger, b <= result_vals.second - a_vals.first, justify(Conclude::LE),
-            ExplicitReason{ReasonLiterals{result <= result_vals.second, a >= a_vals.first}});
+            // max(a) = max(result) - min(b);
+            inference.infer(logger, a <= result_vals.second - b_vals.first, justify(Conclude::LE),
+                ExplicitReason{ReasonLiterals{result <= result_vals.second, b >= b_vals.first}});
 
-        return PropagatorState::Enable;
+            // min(b) = min(result) - max(a);
+            inference.infer(logger, b >= result_vals.first - a_vals.second, justify(Conclude::GE),
+                ExplicitReason{ReasonLiterals{result >= result_vals.first, a <= a_vals.second}});
+
+            // max(b) = max(result) - min(a);
+            inference.infer(logger, b <= result_vals.second - a_vals.first, justify(Conclude::LE),
+                ExplicitReason{ReasonLiterals{result <= result_vals.second, a >= a_vals.first}});
+
+            if (inference.count_inferences() == before)
+                break;
+        }
+
+        return PropagatorState::EnableButIdempotent;
     }
 }
 

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -521,7 +521,11 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
         [p = _p, vals = move(p_vals), am1_lines, constraint_id = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             propagate_gac_all_different(constraint_id, p, vals, vector<Integer>{}, *am1_lines, state, inference, logger);
-            return PropagatorState::Enable;
+            // Idempotent for the same reason AllDifferent's GAC propagator is:
+            // one call prunes to the closure, and the run is nothing but that
+            // call. Triggers are 1:1 with p, so an aliased scope is caught by
+            // the install-time downgrade.
+            return PropagatorState::EnableButIdempotent;
         },
         ad_triggers);
 

--- a/gcs/innards/idempotent_claim_checker_test.cc
+++ b/gcs/innards/idempotent_claim_checker_test.cc
@@ -1,0 +1,106 @@
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdlib>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+// The GCS_CHECK_IDEMPOTENT_CLAIMS re-run checker. This is a separate binary
+// from propagators_test because the flag is read once per process, and the
+// checker's re-runs would distort that file's run-count assertions. Every test
+// case sets the variable before its first propagate() call, so the once-only
+// read sees it whichever case runs first.
+
+namespace
+{
+    auto enable_checker() -> void
+    {
+        setenv("GCS_CHECK_IDEMPOTENT_CLAIMS", "1", 1);
+    }
+}
+
+TEST_CASE("A lying idempotence claim is caught by the checker")
+{
+    enable_checker();
+
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    // Shaves one value off x per run, so an immediate re-run always infers
+    // more: the claim is a lie, and the checker must abort the solve.
+    Triggers triggers;
+    triggers.on_change = {x};
+    propagators.install(
+        ConstraintID{NumberedConstraint{1}},
+        [x](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            if (state.upper_bound(x) > 0_i)
+                inference.infer(logger, x < state.upper_bound(x), NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::EnableButIdempotent;
+        },
+        triggers);
+
+    CHECK_THROWS_AS(propagators.propagate(Literals{}, state, nullptr), UnexpectedException);
+}
+
+TEST_CASE("An honest idempotence claim passes the checker")
+{
+    enable_checker();
+
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int runs = 0;
+    Triggers triggers;
+    triggers.on_change = {x};
+    propagators.install(
+        ConstraintID{NumberedConstraint{1}},
+        [&runs, x](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++runs;
+            if (state.upper_bound(x) > 5_i)
+                inference.infer(logger, x < 6_i, NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::EnableButIdempotent;
+        },
+        triggers);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 5_i);
+    // Once for the claiming run, once for the checker's re-run; the claim then
+    // suppresses the self-requeue, so there is no third run.
+    CHECK(runs == 2);
+}
+
+TEST_CASE("A downgraded claim is neither honoured nor checked")
+{
+    enable_checker();
+
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 3_i);
+
+    // The same liar as above, but with an aliased trigger scope: install()
+    // ignores its claims, so the checker must not fire, and ordinary
+    // self-requeue walks x down one value per round to the fixpoint.
+    int runs = 0;
+    Triggers triggers;
+    triggers.on_change = {x, x};
+    propagators.install(
+        ConstraintID{NumberedConstraint{1}},
+        [&runs, x](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++runs;
+            if (state.upper_bound(x) > 0_i)
+                inference.infer(logger, x < state.upper_bound(x), NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::EnableButIdempotent;
+        },
+        triggers);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 0_i);
+    CHECK(runs == 4);
+}

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -552,6 +552,16 @@ namespace gcs::innards
             }(_inferences);
         }
 
+        // How many firing inferences have been recorded since the last reset().
+        // Unlike the did_anything_since_last_call_* flags, this is a
+        // non-destructive read: the propagation queue brackets each propagator
+        // run with it to attribute the run's (contiguous) inference range back
+        // to that propagator.
+        [[nodiscard]] auto count_inferences() const -> std::size_t
+        {
+            return _inferences.size();
+        }
+
         auto reset() -> void
         {
             _inferences.clear();

--- a/gcs/innards/propagators-fwd.hh
+++ b/gcs/innards/propagators-fwd.hh
@@ -7,11 +7,52 @@ namespace gcs::innards
      * Should a propagator be called again, or is it guaranteed it cannot
      * perform any more inference?
      *
+     * The values form a strength ladder: Enable promises nothing,
+     * EnableButIdempotent adds a claim about this run only, and
+     * DisableUntilBacktrack disables the propagator for the whole subtree.
+     *
      * \ingroup Innards
      */
     enum class PropagatorState
     {
+        /**
+         * Keep the propagator registered; re-running it might infer more even
+         * if nothing else has changed since.
+         */
         Enable,
+
+        /**
+         * Keep the propagator registered, but this run reached its own
+         * fixpoint: re-running this propagator immediately, against the
+         * domains exactly as this run left them, would infer nothing and not
+         * contradict. The propagation queue uses this to skip re-waking the
+         * propagator from its own inferences; changes made by any other
+         * propagator wake it as usual. Because propagators are monotone the
+         * per-node fixpoint (and so the search tree) is unchanged, though
+         * work can shift by a round, so inference attribution -- and with it
+         * proof line order and the effectful-propagation split -- can differ
+         * from the never-claiming engine.
+         *
+         * The claim is per-run: a propagator whose algorithm is only
+         * sometimes idempotent claims only on the runs where it is true.
+         * Most propagators are only idempotent when no two scope positions
+         * alias the same underlying variable (directly or through a view), so
+         * a claiming propagator must register its Triggers 1:1 with its scope
+         * positions — Propagators::install detects aliased trigger scopes and
+         * silently ignores claims from such propagators — or guarantee its
+         * own de-aliasing. A wrong claim silently under-propagates or, for
+         * constraints whose feasibility is enforced only by repeated
+         * propagation, is unsound: set GCS_CHECK_IDEMPOTENT_CLAIMS (on by
+         * default in the constraint test harness) to have every honoured
+         * claim checked by an immediate re-run.
+         */
+        EnableButIdempotent,
+
+        /**
+         * The constraint is entailed within this whole subtree: disable the
+         * propagator at this search node and every descendant, re-enabling on
+         * backtrack above it.
+         */
         DisableUntilBacktrack
     };
 

--- a/gcs/innards/propagators-fwd.hh
+++ b/gcs/innards/propagators-fwd.hh
@@ -26,12 +26,16 @@ namespace gcs::innards
          * fixpoint: re-running this propagator immediately, against the
          * domains exactly as this run left them, would infer nothing and not
          * contradict. The propagation queue uses this to skip re-waking the
-         * propagator from its own inferences; changes made by any other
-         * propagator wake it as usual. Because propagators are monotone the
+         * propagator from anything it had already seen when its run ended --
+         * its own inferences, and inferences made earlier in the same round
+         * (the store applies them immediately, so the run read them, and a
+         * change the propagator has already processed cannot licence more
+         * from a propagator at its own fixpoint). Changes recorded after the
+         * run ended wake it as usual. Because propagators are monotone the
          * per-node fixpoint (and so the search tree) is unchanged, though
          * work can shift by a round, so inference attribution -- and with it
-         * proof line order and the effectful-propagation split -- can differ
-         * from the never-claiming engine.
+         * proof line order and the total and effectful propagation counts --
+         * can differ from the never-claiming engine, in either direction.
          *
          * The claim is per-run: a propagator whose algorithm is only
          * sometimes idempotent claims only on the runs where it is true.

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdlib>
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -30,6 +31,8 @@ using std::swap;
 using std::to_underlying;
 using std::vector;
 using std::visit;
+using std::ranges::adjacent_find;
+using std::ranges::sort;
 
 namespace
 {
@@ -49,6 +52,28 @@ namespace
             return std::hash<std::string>{}(as_string(id));
         }
     };
+
+    // The GCS_CHECK_IDEMPOTENT_CLAIMS re-run: the claim says an immediate
+    // re-run, against the domains exactly as the claiming run left them,
+    // infers nothing and does not contradict. Check exactly that; a passing
+    // re-run emits nothing, so proofs are unaffected. The re-run's own
+    // PropagatorState is meaningless (the claim covered the first run) and is
+    // discarded. Out of line and noinline so its exception-handling region
+    // stays out of the propagation loop, whose per-run cost is measurable in
+    // whole-program benchmarks.
+    template <typename Tracker_>
+    [[gnu::noinline]] auto recheck_idempotence_claim_or_throw(
+        PropagationFunction & f, const State & state, Tracker_ & tracker, ProofLogger * const logger, const ConstraintID & id) -> void
+    {
+        const auto inferences_before_recheck = tracker.count_inferences();
+        try {
+            (void)f(state, tracker, logger);
+        }
+        catch (const TrackedPropagationFailed &) {
+        }
+        if (tracker.contradicted() || tracker.count_inferences() != inferences_before_recheck)
+            throw UnexpectedException{"propagator for constraint " + as_string(id) + " claimed idempotence, but re-running it did more"};
+    }
 }
 
 struct Propagators::Imp
@@ -68,6 +93,25 @@ struct Propagators::Imp
     // Reused scratch for the disable-until-backtrack propagators of the current round
     // (see the run loop); a member so it isn't reallocated on every propagate() call.
     vector<int> to_disable;
+
+    // One entry per run this round that returned EnableButIdempotent (and whose
+    // claim is not ignored): runs are serial, so each run's inferences form the
+    // contiguous range [first_inference_index, end_inference_index) of the
+    // tracker's inference deque, and the round-boundary replay uses these to
+    // skip re-waking a claiming propagator from its own inferences. Cleared at
+    // every round boundary (and at propagate() entry, since a contradiction or
+    // abort ends a round without replaying it).
+    struct IdempotentRunClaim
+    {
+        std::size_t first_inference_index, end_inference_index;
+        int propagator_id;
+    };
+    vector<IdempotentRunClaim> idempotent_run_claims;
+
+    // Indexed by propagator id: 1 if install() found two trigger positions
+    // aliasing the same underlying variable, in which case any
+    // EnableButIdempotent this propagator returns is treated as Enable.
+    vector<uint8_t> idempotence_claims_ignored;
 
     unsigned long long total_propagations = 0, effectful_propagations = 0, contradicting_propagations = 0;
     vector<TriggerIDs> iv_triggers;
@@ -128,20 +172,46 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         _imp->constraint_ids.push_back(constraint_id);
     _imp->propagator_constraint_index.push_back(it->second);
 
+    // Most propagation algorithms are only idempotent when no two scope
+    // positions alias the same underlying variable, and only the posted scope
+    // (visible here, as the triggers) tells us whether they do: views hide
+    // repeats from the author (x and -x + 3 alias), though a single +-x + c
+    // view on its own is harmless, being a bijection on Z. (If a view kind
+    // that is not a bijection is ever added -- a multiplier, say -- any
+    // occurrence of it must flag the scope as risky, not just a repeat.) So
+    // canonicalise every trigger variable and, on a repeat, ignore any
+    // EnableButIdempotent claims this propagator makes: a false positive
+    // merely restores the always-requeue behaviour.
+    vector<unsigned long long> underlying_trigger_vars;
+    auto add_underlying = [&](const IntegerVariableID & v) {
+        overloaded{
+            [&](const SimpleIntegerVariableID & sv) { underlying_trigger_vars.push_back(sv.index); },                 //
+            [&](const ViewOfIntegerVariableID & vv) { underlying_trigger_vars.push_back(vv.actual_variable.index); }, //
+            [&](const ConstantIntegerVariableID &) {}                                                                 //
+        }
+            .visit(v);
+    };
+
     for (const auto & v : triggers.on_change) {
         trigger_on_change(v, id);
         increase_degree(v);
+        add_underlying(v);
     }
 
     for (const auto & v : triggers.on_bounds) {
         trigger_on_bounds(v, id);
         increase_degree(v);
+        add_underlying(v);
     }
 
     for (const auto & v : triggers.on_instantiated) {
         trigger_on_instantiated(v, id);
         increase_degree(v);
+        add_underlying(v);
     }
+
+    sort(underlying_trigger_vars);
+    _imp->idempotence_claims_ignored.push_back(adjacent_find(underlying_trigger_vars) != underlying_trigger_vars.end() ? 1 : 0);
 }
 
 auto Propagators::install_initialiser(InitialisationFunction && f, InitialiserPriority priority) -> void
@@ -175,21 +245,43 @@ auto Propagators::initialise(State & state, ProofLogger * const logger) const ->
 
 auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger * const logger, atomic<bool> * optional_abort_flag) const -> bool
 {
-    auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) {
-        if (v.index < _imp->iv_triggers.size()) {
-            auto & triggers = _imp->iv_triggers[v.index];
+    // Test-mode net for EnableButIdempotent (see propagators-fwd.hh): re-run
+    // every honoured claim immediately and abort if it infers anything or
+    // contradicts. Read once: the constraint test harness sets this before the
+    // first solve in the process.
+    static const bool check_idempotent_claims = nullptr != std::getenv("GCS_CHECK_IDEMPOTENT_CLAIMS");
 
-            for (auto & [p, mask] : triggers.ids_and_masks)
-                if (mask & (1 << to_underlying(inf))) {
-                    if (_imp->lookup[p] >= _imp->enqueued_end && _imp->lookup[p] < _imp->idle_end) {
-                        auto being_swapped_item = _imp->queue[_imp->enqueued_end];
-                        swap(_imp->queue[_imp->lookup[p]], _imp->queue[_imp->enqueued_end]);
-                        swap(_imp->lookup[p], _imp->lookup[being_swapped_item]);
-                        ++_imp->enqueued_end;
-                    }
-                }
+    auto enqueue_if_idle = [&](const int p) {
+        if (_imp->lookup[p] >= _imp->enqueued_end && _imp->lookup[p] < _imp->idle_end) {
+            auto being_swapped_item = _imp->queue[_imp->enqueued_end];
+            swap(_imp->queue[_imp->lookup[p]], _imp->queue[_imp->enqueued_end]);
+            swap(_imp->lookup[p], _imp->lookup[being_swapped_item]);
+            ++_imp->enqueued_end;
         }
     };
+
+    auto requeue = [&](const SimpleIntegerVariableID & v, const Inference inf) {
+        if (v.index < _imp->iv_triggers.size())
+            for (auto & [p, mask] : _imp->iv_triggers[v.index].ids_and_masks)
+                if (mask & (1 << to_underlying(inf)))
+                    enqueue_if_idle(p);
+    };
+
+    // A run that claimed idempotence must not be re-woken by its own
+    // inferences: the round-boundary replay uses this variant, with the id of
+    // the claim covering the inference being replayed, when (and only when)
+    // the round produced claims -- the plain requeue above keeps the
+    // claim-free hot path free of the extra compare.
+    auto requeue_skipping = [&](const SimpleIntegerVariableID & v, const Inference inf, const int skip_id) {
+        if (v.index < _imp->iv_triggers.size())
+            for (auto & [p, mask] : _imp->iv_triggers[v.index].ids_and_masks)
+                if (p != skip_id && (mask & (1 << to_underlying(inf))))
+                    enqueue_if_idle(p);
+    };
+
+    // A contradiction or an abort ends a round without replaying it, so a
+    // previous propagate() call may have left stale claims behind.
+    _imp->idempotent_run_claims.clear();
 
     if (guesses.empty()) {
         // On the first pass, walk propagators in registration order. The queue runs
@@ -262,10 +354,37 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                 // propagators triggered by this round's inferences. each_inference() yields
                 // oldest-first, so propagators are requeued in the order their triggers
                 // occurred -- keeping the queue properly FIFO (the drain is already FIFO).
+                // An inference inside a claimed range must not re-wake the propagator
+                // that produced it; runs are serial, so the claims are ordered by range
+                // and a single cursor tracks which (if any) covers the current index.
+                // (This can delay work by a round relative to the unclaimed engine: a
+                // self-requeued run there sees, for free, changes made by whoever ran
+                // before it in its round, where the claiming engine waits for those
+                // changes to wake it at the next boundary. Both reach the same per-node
+                // fixpoint -- propagators are monotone, so the fixpoint is unique and
+                // the search tree identical -- but inference attribution, and hence
+                // proof lines and the effectful-propagation split, can differ.)
                 _imp->enqueued_begin = 0;
                 _imp->enqueued_end = 0;
-                for (const auto & [v, inf] : tracker.each_inference())
-                    requeue(v, inf);
+                if (_imp->idempotent_run_claims.empty()) {
+                    for (const auto & [v, inf] : tracker.each_inference())
+                        requeue(v, inf);
+                }
+                else {
+                    auto claim = _imp->idempotent_run_claims.begin();
+                    const auto claims_end = _imp->idempotent_run_claims.end();
+                    std::size_t inference_index = 0;
+                    for (const auto & [v, inf] : tracker.each_inference()) {
+                        while (claim != claims_end && claim->end_inference_index <= inference_index)
+                            ++claim;
+                        if (claim != claims_end && inference_index >= claim->first_inference_index)
+                            requeue_skipping(v, inf, claim->propagator_id);
+                        else
+                            requeue(v, inf);
+                        ++inference_index;
+                    }
+                    _imp->idempotent_run_claims.clear();
+                }
                 tracker.reset();
             }
 
@@ -275,6 +394,7 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
             int propagator_id = _imp->queue[_imp->enqueued_begin++];
             try {
                 ++_imp->total_propagations;
+                const auto inferences_before_run = tracker.count_inferences();
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
                 if (tracker.contradicted()) {
                     // A propagator that opted into the non-throwing failure path
@@ -288,6 +408,19 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                         ++_imp->effectful_propagations;
                     switch (propagator_state) {
                     case PropagatorState::Enable: break;
+                    case PropagatorState::EnableButIdempotent:
+                        // An ignored claim (aliased trigger scope, see install)
+                        // just behaves like Enable. An honoured claim over a run
+                        // that inferred nothing needs no record: there is nothing
+                        // to skip replaying.
+                        if (! _imp->idempotence_claims_ignored[propagator_id]) {
+                            if (check_idempotent_claims) [[unlikely]]
+                                recheck_idempotence_claim_or_throw(_imp->propagation_functions[propagator_id], state, tracker, logger,
+                                    _imp->constraint_ids[_imp->propagator_constraint_index[propagator_id]]);
+                            if (tracker.count_inferences() != inferences_before_run)
+                                _imp->idempotent_run_claims.emplace_back(inferences_before_run, tracker.count_inferences(), propagator_id);
+                        }
+                        break;
                     case PropagatorState::DisableUntilBacktrack: _imp->to_disable.push_back(propagator_id); break;
                     }
                 }
@@ -320,6 +453,8 @@ auto Propagators::fill_in_constraint_stats(Stats & stats) const -> void
     stats.propagations += _imp->total_propagations;
     stats.effectful_propagations += _imp->effectful_propagations;
     stats.contradicting_propagations += _imp->contradicting_propagations;
+    for (const auto & ignored : _imp->idempotence_claims_ignored)
+        stats.idempotence_downgrades += ignored;
 }
 
 auto Propagators::trigger_on_change(IntegerVariableID var, int t) -> void

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -95,15 +95,17 @@ struct Propagators::Imp
     vector<int> to_disable;
 
     // One entry per run this round that returned EnableButIdempotent (and whose
-    // claim is not ignored): runs are serial, so each run's inferences form the
-    // contiguous range [first_inference_index, end_inference_index) of the
-    // tracker's inference deque, and the round-boundary replay uses these to
-    // skip re-waking a claiming propagator from its own inferences. Cleared at
-    // every round boundary (and at propagate() entry, since a contradiction or
-    // abort ends a round without replaying it).
+    // claim is not ignored): runs are serial and the store applies inferences
+    // immediately, so a run whose end left the tracker holding
+    // end_inference_index inferences had seen every one of them -- its own
+    // included -- and the round-boundary replay uses these to skip re-waking a
+    // claiming propagator from any inference it had already seen. Ordered by
+    // end_inference_index (non-decreasing) by construction. Cleared at every
+    // round boundary (and at propagate() entry, since a contradiction or abort
+    // ends a round without replaying it).
     struct IdempotentRunClaim
     {
-        std::size_t first_inference_index, end_inference_index;
+        std::size_t end_inference_index;
         int propagator_id;
     };
     vector<IdempotentRunClaim> idempotent_run_claims;
@@ -112,6 +114,12 @@ struct Propagators::Imp
     // aliasing the same underlying variable, in which case any
     // EnableButIdempotent this propagator returns is treated as Enable.
     vector<uint8_t> idempotence_claims_ignored;
+
+    // Scratch, indexed by propagator id: set transiently during the boundary
+    // replay for claimants that must not be woken by the inference currently
+    // being replayed (it predates their run's end). All zeroes outside that
+    // block.
+    vector<uint8_t> claim_protected;
 
     unsigned long long total_propagations = 0, effectful_propagations = 0, contradicting_propagations = 0;
     vector<TriggerIDs> iv_triggers;
@@ -267,21 +275,28 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                     enqueue_if_idle(p);
     };
 
-    // A run that claimed idempotence must not be re-woken by its own
-    // inferences: the round-boundary replay uses this variant, with the id of
-    // the claim covering the inference being replayed, when (and only when)
-    // the round produced claims -- the plain requeue above keeps the
-    // claim-free hot path free of the extra compare.
-    auto requeue_skipping = [&](const SimpleIntegerVariableID & v, const Inference inf, const int skip_id) {
+    // A run that claimed idempotence must not be re-woken by any inference it
+    // had already seen (everything recorded up to its run's end, its own
+    // inferences included): the round-boundary replay uses this variant, with
+    // claim_protected flagging the claimants whose runs ended after the
+    // inference being replayed, when (and only when) the round produced
+    // claims -- the plain requeue above keeps the claim-free hot path free of
+    // the extra load.
+    auto requeue_unless_already_seen = [&](const SimpleIntegerVariableID & v, const Inference inf) {
         if (v.index < _imp->iv_triggers.size())
             for (auto & [p, mask] : _imp->iv_triggers[v.index].ids_and_masks)
-                if (p != skip_id && (mask & (1 << to_underlying(inf))))
+                if ((mask & (1 << to_underlying(inf))) && ! _imp->claim_protected[p])
                     enqueue_if_idle(p);
     };
 
     // A contradiction or an abort ends a round without replaying it, so a
-    // previous propagate() call may have left stale claims behind.
+    // previous propagate() call may have left stale claims behind. The
+    // claim_protected flags need no such clearing: they are nonzero only
+    // within the boundary-replay block itself, which always clears them
+    // before running anything. Just make sure the scratch is big enough.
     _imp->idempotent_run_claims.clear();
+    if (_imp->claim_protected.size() < _imp->propagation_functions.size())
+        _imp->claim_protected.resize(_imp->propagation_functions.size(), 0);
 
     if (guesses.empty()) {
         // On the first pass, walk propagators in registration order. The queue runs
@@ -354,16 +369,19 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                 // propagators triggered by this round's inferences. each_inference() yields
                 // oldest-first, so propagators are requeued in the order their triggers
                 // occurred -- keeping the queue properly FIFO (the drain is already FIFO).
-                // An inference inside a claimed range must not re-wake the propagator
-                // that produced it; runs are serial, so the claims are ordered by range
-                // and a single cursor tracks which (if any) covers the current index.
-                // (This can delay work by a round relative to the unclaimed engine: a
-                // self-requeued run there sees, for free, changes made by whoever ran
-                // before it in its round, where the claiming engine waits for those
-                // changes to wake it at the next boundary. Both reach the same per-node
-                // fixpoint -- propagators are monotone, so the fixpoint is unique and
-                // the search tree identical -- but inference attribution, and hence
-                // proof lines and the effectful-propagation split, can differ.)
+                // An inference must not re-wake a claiming propagator whose run ended
+                // after it was recorded: that propagator had already seen it (the store
+                // applies inferences immediately, and its claim says re-running against
+                // what it saw infers nothing). Runs are serial, so the claims are
+                // ordered by end index, and a single cursor un-protects each claimant
+                // as the replay passes its run's end. (This can delay work by a round
+                // relative to the unclaimed engine: a re-woken run there sees, for
+                // free, changes made after the wake it was requeued by, where the
+                // claiming engine waits for those changes to wake it at the next
+                // boundary. Both reach the same per-node fixpoint -- propagators are
+                // monotone, so the fixpoint is unique and the search tree identical --
+                // but inference attribution, and hence proof lines, the total and
+                // effectful propagation counts, can differ in either direction.)
                 _imp->enqueued_begin = 0;
                 _imp->enqueued_end = 0;
                 if (_imp->idempotent_run_claims.empty()) {
@@ -371,18 +389,21 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                         requeue(v, inf);
                 }
                 else {
+                    for (const auto & c : _imp->idempotent_run_claims)
+                        _imp->claim_protected[c.propagator_id] = 1;
                     auto claim = _imp->idempotent_run_claims.begin();
                     const auto claims_end = _imp->idempotent_run_claims.end();
                     std::size_t inference_index = 0;
                     for (const auto & [v, inf] : tracker.each_inference()) {
-                        while (claim != claims_end && claim->end_inference_index <= inference_index)
+                        while (claim != claims_end && claim->end_inference_index <= inference_index) {
+                            _imp->claim_protected[claim->propagator_id] = 0;
                             ++claim;
-                        if (claim != claims_end && inference_index >= claim->first_inference_index)
-                            requeue_skipping(v, inf, claim->propagator_id);
-                        else
-                            requeue(v, inf);
+                        }
+                        requeue_unless_already_seen(v, inf);
                         ++inference_index;
                     }
+                    for (; claim != claims_end; ++claim)
+                        _imp->claim_protected[claim->propagator_id] = 0;
                     _imp->idempotent_run_claims.clear();
                 }
                 tracker.reset();
@@ -394,7 +415,6 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
             int propagator_id = _imp->queue[_imp->enqueued_begin++];
             try {
                 ++_imp->total_propagations;
-                const auto inferences_before_run = tracker.count_inferences();
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
                 if (tracker.contradicted()) {
                     // A propagator that opted into the non-throwing failure path
@@ -410,15 +430,21 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                     case PropagatorState::Enable: break;
                     case PropagatorState::EnableButIdempotent:
                         // An ignored claim (aliased trigger scope, see install)
-                        // just behaves like Enable. An honoured claim over a run
-                        // that inferred nothing needs no record: there is nothing
-                        // to skip replaying.
+                        // just behaves like Enable. Every other claiming run is
+                        // recorded, even one that inferred nothing: the record
+                        // protects the claimant from being re-woken by anything
+                        // it had already seen, and a no-op run saw everything
+                        // recorded so far just the same. A run that ended before
+                        // the round's first inference has nothing to be
+                        // protected from, though, and leaving it out keeps the
+                        // boundary replay on its claim-free fast path in rounds
+                        // where the claimants all came up empty early.
                         if (! _imp->idempotence_claims_ignored[propagator_id]) {
                             if (check_idempotent_claims) [[unlikely]]
                                 recheck_idempotence_claim_or_throw(_imp->propagation_functions[propagator_id], state, tracker, logger,
                                     _imp->constraint_ids[_imp->propagator_constraint_index[propagator_id]]);
-                            if (tracker.count_inferences() != inferences_before_run)
-                                _imp->idempotent_run_claims.emplace_back(inferences_before_run, tracker.count_inferences(), propagator_id);
+                            if (const auto seen = tracker.count_inferences(); 0 != seen)
+                                _imp->idempotent_run_claims.emplace_back(seen, propagator_id);
                         }
                         break;
                     case PropagatorState::DisableUntilBacktrack: _imp->to_disable.push_back(propagator_id); break;

--- a/gcs/innards/propagators_test.cc
+++ b/gcs/innards/propagators_test.cc
@@ -117,6 +117,104 @@ TEST_CASE("A claimant's inference wakes a sharing propagator, whose inference re
     CHECK(follower_runs == 3);
 }
 
+TEST_CASE("A claimant is not re-woken by a foreign inference it had already seen")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    // The setter runs first (registration order) and caps y at 7.
+    int setter_runs = 0;
+    Triggers setter_triggers;
+    setter_triggers.on_change = {y};
+    propagators.install(
+        ConstraintID{NumberedConstraint{1}},
+        [&setter_runs, y](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++setter_runs;
+            if (state.upper_bound(y) > 7_i)
+                inference.infer(logger, y < 8_i, NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::Enable;
+        },
+        setter_triggers);
+
+    // The claimant runs after the setter in the same round, so it has already
+    // seen y's change when it acts on it; that change must not re-wake it.
+    // Element-style, it does not watch the variable it writes.
+    int claimant_runs = 0;
+    Triggers claimant_triggers;
+    claimant_triggers.on_change = {y};
+    propagators.install(
+        ConstraintID{NumberedConstraint{2}},
+        [&claimant_runs, x, y](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++claimant_runs;
+            if (state.upper_bound(y) <= 7_i && state.upper_bound(x) > 2_i)
+                inference.infer(logger, x < 3_i, NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::EnableButIdempotent;
+        },
+        claimant_triggers);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 2_i);
+    CHECK(state.upper_bound(y) == 7_i);
+
+    // Round 1: the setter caps y, then the claimant (which saw that) caps x.
+    // The y-inference predates the claimant's run's end, so only the setter is
+    // re-woken (by its own inference); round 2 finds nothing. Without the
+    // already-seen rule the claimant would run a wasted second time.
+    CHECK(setter_runs == 2);
+    CHECK(claimant_runs == 1);
+}
+
+TEST_CASE("A claimant is re-woken by a foreign inference recorded after its run ended")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    // Same two propagators, but with the claimant registered first: in round
+    // one it runs before the setter, finds nothing to do (y is still wide),
+    // and claims; the setter's y-inference lands after the claimant's run
+    // ended, so it must wake the claimant for round two.
+    int claimant_runs = 0;
+    Triggers claimant_triggers;
+    claimant_triggers.on_change = {y};
+    propagators.install(
+        ConstraintID{NumberedConstraint{1}},
+        [&claimant_runs, x, y](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++claimant_runs;
+            if (state.upper_bound(y) <= 7_i && state.upper_bound(x) > 2_i)
+                inference.infer(logger, x < 3_i, NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::EnableButIdempotent;
+        },
+        claimant_triggers);
+
+    int setter_runs = 0;
+    Triggers setter_triggers;
+    setter_triggers.on_change = {y};
+    propagators.install(
+        ConstraintID{NumberedConstraint{2}},
+        [&setter_runs, y](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++setter_runs;
+            if (state.upper_bound(y) > 7_i)
+                inference.infer(logger, y < 8_i, NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::Enable;
+        },
+        setter_triggers);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 2_i);
+    CHECK(state.upper_bound(y) == 7_i);
+
+    // Round 1: claimant no-ops, setter caps y. Round 2: both re-run (the
+    // claimant because y changed after its run ended -- even a no-op run's
+    // claim only covers what it had seen), and the claimant caps x. Nobody
+    // watches x, so round 3 is empty.
+    CHECK(claimant_runs == 2);
+    CHECK(setter_runs == 2);
+}
+
 TEST_CASE("A repeated trigger variable downgrades the claim")
 {
     State state;

--- a/gcs/innards/propagators_test.cc
+++ b/gcs/innards/propagators_test.cc
@@ -1,0 +1,169 @@
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+// Wake semantics for PropagatorState::EnableButIdempotent: a claiming run's own
+// inferences must not re-wake it, everything else about waking is unchanged, and
+// install() must ignore claims from propagators whose trigger scope aliases a
+// variable. The claim checker (GCS_CHECK_IDEMPOTENT_CLAIMS) is deliberately not
+// enabled here -- its re-runs would distort the run counts -- and lives in
+// idempotent_claim_checker_test.cc instead.
+
+namespace
+{
+    // A propagator that caps x at 5 in one go, honestly idempotent: a re-run
+    // against the domains it left behind infers nothing.
+    auto install_capping_propagator(
+        Propagators & propagators, SimpleIntegerVariableID x, const Triggers & triggers, PropagatorState state_to_return, int & runs) -> void
+    {
+        propagators.install(
+            ConstraintID{NumberedConstraint{1}},
+            [&runs, x, state_to_return](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                ++runs;
+                if (state.upper_bound(x) > 5_i)
+                    inference.infer(logger, x < 6_i, NoJustificationNeeded{}, NoReason{});
+                return state_to_return;
+            },
+            triggers);
+    }
+}
+
+TEST_CASE("Claiming propagator is not re-woken by its own inference")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int runs = 0;
+    Triggers triggers;
+    triggers.on_change = {x};
+    install_capping_propagator(propagators, x, triggers, PropagatorState::EnableButIdempotent, runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 5_i);
+    CHECK(runs == 1);
+}
+
+TEST_CASE("Without a claim, a propagator is re-woken by its own inference")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int runs = 0;
+    Triggers triggers;
+    triggers.on_change = {x};
+    install_capping_propagator(propagators, x, triggers, PropagatorState::Enable, runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 5_i);
+    CHECK(runs == 2);
+}
+
+TEST_CASE("A claimant's inference wakes a sharing propagator, whose inference re-wakes the claimant")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    // The claimant's scope is {x, y}: first cap x at 5, and once y is capped at
+    // 7 (by the second propagator, below) cap x at 2. Both runs are honestly
+    // idempotent: each leaves its own guard false.
+    int claimant_runs = 0;
+    Triggers claimant_triggers;
+    claimant_triggers.on_change = {x, y};
+    propagators.install(
+        ConstraintID{NumberedConstraint{1}},
+        [&claimant_runs, x, y](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++claimant_runs;
+            if (state.upper_bound(x) > 5_i)
+                inference.infer(logger, x < 6_i, NoJustificationNeeded{}, NoReason{});
+            else if (state.upper_bound(y) <= 7_i && state.upper_bound(x) > 2_i)
+                inference.infer(logger, x < 3_i, NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::EnableButIdempotent;
+        },
+        claimant_triggers);
+
+    // The follower watches x and caps y at 7 once x is capped at 5.
+    int follower_runs = 0;
+    Triggers follower_triggers;
+    follower_triggers.on_change = {x};
+    propagators.install(
+        ConstraintID{NumberedConstraint{2}},
+        [&follower_runs, x, y](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            ++follower_runs;
+            if (state.upper_bound(x) <= 5_i && state.upper_bound(y) > 7_i)
+                inference.infer(logger, y < 8_i, NoJustificationNeeded{}, NoReason{});
+            return PropagatorState::Enable;
+        },
+        follower_triggers);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 2_i);
+    CHECK(state.upper_bound(y) == 7_i);
+
+    // Round 1: both run (claimant caps x at 5, follower caps y at 7). The
+    // claimant's x-inference wakes only the follower; the follower's
+    // y-inference re-wakes the claimant. Round 2: follower finds nothing,
+    // claimant caps x at 2. Round 3: only the follower is woken, and finds
+    // nothing. Without the claim the claimant would also run a third time.
+    CHECK(claimant_runs == 2);
+    CHECK(follower_runs == 3);
+}
+
+TEST_CASE("A repeated trigger variable downgrades the claim")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int runs = 0;
+    Triggers triggers;
+    triggers.on_change = {x, x};
+    install_capping_propagator(propagators, x, triggers, PropagatorState::EnableButIdempotent, runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 5_i);
+    // The ignored claim behaves exactly like Enable: the second run is the
+    // self-requeued no-op.
+    CHECK(runs == 2);
+}
+
+TEST_CASE("A view aliasing another trigger variable downgrades the claim")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int runs = 0;
+    Triggers triggers;
+    triggers.on_change = {x, -x + 3_i};
+    install_capping_propagator(propagators, x, triggers, PropagatorState::EnableButIdempotent, runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 5_i);
+    CHECK(runs == 2);
+}
+
+TEST_CASE("A view of a distinct variable does not downgrade the claim")
+{
+    State state;
+    Propagators propagators;
+    auto x = state.allocate_integer_variable_with_state(0_i, 10_i);
+    auto y = state.allocate_integer_variable_with_state(0_i, 10_i);
+
+    int runs = 0;
+    Triggers triggers;
+    triggers.on_change = {x, -y + 3_i};
+    install_capping_propagator(propagators, x, triggers, PropagatorState::EnableButIdempotent, runs);
+
+    REQUIRE(propagators.propagate(Literals{}, state, nullptr));
+    CHECK(state.upper_bound(x) == 5_i);
+    CHECK(runs == 1);
+}

--- a/gcs/stats.cc
+++ b/gcs/stats.cc
@@ -10,6 +10,8 @@ using std::ostream;
 auto gcs::operator<<(ostream & o, const Stats & s) -> ostream &
 {
     o << "propagators: " << s.n_propagators << '\n';
+    if (0 != s.idempotence_downgrades)
+        o << "idempotence downgrades: " << s.idempotence_downgrades << '\n';
     o << "recursions: " << s.recursions << '\n';
     o << "failures: " << s.failures << '\n';
     o << "propagations: " << s.propagations << " " << s.effectful_propagations << " " << s.contradicting_propagations << '\n';

--- a/gcs/stats.hh
+++ b/gcs/stats.hh
@@ -33,6 +33,13 @@ namespace gcs
 
         unsigned long long n_propagators = 0;
 
+        /// How many propagators had their EnableButIdempotent claims ignored
+        /// because their trigger scope aliases a variable (directly or
+        /// through a view). A downgraded propagator just keeps today's
+        /// always-requeue behaviour; this counter makes the downgrade
+        /// observable.
+        unsigned long long idempotence_downgrades = 0;
+
         std::chrono::microseconds solve_time;
     };
 


### PR DESCRIPTION
Implements the revised plan on #416: a per-run idempotence claim, `PropagatorState::EnableButIdempotent`, the wave-1 adopters (VC and GAC AllDifferent, Table/`propagate_extensional`, LinearLessThanEqual/GreaterThanEqual), the wave-2 Element claims, and the plan's Phase D refinement (skip re-waking a claimant from anything it had already seen). One commit for the mechanism (zero behaviour change on its own), one per adopter with its audit note in the code, and one for the already-seen refinement, so anything can be reverted in isolation.

## Mechanism

A propagator whose run reached its own fixpoint returns `EnableButIdempotent`: re-running it immediately, against the domains exactly as the run left them, would infer nothing and not contradict. Because the store applies inferences immediately and runs are serial, the run has seen every inference recorded up to its end — so the queue skips re-waking it from any of those (its own included), and only changes recorded after its run ended wake it. This subsumes the classic "skip self-requeue" and also stops the very common wasted wake where a propagator is re-run because of a change it had already acted on; a claiming run that inferred nothing earns the same protection.

Safety nets, per the plan:

* **Install-time aliasing downgrade.** Most algorithms are only idempotent when no two scope positions alias the same underlying variable, and only the engine sees the posted scope. `install()` canonicalises trigger variables through views and silently ignores claims from any propagator with a repeat (`x` twice, or `x` and `-x + 3`), with a `Stats` counter (`idempotence_downgrades`) so it is observable. Claiming propagators must register triggers 1:1 with their scope — or de-alias themselves: Element's propagators deliberately do not watch the variables they write, so Element performs its own whole-scope aliasing check at install (the `*_dup_xx` tests exercise it).
* **Claim checker.** `GCS_CHECK_IDEMPOTENT_CLAIMS` re-runs every honoured claim immediately and aborts the solve if it infers anything or contradicts. `solve_for_tests_with_callbacks` turns it on for every data-driven constraint test, so all existing lanes double as idempotence nets; a passing re-run emits nothing, so proof lanes are unaffected.
* **Directed unit tests** (`propagators_test`, `idempotent_claim_checker_test`): self-wake skipped; already-seen foreign wake skipped; post-run foreign wake preserved (including for no-op claiming runs); repeated-variable and view-aliasing downgrades; non-aliasing views not downgraded; lying claimant caught; downgraded claims neither honoured nor checked.

## Audit summary per adopter

* **VCAllDifferent**: internal worklist re-checks `optional_single_value` after every removal and cascades to quiescence in one call. Claimed at the AllDifferent call site only — circuit wraps the same helper in propagators that do more per run and must not claim.
* **GACAllDifferent** (and ArgSort's permutation propagator): one call prunes to the union of maximum matchings; every surviving edge is in some maximum matching, so a re-run deletes nothing. SymmetricAllDifferent, Inverse, and AllDifferentExcept do channelling or phantom-edge work in the same runs and stay unclaimed pending their own audits.
* **Table / `propagate_extensional`** (covers Table, AutoTable, and the tabulation propagators, including tabulated arithmetic): each surviving value is witnessed by a still-selectable tuple whose own entries all survive. Repeated variables break exactly that self-witnessing and are downgraded via the 1:1 triggers.
* **LinearLessThanEqual/GreaterThanEqual**: the inequality pass writes only max-side bounds and reads only min-side contributions (and vice versa), disjoint per variable, robust to hole-snapping. Equality's inverted second pass reads what the first pass wrote — the closed loop that under-propagated magic_square in the prototype — so equalities never claim. Prerequisite included: triggers built from the sanitised terms, and the reified dispatcher's runtime path strips claims (the install-time decided paths forward them).
* **Element**: the index propagators' support tests never read the index variable they prune; the union result propagator's supported-set never reads result; the endgame equality pass leaves both sides equal. The bounds-only result propagator does **not** claim — it reads and writes result's bounds, and snapping past a hole can licence a strictly tighter inference on a re-run (counterexample in the code).
* **Circuit (prevent)**: the propagator that made the global-skip prototype unsound. Both of its phases already run internal worklists to quiescence, but a small-cycle prevention or forced closing can fix a successor whose alldifferent consequences only the self-requeue used to catch; the fix is alternating the two existing passes until the prevention pass stops fixing successors (the common run still makes exactly one pass of each). A full tsp solve with the checker on verifies every claim by immediate re-run. The SCC propagator stays unclaimed.

## Deviations from the plan

* **No byte-identical `.pbp`.** The plan expected skipped runs to leave the proof byte-identical; that is unattainable in principle. A re-woken run in the unclaimed engine free-rides on changes applied after the wake that requeued it, so skipping shifts work between rounds. Because propagators are monotone the per-node fixpoint is unique — the search tree is identical, which the gates below verify — but inference attribution (which constraint prunes what, citing which reason) legitimately shifts, and with it proof line order and the propagation-count split. The claims themselves were confirmed honest by running the checker over full solves; the proof gate is therefore **veripb verifies** (confirmed on ortho_latin vc and gac, langford, and tables --prove runs, all complete enumerations).
* **Element claims alone move nothing.** Element never had self-wakes to skip (it does not watch what it writes), which is why the plain wave-2 claim left langford and qap propagation counts unchanged to the last digit, and why the Phase D already-seen refinement is included: that is where Element-style propagators actually pay.

## Benchmarks

Release build, 5 interleaved runs per configuration per build, medians; baseline is current `main`. **Every row has identical recursions, failures, contradicting propagations, and solutions across all runs of both builds**, and tsp reports the true gr17 optimum 2085.

| benchmark | claiming propagators | propagations | wall time |
|---|---|---:|---:|
| ortho_latin 6 gac (UNSAT) | GAC alldiff, tabulated div/mod | **−22.1%** | **−20.9%** (20.05s → 15.86s) |
| ortho_latin 6 vc (UNSAT) | VC alldiff, tabulated div/mod | **−22.0%** | **−18.2%** (18.81s → 15.40s) |
| langford 10 (UNSAT) | GAC alldiff, Element, tabulated Plus | +1.7% | **−11.7%** (1.38s → 1.22s) |
| sudoku --all | GAC alldiff | −26.4% | −14.6% (12ms scale) |
| crystal_maze | alldiff + linear≤ | −8.5% | −8.7% (4ms scale) |
| money | alldiff + linear | 0.0% | (3ms, noise scale) |
| magic_square 5 vc | VC alldiff among linear eq | +0.1% | −0.3% |
| magic_square 5 (not-equals) | none — control | 0.0% (identical) | −0.1% |
| minicp n_queens 12 --all | none — control | 0.0% (identical) | +0.4% |
| minicp tsp (gr17 = 2085) | Circuit prevent, objective bound | −1.2% | +0.9% |
| minicp qap | Element (2d, const arrays) | −0.9% | +2.4% |

Notes:

* langford's wall time drops 11.7% despite slightly more runs: the runs that disappear are the expensive ones (GAC matching, Element support scans), and the extra ones are cheap no-ops from the one-round work shift. Its wave-1-only state was a +21%-propagations regression, which decomposes as the GAC alldifferent claim (+19pp) plus the tabulated-Plus tables (+1.9pp); the already-seen refinement recovers it.
* tsp (+0.9%) and qap (+2.5%) are the residual cost of the claims-path bookkeeping on models where claims fire but yield little; both are propagation-bound at ~65–140ns/run, the pure controls (identical propagation counts) sit at −0.3% to +0.4%, and rounds whose claimants all come up empty before the first inference stay on the claim-free fast path. tsp's byte-identical search (the entire 104-incumbent sequence ending at the true optimum 2085) is preserved by the prevent claim; its remaining propagation volume is dominated by the 34 Element propagators and by branching wakes carrying genuinely new information, which no idempotence mechanism can soundly skip.

## Phase C assessment against the plan's bar

The bar was "two gain benchmarks ≥10% wall with identical trees, controls within ~2%". **Met**: three wall-time wins over 10% at real scale (ortho_latin gac −20.9%, ortho_latin vc −18.2%, langford −11.7%), every pure control within noise, all proofs verify, and the checker-on caps-off suite is green after every commit. The residual +2.4% on qap is the one number over the noise bar, and it is a claim-active model rather than a control; frontend XCSP/MiniZinc table- and inequality-heavy instances remain the natural next measurement, now from a position of strength.

Also on record: one caps-off suite run during wave 1 had `linear_constraint_ne_if_stateless` and `linear_constraint_ne_iff_incremental` fail; those lanes exercise `propagate_linear_not_equals` and linear_equality's own dispatch, which this branch does not touch, the failures did not reproduce in 25+ fresh-process runs of the exact lane configurations, and every subsequent full suite run passed 494/494 — consistent with the known seed-dependent flakiness of those tests.

Part of #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KhPJ5EmGUS6S77me9ib3Z
