### PR TITLE
constraints: build fixed-scope reasons once, not per wake/inference (+ perf dev doc)

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -772,6 +772,13 @@ correctness work wants the full enumeration check.
 
 ## See also
 
+- [propagator-performance.md](propagator-performance.md) — making a
+  *correct* propagator faster: triggers/idempotence, reusing reasons and
+  scratch data structures, fast data structures, iteration order,
+  incrementality, backtrackable state, and removing variant-dispatch
+  overhead — plus the discipline that keeps a performance change from
+  becoming a strength or correctness change. Read this only once the
+  propagator works and its proofs verify.
 - [state-and-variables.md](state-and-variables.md) — the variable-ID
   family, the `State` class, `IntervalSet` domain storage, epoch-based
   backtracking, and the `change_state_for_*` inference paths your

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -1,0 +1,310 @@
+# Making a propagator faster
+
+This is a companion to [constraints.md](constraints.md), which covers how to
+*write* a correct, proof-logging propagator. This document is about how to make
+one *faster* once it is correct. It is a checklist of the levers we have found
+useful, roughly cheapest/safest first, plus the discipline that keeps a
+performance change from quietly becoming a correctness or strength change.
+
+Read [benchmarking.md](benchmarking.md) alongside this: it describes the curated
+benchmark set and how to run a before/after comparison. This document is about
+*what* to change; that one is about *how to measure* whether it helped.
+
+## Ground rules
+
+These come first because they are what stop performance work from going wrong.
+
+### Correctness comes first
+
+Do not start performance work until the propagator is finished: correct, with
+wide test coverage (enumeration tests over varied instances, GAC-at-each-node
+checks where applicable), and with proof logging that VeriPB accepts. A fast
+propagator that is wrong, or whose proofs don't verify, is worthless, and a
+half-built one is a moving target you can't benchmark. Optimise a thing that
+works.
+
+### Distinguish strength from performance
+
+There are two completely different kinds of "the propagator got better":
+
+- **Strength** — it prunes more (fewer search nodes). This is a change to *what*
+  the solver does. It is a separate concern from this document and is usually
+  out of scope for a performance pass.
+- **Performance** — it does the same work faster (same search, less time per
+  node). This is what a performance change should be.
+
+Keep them apart. A pure performance change **must not change the search**:
+`recursions` and the first integer of `propagations:` must be identical before
+and after, on every benchmark. The benchmark harness prints both precisely so
+you can diff them; treat any divergence as a correctness signal first and a
+performance signal second (benchmarking.md, "What to capture"). If you find
+yourself explaining a speedup by "well, it also prunes a bit differently now",
+stop — you have conflated the two, and you need to re-evaluate the change as a
+strength change (with its own soundness and proof review) rather than a free
+win.
+
+### Have good, varied benchmarks, and don't commit on a hunch
+
+Propagator behaviour is extremely data-sensitive: large vs small domains, holey
+vs contiguous domains, many vs few variables, tight vs loose constraints, and
+search-heavy vs propagation-heavy instances can each flip which implementation
+wins. A change that is 2× faster on one shape can be 2× slower on another. So:
+
+- Measure on more than one instance shape before committing to anything
+  complicated. The curated set in benchmarking.md is the baseline sanity check;
+  supplement it with a shape that actually exercises *your* constraint.
+- Don't commit a complicated change (incrementality, a bespoke data structure, a
+  backtrackable cache) without evidence that it wins across the shapes you care
+  about, not just the one you developed against.
+
+There is one deliberate exception. A change that is *applied uniformly
+everywhere* and is *generally sound as a principle* — the reason-reuse hoist
+below is the archetype — gets a pass even if it doesn't measurably speed up some
+individual constraint, as long as it never makes anything slower and the general
+idea is worthwhile. Consistency has value: it removes a whole class of avoidable
+work and makes the next propagator's default the good one. Don't use this as a
+loophole for speculative single-constraint cleverness.
+
+## Levers, cheapest first
+
+### Better triggers and idempotence
+
+The cheapest propagation is the one that never runs. Two mechanisms cut
+unnecessary calls:
+
+- **Triggers.** Register the propagator to wake only on the events that can
+  actually change its output (`on_bounds` vs `on_change`, and only the variables
+  it reads). Waking on changes you don't care about is pure overhead. See
+  constraints.md, "Triggers".
+- **Idempotence.** If a propagator reaches a fixpoint in a single call, it can
+  tell the engine so (return the right `PropagatorState`, or claim idempotence)
+  and avoid being re-queued to discover it changed nothing. Conversely, a
+  propagator that reports `NoChange` when it *did* change state causes the
+  engine to stop too early — see the `Inference::NoChange` note in the state
+  docs.
+
+Both are about not calling the propagator when there is nothing for it to do.
+Get these right before micro-optimising the body.
+
+### Reuse the reason instead of rebuilding it
+
+A propagator that reasons over a fixed variable scope should build **one**
+`Reason` and reuse it, not call `generic_reason(vars)` / `bounds_reason(vars)`
+on every wake or at every inference site. Those factories take the scope
+by-value (`ArrayParam`'s owning constructor), so each call copies the whole
+scope vector into a fresh `shared_ptr` — and it happens even with proofs off,
+where the reason is never materialised.
+
+The `*_reason()` factories are *declarative*: they capture the variable scope
+and defer reading domains to `materialise()` (see
+[reasons-improvement.md](reasons-improvement.md)). So a reason over a fixed
+scope is identical on every wake; the only per-call part is materialisation,
+which the tracker does lazily and only when a proof actually needs it. That
+means you can build the reason once — at install, as a capture-init, or captured
+and threaded into a per-wake helper by `const Reason &` — and hand the same
+object to every `infer()`.
+
+```cpp
+// once, at install:
+auto all_vars_reason = generic_reason(all_vars);
+propagators.install(id, [/* ... */, reason = std::move(all_vars_reason)](
+    const State & state, auto & inference, ProofLogger * const logger) {
+    /* ... */
+    inference.infer(logger, lit, JustifyUsingRUP{...}, reason);   // reuse
+});
+```
+
+This was applied across `count`, `n_value`, `at_most_one`, `value_precede`,
+`linear_equality`, `linear_inequality`, `negative_table`, `regular`, and `sort`.
+It is the archetype of the "uniform, generally-sound" change above: on some
+constraints it's immeasurable, but it never hurts and removes an avoidable
+allocation from every hot path.
+
+The one thing to watch: this only applies to a reason that is genuinely fixed.
+If the reason is materialised eagerly against the current state
+(`eager_reason(reason, state)`), or its literal set depends on what changed,
+it is per-call by nature and must not be hoisted. (`lex` is the in-tree example
+that is *not* hoisted for exactly this reason.)
+
+### Reuse data structures to avoid per-wake allocation
+
+The same principle applies to scratch state generally: a propagator that
+allocates working buffers (`vector`s, sets, maps) on every wake is paying malloc
+and cache-miss cost per call for storage whose size it already knows. Allocate
+once and reuse.
+
+The model that makes this safe is: **each search gets its own clone of a
+constraint** (`Constraint::clone()`), including if we ever run searches in
+parallel threads. A propagator's captured state therefore belongs to exactly one
+search on one thread. You do **not** need `thread_local` or any synchronisation
+for reusable scratch — just hold it behind the constraint's own storage (a
+`shared_ptr` to a scratch struct captured into the propagator lambda works
+well, since the lambda's other captures are `const` inside a non-`mutable`
+lambda) and reset (don't reallocate) it at the top of each wake.
+
+`bin_packing`'s Stage 3 sweep is the worked example: it used to build three
+`vector<unordered_set<long long>>` per bin per wake; replacing them with flat,
+position-indexed bitmaps held in per-clone scratch (reset with `fill`, never
+regrown) removed ~50% of its runtime that was pure hash-table allocation and
+rehashing. See [bin-packing.md](bin-packing.md).
+
+### Fast data structures for small collections
+
+`std::set` / `std::map` (red-black trees) and `std::unordered_set` /
+`std::unordered_map` (hash tables) have poor constant factors for the small
+collections that dominate propagator inner loops: node-per-element allocation,
+pointer chasing, and (for the hash containers) rehashing. For the sizes we
+typically see — a handful to a few hundred elements, rebuilt constantly — a flat
+`std::vector` (or `gch::small_vector`, which keeps the common small case off the
+heap entirely) is usually much faster, even when an operation becomes O(n)
+instead of O(log n) or O(1): the n is small and the memory is contiguous.
+
+There is a real readability trade-off. A `set` membership test reads better than
+a sorted-vector `binary_search`, and an `unordered_map<K,V>` lookup reads better
+than a parallel-array scan. Reach for the flat structure when the collection is
+small and hot (a profile says so, or it's rebuilt every wake); keep the
+associative container when the code is cold or the collection is genuinely large
+and the clarity matters more than the constant. `small_vector` is often the
+sweet spot: vector performance, and it still reads like a vector.
+
+### Iteration order in "for each value" loops
+
+When you iterate a variable's domain, the order you visit values in can matter,
+because it can let you use a faster `IntervalSet` primitive or exit early. The
+domain is stored as an `IntervalSet<Integer>` — a sorted run of disjoint
+intervals with a small-buffer optimisation for the common one-or-two-interval
+case (see [state-and-variables.md](state-and-variables.md)). Operations that
+work *with* that representation (interval-at-a-time, ascending/descending
+sweeps, `domain_intersects_with` against another `IntervalSet`) are much cheaper
+than ones that force a value-by-value materialisation or a copy.
+
+Prefer the non-copying primitives: `for_each_value_immutable` /
+`for_each_value_mutable` (which iterate without the coroutine/allocation cost of
+the older `each_value_*`), and `domains_intersect` /`domain_intersects_with`
+instead of building a set of one domain and testing membership. If an algorithm
+is free to choose the order it processes values or variables, choosing the one
+that matches the interval structure — or that lets it stop as soon as it has its
+answer — can be a real win for free.
+
+### Incrementality
+
+If most of a propagator's work is recomputing something that changed only
+slightly since the last wake, compute the delta instead of the whole thing. This
+is the most powerful lever and also the most work and the most risk, so reach
+for it only when a profile shows the recomputation dominating.
+
+The subtlety in a backtracking solver is that "since the last wake" spans
+descents *and* backtracks, and your cached state must stay consistent across
+both. Two broad approaches:
+
+- **Diff against cached inputs, recompute the affected range.** If the output is
+  a pure function of some per-variable summary (e.g. per-item admissibility
+  flags), cache that summary alongside the output; each wake, diff current vs
+  cached to find what changed and recompute only the dependent part. This is
+  automatically correct across backtrack *without any trailing*, because a
+  backtrack simply relaxes the inputs, which the diff sees as a change like any
+  other. `bin_packing`'s incremental Stage 3 works this way.
+- **Backtrackable state** (below) when you genuinely need to restore a data
+  structure to its earlier value on backtrack.
+
+Either way, an incremental propagator is much harder to test than a
+recompute-from-scratch one: bugs hide in the "only on this backtrack pattern"
+cases. Keep the from-scratch version around (even if only in comments or a test)
+to differential-test against, and lean on enumeration + proof verification.
+
+### Backtrackable state — but expensive state isn't always a win
+
+The engine can hold per-constraint state that is saved and restored across the
+search (`add_constraint_state` / `get_constraint_state`; constraints.md,
+"Backtrackable propagator state"). This is the natural home for an incremental
+data structure that must track the search: a watched-literal structure, a
+cached matching, a dead-value cache.
+
+But trailing is not free: every backtrackable field costs save/restore work at
+every relevant search node, and a large or deeply-structured piece of
+backtrackable state can cost more to maintain than the recomputation it
+replaces. Before committing to it, weigh the trailing cost against the
+recompute cost. Sometimes the winning design is *non*-backtrackable state that
+is sound to leave stale on backtrack (`negative_table`'s watches are left where
+they moved — a moved watch is still a valid watch as the state relaxes), or the
+diff-against-cached-inputs approach above, which needs no trailing at all.
+
+### Removing variant-dispatch overhead
+
+`IntegerVariableID` is a variant (`SimpleIntegerVariableID` /
+`ViewOfIntegerVariableID` / `ConstantIntegerVariableID`), and every generic
+`State` read visits it. GCC and clang usually lower that visit to a plain
+discriminant switch, so it is not automatically a problem — but in a hot enough
+read path the per-read view arithmetic and dispatch can show up in a profile. If
+it does, two tools help:
+
+- **Known-subtype overloads in `State`.** The hot read accessors have
+  `SimpleIntegerVariableID` fast paths that skip the view arithmetic and the
+  variant machinery for the common no-view case (this was issue #513 / the
+  `State::bounds` fast path). If you are adding a hot read primitive, giving it a
+  concrete-subtype overload can pay off.
+- **Compile the propagator once per variable-kind mix.** `as_homogeneous(vars)`
+  (`gcs/innards/variable_id_utils.hh`) inspects a variable list and, when they
+  are all the same concrete kind, hands back a vector specialised to that kind,
+  so you can `std::visit` once at install and instantiate the propagator body
+  over the concrete type — an "all simple variables" specialisation with no
+  per-read dispatch, versus a mixed fallback. `element` uses this. It costs
+  compile time and code size, so reserve it for propagators where reads
+  genuinely dominate.
+
+Both are profile-driven: don't pre-emptively specialise. Confirm the dispatch is
+actually costing you first.
+
+## Is it the propagator, the strength, or the search?
+
+When a model is slow, "the propagator is slow" is only one of three
+possibilities, and they have completely different fixes:
+
+1. the propagator is slow **per call** (this document);
+2. the propagator's **strength** is wrong for the problem — too weak (search
+   explores too much) or too strong (propagation costs more than the nodes it
+   saves);
+3. the **search heuristic** is making bad decisions, so no propagator speed
+   fixes the node count.
+
+Comparing against **Gecode** and the **MiniCP benchmarks** is a useful way to
+tell these apart: if we explore far more nodes than Gecode on the same model,
+suspect strength or search, not per-call speed; if we explore *similar or fewer*
+nodes but take longer, suspect per-call speed. But investigate before
+concluding — matching node counts requires matching search order, propagation
+strength differences change the tree, and "fewer nodes but slower" can be a
+propagator that is correctly stronger and worth its cost. A node-count and
+per-node-time comparison (which the benchmark harness gives you) is the evidence;
+the framing above is just where to point it.
+
+## Feeding back into the benchmark set
+
+Use the benchmarking.md table as the standard before/after sanity check, and
+treat improving the benchmark situation as part of the work:
+
+- If you find a good new benchmark candidate — a problem that exercises a
+  constraint the current set doesn't, or a data shape that flips a decision —
+  consider adding it. The long-term goal is a set with a representative problem
+  for **every** constraint, each running in roughly the one-second-to-one-minute
+  range (long enough to measure, short enough to iterate). Ask the user before
+  adding one, so the set stays curated rather than sprawling.
+- Converting a MiniZinc Challenge instance into an `examples/` entry that posts
+  the model through the API is sometimes the cleanest way to get a realistic,
+  constraint-specific benchmark that isn't gated on the whole FlatZinc pipeline.
+
+A performance change that also leaves behind a better benchmark for the next
+person is worth more than one that doesn't.
+
+## See also
+
+- [benchmarking.md](benchmarking.md) — the curated benchmark set, the
+  before/after harness, and the proof-shape benchmarking notes.
+- [constraints.md](constraints.md) — writing the propagator in the first place:
+  triggers, backtrackable state, reasons, justifications, testing.
+- [reasons-improvement.md](reasons-improvement.md) — the declarative `Reason`
+  design that makes reason-reuse sound (lazy materialisation, the tracker seam).
+- [state-and-variables.md](state-and-variables.md) — `IntervalSet` domain
+  storage, the `IntegerVariableID` variant, and the `State` read/inference
+  paths this document tells you to be careful with.
+
+<!-- vim: set tw=78 spell spelllang=en : -->

--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -34,14 +34,30 @@ There are two completely different kinds of "the propagator got better":
   node). This is what a performance change should be.
 
 Keep them apart. A pure performance change **must not change the search**:
