### PR TITLE
Refined-watch API: declare propagator scope without arming a coarse trigger (#506)

### DIFF
--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -354,16 +354,16 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
             // so a wake touches just the affected tuples rather than rescanning all.
             //
             // The variables are still declared as the propagator's scope, via
-            // on_instantiated triggers, so degree-based branchers (dom_then_deg,
-            // dom-wdeg) see this constraint on its variables exactly as the coarse
-            // version did -- a watch-only (empty-Triggers) propagator is otherwise
-            // invisible to those heuristics and perturbs the search. on_instantiated is
-            // the least-frequent coarse trigger, and after the one-off setup every such
-            // wake finds fired-payloads empty and the tuples already armed, so it is an
-            // O(1) no-op: the real work still happens only on watch fires.
+            // scope_only, so degree-based branchers (dom_then_deg, dom-wdeg) see this
+            // constraint on its variables exactly as the coarse version did -- a
+            // watch-only (empty-Triggers) propagator is otherwise invisible to those
+            // heuristics and perturbs the search. scope_only declares scope without
+            // arming any wake, so unlike an on_instantiated trigger it costs no coarse
+            // no-op wake: the propagator runs once at the root (the first pass enqueues
+            // every propagator) to arm its watches, then only on watch fires.
             Triggers scope_triggers;
             for (auto & v : _vars)
-                scope_triggers.on_instantiated.emplace_back(v);
+                scope_triggers.scope_only.emplace_back(v);
 
             propagators.install(
                 constraint_id(),

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -353,11 +353,30 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
     int constraint_index = it->second;
     _imp->propagator_constraint_index.push_back(constraint_index);
 
-    // Record this propagator's scope (its trigger variables, views resolved and
-    // deduplicated) and add it to each variable's constraint adjacency.
+    // A propagator's SCOPE -- the variables it constrains -- is a first-class
+    // notion, distinct from how the propagator is WOKEN. Three things read the
+    // scope: each variable's degree (for the dom_then_deg / dom-wdeg branchers),
+    // the variable->constraint adjacency, and the idempotence-aliasing check.
+    // Waking is a separate concern, wired at the end via trigger_on_* and
+    // register_refined_watch. For an ordinary propagator the two coincide -- a
+    // coarse trigger both wakes it and marks scope -- but a propagator woken only
+    // by refined watches declares its scope via triggers.scope_only, arming no
+    // wake. So derive scope once here, then the wake wiring afterwards.
+    //
+    // The algorithmic positions -- the coarse triggers and scope_only -- carry
+    // multiplicity, which the aliasing check needs: two positions aliasing the
+    // same underlying variable break most propagators' idempotence, and views
+    // hide the repeat from the author (x and -x + 3 alias; a lone +-x + c view is
+    // harmless, being a bijection on Z -- if a non-bijective view kind is ever
+    // added, a multiplier say, any occurrence must flag the scope as risky, not
+    // just a repeat). Refined-watch literals also put their variable in scope (so
+    // it counts for degree and adjacency), but a watch is a wake mechanism that
+    // may legitimately arm many watches on one variable, so it is not an
+    // algorithmic position and does not feed the aliasing multiset.
     auto & scope = _imp->propagator_scope.emplace_back();
-    scope.reserve(triggers.on_change.size() + triggers.on_bounds.size() + triggers.on_instantiated.size());
-    auto add_to_scope = [&](IntegerVariableID var) {
+    scope.reserve(triggers.on_change.size() + triggers.on_bounds.size() + triggers.on_instantiated.size() + triggers.scope_only.size());
+
+    auto add_scope_var = [&](const IntegerVariableID & var) {
         overloaded{//
             [&](const SimpleIntegerVariableID & v) {
                 if (! contains(scope, v))
@@ -370,16 +389,33 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
             [&](const ConstantIntegerVariableID &) {}}
             .visit(var);
     };
+
+    // The underlying-variable indices of the algorithmic positions, WITH
+    // multiplicity, for the aliasing check.
+    vector<unsigned long long> position_underlying;
+    auto add_position = [&](const IntegerVariableID & var) {
+        add_scope_var(var);
+        overloaded{
+            [&](const SimpleIntegerVariableID & sv) { position_underlying.push_back(sv.index); },                 //
+            [&](const ViewOfIntegerVariableID & vv) { position_underlying.push_back(vv.actual_variable.index); }, //
+            [&](const ConstantIntegerVariableID &) {}                                                             //
+        }
+            .visit(var);
+    };
+
     for (const auto & v : triggers.on_change)
-        add_to_scope(v);
+        add_position(v);
     for (const auto & v : triggers.on_bounds)
-        add_to_scope(v);
+        add_position(v);
     for (const auto & v : triggers.on_instantiated)
-        add_to_scope(v);
+        add_position(v);
+    for (const auto & v : triggers.scope_only)
+        add_position(v);
     for (const auto & refined : triggers.refined)
         if (auto cond = std::get_if<IntegerVariableCondition>(&refined.first))
-            add_to_scope(cond->var);
+            add_scope_var(cond->var);
 
+    // Adjacency: each scope variable participates in this constraint.
     for (const auto & v : scope) {
         if (_imp->var_constraint_indices.size() <= v.index)
             _imp->var_constraint_indices.resize(v.index + 1);
@@ -398,52 +434,29 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         if (! contains(cscope, v))
             cscope.push_back(v);
 
-    // Most propagation algorithms are only idempotent when no two scope
-    // positions alias the same underlying variable, and only the posted scope
-    // (visible here, as the triggers) tells us whether they do: views hide
-    // repeats from the author (x and -x + 3 alias), though a single +-x + c
-    // view on its own is harmless, being a bijection on Z. (If a view kind
-    // that is not a bijection is ever added -- a multiplier, say -- any
-    // occurrence of it must flag the scope as risky, not just a repeat.) So
-    // canonicalise every trigger variable and, on a repeat, ignore any
-    // EnableButIdempotent claims this propagator makes: a false positive
-    // merely restores the always-requeue behaviour.
-    vector<unsigned long long> underlying_trigger_vars;
-    auto add_underlying = [&](const IntegerVariableID & v) {
-        overloaded{
-            [&](const SimpleIntegerVariableID & sv) { underlying_trigger_vars.push_back(sv.index); },                 //
-            [&](const ViewOfIntegerVariableID & vv) { underlying_trigger_vars.push_back(vv.actual_variable.index); }, //
-            [&](const ConstantIntegerVariableID &) {}                                                                 //
-        }
-            .visit(v);
-    };
+    // Degree: once per distinct scope variable. A variable the propagator
+    // constrains raises its degree by one, no matter how many trigger slots or
+    // watches mention it.
+    for (const auto & v : scope)
+        increase_degree(v);
 
-    for (const auto & v : triggers.on_change) {
+    // Aliasing: if two algorithmic positions resolve to the same underlying
+    // variable, ignore any EnableButIdempotent this propagator claims (a false
+    // positive merely restores the always-requeue behaviour).
+    sort(position_underlying);
+    _imp->idempotence_claims_ignored.push_back(adjacent_find(position_underlying) != position_underlying.end() ? 1 : 0);
+
+    // Wake wiring, separate from scope: coarse triggers enqueue the propagator on
+    // the matching event; refined watches are armed in the index. scope_only
+    // arms nothing -- it is scope, not a wake.
+    for (const auto & v : triggers.on_change)
         trigger_on_change(v, id);
-        increase_degree(v);
-        add_underlying(v);
-    }
-
-    for (const auto & v : triggers.on_bounds) {
+    for (const auto & v : triggers.on_bounds)
         trigger_on_bounds(v, id);
-        increase_degree(v);
-        add_underlying(v);
-    }
-
-    for (const auto & v : triggers.on_instantiated) {
+    for (const auto & v : triggers.on_instantiated)
         trigger_on_instantiated(v, id);
-        increase_degree(v);
-        add_underlying(v);
-    }
-
-    sort(underlying_trigger_vars);
-    _imp->idempotence_claims_ignored.push_back(adjacent_find(underlying_trigger_vars) != underlying_trigger_vars.end() ? 1 : 0);
-
-    for (const auto & [literal, payload] : triggers.refined) {
-        if (auto cond = std::get_if<IntegerVariableCondition>(&literal))
-            increase_degree(cond->var);
+    for (const auto & [literal, payload] : triggers.refined)
         _imp->register_refined_watch(id, literal, payload, false);
-    }
 }
 
 auto Propagators::install_initialiser(InitialisationFunction && f, InitialiserPriority priority) -> void

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -350,6 +350,25 @@ namespace gcs::innards
          * backtrack. \sa RefinedWatchContext
          */
         std::vector<std::pair<Literal, std::uint32_t>> refined = {};
+
+        /**
+         * \brief Variables that are in the propagator's scope but arm no wake.
+         *
+         * A propagator's *scope* — the variables it constrains — is a distinct
+         * notion from how it is *woken*. Scope drives each variable's degree (for
+         * the dom_then_deg / dom-wdeg branchers), the variable→constraint
+         * adjacency, and the idempotence-aliasing check; waking is what the coarse
+         * triggers and \ref refined watches do. For an ordinary propagator the two
+         * coincide, so listing a variable in on_change/on_bounds/on_instantiated
+         * serves both. A propagator woken *only* by refined watches it arms
+         * dynamically (its install-time \ref refined and coarse triggers being
+         * empty) would otherwise have an empty scope and so be invisible to
+         * degree-based heuristics and the aliasing check. List its variables here
+         * to declare them in scope without arming a coarse trigger: they raise
+         * degree and count as algorithmic positions for aliasing, but generate no
+         * wake of their own. \sa RefinedWatchContext
+         */
+        std::vector<IntegerVariableID> scope_only = {};
     };
 
     /**

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -102,10 +102,12 @@ TEST_CASE("dom_wdeg tie-breaks on degree")
     auto b = state.allocate_integer_variable_with_state(0_i, 3_i);
 
     Propagators propagators;
-    // Both share the single constraint, so W(a)=W(b)=1 and dom/W ties. But a is
-    // registered on an extra trigger, giving it the higher degree, so the
-    // tie-break prefers it.
-    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}, .on_bounds = {a}});
+    // Both share the one binary constraint, so W(a)=W(b)=1 and dom/W ties. a is
+    // also in a second, unary constraint: a unary constraint never has two
+    // unassigned variables, so weighted_degree_of filters it out (W(a) stays 1),
+    // but it still raises a's plain degree, so the degree tie-break prefers a.
+    propagators.install(NumberedConstraint{1}, a_propagator_that_does_nothing(), Triggers{.on_change = {a, b}});
+    propagators.install(NumberedConstraint{2}, a_propagator_that_does_nothing(), Triggers{.on_change = {a}});
 
     REQUIRE(propagators.degree_of(a) > propagators.degree_of(b));
 


### PR DESCRIPTION
Closes #506.

A propagator's **scope** — the variables it constrains — drives three things:
each variable's degree (for the `dom_then_deg` / `dom-wdeg` branchers), the
variable→constraint adjacency, and the idempotence-aliasing check. All three
read scope out of the coarse `Triggers`, so a propagator woken *only* by refined
watches (empty `Triggers`) is invisible to all of them. NegativeTable worked
around this with an `on_instantiated` trigger whose only job was to declare scope
— an O(1) no-op wake per instantiation.

This also subsumes a second, independent symptom: the idempotence-aliasing check
(`propagators.cc`, the "variable appears more than once in scope" multiset) reads
scope out of triggers too, so a refined-watch propagator with an aliased position
could not have it detected.

### What changed
- Add `Triggers::scope_only`: variables in scope that arm no wake.
- `install()` now builds the scope **once** as an explicit list of positions —
  coarse triggers + `scope_only` (the algorithmic positions, carrying the
  multiplicity the aliasing check needs) + refined-watch literals (in scope, but
  a wake mechanism that may arm many watches per variable, so excluded from the
  aliasing multiset) — and derives degree, adjacency, and aliasing from it.
  Waking (`trigger_on_*`, `register_refined_watch`) is wired separately.
- Degree is now once per **distinct** scope variable rather than once per trigger
  slot, fixing a latent double-count. No real constraint double-registers, so
  search is unchanged; the one artificial test that leveraged it (an extra trigger
  slot to inflate degree) is rewritten to build the gap legitimately via a unary
  second constraint that `weighted_degree_of` filters out.
- Port NegativeTable off `on_instantiated` onto `scope_only`: it runs once at the
  root to arm watches, then only on watch fires — no coarse no-op wakes.

All 517 tests pass; `negative_table` and `mini_linear` proofs still verify.

Stacked on #509 (`table-performance`). First of a small stack toward #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)