### PR TITLE
Annotate public API lifetime contracts for clang lifetime analysis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,11 @@ AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
+AttributeMacros: [GCS_LIFETIME_BOUND, GCS_GSL_POINTER]
 BinPackArguments: true
+Macros:
+  - GCS_LIFETIME_BOUND=[[clang::lifetimebound]]
+  - GCS_GSL_POINTER=[[gsl::Pointer]]
 BinPackParameters: true
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,13 +9,24 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }}${{ matrix.cxx && format(' ({0})', matrix.cxx) || '' }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, ubuntu-26.04, macos-15, macos-26 ]
+        # The Ubuntu lanes with caps: OFF build with the runner's default GCC
+        # and turn the constraint-test runtime caps off so they do
+        # full-enumeration completeness checking. The clang lane covers the
+        # clang + libstdc++ toolchain (including the clang-only lifetime
+        # annotation probe tests) and keeps the (faster) capped defaults, as
+        # do the macOS lanes, which build with Apple Clang + libc++.
+        include:
+          - { os: ubuntu-24.04, caps: 'OFF' }
+          - { os: ubuntu-26.04, caps: 'OFF' }
+          - { os: ubuntu-26.04, cc: clang, cxx: clang++ }
+          - { os: macos-15 }
+          - { os: macos-26 }
 
     steps:
     - name: Checkout
@@ -48,11 +59,19 @@ jobs:
         dirname "$mzn" >> "$GITHUB_PATH"
         "$mzn" --version
 
+    - name: Install clang
+      # Don't rely on the runner image preinstalling a particular clang; the
+      # distro package is the version this lane is meant to cover.
+      if: matrix.cxx == 'clang++'
+      run: sudo apt-get update && sudo apt-get install -y clang
+
     - name: Configure CMake