-`recursions` and the first integer of `propagations:` must be identical before
-and after, on every benchmark. The benchmark harness prints both precisely so
-you can diff them; treat any divergence as a correctness signal first and a
-performance signal second (benchmarking.md, "What to capture"). If you find
-yourself explaining a speedup by "well, it also prunes a bit differently now",
-stop — you have conflated the two, and you need to re-evaluate the change as a
-strength change (with its own soundness and proof review) rather than a free
-win.
+`recursions` must be identical before and after, on every benchmark. So must
+the first integer of `propagations:` — *unless* the change is to when the
+propagator runs at all (triggers and idempotence, the first lever below), in
+which case fewer executions is the whole point, and `propagations` should
+generally fall while `recursions` stays fixed. The benchmark harness prints
+both precisely so you can diff them; treat any divergence you didn't set out
+to cause as a correctness signal first and a performance signal second
+(benchmarking.md, "What to capture"). If you find yourself explaining a
+speedup by "well, it also prunes a bit differently now", stop — you have
+conflated the two, and you need to re-evaluate the change as a strength change
+(with its own soundness and proof review) rather than a free win.
+
+Two caveats on the trigger exception. First, don't expect the drop in
+`propagations` to be tidy: skipping a wake reorders the propagation queue, and
+with other constraints in the model the work can redistribute — another
+propagator may run more or fewer times, or pick up an inference the skipped
+wake would have made — so the count can move in perverse directions,
+occasionally even up. Second, what makes that reordering safe is
+monotonicity: when every propagator infers at least as much from a smaller
+domain, the queue reaches the same fixpoint in any order, and the search
+cannot tell the difference. A propagator whose inferences depend on
+scheduling order in a non-monotonic way loses that guarantee, so a trigger
+change interacting with one can, in principle, change `recursions` — at which
+point it must be re-evaluated as a strength change, exactly as above.
 
 ### Have good, varied benchmarks, and don't commit on a hunch
 
