### PR TITLE
state: SimpleIntegerVariableID fast path for domains_intersect

### DIFF
--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -588,6 +588,14 @@ auto State::domain_intersects_with(const VarType_ & var, const IntervalSet<Integ
 
 auto State::domains_intersect(const IntegerVariableID & var1, const IntegerVariableID & var2) const -> bool
 {
+    // Fast path for the common no-view case (cf. the SimpleIntegerVariableID
+    // fast paths above, #513): both plain SimpleIntegerVariableIDs walk the two
+    // stored interval sets directly, skipping deview and the nested visit_actual
+    // dispatch. This is a hot path for GAC element / count support checks.
+    if (const auto * s1 = get_if<SimpleIntegerVariableID>(&var1))
+        if (const auto * s2 = get_if<SimpleIntegerVariableID>(&var2))
+            return state_of(*s1).contains_any_of(state_of(*s2));
+
     auto [actual1, neg1, add1] = deview(var1);
     auto [actual2, neg2, add2] = deview(var2);
     if (neg1 || neg2) {


### PR DESCRIPTION
Stacked on #520 (base branch `element-interval-copy-515`). A small profile-driven follow-on.

## What

Once #520 removed the `IntervalSet::erase` hotspot from hitori, the next self-time peak (perf `--no-inline`) was `State::domains_intersect` — the GAC support check used by both `element` and `count`. It has a no-copy merge-walk for the common both-`Simple`-no-view case, but reaches it via `deview` + a nested `visit_actual` dispatch. This adds the same `get_if<SimpleIntegerVariableID>` fast path that #516 gave the single-variable accessors, walking the two stored interval sets directly.

## Honest assessment

Small. hitori h5-1 1.076 s → 1.059 s (~1.5%, same 113671 nodes), h11-1 ~+1% throughput. The merge-walk (`contains_any_of`) is the bulk of `domains_intersect`'s cost and is inherent to the check, so removing the dispatch only recovers a slice. It's included because it's strictly-less-work, matches the established #516 pattern, and helps every `domains_intersect` caller — not for a headline number.

## Correctness

Search-unaffected (h5-1 = 113671 nodes before/after), full `ctest` **510/510**. The fast path returns exactly what the general path's both-Simple-no-offset branch already computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)