### PR TITLE
cake_pb_cp validation probe and encoding conformance fixes (#478-#485)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(glasgow_constraint_solver
         constraints/global_cardinality/justify.cc
         constraints/in/in.cc
         constraints/increasing/increasing.cc
+        constraints/innards/cake_truthiness.cc
         constraints/innards/linear_stages.cc
         constraints/innards/product_encoding.cc
         constraints/innards/product_justify.cc

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -76,9 +76,13 @@ auto AllDifferentExcept::prepare(Propagators &, State & initial_state, ProofMode
     sort(_sanitised_vars);
 
     // Drop excluded values that don't appear in any variable's initial domain.
-    // Such values can never be taken anyway, so they neither shape the OPB
-    // encoding nor warrant phantom edges in the propagator's matching graph.
-    _sanitised_excluded = move(_excluded);
+    // Such values can never be taken anyway, so they don't warrant phantom
+    // edges in the propagator's matching graph. The OPB encoding keeps the
+    // original list (a copy, so s_expr and define_proof_model still see it):
+    // cake_pb_cp encodes every listed exception value uniformly, and dropping
+    // one changes the rows' unit-propagation strength, which the aliased-pair
+    // case turns into a chain-verification failure (issue #480).
+    _sanitised_excluded = _excluded;
     sort(_sanitised_excluded);
     _sanitised_excluded.erase(std::unique(_sanitised_excluded.begin(), _sanitised_excluded.end()), _sanitised_excluded.end());
     _sanitised_excluded.erase(std::remove_if(_sanitised_excluded.begin(), _sanitised_excluded.end(),
@@ -122,12 +126,22 @@ auto AllDifferentExcept::prepare(Propagators &, State & initial_state, ProofMode
 auto AllDifferentExcept::define_proof_model(ProofModel & model) -> void
 {
     _value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
-    _duplicate_selectors = define_clique_not_equals_except_encoding(model, _sanitised_vars, _sanitised_excluded);
+    // Encode from the original exception list, matching cake_pb_cp: an
+    // out-of-domain exception value still contributes its (statically-true)
+    // literals to the pair rows, keeping the rows' propagation strength -- and
+    // hence the proof steps they support -- identical on both sides.
+    _duplicate_selectors = define_clique_not_equals_except_encoding(model, _sanitised_vars, _excluded);
 }
 
 auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
 {
-    if (_has_duplicates && _sanitised_excluded.empty()) {
+    // Only the genuinely-no-exceptions form may assert the duplicate
+    // contradiction bare: its pair rows collapse to units on both our and
+    // cake's side, so the contradiction is unit-propagatable everywhere. With
+    // exception values present (even out-of-domain ones, which the encoding
+    // keeps -- see define_proof_model), the rows need the per-value inferences
+    // of the general duplicate path below to reach the wipeout.
+    if (_has_duplicates && _excluded.empty()) {
         install_clique_duplicate_contradiction_initialiser(propagators, hints::AllDifferentExcept{constraint_id()});
         return;
     }

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -159,13 +159,18 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
         _per_task_t_hi[i] = s_hi + _length_ub[i] - 1_i;
     }
 
-    // Non-strict mode: note which active tasks' durations can be 0, so
-    // define_proof_model can add a zero-length escape to the separation clause.
-    // The propagator already ignores zero-mandatory tasks via lb(l).
-    _can_be_zero.assign(n, 0);
+    // Non-strict mode: every variable-duration task gets a zero-length escape
+    // in the separation clause, matching cake_pb_cp, which adds the zw
+    // disjunct for every variable-length argument regardless of its bounds.
+    // Gating it on lower_bound == 0 changes the labelled @c[id][.._sepal1]
+    // row's content, and proofs that pol-cite that label then fail to
+    // chain-verify (issue #482). An always-positive duration's escape is just
+    // statically false; add_escape_pins refutes it in one RUP step. The
+    // propagator already ignores zero-mandatory tasks via lb(l).
+    _zero_escape.assign(n, 0);
     if (! _strict)
         for (auto i : _active_tasks)
-            _can_be_zero[i] = (! is_constant_variable(_lengths[i]) && initial_state.lower_bound(_lengths[i]) == 0_i) ? 1 : 0;
+            _zero_escape[i] = is_constant_variable(_lengths[i]) ? 0 : 1;
 
     return true;
 }
@@ -201,12 +206,12 @@ auto Disjunctive::define_proof_model(ProofModel & model) -> void
         if (! is_constant_variable(_lengths[i]))
             _end[i] = model.create_proof_only_integer_variable_in_proof(0_i, _per_task_t_hi[i] + 1_i, "disjend");
 
-    // Non-strict mode: a "duration <= 0" escape flag per can-be-zero task, added
-    // as a disjunct to the separation clause below (a zero-length task does not
-    // constrain). nullopt otherwise.
+    // Non-strict mode: a "duration <= 0" escape flag per variable-duration
+    // task, added as a disjunct to the separation clause below (a zero-length
+    // task does not constrain). nullopt otherwise.
     _zero.assign(_starts.size(), nullopt);
     for (auto i : _active_tasks)
-        if (_can_be_zero[i])
+        if (_zero_escape[i])
             // cake_pb_cp names the zero-duration escape x[id][i][zw].
             _zero[i] = model.create_proof_flag_fully_reifying(
                 _constraint_id, vector<long long>{static_cast<long long>(i)}, "zw", WPBSum{} + 1_i * _lengths[i] <= 0_i);

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -93,11 +93,13 @@ namespace gcs
         // task whose duration is constant (those reify after on s directly).
         std::vector<std::optional<innards::ProofOnlySimpleIntegerVariableID>> _end;
 
-        // Non-strict mode: whether each task's duration can be 0 (std::uint8_t
-        // rather than the vector<bool> bitset specialisation), and, for those
-        // tasks, a reified "duration <= 0" flag that escapes the separation
-        // clause (a zero-length task does not constrain in non-strict mode).
-        std::vector<std::uint8_t> _can_be_zero;
+        // Non-strict mode: whether each task gets a zero-length escape in the
+        // separation clause -- every variable-duration task does, matching
+        // cake_pb_cp (std::uint8_t rather than the vector<bool> bitset
+        // specialisation) -- and, for those tasks, the reified "duration <= 0"
+        // escape flag itself (a zero-length task does not constrain in
+        // non-strict mode).
+        std::vector<std::uint8_t> _zero_escape;
         std::vector<std::optional<innards::ProofFlag>> _zero;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -162,17 +162,21 @@ auto Disjunctive2D::prepare(Propagators &, State & initial_state, ProofModel * c
         _active_rects.push_back(i);
     }
 
-    // Non-strict mode: a rectangle whose width or height can be 0 may be
-    // zero-area for some assignments, in which case it does not constrain. Note
-    // which sizes can be zero so define_proof_model can add a zero-size escape
-    // to the separation clause; the propagator already ignores zero-mandatory
+    // Non-strict mode: a rectangle whose width or height is 0 does not
+    // constrain, so every variable size gets a zero-size escape in the
+    // separation clause -- matching cake_pb_cp, which adds the zw/zh disjunct
+    // for every variable-size argument regardless of its bounds. Gating on
+    // lower_bound == 0 changes the labelled separation row's content, and
+    // proofs that pol-cite that label then fail to chain-verify (issue #482).
+    // An always-positive size's escape is statically false and is refuted in
+    // one RUP step where cited; the propagator already ignores zero-mandatory
     // rectangles via lb(size).
-    _can_be_zero_w.assign(n, false);
-    _can_be_zero_h.assign(n, false);
+    _zero_escape_w.assign(n, false);
+    _zero_escape_h.assign(n, false);
     if (! _strict)
         for (auto i : _active_rects) {
-            _can_be_zero_w[i] = ! is_constant_variable(_widths[i]) && initial_state.lower_bound(_widths[i]) == 0_i;
-            _can_be_zero_h[i] = ! is_constant_variable(_heights[i]) && initial_state.lower_bound(_heights[i]) == 0_i;
+            _zero_escape_w[i] = ! is_constant_variable(_widths[i]);
+            _zero_escape_h[i] = ! is_constant_variable(_heights[i]);
         }
 
     if (_active_rects.size() < 2)
@@ -240,10 +244,10 @@ auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
     _zero_h.assign(_xs.size(), nullopt);
     for (auto i : _active_rects) {
         // cake_pb_cp names the zero-size escapes x[id][i][zw] / x[id][i][zh].
-        if (_can_be_zero_w[i])
+        if (_zero_escape_w[i])
             _zero_w[i] = model.create_proof_flag_fully_reifying(
                 _constraint_id, vector<long long>{static_cast<long long>(i)}, "zw", WPBSum{} + 1_i * _widths[i] <= 0_i);
-        if (_can_be_zero_h[i])
+        if (_zero_escape_h[i])
             _zero_h[i] = model.create_proof_flag_fully_reifying(
                 _constraint_id, vector<long long>{static_cast<long long>(i)}, "zh", WPBSum{} + 1_i * _heights[i] <= 0_i);
     }

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
@@ -61,9 +61,11 @@ namespace gcs
         // possible-active window and the active-rect filter).
         std::vector<Integer> _width_vals, _width_ub;
         std::vector<Integer> _height_vals, _height_ub;
-        // Non-strict mode: whether each rectangle's width/height can be 0
-        // (std::uint8_t rather than the vector<bool> bitset specialisation).
-        std::vector<std::uint8_t> _can_be_zero_w, _can_be_zero_h;
+        // Non-strict mode: whether each rectangle's width/height gets a
+        // zero-size escape in the separation clause -- every variable size
+        // does, matching cake_pb_cp (std::uint8_t rather than the
+        // vector<bool> bitset specialisation).
+        std::vector<std::uint8_t> _zero_escape_w, _zero_escape_h;
 
         // Per-rectangle possible-active windows in each dimension, from root
         // bounds in prepare(). Used to size the proof bridge and to index the

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -10,7 +10,6 @@
 #include <gcs/constraints/linear/hints.hh>
 #include <gcs/constraints/linear/propagate.hh>
 #include <gcs/constraints/linear/utils.hh>
-#include <gcs/constraints/multiply/signed_multiply.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/power.hh>
@@ -846,33 +845,68 @@ namespace
         }
     }
 
+    // cake's sign atoms for one operand slot, in the two shapes the encoding
+    // uses them: WPBSum terms for the sign/nonzero clauses, and gates for the
+    // half-reified remainder/identity rows. A variable operand's atoms are its
+    // reified conditions, exactly as before; a constant k's are its pinned
+    // n[k][...] atoms, which is how cake encodes a constant slot (issue #483).
+    struct OperandSignAtoms
+    {
+        PseudoBooleanTerm ge0, lt0, ge1, lt1, ne0;
+        HalfReifyOnConjunctionOf ge0_gate, lt1_gate;
+    };
+
+    auto operand_sign_atoms(ProofModel & model, const IntegerVariableID & v) -> OperandSignAtoms
+    {
+        if (auto cv = get_if<ConstantIntegerVariableID>(&v)) {
+            auto atoms = model.cake_constant_atoms(cv->const_value);
+            return {atoms.ge0, ! atoms.ge0, atoms.ge1, ! atoms.ge1, ! atoms.eq0, HalfReifyOnConjunctionOf{atoms.ge0},
+                HalfReifyOnConjunctionOf{! atoms.ge1}};
+        }
+        return {ProofLiteral{v >= 0_i}, ProofLiteral{v < 0_i}, ProofLiteral{v >= 1_i}, ProofLiteral{v < 1_i}, ProofLiteral{v != 0_i},
+            HalfReifyOnConjunctionOf{v >= 0_i}, HalfReifyOnConjunctionOf{v < 1_i}};
+    }
+
     // The four stages pinning mag = |v| in both directions off its cake channel, split on
     // sign(v). pos_threshold gates the non-negative half: 0 when v may be zero (the quotient),
-    // 1 when v is known non-zero (the divisor).
+    // 1 when v is known non-zero (the divisor). A constant operand's sign is static, so only
+    // the matching half's stages exist, ungated: they pin mag = |v| at the root, and the
+    // concluding RUP discharges the channel rows' pinned-atom gate terms.
     auto append_magnitude_stages(std::vector<LinearStage> & stages, SimpleIntegerVariableID mag, IntegerVariableID v, const CakeMagnitude & chan,
         Integer pos_threshold) -> void
     {
-        auto [t_le, m_le] = tidy_up_linear(WeightedSum{} + 1_i * mag + -1_i * v);
-        stages.emplace_back(LinearStage{t_le, 0_i + m_le, false, {chan.pos_ge, nullopt}, optional{v >= pos_threshold}});
-        auto [t_ge, m_ge] = tidy_up_linear(WeightedSum{} + -1_i * mag + 1_i * v);
-        stages.emplace_back(LinearStage{t_ge, 0_i + m_ge, false, {chan.pos_le, nullopt}, optional{v >= pos_threshold}});
-        auto [t_nle, m_nle] = tidy_up_linear(WeightedSum{} + 1_i * mag + 1_i * v);
-        stages.emplace_back(LinearStage{t_nle, 0_i + m_nle, false, {chan.neg_le, nullopt}, optional{v < 0_i}});
-        auto [t_nge, m_nge] = tidy_up_linear(WeightedSum{} + -1_i * mag + -1_i * v);
-        stages.emplace_back(LinearStage{t_nge, 0_i + m_nge, false, {chan.neg_ge, nullopt}, optional{v < 0_i}});
+        optional<IntegerVariableCondition> pos_gate = v >= pos_threshold, neg_gate = v < 0_i;
+        bool want_pos = true, want_neg = true;
+        if (auto cv = get_if<ConstantIntegerVariableID>(&v)) {
+            want_pos = cv->const_value >= pos_threshold;
+            want_neg = cv->const_value < 0_i;
+            pos_gate = nullopt;
+            neg_gate = nullopt;
+        }
+        if (want_pos) {
+            auto [t_le, m_le] = tidy_up_linear(WeightedSum{} + 1_i * mag + -1_i * v);
+            stages.emplace_back(LinearStage{t_le, 0_i + m_le, false, {chan.pos_ge, nullopt}, pos_gate});
+            auto [t_ge, m_ge] = tidy_up_linear(WeightedSum{} + -1_i * mag + 1_i * v);
+            stages.emplace_back(LinearStage{t_ge, 0_i + m_ge, false, {chan.pos_le, nullopt}, pos_gate});
+        }
+        if (want_neg) {
+            auto [t_nle, m_nle] = tidy_up_linear(WeightedSum{} + 1_i * mag + 1_i * v);
+            stages.emplace_back(LinearStage{t_nle, 0_i + m_nle, false, {chan.neg_le, nullopt}, neg_gate});
+            auto [t_nge, m_nge] = tidy_up_linear(WeightedSum{} + -1_i * mag + -1_i * v);
+            stages.emplace_back(LinearStage{t_nge, 0_i + m_nge, false, {chan.neg_ge, nullopt}, neg_gate});
+        }
     }
 
     // The shared decomposition: x = q * y + r, |r| < |y|, sign(r) = sign(x)
     // (or r = 0), all emitted as one flat @c[id][role] OPB block and run by
     // one propagator (issue #448). Divide exposes q and creates r as an
-    // auxiliary; Modulus the other way around. A constant divisor (or, for
-    // Divide, a constant quotient) makes the product a linear term, so there
-    // is no multiplication at all; otherwise the product goes through the
-    // exposed mult_bc machinery on plain variables, with any views channelled
-    // through plain copies first -- once the user's variables are fixed, the
-    // multiplication must pin the unbranched auxiliary (or fail) by
-    // propagation alone, and mult_bc's quotient filtering does exactly that
-    // for plain arguments.
+    // auxiliary; Modulus the other way around. Every operand shape -- views
+    // and constants included -- goes through the one magnitude-product
+    // machinery, matching cake_pb_cp's uniform encoding: a constant operand
+    // just folds into the rows, gated on its pinned n[k][...] atoms (issue
+    // #483). Once the user's variables are fixed, the multiplication must pin
+    // the unbranched auxiliary (or fail) by propagation alone, and the
+    // quotient filtering does exactly that.
     template <typename Hint_>
     auto install_divide_modulus(const ConstraintID & owner, bool expose_quotient, const IntegerVariableID & x, const IntegerVariableID & y,
         const IntegerVariableID & out, const std::variant<consistency::Auto, consistency::BC, consistency::Tabulated> & level,
@@ -881,7 +915,6 @@ namespace
         auto ax = affine_of(x), ay = affine_of(y), aout = affine_of(out);
 
         auto [xlo, xhi] = initial_state.bounds(x);
-        auto [ylo, yhi] = initial_state.bounds(y);
 
         // A structurally constant zero divisor makes the whole constraint
         // unsatisfiable, relationally rather than as an error.
@@ -897,30 +930,22 @@ namespace
             return;
         }
 
-        // Biggest possible |y| bounds the remainder: |r| <= max|y| - 1.
-        auto may = max(ylo < 0_i ? -ylo : ylo, yhi < 0_i ? -yhi : yhi);
-        auto rmax = max(0_i, may - 1_i);
-
-        // The quotient can be no bigger in magnitude than the dividend (as
-        // |y| >= 1 whenever the relation holds at all), and when the divisor
-        // has a fixed sign, truncated division is monotone enough that the
-        // box corners bound it.
+        // The quotient magnitude can be no bigger than the dividend's (as
+        // |y| >= 1 whenever the relation holds at all).
         auto mx = max(xlo < 0_i ? -xlo : xlo, xhi < 0_i ? -xhi : xhi);
-        auto q_lo = -mx, q_hi = mx;
-        if (ylo > 0_i || yhi < 0_i) {
-            q_lo = min({xlo / ylo, xlo / yhi, xhi / ylo, xhi / yhi});
-            q_hi = max({xlo / ylo, xlo / yhi, xhi / ylo, xhi / yhi});
-        }
 
-        // The default divide/modulus route emits cake_pb_cp's encoding: the product |q|*|y|
-        // lives only in the bit-product grid feeding the remainder/identity rows, with no w
-        // (and, for divide, no r) anywhere -- not in the OPB, not in the State, not in the
-        // proof. Both directions multiply the two NON-NEGATIVE magnitudes, split the
+        // Both routes emit cake_pb_cp's encoding: the product |q|*|y| lives only in the
+        // bit-product grid feeding the remainder/identity rows, with no w (and, for
+        // divide, no r) anywhere -- not in the OPB, not in the State, not in the proof.
+        // Both directions multiply the two NON-NEGATIVE magnitudes, split the
         // identity/remainder on sign(x), and recover signed values in the tabulation -- a
-        // single magnitude machinery covering every sign of both operands, views included.
+        // single magnitude machinery covering every sign of both operands, views and
+        // constants included: a constant operand's channel folds the constant into the
+        // rows and gates on its pinned n[k][...] atoms, exactly as cake encodes a
+        // constant slot (issue #483).
         //
-        // Divide (default_divide): the exposed slot is q. magq = |q| (a state var channelled
-        // to q by cake's Zge0/Zlt0 channel) and absy = |y| (channelled by Yge0/Ylt0) are the
+        // Divide: the exposed slot is q. magq = |q| (a state var channelled to q by
+        // cake's Zge0/Zlt0 channel) and absy = |y| (channelled by Yge0/Ylt0) are the
         // grid operands; cake's rem_* rows range 0 <= x - w < |y| over the grid sum and x
         // directly (rem_pos gated [x>=0], rem_neg gated [x<1]), so no remainder is
         // materialised at all. The exposed quotient's sign is pinned off the five sgn_*
@@ -928,43 +953,24 @@ namespace
         // rejected leaf pins magq/absy by unit propagation from the assigned q, y and the
         // rem rows refute it.
         //
-        // Modulus (default_modulus): the exposed slot is r, and cake leaves the quotient's
+        // Modulus: the exposed slot is r, and cake leaves the quotient's
         // magnitude a FREE axis-0 bit-sum with no i[Q] channel (no Zge0/Zlt0, no sgn_*). The
         // aux is the quotient magnitude |q|; absy = |y| is the second grid operand. cake
         // splits the identity r = x -/+ |q||y| on sign(x), the range/sign rows bound r, and
         // the tabulation recovers the signed quotient sign(x)sign(y)|q|.
-        // The default route runs whenever there is a product to reason about:
-        // a variable divisor and (for Divide) a variable exposed quotient,
-        // views included -- the channel rows, the rem/id rows and the sign
-        // clauses all take view terms directly. A constant divisor or a
-        // constant quotient leaves only linear structure, handled below.
-        bool default_divide = expose_quotient && ay.var.has_value() && aout.var.has_value();
-        bool default_modulus = (! expose_quotient) && ay.var.has_value();
 
-        // The exposed slot is the user's; the other is an auxiliary, with
-        // bounds tightened by the sign-of-dividend rule where easy.
+        // The exposed slot is the user's; the other is an auxiliary.
         IntegerVariableID q = 0_c, r = 0_c;
         SimpleIntegerVariableID aux = SimpleIntegerVariableID{0};
-        if (expose_quotient && default_divide) {
+        if (expose_quotient) {
             q = out;
-            // The default divide path materialises no remainder (neither in the OPB nor in the
+            // The divide path materialises no remainder (neither in the OPB nor in the
             // proof): cake's rem_* rows range x - w directly, so the aux is an inert state
             // slot, never introduced, enumerated, or meaningfully watched.
             aux = initial_state.allocate_integer_variable_with_state(0_i, 0_i);
             r = aux;
         }
-        else if (expose_quotient) {
-            // Divide with a constant divisor or quotient: the remainder is a
-            // signed auxiliary in the OPB, pinned by the linear identity.
-            q = out;
-            auto r_lo = xlo >= 0_i ? 0_i : -rmax;
-            auto r_hi = xhi <= 0_i ? 0_i : rmax;
-            aux = initial_state.allocate_integer_variable_with_state(r_lo, r_hi);
-            if (optional_model)
-                optional_model->set_up_integer_variable(aux, r_lo, r_hi, "aux_divide_remainder" + to_string(aux.index), nullopt);
-            r = aux;
-        }
-        else if (default_modulus) {
+        else {
             r = out;
             // The aux is the quotient MAGNITUDE |q|, a free axis-0 bit-sum sized by the
             // dividend's magnitude (|q| <= |x| since |y| >= 1). Its provable range is the
@@ -983,33 +989,13 @@ namespace
                     aux, 0_i, q_bit_max, "aux_modulus_quotient" + to_string(aux.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
             q = aux;
         }
-        else {
-            r = out;
-            aux = initial_state.allocate_integer_variable_with_state(q_lo, q_hi);
-            if (optional_model)
-                optional_model->set_up_integer_variable(aux, q_lo, q_hi, "aux_modulus_quotient" + to_string(aux.index), nullopt);
-            q = aux;
-        }
-        auto aq = affine_of(q);
 
         auto label = as_string(owner);
 
-        vector<LinearStage> legacy_stages;
-        auto add_equality = [&](const WeightedSum & sum, Integer value, const string & role) {
-            add_equality_stage(legacy_stages, optional_model, label, sum, value, role);
-        };
-        auto add_le = [&](const WeightedSum & sum, Integer value, const string & role, const optional<IntegerVariableCondition> & gate) {
-            add_le_stage(legacy_stages, optional_model, label, sum, value, role, gate);
-        };
-
-        // x = q * y + r. With a constant divisor or a constant quotient the
-        // product is a linear term and everything is stages; otherwise the
-        // default path's grid carries the product.
-        bool needs_mult = ay.var && aq.var;
         shared_ptr<DefaultProductData> default_data;
         shared_ptr<vector<LinearStage>> default_stages;
 
-        if (default_divide) {
+        if (expose_quotient) {
             // Divide, any sign of the dividend. BOTH the x >= 0 and x < 0 remainder rows
             // are live, each gated on sign(x) so only the matching regime fires once x is
             // branched. The quotient's sign is pinned off the sgn_* clauses (for whichever
@@ -1046,33 +1032,35 @@ namespace
                 const auto & product_sum = default_data->grid.sum;
                 const auto & neg_product = default_data->grid.neg_sum;
 
+                auto xa = operand_sign_atoms(*optional_model, x);
+                auto ya = operand_sign_atoms(*optional_model, y);
+                auto qa = operand_sign_atoms(*optional_model, q);
+
                 // Both remainder-row sets: 0 <= x - |q||y| < |y| (rem_pos, gated [x>=0]) and
                 // 0 <= -x - |q||y| < |y| (rem_neg, gated [x<1]).
-                auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
-                auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
-                default_data->rem_pos_lo =
-                    optional_model->add_labelled_constraint(label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xge0);
+                default_data->rem_pos_lo = optional_model->add_labelled_constraint(
+                    label, "rem_pos_lo", "Divide", "remainder", neg_product + 1_i * x_eff >= 0_i, xa.ge0_gate);
                 default_data->rem_pos_hi = optional_model->add_labelled_constraint(
-                    label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xge0);
-                default_data->rem_neg_hi =
-                    optional_model->add_labelled_constraint(label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xlt0);
+                    label, "rem_pos_hi", "Divide", "remainder", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xa.ge0_gate);
+                default_data->rem_neg_hi = optional_model->add_labelled_constraint(
+                    label, "rem_neg_hi", "Divide", "remainder", neg_product + -1_i * x_eff >= 0_i, xa.lt1_gate);
                 default_data->rem_neg_lo = optional_model->add_labelled_constraint(
-                    label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xlt0);
+                    label, "rem_neg_lo", "Divide", "remainder", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xa.lt1_gate);
 
                 optional_model->add_labelled_constraint(
-                    label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y < 1_i) + 1_i * (q >= 0_i) >= 1_i);
+                    label, "sgn_pp", "Divide", "sign", WPBSum{} + 1_i * xa.lt1 + 1_i * ya.lt1 + 1_i * qa.ge0 >= 1_i);
                 optional_model->add_labelled_constraint(
-                    label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y >= 0_i) + 1_i * (q >= 0_i) >= 1_i);
+                    label, "sgn_nn", "Divide", "sign", WPBSum{} + 1_i * xa.ge0 + 1_i * ya.ge0 + 1_i * qa.ge0 >= 1_i);
                 optional_model->add_labelled_constraint(
-                    label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * (x < 1_i) + 1_i * (y >= 0_i) + 1_i * (q < 1_i) >= 1_i);
+                    label, "sgn_pn", "Divide", "sign", WPBSum{} + 1_i * xa.lt1 + 1_i * ya.ge0 + 1_i * qa.lt1 >= 1_i);
                 optional_model->add_labelled_constraint(
-                    label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * (x >= 0_i) + 1_i * (y < 1_i) + 1_i * (q < 1_i) >= 1_i);
-                optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * (x != 0_i) + 1_i * (q < 1_i) >= 1_i);
+                    label, "sgn_np", "Divide", "sign", WPBSum{} + 1_i * xa.ge0 + 1_i * ya.lt1 + 1_i * qa.lt1 >= 1_i);
+                optional_model->add_labelled_constraint(label, "sgn_x0", "Divide", "sign", WPBSum{} + 1_i * xa.ne0 + 1_i * qa.lt1 >= 1_i);
                 optional_model->add_labelled_constraint(
-                    label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+                    label, "nonzero", "Divide", "divisor is not zero", WPBSum{} + 1_i * ya.ge1 + 1_i * ya.lt0 >= 1_i);
             }
         }