@@ -84,7 +100,9 @@ unnecessary calls:
   docs.
 
 Both are about not calling the propagator when there is nothing for it to do.
-Get these right before micro-optimising the body.
+They are the one legitimate way to lower the `propagations:` count — see the
+ground rule above for what must still hold, and its caveats. Get these right
+before micro-optimising the body.
 
 ### Reuse the reason instead of rebuilding it
 

--- a/gcs/constraints/at_most_one/at_most_one.cc
+++ b/gcs/constraints/at_most_one/at_most_one.cc
@@ -95,9 +95,14 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
     vector<IntegerVariableID> all_vars = _vars;
     all_vars.push_back(_val);
 
+    // Build the whole-scope reason once and reuse it at every inference site,
+    // rather than rebuilding it (copying the scope into a fresh shared_ptr) on
+    // each inference. See dev_docs/propagator-performance.md.
+    auto all_vars_reason = generic_reason(all_vars);
+
     propagators.install(
         constraint_id(),
-        [vars = _vars, val = _val, all_vars = move(all_vars), owner = constraint_id()](
+        [vars = _vars, val = _val, reason = std::move(all_vars_reason), owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // For each candidate value v of `val`: if two or more vars
             // are fixed to v, infer val ≠ v. (RUP from the encoding's
@@ -111,7 +116,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
                     }
                 }
                 if (fixed_to_v >= 2)
-                    inference.infer(logger, val != v, JustifyUsingRUP{hints::AtMostOne{owner}}, generic_reason(all_vars));
+                    inference.infer(logger, val != v, JustifyUsingRUP{hints::AtMostOne{owner}}, reason);
             }
 
             // If val is now fixed to v and exactly one var is fixed to v,
