### PR TITLE
[DRAFT] Experimental constraint-group RUP hints (GCS_RUP_GROUPS)

### DIFF
--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -564,8 +564,16 @@ namespace gcs::innards
                     ReasonLiterals reason_lits = materialise(snapshotted, _state);
                     auto t = logger->temporary_proof_level();
                     emit_explicit_steps(*logger, why.emit, reason_lits);
+                    // The concluding per-literal RUPs depend on the temporary
+                    // steps just emitted, so they must propagate over the whole
+                    // database rather than a constraint's @@cv[...] group.
+                    // Suppress the group hint around them (constraint-group RUP
+                    // hints).
+                    auto saved_constraint = logger->current_constraint();
+                    logger->set_current_constraint(std::nullopt);
                     for (const auto & lit : lits)
                         infer(logger, lit, JustifyUsingRUP{}, snapshotted);
+                    logger->set_current_constraint(saved_constraint);
                     logger->forget_proof_level(t);
                     return;
                 }

--- a/gcs/innards/proofs/infer_explicitly.hh
+++ b/gcs/innards/proofs/infer_explicitly.hh
@@ -142,8 +142,16 @@ namespace gcs::innards
         }
         auto t = logger.temporary_proof_level();
         emit_explicit_steps(logger, emit, reason);
-        if (then_rup == ThenRUP::Yes)
+        if (then_rup == ThenRUP::Yes) {
+            // The concluding RUP depends on the temporary steps just emitted, so
+            // it must propagate over the whole database, not a constraint's
+            // @@cv[...] group. Suppress the group hint (constraint-group RUP
+            // hints treat an explicitly justified step as already better hinted).
+            auto saved_constraint = logger.current_constraint();
+            logger.set_current_constraint(std::nullopt);
             logger.infer(lit, JustifyUsingRUP{}, reason);
+            logger.set_current_constraint(saved_constraint);
+        }
         logger.forget_proof_level(t);
     }
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -158,6 +158,37 @@ struct NamesAndIDsTracker::Imp
     bool verbose_names;
     bool use_compact_boolean_encoding = false;
     AssertionLevel assertion_level = AssertionLevel::Off;
+
+    // --- Constraint-group RUP hints (ProofOptions::emit_rup_group_hints) ---
+    bool emit_rup_group_hints = false;
+    // @@v[...]: every proof line that forms part of a variable's encoding
+    // (atom definitions, bound-link ladder rungs, boundary pins, bits bound
+    // rows, AL1/AM1, view links, containment/partition rows), in emission
+    // order. The variable's whole transparency closure -- unit propagation is
+    // only guaranteed to simulate bounds/domain reasoning over the complete
+    // encoding, so the group must carry all of it, never a subset.
+    map<SimpleOrProofOnlyIntegerVariableID, vector<ProofLine>> hint_lines_for_variable;
+    // Members of each @@v[...] already announced to the checker (via a grpa
+    // line), so a flush only emits the ones added since.
+    map<SimpleOrProofOnlyIntegerVariableID, std::set<ProofLine>> announced_v_members;
+    // @@v[...] / @@c[...] that have been declared (a grpa emitted at least
+    // once, even with no members), so an empty group is still defined before it
+    // is nested or cited.
+    std::set<SimpleOrProofOnlyIntegerVariableID> v_declared;
+    std::set<ConstraintID> c_declared;
+    // @@c[...]: the defining OPB rows of each constraint, captured from its
+    // model block (see current_constraint_block), plus any later top-level
+    // rows the constraint tags to itself.
+    map<ConstraintID, vector<ProofLine>> constraint_lines;
+    map<ConstraintID, std::set<ProofLine>> announced_c_members;
+    // The constraint whose OPB block is currently being written at model-build
+    // time (set by begin_constraint_block_comment), so advance_constraint_counter
+    // can attribute each row it emits to that constraint.
+    optional<ConstraintID> current_constraint_block;
+    // @@cv[...] bookkeeping: which constraints have had their @@cv declared
+    // (nesting @@c), and which @@v[...] each @@cv already nests.
+    std::set<ConstraintID> announced_cv_base;
+    map<ConstraintID, std::set<SimpleOrProofOnlyIntegerVariableID>> cv_nested_vars;
 };
 
 NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) : _imp(make_unique<Imp>())
@@ -165,6 +196,7 @@ NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) : _im
     _imp->verbose_names = proof_options.verbose_names;
     _imp->use_compact_boolean_encoding = proof_options.use_compact_boolean_encoding;
     _imp->assertion_level = proof_options.assertion_level;