-        else if (default_modulus) {
+        else {
             // The default modulus path: the exposed slot is r; the quotient magnitude |q| (the
             // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, pinned to |y| by
             // cake's Yge0/Ylt0 channel) multiply through the bit-product grid. The identity
@@ -1111,29 +1099,30 @@ namespace
                 const auto & product_sum = default_data->grid.sum;
                 const auto & neg_product = default_data->grid.neg_sum;
 
+                auto xa = operand_sign_atoms(*optional_model, x);
+                auto ya = operand_sign_atoms(*optional_model, y);
+
                 optional_model->add_labelled_constraint(
-                    label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
+                    label, "nonzero", "Modulus", "divisor is not zero", WPBSum{} + 1_i * ya.ge1 + 1_i * ya.lt0 >= 1_i);
 
                 // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0], r = x - Sum) and
                 // id_neg_* (gated [x<0], r = x + Sum -- since for x < 0 the quotient product
                 // q*y has sign(x), i.e. q*y = -Sum).
-                auto xge0 = HalfReifyOnConjunctionOf{x_eff >= 0_i};
-                auto xlt0 = HalfReifyOnConjunctionOf{x_eff < 1_i};
                 default_data->id_pos_ge = optional_model->add_labelled_constraint(
-                    label, "id_pos_ge", "Modulus", "identity", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xge0);
+                    label, "id_pos_ge", "Modulus", "identity", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xa.ge0_gate);
                 default_data->id_pos_le = optional_model->add_labelled_constraint(
-                    label, "id_pos_le", "Modulus", "identity", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xge0);
+                    label, "id_pos_le", "Modulus", "identity", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xa.ge0_gate);
                 default_data->id_neg_ge = optional_model->add_labelled_constraint(
-                    label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xlt0);
+                    label, "id_neg_ge", "Modulus", "identity", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xa.lt1_gate);
                 default_data->id_neg_le = optional_model->add_labelled_constraint(
-                    label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xlt0);
+                    label, "id_neg_le", "Modulus", "identity", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xa.lt1_gate);
 
                 // |r| < |y| = absy: rng_hi (r < absy) and rng_lo (r > -absy), plus the r-sign
                 // rows (r takes x's sign; sgn_pos gated [x>=0], sgn_neg gated [x<0]).
                 rng_hi = optional_model->add_labelled_constraint(label, "rng_hi", "Modulus", "range", WPBSum{} + -1_i * r_eff + 1_i * absy >= 1_i);
                 rng_lo = optional_model->add_labelled_constraint(label, "rng_lo", "Modulus", "range", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
-                sgn_pos = optional_model->add_labelled_constraint(label, "sgn_pos", "Modulus", "sign", WPBSum{} + 1_i * r_eff >= 0_i, xge0);
-                sgn_neg = optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xlt0);
+                sgn_pos = optional_model->add_labelled_constraint(label, "sgn_pos", "Modulus", "sign", WPBSum{} + 1_i * r_eff >= 0_i, xa.ge0_gate);
+                sgn_neg = optional_model->add_labelled_constraint(label, "sgn_neg", "Modulus", "sign", WPBSum{} + -1_i * r_eff >= 0_i, xa.lt1_gate);
             }
 
             // Stages (built regardless of proofs): the range 0 <= r < absy (x>=0) /
