### PR TITLE
Refined-watch API: clear/replace a propagator's whole watch set (#505)

### DIFF
--- a/examples/slack_watch/slack_watch.cc
+++ b/examples/slack_watch/slack_watch.cc
@@ -133,6 +133,14 @@ namespace
 
         auto install_watched(Propagators & propagators) -> void
         {
+            // Declare every variable in scope via scope_only: the propagator is woken
+            // only by the refined watches it arms, but its variables must still count
+            // for degree/adjacency (so degree-based branchers behave as the coarse
+            // version would) and, crucially, clear_watches() searches the declared
+            // scope -- so an empty scope would make it a silent no-op.
+            Triggers triggers;
+            for (const auto & v : _vars)
+                triggers.scope_only.push_back(v);
             propagators.install(
                 constraint_id(),
                 [vars = _vars, value = _value, wakes = _wakes](
@@ -162,20 +170,23 @@ namespace
                     for (auto i : order)
                         unwatched_sum += pot[i];
 
-                    // Walk from largest potential: a variable is watched until the
-                    // remaining (smaller) potentials fit inside the margin.
+                    // Recompute the covering set from scratch each wake: drop every
+                    // current watch, then walk from the largest potential, arming a
+                    // variable until the remaining (smaller) potentials fit inside the
+                    // margin. clear_watches() means a variable that leaves the covering
+                    // set keeps no stale watch -- under the earlier is_watching
+                    // idempotent re-arm it would linger until it happened to fire, a
+                    // residual wake this eliminates.
+                    ctx.clear_watches();
                     for (auto i : order) {
                         if (unwatched_sum <= margin)
                             break;
                         unwatched_sum -= pot[i];
-                        // is_watching keeps this idempotent: at most one live watch per
-                        // variable, so re-arming every wake does not accumulate watches.
-                        if (! ctx.is_watching(vars[i]))
-                            ctx.watch(vars[i] >= state.lower_bound(vars[i]) + 1_i, static_cast<std::uint32_t>(i));
+                        ctx.watch(vars[i] >= state.lower_bound(vars[i]) + 1_i, static_cast<std::uint32_t>(i));
                     }
                     return PropagatorState::Enable;
                 },
-                Triggers{});
+                std::move(triggers));
         }
     };
 

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -305,6 +305,33 @@ struct Propagators::Imp : RefinedWatchSink
                 return true;
         return false;
     }
+
+    auto clear_refined_watches(int owner_propagator) -> void override
+    {
+        // Walk the propagator's declared scope (its trigger and scope_only
+        // variables) and drop every watch it owns, trailing each removal exactly as
+        // the firing loop does, so backtrack re-adds them. A propagator only ever
+        // watches variables it has declared in scope, so scope is the complete set
+        // of variables its watches can live on. If clear+re-arm run in the same
+        // wake, the Removed edits here sit below the Added edits of the re-arm, and
+        // reverse replay on backtrack undoes the re-arm then restores these.
+        if (owner_propagator < 0 || static_cast<std::size_t>(owner_propagator) >= propagator_scope.size())
+            return;
+        for (const auto & v : propagator_scope[owner_propagator]) {
+            if (v.index >= refined_watches_by_var.size())
+                continue;
+            auto & watches = refined_watches_by_var[v.index];
+            for (std::size_t i = 0; i < watches.size();) {
+                if (watches[i].owner == owner_propagator) {
+                    refined_watch_edit_trail.push_back({WatchEditOp::Removed, v.index, watches[i]});
+                    watches[i] = watches.back();
+                    watches.pop_back();
+                }
+                else
+                    ++i;
+            }
+        }
+    }
 };
 
 Propagators::Propagators() : _imp(make_unique<Imp>())

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -57,6 +57,13 @@ namespace gcs::innards
         [[nodiscard]] virtual auto is_watching(int owner_propagator, const IntegerVariableID & var) const -> bool = 0;
 
         /**
+         * \brief Remove every refined watch owned by the given propagator, trailed so
+         * backtrack restores them in lockstep with any watches re-armed afterwards.
+         * \sa RefinedWatchContext::clear_watches
+         */
+        virtual auto clear_refined_watches(int owner_propagator) -> void = 0;
+
+        /**
          * \brief Read this propagator's backtrackable scratch value for `key`, or 0
          * if never set. \sa RefinedWatchContext::watch_state
          */
@@ -133,6 +140,24 @@ namespace gcs::innards
         [[nodiscard]] auto is_watching(const IntegerVariableID & var) const -> bool
         {
             return _sink->is_watching(_owner, var);
+        }
+
+        /**
+         * \brief Drop every refined watch this propagator currently has armed.
+         *
+         * For a propagator whose natural pattern is to recompute its whole watched
+         * set each wake (rather than moving watches individually, like a
+         * two-watched-literal clause): clear, then re-arm the fresh set with watch().
+         * The removals are trailed like watch(), so backtrack restores exactly the
+         * pre-wake watch set. Only variables in the propagator's declared scope (its
+         * triggers and scope_only) are searched, so a propagator must watch only
+         * variables it has declared in scope -- the intended usage in any case, and
+         * what lets degree/adjacency see them. watch_state is independent and left
+         * untouched; reset any of it the new watch set no longer matches.
+         */
+        auto clear_watches() const -> void
+        {
+            _sink->clear_refined_watches(_owner);
         }
 
         /**


### PR DESCRIPTION
Closes #505.

The refined-watch API only let a propagator move watches individually (armed on
fire, consumed when they fire) — the right shape for two-watched-literal
constraints (learned nogoods, NegativeTable). It did not fit a propagator whose
natural pattern is to **recompute its entire watched set each wake**: there was no
way to drop the old set, so re-arming every wake would accumulate watches. The
`slack_watch` experiment worked around it with `is_watching()` (idempotent
re-arm), but a variable that left the covering set kept a stale watch until it
happened to fire — a residual wake.

### What changed
- Add `RefinedWatchContext::clear_watches()` (and `RefinedWatchSink::
  clear_refined_watches`): drop every watch the propagator owns, trailed exactly
  like an individual arm, so backtrack restores the pre-wake set in lockstep with
  any watches re-armed afterwards.
- It searches the propagator's **declared scope** (triggers + `scope_only`) — the
  complete set of variables its watches can live on — which is why a
  clear-and-recompute propagator must declare scope via `scope_only` (#506); an
  empty scope makes `clear_watches` a silent no-op.
- Update `slack_watch` to `clear_watches()` then re-arm the fresh covering set,
  and to declare its variables via `scope_only`. Trees stay identical to the
  coarse propagator; the wake reduction is preserved (6× at sum length 5, 81× at
  80) with no residual stale-watch wakes.

Stacked on #510 (#506). Second of the stack toward #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)