+    _imp->emit_rup_group_hints = proof_options.emit_rup_group_hints;
 
     if (proof_options.proof_file_names.variables_map_file) {
         _imp->variables_map_file_name = *proof_options.proof_file_names.variables_map_file;
@@ -236,6 +268,134 @@ auto NamesAndIDsTracker::associate_condition_with_xliteral(const VariableConditi
 auto NamesAndIDsTracker::track_variable_takes_at_least_one_value(const SimpleOrProofOnlyIntegerVariableID & id, ProofLine line) -> void
 {
     _imp->variable_at_least_one_constraints.emplace(id, line);
+    note_rup_hint_line_for(id, line);
+}
+
+// ----- Constraint-group RUP hints -----------------------------------------
+//
+// The design: each variable's whole encoding closure is a checker-side group
+// @@v[...]; each constraint's defining OPB rows are a group @@c[...]; and each
+// constraint gets a combined @@cv[...] = @@c[...] nested with @@v[...] for
+// every variable it reasons about. A bare-RUP propagator step cites the single
+// token @@cv[...] of its owning constraint. Groups are announced/extended
+// lazily via `grpa` lines just before the step that first needs them; nesting
+// is by live reference, so extending a @@v[...] later automatically updates
+// every @@cv[...] that nests it. See dev_docs and
+// project_rup_constraint_groups_benchmark.
+
+auto NamesAndIDsTracker::emitting_rup_group_hints() const -> bool
+{
+    return _imp->emit_rup_group_hints;
+}
+
+auto NamesAndIDsTracker::note_rup_hint_line_for(const SimpleOrProofOnlyIntegerVariableID & id, const ProofLine & line) -> void
+{
+    if (! _imp->emit_rup_group_hints)
+        return;
+    // A zero (no-line) sentinel / assertion-level placeholder carries no
+    // defining row -- there is nothing to cite.
+    if (auto n = std::get_if<ProofLineNumber>(&line); n && n->number == 0)
+        return;
+    _imp->hint_lines_for_variable[id].push_back(line);
+}
+
+auto NamesAndIDsTracker::begin_constraint_block(const ConstraintID & id) -> void
+{
+    if (_imp->emit_rup_group_hints)
+        _imp->current_constraint_block = id;
+}
+
+auto NamesAndIDsTracker::note_constraint_line(const ProofLine & line) -> void
+{
+    if (! _imp->emit_rup_group_hints || ! _imp->current_constraint_block)
+        return;
+    if (auto n = std::get_if<ProofLineNumber>(&line); n && n->number == 0)
+        return;
+    _imp->constraint_lines[*_imp->current_constraint_block].push_back(line);
+}
+
+auto NamesAndIDsTracker::note_constraint_cache_line(const ConstraintID & cid, const ProofLine & line) -> void
+{
+    // A top-level line emitted while a propagator was firing: a cached lemma
+    // the constraint may rely on in a later bare-RUP step (e.g. a linear
+    // parity/rounding cut, an all_different value-clique AM1). It becomes part
+    // of that constraint's @@c[...] group -- the "dynamically extended to
+    // include top-level caches" part of the scheme.
+    if (! _imp->emit_rup_group_hints)
+        return;
+    if (auto n = std::get_if<ProofLineNumber>(&line); n && n->number == 0)
+        return;
+    _imp->constraint_lines[cid].push_back(line);
+}
+
+auto NamesAndIDsTracker::append_rup_hint_lines_for(const SimpleOrProofOnlyIntegerVariableID & id, vector<ProofLine> & lines) -> void
+{
+    if (auto noted = _imp->hint_lines_for_variable.find(id); noted != _imp->hint_lines_for_variable.end())
+        lines.insert(lines.end(), noted->second.begin(), noted->second.end());
+
+    // A view's atoms only reach the underlying variable's encoding through the
+    // bit-vector link rows (recorded above under the view id) and the
+    // underlying variable's own encoding, so recurse into it.
+    if (auto pid_ptr = std::get_if<ProofOnlySimpleIntegerVariableID>(&id)) {
+        if (auto view_it = _imp->view_proof_only_to_view.find(*pid_ptr); view_it != _imp->view_proof_only_to_view.end())
+            append_rup_hint_lines_for(view_it->second.actual_variable, lines);
+    }
+}
+
+auto NamesAndIDsTracker::flush_v_group(const SimpleOrProofOnlyIntegerVariableID & id) -> ProofLine
+{
+    auto name = "v[" + definitional_label_base(id) + "]";
+    vector<ProofLine> closure;
+    append_rup_hint_lines_for(id, closure);
+    auto & announced = _imp->announced_v_members[id];
+    vector<ProofLine> fresh;
+    for (const auto & line : closure)
+        if (announced.insert(line).second)
+            fresh.push_back(line);
+    bool newly_declared = _imp->v_declared.insert(id).second;
+    // Declare the group the first time (even with no members, so nesting/citing
+    // it does not reference an undefined group), then extend it as it grows.
+    if ((newly_declared || ! fresh.empty()) && _imp->logger)
+        _imp->logger->emit_rup_hint_group_add(name, fresh);
+    return ProofLine{ProofLineLabel{"@" + name}};
+}
+
+auto NamesAndIDsTracker::ensure_c_group(const ConstraintID & cid) -> ProofLine
+{
+    auto name = "c[" + as_string(cid) + "]";
+    auto & announced = _imp->announced_c_members[cid];
+    vector<ProofLine> fresh;
+    if (auto it = _imp->constraint_lines.find(cid); it != _imp->constraint_lines.end())
+        for (const auto & line : it->second)
+            if (announced.insert(line).second)
+                fresh.push_back(line);
+    bool newly_declared = _imp->c_declared.insert(cid).second;
+    if ((newly_declared || ! fresh.empty()) && _imp->logger)
+        _imp->logger->emit_rup_hint_group_add(name, fresh);
+    return ProofLine{ProofLineLabel{"@" + name}};
+}
+
+auto NamesAndIDsTracker::cv_group_hint_token(const ConstraintID & cid, const vector<SimpleOrProofOnlyIntegerVariableID> & vars) -> ProofLine
+{
+    auto cv_name = "cv[" + as_string(cid) + "]";
+
+    // 1. Declare/extend @@c[cid] (its defining OPB rows), get its group token.
+    auto c_token = ensure_c_group(cid);
+
+    // 2. Declare @@cv[cid] once, nesting @@c[cid] by live reference.
+    if (_imp->announced_cv_base.insert(cid).second && _imp->logger)
+        _imp->logger->emit_rup_hint_group_add(cv_name, {c_token});
+
+    // 3. For each variable this step reasons about: flush its @@v[...]
+    //    (declare/extend) and nest it into @@cv[cid] the first time.
+    auto & nested = _imp->cv_nested_vars[cid];
+    for (const auto & v : vars) {
+        auto v_token = flush_v_group(v);
+        if (nested.insert(v).second && _imp->logger)
+            _imp->logger->emit_rup_hint_group_add(cv_name, {v_token});
+    }
+
+    return ProofLine{ProofLineLabel{"@" + cv_name}};
 }
 
 auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_value(IntegerVariableID var) -> ProofLine
@@ -251,6 +411,7 @@ auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_valu
                     al1s += 1_i * (var == v);
 
                 auto line = _imp->logger->emit_rup_proof_line(al1s >= 1_i, ProofLevel::Top);
+                note_rup_hint_line_for(var, line);
                 result = _imp->variable_at_least_one_constraints.emplace(var, line).first;
             }
             return result->second;
@@ -273,6 +434,7 @@ auto NamesAndIDsTracker::need_constraint_saying_variable_takes_at_least_one_valu
                         al1s += 1_i * (*v_id == v);
 
                     auto line = _imp->logger->emit_rup_proof_line(al1s >= 1_i, ProofLevel::Top);
+                    note_rup_hint_line_for(*v_id, line);
                     result = _imp->variable_at_least_one_constraints.emplace(*v_id, line).first;
                 }
                 return result->second;