@@ -1152,56 +1141,6 @@ namespace
             append_magnitude_stages(*default_stages, absy, y_eff, ychan, 1_i);
         }
 
-        if (! needs_mult) {
-            // one of d * q + r - x = 0 (constant divisor) or c * y + r - x = 0
-            // (Divide with a constant quotient)
-            if (! ay.var)
-                add_equality(WeightedSum{} + ay.offset * q + 1_i * r + -1_i * x, 0_i, "sum");
-            else
-                add_equality(WeightedSum{} + aq.offset * y + 1_i * r + -1_i * x, 0_i, "sum");
-        }
-
-        // |r| < |y|, plus y != 0, which is where the relational division-by-
-        // zero semantics comes from. With a constant divisor the remainder
-        // slot's range suffices: it is baked into the auxiliary's bounds for
-        // Divide, and posted on the user's remainder for Modulus. With a
-        // variable divisor, split on the divisor's sign.
-        if (! needs_mult) {
-            if (! ay.var) {
-                if (! expose_quotient) {
-                    add_le(WeightedSum{} + 1_i * r, rmax, "remhi", nullopt);
-                    add_le(WeightedSum{} + -1_i * r, rmax, "remlo", nullopt);
-                }
-            }
-            else {
-                if (optional_model)
-                    optional_model->add_labelled_constraint(
-                        label, "nonzero", "DivideModulus", "divisor is not zero", WPBSum{} + 1_i * (y >= 1_i) + 1_i * (y < 0_i) >= 1_i);
-
-                // y >= 1 -> r <= y - 1 and r >= -y + 1
-                add_le(WeightedSum{} + 1_i * r + -1_i * y, -1_i, "rangeposhi", y >= 1_i);
-                add_le(WeightedSum{} + -1_i * r + -1_i * y, -1_i, "rangeposlo", y >= 1_i);
-                // y <= -1 -> r <= -y - 1 and r >= y + 1
-                add_le(WeightedSum{} + 1_i * r + 1_i * y, -1_i, "rangeneghi", y < 0_i);
-                add_le(WeightedSum{} + -1_i * r + 1_i * y, -1_i, "rangeneglo", y < 0_i);
-            }
-
-            // The remainder takes the sign of the dividend, which is what pins
-            // truncation: without it, the identity and |r| < |y| admit both the
-            // truncated and the floored (quotient, remainder) pair when the signs
-            // differ.
-            if (ax.var) {
-                add_le(WeightedSum{} + -1_i * r, 0_i, "signpos", x >= 0_i);
-                add_le(WeightedSum{} + 1_i * r, 0_i, "signneg", x < 1_i);
-            }
-            else {
-                if (ax.offset >= 0_i)
-                    add_le(WeightedSum{} + -1_i * r, 0_i, "signpos", nullopt);
-                if (ax.offset <= 0_i)
-                    add_le(WeightedSum{} + 1_i * r, 0_i, "signneg", nullopt);
-            }
-        }
-
         Triggers triggers;
         vector<IntegerVariableID> watched;
         auto watch = [&](const IntegerVariableID & v) {
@@ -1212,81 +1151,52 @@ namespace
         watch(y);
         watch(out);
         watch(aux);
-        if (needs_mult) {
-            watch(default_data->mag_a);
-            watch(default_data->mag_b);
-        }
+        watch(default_data->mag_a);
+        watch(default_data->mag_b);
         triggers.on_bounds = watched;
 
-        bool prune_zero = ay.var != nullopt;
-        if (needs_mult) {
-            propagators.install(
-                owner,
-                [data = default_data, stg = default_stages, y = y, q = q, x = x, pin_q_sign = default_divide,
-                    modulus_r = default_modulus ? optional{out} : optional<IntegerVariableID>{},
-                    owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                    do {
-                        if (state.in_domain(y, 0_i))
-                            inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
+        propagators.install(
+            owner,
+            [data = default_data, stg = default_stages, y = y, q = q, x = x, pin_q_sign = expose_quotient,
+                modulus_r = expose_quotient ? optional<IntegerVariableID>{} : optional{out},
+                owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                do {
+                    if (state.in_domain(y, 0_i))
+                        inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
 
-                        if (pin_q_sign) {
-                            // The grid carries no signed reasoning, so the exposed quotient's
-                            // sign is pinned off the sgn_* clauses by RUP once the signs of x
-                            // and y are both established. sgn_pp: x>0 & y>0 -> q>=0; sgn_pn:
-                            // x>0 & y<0 -> q<=0; sgn_nn: x<0 & y<0 -> q>=0; sgn_np: x<0 & y>0
-                            // -> q<=0.
-                            if (state.lower_bound(x) >= 1_i) {
-                                if (state.lower_bound(y) >= 1_i && state.lower_bound(q) < 0_i)
-                                    inference.infer(
-                                        logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y >= 1_i}});
-                                else if (state.upper_bound(y) < 0_i && state.upper_bound(q) > 0_i)
-                                    inference.infer(
-                                        logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y < 0_i}});
-                            }
-                            else if (state.upper_bound(x) < 0_i) {
-                                if (state.upper_bound(y) < 0_i && state.lower_bound(q) < 0_i)
-                                    inference.infer(
-                                        logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y < 0_i}});
-                                else if (state.lower_bound(y) >= 1_i && state.upper_bound(q) > 0_i)
-                                    inference.infer(
-                                        logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y >= 1_i}});
-                            }
+                    if (pin_q_sign) {
+                        // The grid carries no signed reasoning, so the exposed quotient's
+                        // sign is pinned off the sgn_* clauses by RUP once the signs of x
+                        // and y are both established. sgn_pp: x>0 & y>0 -> q>=0; sgn_pn:
+                        // x>0 & y<0 -> q<=0; sgn_nn: x<0 & y<0 -> q>=0; sgn_np: x<0 & y>0
+                        // -> q<=0.
+                        if (state.lower_bound(x) >= 1_i) {
+                            if (state.lower_bound(y) >= 1_i && state.lower_bound(q) < 0_i)
+                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y >= 1_i}});
+                            else if (state.upper_bound(y) < 0_i && state.upper_bound(q) > 0_i)
+                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y < 0_i}});
                         }
+                        else if (state.upper_bound(x) < 0_i) {
+                            if (state.upper_bound(y) < 0_i && state.lower_bound(q) < 0_i)
+                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y < 0_i}});
+                            else if (state.lower_bound(y) >= 1_i && state.upper_bound(q) > 0_i)
+                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y >= 1_i}});
+                        }
+                    }
 
-                        if (! propagate_stages(*stg, state, inference, logger, owner))
-                            return PropagatorState::Enable;
+                    if (! propagate_stages(*stg, state, inference, logger, owner))
+                        return PropagatorState::Enable;
 
-                        propagate_default_product<Hint_>(*data, modulus_r, state, inference, logger, owner);
-                    } while (inference.did_anything_since_last_call_inside_propagator());
+                    propagate_default_product<Hint_>(*data, modulus_r, state, inference, logger, owner);
+                } while (inference.did_anything_since_last_call_inside_propagator());
 
-                    // Idempotent: the do-while ran the stages (and the default product)
-                    // to quiescence, so an immediate re-run is one no-op pass (see
-                    // multiply.cc for the same argument). The mid-loop return above is
-                    // the contradiction path and its state is ignored.
-                    return PropagatorState::EnableButIdempotent;
-                },
-                triggers);
-        }
-        else
-            propagators.install(
-                owner,
-                [stages = legacy_stages, prune_zero = prune_zero, y = y, owner = owner](
-                    const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                    do {
-                        if (prune_zero && state.in_domain(y, 0_i))
-                            inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
-
-                        if (! propagate_stages(stages, state, inference, logger, owner))
-                            return PropagatorState::Enable;
-                    } while (inference.did_anything_since_last_call_inside_propagator());
-
-                    // Idempotent: the do-while ran the stages (and the default product)
-                    // to quiescence, so an immediate re-run is one no-op pass (see
-                    // multiply.cc for the same argument). The mid-loop return above is
-                    // the contradiction path and its state is ignored.
-                    return PropagatorState::EnableButIdempotent;
-                },
-                triggers);
+                // Idempotent: the do-while ran the stages (and the default product)
+                // to quiescence, so an immediate re-run is one no-op pass (see
+                // multiply.cc for the same argument). The mid-loop return above is
+                // the contradiction path and its state is ignored.
+                return PropagatorState::EnableButIdempotent;
+            },
+            triggers);
 
         // Tabulation for GAC: enumerate the distinct underlying variables and
         // the auxiliary slot, so a complete assignment fixes x, y, q and r and
@@ -1296,44 +1206,30 @@ namespace
         auto px = ax.var ? optional{enum_vars.position_of(*ax.var)} : nullopt;
         auto py = ay.var ? optional{enum_vars.position_of(*ay.var)} : nullopt;
         auto pout = aout.var ? optional{enum_vars.position_of(*aout.var)} : nullopt;
-        // The default divide path materialises no remainder in the proof (cake's rem_* rows range
+        // The divide path materialises no remainder in the proof (cake's rem_* rows range
         // x - w directly, and a rejected (x, y, q) leaf pins magq/absy/w by unit propagation
         // from the assigned q, y so the rem rows refute a wrong remainder), so it enumerates
-        // only x, y and q, with no remainder aux and no determined slots.
-        bool no_rem_aux = default_divide;
+        // only x, y and q, with no remainder aux and no determined slots. The modulus path
+        // enumerates the quotient MAGNITUDE aux |q|; the signed quotient is recovered as
+        // sign(x)sign(y)|q| (a magnitude 0 keeps sign 0).
         std::size_t paux = 0;
-        if (! no_rem_aux)
+        if (! expose_quotient)
             paux = enum_vars.position_of(aux);
 
-        // x and r are each a function of the others, pinned by unit
-        // propagation forwards through the stages: q and y assigned pin
-        // w = q * y through the multiplication's bit products, and the
-        // linear x = w + r stage then pins whichever of x and r is left.
-        // q is a function of the others too, but recovering it means
-        // going backwards through the multiplication, which unit
-        // propagation cannot do; and y is not a function at all, since
-        // q = 0 leaves it anywhere bigger than the remainder. Aliasing
-        // spoils the argument, so only distinct slots are claimed (the
-        // auxiliary is always fresh).
-        // On the cake modulus path the aux is the quotient MAGNITUDE |q|; recover the signed
-        // quotient sign(x)sign(y)|q| (a magnitude 0 keeps sign 0). Everywhere else the aux is
-        // the signed quotient directly.
-        bool aux_is_magnitude = default_modulus;
-        auto recover_q = [aux_is_magnitude](Integer auxv, Integer xv, Integer yv) -> Integer {
-            return (aux_is_magnitude && ((xv >= 0_i) != (yv >= 0_i))) ? -auxv : auxv;
-        };
+        auto recover_q = [](Integer auxv, Integer xv, Integer yv) -> Integer { return ((xv >= 0_i) != (yv >= 0_i)) ? -auxv : auxv; };
 
+        // x is a function of the others, pinned by unit propagation forwards
+        // through the stages -- but only on the modulus path (divide has no
+        // aux to enumerate) and only when x has a fixed sign (for x spanning
+        // zero, r = 0 leaves x = +/-|q||y| ambiguous). Its sign then fixes
+        // the product's sign: x = sign(x)|q||y| + r. q is a function of the
+        // others too, but recovering it means going backwards through the
+        // multiplication, which unit propagation cannot do; and y is not a
+        // function at all, since q = 0 leaves it anywhere bigger than the
+        // remainder. Aliasing spoils the argument, so only distinct slots
+        // are claimed.
         vector<DeterminedVariable> determined;
-        // Only a constant-shape divide reaches here with a materialised remainder
-        // aux; there the aux is the signed remainder r = x - q * y.
-        if (expose_quotient && ! no_rem_aux)
-            determined.push_back({aux, [ax, ay, aout, px, py, pout](const vector<Integer> & vals) -> optional<Integer> {
-                                      auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
-                                      auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
-                                      auto qv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                                      return xv - qv * yv;
-                                  }});
-        else if (! expose_quotient && pout && pout != px && pout != py)
+        if (! expose_quotient && pout && pout != px && pout != py)
             determined.push_back({*aout.var, [ax, ay, aout, px, py, paux, recover_q](const vector<Integer> & vals) -> optional<Integer> {
                                       auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                                       auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
@@ -1342,40 +1238,28 @@ namespace
                                           return nullopt;
                                       return (want - aout.offset) / aout.coeff;
                                   }});
-        // On the magnitude path x is a function of the others only when it has a fixed sign
-        // (for x spanning zero, r = 0 leaves x = +/-|q||y| ambiguous). Its sign then fixes
-        // the product's sign: x = sign(x)|q||y| + r.
         bool x_fixed_sign = xlo >= 0_i || xhi <= 0_i;
         Integer x_sign = xhi <= 0_i ? -1_i : 1_i;