-      # Turn the constraint-test runtime caps off on the Ubuntu release runners
-      # so they do full-enumeration completeness checking; the macOS runners
-      # keep the (faster) capped defaults.
-      run: cmake --preset release -B ${{github.workspace}}/build ${{ startsWith(matrix.os, 'ubuntu') && '-DGCS_TEST_CAP_DEFAULTS=OFF' || '' }}
+      # An empty CC/CXX is ignored by CMake's compiler detection, so the
+      # default-compiler lanes are unaffected.
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+      run: cmake --preset release -B ${{github.workspace}}/build ${{ matrix.caps == 'OFF' && '-DGCS_TEST_CAP_DEFAULTS=OFF' || '' }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -151,6 +151,35 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(array_param_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME array_param_test COMMAND $<TARGET_FILE:array_param_test>)
 
+    # The lifetime annotations in gcs/lifetime.hh only expand to anything under
+    # clang, so these probes are clang-only. Each dangling_*.cc probe contains a
+    # lifetime misuse that the annotations must turn into a -Wdangling
+    # diagnostic, promoted to an error here: the test builds the probe and
+    # passes only if the output contains that diagnostic, so it fails both if
+    # an annotation stops working and if a probe breaks for some other reason.
+    # valid_uses.cc holds the corrected twins and must build cleanly under the
+    # same flags. The RESOURCE_LOCK stops parallel ctest from running several
+    # builds of this tree at once.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        add_library(lifetime_annotation_valid_uses OBJECT EXCLUDE_FROM_ALL lifetime_annotation_tests/valid_uses.cc)
+        target_link_libraries(lifetime_annotation_valid_uses PRIVATE glasgow_constraint_solver)
+        target_compile_options(lifetime_annotation_valid_uses PRIVATE -Werror=dangling -Werror=dangling-gsl)
+        add_test(NAME lifetime_annotation_valid_uses
+                COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target lifetime_annotation_valid_uses --config $<CONFIG>)
+        set_tests_properties(lifetime_annotation_valid_uses PROPERTIES RESOURCE_LOCK lifetime_annotation_build)
+
+        foreach(probe dangling_array_param_deref dangling_all_normal_variables dangling_create_integer_variable)
+            add_library(lifetime_annotation_${probe} OBJECT EXCLUDE_FROM_ALL lifetime_annotation_tests/${probe}.cc)
+            target_link_libraries(lifetime_annotation_${probe} PRIVATE glasgow_constraint_solver)
+            target_compile_options(lifetime_annotation_${probe} PRIVATE -Werror=dangling -Werror=dangling-gsl)
+            add_test(NAME lifetime_annotation_${probe}
+                    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target lifetime_annotation_${probe} --config $<CONFIG>)
+            set_tests_properties(lifetime_annotation_${probe} PROPERTIES
+                    PASS_REGULAR_EXPRESSION "-Wdangling"
+                    RESOURCE_LOCK lifetime_annotation_build)
+        endforeach()
+    endif()
+
     add_executable(abs_test constraints/abs/abs_test.cc)
     add_executable(all_different_test constraints/all_different/all_different_test.cc)
     add_executable(all_different_except_test constraints/all_different/all_different_except_test.cc)

--- a/gcs/array_param.hh
+++ b/gcs/array_param.hh
@@ -1,6 +1,8 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ARRAY_PARAM_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_ARRAY_PARAM_HH
 
+#include <gcs/lifetime.hh>
+
 #include <initializer_list>
 #include <memory>
 #include <utility>
@@ -47,16 +49,16 @@ namespace gcs
         {
         }
 
-        ArrayParam(const C_ * borrowed) : _data(std::shared_ptr<const C_>{}, borrowed)
+        ArrayParam(const C_ * borrowed GCS_LIFETIME_BOUND) : _data(std::shared_ptr<const C_>{}, borrowed)
         {
         }
 
-        [[nodiscard]] auto operator*() const -> const C_ &
+        [[nodiscard]] auto operator*() const GCS_LIFETIME_BOUND -> const C_ &
         {
             return *_data;
         }
 
-        [[nodiscard]] auto operator->() const -> const C_ *
+        [[nodiscard]] auto operator->() const GCS_LIFETIME_BOUND -> const C_ *
         {
             return _data.get();
         }

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -6,6 +6,7 @@
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/s_expr-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
+#include <gcs/lifetime.hh>
 
 #include <memory>
 #include <string>
@@ -51,7 +52,7 @@ namespace gcs
          * name --- as set by Problem::post() / Problem::post_named(). This is the
          * identity, not the type (e.g. `abs`); see ConstraintID.
          */
-        [[nodiscard]] auto constraint_id() const -> const ConstraintID &
+        [[nodiscard]] auto constraint_id() const GCS_LIFETIME_BOUND -> const ConstraintID &
         {
             return _constraint_id;
         }

--- a/gcs/current_state.hh
+++ b/gcs/current_state.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/interval_set-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
 #include <gcs/integer.hh>
+#include <gcs/lifetime.hh>
 #include <gcs/variable_id.hh>
 
 #include <functional>
@@ -44,7 +45,7 @@ namespace gcs
      *
      * \ingroup Core
      */
-    class CurrentState
+    class GCS_GSL_POINTER CurrentState
     {
     private:
         std::unique_ptr<innards::State> _state_copy;
@@ -57,7 +58,7 @@ namespace gcs
          * \name Constructors, destructors, etc.
          * @{
          */
-        explicit CurrentState(innards::State & state);
+        explicit CurrentState(innards::State & state GCS_LIFETIME_BOUND);
         ~CurrentState();
 
         CurrentState(CurrentState &&);

--- a/gcs/lifetime.hh
+++ b/gcs/lifetime.hh
@@ -1,0 +1,41 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_LIFETIME_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_LIFETIME_HH
+
+/**
+ * \file
+ * \brief Lifetime-annotation macros for the public API.
+ *
+ * Several parts of the API hand out handles, references, or pointers that are
+ * only valid for as long as some other object is alive. Where clang provides
+ * lifetime attributes, we use them to turn misuse of these contracts into
+ * compile-time `-Wdangling` warnings at the call site; the analysis is purely
+ * static, and the attributes have no effect on ABI or semantics. On compilers
+ * without the attributes, these macros expand to nothing.
+ *
+ * GCS_LIFETIME_BOUND marks a function parameter (including the implicit this
+ * parameter, when placed after the parameter list) whose referent the return
+ * value points into: the result must not outlive that argument.
+ *
+ * GCS_GSL_POINTER marks a class type that behaves like a non-owning pointer
+ * or view into some other object, so that the analysis tracks what it points
+ * to across initialisations.
+ */
+
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::lifetimebound)
+#define GCS_LIFETIME_BOUND [[clang::lifetimebound]]
+#endif
+#if __has_cpp_attribute(gsl::Pointer)
+#define GCS_GSL_POINTER [[gsl::Pointer]]
+#endif
+#endif
+
+#ifndef GCS_LIFETIME_BOUND
+#define GCS_LIFETIME_BOUND
+#endif
+
+#ifndef GCS_GSL_POINTER
+#define GCS_GSL_POINTER
+#endif
+
+#endif

--- a/gcs/lifetime_annotation_tests/dangling_all_normal_variables.cc
+++ b/gcs/lifetime_annotation_tests/dangling_all_normal_variables.cc
@@ -1,0 +1,13 @@
+#include <gcs/problem.hh>
+
+// This file must not compile under -Werror=dangling: binding a reference to
+// the result of Problem::all_normal_variables() on a temporary Problem must
+// trigger clang's -Wdangling diagnostic. If it compiles, the
+// GCS_LIFETIME_BOUND annotations in gcs/problem.hh have stopped working. See
+// valid_uses.cc for the corrected twin.
+
+auto dangling() -> unsigned long long
+{
+    const auto & vars = gcs::Problem{}.all_normal_variables();
+    return vars.size();
+}

--- a/gcs/lifetime_annotation_tests/dangling_array_param_deref.cc
+++ b/gcs/lifetime_annotation_tests/dangling_array_param_deref.cc
@@ -1,0 +1,15 @@
+#include <gcs/array_param.hh>
+
+#include <vector>
+
+// This file must not compile under -Werror=dangling: binding a reference to
+// the contents of a temporary ArrayParam must trigger clang's -Wdangling
+// diagnostic. If it compiles, the GCS_LIFETIME_BOUND annotations in
+// gcs/array_param.hh have stopped working. See valid_uses.cc for the
+// corrected twin.
+
+auto dangling() -> int
+{
+    const std::vector<int> & v = *gcs::VectorArrayParam<int>{{1, 2, 3}};
+    return v[0];
+}

--- a/gcs/lifetime_annotation_tests/dangling_create_integer_variable.cc
+++ b/gcs/lifetime_annotation_tests/dangling_create_integer_variable.cc
@@ -1,0 +1,15 @@
+#include <gcs/problem.hh>
+
+// This file must not compile under -Werror=dangling: keeping a variable
+// handle created by a temporary Problem must trigger clang's -Wdangling
+// diagnostic, because the handle is only meaningful while its Problem is
+// alive. If it compiles, the GCS_LIFETIME_BOUND annotation on
+// Problem::create_integer_variable() or the GCS_GSL_POINTER annotation on
+// SimpleIntegerVariableID has stopped working. See valid_uses.cc for the
+// corrected twin.
+
+auto dangling() -> unsigned long long
+{
+    auto id = gcs::Problem{}.create_integer_variable(gcs::Integer{1}, gcs::Integer{3});
+    return id.index;
+}

--- a/gcs/lifetime_annotation_tests/valid_uses.cc
+++ b/gcs/lifetime_annotation_tests/valid_uses.cc
@@ -1,0 +1,31 @@
+#include <gcs/array_param.hh>
+#include <gcs/problem.hh>
+
+#include <vector>
+
+// Corrected twins of the dangling_*.cc probes in this directory: the same
+// operations, but against named objects that live long enough. This file is
+// compiled with the same -Werror=dangling flags as the probes and must build
+// cleanly, so that a failing probe means its annotation fired, rather than
+// that the probe code never compiled in the first place.
+
+auto valid_array_param_deref() -> int
+{
+    gcs::VectorArrayParam<int> param{{1, 2, 3}};
+    const std::vector<int> & v = *param;
+    return v[0];
+}
+
+auto valid_all_normal_variables() -> unsigned long long
+{
+    gcs::Problem problem;
+    const auto & vars = problem.all_normal_variables();
+    return vars.size();
+}
+
+auto valid_create_integer_variable() -> unsigned long long
+{
+    gcs::Problem problem;
+    auto id = problem.create_integer_variable(gcs::Integer{1}, gcs::Integer{3});
+    return id.index;
+}

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -7,6 +7,7 @@
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
+#include <gcs/lifetime.hh>
 #include <gcs/presolver.hh>
 #include <gcs/proof.hh>
 #include <gcs/stats.hh>
@@ -130,17 +131,23 @@ namespace gcs
          * \brief Create a new integer variable, whose domain goes from lower to
          * upper (inclusive). The final argument gives an optional name that
          * will appear in some output; it does not have to be unique.
+         *
+         * The returned handle is only meaningful for as long as this Problem
+         * (or a search state created from it) is alive.
          */
         [[nodiscard]] auto create_integer_variable(Integer lower, Integer upper, const std::optional<std::string> & name = std::nullopt)
-            -> SimpleIntegerVariableID;
+            GCS_LIFETIME_BOUND -> SimpleIntegerVariableID;
 
         /**
          * \brief Create a new integer variable, whose domain is selected from
          * among the chosen values. The final argument gives an optional name that
          * will appear in some output; it does not have to be unique.
+         *
+         * The returned handle is only meaningful for as long as this Problem
+         * (or a search state created from it) is alive.
          */
         [[nodiscard]] auto create_integer_variable(const std::vector<Integer> & domain, const std::optional<std::string> & name = std::nullopt)
-            -> SimpleIntegerVariableID;
+            GCS_LIFETIME_BOUND -> SimpleIntegerVariableID;
 
         /**
          * \brief Create a vector of how_many integer variables, each of
@@ -149,7 +156,7 @@ namespace gcs
          * have to be unique.
          */
         [[nodiscard]] auto create_integer_variable_vector(std::size_t how_many, Integer lower, Integer upper,
-            const std::optional<std::string> & name = std::nullopt) -> std::vector<IntegerVariableID>;
+            const std::optional<std::string> & name = std::nullopt) GCS_LIFETIME_BOUND -> std::vector<IntegerVariableID>;
 
         /**
          * \brief Create n integer variables, each of whose domain goes
@@ -164,7 +171,7 @@ namespace gcs
          */
         template <std::size_t n_>
         [[nodiscard]] auto create_n_integer_variables(Integer lower, Integer upper, const std::optional<std::string> & name = std::nullopt)
-            -> std::array<SimpleIntegerVariableID, n_>;
+            GCS_LIFETIME_BOUND -> std::array<SimpleIntegerVariableID, n_>;
 
         auto minimise(IntegerVariableID) -> void;
         auto maximise(IntegerVariableID) -> void;
@@ -180,10 +187,22 @@ namespace gcs
 
         [[nodiscard]] auto create_propagators(innards::State &, innards::ProofModel * const) const -> innards::Propagators;
 
+        /**
+         * \warning The yielded references alias objects owned by this Problem,
+         * and are valid only while the Problem is alive.
+         */
         [[nodiscard]] auto each_presolver() const -> std::generator<Presolver &>;
 
-        [[nodiscard]] auto all_normal_variables() const -> const std::vector<IntegerVariableID> &;
+        /**
+         * \warning The returned reference is into this Problem, and is valid
+         * only for as long as the Problem is alive.
+         */
+        [[nodiscard]] auto all_normal_variables() const GCS_LIFETIME_BOUND -> const std::vector<IntegerVariableID> &;
 
+        /**
+         * \warning The yielded references alias objects owned by this Problem,
+         * and are valid only while the Problem is alive.
+         */
         [[nodiscard]] auto each_constraint() const -> std::generator<const Constraint &>;
 
         [[nodiscard]] auto each_variable_with_bounds_and_name() const -> std::generator<std::tuple<IntegerVariableID, Integer, Integer, std::string>>;

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -183,8 +183,15 @@ namespace gcs
          * @{
          */
 
+        /**
+         * \brief Create a fresh state for a new search, returned by value.
+         */
         [[nodiscard]] auto create_state_for_new_search(innards::ProofModel * const) const -> innards::State;
 
+        /**
+         * \brief Create the propagators for a search over this Problem,
+         * returned by value.
+         */
         [[nodiscard]] auto create_propagators(innards::State &, innards::ProofModel * const) const -> innards::Propagators;
 
         /**
@@ -205,6 +212,10 @@ namespace gcs
          */
         [[nodiscard]] auto each_constraint() const -> std::generator<const Constraint &>;
 
+        /**
+         * \brief Returns a generator giving each variable together with its
+         * bounds and its name, all yielded by value.
+         */
         [[nodiscard]] auto each_variable_with_bounds_and_name() const -> std::generator<std::tuple<IntegerVariableID, Integer, Integer, std::string>>;
 
         /**

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
+#include <gcs/lifetime.hh>
 
 #include <memory>
 #include <optional>
@@ -107,8 +108,21 @@ namespace gcs
         auto operator=(const Proof &) -> Proof & = delete;
         Proof(const Proof &) = delete;
 
-        [[nodiscard]] auto logger() -> innards::ProofLogger *;
-        [[nodiscard]] auto model() -> innards::ProofModel *;
+        /**
+         * \brief The proof logger, for writing proof steps.
+         *
+         * \warning This is a pointer into this Proof, and is valid only for as
+         * long as the Proof is alive.
+         */
+        [[nodiscard]] auto logger() GCS_LIFETIME_BOUND -> innards::ProofLogger *;
+
+        /**
+         * \brief The proof model, for writing OPB-level definitions.
+         *
+         * \warning This is a pointer into this Proof, and is valid only for as
+         * long as the Proof is alive.
+         */
+        [[nodiscard]] auto model() GCS_LIFETIME_BOUND -> innards::ProofModel *;
     };
 }
 

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -12,6 +12,10 @@ namespace gcs
     /**
      * \defgroup SearchHeuristics Common search heuristics for gcs::solve_with
      *
+     * \warning The CurrentState and Propagators references passed to a
+     * heuristic are into live solver internals, and are valid only for the
+     * duration of that call: they must not be stored for later use.
+     *
      * \sa SolveCallbacks
      */
 