@@ -596,6 +758,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     }
 
     _imp->eqvars_that_exist[id].emplace(v, pair{forwards_line, reverse_line});
+    note_rup_hint_line_for(id, forwards_line);
+    note_rup_hint_line_for(id, reverse_line);
 
     // If `id` is a view's proof-only var, eagerly emit the
     // eq-atom-level link `V=v <=> X=k_x` as two RUP lines. The GE-atom
@@ -632,14 +796,14 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             // drops the step entirely during model building, losing the
             // channelling between the proof-only encoding and the actual
             // variable. See the matching pattern in need_gevar's bound links.
-            emit_proof_line_now_or_at_start([v_cond, x_cond](ProofLogger * const logger) {
+            emit_proof_line_now_or_at_start([this, id, v_cond, x_cond](ProofLogger * const logger) {
                 if (logger->get_assertion_level() > AssertionLevel::Links)
                     return;
 
                 auto assert_or_rup =
                     logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top);
-                logger->emit(assert_or_rup, WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top);
+                note_rup_hint_line_for(id, logger->emit(assert_or_rup, WPBSum{} + 1_i * ! v_cond + 1_i * x_cond >= 1_i, ProofLevel::Top));
+                note_rup_hint_line_for(id, logger->emit(assert_or_rup, WPBSum{} + 1_i * ! x_cond + 1_i * v_cond >= 1_i, ProofLevel::Top));
             });
         }
     }
@@ -703,6 +867,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     else if (_imp->logger) {
         auto def_lines = visit(
             [&](const auto & id) { return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Top); }, id);
+        note_rup_hint_line_for(id, def_lines.first);
+        note_rup_hint_line_for(id, def_lines.second);
         _imp->gevars_that_exist[id].emplace(v, def_lines);
     }
     else {
@@ -712,13 +878,15 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // ~ge..) is cake's [r]; the second is [f]. v may be negative -- veripb
         // 3.0.2 allows `-` in @labels.
         string ge_label = definitional_label_base(id) + "[ge" + to_string(v.raw_value) + "]";
-        _imp->gevars_that_exist[id].emplace(v,
-            visit(
-                [&](const auto & vid) -> pair<ProofLine, ProofLine> {
-                    return pair{_imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
-                        _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
-                },
-                id));
+        auto ge_def_lines = visit(
+            [&](const auto & vid) -> pair<ProofLine, ProofLine> {
+                return pair{_imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
+                    _imp->model->add_labelled_constraint(ge_label + "[f]", WPBSum{} + (-1_i * vid) >= -v + 1_i, {{vid < v}})};
+            },
+            id);
+        note_rup_hint_line_for(id, ge_def_lines.first);
+        note_rup_hint_line_for(id, ge_def_lines.second);
+        _imp->gevars_that_exist[id].emplace(v, ge_def_lines);
         ++_imp->model_variables;
 
         // For a variable whose @i[..][ge] labels a cake_pb_cp OPB will not create (see
@@ -758,7 +926,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // throughout both enumeration and refutation. emit_proof_line_now_or_at_start
         // queues it to proof start when the logger is not yet attached (model
         // building) and emits it immediately otherwise.
-        emit_proof_line_now_or_at_start([id, v, negated](ProofLogger * const logger) {
+        emit_proof_line_now_or_at_start([this, id, v, negated](ProofLogger * const logger) {
             if (logger->get_assertion_level() > AssertionLevel::Links)
                 return;
             ProofRule assert_or_rup =
@@ -766,7 +934,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
             auto annotation = AssertionAnnotation{.hint_name = hints::InitialBound::hint_name};
             visit(
                 [&](auto vid) {
-                    logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (vid >= v) : (vid >= v)) >= 1_i, ProofLevel::Top, annotation);
+                    note_rup_hint_line_for(
+                        id, logger->emit(assert_or_rup, WPBSum{} + 1_i * (negated ? ! (vid >= v) : (vid >= v)) >= 1_i, ProofLevel::Top, annotation));
                 },
                 id);
         });
@@ -810,12 +979,12 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) {
+                emit_proof_line_now_or_at_start([this, id, c = chain_con, link_hint](ProofLogger * const logger) {
                     if (logger->get_assertion_level() > AssertionLevel::Links)
                         return;
                     ProofRule assert_or_rup =
                         logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-                    logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint);
+                    note_rup_hint_line_for(id, logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint));
                 });
             }, //
             [&](const SimpleIntegerVariableID & id) {
@@ -829,7 +998,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 }
                 else {
                     auto pol = make_pol_chain_line(id >= v, ! (id >= higher_gevar->first));
-                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                    emit_proof_line_now_or_at_start(
+                        [this, id, pol](ProofLogger * const logger) { note_rup_hint_line_for(id, pol->emit(*logger, ProofLevel::Top)); });
                 }
             } //
         }