@@ -131,7 +136,7 @@ auto AtMostOne::install_propagators(Propagators & propagators) -> void
                 if (fixed_count == 1) {
                     for (size_t i = 0; cmp_less(i, vars.size()); ++i) {
                         if (i != fixed_idx)
-                            inference.infer(logger, vars[i] != *val_fixed, JustifyUsingRUP{hints::AtMostOne{owner}}, generic_reason(all_vars));
+                            inference.infer(logger, vars[i] != *val_fixed, JustifyUsingRUP{hints::AtMostOne{owner}}, reason);
                     }
                 }
             }

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -99,9 +99,15 @@ auto Count::install_propagators(Propagators & propagators) -> void
     all_vars.push_back(_value_of_interest);
     all_vars.push_back(_how_many);
 
+    // The reason ranges over the whole (fixed) variable scope, so build it once
+    // here and reuse it at every inference site rather than reconstructing it —
+    // and re-copying the scope into a fresh shared_ptr — on each inference. See
+    // dev_docs/propagator-performance.md.
+    auto all_vars_reason = generic_reason(all_vars);
+
     propagators.install(
         constraint_id(),
-        [vars = _vars, value_of_interest = _value_of_interest, how_many = _how_many, flags = _flags, all_vars = move(all_vars),
+        [vars = _vars, value_of_interest = _value_of_interest, how_many = _how_many, flags = _flags, reason = std::move(all_vars_reason),
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // check support for how many by seeing how many array values
             // intersect with a potential value of interest
@@ -126,8 +132,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                     }
                 }
             };
-            inference.infer(
-                logger, how_many < how_many_is_less_than, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, generic_reason(all_vars));
+            inference.infer(logger, how_many < how_many_is_less_than, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason);
 
             // must have at least this many occurrences of the value of interest
             int how_many_must = 0;
@@ -137,7 +142,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                     if (state.optional_single_value(v) == voi)
                         ++how_many_must;
             }
-            inference.infer(logger, how_many >= Integer(how_many_must), JustifyUsingRUP{hints::Count{owner}}, generic_reason(all_vars));
+            inference.infer(logger, how_many >= Integer(how_many_must), JustifyUsingRUP{hints::Count{owner}}, reason);
 
             // is each value of interest supported? also track how_many bounds supports
             // whilst we're here
@@ -168,13 +173,12 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             }
                         }
                     };
-                    inference.infer(
-                        logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, generic_reason(all_vars));
+                    inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason);
                 }
                 else if (how_many_must > state.upper_bound(how_many)) {
                     // unlike above, we don't need to help, because the equality flag will propagate
                     // from the fixed assignment
-                    inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{hints::Count{owner}}, generic_reason(all_vars));
+                    inference.infer(logger, value_of_interest != voi, JustifyUsingRUP{hints::Count{owner}}, reason);
                 }
                 else {
                     // [how_many_must, how_many_might] is the range of counts
@@ -220,8 +224,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             logger->emit_rup_proof_line_under_reason(reason,
                                 WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= how_many_must) >= 1_i, ProofLevel::Temporary);
                         };
