### PR TITLE
Fast-path SimpleIntegerVariableID in State bounds/domain reads (#513)

### DIFF
--- a/dev_docs/benchmarking.md
+++ b/dev_docs/benchmarking.md
@@ -18,19 +18,25 @@ release`; binaries land in `build/`.
 
 | Benchmark               | Command                                       | Approx wall time |
 |-------------------------|-----------------------------------------------|------------------|
-| `magic_series_300`      | `./build/magic_series --size=300`             | ~6 s             |
-| `qap_12`                | `./build/qap --size=12`                       | ~7 s             |
-| `langford_11`           | `./build/langford --size=11 --stats`          | ~12 s            |
-| `n_queens_14_all`       | `./build/n_queens --size=14 --all`            | ~18 s            |
-| `ortho_latin_6_all`     | `./build/ortho_latin --size=6 --all --stats`  | ~20 s            |
-| `magic_square_5`        | `./build/magic_square --size=5`               | ~32 s            |
-| `tsp_default`           | `./build/tsp`                                 | ~50 s            |
-| `n_queens_88`           | `./build/n_queens --size=88`                  | ~5 min           |
+| `qap_12`                | `./build/qap --size=12`                       | ~1.5 s           |
+| `magic_series_300`      | `./build/magic_series --size=300`             | ~5 s             |
+| `langford_11`           | `./build/langford --size=11 --stats`          | ~8 s             |
+| `tsp_default`           | `./build/tsp`                                 | ~10 s            |
+| `n_queens_14_all`       | `./build/n_queens --size=14 --all`            | ~12 s            |
+| `magic_square_5`        | `./build/magic_square --size=5`               | ~18 s            |
+| `ortho_latin_6_all`     | `./build/ortho_latin --size=6 --all --stats`  | ~23 s            |
+| `n_queens_88`           | `./build/n_queens --size=88`                  | ~3.5 min         |
 
-The first four cover under-30 s workloads that are quick to iterate on. The
-last four (`ortho_latin` onwards) push out further, with `n_queens_88` being
-the long pole — keep it in the set even though it dominates total runtime,
-because it is the only one that exercises a large search tree at scale.
+Wall times re-measured on the dev VM (2026-07); they are much lower than in
+earlier revisions of this doc thanks to accumulated propagation/search work
+(`qap` and `tsp` are ~4–5× faster than when the set was first curated).
+Absolute numbers are machine-dependent — see Reproducibility caveats — so
+treat them as rough ranges, not a fixed baseline.
+
+Every benchmark except `n_queens_88` now finishes in well under half a minute,
+so they are quick to iterate on. `n_queens_88` is the long pole — keep it in
+the set even though it dominates total runtime, because it is the only one
+that exercises a large search tree at scale.
 
 `magic_series` and `magic_square` are worth keeping for their
 linear-arithmetic-heavy propagation, which the others don't exercise.
@@ -125,8 +131,8 @@ bench n_queens_14_all    "n_queens --size=14 --all"
 bench ortho_latin_6_all  "ortho_latin --size=6 --all --stats"
 ```
 
-Total wall time for the full sweep at 3 trials per build is ~50 minutes,
-dominated by `n_queens_88` (~30 minutes alone).
+Total wall time for the full sweep at 3 trials per build is ~30 minutes,
+dominated by `n_queens_88` (~20 minutes alone).
 
 ## What to capture
 

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace gcs;
@@ -17,6 +18,7 @@ using namespace gcs::innards;
 
 using std::function;
 using std::generator;
+using std::get_if;
 using std::list;
 using std::make_optional;
 using std::make_unique;
@@ -141,17 +143,17 @@ auto State::what_variable_id_will_be_created_next() const -> SimpleIntegerVariab
 
 auto State::state_of(const SimpleIntegerVariableID & v) -> IntervalSet<Integer> &
 {
-    return _imp->integer_variable_states.back().at(v.index);
+    return _imp->integer_variable_states.back()[v.index];
 }
 
 auto State::state_of(const SimpleIntegerVariableID & v) const -> const IntervalSet<Integer> &
 {
-    return _imp->integer_variable_states.back().at(v.index);
+    return _imp->integer_variable_states.back()[v.index];
 }
 
 auto State::state_of_for_iteration(const SimpleIntegerVariableID & v) const -> const IntervalSet<Integer> &
 {
-    return _imp->integer_variable_states.back().at(v.index);
+    return _imp->integer_variable_states.back()[v.index];
 }
 
 auto State::change_state_for_equal(const SimpleIntegerVariableID & var, Integer value) -> Inference
@@ -404,6 +406,12 @@ auto State::add_extra_proof_condition(const Literal & lit) -> void
 
 auto State::lower_bound(const IntegerVariableID var) const -> Integer
 {
+    // Fast path: the overwhelmingly common case is a plain
+    // SimpleIntegerVariableID with no view, where we can read the stored
+    // bound directly. This skips two std::variant visits (deview then the
+    // overloaded visit), which profiling showed to dominate per-node time.
+    if (const auto * simple = get_if<SimpleIntegerVariableID>(&var))
+        return state_of(*simple).lower();
     auto [actual_var, negate_first, then_add] = deview(var);
     auto raw = overloaded{
         [&](const SimpleIntegerVariableID & v) { return negate_first ? state_of(v).upper() : state_of(v).lower(); }, //
@@ -415,6 +423,8 @@ auto State::lower_bound(const IntegerVariableID var) const -> Integer
 
 auto State::upper_bound(const IntegerVariableID var) const -> Integer
 {
+    if (const auto * simple = get_if<SimpleIntegerVariableID>(&var))
+        return state_of(*simple).upper();
     auto [actual_var, negate_first, then_add] = deview(var);
     auto raw = overloaded{
         [&](const SimpleIntegerVariableID & v) { return negate_first ? state_of(v).lower() : state_of(v).upper(); }, //
@@ -427,6 +437,16 @@ auto State::upper_bound(const IntegerVariableID var) const -> Integer
 template <IntegerVariableIDLike VarType_>
 auto State::bounds(const VarType_ & var) const -> pair<Integer, Integer>
 {
+    // Fast path for a plain SimpleIntegerVariableID with no view, skipping the
+    // deview and visit_actual std::variant visits. Only the general
+    // IntegerVariableID caller can hold a view or constant; the concrete
+    // instantiations already avoid the variant machinery.
+    if constexpr (std::is_same_v<VarType_, IntegerVariableID>) {
+        if (const auto * simple = get_if<SimpleIntegerVariableID>(&var)) {
+            const auto & set = state_of(*simple);
+            return pair{set.lower(), set.upper()};
+        }
+    }
     auto [actual_var, negate_first, then_add] = deview(var);
     auto raw = visit_actual(
         actual_var, [&](const SimpleIntegerVariableID & v) { return pair{state_of(v).lower(), state_of(v).upper()}; },
@@ -440,6 +460,10 @@ auto State::bounds(const VarType_ & var) const -> pair<Integer, Integer>
 template <IntegerVariableIDLike VarType_>
 auto State::in_domain(const VarType_ & var, const Integer val) const -> bool
 {
+    if constexpr (std::is_same_v<VarType_, IntegerVariableID>) {
+        if (const auto * simple = get_if<SimpleIntegerVariableID>(&var))
+            return state_of(*simple).contains(val);
+    }
     auto [actual_var, negate_first, then_add] = deview(var);
     auto adjusted = (negate_first ? -val + then_add : val - then_add);
     return visit_actual(
@@ -460,6 +484,14 @@ auto State::domain_has_holes(const IntegerVariableID var) const -> bool
 template <IntegerVariableIDLike VarType_>
 auto State::optional_single_value(const VarType_ & var) const -> optional<Integer>
 {
+    if constexpr (std::is_same_v<VarType_, IntegerVariableID>) {
+        if (const auto * simple = get_if<SimpleIntegerVariableID>(&var)) {
+            const auto & set = state_of(*simple);
+            if (set.lower() == set.upper())
+                return make_optional(set.lower());
+            return nullopt;
+        }
+    }
     auto [actual_var, negate_first, then_add] = deview(var);
     auto raw = visit_actual(
         actual_var,
@@ -476,6 +508,10 @@ auto State::optional_single_value(const VarType_ & var) const -> optional<Intege
 
 auto State::has_single_value(const IntegerVariableID var) const -> bool
 {
+    if (const auto * simple = get_if<SimpleIntegerVariableID>(&var)) {
+        const auto & set = state_of(*simple);
+        return set.lower() == set.upper();
+    }
     auto [actual_var, _1, _2] = deview(var);
     return overloaded{
         [&](const SimpleIntegerVariableID & v) { return state_of(v).lower() == state_of(v).upper(); }, //
@@ -487,6 +523,10 @@ auto State::has_single_value(const IntegerVariableID var) const -> bool
 template <IntegerVariableIDLike VarType_>
 auto State::domain_size(const VarType_ & var) const -> Integer
 {
+    if constexpr (std::is_same_v<VarType_, IntegerVariableID>) {
+        if (const auto * simple = get_if<SimpleIntegerVariableID>(&var))
+            return Integer(state_of(*simple).size());
+    }
     auto [actual_var, _1, _2] = deview(var);
     return visit_actual(
         actual_var, [&](const SimpleIntegerVariableID & v) { return Integer(state_of(v).size()); }, //


### PR DESCRIPTION
Closes #513.

## What

`State::bounds` and `State::in_domain` are the two hottest functions in per-node profiling of the MiniZinc Challenge instances (`bounds` alone ~21% self-time). This adds a `SimpleIntegerVariableID` fast path to the hot read accessors — `bounds`, `in_domain`, `lower_bound`, `upper_bound`, `optional_single_value`, `has_single_value`, `domain_size` — and switches `State::state_of` from `.at()` to `operator[]`.

## Why (what profiling actually showed)

`#513` proposed skipping the variant dispatch. But `perf annotate` shows GCC already lowers the `IntegerVariableID` variant visit to a plain discriminant switch — there is no indirect call to remove. The real self-time is:

- **redundant view arithmetic** (negate/offset + integer-overflow checks) run even for plain variables with no view, and
- the **`.at()` bounds check** in `state_of`, whose reciprocal-divide size computation runs on *every* domain access.

So the fast path's value is reading the stored interval set directly for the common no-view case (skipping the `deview`/`visit_actual` machinery *and* the view arithmetic), and `operator[]` drops the dead bounds check. `bounds` self-time falls 21.2% → 18.9% (fast path) → 16.3% (+`operator[]`) on `community-detection`.

`operator[]` is safe: every `SimpleIntegerVariableID` index is `< back().size()` (variables are allocated into the current-epoch vector, and epochs preserve size), so `.at()` never throws — as evidenced by the entire passing test corpus.

## Correctness

Pure performance change — search is unaffected. `recursions` and `propagations` are **identical** baseline↔branch on every benchmark, and all **474 tests pass, including the VeriPB proof checks**.

## Measured (benchmarking.md set, same machine, `taskset -c 4`, median, identical trees)

| Benchmark | main | branch | speedup |
|---|--:|--:|--:|
| magic_square_5 | 24.27 s | 17.52 s | **1.39×** |
| n_queens_88 | 273.6 s | 213.4 s | **1.28×** |
| ortho_latin_6_all | 28.00 s | 23.46 s | **1.19×** |
| n_queens_14_all | 14.17 s | 11.93 s | **1.19×** |
| magic_series_300 | 5.60 s | 4.91 s | **1.14×** |
| tsp_default | 11.65 s | 10.36 s | **1.13×** |
| langford_11 | 7.97 s | 7.88 s | 1.01× |
| qap_12 | 1.567 s | 1.557 s | 1.01× |

Propagation-heavy workloads (linear arithmetic, AllDifferent, the large search trees) win 1.13–1.39×; the two bottlenecked elsewhere are flat.

This also refreshes the stale `dev_docs/benchmarking.md` wall-time figures to current values (they had drifted far below the old numbers from accumulated prior work — `qap` ~4.5×, `tsp` ~4.8× faster than when the set was first curated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)