@@ -841,12 +1011,12 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
                 auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
-                emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) {
+                emit_proof_line_now_or_at_start([this, id, c = chain_con, link_hint = link_hint](ProofLogger * const logger) {
                     if (logger->get_assertion_level() > AssertionLevel::Links)
                         return;
                     ProofRule assert_or_rup =
                         logger->get_assertion_level() == AssertionLevel::Links ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-                    logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint);
+                    note_rup_hint_line_for(id, logger->emit(assert_or_rup, c, ProofLevel::Top, link_hint));
                 });
             }, //
             [&](const SimpleIntegerVariableID & id) {
@@ -861,7 +1031,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 }
                 else {
                     auto pol = make_pol_chain_line(id >= prev(this_gevar)->first, ! (id >= v));
-                    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
+                    emit_proof_line_now_or_at_start(
+                        [this, id, pol](ProofLogger * const logger) { note_rup_hint_line_for(id, pol->emit(*logger, ProofLevel::Top)); });
                 }
             } //
         }
@@ -930,9 +1101,9 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 b1->add(*v_fwd_line).add(link.first).add(d1_x).saturate();
                 auto b2 = make_shared<PolBuilder>();
                 b2->add(*v_rev_line).add(link.second).add(d2_x).saturate();
-                emit_proof_line_now_or_at_start([b1, b2](ProofLogger * const logger) {
-                    b1->emit(*logger, ProofLevel::Top);
-                    b2->emit(*logger, ProofLevel::Top);
+                emit_proof_line_now_or_at_start([this, id, b1, b2](ProofLogger * const logger) {
+                    note_rup_hint_line_for(id, b1->emit(*logger, ProofLevel::Top));
+                    note_rup_hint_line_for(id, b2->emit(*logger, ProofLevel::Top));
                 });
             }
         }
@@ -977,7 +1148,7 @@ auto NamesAndIDsTracker::link_immediate_containment(SimpleOrProofOnlyIntegerVari
                 else
                     edge += 1_i * not_in_range(id, clo, chi);
                 edge += 1_i * in_range(id, plo, phi);
-                _imp->logger->emit_rup_proof_line(move(edge) >= 1_i, ProofLevel::Top);
+                note_rup_hint_line_for(id, _imp->logger->emit_rup_proof_line(move(edge) >= 1_i, ProofLevel::Top));
             },
             id);
     };
@@ -1042,6 +1213,8 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
         : make_pair(ProofLine{}, ProofLine{});
 
     _imp->invars_that_exist[id].emplace(pair{lo, hi}, lines);
+    note_rup_hint_line_for(id, lines.first);
+    note_rup_hint_line_for(id, lines.second);
 
     // No containment tree apparatus needed at higher assertion levels.
     if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
@@ -1107,7 +1280,7 @@ auto NamesAndIDsTracker::ensure_partition_cut(SimpleOrProofOnlyIntegerVariableID
     visit([&](const auto & id) { covering += 1_i * not_in_range(id, a, b); }, id);
     append_cell_literal_to(covering, id, a, p - 1_i);
     append_cell_literal_to(covering, id, p, b);
-    _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::Top);
+    note_rup_hint_line_for(id, _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::Top));
 }
 
 auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariableID id, Integer request_lo, Integer request_hi) -> void
@@ -1145,7 +1318,7 @@ auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariabl
             define_plain_invar(id, cell_lo, cell_hi);
         append_cell_literal_to(root_covering, id, cell_lo, cell_hi);
     }
-    _imp->logger->emit_rup_proof_line(move(root_covering) >= 1_i, ProofLevel::Top);
+    note_rup_hint_line_for(id, _imp->logger->emit_rup_proof_line(move(root_covering) >= 1_i, ProofLevel::Top));
 }
 
 auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integer lo, Integer hi) -> ProofLiteral
@@ -1204,7 +1377,7 @@ auto NamesAndIDsTracker::need_invar(SimpleOrProofOnlyIntegerVariableID id, Integ
     visit([&](const auto & id) { covering += 1_i * not_in_range(id, lo, hi); }, id);
     for (auto it = boundaries.find(span_lo); *it != span_hi + 1_i; ++it)
         append_cell_literal_to(covering, id, *it, *next(it) - 1_i);
-    _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::Top);
+    note_rup_hint_line_for(id, _imp->logger->emit_rup_proof_line(move(covering) >= 1_i, ProofLevel::Top));
     return as_literal();
 }
 
@@ -1247,6 +1420,8 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
     _imp->view_proof_only_vars.emplace(view, v_id);
     _imp->view_proof_only_to_view.emplace(v_id, view);
     _imp->view_link_ids.emplace(v_id, pair{link_le, link_ge});
