### PR TITLE
Give the decision-diagram constraints a single fluent front-end each

### DIFF
--- a/dev_docs/bin-packing.md
+++ b/dev_docs/bin-packing.md
@@ -21,24 +21,26 @@ Item sizes are non-negative. Frontends with non-zero-based bin indices
 ranges) shift to 0-based at the binding so the gcs class always sees
 items in `0..num_bins − 1`.
 
-A `bounds_only` flag on every constructor selects the cheaper
-propagation strategy: when set, only the Stage 2 bounds pass runs;
-when clear (the default), Stage 2 is followed by the Stage 3
-per-bin DAG sweep.
+The `with_consistency(...)` fluent setter selects the propagation
+strength: `consistency::GAC` (the default) runs the Stage 2 bounds pass
+followed by the Stage 3 per-bin DAG sweep (per-bin GAC); `consistency::BC`
+runs the Stage 2 bounds pass alone (the cheaper option, for when per-bin
+capacity is much larger than the number of items).
 
-An `upfront_proof` flag (default `false`) selects the Stage 3
-*proof-emission* strategy. It changes only the proof, never the set of
-inferences drawn or the solutions found:
+The `with_proof_strategy(...)` fluent setter selects the Stage 3
+*proof-emission* strategy (only meaningful under `consistency::GAC`). It
+changes only the proof, never the set of inferences drawn or the
+solutions found:
 
-- **`upfront_proof = false` (default) — per-call.** Only the reified
-  per-node state flags are defined at `ProofLevel::Top`; every
-  aggregation is left to the per-call sweep's `JustifyUsingRUP` prunes,
-  which RUP-close through those flags plus the natural per-bin OPB
-  equations. This wins on both proof size and VeriPB verify time (see
-  the benchmark table below), so it is the default.
-- **`upfront_proof = true` — upfront (opt-in).** The initialiser
-  additionally derives the full forward/backward chain scaffolding once
-  at `ProofLevel::Top`, so the per-call sweep only has to reference it.
+- **`proof_strategy::PerCall` (the default).** Only the reified per-node
+  state flags are defined at `ProofLevel::Top`; every aggregation is left
+  to the per-call sweep's `JustifyUsingRUP` prunes, which RUP-close
+  through those flags plus the natural per-bin OPB equations. This wins
+  on both proof size and VeriPB verify time (see the benchmark table
+  below), so it is the default.
+- **`proof_strategy::Upfront` (opt-in).** The initialiser additionally
+  derives the full forward/backward chain scaffolding once at
+  `ProofLevel::Top`, so the per-call sweep only has to reference it.
   Larger, slower-to-verify proofs with no measured benefit on the
   in-tree benchmarks; kept for robustness and A/B measurement.
 

--- a/dev_docs/decision-diagram-proof-strategies.md
+++ b/dev_docs/decision-diagram-proof-strategies.md
@@ -80,10 +80,15 @@ not change). All proofs verified (`s VERIFIED`, zero failures).
 
 | Propagator | Proof size (upfront vs per-call) | Verify time (upfront vs per-call) | Default | Opt-in |
 |---|---|---|---|---|
