### PR TITLE
Wave-3 idempotence claims: arithmetic cores + Inverse

### DIFF
--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -1259,7 +1259,11 @@ namespace
                         propagate_default_product<Hint_>(*data, modulus_r, state, inference, logger, owner);
                     } while (inference.did_anything_since_last_call_inside_propagator());
 
-                    return PropagatorState::Enable;
+                    // Idempotent: the do-while ran the stages (and the default product)
+                    // to quiescence, so an immediate re-run is one no-op pass (see
+                    // multiply.cc for the same argument). The mid-loop return above is
+                    // the contradiction path and its state is ignored.
+                    return PropagatorState::EnableButIdempotent;
                 },
                 triggers);
         }
@@ -1276,7 +1280,11 @@ namespace
                             return PropagatorState::Enable;
                     } while (inference.did_anything_since_last_call_inside_propagator());
 
-                    return PropagatorState::Enable;
+                    // Idempotent: the do-while ran the stages (and the default product)
+                    // to quiescence, so an immediate re-run is one no-op pass (see
+                    // multiply.cc for the same argument). The mid-loop return above is
+                    // the contradiction path and its state is ignored.
+                    return PropagatorState::EnableButIdempotent;
                 },
                 triggers);
 

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -170,23 +170,31 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
         [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s,
             constraint_id = constraint_id(),
             owner = constraint_id()](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
-            for (const auto & [i, x_i] : enumerate(x)) {
-                for (auto x_i_value : state.each_value_mutable(x_i))
-                    if (! state.in_domain(y.at((x_i_value - y_start).as_index()), Integer(i) + x_start))
-                        inf.infer(logger, x_i != x_i_value, JustifyUsingRUP{hints::Inverse{owner}},
-                            ExplicitReason{ReasonLiterals{y.at((x_i_value - y_start).as_index()) != Integer(i) + x_start}});
-            }
+            // Channel x<->y and GAC-alldifferent on x feed each other: a GAC
+            // removal on x can leave a y value with no back-support (more
+            // channelling), which can force more x removals (more GAC), so a
+            // single pass is not the fixpoint. Alternate to quiescence so the run
+            // reaches its own fixpoint in one call and can claim idempotence (the
+            // arithmetic-core pattern). A contradicting infer throws straight out.
+            do {
+                for (const auto & [i, x_i] : enumerate(x)) {
+                    for (auto x_i_value : state.each_value_mutable(x_i))
+                        if (! state.in_domain(y.at((x_i_value - y_start).as_index()), Integer(i) + x_start))
+                            inf.infer(logger, x_i != x_i_value, JustifyUsingRUP{hints::Inverse{owner}},
+                                ExplicitReason{ReasonLiterals{y.at((x_i_value - y_start).as_index()) != Integer(i) + x_start}});
+                }
 
-            for (const auto & [i, y_i] : enumerate(y)) {
-                for (auto y_i_value : state.each_value_mutable(y_i))
-                    if (! state.in_domain(x.at((y_i_value - x_start).as_index()), Integer(i) + y_start))
-                        inf.infer(logger, y_i != y_i_value, JustifyUsingRUP{hints::Inverse{owner}},
-                            ExplicitReason{ReasonLiterals{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}});
-            }
+                for (const auto & [i, y_i] : enumerate(y)) {
+                    for (auto y_i_value : state.each_value_mutable(y_i))
+                        if (! state.in_domain(x.at((y_i_value - x_start).as_index()), Integer(i) + y_start))
+                            inf.infer(logger, y_i != y_i_value, JustifyUsingRUP{hints::Inverse{owner}},
+                                ExplicitReason{ReasonLiterals{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}});
+                }
 
-            propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
+                propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
+            } while (inf.did_anything_since_last_call_inside_propagator());
 
-            return PropagatorState::Enable;
+            return PropagatorState::EnableButIdempotent;
         },
         triggers);
 }

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -149,7 +149,13 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
             do {
                 signed_multiply::propagate(*product_data, state, inference, logger, owner);
             } while (inference.did_anything_since_last_call_inside_propagator());