+    note_rup_hint_line_for(v_id, link_le);
+    note_rup_hint_line_for(v_id, link_ge);
     _imp->views_of_variable[view.actual_variable].push_back(v_id);
 
     if (_imp->assertion_level > AssertionLevel::Links) // No further linking needed at higher assertion levels.

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -125,6 +125,15 @@ namespace gcs::innards
         // emit the at-least-one clause over the top-level partition.
         auto init_interval_partition(SimpleOrProofOnlyIntegerVariableID id, Integer request_lo, Integer request_hi) -> void;
 
+        // Declare (first time, even if empty) or extend the @@v[...] group for a
+        // variable's encoding closure, emitting a grpa line for any members not
+        // yet announced, and return the @@v[...] group token. Group hints only.
+        auto flush_v_group(const SimpleOrProofOnlyIntegerVariableID &) -> ProofLine;
+
+        // Declare/extend the @@c[...] group for a constraint's recorded OPB
+        // rows and return its @@c[...] group token. Group hints only.
+        auto ensure_c_group(const ConstraintID &) -> ProofLine;
+
     public:
         /**
          * \name Constructors, destructors, and the like.
@@ -397,6 +406,60 @@ namespace gcs::innards
          * Track that an at-least-one constraint exists for a given variable.
          */
         auto track_variable_takes_at_least_one_value(const SimpleOrProofOnlyIntegerVariableID &, ProofLine) -> void;