-        if (px && px != py && px != pout && ! no_rem_aux && (! aux_is_magnitude || x_fixed_sign))
-            determined.push_back({*ax.var,
-                [ax, ay, aout, py, pout, paux, expose_quotient, aux_is_magnitude, x_sign](const vector<Integer> & vals) -> optional<Integer> {
-                    auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
-                    auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                    auto auxv = vals[paux];
-                    // The remainder is the aux for a constant-shape Divide and the exposed slot for
-                    // Modulus; x = q * y + r.
-                    auto rv = expose_quotient ? auxv : outv;
-                    auto want = aux_is_magnitude ? x_sign * auxv * (yv < 0_i ? -yv : yv) + outv : (expose_quotient ? outv : auxv) * yv + rv;
-                    if ((want - ax.offset) % ax.coeff != 0_i)
-                        return nullopt;
-                    return (want - ax.offset) / ax.coeff;
-                }});
+        if (! expose_quotient && px && px != py && px != pout && x_fixed_sign)
+            determined.push_back({*ax.var, [ax, ay, py, pout, paux, aout, x_sign](const vector<Integer> & vals) -> optional<Integer> {
+                                      auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
+                                      auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
+                                      auto want = x_sign * vals[paux] * (yv < 0_i ? -yv : yv) + outv;
+                                      if ((want - ax.offset) % ax.coeff != 0_i)
+                                          return nullopt;
+                                      return (want - ax.offset) / ax.coeff;
+                                  }});
 
         if (want_tabulation(level, enum_vars.vars(), determined, initial_state)) {
-            auto accept = [ax, ay, aout, px, py, pout, paux, no_rem_aux, expose_quotient, recover_q](const vector<Integer> & vals) -> bool {
+            auto accept = [ax, ay, aout, px, py, pout, paux, expose_quotient, recover_q](const vector<Integer> & vals) -> bool {
                 auto xv = px ? ax.coeff * vals[*px] + ax.offset : ax.offset;
                 auto yv = py ? ay.coeff * vals[*py] + ay.offset : ay.offset;
                 auto outv = pout ? aout.coeff * vals[*pout] + aout.offset : aout.offset;
-                // The default divide path enumerates no remainder aux: q is the exposed slot and
-                // the remainder is derived. Elsewhere the aux is the remainder (constant-shape Divide)
-                // or the quotient magnitude (Modulus).
-                if (no_rem_aux)
+                // Divide enumerates no remainder aux: q is the exposed slot and the
+                // remainder is derived. Modulus's aux is the quotient magnitude.
+                if (expose_quotient)
                     return is_in_relation(xv, yv, outv, xv - outv * yv);
-                auto auxv = vals[paux];
-                auto qv = expose_quotient ? outv : recover_q(auxv, xv, yv);
-                auto rv = expose_quotient ? auxv : outv;
-                return is_in_relation(xv, yv, qv, rv);
+                return is_in_relation(xv, yv, recover_q(vals[paux], xv, yv), outv);
             };
 
             install_tabulation<Hint_>(propagators, owner, enum_vars.vars(), move(determined), nullopt, accept, expose_quotient ? "divtab" : "modtab",

--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -160,6 +160,30 @@ auto run_divmod_alias_test(bool proofs, bool is_div, const DivideConsistency & l
     check_results(proof_name, expected, actual);
 }
 
+// Divisor and result both constants: only the dividend is a variable.
+auto run_divmod_two_constant_test(bool proofs, bool is_div, const DivideConsistency & level, int y_const, int out_const, pair<int, int> a_range)
+    -> void
+{
+    print(cerr, "{} {} two constants y={} out={} {} {}", is_div ? "divide" : "modulus", level_name(level), y_const, out_const, a_range,
+        proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    Problem p;
+    auto a = p.create_integer_variable(Integer(a_range.first), Integer(a_range.second), "a");
+
+    auto op_ok = [&](int av) { return is_div ? div_ok(av, y_const, out_const) : mod_ok(av, y_const, out_const); };
+
+    set<tuple<int>> expected, actual;
+    build_expected(expected, op_ok, a_range);
+    println(cerr, " expecting {} solutions", expected.size());
+
+    post_divmod(p, is_div, a, constant_variable(Integer{y_const}), constant_variable(Integer{out_const}), level);
+
+    auto proof_name = proofs ? make_optional("divide_modulus_test" + test_proof_suffix) : nullopt;
+    solve_for_tests(p, proof_name, actual, tuple{a});
+    check_results(proof_name, expected, actual);
+}
+
 // One slot is a constant: divisor (including zero and negative), dividend, or
 // result.
 auto run_divmod_constant_test(bool proofs, bool is_div, const DivideConsistency & level, const string & which, int constant, pair<int, int> a_range,
@@ -294,13 +318,22 @@ auto main(int argc, char * argv[]) -> int
                 run_divmod_alias_test(proofs, is_div, level, force_gac, "xyx", {-2, 2}, {-2, 2});
                 run_divmod_alias_test(proofs, is_div, level, force_gac, "yxx", {-2, 2}, {-2, 2});
 
-                // Constants in each slot, including the relational
-                // divide-by-constant-zero case (no solutions, not an error).
+                // Constants in each slot, both signs, including the relational
+                // divide-by-constant-zero case (no solutions, not an error) and
+                // a constant zero result (a zero-width quotient magnitude for
+                // Divide, a zero remainder for Modulus).
                 run_divmod_constant_test(proofs, is_div, level, "y", 3, {-7, 7}, {-3, 3});
                 run_divmod_constant_test(proofs, is_div, level, "y", -2, {-5, 5}, {-3, 3});
                 run_divmod_constant_test(proofs, is_div, level, "y", 0, {-2, 2}, {-2, 2});
                 run_divmod_constant_test(proofs, is_div, level, "x", 7, {-3, 3}, {-7, 7});
+                run_divmod_constant_test(proofs, is_div, level, "x", -7, {-3, 3}, {-7, 7});
                 run_divmod_constant_test(proofs, is_div, level, "out", 2, {-8, 8}, {-3, 3});
+                run_divmod_constant_test(proofs, is_div, level, "out", -2, {-8, 8}, {-3, 3});
+                run_divmod_constant_test(proofs, is_div, level, "out", 0, {-5, 5}, {-3, 3});
+
+                // Divisor and result both constants, both signs.
+                run_divmod_two_constant_test(proofs, is_div, level, 3, 2, {-7, 7});
+                run_divmod_two_constant_test(proofs, is_div, level, -3, -2, {-7, 7});
             }
 
             // Random instances, forced BC.

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -418,8 +418,15 @@ auto ReifiedEquals::s_expr(const innards::ProofModel * const model) const -> SEx
     }
                                  .visit(_cond);
 
+    // A not-equals iff stores the negated condition (equality holds iff NOT the
+    // user's condition), but the not_equals_iff keyword already carries the
+    // negation: cake reads (r not_equals_iff (cond) v1 v2) as cond <=> v1 != v2.
+    // Emit the user's original condition, not the stored one, or the two
+    // negations cancel into the opposite constraint.
+    auto cond_to_write =
+        _neq && std::holds_alternative<reif::Iff>(_cond) ? ReificationCondition{reif::Iff{! std::get<reif::Iff>(_cond).cond}} : _cond;
     vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type)};
-    if (auto cond = tracker.s_expr_term_of(_cond))
+    if (auto cond = tracker.s_expr_term_of(cond_to_write))
         terms.push_back(std::move(*cond));
     terms.push_back(tracker.s_expr_term_of(_v1));
     terms.push_back(tracker.s_expr_term_of(_v2));

--- a/gcs/constraints/innards/cake_truthiness.cc
+++ b/gcs/constraints/innards/cake_truthiness.cc
@@ -1,0 +1,82 @@
+#include <gcs/constraints/innards/cake_truthiness.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/s_expr.hh>
+
+#include <util/overloaded.hh>
+
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::function;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::vector;
+
+auto gcs::innards::cake_positive_form(const Literal & lit, const function<pair<Integer, Integer>(const SimpleIntegerVariableID &)> & bounds_of)
+    -> optional<IntegerVariableID>
+{
+    return overloaded{[](const TrueLiteral &) -> optional<IntegerVariableID> { return IntegerVariableID{1_c}; },
+        [](const FalseLiteral &) -> optional<IntegerVariableID> { return IntegerVariableID{0_c}; },
+        [&](const IntegerVariableCondition & cond) -> optional<IntegerVariableID> {
+            return overloaded{[&](const SimpleIntegerVariableID & var) -> optional<IntegerVariableID> {
+                                  auto [lower, upper] = bounds_of(var);
+                                  using enum VariableConditionOperator;
+                                  switch (cond.op) {
+                                  case NotEqual:
+                                      if (0_i == cond.value && lower >= 0_i)
+                                          return IntegerVariableID{var};
+                                      return nullopt;
+                                  case GreaterEqual:
+                                      if (1_i == cond.value && lower >= 0_i)
+                                          return IntegerVariableID{var};
+                                      return nullopt;
+                                  case Equal:
+                                      if (1_i == cond.value && lower >= 0_i && upper <= 1_i)
+                                          return IntegerVariableID{var};
+                                      return nullopt;
+                                  case Less: return nullopt;
+                                  }
+                                  return nullopt;
+                              },
+                [&](const ConstantIntegerVariableID & var) -> optional<IntegerVariableID> {
+                    // A condition over a constant is statically valued.
+                    using enum VariableConditionOperator;
+                    bool holds = false;
+                    switch (cond.op) {
+                    case Equal: holds = var.const_value == cond.value; break;
+                    case NotEqual: holds = var.const_value != cond.value; break;
+                    case GreaterEqual: holds = var.const_value >= cond.value; break;
+                    case Less: holds = var.const_value < cond.value; break;
+                    }
+                    return IntegerVariableID{holds ? 1_c : 0_c};
+                },
+                [](const ViewOfIntegerVariableID &) -> optional<IntegerVariableID> { return nullopt; }}
+                .visit(cond.var);
+        }}
+        .visit(lit);
+}
+
+auto gcs::innards::cake_positive_literal(const IntegerVariableID & form) -> Literal
+{
+    return overloaded{[](const ConstantIntegerVariableID & c) -> Literal {
+                          if (c.const_value >= 1_i)
+                              return TrueLiteral{};
+                          return FalseLiteral{};
+                      },
+        [](const SimpleIntegerVariableID & var) -> Literal { return var >= 1_i; },
+        [](const ViewOfIntegerVariableID & var) -> Literal { return var >= 1_i; }}
+        .visit(form);
+}
+
+auto gcs::innards::faithful_literal_term(const Literal & lit, const NamesAndIDsTracker & tracker) -> SExpr
+{
+    return overloaded{[](const TrueLiteral &) -> SExpr { return SExpr::atom("1"); }, [](const FalseLiteral &) -> SExpr { return SExpr::atom("0"); },
+        [&](const IntegerVariableCondition & cond) -> SExpr {
+            return SExpr::list(
+                vector<SExpr>{tracker.s_expr_term_of(cond.var), SExpr::atom(tracker.s_expr_name_of(cond.op)), SExpr::atom(cond.value.to_string())});
+        }}
+        .visit(lit);
+}

--- a/gcs/constraints/innards/cake_truthiness.hh
+++ b/gcs/constraints/innards/cake_truthiness.hh
@@ -1,0 +1,61 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_CAKE_TRUTHINESS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_CAKE_TRUTHINESS_HH
+
+#include <gcs/innards/literal.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <functional>
+#include <optional>
+#include <utility>
+
+namespace gcs::innards
+{
+    /**
+     * \brief The cake_pb_cp positive form of a literal, if it has one.
+     *
+     * cake reads a bare operand X of its `and` / `or` / `parity` terms as the
+     * test "X > 0". A literal is representable as such an operand exactly when
+     * it is semantically equivalent to "X > 0" for some variable or constant X
+     * under the variables' initial bounds: `v != 0` or `v >= 1` with lb(v) >= 0,
+     * `v == 1` with bounds within [0, 1], or a statically-valued literal (as
+     * the constant 1 or 0). Negations (`v == 0`), shifted comparisons, `!= 0`
+     * over a negative-capable domain (where our non-zero semantics diverges
+     * from cake's positive semantics), and view conditions have no such form.
+     *
+     * `bounds_of` supplies a variable's initial bounds; callers pass
+     * State::bounds at prepare time or NamesAndIDsTracker::tracked_bounds at
+     * scp-writing time (identical values, see Regular's s_expr).
+     */
+    [[nodiscard]] auto cake_positive_form(const Literal & lit,
+        const std::function<std::pair<Integer, Integer>(const SimpleIntegerVariableID &)> & bounds_of) -> std::optional<IntegerVariableID>;
+
+    /**
+     * \brief The literal a cake positive form stands for: `var >= 1` for a
+     * variable, TrueLiteral / FalseLiteral for a constant.
+     *
+     * When every literal of a logical constraint has a positive form, the
+     * constraint's rows and its propagator's inferences use these in place of
+     * the originals (they are state-equivalent given the bounds check above),
+     * so the proof never touches the `!= 0` atom machinery whose ge0 boundary
+     * atoms cake's OPB does not define.
+     */
+    [[nodiscard]] auto cake_positive_literal(const IntegerVariableID & form) -> Literal;
+
+    class NamesAndIDsTracker;
+    class SExpr;
+
+    /**
+     * \brief A faithful s-expression term for a literal: `1` / `0` for the
+     * static literals, and a `(var op value)` triple otherwise.
+     *
+     * Used by the `_lits` forms of the logical constraints' s_expr when a
+     * literal has no cake positive form: cake_pb_cp has no term for these, so
+     * the writer records the literal's real shape (rather than a bare variable
+     * cake would silently reinterpret as "> 0") and the chain skips the
+     * instance. read_scp reads the triples back for round-trip stability.
+     */
+    [[nodiscard]] auto faithful_literal_term(const Literal & lit, const NamesAndIDsTracker & tracker) -> SExpr;
+}
+
+#endif

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -135,16 +135,10 @@ namespace gcs::test_innards
             std::remove(vopb.c_str());
             return;
         }
-        // Known cake bug (reported upstream): a domain-{0} (ub == 0) variable
-        // gets a zero-bit encoding, so its bound lines print with an EMPTY
-        // left-hand side ("@i[X][lb]  >= 0"), which is invalid OPB. Filter these
-        // instances out so this one case doesn't mask other divergences.
-        if (! cake_capture("grep -qE '\\[(lb|ub)\\][[:space:]]*[<>]=' " + vopb + " && echo Y").empty()) {
-            log("SKIP_ZERO_DOMAIN");
-            std::remove(vopb.c_str());
-            return;
-        }
         // 2. veripb elaborates OUR proof against CAKE's OPB (the divergence gate).