--- a/gcs/solve.hh
+++ b/gcs/solve.hh
@@ -22,6 +22,10 @@ namespace gcs
     /**
      * \defgroup SolveCallbacks Callbacks for solving
      *
+     * \warning The references passed to a callback are valid only for the
+     * duration of that call, and must not be stored for later use. Use
+     * CurrentState::clone() if you need to save a state.
+     *
      * \sa SearchHeuristics
      */
 
@@ -47,6 +51,9 @@ namespace gcs
      * instances (which may be range conditions, for interval accept/reject
      * branching) that corresponds to a complete branching choice, or that
      * yields nothing if every variable is instantiated.
+     *
+     * \warning The CurrentState and Propagators references are into live
+     * solver internals, and are valid only for the duration of the call.
      *
      * \ingroup SolveCallbacks
      * \sa SearchHeuristics

--- a/gcs/variable_id.hh
+++ b/gcs/variable_id.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_VARIABLE_ID_HH
 
 #include <gcs/integer.hh>
+#include <gcs/lifetime.hh>
 #include <gcs/variable_id-fwd.hh>
 
 #include <functional>
@@ -15,10 +16,13 @@ namespace gcs
      * Usually you can work with IntegerVariableID instead, but some operations
      * specifically require a genuine variable.
      *
+     * This is a lightweight handle, only meaningful for as long as the Problem
+     * (or a search state created from it) that created it is alive.
+     *
      * \sa IntegerVariableID
      * \ingroup Core
      */