+
+        /**
+         * \name Constraint-group RUP hints (ProofOptions::emit_rup_group_hints)
+         * \{
+         */
+
+        /**
+         * Are we emitting constraint-group RUP hints?
+         */
+        [[nodiscard]] auto emitting_rup_group_hints() const -> bool;
+
+        /**
+         * Record a proof line as part of a variable's encoding closure (the
+         * @@v[...] group), so a hinted RUP step touching the variable can cite
+         * the whole closure. No-op unless group hints are on.
+         */
+        auto note_rup_hint_line_for(const SimpleOrProofOnlyIntegerVariableID &, const ProofLine &) -> void;
+
+        /**
+         * Note that the OPB rows emitted from now on (until the next call)
+         * belong to the given constraint's defining block (the @@c[...] group).
+         * Called by ProofModel::begin_constraint_block_comment.
+         */
+        auto begin_constraint_block(const ConstraintID &) -> void;
+
+        /**
+         * Record a model OPB row as a member of the current constraint block's
+         * @@c[...] group. Called by ProofModel::advance_constraint_counter.
+         */
+        auto note_constraint_line(const ProofLine &) -> void;
+
+        /**
+         * Record a top-level proof line emitted while the given constraint's
+         * propagator was firing as a member of its @@c[...] group (a cached
+         * lemma it may cite in a later bare-RUP step).
+         */
+        auto note_constraint_cache_line(const ConstraintID &, const ProofLine &) -> void;
+
+        /**
+         * Append a variable's whole recorded encoding closure (recursing into a
+         * view's underlying variable) to the given vector.
+         */
+        auto append_rup_hint_lines_for(const SimpleOrProofOnlyIntegerVariableID &, std::vector<ProofLine> &) -> void;
+
+        /**
+         * The @@cv[...] hint token for a bare-RUP step by constraint \p cid over
+         * the given scope variables (those in its reason and inferred literal).
+         * Declares/extends @@c[cid], @@v[...] for each variable, and @@cv[cid]
+         * (nesting them) as needed, then returns the single @@cv[cid] token to
+         * cite. Group hints must be on and the proof started.
+         */
+        auto cv_group_hint_token(const ConstraintID &, const std::vector<SimpleOrProofOnlyIntegerVariableID> &) -> ProofLine;
+
+        /** \} */
 
         /**
          * Track that a given proof flag exists with this name.

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -117,6 +117,13 @@ struct ProofLogger::Imp
     int current_indent = 0;
     AssertionLevel assertion_level;
 
+    // Constraint-group RUP hints (ProofOptions::emit_rup_group_hints): whether
+    // on, and the constraint whose propagator is currently firing (set by
+    // Propagators around each propagation call), so a bare-RUP step it emits can
+    // cite that constraint's @@cv[...] group.
+    bool emit_rup_group_hints = false;
+    std::optional<ConstraintID> current_constraint;
+
     Imp(NamesAndIDsTracker & t) : tracker(t)
     {
     }
@@ -127,6 +134,7 @@ ProofLogger::ProofLogger(const ProofOptions & proof_options, NamesAndIDsTracker 
     _imp->proof_file = proof_options.proof_file_names.proof_file;
     _imp->proof_lines_by_level.resize(2);
     _imp->assertion_level = proof_options.assertion_level;
+    _imp->emit_rup_group_hints = proof_options.emit_rup_group_hints;
 }
 
 ProofLogger::~ProofLogger() = default;
@@ -331,7 +339,33 @@ auto ProofLogger::infer(
     overloaded{
         [&]([[maybe_unused]] const JustifyUsingRUP<NoHint> & j) {
             if (! is_literally_true(lit)) {
-                emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current);
+                auto ineq = WPBSum{} + 1_i * lit >= 1_i;
+                if (_imp->emit_rup_group_hints && _imp->current_constraint) {
+                    // Introduce every atom this step references FIRST, so their
+                    // definition lines are recorded into the variables' @@v[...]
+                    // closures before we flush the groups (otherwise a lazily
+                    // introduced atom's def would land after the grpa that was
+                    // meant to carry it, and the group would be incomplete).
+                    // This mirrors what emit_under_reason does below; the repeat
+                    // there is then a no-op.
+                    if (! reason.empty())
+                        names_and_ids_tracker().need_all_proof_names_in(reason);
+                    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
+
+                    // Cite the owning constraint's @@cv[...] group: its own OPB
+                    // rows plus the encoding of every variable in this step's
+                    // reason and inferred literal. Declares/extends the groups
+                    // first (grpa lines above the step), then cites one token.
+                    std::vector<SimpleOrProofOnlyIntegerVariableID> scope_vars;
+                    for (const auto & term : reason)
+                        collect_group_hint_vars(term, scope_vars);
+                    collect_group_hint_vars(ProofLiteralOrFlag{ProofLiteral{lit}}, scope_vars);
+                    auto hint = names_and_ids_tracker().cv_group_hint_token(*_imp->current_constraint, scope_vars);
+                    emit_rup_proof_line_under_reason(reason, ineq, ProofLevel::Current, {hint});
+                }
+                else {
+                    emit_rup_proof_line_under_reason(reason, ineq, ProofLevel::Current);
+                }
             }
         }, //
         [&]([[maybe_unused]] const AssertRatherThanJustifying & j) {
@@ -500,6 +534,52 @@ auto ProofLogger::emit_rup_proof_line_under_reason(
     return emit_under_reason(RUPProofRule{}, ineq, level, reason);
 }
 
+auto ProofLogger::emit_rup_proof_line_under_reason(const ReasonLiterals & reason, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
+    ProofLevel level, std::vector<ProofLine> hints) -> ProofLine
+{
+    return emit_under_reason(RUPProofRule{std::move(hints)}, ineq, level, reason);
+}
+
+auto ProofLogger::set_current_constraint(const std::optional<ConstraintID> & constraint_id) -> void
+{
+    _imp->current_constraint = constraint_id;
+}
+
+auto ProofLogger::current_constraint() const -> std::optional<ConstraintID>
+{
+    return _imp->current_constraint;
+}
+
+auto ProofLogger::emit_rup_hint_group_add(const std::string & name, const std::vector<ProofLine> & members) -> void
+{
+    // A `grpa` line declares/extends a checker-side group; it derives no
+    // constraint, so the proof line counter is deliberately not advanced.
+    log_stacktrace();
+    write_indent();
+    _imp->proof << "grpa @@" << name << " :";
+    for (const auto & line : members)
+        _imp->proof << ' ' << relative_proof_line(line, _imp->proof_line.number);
+    _imp->proof << " ;\n";
+}
+
+auto ProofLogger::collect_group_hint_vars(const ProofLiteralOrFlag & term, std::vector<SimpleOrProofOnlyIntegerVariableID> & out) -> void
+{
+    overloaded{
+        [&](const ProofLiteral & pl) {
+            overloaded{
+                [&](const VariableConditionFrom<SimpleIntegerVariableID> & c) { out.push_back(c.var); }, //
+                [&](const ProofVariableCondition & c) { out.push_back(c.var); },                         //
+                [&](const TrueLiteral &) {},                                                             //
+                [&](const FalseLiteral &) {}                                                             //
+            }
+                .visit(simplify_literal(names_and_ids_tracker(), pl));
+        },                                                                //
+        [&](const ProofFlag &) {},                                        //
+        [&](const ProofBitVariable & bit) { out.push_back(bit.for_var); } //
+    }
+        .visit(term);
+}
+
 auto ProofLogger::emit_rup_proof_line_under_reason_then_deview(
     const ReasonLiterals & reason, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> ProofLine
 {
@@ -586,7 +666,14 @@ auto ProofLogger::start_proof(const ProofModel & model) -> void
 auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level) -> ProofLineNumber
 {
     switch (level) {
-    case ProofLevel::Top: _imp->proof_lines_by_level.at(0).insert_at_end(line.number); break;
+    case ProofLevel::Top:
+        _imp->proof_lines_by_level.at(0).insert_at_end(line.number);
+        // A top-level line emitted while a propagator is firing joins that
+        // constraint's @@c[...] group, so a later bare-RUP step of the same
+        // constraint that relies on the cached lemma can cite it via @@cv[...].
+        if (_imp->emit_rup_group_hints && _imp->current_constraint)
+            _imp->tracker.note_constraint_cache_line(*_imp->current_constraint, line);
+        break;
     case ProofLevel::Current: _imp->proof_lines_by_level.at(_imp->active_proof_level).insert_at_end(line.number); break;
     case ProofLevel::Temporary: _imp->proof_lines_by_level.at(_imp->active_proof_level + 1).insert_at_end(line.number); break;
     }

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -53,6 +53,11 @@ namespace gcs::innards
 
         auto record_proof_line(ProofLineNumber line, ProofLevel level) -> ProofLineNumber;
 
+        // Append the scope variable(s) a reason/inferred term mentions (a
+        // condition's variable, a proof bit's variable) to `out`, for building
+        // a constraint's @@cv[...] group hint. Skips flags and true/false.
+        auto collect_group_hint_vars(const ProofLiteralOrFlag & term, std::vector<SimpleOrProofOnlyIntegerVariableID> & out) -> void;
+
         auto end_proof() -> void;
 
         auto emit_subproofs(const std::map<ProofGoal, Subproof> & subproofs) -> auto;
@@ -134,6 +139,29 @@ namespace gcs::innards
          */
         auto infer(const Literal & lit, const Justification & why, const ReasonLiterals & reason,
             const std::optional<AssertionAnnotation> & annotation = std::nullopt) -> void;
