### PR TITLE
bin_packing: remove per-wake hash allocation in the Stage 3 sweep (#514)

### DIFF
--- a/gcs/constraints/bin_packing/bin_packing.cc
+++ b/gcs/constraints/bin_packing/bin_packing.cc
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <any>
+#include <cstdint>
 #include <list>
 #include <map>
 #include <optional>
@@ -82,6 +83,32 @@ namespace
         vector<unordered_set<long long>> node_set;
         vector<vector<long long>> phantoms_at;
         vector<unordered_set<long long>> phantom_set;
+
+        // Precomputed static DAG edges for the per-call sweep, indexed by
+        // layer i in [0, n) and node position p within nodes_at[i]. The value
+        // is the position of the branch's successor within nodes_at[i+1], or
+        // -1 if that successor is not a DAG node. These are structural (the
+        // DAG never changes across the search); the per-wake sweep gates them
+        // by the current item domains. Computed once, so the hot path needs no
+        // hash lookups at all.
+        //   exclude_succ[i][p]: items[i] != b  (partial load unchanged)
+        //   include_succ[i][p]: items[i] == b  (partial load += sizes[i])
+        vector<vector<int>> exclude_succ;
+        vector<vector<int>> include_succ;
+    };
+
+    // Per-bin scratch for the per-call sweep (run_stage3_for_bin), owned by the
+    // DagBridge and reused across every wake so the hot path allocates nothing
+    // after warm-up. fwd/bwd are position-indexed reachability bitmaps parallel
+    // to PerBinDag::nodes_at; can_be_b/can_be_notb hold the current per-item
+    // admissibility. Each search gets its own constraint clone (and hence its
+    // own bridge), so no synchronisation is needed even across threads.
+    struct Stage3Scratch
+    {
+        vector<vector<uint8_t>> fwd;
+        vector<vector<uint8_t>> bwd;
+        vector<char> can_be_b;
+        vector<char> can_be_notb;
     };
 
     struct PerBinCoordFlags
@@ -175,6 +202,28 @@ namespace
         for (size_t i = 0; i <= n; ++i) {
             dag.nodes_at[i].assign(fwd[i].begin(), fwd[i].end());
             dag.node_set[i].insert(dag.nodes_at[i].begin(), dag.nodes_at[i].end());
+        }
+
+        // Precompute the static successor-position edges used by the per-call
+        // sweep. nodes_at is sorted, so a node's position in the next layer is
+        // a binary search; -1 marks "successor is not a DAG node".
+        auto pos_in = [](const vector<long long> & sorted, long long w) -> int {
+            auto it = std::lower_bound(sorted.begin(), sorted.end(), w);
+            if (it != sorted.end() && *it == w)
+                return static_cast<int>(it - sorted.begin());
+            return -1;
+        };
+        dag.exclude_succ.assign(n, {});
+        dag.include_succ.assign(n, {});
+        for (size_t i = 0; i < n; ++i) {
+            auto sz = sizes[i].raw_value;
+            dag.exclude_succ[i].resize(dag.nodes_at[i].size());
+            dag.include_succ[i].resize(dag.nodes_at[i].size());
+            for (size_t p = 0; p < dag.nodes_at[i].size(); ++p) {
+                auto w = dag.nodes_at[i][p];
+                dag.exclude_succ[i][p] = pos_in(dag.nodes_at[i + 1], w);
+                dag.include_succ[i][p] = pos_in(dag.nodes_at[i + 1], w + sz);
+            }
         }
         return dag;
     }