-| **Regular** (#213) | upfront **13–55× smaller** (9 MB vs 496 MB @7660 sol) | upfront **2.3–7× faster** (1.66 s vs 11.69 s) | **upfront `Regular`** | per-call `RegularLegacy` via `--legacy` |
-| **MDD** (#211) | upfront **7–9× smaller** (1.8 MB vs 15.8 MB) | upfront **4–5× faster** (0.04 s vs 0.21 s) | **upfront (default)** | per-call **deferred** (see below) |
-| **Knapsack** (#210) | upfront **3–6× smaller** (20.7 MB vs 121 MB) | upfront **3.6–18× SLOWER** (6.68 s vs 1.85 s) | **per-call `Knapsack`** | upfront `KnapsackUpfront` |
-| **BinPacking** (#212) | upfront **6–10× BIGGER** (8 MB vs 1.3 MB) | upfront **8–16× SLOWER** (4.45 s vs 0.55 s) | **per-call (Stage 3)** | upfront via `upfront_proof=true` |
+| **Regular** (#213) | upfront **13–55× smaller** (9 MB vs 496 MB @7660 sol) | upfront **2.3–7× faster** (1.66 s vs 11.69 s) | **`proof_strategy::Upfront`** | `PerCall` (`--legacy`), `Bacchus` |
+| **MDD** (#211) | upfront **7–9× smaller** (1.8 MB vs 15.8 MB) | upfront **4–5× faster** (0.04 s vs 0.21 s) | **upfront (only)** | per-call **deferred** (see below) |
+| **Knapsack** (#210) | upfront **3–6× smaller** (20.7 MB vs 121 MB) | upfront **3.6–18× SLOWER** (6.68 s vs 1.85 s) | **`proof_strategy::PerCall`** | `proof_strategy::Upfront` |
+| **BinPacking** (#212) | upfront **6–10× BIGGER** (8 MB vs 1.3 MB) | upfront **8–16× SLOWER** (4.45 s vs 0.55 s) | **`proof_strategy::PerCall`** | `proof_strategy::Upfront` |
+
+All four expose the choice through the fluent `with_proof_strategy(...)`
+setter over the shared `gcs::proof_strategy` tags (`PerCall`, `Upfront`,
+and, for Regular, `Bacchus`); BinPacking additionally selects Stage 2-only
+bounds via `with_consistency(consistency::BC{})`.
 
 The per-line cost (`us/line`) is the DB-tax signature: Regular upfront 6.8–16 vs
 legacy 3.2–5; MDD upfront 2.5–2.8 vs 2.6–3.5; Knapsack upfront **38–68** vs
@@ -115,7 +120,7 @@ Why each lands where it does:
   *k-dimensional* partial-sum DAG with phantom nodes — huge and permanent (`red`
   ≈ 11k–33k at root; ≈ 60% of upfront's lines). DB-tax ≈ 10–15× ≫ displacement
   (2–3×) → the proof shrinks in bytes but verifies 3.6–18× slower. So the
-  default is **per-call**; `KnapsackUpfront` remains as the opt-in when byte size
+  default is **per-call**; `proof_strategy::Upfront` remains the opt-in when byte size
   is the priority.
 - **BinPacking — per-call wins both.** Stage 3 is *already* an upfront-flag
   design (`bpup/bpdn/bpat` reifications emitted once at Top, all pruning via
@@ -124,7 +129,7 @@ Why each lands where it does:
   *adds* 27 more Top lines (forward/backward chains, layer ALOs, per-state
   implications, phantoms) → a bigger permanent DB (`red` 2k–8k, DB-tax ≈ 2.5×)
   taxing every enumeration RUP. Both factors align against it → bigger *and*
-  slower. Default **per-call**, `upfront_proof=true` the opt-in.
+  slower. Default **per-call** (`proof_strategy::PerCall`), `proof_strategy::Upfront` the opt-in.
 
 ### Note on the MDD per-call opt-in
 

--- a/dev_docs/knapsack.md
+++ b/dev_docs/knapsack.md
@@ -1,31 +1,35 @@
-# `Knapsack`: default vs. `KnapsackUpfront`, and the upfront-DAG design
+# `Knapsack`: proof strategies, and the upfront-DAG design
 
-There are two `Knapsack` implementations in the tree, both fully
-proof-logging and both cake-conformant (#200):
+There is a single public `Knapsack` constraint with two proof-logging
+strategies, both fully proof-logging and both cake-conformant (#200),
+selected with `with_proof_strategy(proof_strategy::…)`:
 
-- **`Knapsack` (the default)** — the per-call DP implementation. It
-  rebuilds its DP table and proof scaffolding from scratch on every
-  propagation call, at `ProofLevel::Temporary`. This is what all
-  frontends, `scp_reader`, the `examples/knapsack` solver and the
-  primary `knapsack_test` post. **It is the default because its proofs
-  verify substantially faster** (3.6–18× faster VeriPB time than the
-  upfront variant — see "Benchmarking" below).
-- **`KnapsackUpfront` (opt-in)** — the upfront-DAG reimplementation. It
-  builds the statically-reduced layered DAG once in `prepare()` and
-  emits paper-style proof scaffolding once at `ProofLevel::Top`, leaving
-  only search-state-dependent `pol` steps for the per-call sweep. **It
-  produces 3–6× smaller proofs** (and ~3× faster solver wall time), at
-  the cost of the slower verification above. Prefer it only when proof
-  size or its distribution matters. It lives in
-  `gcs/constraints/knapsack/knapsack_upfront.{hh,cc}`, is exposed via
-  the aggregator `gcs/constraints/knapsack.hh`, and is exercised by
-  `knapsack_upfront_test`.
+- **`proof_strategy::PerCall` (the default)** — the per-call DP
+  implementation. It rebuilds its DP table and proof scaffolding from
+  scratch on every propagation call, at `ProofLevel::Temporary`. This is
+  what all frontends, `scp_reader`, the `examples/knapsack` solver and
+  the primary `knapsack_test` get. **It is the default because its
+  proofs verify substantially faster** (3.6–18× faster VeriPB time than
+  the upfront variant — see "Benchmarking" below). It lives in
+  `gcs/constraints/knapsack/knapsack.{hh,cc}`.
+- **`proof_strategy::Upfront` (opt-in)** — the upfront-DAG
+  reimplementation. It builds the statically-reduced layered DAG once in
+  `prepare()` and emits paper-style proof scaffolding once at
+  `ProofLevel::Top`, leaving only search-state-dependent `pol` steps for
+  the per-call sweep. **It produces 3–6× smaller proofs** (and ~3× faster
+  solver wall time), at the cost of the slower verification above. Prefer
+  it only when proof size or its distribution matters. Its install path
+  (`install_knapsack_upfront`) lives in
+  `gcs/constraints/knapsack/knapsack_upfront.{hh,cc}` and is exercised by
+  `knapsack_upfront_test` (which posts
+  `Knapsack{…}.with_proof_strategy(proof_strategy::Upfront{})`). Both
+  strategies draw the same inferences and share the same OPB; the choice
+  is proof-only.
 
 The rest of this note is a working-design record of the **upfront-DAG**
-approach (`KnapsackUpfront`), retained because it is the more intricate
-of the two and because it is the candidate for the #200 unified
-layered-DAG framework. It is not a record of what currently exists in
-every stage — read
+approach, retained because it is the more intricate of the two and
+because it is the candidate for the #200 unified layered-DAG framework.
+It is not a record of what currently exists in every stage — read
 `gcs/constraints/knapsack/knapsack_upfront.{hh,cc}` for that, and
 `gcs/constraints/knapsack/knapsack.{hh,cc}` for the default per-call DP.
 

--- a/dev_docs/regular.md
+++ b/dev_docs/regular.md
@@ -9,37 +9,43 @@ chains, statically-dead-state lines) once at `ProofLevel::Top` via
 most one cache-gated `~state[i][q]` line at `ProofLevel::Current`
 per state-death.
 
-## The three implementations
+## The three proof strategies
 
-This file covers three implementations of the `Regular` constraint that
-coexist in the codebase:
+There is a single public `Regular` constraint. Its proof-logging
+strategy is selected with the fluent
+`with_proof_strategy(proof_strategy::…)` setter (see
+[`proof_strategy.hh`](../gcs/proof_strategy.hh)), defaulting to
+`Upfront`:
 
-| Class                | Strategy                                                                 | File                                  |
-|----------------------|--------------------------------------------------------------------------|---------------------------------------|
-| `RegularLegacy`      | Per-call propagator emits per-(parent, val) intermediates each call.     | `gcs/constraints/regular/regular_legacy.{cc,hh}` |
-| `Regular`            | Upfront per-val backward chains + statically-dead-state lines at Top, then per-call cache-gated `~state[i][q]` lines for dynamic state-deaths. | `gcs/constraints/regular/regular.{cc,hh}` |
-| `RegularBacchus`     | Upfront Bacchus encoding (per-(i, q, v) transition extension variables + AL1s) derived from the natural OPB at Top; per-call propagator emits no proof. | `gcs/constraints/regular/regular_bacchus.{cc,hh}` |
+| `proof_strategy::` | Strategy                                                                 | Implementation |
+|--------------------|--------------------------------------------------------------------------|----------------|
+| `PerCall`          | Per-call propagator emits per-(parent, val) intermediates each call.     | `gcs/constraints/regular/regular_legacy.{cc,hh}` |
+| `Upfront` (default) | Upfront per-val backward chains + statically-dead-state lines at Top, then per-call cache-gated `~state[i][q]` lines for dynamic state-deaths. | `gcs/constraints/regular/regular.{cc,hh}` |
+| `Bacchus`          | Upfront Bacchus encoding (per-(i, q, v) transition extension variables + AL1s) derived from the natural OPB at Top; per-call propagator emits no proof. Deterministic automata only (not regex/NFA input). | `gcs/constraints/regular/regular_bacchus.{cc,hh}` |
 
 The OPB is identical across all three — DFA semantics, no propagator
 internals (see [Constraint definition](#constraint-definition) and
-[OPB encoding](#opb-encoding) below). What differs is what each
-implementation derives in its initialiser at search root, and what its
-per-call propagator emits.
+[OPB encoding](#opb-encoding) below). What differs is what each strategy
+derives in its initialiser at search root, and what its per-call
+propagator emits; the choice never changes the inferences drawn or the
+solutions found.
 
-`gcs/constraints/regular.hh` is a top-level shim that includes all three.
-For new code, post `Regular` (the default — see below); `RegularLegacy`
-and `RegularBacchus` are retained primarily for benchmarking and for
-issue #200's unified layered-DAG follow-up.
+The public `Regular` front-end (`gcs/constraints/regular/regular.{cc,hh}`)
+*is* the `Upfront` implementation; for `PerCall` and `Bacchus` its
+`install()` constructs and delegates to the sibling implementations,
+which are internal to the constraint (not part of the public API — they
+are no longer named in `gcs/constraints/regular.hh`). Everything posts
+`Regular`; benchmarking picks a strategy with `with_proof_strategy(...)`.
 
-## Default: the upfront `Regular`
+## Default: `proof_strategy::Upfront`
 
-**`Regular` (this upfront-scaffolding propagator) is the default.**
-Everything posts it — both frontends
-(`xcsp_glasgow_constraint_solver`, `fzn_glasgow`), the constraint
-tests, and the `regular_random` example. `RegularLegacy` — the older
-per-call propagator that re-emits per-`(parent state, val)`
-intermediate aggregations on every propagation call — is preserved
-only as the `--legacy` opt-in twin, for side-by-side benchmarking and
+**The upfront-scaffolding strategy is the default.** Everything posts a
+plain `Regular` — both frontends (`xcsp_glasgow_constraint_solver`,
+`fzn_glasgow`), the constraint tests, and the `regular_random` example.
+The `PerCall` strategy — the older per-call implementation that re-emits
+per-`(parent state, val)` intermediate aggregations on every propagation
+call — is reachable via `with_proof_strategy(proof_strategy::PerCall{})`
+(the `regular_random --legacy` flag), for side-by-side benchmarking and
 as a correctness reference.
 
 The reason for defaulting to upfront is that it **wins on both axes
@@ -84,12 +90,12 @@ by a deterministic finite automaton:
 The sequence `vars[0..n-1]` is accepted iff feeding the symbols from
 left to right starting at state `0` ends in a state in `final_states`.
 
-Each of the three classes supports the same two constructors (sparse
-map / dense table form) plus a `short_reasons` boolean that is
-forwarded to the propagator but unused (or near-unused) by `Regular`
-and `RegularBacchus`. Keeping the flag as a dummy lets one
-`regular_random` binary benchmark all three variants from one call
-site.
+`Regular` supports two automaton constructors (sparse map / dense table
+form) plus a regex form, and a `short_reasons` boolean (via
+`with_short_reasons()`) forwarded to the propagator but unused (or
+near-unused) by the `Upfront` and `Bacchus` strategies. Keeping the flag
+as a dummy lets one `regular_random` binary benchmark all three
+strategies from one call site.
 
 ## Layered DAG view
 

--- a/examples/bin_packing/bin_packing_bench.cc
+++ b/examples/bin_packing/bin_packing_bench.cc
@@ -126,6 +126,8 @@ auto main(int argc, char * argv[]) -> int
     auto inst = curated_instance(vars["instance"].as<int>());
     bool bounds_only = vars.contains("bounds-only");
     bool upfront = vars.contains("upfront");
+    auto level = bounds_only ? BinPackingConsistency{consistency::BC{}} : BinPackingConsistency{consistency::GAC{}};
+    auto strategy = upfront ? BinPackingProofStrategy{proof_strategy::Upfront{}} : BinPackingProofStrategy{proof_strategy::PerCall{}};
 
     Problem p;
     vector<IntegerVariableID> items;
@@ -139,11 +141,15 @@ auto main(int argc, char * argv[]) -> int
         loads.reserve(loads_bounds.size());
         for (size_t b = 0; b < loads_bounds.size(); ++b)
             loads.push_back(p.create_integer_variable(loads_bounds[b].first, loads_bounds[b].second, "load" + std::to_string(b)));
-        p.post(BinPacking{items, inst.sizes, loads, bounds_only, upfront});
+        p.post(BinPacking{items, inst.sizes, loads} //
+                .with_consistency(level)
+                .with_proof_strategy(strategy));
     }
     else {
         const auto & caps = std::get<vector<Integer>>(inst.bins);
-        p.post(BinPacking{items, inst.sizes, caps, bounds_only, upfront});
+        p.post(BinPacking{items, inst.sizes, caps} //
+                .with_consistency(level)
+                .with_proof_strategy(strategy));
     }
 
     bool root_only = vars.contains("root-only");

--- a/examples/knapsack/knapsack_bench.cc
+++ b/examples/knapsack/knapsack_bench.cc
@@ -151,10 +151,8 @@ auto main(int argc, char * argv[]) -> int
     for (size_t x = 0; x < inst.total_bounds.size(); ++x)
         totals.push_back(p.create_integer_variable(inst.total_bounds[x].first, inst.total_bounds[x].second, "t" + std::to_string(x)));
 
-    if (upfront)
-        p.post(KnapsackUpfront{inst.coeffs, items, totals});
-    else
-        p.post(Knapsack{inst.coeffs, items, totals});
+    p.post(Knapsack{inst.coeffs, items, totals} //
+            .with_proof_strategy(upfront ? KnapsackProofStrategy{proof_strategy::Upfront{}} : KnapsackProofStrategy{proof_strategy::PerCall{}}));
 
     if (inst.optimise_max_first_total)
         p.maximise(totals[0]);

--- a/examples/regular_random/regular_random.cc
+++ b/examples/regular_random/regular_random.cc
@@ -79,14 +79,12 @@ auto post_random_regular(Problem & p, const int & n, mt19937 & rng, bool short_r
         }
     }
 
-    if (legacy)
-        p.post(RegularLegacy{x, num_states, transitions, final_states} //
-                .with_short_reasons(short_reasons));
-    else if (bacchus)
-        p.post(RegularBacchus{x, num_states, transitions, final_states, short_reasons});
-    else
-        p.post(Regular{x, num_states, transitions, final_states} //
-                .with_short_reasons(short_reasons));
+    auto strategy = legacy ? RegularProofStrategy{proof_strategy::PerCall{}}
+        : bacchus          ? RegularProofStrategy{proof_strategy::Bacchus{}}
+                           : RegularProofStrategy{proof_strategy::Upfront{}};
+    p.post(Regular{x, num_states, transitions, final_states} //
+            .with_short_reasons(short_reasons)
+            .with_proof_strategy(strategy));
 }
 
 auto main(int argc, char * argv[]) -> int

--- a/gcs/constraints/bin_packing/bin_packing.cc
+++ b/gcs/constraints/bin_packing/bin_packing.cc
@@ -37,6 +37,7 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::any_cast;
+using std::holds_alternative;
 using std::list;
 using std::make_shared;
 using std::make_unique;
@@ -901,24 +902,35 @@ struct BinPacking::DagBridge
     vector<pair<optional<ProofLine>, optional<ProofLine>>> opb_lines;
 };
 
-BinPacking::BinPacking(
-    vector<IntegerVariableID> items, vector<Integer> sizes, vector<IntegerVariableID> loads, bool bounds_only, bool upfront_proof) :
-    _items(move(items)), _sizes(move(sizes)), _loads(move(loads)), _capacities(), _have_loads(true), _bounds_only(bounds_only),
-    _upfront_proof(upfront_proof)
+BinPacking::BinPacking(vector<IntegerVariableID> items, vector<Integer> sizes, vector<IntegerVariableID> loads) :
+    _items(move(items)), _sizes(move(sizes)), _loads(move(loads)), _capacities(), _have_loads(true)
 {
 }
 
-BinPacking::BinPacking(vector<IntegerVariableID> items, vector<Integer> sizes, vector<Integer> capacities, bool bounds_only, bool upfront_proof) :
-    _items(move(items)), _sizes(move(sizes)), _loads(), _capacities(move(capacities)), _have_loads(false), _bounds_only(bounds_only),
-    _upfront_proof(upfront_proof)
+BinPacking::BinPacking(vector<IntegerVariableID> items, vector<Integer> sizes, vector<Integer> capacities) :
+    _items(move(items)), _sizes(move(sizes)), _loads(), _capacities(move(capacities)), _have_loads(false)
 {
+}
+
+auto BinPacking::with_consistency(BinPackingConsistency level) -> BinPacking &
+{
+    _bounds_only = holds_alternative<consistency::BC>(level);
+    return *this;
+}
+
+auto BinPacking::with_proof_strategy(BinPackingProofStrategy strategy) -> BinPacking &
+{
+    _upfront_proof = holds_alternative<proof_strategy::Upfront>(strategy);
+    return *this;
 }
 
 auto BinPacking::clone() const -> unique_ptr<Constraint>
 {
-    if (_have_loads)
-        return make_unique<BinPacking>(_items, _sizes, _loads, _bounds_only, _upfront_proof);
-    return make_unique<BinPacking>(_items, _sizes, _capacities, _bounds_only, _upfront_proof);
+    auto cloned = _have_loads ? make_unique<BinPacking>(_items, _sizes, _loads) : make_unique<BinPacking>(_items, _sizes, _capacities);
+    cloned->with_consistency(_bounds_only ? BinPackingConsistency{consistency::BC{}} : BinPackingConsistency{consistency::GAC{}});
+    cloned->with_proof_strategy(
+        _upfront_proof ? BinPackingProofStrategy{proof_strategy::Upfront{}} : BinPackingProofStrategy{proof_strategy::PerCall{}});
+    return cloned;
 }
 
 auto BinPacking::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void

--- a/gcs/constraints/bin_packing/bin_packing.hh
+++ b/gcs/constraints/bin_packing/bin_packing.hh
@@ -1,18 +1,45 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_BIN_PACKING_BIN_PACKING_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_BIN_PACKING_BIN_PACKING_HH
 
+#include <gcs/consistency.hh>
 #include <gcs/constraint.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/integer.hh>
+#include <gcs/proof_strategy.hh>
 #include <gcs/variable_id.hh>
 
 #include <memory>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace gcs
 {
+    /**
+     * \brief The consistency levels BinPacking supports: per-bin generalised
+     * arc consistency (the stronger default — the Stage 2 bounds pass followed
+     * by the Stage 3 partial-load DAG sweep), or bounds consistency (the
+     * cheaper Stage 2 pass alone). Joint GAC is NP-hard, so consistency::GAC
+     * here means per-bin GAC. The choice selects propagation strength only and
+     * never changes the OPB encoding.
+     *
+     * \ingroup Consistency
+     */
+    using BinPackingConsistency = std::variant<consistency::GAC, consistency::BC>;
+
+    /**
+     * \brief The proof-logging strategies BinPacking supports for its Stage 3
+     * sweep: proof_strategy::PerCall (the default — reified per-node state
+     * flags at Top, per-call RUP prunes) or proof_strategy::Upfront (also
+     * derive the full forward/backward chain scaffolding at Top). Both draw
+     * the same inferences; PerCall's proofs are smaller and verify faster on
+     * the in-tree benchmarks. No effect under consistency::BC (no Stage 3
+     * sweep) or with proof logging off.
+     *
+     * \ingroup ProofStrategy
+     */
+    using BinPackingProofStrategy = std::variant<proof_strategy::PerCall, proof_strategy::Upfront>;
     /**
      * \brief Bin packing constraint: each item is assigned to exactly one bin
      * (via `items[i]`), and each bin's total assigned size matches its load
@@ -69,8 +96,8 @@ namespace gcs
         std::vector<IntegerVariableID> _loads;
         std::vector<Integer> _capacities;
         const bool _have_loads;
-        const bool _bounds_only;
-        const bool _upfront_proof;
+        bool _bounds_only = false;
+        bool _upfront_proof = false;
 
         std::shared_ptr<DagBridge> _bridge;
         std::optional<innards::ConstraintStateHandle> _dead_cache_idx;
@@ -85,16 +112,26 @@ namespace gcs
          * items assigned to bin `b`. Items must take values in
          * `0..loads.size() - 1`.
          */
-        explicit BinPacking(std::vector<IntegerVariableID> items, std::vector<Integer> sizes, std::vector<IntegerVariableID> loads,
-            bool bounds_only = false, bool upfront_proof = false);
+        explicit BinPacking(std::vector<IntegerVariableID> items, std::vector<Integer> sizes, std::vector<IntegerVariableID> loads);
 
         /**
          * \brief Constant-capacity form: the sum of sizes of items assigned
          * to bin `b` must not exceed `capacities[b]`. Items must take values
          * in `0..capacities.size() - 1`.
          */
-        explicit BinPacking(std::vector<IntegerVariableID> items, std::vector<Integer> sizes, std::vector<Integer> capacities,
-            bool bounds_only = false, bool upfront_proof = false);
+        explicit BinPacking(std::vector<IntegerVariableID> items, std::vector<Integer> sizes, std::vector<Integer> capacities);
+
+        /// Select the consistency level: consistency::GAC (per-bin GAC, the
+        /// default) or consistency::BC (the cheaper bounds pass alone). The
+        /// choice selects propagation strength only and never changes the OPB
+        /// encoding.
+        auto with_consistency(BinPackingConsistency level) -> BinPacking &;
+
+        /// Select the Stage 3 proof-logging strategy: proof_strategy::PerCall
+        /// (the default) or proof_strategy::Upfront. Proof-only: it never
+        /// changes the inferences drawn or the solutions found, and has no
+        /// effect under consistency::BC or with proof logging off.
+        auto with_proof_strategy(BinPackingProofStrategy strategy) -> BinPacking &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/bin_packing/bin_packing_test.cc
+++ b/gcs/constraints/bin_packing/bin_packing_test.cc
@@ -80,7 +80,9 @@ namespace
         for (auto c : capacities)
             caps_i.push_back(Integer{c});
 
-        p.post(BinPacking{items, sizes_i, caps_i, false, upfront});
+        p.post(BinPacking{items, sizes_i, caps_i} //
+                .with_proof_strategy(
+                    upfront ? BinPackingProofStrategy{proof_strategy::Upfront{}} : BinPackingProofStrategy{proof_strategy::PerCall{}}));
 
         auto proof_name = proofs ? make_optional("bin_packing_test") : nullopt;
         // Enumeration only — Stage 3 achieves per-bin GAC, not joint GAC
@@ -132,7 +134,9 @@ namespace
         for (auto s : sizes)
             sizes_i.push_back(Integer{s});
 
-        p.post(BinPacking{items, sizes_i, loads, false, upfront});
+        p.post(BinPacking{items, sizes_i, loads} //
+                .with_proof_strategy(
+                    upfront ? BinPackingProofStrategy{proof_strategy::Upfront{}} : BinPackingProofStrategy{proof_strategy::PerCall{}}));
 
         auto proof_name = proofs ? make_optional("bin_packing_test") : nullopt;
         // Enumeration only; see capa runner for why per-bin GAC isn't

--- a/gcs/constraints/knapsack.hh
+++ b/gcs/constraints/knapsack.hh
@@ -2,6 +2,5 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_KNAPSACK_HH
 
 #include <gcs/constraints/knapsack/knapsack.hh>
-#include <gcs/constraints/knapsack/knapsack_upfront.hh>
 
 #endif

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/knapsack/hints.hh>
 #include <gcs/constraints/knapsack/knapsack.hh>
+#include <gcs/constraints/knapsack/knapsack_upfront.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -20,6 +21,7 @@
 #endif
 
 #include <util/enumerate.hh>
+#include <util/overloaded.hh>
 
 #include <algorithm>
 #include <list>
@@ -65,9 +67,17 @@ Knapsack::Knapsack(vector<vector<Integer>> coefficients, vector<IntegerVariableI
 {
 }
 
+auto Knapsack::with_proof_strategy(KnapsackProofStrategy strategy) -> Knapsack &
+{
+    _proof_strategy = strategy;
+    return *this;
+}
+
 auto Knapsack::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Knapsack>(_coeffs, _vars, _totals);
+    auto cloned = make_unique<Knapsack>(_coeffs, _vars, _totals);
+    cloned->with_proof_strategy(_proof_strategy);
+    return cloned;
 }
 
 namespace
@@ -566,76 +576,75 @@ namespace
     }
 }
 
-auto Knapsack::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+namespace
 {
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
+    auto install_knapsack_percall(Propagators & propagators, State & initial_state, ProofModel * const optional_model, const ConstraintID & owner,
+        vector<vector<Integer>> coeffs, vector<IntegerVariableID> vars, vector<IntegerVariableID> totals) -> void
+    {
+        if (coeffs.size() != totals.size())
+            throw InvalidProblemDefinitionException{"mismatch between coefficients and totals sizes for knapsack"};
 
-    if (optional_model)
-        define_proof_model(*optional_model);
+        if (coeffs.empty())
+            throw InvalidProblemDefinitionException{"empty knapsack coefficients"};
+        unsigned n_vars = coeffs.begin()->size();
 
-    install_propagators(propagators);
-}
+        for (auto & c : coeffs)
+            if (c.size() != n_vars)
+                throw InvalidProblemDefinitionException{"not sure what to do about different coefficient array sizes for knapsack"};
 
-auto Knapsack::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
-{
-    if (_coeffs.size() != _totals.size())
-        throw InvalidProblemDefinitionException{"mismatch between coefficients and totals sizes for knapsack"};
+        for (auto & cc : coeffs)
+            for (auto & c : cc)
+                if (c < 0_i)
+                    throw InvalidProblemDefinitionException{"not sure what to do about negative coefficients for knapsack"};
 
-    if (_coeffs.empty())
-        throw InvalidProblemDefinitionException{"empty knapsack coefficients"};
-    unsigned n_vars = _coeffs.begin()->size();
+        for (auto & v : vars)
+            if (initial_state.lower_bound(v) < 0_i)
+                throw InvalidProblemDefinitionException{"can only support non-negative variables for knapsack"};
 
-    for (auto & c : _coeffs)
-        if (c.size() != n_vars)
-            throw InvalidProblemDefinitionException{"not sure what to do about different coefficient array sizes for knapsack"};
+        for (auto & t : totals)
+            if (initial_state.lower_bound(t) < 0_i)
+                throw InvalidProblemDefinitionException{"not sure what to do about negative permitted totals for knapsack"};
 
-    for (auto & cc : _coeffs)
-        for (auto & c : cc)
-            if (c < 0_i)
-                throw InvalidProblemDefinitionException{"not sure what to do about negative coefficients for knapsack"};
+        vector<pair<ProofLine, ProofLine>> eqns_lines;
+        if (optional_model) {
+            for (const auto & [cc_idx, cc] : enumerate(coeffs)) {
+                WPBSum sum_eq;
+                for (const auto & [idx, v] : enumerate(vars))
+                    sum_eq += cc.at(idx) * v;
+                // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
+                // the row index lives in the annotation tag, not the constraint name (a
+                // name-embedded row could collide with a sibling constraint's name). Match
+                // that so the propagator's pol steps, which cite these lines by label,
+                // resolve against cake's OPB. The bodies are identical.
+                auto [eq1, eq2] = optional_model->add_labelled_constraint(
+                    owner, std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * totals.at(cc_idx));
+                eqns_lines.emplace_back(eq1, eq2);
+            }
+        }
 
-    for (auto & v : _vars)
-        if (initial_state.lower_bound(v) < 0_i)
-            throw InvalidProblemDefinitionException{"can only support non-negative variables for knapsack"};
+        Triggers triggers;
+        triggers.on_change = {vars.begin(), vars.end()};
+        triggers.on_change.insert(triggers.on_change.end(), totals.begin(), totals.end());
 
-    for (auto & t : _totals)
-        if (initial_state.lower_bound(t) < 0_i)
-            throw InvalidProblemDefinitionException{"not sure what to do about negative permitted totals for knapsack"};
-
-    return true;
-}
-
-auto Knapsack::define_proof_model(ProofModel & model) -> void
-{
-    for (const auto & [cc_idx, cc] : enumerate(_coeffs)) {
-        WPBSum sum_eq;
-        for (const auto & [idx, v] : enumerate(_vars))
-            sum_eq += cc.at(idx) * v;
-        // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
-        // the row index lives in the annotation tag, not the constraint name (a
-        // name-embedded row could collide with a sibling constraint's name). Match
-        // that so the propagator's pol steps, which cite these lines by label,
-        // resolve against cake's OPB. The bodies are identical.
-        auto [eq1, eq2] = model.add_labelled_constraint(
-            constraint_id(), std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * _totals.at(cc_idx));
-        _eqns_lines.emplace_back(eq1, eq2);
+        propagators.install(
+            owner,
+            [coeffs = move(coeffs), vars = move(vars), totals = move(totals), eqns_lines = move(eqns_lines), owner](
+                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                return knapsack(state, logger, inference, owner, coeffs, vars, totals, eqns_lines);
+            },
+            triggers);
     }
 }
 
-auto Knapsack::install_propagators(Propagators & propagators) -> void
+auto Knapsack::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    Triggers triggers;
-    triggers.on_change = {_vars.begin(), _vars.end()};
-    triggers.on_change.insert(triggers.on_change.end(), _totals.begin(), _totals.end());
-
-    propagators.install(
-        constraint_id(),
-        [coeffs = move(_coeffs), vars = move(_vars), totals = move(_totals), eqns_lines = move(_eqns_lines), owner = constraint_id()](
-            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            return knapsack(state, logger, inference, owner, coeffs, vars, totals, eqns_lines);
-        },
-        triggers);
+    overloaded{[&](const proof_strategy::PerCall &) {
+                   install_knapsack_percall(propagators, initial_state, optional_model, constraint_id(), move(_coeffs), move(_vars), move(_totals));
+               },
+        [&](const proof_strategy::Upfront &) {
+            install_knapsack_upfront(propagators, initial_state, optional_model, constraint_id(), move(_coeffs), move(_vars), move(_totals));
+        }}
+        .visit(_proof_strategy);
 }
 
 auto Knapsack::constraint_type() const -> std::string

--- a/gcs/constraints/knapsack/knapsack.hh
+++ b/gcs/constraints/knapsack/knapsack.hh
@@ -2,51 +2,64 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_KNAPSACK_KNAPSACK_HH
 
 #include <gcs/constraint.hh>
-#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/proof_strategy.hh>
 #include <gcs/variable_id.hh>
 
-#include <utility>
+#include <variant>
 #include <vector>
 
 namespace gcs
 {
+    /**
+     * \brief The proof-logging strategies Knapsack supports:
+     * proof_strategy::PerCall (the default) or proof_strategy::Upfront.
+     *
+     * PerCall rebuilds the DP table and proof scaffolding from scratch on
+     * every propagation call, at ProofLevel::Temporary; Upfront emits
+     * paper-style scaffolding once at the search root, at ProofLevel::Top.
+     * Both draw the same inferences and find the same solutions; PerCall's
+     * proofs verify 3.6–18× faster (so it is the default), Upfront's are
+     * 3–6× smaller. See dev_docs/knapsack.md.
+     *
+     * \ingroup ProofStrategy
+     */
+    using KnapsackProofStrategy = std::variant<proof_strategy::PerCall, proof_strategy::Upfront>;
+
     /**
      * \brief Knapsack constraint:
      * <code>sum(coefficients[x][i] * vars[i]) = totals[x]</code> for
      * each <code>x</code>. Coefficients and item domains must be
      * non-negative.
      *
-     * This is the default implementation: it builds its DP table and
-     * proof scaffolding from scratch on every propagation call, at
-     * <code>ProofLevel::Temporary</code>. It is chosen as the default
-     * because its proofs verify substantially faster (3.6–18×) than the
-     * upfront-DAG alternative.
-     *
-     * For an opt-in variant that emits upfront paper-style proof
-     * scaffolding once at the search root — producing 3–6× smaller proofs
-     * at the cost of slower verification — see KnapsackUpfront. Prefer it
-     * only when proof size or distribution matters. See
-     * <code>dev_docs/knapsack.md</code> for the measured rationale.
+     * By default the proof is logged per propagation call
+     * (proof_strategy::PerCall), which verifies substantially faster. Request
+     * proof_strategy::Upfront via with_proof_strategy() for the opt-in
+     * upfront-DAG scaffolding, which produces smaller but slower-to-verify
+     * proofs; it draws the same inferences and finds the same solutions, and
+     * never changes the OPB encoding. See <code>dev_docs/knapsack.md</code>
+     * for the measured rationale.
      *
      * \ingroup Constraints
      */
     class Knapsack : public Constraint
     {
     private:
-        const std::vector<std::vector<Integer>> _coeffs;
-        const std::vector<IntegerVariableID> _vars;
-        const std::vector<IntegerVariableID> _totals;
-        std::vector<std::pair<innards::ProofLine, innards::ProofLine>> _eqns_lines;
-
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
+        std::vector<std::vector<Integer>> _coeffs;
+        std::vector<IntegerVariableID> _vars;
+        std::vector<IntegerVariableID> _totals;
+        KnapsackProofStrategy _proof_strategy = proof_strategy::PerCall{};
 
     public:
         explicit Knapsack(std::vector<Integer> weights, std::vector<Integer> profits, std::vector<IntegerVariableID> vars, IntegerVariableID weight,
             IntegerVariableID profit);
 
         explicit Knapsack(std::vector<std::vector<Integer>> coefficients, std::vector<IntegerVariableID> vars, std::vector<IntegerVariableID> totals);
+
+        /// Select the proof-logging strategy: proof_strategy::PerCall (the
+        /// default, fastest to verify) or proof_strategy::Upfront (smaller
+        /// proofs). Proof-only: it never changes the inferences drawn, the
+        /// solutions found, or the OPB encoding.
+        auto with_proof_strategy(KnapsackProofStrategy strategy) -> Knapsack &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/knapsack/knapsack_upfront.cc
+++ b/gcs/constraints/knapsack/knapsack_upfront.cc
@@ -831,103 +831,75 @@ namespace
     }
 }
 
-struct KnapsackUpfront::DagBridge
+namespace
 {
-    Dag dag;
-    Flags flags;
-    vector<pair<ProofLine, ProofLine>> opb_lines;
-};
-
-KnapsackUpfront::KnapsackUpfront(vector<Integer> weights, vector<Integer> profits, vector<IntegerVariableID> vars, IntegerVariableID weight,
-    IntegerVariableID profit) : _coeffs({move(weights), move(profits)}), _vars(move(vars)), _totals({weight, profit})
-{
+    struct KnapsackUpfrontBridge
+    {
+        Dag dag;
+        Flags flags;
+        vector<pair<ProofLine, ProofLine>> opb_lines;
+    };
 }
 
-KnapsackUpfront::KnapsackUpfront(vector<vector<Integer>> coefficients, vector<IntegerVariableID> vars, vector<IntegerVariableID> totals) :
-    _coeffs(move(coefficients)), _vars(move(vars)), _totals(move(totals))
+auto gcs::innards::install_knapsack_upfront(Propagators & propagators, State & initial_state, ProofModel * const optional_model,
+    const ConstraintID & owner, vector<vector<Integer>> coeffs, vector<IntegerVariableID> vars, vector<IntegerVariableID> totals) -> void
 {
-}
-
-auto KnapsackUpfront::clone() const -> unique_ptr<Constraint>
-{
-    return make_unique<KnapsackUpfront>(_coeffs, _vars, _totals);
-}
-
-auto KnapsackUpfront::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model);
-
-    install_propagators(propagators);
-}
-
-auto KnapsackUpfront::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
-{
-    if (_coeffs.size() != _totals.size())
+    if (coeffs.size() != totals.size())
         throw InvalidProblemDefinitionException{"KnapsackUpfront: coefficients and totals must have the same number of equations"};
-    if (_coeffs.empty())
+    if (coeffs.empty())
         throw InvalidProblemDefinitionException{"KnapsackUpfront: at least one equation is required"};
 
-    auto n_vars = _coeffs.front().size();
-    for (const auto & c : _coeffs)
+    auto n_vars = coeffs.front().size();
+    for (const auto & c : coeffs)
         if (c.size() != n_vars)
             throw InvalidProblemDefinitionException{"KnapsackUpfront: every coefficient row must have the same length"};
-    if (n_vars != _vars.size())
+    if (n_vars != vars.size())
         throw InvalidProblemDefinitionException{"KnapsackUpfront: coefficient row length must match number of variables"};
 
-    for (const auto & cc : _coeffs)
+    for (const auto & cc : coeffs)
         for (const auto & c : cc)
             if (c < 0_i)
                 throw InvalidProblemDefinitionException{"KnapsackUpfront: coefficients must be non-negative"};
 
-    for (const auto & v : _vars)
+    for (const auto & v : vars)
         if (initial_state.lower_bound(v) < 0_i)
             throw InvalidProblemDefinitionException{"KnapsackUpfront: item variables must be non-negative"};
 
-    for (const auto & t : _totals)
+    for (const auto & t : totals)
         if (initial_state.lower_bound(t) < 0_i)
             throw InvalidProblemDefinitionException{"KnapsackUpfront: total variables must be non-negative"};
 
-    auto caps = compute_caps(initial_state, _coeffs, _vars, _totals);
-    _bridge = make_shared<DagBridge>();
-    _bridge->dag = build_static_dag(initial_state, _vars, _coeffs, _totals, caps);
+    auto caps = compute_caps(initial_state, coeffs, vars, totals);
+    auto bridge = make_shared<KnapsackUpfrontBridge>();
+    bridge->dag = build_static_dag(initial_state, vars, coeffs, totals, caps);
 
     // Backtrack-restored cache of pure dead-state proof lines we've
     // already emitted at or above the current search depth, so the
     // per-call propagator can skip the entire pol+RUP scaffolding for
     // a state that's already been proven dead in this subtree.
     DeadCache initial_cache{
-        vector<set<vector<Integer>>>(_vars.size() + 1), vector<vector<set<long long>>>(_vars.size() + 1, vector<set<long long>>(_totals.size()))};
-    _dead_cache_handle = initial_state.add_constraint_state(move(initial_cache));
+        vector<set<vector<Integer>>>(vars.size() + 1), vector<vector<set<long long>>>(vars.size() + 1, vector<set<long long>>(totals.size()))};
+    auto dead_cache_handle = initial_state.add_constraint_state(move(initial_cache));
 
-    return true;
-}
-
-auto KnapsackUpfront::define_proof_model(ProofModel & model) -> void
-{
-    for (const auto & [cc_idx, cc] : enumerate(_coeffs)) {
-        WPBSum sum_eq;
-        for (const auto & [idx, v] : enumerate(_vars))
-            sum_eq += cc.at(idx) * v;
-        // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
-        // the row index lives in the annotation tag, not the constraint name (a
-        // name-embedded row could collide with a sibling constraint's name). Match
-        // that so the propagator's pol steps, which cite these lines by label,
-        // resolve against cake's OPB. The bodies are identical.
-        auto [eq1, eq2] = model.add_labelled_constraint(
-            constraint_id(), std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * _totals.at(cc_idx));
-        _bridge->opb_lines.emplace_back(eq1, eq2);
+    if (optional_model) {
+        for (const auto & [cc_idx, cc] : enumerate(coeffs)) {
+            WPBSum sum_eq;
+            for (const auto & [idx, v] : enumerate(vars))
+                sum_eq += cc.at(idx) * v;
+            // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
+            // the row index lives in the annotation tag, not the constraint name (a
+            // name-embedded row could collide with a sibling constraint's name). Match
+            // that so the propagator's pol steps, which cite these lines by label,
+            // resolve against cake's OPB. The bodies are identical.
+            auto [eq1, eq2] = optional_model->add_labelled_constraint(
+                owner, std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * totals.at(cc_idx));
+            bridge->opb_lines.emplace_back(eq1, eq2);
+        }
     }
-}
 
-auto KnapsackUpfront::install_propagators(Propagators & propagators) -> void
-{
     Triggers triggers;
-    triggers.on_change = {_vars.begin(), _vars.end()};
-    triggers.on_change.insert(triggers.on_change.end(), _totals.begin(), _totals.end());
+    triggers.on_change = {vars.begin(), vars.end()};
+    triggers.on_change.insert(triggers.on_change.end(), totals.begin(), totals.end());
 
     // Emit per-(i, w) Top-level scaffolding once at search root: for
     // every forward-reachable node in the static DAG, create reified flags
@@ -941,49 +913,19 @@ auto KnapsackUpfront::install_propagators(Propagators & propagators) -> void
     // ProofLevel::Temporary. In assertion mode the per-call inferences
     // are asserted under the typed hint instead, so the scaffolding is
     // skipped entirely.
-    propagators.install_initialiser(
-        [vars = _vars, coeffs = _coeffs, k = _totals.size(), bridge = _bridge](State & state, auto &, ProofLogger * const logger) -> void {
-            if (! logger || logger->get_assertion_level() != AssertionLevel::Off)
-                return;
-            emit_scaffolding(logger, state, vars, coeffs, k, bridge->dag, bridge->flags);
-        });
+    propagators.install_initialiser([vars, coeffs, k = totals.size(), bridge](State & state, auto &, ProofLogger * const logger) -> void {
+        if (! logger || logger->get_assertion_level() != AssertionLevel::Off)
+            return;
+        emit_scaffolding(logger, state, vars, coeffs, k, bridge->dag, bridge->flags);
+    });
 
     propagators.install(
-        constraint_id(),
-        [vars = _vars, coeffs = _coeffs, totals = _totals, bridge = _bridge, dead_cache_handle = *_dead_cache_handle, owner = constraint_id()](
+        owner,
+        [vars = move(vars), coeffs = move(coeffs), totals = move(totals), bridge, dead_cache_handle, owner](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto & cache = any_cast<DeadCache &>(state.get_constraint_state(dead_cache_handle));
             propagate(state, inference, logger, owner, vars, coeffs, totals, bridge->dag, bridge->flags, bridge->opb_lines, cache);
             return PropagatorState::Enable;
         },
         triggers);
-}
-
-auto KnapsackUpfront::constraint_type() const -> std::string
-{
-    return "knapsack_upfront";
-}
-
-auto KnapsackUpfront::s_expr(const innards::ProofModel * const model) const -> SExpr
-{
-    auto & tracker = model->names_and_ids_tracker();
-
-    vector<SExpr> coeff_rows;
-    for (const auto & cs : _coeffs) {
-        vector<SExpr> row;
-        for (const auto & c : cs)
-            row.push_back(SExpr::atom(c.to_string()));
-        coeff_rows.push_back(SExpr::list(move(row)));
-    }
-
-    vector<SExpr> vars;
-    for (const auto & v : _vars)
-        vars.push_back(tracker.s_expr_term_of(v));
-
-    vector<SExpr> totals;
-    for (const auto & t : _totals)
-        totals.push_back(tracker.s_expr_term_of(t));
-
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(move(coeff_rows)),
-        SExpr::list(move(vars)), SExpr::list(move(totals))});
 }

--- a/gcs/constraints/knapsack/knapsack_upfront.hh
+++ b/gcs/constraints/knapsack/knapsack_upfront.hh
@@ -2,74 +2,30 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_KNAPSACK_KNAPSACK_UPFRONT_HH
 
 #include <gcs/constraint.hh>
-#include <gcs/innards/proofs/proof_logger.hh>
-#include <gcs/innards/state.hh>
+#include <gcs/constraint_id.hh>
+#include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
-#include <memory>
-#include <optional>
-#include <utility>
 #include <vector>
 
-namespace gcs
+namespace gcs::innards
 {
     /**
-     * \brief Knapsack constraint (opt-in upfront-DAG variant):
-     * <code>sum(coefficients[x][i] * vars[i]) = totals[x]</code> for
-     * each <code>x</code>. Coefficients and item domains must be
-     * non-negative.
+     * \brief Install the up-front (paper-style, `ProofLevel::Top`) proof-logging
+     * variant of the Knapsack propagator, selected by
+     * `Knapsack::with_proof_strategy(proof_strategy::Upfront{})`.
      *
-     * This is the opt-in alternative to the default per-call Knapsack.
-     * It follows the same upfront-DAG pattern as BinPacking and MDD:
-     * <code>prepare()</code> builds the statically-reduced layered DAG
-     * once from the initial domains (forward reach from
-     * <code>(0,...,0)</code> intersected with backward reach from
-     * layer-n states whose every coordinate lies in
-     * <code>initial dom(totals[x])</code>);
-     * <code>install_initialiser</code> emits one-shot proof scaffolding
-     * — per-coordinate <code>g_up</code> / <code>g_dn</code> reified
-     * inequality flags and per-state conjunction flags — at
-     * <code>ProofLevel::Top</code>; the per-call propagator does
-     * forward+backward reachability against the current item and total
-     * domains restricted to the static DAG and prunes items / total
-     * bounds via <code>JustifyUsingRUP</code>. RUP closes through the
-     * bridge reifications plus the natural per-equation OPB constraints.
-     *
-     * This produces 3–6× smaller proofs than the default Knapsack, but
-     * verifies 3.6–18× more slowly, so it is not the default. Prefer it
-     * only when proof size or distribution matters. See
-     * <code>dev_docs/knapsack.md</code> for the staged design and the
-     * measured rationale.
-     *
-     * \ingroup Constraints
+     * It builds the statically-reduced layered DAG once from the initial
+     * domains, emits per-coordinate `g_up` / `g_dn` reified inequality flags
+     * and per-state conjunction flags once at the search root, and prunes items
+     * / total bounds with a per-call `JustifyUsingRUP` that RUP-closes through
+     * that scaffolding plus the natural per-equation OPB constraints. It draws
+     * exactly the same inferences as the default per-call `Knapsack`; only the
+     * proof differs (3–6× smaller, but 3.6–18× slower to verify). See
+     * `dev_docs/knapsack.md`.
      */
-    class KnapsackUpfront : public Constraint
-    {
-    private:
-        struct DagBridge;
-
-        std::vector<std::vector<Integer>> _coeffs;
-        std::vector<IntegerVariableID> _vars;
-        std::vector<IntegerVariableID> _totals;
-        std::shared_ptr<DagBridge> _bridge;
-        std::optional<innards::ConstraintStateHandle> _dead_cache_handle;
-
-        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
-        virtual auto install_propagators(innards::Propagators &) -> void override;
-
-    public:
-        explicit KnapsackUpfront(std::vector<Integer> weights, std::vector<Integer> profits, std::vector<IntegerVariableID> vars,
-            IntegerVariableID weight, IntegerVariableID profit);
-
-        explicit KnapsackUpfront(
-            std::vector<std::vector<Integer>> coefficients, std::vector<IntegerVariableID> vars, std::vector<IntegerVariableID> totals);
-
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-        virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
-        [[nodiscard]] virtual auto constraint_type() const -> std::string override;
-    };
+    auto install_knapsack_upfront(Propagators & propagators, State & initial_state, ProofModel * const optional_model, const ConstraintID & owner,
+        std::vector<std::vector<Integer>> coeffs, std::vector<IntegerVariableID> vars, std::vector<IntegerVariableID> totals) -> void;
 }
 
 #endif

--- a/gcs/constraints/knapsack/knapsack_upfront_test.cc
+++ b/gcs/constraints/knapsack/knapsack_upfront_test.cc
@@ -1,5 +1,5 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
-#include <gcs/constraints/knapsack/knapsack_upfront.hh>
+#include <gcs/constraints/knapsack/knapsack.hh>
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
@@ -106,7 +106,7 @@ auto run_knapsack_upfront_test(bool proofs, pair<int, int> valrange, const vecto
         for (const auto & w : coeffs[i])
             coeffs_integers[i].push_back(Integer(w));
 
-    p.post(KnapsackUpfront{coeffs_integers, vs, bs});
+    p.post(Knapsack{coeffs_integers, vs, bs}.with_proof_strategy(proof_strategy::Upfront{}));
 
     auto proof_name = proofs ? make_optional("knapsack_upfront_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vs, bs});
@@ -161,7 +161,7 @@ auto run_dup_knapsack_upfront_test(bool proofs, const string & label, pair<int, 
         for (auto c : row)
             coeffs_i.back().push_back(Integer(c));
     }
-    p.post(KnapsackUpfront{coeffs_i, vs, bs});
+    p.post(Knapsack{coeffs_i, vs, bs}.with_proof_strategy(proof_strategy::Upfront{}));
 
     auto proof_name = proofs ? make_optional("knapsack_upfront_test_dup_" + label) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{unique_vars, bs});
@@ -206,7 +206,7 @@ auto run_knapsack_upfront_regression(pair<int, int> valrange, const vector<vecto
         for (const auto & w : coeffs[i])
             coeffs_integers[i].push_back(Integer(w));
 
-    p.post(KnapsackUpfront{coeffs_integers, items, totals});
+    p.post(Knapsack{coeffs_integers, items, totals}.with_proof_strategy(proof_strategy::Upfront{}));
 
     set<tuple<vector<int>, vector<int>>> actual;
     auto record_solution = [&](const CurrentState & s) -> bool {

--- a/gcs/constraints/regular.hh
+++ b/gcs/constraints/regular.hh
@@ -2,7 +2,5 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_REGULAR_HH
 
 #include <gcs/constraints/regular/regular.hh>
-#include <gcs/constraints/regular/regular_bacchus.hh>
-#include <gcs/constraints/regular/regular_legacy.hh>
 
 #endif

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -1,6 +1,8 @@
 #include <gcs/constraints/regular/hints.hh>
 #include <gcs/constraints/regular/regex.hh>
 #include <gcs/constraints/regular/regular.hh>
+#include <gcs/constraints/regular/regular_bacchus.hh>
+#include <gcs/constraints/regular/regular_legacy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -9,6 +11,8 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/proof.hh>
+
+#include <util/overloaded.hh>
 
 #include <version>
 
@@ -498,20 +502,55 @@ auto Regular::with_short_reasons(std::optional<bool> short_reasons) -> Regular &
     return *this;
 }
 
+auto Regular::with_proof_strategy(RegularProofStrategy strategy) -> Regular &
+{
+    _proof_strategy = strategy;
+    return *this;
+}
+
 auto Regular::clone() const -> unique_ptr<Constraint>
 {
-    return unique_ptr<Constraint>(new Regular(_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex));
+    auto cloned = unique_ptr<Regular>(new Regular(_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex));
+    cloned->with_proof_strategy(_proof_strategy);
+    return cloned;
 }
 
 auto Regular::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model);
-
-    install_propagators(propagators);
+    // The three strategies share this constraint's OPB encoding and its
+    // inferences; they differ only in the proof scaffolding, so each is a
+    // distinct install path over the same automaton. Upfront is this class's
+    // own path; PerCall and Bacchus delegate to the sibling implementations,
+    // which are internal to this constraint (not part of the public API).
+    overloaded{[&](const proof_strategy::Upfront &) {
+                   if (! prepare(propagators, initial_state, optional_model))
+                       return;
+                   if (optional_model)
+                       define_proof_model(*optional_model);
+                   install_propagators(propagators);
+               },
+        [&](const proof_strategy::PerCall &) {
+            RegularLegacy legacy{_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex};
+            legacy.set_constraint_id(constraint_id());
+            move(legacy).install(propagators, initial_state, optional_model);
+        },
+        [&](const proof_strategy::Bacchus &) {
+            if (_regex)
+                throw UnimplementedException{"the Bacchus proof strategy for Regular does not support regular-expression / NFA input"};
+            // Recover the deterministic transition map the Bacchus encoding
+            // needs from the shared (possibly non-deterministic) representation.
+            vector<unordered_map<Integer, long>> dfa(_transitions.size());
+            for (size_t q = 0; q < _transitions.size(); ++q)
+                for (const auto & [val, targets] : _transitions[q]) {
+                    if (targets.size() != 1)
+                        throw UnimplementedException{"the Bacchus proof strategy for Regular requires a deterministic automaton"};
+                    dfa[q][val] = *targets.begin();
+                }
+            RegularBacchus bacchus{_vars, _num_states, dfa, _final_states, _short_reasons};
+            bacchus.set_constraint_id(constraint_id());
+            move(bacchus).install(propagators, initial_state, optional_model);
+        }}
+        .visit(_proof_strategy);
 }
 
 auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool

--- a/gcs/constraints/regular/regular.hh
+++ b/gcs/constraints/regular/regular.hh
@@ -5,6 +5,7 @@
 #include <gcs/extensional.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/state.hh>
+#include <gcs/proof_strategy.hh>
 #include <gcs/variable_id.hh>
 
 #include <memory>
@@ -12,10 +13,30 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace gcs
 {
+    /**
+     * \brief The proof-logging strategies Regular supports:
+     * proof_strategy::Upfront (the default), proof_strategy::PerCall, or
+     * proof_strategy::Bacchus.
+     *
+     * All three draw the same inferences (generalised arc consistency on the
+     * automaton) and find the same solutions; they differ only in the proof.
+     * Upfront (the default, because a Regular automaton is narrow so its
+     * Top-level scaffold is tiny) emits per-val backward chains and
+     * statically-dead-node lines once at the root; PerCall re-emits
+     * per-(parent, val) intermediates on every propagation call; Bacchus emits
+     * a stronger transition-extension encoding at the root so the per-call
+     * propagator needs no proof lines. Bacchus supports only a deterministic
+     * automaton, not regular-expression / NFA input. See dev_docs/regular.md.
+     *
+     * \ingroup ProofStrategy
+     */
+    using RegularProofStrategy = std::variant<proof_strategy::Upfront, proof_strategy::PerCall, proof_strategy::Bacchus>;
+
     /**
      * \brief Constrain that the sequence of variables is a member of the
      * language recognised by the given finite automaton, equivalent to a regex
@@ -26,17 +47,18 @@ namespace gcs
      * is compiled to an NFA over the constrained variables' domains. The syntax
      * matches MiniZinc/Gecode (see regular/regex.hh).
      *
-     * Proof scaffolding mirrors the upfront pattern used by MDD, Knapsack, and
-     * BinPacking Stage 3: the OPB encoding is the natural per-(state, val)
-     * forward chains plus per-layer exactly-one, and a one-shot Top-level
-     * initialiser derives per-val backward chains plus statically-dead-node
-     * lines. The per-call propagator's `~state[i][q]` derivations RUP-close
-     * through that scaffolding instead of re-emitting per-(parent, val)
-     * intermediates on every propagation call.
+     * The OPB encoding — the natural per-(state, val) forward chains plus
+     * per-layer exactly-one — is shared by every proof strategy. By default the
+     * upfront strategy is used: a one-shot Top-level initialiser derives
+     * per-val backward chains plus statically-dead-node lines, and the per-call
+     * propagator's `~state[i][q]` derivations RUP-close through that
+     * scaffolding. Select a different strategy with with_proof_strategy() (see
+     * RegularProofStrategy); the choice is proof-only and never changes the
+     * inferences, solutions, or OPB encoding.
      *
-     * The `short_reasons` flag is retained for API parity with RegularLegacy
-     * and benchmarking. The new propagator emits at most one proof line per
-     * state-death, so the effect of the flag is small or zero here.
+     * The `short_reasons` flag (with_short_reasons()) is a proof-log tuning
+     * knob retained for benchmarking; it has little or no effect on the default
+     * upfront strategy.
      *
      * \ingroup Constraints
      */
@@ -50,6 +72,7 @@ namespace gcs
         std::vector<std::unordered_map<Integer, std::set<long>>> _transitions;
         std::vector<long> _final_states;
         bool _short_reasons = true;
+        RegularProofStrategy _proof_strategy = proof_strategy::Upfront{};
         const std::optional<std::string> _regex;
         std::vector<Integer> _symbols;
         std::shared_ptr<Bridge> _bridge;
@@ -84,6 +107,13 @@ namespace gcs
         /// std::optional<bool> so a runtime flag can be passed directly; nullopt
         /// or no argument leaves it at true.
         auto with_short_reasons(std::optional<bool> short_reasons = true) -> Regular &;
+
+        /// Select the proof-logging strategy: proof_strategy::Upfront (the
+        /// default), proof_strategy::PerCall, or proof_strategy::Bacchus.
+        /// Proof-only: it never changes the inferences drawn, the solutions
+        /// found, or the OPB encoding. proof_strategy::Bacchus requires a
+        /// deterministic automaton (not regular-expression / NFA input).
+        auto with_proof_strategy(RegularProofStrategy strategy) -> Regular &;
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/regular/regular_bacchus_test.cc
+++ b/gcs/constraints/regular/regular_bacchus_test.cc
@@ -68,7 +68,7 @@ auto run_regular_bacchus_test(bool proofs, const string & desc, vector<pair<int,
     vector<IntegerVariableID> vars;
     for (const auto & [lo, hi] : var_ranges)
         vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
-    p.post(RegularBacchus{vars, num_states, transitions, final_states});
+    p.post(Regular{vars, num_states, transitions, final_states}.with_proof_strategy(proof_strategy::Bacchus{}));
 
     auto proof_name = proofs ? make_optional("regular_bacchus_test") : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});

--- a/gcs/constraints/regular/regular_legacy.hh
+++ b/gcs/constraints/regular/regular_legacy.hh
@@ -29,6 +29,11 @@ namespace gcs
      */
     class RegularLegacy : public Constraint
     {
+        // Regular is the public front-end; it constructs a RegularLegacy through
+        // the internal representation constructor below when its proof strategy
+        // is proof_strategy::PerCall.
+        friend class Regular;
+
     private:
         const std::vector<IntegerVariableID> _vars;
         long _num_states;

--- a/gcs/constraints/regular/regular_legacy_test.cc
+++ b/gcs/constraints/regular/regular_legacy_test.cc
@@ -1,6 +1,6 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/regular.hh>
 #include <gcs/constraints/regular/regex.hh>
-#include <gcs/constraints/regular/regular_legacy.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -71,7 +71,7 @@ auto run_regular_test(bool proofs, const ViewWrapConfig & view_cfg, const string
     vector<IntegerVariableID> vars;
     for (std::size_t i = 0; i < var_ranges.size(); ++i)
         vars.push_back(create_integer_variable_or_constant_with_view(p, var_ranges.at(i), wraps.at(i)));
-    p.post(RegularLegacy{vars, num_states, transitions, final_states});
+    p.post(Regular{vars, num_states, transitions, final_states}.with_proof_strategy(proof_strategy::PerCall{}));
 
     auto proof_name = proofs ? make_optional("regular_legacy_test_" + view_wrap_config_label(view_cfg)) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});
@@ -118,7 +118,7 @@ auto run_dup_regular_test(bool proofs, const string & label, const vector<pair<i
     vector<IntegerVariableID> vars;
     for (auto pos : positions)
         vars.push_back(unique_vars.at(pos));
-    p.post(RegularLegacy{vars, num_states, transitions, final_states});
+    p.post(Regular{vars, num_states, transitions, final_states}.with_proof_strategy(proof_strategy::PerCall{}));
 
     auto proof_name = proofs ? make_optional("regular_legacy_test_dup_" + label) : nullopt;
     solve_for_tests(p, proof_name, actual, tuple{unique_vars});
@@ -157,7 +157,7 @@ auto run_regular_regex_test(bool proofs, const string & label, const string & re
     vector<IntegerVariableID> vars;
     for (const auto & [a, b] : var_ranges)
         vars.push_back(p.create_integer_variable(Integer(a), Integer(b)));
-    p.post(RegularLegacy{vars, regex});
+    p.post(Regular{vars, regex}.with_proof_strategy(proof_strategy::PerCall{}));
 
     auto proof_name = proofs ? make_optional("regular_legacy_regex_test_" + label) : nullopt;
     solve_for_tests_checking_gac(p, proof_name, expected, actual, tuple{vars});

--- a/gcs/proof_strategy.hh
+++ b/gcs/proof_strategy.hh
@@ -1,0 +1,88 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOF_STRATEGY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOF_STRATEGY_HH
+
+namespace gcs
+{
+    /**
+     * \defgroup ProofStrategy Selecting a proof-logging strategy
+     *
+     * A handful of constraints — the decision-diagram family `Regular`, `MDD`,
+     * `Knapsack` and `BinPacking` — can log their reasoning in more than one
+     * way. Every strategy draws exactly the same inferences and finds exactly
+     * the same solutions; they differ only in the shape and size of the VeriPB
+     * proof, and hence in how quickly that proof verifies. A constraint that
+     * offers a choice exposes a `with_proof_strategy()` fluent setter taking a
+     * `std::variant` over the tag types below that name exactly the strategies
+     * it supports, defaulted to the one that is fastest to verify in practice,
+     * for example
+     *
+     * \code{.cc}
+     * problem.post(Knapsack{coeffs, vars, totals}.with_proof_strategy(proof_strategy::Upfront{}));
+     * \endcode
+     *
+     * Requesting a strategy a constraint does not support is a compile-time
+     * error: the setter's signature is the documentation. Because the choice
+     * is proof-only, it never changes the constraint's meaning, the inferences
+     * it draws, the solutions it finds, or the OPB encoding written for the
+     * proof — only the proof steps that justify those inferences. When proof
+     * logging is switched off, the choice has no effect at all.
+     *
+     * See `dev_docs/decision-diagram-proof-strategies.md` for the cost model
+     * that motivates each default.
+     */
+
+    namespace proof_strategy
+    {
+        /**
+         * \brief Emit proof scaffolding lazily, during search: on each
+         * propagation call the propagator writes the justification it needs at
+         * that node (at `ProofLevel::Current` or `ProofLevel::Temporary`).
+         *
+         * This keeps the permanent proof database small at the cost of
+         * re-deriving per-call material, and is typically the fastest to
+         * verify — it is the default for `Knapsack` and `BinPacking`. See
+         * `dev_docs/decision-diagram-proof-strategies.md`.
+         *
+         * \ingroup ProofStrategy
+         */
+        struct PerCall final
+        {
+        };
+
+        /**
+         * \brief Emit the proof scaffolding once, up front at the search root
+         * (at `ProofLevel::Top`), so the per-call propagator's inferences
+         * RUP-close through it instead of re-deriving material on every call.
+         *
+         * This generally produces smaller proofs, but with a wider permanent
+         * proof database each RUP can be more expensive to check. It is the
+         * default for the narrow-automaton `Regular`, where the fixed scaffold
+         * is tiny; for `Knapsack` and `BinPacking` it is the opt-in that
+         * trades verify time for proof size. See
+         * `dev_docs/decision-diagram-proof-strategies.md`.
+         *
+         * \ingroup ProofStrategy
+         */
+        struct Upfront final
+        {
+        };
+
+        /**
+         * \brief Emit a stronger up-front encoding, following Bacchus's "GAC
+         * via unit propagation" (CP 2007), so that the per-call propagator can
+         * justify its prunes with no proof lines at all — VeriPB closes the
+         * eventual backtrack by unit propagation on the Top-level encoding.
+         *
+         * Specific to `Regular`, whose layer-uniform automaton makes the
+         * transition-extension encoding cheap. See
+         * `dev_docs/decision-diagram-proof-strategies.md`.
+         *
+         * \ingroup ProofStrategy
+         */
+        struct Bacchus final
+        {
+        };
+    }
+}
+
+#endif


### PR DESCRIPTION
Converts the four decision-diagram constraints — **Regular, MDD, Knapsack, BinPacking** — to the "single public constraint, fluent setters for every option" style already used by `Circuit` and `AllDifferent` (the issue #299 fluent-options sweep). No functional change: same inferences, same solutions, same OPB encodings — only how you *select* a variant changes.

### New shared vocabulary

`gcs/proof_strategy.hh` adds `proof_strategy::{PerCall, Upfront, Bacchus}`, parallel to `gcs::consistency`. A constraint that can log its reasoning more than one way takes its own supported subset as a `std::variant` via a fluent `with_proof_strategy()` setter. The choice is **proof-only** — it never changes the inferences, the solutions, or the OPB encoding (and is a no-op with proof logging off).

> **Naming** (the one genuinely new API decision — flagged for review): I went with `with_proof_strategy` + a shared `proof_strategy` tag family, matching how `consistency::` tags are shared across constraints. Easy to rename if you'd prefer something else.

### Per constraint

| Constraint | Before | After |
|---|---|---|
| **Regular** | 3 public classes `Regular` / `RegularLegacy` / `RegularBacchus` | one `Regular`, `with_proof_strategy(proof_strategy::{Upfront (default), PerCall, Bacchus})` + `with_short_reasons()` |
| **Knapsack** | 2 public classes `Knapsack` / `KnapsackUpfront` | one `Knapsack`, `with_proof_strategy(proof_strategy::{PerCall (default), Upfront})` |
| **BinPacking** | positional `bool bounds_only, bool upfront_proof` ctor args | `with_consistency(consistency::{GAC (default), BC})` + `with_proof_strategy(proof_strategy::{PerCall (default), Upfront})` |
| **MDD** | already one class, upfront-only (per-call deferred, #211) | unchanged — already conformant |

### How the collapse was done

- **Knapsack** follows the house recipe (AllDifferent/GCC/Circuit): the two install paths become free functions `install_knapsack_percall` / `install_knapsack_upfront`, and `Knapsack::install()` dispatches with `overloaded{…}.visit(_proof_strategy)`. `KnapsackUpfront` the class is deleted; both strategies emit `constraint_type()` `"knapsack"` (identical OPB).
- **Regular**'s three implementations are genuinely heterogeneous — NFA vs DFA transition data, and regex/NFA input is supported by upfront/per-call but not Bacchus — so rather than force one class with a unified `prepare()`, the public `Regular` (the `Upfront` implementation) dispatches: it runs the upfront path itself and, for `PerCall`/`Bacchus`, constructs and delegates to the now-internal sibling implementations. `proof_strategy::Bacchus` requires a deterministic automaton and throws on regex/NFA input (which `RegularBacchus` never accepted).
- **BinPacking** already dispatched internally on its two bools; the setters just set them, and `clone()` rebuilds through the setters.

Frontends (XCSP, FlatZinc, `scp_reader`) post the defaults and are **unchanged**. Benches and the constraint tests select variants through the new setters.

### Verification

- Full build including the XCSP/MiniZinc frontends.
- **All 505 ctests pass**, including every constraint's proof-verified test at each strategy and the cake `scp_chain_{regular,knapsack}` round-trips (the upfront/bacchus paths now round-trip through cake as `"knapsack"` / `"regular"`).

dev_docs (`regular.md`, `knapsack.md`, `bin-packing.md`, `decision-diagram-proof-strategies.md`) updated to the fluent API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