+
+        /**
+         * \brief Constraint-group RUP hints: set (or clear) the constraint
+         * whose propagator is currently firing, so a bare-RUP step it emits
+         * cites that constraint's @@cv[...] group. Called by Propagators around
+         * each propagation call. No effect unless group hints are on.
+         */
+        auto set_current_constraint(const std::optional<ConstraintID> & constraint_id) -> void;
+
+        /**
+         * \brief The constraint currently firing (for constraint-group RUP
+         * hints), if any. Lets a caller save/clear/restore it around a nested
+         * inference that must stay hint-free (e.g. a JustifyExplicitly's
+         * concluding RUP, which depends on its just-emitted temporary steps).
+         */
+        [[nodiscard]] auto current_constraint() const -> std::optional<ConstraintID>;
+
+        /**
+         * \brief Write a `grpa @@name : members ;` line declaring or extending
+         * a checker-side constraint group. Derives no constraint, so the proof
+         * line counter does not advance. For constraint-group RUP hints only.
+         */
+        auto emit_rup_hint_group_add(const std::string & name, const std::vector<ProofLine> & members) -> void;
 
         /**
          * \brief Return the current <em>active proof level</em> &mdash; the
@@ -261,6 +289,14 @@ namespace gcs::innards
          */
         auto emit_rup_proof_line_under_reason(const ReasonLiterals &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level)
             -> ProofLine;
+
+        /**
+         * As `emit_rup_proof_line_under_reason`, but attaches the given RUP hint
+         * lines (e.g. a single @@cv[...] group token) so VeriPB restricts
+         * propagation to those constraints. For constraint-group RUP hints.
+         */
+        auto emit_rup_proof_line_under_reason(const ReasonLiterals &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> &, ProofLevel level,
+            std::vector<ProofLine> hints) -> ProofLine;
 
         /**
          * Like `emit_rup_proof_line_under_reason`, but returns the deview-form

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -97,7 +97,12 @@ ProofModel::~ProofModel()
 
 auto ProofModel::advance_constraint_counter() -> ProofLineNumber
 {
-    return ProofLineNumber{++_imp->number_of_constraints.number};
+    auto line = ProofLineNumber{++_imp->number_of_constraints.number};
+    // Attribute this OPB row to the constraint whose block is being written, so
+    // it becomes a member of that constraint's @@c[...] group (no-op unless
+    // constraint-group RUP hints are on).
+    names_and_ids_tracker().note_constraint_line(line);
+    return line;
 }
 
 auto ProofModel::emit_constraint_label(const string & constraint_id, const string & role) -> ProofLineLabel
@@ -109,6 +114,7 @@ auto ProofModel::emit_constraint_label(const string & constraint_id, const strin
 auto ProofModel::begin_constraint_block_comment(const string & constraint_type, const ConstraintID & constraint_id) -> void
 {
     _imp->opb << "* constraint " << constraint_type << ' ' << as_string(constraint_id) << '\n';
+    names_and_ids_tracker().begin_constraint_block(constraint_id);
 }
 
 auto ProofModel::add_constraint(const Literals & lits) -> void
@@ -428,7 +434,8 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
             _imp->opb << "-1 " << names_and_ids_tracker().pb_file_string_for(id == v) << " ";
         }
         _imp->opb << ">= -1 ;\n";
-        advance_constraint_counter();
+        // The at-most-one row is part of this variable's encoding closure.
+        names_and_ids_tracker().note_rup_hint_line_for(id, advance_constraint_counter());
     }
 }
 
@@ -541,7 +548,9 @@ auto ProofModel::set_up_bits_variable_encoding(
     for (auto & [coeff, var] : bits)
         _imp->opb << coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
     _imp->opb << ">= " << lower << " ;\n";
-    advance_constraint_counter();
+    // The bit-vector lower/upper bound rows are part of this variable's encoding
+    // closure (they relate its bits to its numeric bounds).
+    names_and_ids_tracker().note_rup_hint_line_for(id, advance_constraint_counter());
 
     // upper bound
     if (labelled)
@@ -549,7 +558,7 @@ auto ProofModel::set_up_bits_variable_encoding(
     for (auto & [coeff, var] : bits)
         _imp->opb << -coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
     _imp->opb << ">= " << -upper << " ;\n";
-    advance_constraint_counter();
+    names_and_ids_tracker().note_rup_hint_line_for(id, advance_constraint_counter());
 
     if (_imp->always_use_full_encoding)
         overloaded{

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -412,6 +412,12 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                 break;
 
             int propagator_id = _imp->queue[_imp->enqueued_begin++];
+            // Tell the logger which constraint is firing, so a bare-RUP step it
+            // emits can cite that constraint's @@cv[...] group (constraint-group
+            // RUP hints). Cleared after the call so non-propagator lines
+            // (backtrack, solution exclusion) stay hint-free.
+            if (logger)
+                logger->set_current_constraint(_imp->constraint_ids[_imp->propagator_constraint_index[propagator_id]]);
             try {
                 ++_imp->total_propagations;
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
@@ -454,6 +460,8 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                 contradiction = true;
                 ++_imp->contradicting_propagations;
             }
+            if (logger)
+                logger->set_current_constraint(std::nullopt);
 
             if (contradiction || (optional_abort_flag && optional_abort_flag->load()))
                 break;

--- a/gcs/proof.cc
+++ b/gcs/proof.cc
@@ -58,11 +58,35 @@ namespace
      * Environment variables act as defaults only: an option set explicitly in code
      * takes precedence.
      */