@@ -755,67 +804,79 @@ namespace
     // dev_docs/bin-packing.md); the upfront alternative (propagate_bin) is
     // the opt-in enabled by upfront_proof=true.
     auto run_stage3_for_bin(const State & state, auto & inference, ProofLogger * logger, const vector<IntegerVariableID> & items,
-        const vector<Integer> & sizes, const PerBinDag & dag, size_t b, const Reason & reason, const ConstraintID & owner) -> void
+        const PerBinDag & dag, Stage3Scratch & scratch, size_t b, const Reason & reason, const ConstraintID & owner) -> void
     {
         auto n = items.size();
         auto bin_idx = Integer{static_cast<long long>(b)};
 
-        vector<bool> can_be_b(n), can_be_notb(n);
+        auto & can_be_b = scratch.can_be_b;
+        auto & can_be_notb = scratch.can_be_notb;
         for (size_t i = 0; i < n; ++i) {
-            can_be_b[i] = state.in_domain(items[i], bin_idx);
+            can_be_b[i] = static_cast<char>(state.in_domain(items[i], bin_idx));
             auto v = state.optional_single_value(items[i]);
-            can_be_notb[i] = ! (v && *v == bin_idx);
+            can_be_notb[i] = static_cast<char>(! (v && *v == bin_idx));
         }
 
-        // Forward reachability under current domains, restricted to static DAG.
-        vector<unordered_set<long long>> fwd(n + 1);
-        if (dag.node_set[0].contains(0))
-            fwd[0].insert(0);
+        auto & fwd = scratch.fwd;
+        auto & bwd = scratch.bwd;
+
+        // Forward reachability under current domains, restricted to the static
+        // DAG, over position-indexed bitmaps. fwd starts all-zero; layer 0 has
+        // exactly node 0 (build_fwd_dag seeds it), which is always reachable.
+        for (auto & layer : fwd)
+            std::fill(layer.begin(), layer.end(), uint8_t{0});
+        if (! dag.nodes_at[0].empty())
+            fwd[0][0] = 1;
         for (size_t i = 0; i < n; ++i) {
-            for (auto w : fwd[i]) {
-                if (can_be_notb[i] && dag.node_set[i + 1].contains(w))
-                    fwd[i + 1].insert(w);
-                if (can_be_b[i]) {
-                    auto w2 = w + sizes[i].raw_value;
-                    if (dag.node_set[i + 1].contains(w2))
-                        fwd[i + 1].insert(w2);
-                }
+            const auto & excl = dag.exclude_succ[i];
+            const auto & incl = dag.include_succ[i];
+            auto & next_layer = fwd[i + 1];
+            for (size_t p = 0; p < fwd[i].size(); ++p) {
+                if (! fwd[i][p])
+                    continue;
+                if (can_be_notb[i] && excl[p] >= 0)
+                    next_layer[excl[p]] = 1;
+                if (can_be_b[i] && incl[p] >= 0)
+                    next_layer[incl[p]] = 1;
             }
         }
 
-        // Backward reachability from accepting terminals (the layer-n nodes
-        // already encode the acceptance predicate via static reduction).
-        vector<unordered_set<long long>> bwd(n + 1);
-        for (auto w : dag.nodes_at[n])
-            if (fwd[n].contains(w))
-                bwd[n].insert(w);
+        // Backward reachability. Layer n's accepting terminals are the
+        // forward-reachable layer-n nodes (static reduction already encodes
+        // acceptance). A node at layer i is backward-reachable if some
+        // admissible branch lands on a backward-reachable successor. Every
+        // cell is overwritten, so no pre-zeroing is needed.
+        for (size_t p = 0; p < bwd[n].size(); ++p)
+            bwd[n][p] = fwd[n][p];
         for (long long i = static_cast<long long>(n) - 1; i >= 0; --i) {
-            for (auto w : bwd[i + 1]) {
-                if (can_be_notb[i] && dag.node_set[i].contains(w))
-                    bwd[i].insert(w);
-                if (can_be_b[i]) {
-                    auto w_prev = w - sizes[i].raw_value;
-                    if (dag.node_set[i].contains(w_prev))
-                        bwd[i].insert(w_prev);
-                }
+            const auto & excl = dag.exclude_succ[i];
+            const auto & incl = dag.include_succ[i];
+            const auto & next_bwd = bwd[i + 1];
+            for (size_t p = 0; p < bwd[i].size(); ++p) {
+                uint8_t reachable = 0;
+                if (can_be_notb[i] && excl[p] >= 0 && next_bwd[excl[p]])
+                    reachable = 1;
+                else if (can_be_b[i] && incl[p] >= 0 && next_bwd[incl[p]])
+                    reachable = 1;
+                bwd[i][p] = reachable;
             }
         }
 
-        // Alive = forward ∩ backward.
-        vector<unordered_set<long long>> alive(n + 1);
-        for (size_t i = 0; i <= n; ++i)
-            for (auto w : fwd[i])
-                if (bwd[i].contains(w))
-                    alive[i].insert(w);
-
-        // Prune items[i] != b when no support exists in the alive DAG.
+        // Prune items[i] != b when the "include" branch has no support: no
+        // alive node (fwd ∩ bwd) at layer i whose include-successor is also
+        // alive at layer i+1.
         for (size_t i = 0; i < n; ++i) {
             if (! can_be_b[i])
                 continue;
+            const auto & incl = dag.include_succ[i];
+            const auto & next_fwd = fwd[i + 1];
+            const auto & next_bwd = bwd[i + 1];
             bool supported = false;
-            for (auto w : alive[i]) {
-                auto w2 = w + sizes[i].raw_value;
-                if (alive[i + 1].contains(w2)) {
+            for (size_t p = 0; p < fwd[i].size(); ++p) {
+                if (! (fwd[i][p] && bwd[i][p]))
+                    continue;
+                auto q = incl[p];
+                if (q >= 0 && next_fwd[q] && next_bwd[q]) {
                     supported = true;
                     break;
                 }
@@ -830,21 +891,31 @@ namespace
         const ConstraintID & owner) -> void
     {
         auto num_bins = have_loads ? loads.size() : capacities.size();
+        // The reason literal lists are only consumed by a reason-materialising
+        // (proof-logging) tracker; off that path skip building them entirely.
+        // still_possible drives the inference logic, so it is always built, but
+        // reused across bins to keep the per-wake allocation count down.
+        const bool need_reasons = inference.want_reasons();
+        ReasonLiterals forced_reason, excluded_reason;
+        vector<size_t> still_possible;
         for (size_t b = 0; b < num_bins; ++b) {
             auto bin_idx = Integer(static_cast<long long>(b));
 
-            ReasonLiterals forced_reason, excluded_reason;
+            forced_reason.clear();
+            excluded_reason.clear();
+            still_possible.clear();
             Integer floor = 0_i, ceiling = 0_i;
-            vector<size_t> still_possible;
             for (size_t i = 0; i < items.size(); ++i) {
                 auto v = state.optional_single_value(items[i]);
                 if (v && *v == bin_idx) {
                     floor += sizes[i];
                     ceiling += sizes[i];
-                    forced_reason.emplace_back(items[i] == bin_idx);
+                    if (need_reasons)
+                        forced_reason.emplace_back(items[i] == bin_idx);
                 }
                 else if (! state.in_domain(items[i], bin_idx)) {
-                    excluded_reason.emplace_back(items[i] != bin_idx);
+                    if (need_reasons)
+                        excluded_reason.emplace_back(items[i] != bin_idx);
                 }
                 else {
                     still_possible.push_back(i);
@@ -900,6 +971,10 @@ struct BinPacking::DagBridge
     //   variable-load: (sum <= load, sum >= load)
     //   constant-cap:  (sum <= cap,  nullopt)
     vector<pair<optional<ProofLine>, optional<ProofLine>>> opb_lines;
+    // Per-bin reusable scratch for the per-call sweep, sized once in prepare()
+    // to match each bin's DAG so the hot path never allocates. The bridge is
+    // per-constraint-clone, so a search owns its scratch exclusively.
+    vector<Stage3Scratch> stage3_scratch;
 };
 
 BinPacking::BinPacking(vector<IntegerVariableID> items, vector<Integer> sizes, vector<IntegerVariableID> loads) :
@@ -985,10 +1060,24 @@ auto BinPacking::prepare(Propagators &, State & initial_state, ProofModel * cons
         _bridge->dags.reserve(num_bins);
         _bridge->flags.assign(num_bins, {});
         _bridge->opb_lines.assign(num_bins, {nullopt, nullopt});
+        _bridge->stage3_scratch.assign(num_bins, {});
         for (size_t b = 0; b < num_bins; ++b) {
             auto cap = per_bin_cap(initial_state, _sizes, _have_loads, _loads, _capacities, b);
             auto dag = build_fwd_dag(initial_state, _items, _sizes, b, cap);
             compute_phantoms(dag, initial_state, _items, _sizes, b);
+
+            // Size the per-call scratch to this bin's DAG so the hot path only
+            // fills existing buffers, never grows them.
+            auto & sc = _bridge->stage3_scratch[b];
+            sc.fwd.resize(dag.nodes_at.size());
+            sc.bwd.resize(dag.nodes_at.size());
+            for (size_t i = 0; i < dag.nodes_at.size(); ++i) {
+                sc.fwd[i].assign(dag.nodes_at[i].size(), uint8_t{0});
+                sc.bwd[i].assign(dag.nodes_at[i].size(), uint8_t{0});
+            }
+            sc.can_be_b.assign(_items.size(), char{0});
+            sc.can_be_notb.assign(_items.size(), char{0});
+
             _bridge->dags.push_back(move(dag));
         }
 
@@ -1106,7 +1195,7 @@ auto BinPacking::install_propagators(Propagators & propagators) -> void
                     // flag definitions + the per-bin OPB equation).
                     auto reason = generic_reason(items);
                     for (size_t b = 0; b < num_bins; ++b)
-                        run_stage3_for_bin(state, inference, logger, items, sizes, bridge->dags[b], b, reason, owner);
+                        run_stage3_for_bin(state, inference, logger, items, bridge->dags[b], bridge->stage3_scratch[b], b, reason, owner);
                 }
             }
 

--- a/gcs/constraints/bin_packing/bin_packing.cc
+++ b/gcs/constraints/bin_packing/bin_packing.cc
@@ -1228,6 +1228,18 @@ auto BinPacking::install_propagators(Propagators & propagators) -> void
         });
     }
 
+    // The Stage 3 reason ranges over a fixed variable scope, so build it once
+    // here rather than reconstructing it — and re-copying the scope vector into
+    // a fresh shared_ptr — on every wake. The default (per-call) strategy
+    // reasons over the item variables alone; the upfront strategy additionally
+    // needs the load variables in the variable-load form, otherwise the
+    // cap-exceeded / load-bound / interior-hole ~S lines aren't sound under
+    // their reasons (for constant-cap the cap is static, so items suffice).
+    vector<IntegerVariableID> stage3_reason_vars = _items;
+    if (_upfront_proof && _have_loads)
+        stage3_reason_vars.insert(stage3_reason_vars.end(), _loads.begin(), _loads.end());
+    auto stage3_reason = generic_reason(stage3_reason_vars);
+
     // Stage 2 (per-bin bounds) always runs. Stage 3 (per-bin DAG sweep) only
     // runs when ! bounds_only. Both share state through `state`; Stage 3 sees
     // the bounds Stage 2 derived. The Stage 3 proof strategy is chosen by
@@ -1236,34 +1248,19 @@ auto BinPacking::install_propagators(Propagators & propagators) -> void
     propagators.install(
         constraint_id(),
         [items = _items, sizes = _sizes, loads = _loads, capacities = _capacities, have_loads = _have_loads, bounds_only = _bounds_only,
-            bridge = _bridge, dead_cache_handle = _dead_cache_idx, upfront = _upfront_proof,
+            bridge = _bridge, dead_cache_handle = _dead_cache_idx, upfront = _upfront_proof, reason = move(stage3_reason),
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             run_stage2(state, inference, logger, items, sizes, loads, capacities, have_loads, owner);
 
             if (! bounds_only && bridge) {
                 auto num_bins = have_loads ? loads.size() : capacities.size();
                 if (upfront) {
-                    // Reason has to include the load variables when variable-load
-                    // form is in use, otherwise the cap-exceeded / load-bound /
-                    // interior-hole ~S lines aren't sound under their reasons.
-                    // For constant-cap, items alone suffice (the cap is static).
-                    vector<IntegerVariableID> reason_vars;
-                    reason_vars.reserve(items.size() + (have_loads ? loads.size() : 0));
-                    reason_vars.insert(reason_vars.end(), items.begin(), items.end());
-                    if (have_loads)
-                        reason_vars.insert(reason_vars.end(), loads.begin(), loads.end());
-                    auto reason = generic_reason(reason_vars);
                     auto & cache = any_cast<DeadCache &>(state.get_constraint_state(*dead_cache_handle));
                     for (size_t b = 0; b < num_bins; ++b)
                         propagate_bin(state, inference, logger, items, sizes, have_loads, loads, capacities, b, bridge->dags[b], bridge->flags[b],
                             bridge->opb_lines[b], cache, reason, owner);
                 }
                 else {
-                    // Default per-call strategy: item-var pruning only; the
-                    // load bounds are handled by Stage 2. Reason is the item
-                    // variables (the bare RUP prune closes through the Top
-                    // flag definitions + the per-bin OPB equation).
-                    auto reason = generic_reason(items);
                     for (size_t b = 0; b < num_bins; ++b)
                         run_stage3_for_bin(state, inference, logger, items, bridge->dags[b], bridge->stage3_scratch[b], b, reason, owner);
                 }

--- a/gcs/constraints/bin_packing/bin_packing.cc
+++ b/gcs/constraints/bin_packing/bin_packing.cc
@@ -103,12 +103,25 @@ namespace
     // to PerBinDag::nodes_at; can_be_b/can_be_notb hold the current per-item
     // admissibility. Each search gets its own constraint clone (and hence its
     // own bridge), so no synchronisation is needed even across threads.
+    //
+    // Incremental recompute: fwd/bwd are a pure function of the per-item flags,
+    // so we cache the flags they were last built from (prev_can_be_*). On the
+    // next wake we diff current-vs-cached flags to find the changed layer range
+    // and recompute only that. This is correct across backtrack without any
+    // trailing: a backtrack simply relaxes the flags, which the diff sees as a
+    // change and rebuilds from. warm gates the first (full) build; old_fwd_n
+    // snapshots the terminal layer to decide whether the backward pass can be
+    // partial.
     struct Stage3Scratch
     {
         vector<vector<uint8_t>> fwd;
         vector<vector<uint8_t>> bwd;
         vector<char> can_be_b;
         vector<char> can_be_notb;
+        vector<char> prev_can_be_b;
+        vector<char> prev_can_be_notb;
+        vector<uint8_t> old_fwd_n;
+        bool warm = false;
     };
 
     struct PerBinCoordFlags
@@ -811,55 +824,108 @@ namespace
 
         auto & can_be_b = scratch.can_be_b;
         auto & can_be_notb = scratch.can_be_notb;
-        for (size_t i = 0; i < n; ++i) {
-            can_be_b[i] = static_cast<char>(state.in_domain(items[i], bin_idx));
-            auto v = state.optional_single_value(items[i]);
-            can_be_notb[i] = static_cast<char>(! (v && *v == bin_idx));
-        }
-
         auto & fwd = scratch.fwd;
         auto & bwd = scratch.bwd;
 
-        // Forward reachability under current domains, restricted to the static
-        // DAG, over position-indexed bitmaps. fwd starts all-zero; layer 0 has
-        // exactly node 0 (build_fwd_dag seeds it), which is always reachable.
-        for (auto & layer : fwd)
-            std::fill(layer.begin(), layer.end(), uint8_t{0});
-        if (! dag.nodes_at[0].empty())
-            fwd[0][0] = 1;
+        // Read the current per-item admissibility and, against the flags the
+        // cached bitmaps were built from, find the changed layer range. Flags
+        // only ever relax on backtrack and tighten on descent, but the diff is
+        // direction-agnostic, so the same code is correct either way.
+        auto first_change = n;
+        size_t last_change = 0;
+        bool any_change = false;
         for (size_t i = 0; i < n; ++i) {
-            const auto & excl = dag.exclude_succ[i];
-            const auto & incl = dag.include_succ[i];
-            auto & next_layer = fwd[i + 1];
-            for (size_t p = 0; p < fwd[i].size(); ++p) {
-                if (! fwd[i][p])
-                    continue;
-                if (can_be_notb[i] && excl[p] >= 0)
-                    next_layer[excl[p]] = 1;
-                if (can_be_b[i] && incl[p] >= 0)
-                    next_layer[incl[p]] = 1;
+            auto nb = static_cast<char>(state.in_domain(items[i], bin_idx));
+            auto v = state.optional_single_value(items[i]);
+            auto nnb = static_cast<char>(! (v && *v == bin_idx));
+            can_be_b[i] = nb;
+            can_be_notb[i] = nnb;
+            if (nb != scratch.prev_can_be_b[i] || nnb != scratch.prev_can_be_notb[i]) {
+                if (! any_change)
+                    first_change = i;
+                last_change = i;
+                any_change = true;
             }
         }
 
-        // Backward reachability. Layer n's accepting terminals are the
-        // forward-reachable layer-n nodes (static reduction already encodes
-        // acceptance). A node at layer i is backward-reachable if some
-        // admissible branch lands on a backward-reachable successor. Every
-        // cell is overwritten, so no pre-zeroing is needed.
-        for (size_t p = 0; p < bwd[n].size(); ++p)
-            bwd[n][p] = fwd[n][p];
-        for (long long i = static_cast<long long>(n) - 1; i >= 0; --i) {
-            const auto & excl = dag.exclude_succ[i];
-            const auto & incl = dag.include_succ[i];
-            const auto & next_bwd = bwd[i + 1];
-            for (size_t p = 0; p < bwd[i].size(); ++p) {
-                uint8_t reachable = 0;
-                if (can_be_notb[i] && excl[p] >= 0 && next_bwd[excl[p]])
-                    reachable = 1;
-                else if (can_be_b[i] && incl[p] >= 0 && next_bwd[incl[p]])
-                    reachable = 1;
-                bwd[i][p] = reachable;
+        // Forward reachability, restricted to the static DAG, over
+        // position-indexed bitmaps: recompute fwd[from+1 .. n] from fwd[from]
+        // (which is left untouched and valid). Each rebuilt layer is zeroed
+        // before its reachable cells are set.
+        auto recompute_forward = [&](size_t from) {
+            for (size_t i = from; i < n; ++i) {
+                auto & next_layer = fwd[i + 1];
+                std::fill(next_layer.begin(), next_layer.end(), uint8_t{0});
+                const auto & excl = dag.exclude_succ[i];
+                const auto & incl = dag.include_succ[i];
+                for (size_t p = 0; p < fwd[i].size(); ++p) {
+                    if (! fwd[i][p])
+                        continue;
+                    if (can_be_notb[i] && excl[p] >= 0)
+                        next_layer[excl[p]] = 1;
+                    if (can_be_b[i] && incl[p] >= 0)
+                        next_layer[incl[p]] = 1;
+                }
             }
+        };
+
+        // Backward reachability: a node is backward-reachable if some admissible
+        // branch lands on a backward-reachable successor. Recompute bwd[hi .. 0]
+        // assuming bwd[hi+1 .. n] (and bwd[n] itself) are already valid.
+        auto recompute_backward = [&](long long hi) {
+            for (long long i = hi; i >= 0; --i) {
+                const auto & excl = dag.exclude_succ[i];
+                const auto & incl = dag.include_succ[i];
+                const auto & next_bwd = bwd[i + 1];
+                for (size_t p = 0; p < bwd[i].size(); ++p) {
+                    uint8_t reachable = 0;
+                    if (can_be_notb[i] && excl[p] >= 0 && next_bwd[excl[p]])
+                        reachable = 1;
+                    else if (can_be_b[i] && incl[p] >= 0 && next_bwd[incl[p]])
+                        reachable = 1;
+                    bwd[i][p] = reachable;
+                }
+            }
+        };
+
+        if (! scratch.warm) {
+            // First wake for this clone: full build. Layer 0 is exactly {0},
+            // always reachable; fwd was zero-initialised in prepare().
+            if (! dag.nodes_at[0].empty())
+                fwd[0][0] = 1;
+            recompute_forward(0);
+            for (size_t p = 0; p < bwd[n].size(); ++p)
+                bwd[n][p] = fwd[n][p];
+            recompute_backward(static_cast<long long>(n) - 1);
+            scratch.warm = true;
+        }
+        else if (any_change) {
+            // Forward is valid up to and including first_change; rebuild the
+            // rest. Snapshot the terminal layer first so we can tell whether
+            // the backward pass has to restart from n or only from last_change.
+            std::copy(fwd[n].begin(), fwd[n].end(), scratch.old_fwd_n.begin());
+            recompute_forward(first_change);
+            if (! std::equal(fwd[n].begin(), fwd[n].end(), scratch.old_fwd_n.begin())) {
+                for (size_t p = 0; p < bwd[n].size(); ++p)
+                    bwd[n][p] = fwd[n][p];
+                recompute_backward(static_cast<long long>(n) - 1);
+            }
+            else {
+                // Terminals unchanged, so bwd[last_change+1 .. n] is still
+                // valid (those layers' edges did not change either).
+                recompute_backward(static_cast<long long>(last_change));
+            }
+        }
+        else {
+            // Nothing this bin depends on changed since the last sweep: the
+            // cached alive DAG — and hence every prune decision — is identical,
+            // and those prunes were already drawn. Skip the bin entirely.
+            return;
+        }
+
+        for (size_t i = 0; i < n; ++i) {
+            scratch.prev_can_be_b[i] = can_be_b[i];
+            scratch.prev_can_be_notb[i] = can_be_notb[i];
         }
 
         // Prune items[i] != b when the "include" branch has no support: no
@@ -1077,6 +1143,10 @@ auto BinPacking::prepare(Propagators &, State & initial_state, ProofModel * cons
             }
             sc.can_be_b.assign(_items.size(), char{0});
             sc.can_be_notb.assign(_items.size(), char{0});
+            sc.prev_can_be_b.assign(_items.size(), char{0});
+            sc.prev_can_be_notb.assign(_items.size(), char{0});
+            sc.old_fwd_n.assign(dag.nodes_at.back().size(), uint8_t{0});
+            sc.warm = false;
 
             _bridge->dags.push_back(move(dag));
         }


### PR DESCRIPTION
Closes #514. Stacked on top of #516 (base branch `state-bounds-fast-path`); rebase to `main` once that merges.

## What

The default per-call Stage 3 sweep (`run_stage3_for_bin`) rebuilt three `vector<unordered_set<long long>>` (forward / backward / alive) **per bin on every wake** — `3·(n+1)` hash tables allocated, grown and freed per propagation. The issue's `ccmcp` profile (kidney-exchange, `bin_packing` + `maximum`) showed ~50% of runtime in `std::_Hashtable` + malloc/free/rehash, dwarfing the actual propagation (~5%).

This replaces the hash sets with **position-indexed reachability bitmaps** parallel to `PerBinDag::nodes_at`, held in per-bin scratch owned by the (per-clone) `DagBridge` and reused across every wake — zero allocation after warm-up.

- The DAG is static, so each node's exclude/include **successor position** in the next layer is precomputed once (`exclude_succ` / `include_succ`, `-1` = not a DAG node). The per-wake sweep is then a flat array walk gated by the current item domains, with **no hashing at all** — no `node_set` lookups in the hot path.
- Backward reachability is rewritten as a reverse-edge scan over those precomputed successors. This is algebraically identical to the old value-set formulation (verified branch-by-branch and empirically by identical search).
- Stage 2 is trimmed too: the reason literal lists are built only when a reason-materialising (proof-logging) tracker will read them (`inference.want_reasons()`), and the `still_possible` buffer is reused across bins instead of reallocated per bin.

## Correctness

Pure performance change — search is unaffected. `recursions`, `propagations` and enumerated solutions are **identical** baseline↔branch on every bench instance. The bin_packing test corpus passes its VeriPB proof checks (all `VERIFIED COMPLETE`, 0 failures) — both the per-call and upfront proof strategies (19 proof configs each), load and capacity forms. `ctest -R bin_packing` green.

Identical propagation counts also confirm the pruning **strength** is unchanged: a weaker propagator would recurse more.

## Measured (`examples/bin_packing_bench`, `taskset -c 4`, median, identical trees)

Instruction counts are deterministic (same search tree), so they are an exact before/after signal; wall time confirms the real speedup.

| instance | before (wall / instr) | after (wall / instr) | speedup |
|---|--:|--:|--:|
| 2 — 10it 3bin load | 0.293 s / 5.20e9 | 0.066 s / 1.18e9 | **4.4×** |
| 3 — 12it 4bin capa | 60.65 s / 1.208e12 | 13.28 s / 0.299e12 | **4.6×** |
| 4 — 12it 4bin load | 55.56 s / 1.104e12 | 11.59 s / 0.262e12 | **4.8×** |

The `_Hashtable` / `_int_malloc` / `_int_free` self-time that dominated the profile is gone after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up commit: incremental across wakes (decide separately)

The second commit (`make the Stage 3 sweep incremental across wakes`) is kept separate so its complexity/reward can be judged on its own — drop it with a single `git revert`/reset if it isn't worth it.

`fwd`/`bwd` are a pure function of the per-item flags, so it caches the flags the bitmaps were last built from and diffs current-vs-cached each wake: forward rebuilds only the suffix from the first changed layer; backward restarts from `n` only if the terminal layer actually changed, else from the last changed layer; a bin whose flags didn't change is skipped entirely (reachability **and** prune scan). Correct across backtrack **with no trailing** — a backtrack just relaxes the flags, which the diff sees as a change and rebuilds from.

**Cost:** +4 scratch fields, ~70 lines (two recompute lambdas + the diff/branch logic). **Reward** (on top of the flat-scratch commit):

| instance | scratch only | + incremental | further | total vs baseline |
|---|--:|--:|--:|--:|
| 2 — var-load | 0.066 s | 0.050 s | 1.3× | **5.9×** |
| 3 — const-cap | 13.28 s | 10.40 s | 1.3× | **5.8×** |
| 4 — var-load | 11.59 s | 7.24 s | 1.6× | **7.7×** |

Variable-load (the ccmcp form) wins most — a value-prune touches one bin, so the others short-circuit. Search and all 34 proofs remain identical. The remaining lever (not done) would be making the final prune scan incremental too, but a change anywhere can unsupport any item, so that needs per-item support counters and is a bigger step.
