### PR TITLE
Delete test proof files once VeriPB has verified them

### DIFF
--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdio>
 #include <cstdlib>
 #include <functional>
 #include <iostream>
@@ -66,6 +67,29 @@ namespace gcs::test_innards
     [[nodiscard]] inline auto can_run_veripb() -> bool
     {
         return run_veripb("--help", ">/dev/null");
+    }
+
+    /**
+     * Verify a test's proof with VeriPB, then, on success, delete its .opb/.pbp
+     * files.
+     *
+     * Every proving test instance writes its proof into the working directory,
+     * and VeriPB .pbp files for enumeration tests routinely reach hundreds of
+     * megabytes. Left in place they accumulate over a run: a full parallel
+     * `ctest` otherwise holds gigabytes of proofs at once, which can exhaust the
+     * disk mid-run and make an *unrelated* lane's proof write fail (an uncaught
+     * std::ios_failure that terminates that test). Deleting each proof as soon as
+     * it verifies bounds the footprint to the lanes running concurrently.
+     *
+     * The files are kept when verification fails, so a failing proof is still on
+     * disk to inspect. std::remove of an already-absent file is a harmless no-op.
+     */
+    inline auto verify_proof_and_clean_up(const std::string & proof_name) -> void
+    {
+        if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
+            throw UnexpectedException{"veripb verification failed"};
+        std::remove((proof_name + ".opb").c_str());
+        std::remove((proof_name + ".pbp").c_str());
     }
 
     /**
@@ -280,8 +304,7 @@ namespace gcs::test_innards
                 }
             println(cerr, "[truncated run: {} of <= {} solutions checked sound]", actual.size(), expected.size());
             if (proof_name)
-                if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
-                    throw UnexpectedException{"veripb verification failed"};
+                verify_proof_and_clean_up(*proof_name);
             return;
         }
 
@@ -300,8 +323,7 @@ namespace gcs::test_innards
         }
 
         if (proof_name)
-            if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
-                throw UnexpectedException{"veripb verification failed"};
+            verify_proof_and_clean_up(*proof_name);
     }
 
     /**
@@ -415,8 +437,7 @@ namespace gcs::test_innards
         solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }, .branch = random_branch_with_optional_seed(p)},
             std::make_optional<ProofOptions>(ProofFileNames{proof_name}));
 
-        if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
-            throw UnexpectedException{"veripb verification failed"};
+        verify_proof_and_clean_up(proof_name);
     }
 
     auto extract_from_state(const CurrentState & s, IntegerVariableID v) -> int


### PR DESCRIPTION
## Problem

The data-driven constraint tests prove many instances per run through `check_results()`, each writing an `.opb/.pbp` into the working directory, and VeriPB `.pbp` files for enumeration tests routinely reach **hundreds of megabytes**. Nothing ever removed them, so they accumulated — a full parallel `ctest` could hold gigabytes at once and leave gigabytes behind between runs.

On a disk that isn't very roomy this exhausts free space mid-run, and the next proof write throws an uncaught `std::ios_failure`:

```
terminate called after throwing an instance of 'std::__ios_failure'
  what():  basic_ios::clear: iostream error
```

which terminates whichever lane happened to be writing. That surfaces as "flaky under parallel load" test failures that **move between lanes run to run and never reproduce in isolation** — the failing lane is just whoever hit the full disk first, not a solver or test bug. (This is what was intermittently failing the `linear_constraint_ne_*` lanes.)

## Fix

Route the three `check_results` / initialisation-only VeriPB calls through a `verify_proof_and_clean_up()` helper that deletes the `.opb/.pbp` after a **successful** verification, bounding the footprint to the lanes running concurrently. Files are **kept on failure**, so a failing proof is still on disk to inspect.

## Effect

A full caps-off suite that previously left **~840 proof files (~3 GB)** now leaves **68** — and those 68 are the separate `run_test_and_verify.bash` scenario path (proofs named after the binary, e.g. `circuit_disconnected_test_*`), not `check_results`. That script's own `rm` is commented out and could be re-enabled as a follow-up; I've left it, since it was deliberately disabled and its proofs are small single-scenario files that don't accumulate unboundedly.

`494/494` pass. No behaviour change to the solver or to what any test checks — only the generated proof artifacts' lifetime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KhPJ5EmGUS6S77me9ib3Z