-            return PropagatorState::Enable;
+            // Idempotent: the do-while ran signed_multiply::propagate to quiescence
+            // (it exits only when a whole pass inferred nothing), so an immediate
+            // re-run is a single no-op pass. This needs no 1:1-trigger / non-aliasing
+            // assumption -- the loop reaches whatever fixpoint the true relation has,
+            // aliased or repeated operands (the square case) included, per the note at
+            // the scope above.
+            return PropagatorState::EnableButIdempotent;
         },
         triggers);
 

--- a/gcs/constraints/power/power.cc
+++ b/gcs/constraints/power/power.cc
@@ -232,7 +232,11 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
                         signed_multiply::propagate(link, state, inference, logger, owner);
                 } while (inference.did_anything_since_last_call_inside_propagator());
 
-                return PropagatorState::Enable;
+                // Idempotent: the do-while ran the stages and multiply links to
+                // quiescence, so an immediate re-run is one no-op pass (see multiply.cc
+                // for the same argument). The mid-loop return above is the contradiction
+                // path and its state is ignored.
+                return PropagatorState::EnableButIdempotent;
             },
             triggers);
     }


### PR DESCRIPTION
Wave 3 of the `EnableButIdempotent` work (#416), following the wave-1/2 claims already in main. Two adopters that are genuine measured wins; a batch of others audited and deliberately left out (below). One commit per adopter, each with its audit note; full caps-off suite passes **494/494** with the claim checker on, every benchmark is tree-identical, and all proofs verify.

## Multiply / Divide / Modulus / Power cores — the win

Each of these already drives its sub-propagators to a fixpoint with a `do { … } while (did_anything_since_last_call_inside_propagator())` loop, so the propagator is **idempotent by construction** — a re-run against the domains it just left is a single no-op pass. The change is the four final (post-loop) returns, `Enable` → `EnableButIdempotent`.

Unlike the single-pass claimants (Table etc.), this needs **no 1:1-trigger / non-aliasing assumption**: the loop reaches whatever fixpoint the true relation has, so aliased/repeated operands (`x*x=z` via the square path, `x*y=x`) are handled and the constraints' deliberate trigger deduplication stays correct.

| benchmark | propagations | wall |
|---|---:|---:|
| n_fractions | **−24.6%** | −5.3% |
| ortho_latin vc 6 | **−11.8%** | −1.6% |
| ortho_latin gac 6 | **−11.8%** | −0.7% |

(ortho_latin's default `Divide`/`Modulus` resolve to the core BC path at these sizes, so this stacks on the #416 alldifferent/table wins already in main.)

## Inverse — a small win

Inverse channels x↔y then GAC-alldifferents x; these feed each other (a GAC x-removal can leave a y value unsupported → more channelling → more GAC), so a single pass isn't the fixpoint — the queue was iterating by re-waking it. Wrapping the body in the same `do…while` loop reaches the fixpoint in one call and claims. Legitimate involution aliasing (`inverse(x, x)`) trips the trigger downgrade and is ignored. **talent: propagations −2.1%**, tree-identical. Only talent exercises Inverse in-repo, so the payoff is modest, but it's a clean five-line loop and a real win.

## Audited and deliberately left out

- **Comparison (LessThan/…) and Equals** — both are genuinely idempotent (single-pass disjoint read/write; enforce_equality reaches equal domains in one call) and pass the checker across all modes, but move **zero** in-repo propagations: these thin two-variable constraints entail or single-value fast (→ `DisableUntilBacktrack`), so there are no self-wakes to skip, and claiming can even perturb attribution by a handful of runs. Not worth the change on the current benchmark set; happy to add them for framework completeness if wanted (they'd help frontend models with many live unconditional comparisons/equalities).
- **SymmetricAllDifferent** — no in-repo benchmark uses it, so no gain is measurable.
- **Regular** — its regex/reimplementation rework is unmerged and in flux; touching it now risks conflict for uncertain gain, so left to coordinate with that work.

Part of #416 (wave 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KhPJ5EmGUS6S77me9ib3Z