### PR TITLE
element: cut IntervalSet copy + per-value erase in NDimensionalElement (#515)

### DIFF
--- a/dev_docs/benchmarking.md
+++ b/dev_docs/benchmarking.md
@@ -250,6 +250,71 @@ the three-way `Regular` / `RegularBacchus` / `RegularLegacy`
 comparison, plus a discussion of when each pattern wins. It's a useful
 template for similar three-variant proof-logging work.
 
+## Profiling with `perf`
+
+When a benchmark says a change is slower but not *why*, `perf` gives the
+per-function self-time.
+
+A Release build carries `-g1` debug info: function names and line-number
+tables, but no inline-expansion records (see the debug-info comment in
+the top-level `CMakeLists.txt`). `perf` handles that level comfortably,
+with one attribution caveat: with no inline records, every sample is
+credited to the outermost function that survived inlining, so a hot
+propagator absorbs the self-time of everything inlined into it. The
+line-number tables do still cover the inlined code, so `perf annotate`
+(or `perf script -F ip,sym,srcline`) can usually tell you *what* inside
+the big function is hot.
+
+If you genuinely need per-inlined-frame attribution, raise the Release
+debug level temporarily (edit the `$<IF:...>` debug-level generator
+expression in the top-level `CMakeLists.txt`) — and know the trap that
+comes with it, because it will waste an afternoon if you hit it
+unprepared. On a binary carrying full DWARF from heavy template inlining
+(`fzn-glasgow` was ~380 MB back when Release used `-g3`), `perf report` /
+`perf script` resolve every sample's *inlined* frames by default, and on
+that much `debug_info` the resolution is pathologically slow: it can take
+many minutes to process a few tens of thousands of samples, so
+`perf report` looks **hung** and `perf script` appears to emit only a few
+hundred startup samples before you give up. The symbols are all there;
+the inline expansion is the bottleneck. Skip it whenever you don't need
+it — one flag:
+
+```shell
+perf record -F 2000 --call-graph fp -o out.perf -- taskset -c 4 ./build/fzn-glasgow model.fzn
+perf report  -i out.perf --stdio --inline=no          # completes in seconds
+perf script  -i out.perf -F ip,sym --no-inline        # full, fast output
+```
+
+(On a `-g1` build those flags are harmless no-ops — there are no inline
+records to resolve — so the recipes above are safe defaults everywhere.)
+
+For a clean self-time (leaf) histogram from `perf script`, take the first
+line of each blank-separated sample block and aggregate:
+
+```shell
+perf script -i out.perf -F ip,sym --no-inline \
+  | awk 'BEGIN{want=1} /^[[:space:]]*$/{want=1;next} want{print;want=0}' \
+  | sed -E 's/^\s*[0-9a-f]+\s+//' | sort | uniq -c | sort -rn | head
+```
+
+Two more notes:
+
+- `fzn-glasgow` is launched by MiniZinc as a subprocess, which perf can't
+  easily follow. Flatten once (`minizinc --solver <glasgow.msc> -c --fzn
+  model.fzn model.mzn data.dzn`) and run `fzn-glasgow model.fzn` directly
+  under perf. It has a `-t <ms>` timeout, so an optimisation instance that
+  never finishes still gives a usable sample window.
+- Kernel-mode samples show up as `[unknown]` unless you can read
+  `/proc/kallsyms` (needs `kptr_restrict=0` or root). For a CPU-bound
+  solver these are a small minority and don't obscure the userspace hot
+  path.
+
+If perf is unavailable or a subprocess is genuinely unreachable, a couple
+of `getenv`-gated static counters around the suspected hot lines (printed
+from a destructor) will tell you a call-count distribution in one run —
+crude, but enough to distinguish "expensive once" from "cheap but called a
+billion times".
+
 ## Reproducibility caveats
 
 - Pin CPU governor to `performance` if available; thermal throttling on

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -343,11 +343,11 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                 array_has_nonconstants = array_has_nonconstants, scope_has_aliasing = scope_has_aliasing,
                 owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
                 // for each index variable, update it to only contain values where
-                // there's at least one supporting option. result_var's domain is
-                // not modified by anything inside the loop body (the only infer_*
-                // calls are on index_vars[fixed_dim]), so the looking_for set is
-                // constant across iterations and only needs computing once.
-                auto looking_for = state.copy_of_values(result_var);
+                // there's at least one supporting option. The support tests below
+                // only ask "is this value / this array var's domain within
+                // result_var's domain", which the non-copying State primitives
+                // (in_domain / domains_intersect) answer directly — so we avoid
+                // copying result_var's whole domain on every wake (issue #515).
                 // explored_vars only feeds the reason; building it is a per-test_val
                 // (no-SBO) allocation, so skip it when no reason will be read.
                 auto want_reason = inference.want_reasons();
@@ -367,7 +367,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                     // Constant array: test the value directly, skipping the
                                     // IntegerVariableID construction and the State round-trip.
                                     auto value = get_array_value<dimensions_>(elem, *array);
-                                    if (looking_for.contains(value))
+                                    if (state.in_domain(result_var, value))
                                         return true;
                                 }
                                 else {
@@ -375,7 +375,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                     if (want_reason && array_has_nonconstants)
                                         explored_vars.push_back(array_var);
 
-                                    if (state.domain_intersects_with(array_var, looking_for))
+                                    if (state.domains_intersect(array_var, result_var))
                                         return true;
                                 }
                             }