+    /**
+     * Read a boolean flag from an environment variable, if set. Accepts
+     * 1/on/true/yes (case-insensitive) as true and 0/off/false/no as false; an
+     * unrecognised value is ignored with a warning.
+     */
+    [[nodiscard]] auto bool_from_env(const char * const name) -> optional<bool>
+    {
+        const auto * const env = std::getenv(name);
+        if (! env || ! *env)
+            return nullopt;
+
+        string value{env};
+        if (value == "1" || value == "on" || value == "true" || value == "yes")
+            return true;
+        else if (value == "0" || value == "off" || value == "false" || value == "no")
+            return false;
+
+        print(stderr, "Ignoring unrecognised {} value '{}'\n", name, value);
+        return nullopt;
+    }
+
     [[nodiscard]] auto with_env_overrides(ProofOptions options) -> ProofOptions
     {
         if (! options.assertion_level_set_explicitly)
             if (auto level = assertion_level_from_env())
                 options.assertion_level = *level;
+        if (! options.emit_rup_group_hints_set_explicitly)
+            if (auto groups = bool_from_env("GCS_RUP_GROUPS"))
+                options.emit_rup_group_hints = *groups;
         return options;
     }
 }

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -62,6 +62,16 @@ namespace gcs
         AssertionLevel assertion_level = AssertionLevel::Off;
         bool assertion_level_set_explicitly = false; ///< Was assertion_level set in code (so it overrides the env var)?
 
+        /// Experimental: emit VeriPB constraint-group RUP hints. Each CP
+        /// variable's encoding closure becomes a group @@v[...], each
+        /// constraint's defining OPB rows a group @@c[...], and each
+        /// constraint gets a combined @@cv[...] = @@c[...] plus @@v[...] for
+        /// every variable in its scope. Every bare-RUP propagator step that
+        /// lacks better hinting cites its owning constraint's @@cv[...]. For
+        /// generating benchmark proofs for VeriPB's group/watch-table feature.
+        bool emit_rup_group_hints = false;
+        bool emit_rup_group_hints_set_explicitly = false; ///< Was emit_rup_group_hints set in code (so it overrides the env var)?
+
         /// Write annotated assertions instead of full justifications.
         ProofOptions & set_assertion_level(AssertionLevel a = AssertionLevel::Inferences)
         {
@@ -91,6 +101,14 @@ namespace gcs
         ProofOptions & set_verbose_names(bool v)
         {
             verbose_names = v;
+            return *this;
+        }
+        /// Experimental: emit VeriPB constraint-group RUP hints (see
+        /// emit_rup_group_hints).
+        ProofOptions & set_emit_rup_group_hints(bool g = true)
+        {
+            emit_rup_group_hints = g;
+            emit_rup_group_hints_set_explicitly = true;
             return *this;
         }
     };


### PR DESCRIPTION
**Draft — not for merge.** Experimental proof-logging feature for *generating benchmark
instances* for VeriPB's multiple-watch-table RUP work. Kept on a branch/PR so we can
regenerate or extend the instance set later.

## What it does

Behind `GCS_RUP_GROUPS=1` (or `ProofOptions::set_emit_rup_group_hints()`; **off by default**),
emits VeriPB constraint-group RUP hints:

- `@@v[var]` — one per CP variable: its whole encoding closure (order/eq atom defs, bound-link
  ladder rungs, `[lb]`/`[ub]` bit rows, AL1/AM1, view links), dynamically extended as atoms are
  introduced.
- `@@c[id]` — one per constraint: its defining OPB rows, plus top-level cache lemmas it emits
  during propagation.
- `@@cv[id]` — `@@c[id]` nested with `@@v[var]` for every variable the constraint reasons about.

Every bare-RUP propagator step cites the single `@@cv[id]` of its owning constraint. Groups are
announced/extended lazily via `grpa` lines; nesting is by live reference. Matches the
`grpa @@name : members ;` / `@@name`-in-hints surface syntax from the `hint-stats-experiment`
VeriPB branch.

## Why it's safe

- **Sound, always:** a group hint only restricts which constraints VeriPB propagates over, so it
  can make a check fail but never make a false claim verify — grouped and hint-free proofs are
  equisound.
- **Complete for bare-RUP steps:** the solver emits each propagation as `reify(ineq, reason)`, so
  the reason literals are assumptions rather than database lookups; a step therefore needs only
  definitional constraints (its own OPB rows + the encodings of the variables it touches) = exactly
  `@@cv`. Explicitly-justified concluding RUPs (which depend on just-emitted temporary lemmas) are
  left hint-free.

## Status

- Off by default; no effect on normal proofs (regression-clean against stock VeriPB 3.0.2).
- Validated with a weak-form `grpa` prototype checker across all_different (GAC/Hall), linear,
  element, disjunctive, extensional, and optimisation instances (langford, talent, qap, sudoku,
  skyscrapers, crystal_maze all verify grouped + hint-free).
- **Known gap:** `Tabulated` linear-equality (and similar) introduce a proof-only GAC-table
  variable encoded at proof start, not attributed to its `@@c` — a parity RUP through it fails
  under the group restriction. Default linear equality is fine. Same class as the knapsack DD
  proof-only-variable case. Fixable by attributing proof-start deferred lines to their
  originating constraint; not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)