-    struct SimpleIntegerVariableID final
+    struct GCS_GSL_POINTER SimpleIntegerVariableID final
     {
         unsigned long long index;
 
@@ -35,10 +39,14 @@ namespace gcs
      *
      * Usually this will be constructed using `var + 42_i` or `-var`.
      *
+     * Like SimpleIntegerVariableID, this is a lightweight handle, only
+     * meaningful for as long as the Problem (or a search state created from
+     * it) that created the underlying variable is alive.
+     *
      * \sa IntegerVariableID
      * \ingroup Core
      */
-    struct ViewOfIntegerVariableID final
+    struct GCS_GSL_POINTER ViewOfIntegerVariableID final
     {
         SimpleIntegerVariableID actual_variable;
         bool negate_first;
@@ -78,6 +86,12 @@ namespace gcs
     /**
      * An IntegerVariableID can be a SimpleIntegerVariableID, a
      * ViewOfIntegerVariableID, or a ConstantIntegerVariableID.
+     *
+     * Unless it holds a ConstantIntegerVariableID, this is a lightweight
+     * handle, only meaningful for as long as the Problem (or a search state
+     * created from it) that created the underlying variable is alive. (Being
+     * a `std::variant` alias, it cannot itself carry the lifetime annotations
+     * that SimpleIntegerVariableID and ViewOfIntegerVariableID have.)
      *
      * \ingroup Core
      */


### PR DESCRIPTION
Several parts of the public API hand out handles, references, or pointers whose validity is tied to some other object's lifetime, and until now those contracts lived only in comments (or nowhere). This PR turns the checkable ones into compile-time diagnostics and documents the rest.

## What's annotated

`gcs/lifetime.hh` adds `GCS_LIFETIME_BOUND` / `GCS_GSL_POINTER`, expanding to `[[clang::lifetimebound]]` / `[[gsl::Pointer]]` where supported (guarded by `__has_cpp_attribute`) and to nothing elsewhere, so GCC/MSVC are byte-for-byte unaffected. Applied to:

- `SimpleIntegerVariableID` / `ViewOfIntegerVariableID` (pointer-like handle types) and all four `Problem::create_*` methods — clang tracks the handles even through `std::array` and `std::vector<std::variant<...>>` returns
- `Problem::all_normal_variables()`, `Constraint::constraint_id()`, `Proof::logger()` / `model()`
- `CurrentState` (marked as a view type) and its borrowing constructor
- `ArrayParam`'s borrowed constructor and `operator*` / `operator->` (`ArrayParam` itself is deliberately *not* marked `[[gsl::Pointer]]`: its owned/shared modes would make construction from a temporary container a false positive)

With clang, misuse now warns **by default, with no flags**, at the user's call site:

```
warning: temporary whose address is used as value of local variable 'id' will be
destroyed at the end of the full-expression [-Wdangling]
    auto id = gcs::Problem{}.create_integer_variable(1_i, 3_i);
```

Contracts no shipping tool can check — stashing the `CurrentState` / `Propagators` references passed to solve callbacks and search heuristics, and the `each_constraint()` / `each_presolver()` generators — get explicit `\warning` documentation instead. These same annotations are the input language of clang 22+'s experimental flow-sensitive lifetime analysis, so scope-shaped misuse (a handle outliving a scoped `Problem`) should become detectable as that matures, with no further changes on our side.

## Tests

`gcs/lifetime_annotation_tests/` holds three intentionally-dangling probes plus a corrected twin. The clang-only ctest entries compile each probe with `-Werror=dangling` and pass only if the output contains the diagnostic (`PASS_REGULAR_EXPRESSION`), so they fail both if an annotation rots and if a probe breaks for some other reason; the twin must build cleanly under the same flags.

## CI

The CMake workflow matrix gains an `ubuntu-26.04 (clang++)` lane (distro clang 21 + libstdc++, matching local dev) so the probe tests run on Linux clang as well as the Apple Clang macOS lanes. It keeps capped test defaults; full-enumeration checking stays on the GCC Ubuntu lanes.

`.clang-format` gains `AttributeMacros` + `Macros` entries so clang-format parses the annotation macros as attributes; the whole tree remains format-clean under clang-format 21.

## Verification

- clang 21: full build of library + tests + frontends produces **zero** `-Wdangling` diagnostics (no false positives, including the 22 innards files that use the ID types pervasively); all 498 ctest tests pass, including the 4 new probes
- GCC 15: full compile phase clean (annotations expand to nothing; only pre-existing warning categories); local ctest was skipped due to disk-space contention on the dev VM — the GCC CI lanes cover it
- Misuse TU compiled against `gcs/gcs.hh` with plain `clang++ -std=c++23` (no warning flags) fires the expected warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tc9UsttXJpDviZddAKdPQx