@@ -608,7 +608,18 @@ auto NDimensionalElement<EntryType_, dimensions_>::install_propagators_impl(Prop
                                 auto array_var = get_array_var<dimensions_>(elem, *array);
                                 if (array_has_nonconstants)
                                     considered_vars.push_back(array_var);
-                                state.for_each_value_immutable(array_var, [&](Integer v) { still_to_find_support_for.erase(v); });
+                                // Subtract array_var's domain from the still-unsupported
+                                // set. When that domain is a single contiguous run (the
+                                // common case) this is one erase_range rather than one
+                                // erase per value — the dominant cost of the GAC support
+                                // sweep (issue #515). A holey domain must still go value
+                                // by value: erase_range would also drop values in the
+                                // holes, which this array entry does not support.
+                                auto [lo, hi] = state.bounds(array_var);
+                                if (state.domain_size(array_var) == hi - lo + 1_i)
+                                    still_to_find_support_for.erase_range(lo, hi);
+                                else
+                                    state.for_each_value_immutable(array_var, [&](Integer v) { still_to_find_support_for.erase(v); });
                             }
                         }
                         else {


### PR DESCRIPTION
Closes #515. Stacked on #519 (base branch `reasons-hoist`); rebase down the stack as the earlier PRs merge.

## What the profile actually showed

Issue #515 flagged hitori (connectivity/count flattening to element/lookup) as ~6.5× slower per node, with a `perf` profile of ~42% in a single (symbol-truncated) `IntervalSet` method + ~20% in `NDimensionalElement`. `perf` can't symbolise the 382 MB Release `fzn-glasgow` (the issue predicted this), so I pinned it with **targeted instrumentation**: in ~10 s of h11-1, the GAC support sweep did **24 M domain copies but 3.68 _billion_ `IntervalSet::erase` calls**. The erase loop was the cost — not the copy the issue guessed at.

## Two changes, both pure performance (search + proofs identical)

1. **Index-pruning propagator** — the support tests only ask "is this value / this array var's domain within `result_var`'s domain", which the non-copying `in_domain` / `domains_intersect` primitives answer directly. Drop the per-wake `copy_of_values(result_var)`. (This is the copy the issue suggested removing; it turned out to be ~2%.)

2. **GAC support propagator** — subtract each array var's domain from the still-unsupported set with a single `erase_range` when that domain is a contiguous run (the common case), instead of one `erase` per value. Holey domains still go value-by-value (`erase_range` would also drop the holes, which the entry doesn't support). This turns the ~3.7 B erases into ~107 M — the real win.

Both compute exactly the same `still_to_find` / support sets, so the pruning, the search tree, and the proof lines are unchanged.

## Correctness

- **Search-neutral**: hitori h5-1 explores exactly **113671 nodes** before and after.
- Full `ctest` **510/510 pass**, including the element enumeration proofs, the `scp_chain_element*` cake checks, and the view-mixed variants.

## Measured (`fzn-glasgow`, `taskset -c 4`, hitori)

| instance | metric | before | after | speedup |
|---|---|--:|--:|--:|
| h5-1 (n=5, solved) | solve time (same 113671 nodes) | 1.472 s | 1.076 s | **1.37×** |
| h11-1 (n=11, 30 s cap) | nodes explored | 288714 | 678592 | **2.35× / node** |

Larger boards (bigger domains) gain more, consistent with the erase-per-value cost the profile showed. `erase` calls per equivalent work drop ~34×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)