+        // (A domain-{0} variable's zero-bit bound rows print with an EMPTY
+        // left-hand side, which needs a veripb with the labelled-empty-LHS
+        // parser fix of 2026-07-10.)
         auto elab = cake_capture("veripb " + vopb + " " + pbp + " --elaborate " + core + " 2>&1");
         if (! verified(elab)) {
             log("FAIL_ELAB", lastmeaningful(elab));

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -75,6 +75,14 @@ namespace gcs::test_innards
     // throws: this is for measuring the chain-verify rate across the random
     // data-driven instances, not for gating the suite. Enabled by GCS_TEST_CAKE;
     // cake_pb_cp path overridable via CAKE_PB_CP.
+#ifdef _WIN32
+    // The probe drives cake_pb_cp and veripb through popen() and a POSIX shell,
+    // and cake_pb_cp does not run on Windows anyway, so it compiles out to a
+    // no-op there.
+    inline auto cake_probe_chain(const std::string &) -> void
+    {
+    }
+#else
     inline auto cake_capture(const std::string & cmd) -> std::string
     {
         std::string out;
@@ -162,6 +170,7 @@ namespace gcs::test_innards
         std::remove(vopb.c_str());
         std::remove(core.c_str());
     }
+#endif
 
     /**
      * Verify a test's proof with VeriPB, then, on success, delete its .opb/.pbp

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -69,6 +69,106 @@ namespace gcs::test_innards
         return run_veripb("--help", ">/dev/null");
     }
 
+    // ---- PROBE (measurement only): workflow-2 cake_pb_cp chain -----------------
+    // Runs the full verified-encoding chain on a just-written .scp/.pbp, best
+    // effort, and logs a greppable "CAKECHAIN <name> <OUTCOME>" line. Never
+    // throws: this is for measuring the chain-verify rate across the random
+    // data-driven instances, not for gating the suite. Enabled by GCS_TEST_CAKE;
+    // cake_pb_cp path overridable via CAKE_PB_CP.
+    inline auto cake_capture(const std::string & cmd) -> std::string
+    {
+        std::string out;
+        if (FILE * p = ::popen((cmd + " 2>/dev/null").c_str(), "r")) {
+            char buf[8192];
+            size_t n;
+            while ((n = std::fread(buf, 1, sizeof buf, p)) > 0)
+                out.append(buf, n);
+            ::pclose(p);
+        }
+        return out;
+    }
+
+    inline auto cake_probe_chain(const std::string & pn) -> void
+    {
+        if (auto e = std::getenv("GCS_TEST_CAKE"); ! (e && *e))
+            return;
+        const char * cakeenv = std::getenv("CAKE_PB_CP");
+        std::string cake = (cakeenv && *cakeenv) ? cakeenv : "cake_pb_cp";
+        auto scp = pn + ".scp", pbp = pn + ".pbp";
+        auto vopb = pn + ".cakeopb", core = pn + ".cakecore";
+
+        auto has = [](const std::string & s, const char * m) { return s.find(m) != std::string::npos; };
+        // A VERIFIED line, or "s NO CONCLUSION": the latter is cake's success
+        // output for a proof whose conclusion is NONE (the init-only tests).
+        auto verified = [&](const std::string & s) { return has(s, "s VERIFIED") || has(s, "s NO CONCLUSION"); };
+        auto lastmeaningful = [](const std::string & s) {
+            std::string best;
+            size_t i = 0;
+            while (i < s.size()) {
+                auto e = s.find('\n', i);
+                auto line = s.substr(i, e == std::string::npos ? std::string::npos : e - i);
+                if (! line.empty() && line.find("Running VeriPB") == std::string::npos)
+                    best = line;
+                if (e == std::string::npos)
+                    break;
+                i = e + 1;
+            }
+            return best;
+        };
+        auto log = [&](const std::string & outcome, const std::string & extra = "") {
+            std::string line = "CAKECHAIN " + pn + " " + outcome;
+            if (! extra.empty())
+                line += " :: " + extra;
+            line += "\n";
+            std::fputs(line.c_str(), stderr);
+        };
+        auto firstline = [](const std::string & s) {
+            auto n = s.find('\n');
+            return n == std::string::npos ? s : s.substr(0, n);
+        };
+
+        // 1. cake_pb_cp re-derives its own OPB from the .scp.
+        std::system((cake + " " + scp + " > " + vopb + " 2>/dev/null").c_str());
+        std::string opb = cake_capture("cat " + vopb);
+        if (opb.find(">=") == std::string::npos && opb.find("<=") == std::string::npos) {
+            log("SKIP_NO_OPB");
+            std::remove(vopb.c_str());
+            return;
+        }
+        // Known cake bug (reported upstream): a domain-{0} (ub == 0) variable
+        // gets a zero-bit encoding, so its bound lines print with an EMPTY
+        // left-hand side ("@i[X][lb]  >= 0"), which is invalid OPB. Filter these
+        // instances out so this one case doesn't mask other divergences.
+        if (! cake_capture("grep -qE '\\[(lb|ub)\\][[:space:]]*[<>]=' " + vopb + " && echo Y").empty()) {
+            log("SKIP_ZERO_DOMAIN");
+            std::remove(vopb.c_str());
+            return;
+        }
+        // 2. veripb elaborates OUR proof against CAKE's OPB (the divergence gate).
+        auto elab = cake_capture("veripb " + vopb + " " + pbp + " --elaborate " + core + " 2>&1");
+        if (! verified(elab)) {
+            log("FAIL_ELAB", lastmeaningful(elab));
+            // Preserve the failing triple (scp/pbp + cake's OPB) for inspection.
+            // Uniquely numbered so multiple failures sharing a proof_name don't
+            // overwrite each other.
+            if (auto k = std::getenv("GCS_TEST_CAKE_KEEP"); k && *k) {
+                static int fail_seq = 0;
+                std::string dir{k}, sfx = std::to_string(++fail_seq);
+                for (auto ext : {".scp", ".pbp"})
+                    std::system(("mkdir -p " + dir + " && cp " + pn + ext + " " + dir + "/" + pn + "." + sfx + ext + " 2>/dev/null").c_str());
+                std::system(("cp " + vopb + " " + dir + "/" + pn + "." + sfx + ".cakeopb 2>/dev/null").c_str());
+            }
+            std::remove(vopb.c_str());
+            std::remove(core.c_str());
+            return;
+        }
+        // 3. cake_pb_cp re-checks the elaborated core.
+        auto rc = cake_capture(cake + " " + scp + " " + core);
+        log(verified(rc) ? "OK" : "FAIL_RECHECK", lastmeaningful(rc));
+        std::remove(vopb.c_str());
+        std::remove(core.c_str());
+    }
+
     /**
      * Verify a test's proof with VeriPB, then, on success, delete its .opb/.pbp
      * files.
@@ -88,8 +188,11 @@ namespace gcs::test_innards
     {
         if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
             throw UnexpectedException{"veripb verification failed"};
+        cake_probe_chain(proof_name); // PROBE: measure workflow-2 chain (no-op unless GCS_TEST_CAKE)
         std::remove((proof_name + ".opb").c_str());
         std::remove((proof_name + ".pbp").c_str());
+        std::remove((proof_name + ".scp").c_str());
+        std::remove((proof_name + ".varmap").c_str());
     }
 
     /**

--- a/gcs/constraints/innards/product_encoding.cc
+++ b/gcs/constraints/innards/product_encoding.cc
@@ -4,11 +4,15 @@
 #include <gcs/innards/proofs/proof_model.hh>
 #include <util/overloaded.hh>
 
+#include <utility>
+
 using namespace gcs;
 using namespace gcs::innards;
 using namespace gcs::innards::product_enc;
 
+using std::get_if;
 using std::max;
+using std::pair;
 using std::string;
 using std::vector;
 
@@ -16,6 +20,9 @@ namespace
 {
     // The four half-reified rows pinning mag = |v|: [v>=0] => mag = v and
     // [v<0] => mag = -v, with cake's role names <prefix><letter>{ge0,lt0}_{ge,le}.
+    // A constant operand keeps the same four rows, cake style: the constant
+    // folds into each row's degree and the sign gates become its pinned
+    // n[k][ge0] atom (issue #483).
     auto emit_channel_rows(ProofModel & model, const string & label, const StringLiteral & op, IntegerVariableID v,
         const SimpleOrProofOnlyIntegerVariableID & mag, const string & role_prefix, const string & letter) -> MagnitudeChannel
     {
@@ -24,8 +31,13 @@ namespace
                 [&](const ProofOnlySimpleIntegerVariableID & m) { return Weighted<PseudoBooleanTerm>{coeff, m}; }}
                 .visit(mag);
         };
-        auto ge0 = HalfReifyOnConjunctionOf{v >= 0_i};
-        auto lt0 = HalfReifyOnConjunctionOf{v < 0_i};
+        auto [ge0, lt0] = [&]() -> pair<HalfReifyOnConjunctionOf, HalfReifyOnConjunctionOf> {
+            if (auto cv = get_if<ConstantIntegerVariableID>(&v)) {
+                auto atoms = model.cake_constant_atoms(cv->const_value);
+                return {HalfReifyOnConjunctionOf{atoms.ge0}, HalfReifyOnConjunctionOf{! atoms.ge0}};
+            }
+            return {HalfReifyOnConjunctionOf{v >= 0_i}, HalfReifyOnConjunctionOf{v < 0_i}};
+        }();
         auto pos_ge = model.add_labelled_constraint(
             label, role_prefix + letter + "ge0_ge", op, "magnitude channel", WPBSum{} + 1_i * v + as_term(-1_i) >= 0_i, ge0);
         auto pos_le = model.add_labelled_constraint(

--- a/gcs/constraints/innards/product_encoding.hh
+++ b/gcs/constraints/innards/product_encoding.hh
@@ -57,7 +57,10 @@ namespace gcs::innards::product_enc
      * rows gated on the reified sign atom, `[v>=0] => mag = v` and
      * `[v<0] => mag = -v`. The magnitude is a proof-only variable for
      * Multiply and Power, and a state variable (whose bits are registered
-     * as cake's encoder-internal bits) for Divide and Modulus.
+     * as cake's encoder-internal bits) for Divide and Modulus. A constant
+     * operand gets the same four rows with the constant folded into the
+     * degrees and the gates over its pinned n[k][ge0] atom, exactly as cake
+     * encodes a constant slot (issue #483).
      *
      * Slot-keyed by design: a repeated operand gets one channel per slot,
      * both over the same v, exactly as cake emits for `(multiply X X Z)`.

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -40,6 +40,7 @@ using namespace gcs::innards;
 
 using std::decay_t;
 using std::function;
+using std::get;
 using std::is_same_v;
 using std::make_pair;
 using std::make_shared;
@@ -444,8 +445,15 @@ auto ReifiedLinearEquality::s_expr(const ProofModel * const model) const -> SExp
                            .visit(_reif_cond);
 
     vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(cons)};
-    if (rei)
-        terms.push_back(*tracker.s_expr_term_of(_reif_cond));
+    if (rei) {
+        // A flipped iff stores the negated condition (the equality holds iff NOT
+        // the user's condition), but the not_equals_iff keyword already carries
+        // the negation: cake reads (r lin_not_equals_iff (cond) ...) as cond <=>
+        // sum != value. Emit the user's original condition, not the stored one,
+        // or the two negations cancel into the opposite constraint.
+        auto cond_to_write = _flipped_cond ? ReificationCondition{reif::Iff{! get<reif::Iff>(_reif_cond).cond}} : _reif_cond;
+        terms.push_back(*tracker.s_expr_term_of(cond_to_write));
+    }
 
     vector<SExpr> coeff_vars;
     for (const auto & [c, v] : _coeff_vars.terms) {

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -127,19 +127,25 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
             _proof_lines = pair{line, nullopt};
         }, //
         [&](const reif::If & cond) {
-            _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "lt", "ReifiedLinearInequality", "less than option",
+            // cake_pb_cp labels the half-reified inequality @c[<id>], with no role
+            // suffix, exactly like the unconditional form.
+            _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "", "ReifiedLinearInequality", "less than option",
                                     terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
                 nullopt};
         }, //
         [&](const reif::NotIf & cond) {
+            // s_expr throws on NotIf, so this form never reaches the cake chain and
+            // the invented role is fine.
             _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "ltn", "ReifiedLinearInequality", "less than option",
                                     terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
                 nullopt};
         }, //
         [&](const reif::Iff & cond) {
-            _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "lt", "ReifiedLinearInequality", "less than option",
+            // cake_pb_cp labels the iff halves r (cond -> ineq) and f (~cond -> its
+            // integer negation).
+            _proof_lines = pair{model.add_labelled_constraint(as_string(constraint_id()), "r", "ReifiedLinearInequality", "less than option",
                                     terms <= _value, HalfReifyOnConjunctionOf{cond.cond}),
-                model.add_labelled_constraint(as_string(constraint_id()), "gt", "ReifiedLinearInequality", "greater than option",
+                model.add_labelled_constraint(as_string(constraint_id()), "f", "ReifiedLinearInequality", "greater than option",
                     terms >= _value + 1_i, HalfReifyOnConjunctionOf{! cond.cond})};
         } //
     }

--- a/gcs/constraints/logical/logical.cc
+++ b/gcs/constraints/logical/logical.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/innards/cake_truthiness.hh>
 #include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/logical/hints.hh>
 #include <gcs/constraints/logical/logical.hh>
@@ -27,7 +28,10 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::move;
+using std::nullopt;
 using std::optional;
+using std::pair;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -176,6 +180,75 @@ namespace
             triggers);
     }
 
+    // The cake positive forms of a logical constraint's literals and its
+    // reification, as state-equivalent `>= 1` literals -- or empty / nullopt
+    // when some literal has no such form (see cake_truthiness.hh).
+    auto compute_cake_lits(const Literals & lits, const Literal & full_reif, const State & initial_state) -> pair<Literals, optional<Literal>>
+    {
+        auto bounds = [&](const SimpleIntegerVariableID & v) { return initial_state.bounds(v); };
+        auto reif_form = cake_positive_form(full_reif, bounds);
+        if (! reif_form)
+            return {};
+        Literals cake_lits;
+        for (const auto & l : lits) {
+            auto form = cake_positive_form(l, bounds);
+            if (! form)
+                return {};
+            cake_lits.push_back(cake_positive_literal(*form));
+        }
+        return {move(cake_lits), cake_positive_literal(*reif_form)};
+    }
+
+    // cake_pb_cp's and/or rows: @c[id][pos] says the reification implies the
+    // conjunction (and: all of them; or: at least one), @c[id][neg] the
+    // negation implies the negated disjunction. Uniform, with no
+    // statically-decided shortcuts, so the labelled rows' content matches
+    // cake's whatever the bounds.
+    auto define_cake_logical(ProofModel & model, const ConstraintID & id, const Literals & cake_lits, const Literal & cake_reif, bool is_and) -> void
+    {
+        auto n = Integer(static_cast<long long>(cake_lits.size()));
+        WPBSum pos, neg;
+        pos += (is_and ? -n : -1_i) * PseudoBooleanTerm{cake_reif};
+        neg += (is_and ? -1_i : -n) * PseudoBooleanTerm{! cake_reif};
+        for (const auto & l : cake_lits) {
+            pos += 1_i * PseudoBooleanTerm{l};
+            neg += 1_i * PseudoBooleanTerm{! l};
+        }
+        model.add_labelled_constraint(as_string(id), "pos", "Logical", "reif implies", move(pos) >= 0_i);
+        model.add_labelled_constraint(as_string(id), "neg", "Logical", "negated reif implies", move(neg) >= 0_i);
+    }
+
+    // The bare-operand `and` / `or` scp term when every literal conforms
+    // (recomputed from the tracker: this runs on the stored constraint, which
+    // never sees prepare()); the faithful `_lits` form otherwise, which cake
+    // skips and read_scp round-trips.
+    auto s_expr_logical(
+        const NamesAndIDsTracker & tracker, const ConstraintID & id, const string & op, const Literals & lits, const Literal & full_reif) -> SExpr
+    {
+        auto bounds = [&](const SimpleIntegerVariableID & v) { return tracker.tracked_bounds(v); };
+        vector<SExpr> terms;
+        bool conformable = static_cast<bool>(cake_positive_form(full_reif, bounds));
+        if (conformable)
+            for (const auto & lit : lits) {
+                auto form = cake_positive_form(lit, bounds);
+                if (! form) {
+                    conformable = false;
+                    break;
+                }
+                terms.push_back(tracker.s_expr_term_of(*form));
+            }
+        if (conformable) {
+            auto reif_form = cake_positive_form(full_reif, bounds);
+            return SExpr::list({SExpr::atom(as_string(id)), SExpr::atom(op), SExpr::list(move(terms)), tracker.s_expr_term_of(*reif_form)});
+        }
+
+        terms.clear();
+        for (const auto & lit : lits)
+            terms.push_back(faithful_literal_term(lit, tracker));
+        return SExpr::list(
+            {SExpr::atom(as_string(id)), SExpr::atom(op + "_lits"), SExpr::list(move(terms)), faithful_literal_term(full_reif, tracker)});
+    }
+
     auto define_proof_model_logical(ProofModel & model, const Literals & lits, const Literal & full_reif, LiteralIs reif_state) -> void
     {
         using enum LiteralIs;
@@ -245,27 +318,31 @@ auto And::install(Propagators & propagators, State & initial_state, ProofModel *
 auto And::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _reif_state = initial_state.test_literal(_full_reif);
+    std::tie(_cake_lits, _cake_reif) = compute_cake_lits(_lits, _full_reif, initial_state);
     return true;
 }
 
 auto And::define_proof_model(ProofModel & model) -> void
 {
-    define_proof_model_logical(model, _lits, _full_reif, _reif_state);
+    if (_cake_reif)
+        define_cake_logical(model, _constraint_id, _cake_lits, *_cake_reif, true);
+    else
+        define_proof_model_logical(model, _lits, _full_reif, _reif_state);
 }
 
 auto And::install_propagators(Propagators & propagators) -> void
 {
-    install_propagators_logical<hints::And>(propagators, constraint_id(), _lits, _full_reif, _reif_state);
+    // In cake terms when prepare() found positive forms, so the inferences'
+    // literals are the atoms the (cake-conform) encoding constrains.
+    if (_cake_reif)
+        install_propagators_logical<hints::And>(propagators, constraint_id(), _cake_lits, *_cake_reif, _reif_state);
+    else
+        install_propagators_logical<hints::And>(propagators, constraint_id(), _lits, _full_reif, _reif_state);
 }
 
 auto And::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    auto & tracker = model->names_and_ids_tracker();
-    std::vector<SExpr> lits;
-    for (const auto & lit : _lits)
-        lits.push_back(tracker.s_expr_term_of(lit));
-    return SExpr::list(
-        {SExpr::atom(as_string(_constraint_id)), SExpr::atom("and"), SExpr::list(std::move(lits)), tracker.s_expr_term_of(_full_reif)});
+    return s_expr_logical(model->names_and_ids_tracker(), _constraint_id, "and", _lits, _full_reif);
 }
 
 Or::Or(const vector<IntegerVariableID> & vars, const IntegerVariableID & full_reif) : Or(to_lits(vars), full_reif != 0_i)
@@ -299,11 +376,16 @@ auto Or::install(Propagators & propagators, State & initial_state, ProofModel * 
 auto Or::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _reif_state = initial_state.test_literal(! _full_reif);
+    std::tie(_cake_lits, _cake_reif) = compute_cake_lits(_lits, _full_reif, initial_state);
     return true;
 }
 
 auto Or::define_proof_model(ProofModel & model) -> void
 {
+    if (_cake_reif) {
+        define_cake_logical(model, _constraint_id, _cake_lits, *_cake_reif, false);
+        return;
+    }
     Literals lits = _lits;
     for (auto & l : lits)
         l = ! l;
@@ -312,17 +394,14 @@ auto Or::define_proof_model(ProofModel & model) -> void
 
 auto Or::install_propagators(Propagators & propagators) -> void
 {
-    Literals lits = _lits;
+    // As And: the dualised literals come from the cake forms when available.
+    Literals lits = _cake_reif ? _cake_lits : _lits;
     for (auto & l : lits)
         l = ! l;
-    install_propagators_logical<hints::Or>(propagators, constraint_id(), move(lits), ! _full_reif, _reif_state);
+    install_propagators_logical<hints::Or>(propagators, constraint_id(), move(lits), _cake_reif ? ! *_cake_reif : ! _full_reif, _reif_state);
 }
 
 auto Or::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
-    auto & tracker = model->names_and_ids_tracker();
-    std::vector<SExpr> lits;
-    for (const auto & lit : _lits)
-        lits.push_back(tracker.s_expr_term_of(lit));
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("or"), SExpr::list(std::move(lits)), tracker.s_expr_term_of(_full_reif)});
+    return s_expr_logical(model->names_and_ids_tracker(), _constraint_id, "or", _lits, _full_reif);
 }

--- a/gcs/constraints/logical/logical.hh
+++ b/gcs/constraints/logical/logical.hh
@@ -7,6 +7,7 @@
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
+#include <optional>
 #include <vector>
 
 namespace gcs
@@ -23,6 +24,14 @@ namespace gcs
         const innards::Literals _lits;
         const innards::Literal _full_reif;
         innards::LiteralIs _reif_state = innards::LiteralIs::Undecided;
+
+        // When every literal (and the reification) has a cake positive form
+        // (see cake_truthiness.hh), prepare() fills these with the
+        // state-equivalent `>= 1` literals; the encoding and the propagator
+        // then work in cake's terms, so the proof never touches atoms cake's
+        // OPB does not define. Empty / unset otherwise.
+        innards::Literals _cake_lits;
+        std::optional<innards::Literal> _cake_reif;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
@@ -54,6 +63,14 @@ namespace gcs
         const innards::Literals _lits;
         const innards::Literal _full_reif;
         innards::LiteralIs _reif_state = innards::LiteralIs::Undecided;
+
+        // When every literal (and the reification) has a cake positive form
+        // (see cake_truthiness.hh), prepare() fills these with the
+        // state-equivalent `>= 1` literals; the encoding and the propagator
+        // then work in cake's terms, so the proof never touches atoms cake's
+        // OPB does not define. Empty / unset otherwise.
+        innards::Literals _cake_lits;
+        std::optional<innards::Literal> _cake_reif;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;

--- a/gcs/constraints/parity/parity.cc
+++ b/gcs/constraints/parity/parity.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/innards/cake_truthiness.hh>
 #include <gcs/constraints/innards/triggers.hh>
 #include <gcs/constraints/parity/hints.hh>
 #include <gcs/constraints/parity/parity.hh>
@@ -9,6 +10,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
+#include <util/enumerate.hh>
 
 #include <optional>
 #include <sstream>
@@ -24,9 +26,12 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::move;
+using std::nullopt;
 using std::optional;
 using std::string;
 using std::stringstream;
+using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
@@ -72,8 +77,54 @@ auto ParityOdd::install(Propagators & propagators, State & initial_state, ProofM
     install_propagators(propagators);
 }
 
+auto ParityOdd::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    // If every literal has a cake positive form, work in those terms from here
+    // on (they are state-equivalent), so the encoding, the propagator's
+    // inferences, and the written scp all line up with cake_pb_cp's reading.
+    Literals cake_lits;
+    for (const auto & l : _lits) {
+        auto form = cake_positive_form(l, [&](const SimpleIntegerVariableID & v) { return initial_state.bounds(v); });
+        if (! form)
+            return true;
+        cake_lits.push_back(cake_positive_literal(*form));
+    }
+    _cake_lits = move(cake_lits);
+    return true;
+}
+
 auto ParityOdd::define_proof_model(ProofModel & model) -> void
 {
+    if (! _cake_lits.empty()) {
+        // cake_pb_cp's accumulator scheme: x[id][0] channels the parity bit
+        // (always the constant 1 here, which cake carries as its pinned-true
+        // n[1][ge1] atom; our rows fold it), x[id][k] = x[id][k-1] XOR the k'th
+        // literal via four labelled clauses, and the acc row pins the final
+        // accumulator to 0, i.e. 1 XOR (parity of the literals) = 0.
+        PseudoBooleanTerm acc = FalseLiteral{}, not_acc = TrueLiteral{};
+        auto x0 = model.create_proof_flag(_constraint_id, vector<long long>{0}, nullopt);
+        model.add_labelled_constraint(as_string(_constraint_id), "0ge", "ParityOdd", "seed", WPBSum{} + 1_i * TrueLiteral{} + -1_i * x0 >= 0_i);
+        model.add_labelled_constraint(as_string(_constraint_id), "0le", "ParityOdd", "seed", WPBSum{} + 1_i * x0 + -1_i * TrueLiteral{} >= 0_i);
+        acc = x0;
+        not_acc = ! x0;
+        for (const auto & [k, l] : enumerate(_cake_lits)) {
+            auto new_acc = model.create_proof_flag(_constraint_id, vector<long long>{static_cast<long long>(k) + 1}, nullopt);
+            auto stem = to_string(k + 1);
+            model.add_labelled_constraint(
+                as_string(_constraint_id), stem + "_0_0", "ParityOdd", "xor", WPBSum{} + 1_i * acc + 1_i * l + 1_i * ! new_acc >= 1_i);
+            model.add_labelled_constraint(
+                as_string(_constraint_id), stem + "_1_1", "ParityOdd", "xor", WPBSum{} + 1_i * not_acc + 1_i * ! l + 1_i * ! new_acc >= 1_i);
+            model.add_labelled_constraint(
+                as_string(_constraint_id), stem + "_1_0", "ParityOdd", "xor", WPBSum{} + 1_i * not_acc + 1_i * l + 1_i * new_acc >= 1_i);
+            model.add_labelled_constraint(
+                as_string(_constraint_id), stem + "_0_1", "ParityOdd", "xor", WPBSum{} + 1_i * acc + 1_i * ! l + 1_i * new_acc >= 1_i);
+            acc = new_acc;
+            not_acc = ! new_acc;
+        }
+        model.add_labelled_constraint(as_string(_constraint_id), "acc", "ParityOdd", "result", WPBSum{} + -1_i * acc >= 0_i);
+        return;
+    }
+
     PseudoBooleanTerm acc = FalseLiteral{}, not_acc = TrueLiteral{};
     for (const auto & l : _lits) {
         auto new_acc = model.create_proof_flag("xor");
@@ -91,13 +142,17 @@ auto ParityOdd::define_proof_model(ProofModel & model) -> void
 
 auto ParityOdd::install_propagators(Propagators & propagators) -> void
 {
+    // In cake terms when prepare() found positive forms, so the inferences'
+    // literals are the atoms the (cake-conform) encoding constrains.
+    const Literals & effective_lits = _cake_lits.empty() ? _lits : _cake_lits;
+
     Triggers triggers;
-    for (const auto & l : _lits)
+    for (const auto & l : effective_lits)
         add_trigger_for(triggers, l);
 
     propagators.install(
         constraint_id(),
-        [lits = _lits, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        [lits = effective_lits, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             long how_many_1 = 0, how_many_unknown = 0;
             optional<Literal> an_unknown;
             ReasonLiterals reason;
@@ -143,11 +198,28 @@ auto ParityOdd::s_expr(const innards::ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
 
-    // cake_pb_cp encodes parity as `parity (X1 ... Xn) Y` meaning Y = XOR(Xi).
-    // ParityOdd is the bare odd-parity assertion XOR(Xi) = 1, so we write the
-    // constant Y = 1 (1 = XOR(Xi) <-> XOR(Xi) = 1). The scp_reader requires Y = 1.
+    // cake_pb_cp encodes parity as `parity (X1 ... Xn) Y` meaning Y = XOR(Xi > 0).
+    // ParityOdd is the bare odd-parity assertion, so we write the constant
+    // Y = 1. That bare-operand form is only faithful when every literal has a
+    // cake positive form (this runs on the stored constraint, which never sees
+    // prepare(), so recompute from the tracker's recorded bounds); otherwise
+    // record the literals' real shapes under parity_lits, which cake skips and
+    // read_scp round-trips.
     std::vector<SExpr> lits;
+    bool conformable = true;
+    for (const auto & lit : _lits) {
+        auto form = cake_positive_form(lit, [&](const SimpleIntegerVariableID & v) { return tracker.tracked_bounds(v); });
+        if (! form) {
+            conformable = false;
+            break;
+        }
+        lits.push_back(tracker.s_expr_term_of(*form));
+    }
+    if (conformable)
+        return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("parity"), SExpr::list(std::move(lits)), SExpr::atom("1")});
+
+    lits.clear();
     for (const auto & lit : _lits)
-        lits.push_back(tracker.s_expr_term_of(lit));
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("parity"), SExpr::list(std::move(lits)), SExpr::atom("1")});
+        lits.push_back(faithful_literal_term(lit, tracker));
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("parity_lits"), SExpr::list(std::move(lits)), SExpr::atom("1")});
 }

--- a/gcs/constraints/parity/parity.hh
+++ b/gcs/constraints/parity/parity.hh
@@ -20,6 +20,12 @@ namespace gcs
     private:
         const innards::Literals _lits;
 
+        // When every literal has a cake positive form (see cake_truthiness.hh),
+        // prepare() fills this with the state-equivalent `>= 1` literals; the
+        // encoding and the propagator then work in cake's terms, so the proof
+        // never touches atoms cake's OPB does not define. Empty otherwise.
+        innards::Literals _cake_lits;
+
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
@@ -30,6 +36,7 @@ namespace gcs
         explicit ParityOdd(innards::Literals);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
     };

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -39,9 +39,12 @@ using namespace gcs::innards;
 using std::any_cast;
 using std::cmp_less;
 using std::ios;
+using std::max;
+using std::min;
 using std::move;
 using std::nullopt;
 using std::optional;
+using std::pair;
 using std::set;
 using std::string;
 using std::stringstream;
@@ -556,22 +559,58 @@ auto Regular::s_expr(const ProofModel * const model) const -> SExpr
     for (const auto & var : _vars)
         vars.push_back(tracker.s_expr_term_of(var));
 
+    // A regex-built Regular only compiles its automaton in prepare(), and
+    // prepare runs on the installed clone, never on the stored constraint this
+    // is called on -- so without compiling here too, the written .scp would
+    // describe an empty automaton rather than the constraint actually solved
+    // (issue #481). Rebuild the same alphabet prepare() uses: the contiguous
+    // min..max range over the variables' initial domains, whose extremes are
+    // exactly the bounds the tracker recorded at variable set-up.
+    long num_states = _num_states;
+    const auto * transitions = &_transitions;
+    const auto * final_states = &_final_states;
+    RegexNfa compiled{};
+    if (_regex && 0 == num_states) {
+        auto lo = Integer::max_value(), hi = Integer::min_value();
+        for (const auto & var : _vars) {
+            auto [l, u] = overloaded{[&](const SimpleIntegerVariableID & v) -> pair<Integer, Integer> { return tracker.tracked_bounds(v); },
+                [&](const ViewOfIntegerVariableID & v) -> pair<Integer, Integer> {
+                    auto [al, au] = tracker.tracked_bounds(v.actual_variable);
+                    if (v.negate_first)
+                        return {-au + v.then_add, -al + v.then_add};
+                    return {al + v.then_add, au + v.then_add};
+                },
+                [&](const ConstantIntegerVariableID & v) -> pair<Integer, Integer> {
+                    return {v.const_value, v.const_value};
+                }}.visit(var);
+            lo = min(lo, l);
+            hi = max(hi, u);
+        }
+        vector<Integer> alphabet;
+        for (auto val = lo; val <= hi; ++val)
+            alphabet.push_back(val);
+        compiled = regex_to_nfa(*_regex, alphabet);
+        num_states = compiled.num_states;
+        transitions = &compiled.transitions;
+        final_states = &compiled.final_states;
+    }
+
     // One edge list per state, in state order: position i holds the edges out of
     // state i, and each edge is (symbol target) -- reading `symbol` moves from
     // state i to state `target`. This is the shape cake_pb_cp's regular parser
     // expects: `(vars...) nstates ((edges-of-0) (edges-of-1) ...) (finals...)`,
     // with no separate alphabet list (cake recovers the symbols from the edges).
     // A non-deterministic automaton emits several edges with the same symbol.
-    // _transitions[i] is an unordered_map, so collect the (symbol, target) pairs
+    // The transitions are unordered_maps, so collect the (symbol, target) pairs
     // and sort them: the written .scp must be byte-stable across standard
     // libraries (hash iteration order is not portable, which breaks the
     // write -> read -> write round-trip), and a canonical order does that.
     vector<SExpr> states;
-    for (long i = 0; i < _num_states; ++i) {
+    for (long i = 0; i < num_states; ++i) {
         vector<SExpr> edges;
-        if (static_cast<size_t>(i) < _transitions.size()) {
-            vector<std::pair<Integer, long>> sorted_edges;
-            for (const auto & tran : _transitions[i])
+        if (static_cast<size_t>(i) < transitions->size()) {
+            vector<pair<Integer, long>> sorted_edges;
+            for (const auto & tran : (*transitions)[i])
                 for (const auto & target : tran.second)
                     sorted_edges.emplace_back(tran.first, target);
             sort(sorted_edges);
@@ -582,9 +621,9 @@ auto Regular::s_expr(const ProofModel * const model) const -> SExpr
     }
 
     vector<SExpr> finals;
-    for (const auto & f : _final_states)
+    for (const auto & f : *final_states)
         finals.push_back(SExpr::atom(std::to_string(f)));
 
     return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom("regular"), SExpr::list(move(vars)),
-        SExpr::atom(std::to_string(_num_states)), SExpr::list(move(states)), SExpr::list(move(finals))});
+        SExpr::atom(std::to_string(num_states)), SExpr::list(move(states)), SExpr::list(move(finals))});
 }

--- a/gcs/innards/proofs/bits_encoding.cc
+++ b/gcs/innards/proofs/bits_encoding.cc
@@ -21,9 +21,16 @@ auto gcs::innards::get_bits_encoding_coeffs(Integer lower, Integer upper) -> tup
     // bits rather than one). The negative side is covered by abs(lower) - 1,
     // since the sign bit contributes -2^(shift+1). This matches the tight u+1
     // two's-complement width (Step 5 of Matthew's thesis).
-    Integer highest_abs_value = max({abs(lower) - 1_i, upper, 1_i});
+    //
+    // Step 5's "least strictly positive h" floor belongs to the non-negative
+    // branch only: a negative-capable variable always carries its sign bit, so
+    // the thesis width for {-1} and {-1,0} has *zero* magnitude bits (the value
+    // is -1 * sign). Flooring those to one magnitude bit is what cake_pb_cp
+    // calls out as a divergent encoding (issue #478). Every variable still has
+    // at least one atom: the sign bit when lower < 0, a magnitude bit otherwise.
+    Integer highest_abs_value = lower < 0_i ? max(abs(lower) - 1_i, upper) : max(upper, 1_i);
     Integer highest_bit_shift = Integer{bit_width(static_cast<unsigned long long>(highest_abs_value.raw_value))} - 1_i;
-    Integer highest_bit_coeff = power2(highest_bit_shift);
-    auto negative_bit_coeff = lower < 0_i ? (-highest_bit_coeff * 2_i) : 0_i;
+    Integer highest_bit_coeff = highest_bit_shift >= 0_i ? power2(highest_bit_shift) : 0_i;
+    auto negative_bit_coeff = lower < 0_i ? -power2(highest_bit_shift + 1_i) : 0_i;
     return tuple{highest_bit_shift, highest_bit_coeff, negative_bit_coeff};
 }

--- a/gcs/innards/proofs/bits_encoding.cc
+++ b/gcs/innards/proofs/bits_encoding.cc
@@ -22,13 +22,16 @@ auto gcs::innards::get_bits_encoding_coeffs(Integer lower, Integer upper) -> tup
     // since the sign bit contributes -2^(shift+1). This matches the tight u+1
     // two's-complement width (Step 5 of Matthew's thesis).
     //
-    // Step 5's "least strictly positive h" floor belongs to the non-negative
-    // branch only: a negative-capable variable always carries its sign bit, so
-    // the thesis width for {-1} and {-1,0} has *zero* magnitude bits (the value
-    // is -1 * sign). Flooring those to one magnitude bit is what cake_pb_cp
-    // calls out as a divergent encoding (issue #478). Every variable still has
-    // at least one atom: the sign bit when lower < 0, a magnitude bit otherwise.
-    Integer highest_abs_value = lower < 0_i ? max(abs(lower) - 1_i, upper) : max(upper, 1_i);
+    // No magnitude bits are allocated unless they can reach a value the domain
+    // contains: {-1} and {-1,0} are just the sign bit (the value is -1 * sign),
+    // and {0} is the *empty* sum, identically zero, with no atoms at all -- its
+    // bound rows print with an empty left-hand side, which veripb parses (since
+    // the 2026-07-10 labelled-empty-LHS fix) and every ge/eq atom over it is a
+    // pinned constant. This conforms to cake_pb_cp's width rule (issue #478);
+    // the thesis's "least strictly positive h" floor (eq. 3.21) would instead
+    // give {0} one magnitude bit, a divergence cake upstream asked us to drop
+    // in preference to adding the floor to cake.
+    Integer highest_abs_value = lower < 0_i ? max(abs(lower) - 1_i, upper) : upper;
     Integer highest_bit_shift = Integer{bit_width(static_cast<unsigned long long>(highest_abs_value.raw_value))} - 1_i;
     Integer highest_bit_coeff = highest_bit_shift >= 0_i ? power2(highest_bit_shift) : 0_i;
     auto negative_bit_coeff = lower < 0_i ? -power2(highest_bit_shift + 1_i) : 0_i;

--- a/gcs/innards/proofs/bits_encoding.cc
+++ b/gcs/innards/proofs/bits_encoding.cc
@@ -14,7 +14,14 @@ using std::tuple;
 
 auto gcs::innards::get_bits_encoding_coeffs(Integer lower, Integer upper) -> tuple<Integer, Integer, Integer>
 {
-    Integer highest_abs_value = max({abs(lower) - 1_i, abs(upper), 1_i});
+    // The positive side needs enough magnitude bits to reach `upper` -- which is
+    // no constraint at all for a wholly-negative domain, so use the *signed*
+    // upper, not abs(upper). Using abs(upper) over-allocates a magnitude bit for
+    // negative singletons at powers of two (e.g. {-2} would get two magnitude
+    // bits rather than one). The negative side is covered by abs(lower) - 1,
+    // since the sign bit contributes -2^(shift+1). This matches the tight u+1
+    // two's-complement width (Step 5 of Matthew's thesis).
+    Integer highest_abs_value = max({abs(lower) - 1_i, upper, 1_i});
     Integer highest_bit_shift = Integer{bit_width(static_cast<unsigned long long>(highest_abs_value.raw_value))} - 1_i;
     Integer highest_bit_coeff = power2(highest_bit_shift);
     auto negative_bit_coeff = lower < 0_i ? (-highest_bit_coeff * 2_i) : 0_i;

--- a/gcs/innards/proofs/bits_encoding_test.cc
+++ b/gcs/innards/proofs/bits_encoding_test.cc
@@ -22,7 +22,11 @@ TEST_CASE("Bit encodings")
 
     CHECK(get_bits_encoding_coeffs(1_i, 9_i) == tuple{3_i, 8_i, 0_i});
 
-    CHECK(get_bits_encoding_coeffs(-1_i, 0_i) == tuple{0_i, 1_i, -2_i});
+    // {-1} and {-1,0} need no magnitude bits: the value is -1 * sign (the
+    // thesis's strictly-positive-h floor applies to non-negative ranges only).
+    CHECK(get_bits_encoding_coeffs(-1_i, -1_i) == tuple{-1_i, 0_i, -1_i});
+    CHECK(get_bits_encoding_coeffs(-1_i, 0_i) == tuple{-1_i, 0_i, -1_i});
+    CHECK(get_bits_encoding_coeffs(-2_i, -1_i) == tuple{0_i, 1_i, -2_i});
     CHECK(get_bits_encoding_coeffs(-2_i, 0_i) == tuple{0_i, 1_i, -2_i});
     CHECK(get_bits_encoding_coeffs(-3_i, 0_i) == tuple{1_i, 2_i, -4_i});
 

--- a/gcs/innards/proofs/bits_encoding_test.cc
+++ b/gcs/innards/proofs/bits_encoding_test.cc
@@ -10,6 +10,10 @@ using std::tuple;
 
 TEST_CASE("Bit encodings")
 {
+    // {0} has no atoms at all: the empty bit-sum is identically zero (cake's
+    // width rule; the thesis's strictly-positive-h floor would give one bit).
+    CHECK(get_bits_encoding_coeffs(0_i, 0_i) == tuple{-1_i, 0_i, 0_i});
+
     CHECK(get_bits_encoding_coeffs(0_i, 1_i) == tuple{0_i, 1_i, 0_i});
     CHECK(get_bits_encoding_coeffs(0_i, 2_i) == tuple{1_i, 2_i, 0_i});
     CHECK(get_bits_encoding_coeffs(0_i, 3_i) == tuple{1_i, 2_i, 0_i});

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1391,6 +1391,11 @@ auto NamesAndIDsTracker::track_bounds(const SimpleOrProofOnlyIntegerVariableID &
     _imp->integer_variable_definition_bounds.emplace(id, pair{lower, upper});
 }
 
+auto NamesAndIDsTracker::tracked_bounds(const SimpleOrProofOnlyIntegerVariableID & id) const -> pair<Integer, Integer>
+{
+    return _imp->integer_variable_definition_bounds.at(id);
+}
+
 auto NamesAndIDsTracker::note_bounds_not_trivially_derivable(const SimpleOrProofOnlyIntegerVariableID & id) -> void
 {
     _imp->bounds_not_trivially_derivable.insert(id);

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1468,6 +1468,14 @@ auto NamesAndIDsTracker::create_proof_flag_values(const ConstraintID & id, const
     return make_proof_flag_named(name);
 }
 
+auto NamesAndIDsTracker::create_proof_flag_for_constant(Integer k, const string & atom) -> ProofFlag
+{
+    // Mirror cake_pb_cp's constant-atom rendering (cp_encScript.sml format_var,
+    // Ge/Eq over a constant): n[<k>][<atom>], the constant rendered with a
+    // leading '-' when negative, exactly like the eq/ge literal values.
+    return make_proof_flag_named("n[" + to_string(k.raw_value) + "][" + atom + "]");
+}
+
 auto NamesAndIDsTracker::make_proof_flag_named(const string & full_name) -> ProofFlag
 {
     // The supplied name is used verbatim as the PB-file variable name (rather

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -496,6 +496,16 @@ namespace gcs::innards
             const std::optional<std::string> & annotation = std::nullopt) -> ProofFlag;
 
         /**
+         * Create a flag named `n[k][atom]`, conforming to cake_pb_cp's rendering
+         * of a reified atom over a CONSTANT operand (cp_encScript.sml format_var
+         * for `Ge`/`Eq` over a constant): e.g. `n[3][ge0]`, `n[-2][eq0]`. cake
+         * reifies every operand's atoms uniformly, so a constant slot's atoms
+         * exist by name, pinned to their truth values; the pin rows are the
+         * ProofModel's job (cake_constant_atoms). See issue #483.
+         */
+        [[nodiscard]] auto create_proof_flag_for_constant(Integer k, const std::string & atom) -> ProofFlag;
+
+        /**
          * Reify a PB constraint on a conjunction of ProofFlags or ProofLiterals
          */
         [[nodiscard]] auto reify(const WPBSumLE &, const HalfReifyOnConjunctionOf &) -> WPBSumLE;

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -409,6 +409,14 @@ namespace gcs::innards
         auto track_bounds(const SimpleOrProofOnlyIntegerVariableID & id, Integer, Integer) -> void;
 
         /**
+         * The bounds recorded by track_bounds. For a model variable these are its
+         * initial-domain bounds, letting a constraint's s_expr recover
+         * domain-derived data (e.g. Regular's regex alphabet) at scp-writing
+         * time, when no State is in reach.
+         */
+        [[nodiscard]] auto tracked_bounds(const SimpleOrProofOnlyIntegerVariableID & id) const -> std::pair<Integer, Integer>;
+
+        /**
          * Note that this variable's [lo, hi] bounds are not a trivial consequence of
          * the OPB (cake emits no bound line for it, and its bounds are only entailed
          * through conditional channels), so need_gevar must not pin its boundary order

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -672,6 +672,16 @@ auto ProofLogger::introduce_bits_of(
     // redundancy goal closes by RUP, and the final (k = 0) pair is
     // BinEnc(target) >= form (end_ge) / BinEnc(target) <= form (end_le).
     auto m = names_and_ids_tracker().num_bits(target).raw_value;
+
+    // A [0, 0] target now has zero bits (the empty sum, identically zero), for
+    // which the construction below would return default-constructed lines. No
+    // caller can currently supply one (every end proxy spans [0, t_hi + 1]),
+    // and the degenerate pair it would need (`form <= 0` / `form >= 0`, RUP
+    // from the operands' bound rows) should be written and tested when a real
+    // caller appears, not speculatively.
+    if (0 == m)
+        throw ProofError{"introduce_bits_of does not support a zero-width target"};
+
     pair<ProofLine, ProofLine> bounds;
     SumOf<Weighted<PseudoBooleanTerm>> bitsum; // Sigma_{j > k} 2^j e_j, grows as k descends
     for (long long kk = m - 1; kk >= 0; --kk) {

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -14,6 +14,7 @@
 #include <exception>
 #include <fstream>
 #include <iterator>
+#include <map>
 #include <set>
 #include <sstream>
 
@@ -36,6 +37,7 @@ using std::ios;
 using std::ios_base;
 using std::istreambuf_iterator;
 using std::make_unique;
+using std::map;
 using std::nullopt;
 using std::ofstream;
 using std::optional;
@@ -65,6 +67,8 @@ struct ProofModel::Imp
     optional<IntegerVariableID> optional_minimise_variable;
     optional<vector<IntegerVariableID>> preserved_variables;
     unsigned long long proof_only_integer_variable_nr = 0;
+
+    map<Integer, ProofModel::CakeConstantAtoms> cake_constant_atoms;
 
     string opb_file;
     stringstream opb;
@@ -601,6 +605,34 @@ auto ProofModel::create_proof_flag(const ConstraintID & id, const string & annot
 auto ProofModel::create_proof_flag_values(const ConstraintID & id, const vector<long long> & values, const optional<string> & annotation) -> ProofFlag
 {
     return names_and_ids_tracker().create_proof_flag_values(id, values, annotation);
+}
+
+auto ProofModel::cake_constant_atoms(Integer k) -> CakeConstantAtoms
+{
+    if (auto it = _imp->cake_constant_atoms.find(k); it != _imp->cake_constant_atoms.end())
+        return it->second;
+
+    auto base = "n[" + std::to_string(k.raw_value) + "]";
+    auto ge0 = names_and_ids_tracker().create_proof_flag_for_constant(k, "ge0");
+    auto ge1 = names_and_ids_tracker().create_proof_flag_for_constant(k, "ge1");
+    auto eq0 = names_and_ids_tracker().create_proof_flag_for_constant(k, "eq0");
+
+    // A ge atom's [f] half pins a true atom and is vacuous for a false one; the
+    // [r] half is the mirror image. cake writes each vacuous half with a zero
+    // coefficient; a unit coefficient over a degree-0 row is the same vacuous
+    // truth without leaning on zero-coefficient parsing.
+    auto pin = [&](const string & atom_base, const ProofFlag & atom, bool truth) {
+        add_labelled_constraint(atom_base + "[f]", WPBSum{} + 1_i * atom >= (truth ? 1_i : 0_i));
+        add_labelled_constraint(atom_base + "[r]", WPBSum{} + 1_i * ! atom >= (truth ? 0_i : 1_i));
+    };
+    pin(base + "[ge0]", ge0, k >= 0_i);
+    pin(base + "[ge1]", ge1, k >= 1_i);
+    add_labelled_constraint(base + "[eq0][f]", WPBSum{} + 1_i * eq0 + -1_i * ge0 + -1_i * ! ge1 >= -1_i);
+    add_labelled_constraint(base + "[eq0][r]", WPBSum{} + 2_i * ! eq0 + 1_i * ge0 + 1_i * ! ge1 >= 2_i);
+
+    auto result = CakeConstantAtoms{ge0, ge1, eq0};
+    _imp->cake_constant_atoms.emplace(k, result);
+    return result;
 }
 
 auto ProofModel::finalise() -> void

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -278,6 +278,27 @@ namespace gcs::innards
         [[nodiscard]] auto create_proof_flag(const std::string & stem) -> ProofFlag;
 
         /**
+         * cake_pb_cp reifies every integer operand's sign atoms uniformly, so a
+         * constant operand k carries the same ge0/ge1/eq0 atom family as a
+         * variable, named `n[k][ge0]` / `n[k][ge1]` / `n[k][eq0]`, with each ge
+         * atom pinned to its truth value by its `@n[k][geN][f]` / `[r]` rows and
+         * eq0 defined from the ge pair exactly as for a variable. See issue #483.
+         */
+        struct CakeConstantAtoms
+        {
+            ProofFlag ge0;
+            ProofFlag ge1;
+            ProofFlag eq0;
+        };
+
+        /**
+         * The pinned atom family for a constant operand, emitting the flags and
+         * their pin rows on a constant's first use and returning the same flags
+         * for every later use (the names are global to the model, like cake's).
+         */
+        [[nodiscard]] auto cake_constant_atoms(Integer) -> CakeConstantAtoms;
+
+        /**
          * Create a position-indexed flag named `x[id][i1_i2..][annotation?]`,
          * conforming to cake_pb_cp's naming for verified encodings. See
          * NamesAndIDsTracker::create_proof_flag(const ConstraintID &, const std::vector<long long> &, ...).

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -164,6 +164,29 @@ namespace
         throw ScpReadError{"unknown reification-condition operator '" + op + "'"};
     }
 
+    // A faithful literal term, as the logical constraints' `_lits` forms write
+    // them: the atoms 1 / 0 for the static literals, or a (variable op value)
+    // triple. See faithful_literal_term in cake_truthiness.
+    auto resolve_literal(const map<string, IntegerVariableID> & variables, const SExpr & term) -> innards::Literal
+    {
+        if (term.is_atom()) {
+            if (term.as_atom() == "1")
+                return innards::TrueLiteral{};
+            if (term.as_atom() == "0")
+                return innards::FalseLiteral{};
+            throw ScpReadError{"a literal must be 1, 0, or a (variable op value) triple"};
+        }
+        return resolve_condition(variables, term);
+    }
+
+    auto resolve_literal_list(const map<string, IntegerVariableID> & variables, const SExpr & list_term, const string & what) -> innards::Literals
+    {
+        innards::Literals result;
+        for (const auto & t : children_of(list_term, what.c_str()))
+            result.push_back(resolve_literal(variables, t));
+        return result;
+    }
+
     // For the equals-style families (equals / not_equals and their lin_
     // counterparts): map a keyword's reification suffix to a (condition, flipped)
     // pair. `flipped` is the cosmetic not-equals-iff flag (ReifiedEquals::_neq /
@@ -800,6 +823,28 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
             if (as_integer(terms[3]) != Integer{1})
                 throw ScpReadError{"parity Y must be the constant 1 (only bare odd parity is supported)"};
             post_constraint(problem, ParityOdd{resolve_variable_list(variables, terms[2], "the parity variable list")}, label);
+        }
+        else if (op == "and_lits" || op == "or_lits" || op == "parity_lits") {
+            // The literal-shaped forms the solver writes when a logical
+            // constraint's literals have no cake positive form (negations,
+            // shifted comparisons, non-zero tests over negative-capable
+            // domains). cake_pb_cp has no such terms -- these exist for
+            // faithful round-trips, not for the verified-encoding chain.
+            if (terms.size() != 4)
+                throw ScpReadError{op + " takes (label " + op + " (literals...) reif-literal)"};
+            auto lits = resolve_literal_list(variables, terms[2], "the " + op + " literal list");
+            if (op == "parity_lits") {
+                if (as_integer(terms[3]) != Integer{1})
+                    throw ScpReadError{"parity_lits Y must be the constant 1 (only bare odd parity is supported)"};
+                post_constraint(problem, ParityOdd{move(lits)}, label);
+            }
+            else {
+                auto reif = resolve_literal(variables, terms[3]);
+                if (op == "and_lits")
+                    post_constraint(problem, And{move(lits), reif}, label);
+                else
+                    post_constraint(problem, Or{move(lits), reif}, label);
+            }
         }
         else if (op == "plus") {
             // (label plus a b result): a + b = result.

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -172,8 +172,15 @@ namespace
     auto equality_reification(bool not_equals, bool iff, bool half, const map<string, IntegerVariableID> & variables, const SExpr & cond_term)
         -> std::pair<ReificationCondition, bool>
     {
+        // The not_equals_iff keyword carries the negation (cond <=> operands
+        // differ), and the flipped representation stores the equality's
+        // condition, so reading one means negating the written condition --
+        // mirroring the writers, which un-negate the stored condition. The
+        // half-reified NotIf stores the condition as written.
         if (iff)
-            return {ReificationCondition{reif::Iff{resolve_condition(variables, cond_term)}}, not_equals};
+            return {not_equals ? ReificationCondition{reif::Iff{! resolve_condition(variables, cond_term)}}
+                               : ReificationCondition{reif::Iff{resolve_condition(variables, cond_term)}},
+                not_equals};
         if (half)
             return {not_equals ? ReificationCondition{reif::NotIf{resolve_condition(variables, cond_term)}}
                                : ReificationCondition{reif::If{resolve_condition(variables, cond_term)}},

--- a/gcs/variable_id.cc
+++ b/gcs/variable_id.cc
@@ -8,11 +8,18 @@ using std::string;
 
 auto gcs::operator+(IntegerVariableID v, Integer o) -> IntegerVariableID
 {
+    // An offset of zero is the identity: return the variable itself rather than
+    // a do-nothing view, mirroring the constant-folding in the other branches.
     return overloaded{
-        [&](const SimpleIntegerVariableID & v) -> IntegerVariableID { return ViewOfIntegerVariableID{v, false, o}; },           //
+        [&](const SimpleIntegerVariableID & v) -> IntegerVariableID {
+            return o == 0_i ? IntegerVariableID{v} : IntegerVariableID{ViewOfIntegerVariableID{v, false, o}};
+        },                                                                                                                      //
         [&](const ConstantIntegerVariableID & v) -> IntegerVariableID { return ConstantIntegerVariableID{v.const_value + o}; }, //
         [&](const ViewOfIntegerVariableID & v) -> IntegerVariableID {
-            return ViewOfIntegerVariableID{v.actual_variable, v.negate_first, v.then_add + o};
+            auto then_add = v.then_add + o;
+            if (! v.negate_first && then_add == 0_i)
+                return v.actual_variable;
+            return ViewOfIntegerVariableID{v.actual_variable, v.negate_first, then_add};
         } //
     }
         .visit(v);


### PR DESCRIPTION
Everything from the cake_pb_cp validation effort, as one reviewable series: the measurement probe plus all the encoding-conformance fixes it surfaced (#478–#485). Rebased onto current main; each commit is one concern and carries its own validation notes.

## What's in here

**The probe** (first commit): an opt-in `GCS_TEST_CAKE` hook in the constraint-test verify path that runs the full workflow-2 chain per proving instance (cake_pb_cp re-derives its own OPB from the `.scp` → veripb elaborates *our* proof against *cake's* OPB → cake_pb_cp re-checks the elaborated core) and logs a greppable `CAKECHAIN` outcome line. Measurement only — it never fails a test and costs nothing when the env var is unset. Also fixes the pre-existing `.scp`/`.varmap` cleanup leak.

**The fixes**, in commit order:

| Commit | Issue | What was wrong |
|---|---|---|
| identity `(v + 0)` view | — | `v + 0_i` built a do-nothing view that serialised as `(v + 0)`, which cake rejects at a var/const position; now collapses to the bare variable |
| signed-upper width | — | `abs(upper)` over-allocated a magnitude bit for negative singletons at powers of two ({-2} got two bits); tight u+1 width per the thesis, cake, and Matthew's brain encoder |
| {-1}/{-1,0} sign-only | #478 | the strictly-positive-h floor was applied to negative-capable domains too; those are just the sign bit |
| reified linear labels + ne_iff | #479 | invented `[lt]`/`[gt]` label roles cake never assigns; and the not_equals_iff scp writer emitted the *stored* (negated) condition under a keyword that itself negates — the scp described the opposite constraint |
| AllDifferentExcept | #480 | encodes from the original exception list rather than the sanitised copy (removes a shortcut special case; propagator still uses the sanitised list) |
| Regular s_expr | #481 | the scp wrote an *empty* automaton (prepare() runs on the installed clone, s_expr on the pristine original); the automaton is now compiled on demand |
| Disjunctive zw escape | #482 | cake adds the zero-length escape to the separation clause for *every* variable duration; we gated on lb == 0, so the label-cited clause had different membership |
| Parity/And/Or truthiness | #484/#485 | operands conformable to cake's `> 0` reading are swapped to positive form; non-conformable literals (e.g. fzn `bool_clause`'s `v == 0`) get faithful `and_lits`/`or_lits`/`parity_lits` scp forms that cake skips honestly instead of silently reinterpreting |
| Divide/Modulus constants | #483 | constant divisor/quotient fell to a legacy linear path with a materialised aux; deleted — constants now go through the uniform cake product decomposition via pinned `n[k]` atoms |
| {0} = zero atoms | #478 | the experiment cake upstream asked for: drop the thesis floor so a [0,0] domain is the empty bit-sum. Nothing breaks, no propagator special cases needed |

## What is and isn't fixed

**Fixed and chain-verifying** (final sweep: 12389 OK across 3 seed-repeats, all constraints/modes): every filed issue #478–#485. Small domains ({0}, {-1}, {-1,0}), reified linear/comparison, aliased operands, regex Regular, variable-duration disjunctive (1d and 2d), parity/and/or over conformable operands, div/mod with constant operands including `divide a b 0`.

**Not fixed, by design (waiting on cake upstream):**
- `bool_clause` and other non-conformable logical operands emit faithful `_lits` scp forms that cake *skips* — they become verified once cake ships its planned list-of-reification-terms operands.
- Views are honest `SKIP_NO_OPB` (cake has no view concept).

**Not fixed, now filed separately** (the only remaining FAIL_ELABs, 61 across the sweep; all pre-date this series):
- **in over variable lists** (#487, 34): our `f[N]` flag scaffolding vs cake's `x[id][k][ge/le/eq]` + `al1` — never conformed.
- **Regular with domain ⊊ alphabet** (#489, 18): we emit eq/ge rows for out-of-domain values past cake's ub+1 cutoff.
- **n_value occurs-flags** (#488, 9): our per-value row membership vs cake's whole-union rows, RUP-weaker at partial states.

**Requirements note:** the {0} zero-atom encoding writes bound rows with an empty left-hand side, so proof verification needs a veripb with the labelled-empty-LHS parser fix (2026-07-10).

## Testing

- ctest 494/494: three rounds on the probe branch, one on this rebased branch (fresh random seeds each).
- Full cake-chain sweep on the identical tree: 12389 OK / 61 FAIL_ELAB (the three unfiled buckets above only) / 354 SKIP_NO_OPB.
- Post-rebase spot sweep (divide_modulus, multiply, sort, arg_sort, parity, logical, abs, comparison lt_iff, equals): 813 OK / 0 FAIL.
- Deterministic {0} probes passing the full chain: a real {0} variable through multiply's product grid, a {0} divisor (UNSAT proof), a {0} dividend through modulus, a disjunctive task with {0} start and {0} variable length, and `divide a b 0` (#483's former residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tc9UsttXJpDviZddAKdPQx