-                        inference.infer(
-                            logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, generic_reason(all_vars));
+                        inference.infer(logger, value_of_interest != voi, JustifyExplicitly{justf, ThenRUP::Yes, hints::Count{owner}}, reason);
                     }
                     else {
                         if ((! lowest_how_many_must) || (how_many_must < *lowest_how_many_must))
@@ -240,7 +243,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             WPBSum{} + 1_i * (value_of_interest != voi) + 1_i * (how_many >= *lowest_how_many_must) >= 1_i, ProofLevel::Temporary);
                 };
                 auto just = JustifyExplicitly{emit, ThenRUP::Yes, hints::Count{owner}};
-                inference.infer(logger, how_many >= *lowest_how_many_must, just, generic_reason(all_vars));
+                inference.infer(logger, how_many >= *lowest_how_many_must, just, reason);
             }
 
             if (highest_how_many_might) {
@@ -272,7 +275,7 @@ auto Count::install_propagators(Propagators & propagators) -> void
                             ProofLevel::Temporary);
                 };
                 auto just = JustifyExplicitly{emit, ThenRUP::Yes, hints::Count{owner}};
-                inference.infer(logger, how_many < *highest_how_many_might + 1_i, just, generic_reason(all_vars));
+                inference.infer(logger, how_many < *highest_how_many_might + 1_i, just, reason);
             }
 
             return PropagatorState::Enable;

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -71,8 +71,8 @@ namespace
     template <typename SanitisedCV_, typename Cond_, typename ProofLine_, typename AllVars_, typename Owner_, typename IncMustHold_,
         typename Inference_>
     auto propagate_reified_linear_equality_when_undecided(const SanitisedCV_ & sanitised_cv, Integer value, const Cond_ & cond,
-        const ProofLine_ & proof_line, const AllVars_ & all_vars, const Owner_ & owner, const IncMustHold_ & inc_must_hold, const State & state,
-        Inference_ & inference, ProofLogger * const logger) -> PropagatorState
+        const ProofLine_ & proof_line, const AllVars_ & all_vars, const Reason & reason, const Owner_ & owner, const IncMustHold_ & inc_must_hold,
+        const State & state, Inference_ & inference, ProofLogger * const logger) -> PropagatorState
     {
         return overloaded{
             [&](const evaluated_reif::MustHold & reif) {
@@ -111,12 +111,12 @@ namespace
                     // reified)
                     if (accum == value) {
                         if (auto lit = reif.cond_to_infer_if_constraint_must_hold())
-                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, reason);
                         return PropagatorState::DisableUntilBacktrack;
                     }
                     else {
                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, reason);
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }
@@ -130,7 +130,7 @@ namespace
                             // no way for the remaining variable to take that value, so the condition
                             // has to be false
                             if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                                inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, reason);
                             return PropagatorState::DisableUntilBacktrack;
                         }
                         else {
@@ -142,7 +142,7 @@ namespace
                         // the value that would make the equality work isn't an integer, so the condition
                         // has to be false
                         if (auto lit = reif.cond_to_infer_if_constraint_must_not_hold())
-                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, generic_reason(all_vars));
+                            inference.infer(logger, *lit, JustifyUsingRUP{hints::LinearEquality{owner}}, reason);
                         return PropagatorState::DisableUntilBacktrack;
                     }
                 }
@@ -408,14 +408,17 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators, State
                             inc_must_hold = std::pair{active, handle};
                         }
 
+                        // Whole-scope reason built once here and captured, not
+                        // rebuilt per wake (see dev_docs/propagator-performance.md).
+                        auto all_vars_reason = generic_reason(all_vars);
                         propagators.install(
                             constraint_id(),
                             [sanitised_cv = sanitised_cv, value = _value + modifier, cond = _reif_cond, proof_line = _proof_line,
-                                all_vars = move(all_vars), owner = constraint_id(),
+                                all_vars = move(all_vars), reason = std::move(all_vars_reason), owner = constraint_id(),
                                 inc_must_hold = inc_must_hold](const State & state, auto & inference,
                                 ProofLogger * const logger) -> PropagatorState { // This comment is needed to stop clang-format exploding
                                 return propagate_reified_linear_equality_when_undecided(
-                                    sanitised_cv, value, cond, proof_line, all_vars, owner, inc_must_hold, state, inference, logger);
+                                    sanitised_cv, value, cond, proof_line, all_vars, reason, owner, inc_must_hold, state, inference, logger);
                             },
                             triggers);
                     },

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -228,8 +228,11 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
                 return propagate_linear(sanitised_neg_cv, -value + neg_modifier - 1_i, state, inference, logger, false, proof_lines_swapped, cond);
             };
 
+            // Whole-scope reason built once (capture-init) and reused, not
+            // rebuilt per verdict (see dev_docs/propagator-performance.md).
             auto infer_cond_when_undecided = [sanitised_cv, sanitised_neg_cv, value = _value, modifier = modifier, proof_lines, proof_lines_swapped,
-                                                 vars = vars, owner = constraint_id()](const State & state, auto &, ProofLogger * const,
+                                                 reason = generic_reason(vars),
+                                                 owner = constraint_id()](const State & state, auto &, ProofLogger * const,
                                                  const IntegerVariableCondition &) -> ReificationVerdictFor<LinearCondJustification> {
                 Integer min_possible = 0_i, max_possible = 0_i;
                 for (const auto & cv : sanitised_cv.terms) {
@@ -249,15 +252,15 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
                     return reification_verdict::MustNotHold<LinearCondJustification>{
                         .justification =
                             JustifyExplicitly{hints::LinearInequalityCond<CV>{{owner}, &state, sanitised_cv, proof_lines}, ThenRUP::Yes}, //
-                        .reason = generic_reason(vars)                                                                                    //
+                        .reason = reason                                                                                                  //
                     };
                 }
                 else if (max_possible <= value + modifier) {
                     // must definitely hold
                     return reification_verdict::MustHold<LinearCondJustification>{
                         .justification = JustifyExplicitly{hints::LinearInequalityCond<NegCV>{{owner}, &state, sanitised_neg_cv, proof_lines_swapped},
-                            ThenRUP::Yes},             //
-                        .reason = generic_reason(vars) //
+                            ThenRUP::Yes}, //
+                        .reason = reason   //
                     };
                 }
                 else

