### PR TITLE
Add a MiniZinc test for fully-variable cumulative arguments

### DIFF
--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -49,6 +49,9 @@ set_tests_properties(minizinc-cumulative PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-cumulative-mode COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativemodetest true true)
 set_tests_properties(minizinc-cumulative-mode PROPERTIES SKIP_RETURN_CODE 66)
 
+add_test(NAME minizinc-cumulative-var COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativevartest true true)
+set_tests_properties(minizinc-cumulative-var PROPERTIES SKIP_RETURN_CODE 66)
+
 add_test(NAME minizinc-disjunctive COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctivetest true true)
 set_tests_properties(minizinc-disjunctive PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/tests/cumulativevartest.mzn
+++ b/minizinc/tests/cumulativevartest.mzn
@@ -1,0 +1,24 @@
+include "globals.mzn";
+
+% Variable durations, heights, AND capacity: every non-start argument is a
+% decision variable, exercising glasgow_cumulative's fully-variable path
+% (issue #242's failing shape — the old mznlib fix()-erred at flatten time).
+% The variable heights/capacity also stop MiniZinc's cumulative wrapper from
+% short-circuiting into a disjunctive on the starts (see cumulativetest.mzn).
+% Enumerated against MiniZinc's default solver.
+int: n = 3;
+array[1..n] of var 0..3: s;
+array[1..n] of var 1..2: d;
+array[1..n] of var 1..2: h;
+var 2..3: c;
+
+constraint cumulative(s, d, h, c);
+
+% Force real interaction: total demand must exceed any single capacity value,
+% and everything must fit in a tight horizon.
+constraint sum(h) >= c + 1;
+constraint forall(i in 1..n) (s[i] + d[i] <= 4);
+
+solve satisfy;
+
+output ["ENUMSOL: s=" ++ show(s) ++ " d=" ++ show(d) ++ " h=" ++ show(h) ++ " c=" ++ show(c) ++ "\n"];


### PR DESCRIPTION
Follow-up from closing #242. The frontend passes variable cumulative arguments through natively (no `fix()` left in the mznlib), but only disjunctive had variable-argument coverage at the MiniZinc level — `cumulativetest.mzn` uses constant lengths/heights/capacity, so the fully-variable flatten path was unexercised.

This adds `cumulativevartest.mzn`, where every non-start argument is a decision variable (durations, heights, and the capacity), registered as `minizinc-cumulative-var` in enumeration + proof mode. Checked that the flattened model calls `glasgow_cumulative` — the variable heights/capacity also prevent MiniZinc's cumulative wrapper from short-circuiting into a disjunctive on the starts, which would silently bypass the predicate under test. The harness enumerates 2172 solutions identically against MiniZinc's default solver and VeriPB verifies the proof; runs in under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tc9UsttXJpDviZddAKdPQx