--- a/gcs/constraints/n_value/n_value.cc
+++ b/gcs/constraints/n_value/n_value.cc
@@ -97,9 +97,14 @@ auto NValue::install_propagators(Propagators & propagators) -> void
     vector<IntegerVariableID> all_vars = _vars;
     all_vars.push_back(_n_values);
 
+    // Build the whole-scope reason once and reuse it, rather than rebuilding it
+    // (copying the scope into a fresh shared_ptr) on every wake. See
+    // dev_docs/propagator-performance.md.
+    auto all_vars_reason = generic_reason(all_vars);
+
     propagators.install(
         constraint_id(),
-        [all_vars = move(all_vars), n_values = _n_values, vars = _vars, owner = constraint_id()](
+        [reason = std::move(all_vars_reason), n_values = _n_values, vars = _vars, owner = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             set<Integer> all_possible_values;
             for (const auto & var : vars) {
@@ -107,7 +112,7 @@ auto NValue::install_propagators(Propagators & propagators) -> void
                     all_possible_values.insert(v);
             }
 
-            inference.infer(logger, n_values <= Integer(all_possible_values.size()), JustifyUsingRUP{hints::NValue{owner}}, generic_reason(all_vars));
+            inference.infer(logger, n_values <= Integer(all_possible_values.size()), JustifyUsingRUP{hints::NValue{owner}}, reason);
 
             set<Integer> all_definite_values;
             for (const auto & var : vars) {
@@ -119,8 +124,8 @@ auto NValue::install_propagators(Propagators & propagators) -> void
             // The "at least 1" floor only applies when the array is non-empty;
             // an empty array contributes 0 distinct values.
             auto distinct_floor = vars.empty() ? 0_i : 1_i;
-            inference.infer(logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{hints::NValue{owner}},
-                generic_reason(all_vars));
+            inference.infer(
+                logger, n_values >= max(distinct_floor, Integer(all_definite_values.size())), JustifyUsingRUP{hints::NValue{owner}}, reason);
 
             return PropagatorState::Enable;
         },

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -278,7 +278,7 @@ namespace
     auto propagate_regular(const vector<IntegerVariableID> & vars, const long num_states,
         const vector<unordered_map<Integer, set<long>>> & transitions, const vector<long> & final_states,
         const vector<vector<ProofFlag>> & state_at_pos_flags, const ConstraintStateHandle & graph_handle, const ConstraintStateHandle & cache_handle,
-        const State & state, auto & inference, ProofLogger * const logger, const ConstraintID & owner) -> void
+        const State & state, auto & inference, ProofLogger * const logger, const ConstraintID & owner, const Reason & reason) -> void
     {
         // Degenerate empty sequence (issue #254): with no variables there is
         // nothing to propagate over, but the empty word is accepted only if the
@@ -293,13 +293,12 @@ namespace
                     break;
                 }
             if (! initial_is_final)
-                inference.contradiction(logger, JustifyUsingRUP{hints::Regular{owner}}, generic_reason(vars));
+                inference.contradiction(logger, JustifyUsingRUP{hints::Regular{owner}}, reason);
             return;
         }
 
         auto & graph = any_cast<RegularGraph &>(state.get_constraint_state(graph_handle));
         auto & cache = any_cast<DeadCache &>(state.get_constraint_state(cache_handle));
-        auto reason = generic_reason(vars);
         // All manual proof emission happens before any domain change below, so a
         // single materialised snapshot is sound (see MDD, PORTING-NOTES §13).
         auto eager = eager_reason(reason, state);
@@ -663,11 +662,16 @@ auto Regular::install_propagators(Propagators & propagators) -> void
             cache.dead[i].insert(bridge->static_dead[i].begin(), bridge->static_dead[i].end());
     });
 
+    // Whole-scope declarative reason built once and captured; only its per-wake
+    // eager materialisation stays in propagate_regular (see
+    // dev_docs/propagator-performance.md).
+    auto vars_reason = generic_reason(_vars);
     propagators.install(
         constraint_id(),
         [v = _vars, ns = _num_states, t = _transitions, fs = _final_states, g = _graph_idx, dc = _dead_cache_idx, bridge = _bridge,
-            owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_regular(v, ns, t, fs, bridge->state_at_pos_flags, g, dc, state, inference, logger, owner);
+            owner = constraint_id(),
+            reason = std::move(vars_reason)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_regular(v, ns, t, fs, bridge->state_at_pos_flags, g, dc, state, inference, logger, owner, reason);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -200,7 +200,7 @@ namespace
     auto propagate_sortedness(const vector<IntegerVariableID> & x, const vector<IntegerVariableID> & y, const vector<vector<ProofFlag>> & before,
         const vector<ProofOnlySimpleIntegerVariableID> & pos, const vector<ProofLine> & rank_lines, const vector<ProofLine> & rank_le_lines,
         const vector<ProofLine> & inj_lines, const vector<ProofLine> & al1_lines, const vector<vector<ProofLine>> & anti_lines,
-        const ConstraintID & owner, const State & state, Inference_ & inference, ProofLogger * const logger) -> void
+        const ConstraintID & owner, const State & state, Inference_ & inference, ProofLogger * const logger, const Reason & reason) -> void
     {
         auto n = x.size();
 
@@ -217,10 +217,6 @@ namespace
             ly[j] = oly[j] = lo.raw_value;
             uy[j] = ouy[j] = hi.raw_value;
         }
-
-        vector<IntegerVariableID> all_vars = x;
-        all_vars.insert(all_vars.end(), y.begin(), y.end());
-        auto reason = bounds_reason(all_vars);
 
         // (1) Normalize the y-ranges: they index the sorted output, so the lower
         // bounds are non-decreasing and the upper bounds non-decreasing.
@@ -1110,11 +1106,19 @@ auto gcs::innards::install_sortedness_propagator(Propagators & propagators, cons
     triggers.on_bounds.insert(triggers.on_bounds.end(), x.begin(), x.end());
     triggers.on_bounds.insert(triggers.on_bounds.end(), y.begin(), y.end());
 
+    // Whole-scope bounds reason built once and captured, not rebuilt per wake
+    // (see dev_docs/propagator-performance.md).
+    vector<IntegerVariableID> all_vars = x;
+    all_vars.insert(all_vars.end(), y.begin(), y.end());
+    auto sort_reason = bounds_reason(all_vars);
+
     propagators.install(
         constraint_id,
         [x, y, before = witness.before, pos = witness.pos, rank_lines = witness.rank_ge, rank_le_lines = witness.rank_le, inj_lines, al1_lines,
-            anti_lines, owner = constraint_id](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_sortedness(x, y, before, pos, rank_lines, rank_le_lines, *inj_lines, *al1_lines, *anti_lines, owner, state, inference, logger);
+            anti_lines, owner = constraint_id,
+            reason = std::move(sort_reason)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            propagate_sortedness(
+                x, y, before, pos, rank_lines, rank_le_lines, *inj_lines, *al1_lines, *anti_lines, owner, state, inference, logger, reason);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -172,7 +172,7 @@ namespace
     // lambda inside a generic lambda makes MSVC emit an internal compiler error).
     template <typename Vars_, typename Tuples_, typename Watches_, typename Owner_, typename Inference_>
     auto initialise_negative_table_watches(const Vars_ & vars, const Tuples_ & tuples, const Watches_ & watches, const Owner_ & owner,
-        const State & state, Inference_ & inference, ProofLogger * const logger) -> void
+        const Reason & reason, const State & state, Inference_ & inference, ProofLogger * const logger) -> void
     {
         const auto & tuple_data = depointinate(tuples);
         watches->reserve(tuple_data.size());
@@ -192,14 +192,14 @@ namespace
 
             auto w1 = find_unbroken(no_watch);
             if (! w1) {
-                inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, reason);
             }
 
             auto w2 = find_unbroken(*w1);
             if (! w2) {
                 // Unit clause: vars[*w1] != t[*w1] is the only possibly-true
                 // disjunct, so it must hold.
-                inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                inference.infer(logger, vars[*w1] != t[*w1], JustifyUsingRUP{hints::NegativeTable{owner}}, reason);
                 // Mark the tuple as already handled — both watches at the same
                 // position will read as broken on every subsequent fire, and
                 // any rescue search will discover the inference is now redundant.
@@ -218,8 +218,8 @@ namespace
     // internal compiler error (C1001); a named function template compiles cleanly.
     // Capture types are deduced. See the same treatment in linear_equality.cc.
     template <typename Vars_, typename Tuples_, typename Watches_, typename Owner_, typename Inference_>
-    auto propagate_negative_table(const Vars_ & vars, const Tuples_ & tuples, const Watches_ & watches, const Owner_ & owner, const State & state,
-        Inference_ & inference, ProofLogger * const logger) -> PropagatorState
+    auto propagate_negative_table(const Vars_ & vars, const Tuples_ & tuples, const Watches_ & watches, const Owner_ & owner, const Reason & reason,
+        const State & state, Inference_ & inference, ProofLogger * const logger) -> PropagatorState
     {
         const auto & tuple_data = depointinate(tuples);
         using Tuple = std::remove_cvref_t<decltype(tuple_data[0])>;
@@ -249,11 +249,11 @@ namespace
             if (b1 && b2) {
                 auto new1 = find_unbroken(t, no_watch, no_watch);
                 if (! new1) {
-                    inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                    inference.contradiction(logger, JustifyUsingRUP{hints::NegativeTable{owner}}, reason);
                 }
                 auto new2 = find_unbroken(t, *new1, no_watch);
                 if (! new2) {
-                    inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                    inference.infer(logger, vars[*new1] != t[*new1], JustifyUsingRUP{hints::NegativeTable{owner}}, reason);
                 }
                 else {
                     w.first = *new1;
@@ -263,7 +263,7 @@ namespace
             else if (b1) {
                 auto new1 = find_unbroken(t, w.second, no_watch);
                 if (! new1) {
-                    inference.infer(logger, vars[w.second] != t[w.second], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                    inference.infer(logger, vars[w.second] != t[w.second], JustifyUsingRUP{hints::NegativeTable{owner}}, reason);
                 }
                 else {
                     w.first = *new1;
@@ -272,7 +272,7 @@ namespace
             else {
                 auto new2 = find_unbroken(t, w.first, no_watch);
                 if (! new2) {
-                    inference.infer(logger, vars[w.first] != t[w.first], JustifyUsingRUP{hints::NegativeTable{owner}}, generic_reason(vars));
+                    inference.infer(logger, vars[w.first] != t[w.first], JustifyUsingRUP{hints::NegativeTable{owner}}, reason);
                 }
                 else {
                     w.second = *new2;
@@ -295,6 +295,11 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
     // overhead. Using shared_ptr so the initialiser and main propagator share storage.
     auto watches = make_shared<vector<pair<size_t, size_t>>>();
 
+    // The reason ranges over the fixed variable scope, so build it once here and
+    // share it between the initialiser and the propagator rather than rebuilding
+    // it on every wake (see dev_docs/propagator-performance.md).
+    auto table_reason = generic_reason(_vars);
+
     visit(
         [&, this](auto && tuples) {
             // Init: walk every tuple, find two watch positions, propagate units, raise
@@ -302,16 +307,16 @@ auto NegativeTable::install_propagators(Propagators & propagators) -> void
             // currently DefinitelyTrue — this captures both the "var is forced to t[pos]"
             // case and the "t[pos] is a wildcard" case (since `var == Wildcard` overloads
             // to TrueLiteral, which tests as DefinitelyTrue).
-            propagators.install_initialiser([vars = _vars, tuples = tuples, watches = watches, owner = constraint_id()](
+            propagators.install_initialiser([vars = _vars, tuples = tuples, watches = watches, owner = constraint_id(), reason = table_reason](
                                                 const State & state, auto & inference, ProofLogger * const logger) -> void {
-                initialise_negative_table_watches(vars, tuples, watches, owner, state, inference, logger);
+                initialise_negative_table_watches(vars, tuples, watches, owner, reason, state, inference, logger);
             });
 
             propagators.install(
                 constraint_id(),
-                [vars = move(_vars), tuples = move(tuples), watches = watches, owner = constraint_id()](
+                [vars = move(_vars), tuples = move(tuples), watches = watches, owner = constraint_id(), reason = std::move(table_reason)](
                     const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                    return propagate_negative_table(vars, tuples, watches, owner, state, inference, logger);
+                    return propagate_negative_table(vars, tuples, watches, owner, reason, state, inference, logger);
                 },
                 triggers);
         },

--- a/gcs/constraints/value_precede/value_precede.cc
+++ b/gcs/constraints/value_precede/value_precede.cc
@@ -166,7 +166,11 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
 
         propagators.install(
             constraint_id(),
-            [vars = _vars, s, t, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            // The reason ranges over the fixed variable scope, so build it once
+            // at install (capture-init) and reuse it rather than rebuilding it
+            // every wake. See dev_docs/propagator-performance.md.
+            [vars = _vars, s, t, reason = generic_reason(_vars), owner = constraint_id()](
+                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 auto n = vars.size();
 
                 size_t alpha = n;
@@ -176,8 +180,6 @@ auto ValuePrecede::install_propagators(Propagators & propagators) -> void
                         break;
                     }
                 }
-
-                auto reason = generic_reason(vars);
 
                 // Prune t from positions [0, min(alpha+1, n)). If alpha == n
                 // this is all positions; otherwise it's positions 0..alpha


### PR DESCRIPTION
Stacked on #518 (base branch `bin-packing-stage3-scratch`); rebase down the stack as the earlier PRs merge.

## What

Two commits:

1. **`constraints: build fixed-scope reasons once`** — several propagators reasoned over their whole *fixed* variable scope but rebuilt the reason (`generic_reason(vars)` / `bounds_reason(vars)`) at each inference site or on every wake. That factory binds to `ArrayParam`'s by-value constructor, so each call copies the scope vector into a fresh `shared_ptr` — and it happens even proofs-off, where the reason is never materialised. The scope is fixed and the `*_reason()` factories are declarative (domains read lazily at `materialise()` time), so the reason is identical every time. Build it once (at install / capture-init) and reuse it; where the reason was built inside a per-wake helper, the helper now takes a `const Reason &` threaded from the install site.

   Constraints updated: `count`, `n_value`, `at_most_one`, `value_precede`, `linear_equality`, `linear_inequality`, `negative_table`, `regular`, `sort`. `lex` is intentionally **not** touched — it uses `eager_reason(..., state)`, which materialises against the current state and is genuinely per-call.

2. **`dev_docs: add a propagator-performance guide`** — `dev_docs/propagator-performance.md`, a companion to `constraints.md` on how to make a *correct* propagator faster: correctness-first and strength-vs-performance ground rules, varied-benchmark discipline, then the levers cheapest-first (triggers/idempotence, reason reuse, scratch-data-structure reuse + the per-clone/threading model, fast data structures, iteration order / `IntervalSet` primitives, incrementality, backtrackable state, variant-dispatch removal / `as_homogeneous`), the "is it the propagator, the strength, or the search?" framing, and feeding new instances back into the benchmark set. Linked from `constraints.md`. The reason-reuse hoist is its archetype example.

## Correctness

Proof-neutral and search-neutral: the same lazily-materialised reason is handed to every inference. All affected constraint tests pass with VeriPB verification (per-constraint enumeration proofs, the `scp_chain_*` cake checks, and the view-mixed variants); the linear reification suite (38 ctests) is green. Full `ctest` backstop run.

## Measured (`dev_docs/benchmarking.md` set, `taskset -c 4`, median of 3, baseline = #518 tip)

`recursions` and `propagations` are **byte-identical** baseline↔branch on every benchmark — a pure performance change.

| Benchmark | baseline | branch | Δ |
|---|--:|--:|--:|
| magic_series_300 | 5.178 s | 4.993 s | **−3.6%** |
| n_queens_14_all | 12.069 s | 11.733 s | **−2.8%** |
| magic_square_5 | 17.698 s | 17.419 s | **−1.6%** |
| ortho_latin_6_all | 23.494 s | 23.421 s | −0.3% |
| qap_12 | 1.578 s | 1.576 s | −0.1% |
| n_queens_88 | 214.36 s | 214.29 s | −0.04% |
| tsp_default | 10.535 s | 10.542 s | +0.1% (noise) |
| langford_11 | 7.994 s | 8.047 s | +0.7% (noise) |

Wins land on the linear-arithmetic-heavy instances (the `linear_equality` / `linear_inequality` hoist); `langford`/`tsp` use none of the modified constraints, so their ±0.x% is measurement noise. Several of the updated constraints (`count`, `negative_table`, `n_value`, …) aren't in the curated set, so per the "uniform, generally-sound change" rule in the new doc this is applied for consistency and to remove the avoidable allocation from every hot path, not for a headline number on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)