### PR TITLE
all_different: reuse scratch + iterative Tarjan in the GAC propagator (#522 phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,31 @@ case Value1:
 
 This pattern is already used in the codebase; follow it consistently.
 
+### `overloaded{...}` visitor blocks
+
+Format `overloaded{...}` visitors like a `switch`: nothing after the opening brace, each
+lambda starting on its own line at one indent level, all lambdas indented equally. Pin the
+layout with an empty `//` comment straight after the opening brace:
+
+```cpp
+overloaded{//
+    [&](const consistency::GAC &) {
+        // ...
+    },
+    [&](const consistency::VC &) {
+        // ...
+    }}
+    .visit(_level);
+```
+
+The pin is load-bearing. clang-format's penalty optimiser will otherwise pull the first
+lambda up onto the `overloaded{` line whenever the content happens to make that layout
+score better, and it re-mangles a previously-clean block when the lambda bodies change —
+so an unpinned block that looks stable today is one edit away from being reflowed. When
+you meet an already-mangled block, add the `//` and re-run clang-format rather than
+re-indenting by hand. (Same trick as the trailing `//` that keeps cxxopts `add_options`
+blocks one option per line.)
+
 ### `std::format` / `fmt::format`
 
 Files that use `format()` for string building must use the conditional pattern:

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -69,12 +69,13 @@ auto AllDifferent::prepare(Propagators &, State & initial_state, ProofModel * co
 
     // Set up only what the requested propagator needs: GAC wants the compressed
     // value set; VC wants the not-yet-assigned variables as backtrackable state.
-    overloaded{[&](const consistency::GAC &) {
-                   for (auto & var : _sanitised_vars)
-                       for (const auto & val : initial_state.each_value_immutable(var))
-                           if (_compressed_vals.end() == find(_compressed_vals, val))
-                               _compressed_vals.push_back(val);
-               },
+    overloaded{//
+        [&](const consistency::GAC &) {
+            for (auto & var : _sanitised_vars)
+                for (const auto & val : initial_state.each_value_immutable(var))
+                    if (_compressed_vals.end() == find(_compressed_vals, val))
+                        _compressed_vals.push_back(val);
+        },
         [&](const consistency::VC &) {
             NonGacAllDifferentUnassigned unassigned{};
             for (auto & var : _sanitised_vars)
@@ -104,28 +105,29 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 
-    overloaded{[&](const consistency::GAC &) {
-                   auto value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
-                   propagators.install(
-                       constraint_id(),
-                       [vars = move(_sanitised_vars), vals = move(_compressed_vals),
-                           value_am1_constraint_numbers = move(value_am1_constraint_numbers), scratch = make_gac_all_different_scratch(),
-                           constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                           propagate_gac_all_different(
-                               constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), *scratch, state, inference, logger);
-                           // Idempotent: one call prunes to the GAC closure. The
-                           // matching and SCCs are built from an entry snapshot, and
-                           // what survives is exactly the union of maximum matchings,
-                           // so a re-run deletes nothing (every remaining edge is in
-                           // some maximum matching) and a matching still exists (no
-                           // contradiction). Duplicate scope variables never reach here
-                           // (prepare rejects them), and triggers are 1:1 with the
-                           // scope, so view aliasing is caught by the install-time
-                           // downgrade.
-                           return PropagatorState::EnableButIdempotent;
-                       },
-                       triggers);
-               },
+    overloaded{//
+        [&](const consistency::GAC &) {
+            auto value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
+            propagators.install(
+                constraint_id(),
+                [vars = move(_sanitised_vars), vals = move(_compressed_vals), value_am1_constraint_numbers = move(value_am1_constraint_numbers),
+                    scratch = make_gac_all_different_scratch(),
+                    constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                    propagate_gac_all_different(
+                        constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), *scratch, state, inference, logger);
+                    // Idempotent: one call prunes to the GAC closure. The
+                    // matching and SCCs are built from an entry snapshot, and
+                    // what survives is exactly the union of maximum matchings,
+                    // so a re-run deletes nothing (every remaining edge is in
+                    // some maximum matching) and a matching still exists (no
+                    // contradiction). Duplicate scope variables never reach here
+                    // (prepare rejects them), and triggers are 1:1 with the
+                    // scope, so view aliasing is caught by the install-time
+                    // downgrade.
+                    return PropagatorState::EnableButIdempotent;
+                },
+                triggers);
+        },
         [&](const consistency::VC &) {
             // Prebuild the per-variable "v == its single value" reason once, indexed by the
             // variable's own SimpleIntegerVariableID index (offset by reason_base). This is a

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -104,28 +104,28 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 
-    overloaded{
-        [&](const consistency::GAC &) {
-            auto value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
-            propagators.install(
-                constraint_id(),
-                [vars = move(_sanitised_vars), vals = move(_compressed_vals), value_am1_constraint_numbers = move(value_am1_constraint_numbers),
-                    constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                    propagate_gac_all_different(
-                        constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), state, inference, logger);
-                    // Idempotent: one call prunes to the GAC closure. The
-                    // matching and SCCs are built from an entry snapshot, and
-                    // what survives is exactly the union of maximum matchings,
-                    // so a re-run deletes nothing (every remaining edge is in
-                    // some maximum matching) and a matching still exists (no
-                    // contradiction). Duplicate scope variables never reach here
-                    // (prepare rejects them), and triggers are 1:1 with the
-                    // scope, so view aliasing is caught by the install-time
-                    // downgrade.
-                    return PropagatorState::EnableButIdempotent;
-                },
-                triggers);
-        },
+    overloaded{[&](const consistency::GAC &) {
+                   auto value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
+                   propagators.install(
+                       constraint_id(),
+                       [vars = move(_sanitised_vars), vals = move(_compressed_vals),
+                           value_am1_constraint_numbers = move(value_am1_constraint_numbers), scratch = make_gac_all_different_scratch(),
+                           constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                           propagate_gac_all_different(
+                               constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), *scratch, state, inference, logger);
+                           // Idempotent: one call prunes to the GAC closure. The
+                           // matching and SCCs are built from an entry snapshot, and
+                           // what survives is exactly the union of maximum matchings,
+                           // so a re-run deletes nothing (every remaining edge is in
+                           // some maximum matching) and a matching still exists (no
+                           // contradiction). Duplicate scope variables never reach here
+                           // (prepare rejects them), and triggers are 1:1 with the
+                           // scope, so view aliasing is caught by the install-time
+                           // downgrade.
+                           return PropagatorState::EnableButIdempotent;
+                       },
+                       triggers);
+               },
         [&](const consistency::VC &) {
             // Prebuild the per-variable "v == its single value" reason once, indexed by the
             // variable's own SimpleIntegerVariableID index (offset by reason_base). This is a

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -192,9 +192,9 @@ auto AllDifferentExcept::install_propagators(Propagators & propagators) -> void
     propagators.install(
         constraint_id(),
         [vars = move(_sanitised_vars), vals = move(_compressed_vals), excluded = move(_sanitised_excluded),
-            value_am1_constraint_numbers = _value_am1_constraint_numbers,
+            value_am1_constraint_numbers = _value_am1_constraint_numbers, scratch = make_gac_all_different_scratch(),
             constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_gac_all_different(constraint_id, vars, vals, excluded, *value_am1_constraint_numbers.get(), state, inference, logger);
+            propagate_gac_all_different(constraint_id, vars, vals, excluded, *value_am1_constraint_numbers.get(), *scratch, state, inference, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -56,6 +56,7 @@ using std::variant;
 using std::vector;
 using std::visit;
 using std::ranges::adjacent_find;
+using std::ranges::minmax_element;
 using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
@@ -105,6 +106,17 @@ namespace gcs::innards
         std::vector<std::pair<Left, Right>> edges;
         std::vector<uint8_t> left_covered, right_covered;
         std::vector<std::optional<Right>> matching;
+
+        // value -> index-into-vals lookup (plus one, with zero meaning not a
+        // value of this constraint), dense over [val_lookup_min, val_lookup_min
+        // + size). Built on the first wake -- vals is fixed for an installed
+        // propagator -- and left empty when the value range is too sparse for
+        // a dense table, in which case edge building falls back to probing
+        // every (var, val) pair with in_domain.
+        bool val_lookup_initialised = false;
+        Integer val_lookup_min{0};
+        std::vector<uint32_t> val_to_idx_plus_one;
+        std::vector<uint8_t> vals_in_domain;
 
         // augmenting-path search inside build_matching
         std::vector<uint8_t> reached_on_the_left, reached_on_the_right;
@@ -558,10 +570,57 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
     auto & edges = scratch.edges;
     edges.clear();
 
-    for (const auto & [var_idx, var] : enumerate(vars))
-        for (const auto & [val_idx, val] : enumerate(vals))
-            if (state.in_domain(var, val))
-                edges.emplace_back(Left{var_idx}, Right{val_idx});
+    if (! scratch.val_lookup_initialised) {
+        // vals is fixed for an installed propagator, so build the value ->
+        // index lookup once. The sweep pays a fixed per-variable cost (bitmap
+        // reset, domain iteration, bitmap scan) to avoid a vals.size()
+        // in_domain probe per variable, so it only wins when vals is wide
+        // enough: measured 2% whole-program faster at 33 values (langford 11)
+        // but 1% slower at 10 values (QWH quasigroup7), hence the 32 cutoff.
+        // A dense table also only makes sense if the values aren't too spread
+        // out; in either failure case we stay with the probe loop below.
+        scratch.val_lookup_initialised = true;
+        if (vals.size() >= 32) {
+            auto [min_it, max_it] = minmax_element(vals);
+            auto span = (*max_it - *min_it).as_index() + 1;
+            if (span <= 64 * vals.size() + 1024) {
+                scratch.val_lookup_min = *min_it;
+                scratch.val_to_idx_plus_one.assign(span, 0);
+                for (const auto & [val_idx, val] : enumerate(vals))
+                    scratch.val_to_idx_plus_one[(val - *min_it).as_index()] = val_idx + 1;
+            }
+        }
+    }
+
+    if (! scratch.val_to_idx_plus_one.empty()) {
+        // one sweep over each variable's actual domain marks which vals are
+        // present, then edges are emitted in val-index order: the same edges
+        // in the same order as the probe loop below, without paying a
+        // vals.size() in_domain probe per variable. Domain values that aren't
+        // in vals (all_different_except's excluded values) mark nothing.
+        const auto min_val = scratch.val_lookup_min;
+        const auto span = scratch.val_to_idx_plus_one.size();
+        auto & vals_in_domain = scratch.vals_in_domain;
+        for (const auto & [var_idx, var] : enumerate(vars)) {
+            vals_in_domain.assign(vals.size(), 0);
+            state.for_each_value_immutable(var, [&](Integer val) -> void {
+                if (val < min_val)
+                    return;
+                if (auto offset = (val - min_val).as_index(); offset < span)
+                    if (auto val_idx_plus_one = scratch.val_to_idx_plus_one[offset]; 0 != val_idx_plus_one)
+                        vals_in_domain[val_idx_plus_one - 1] = 1;
+            });
+            for (vector<Integer>::size_type val_idx = 0; val_idx != vals.size(); ++val_idx)
+                if (vals_in_domain[val_idx])
+                    edges.emplace_back(Left{var_idx}, Right{val_idx});
+        }
+    }
+    else {
+        for (const auto & [var_idx, var] : enumerate(vars))
+            for (const auto & [val_idx, val] : enumerate(vals))
+                if (state.in_domain(var, val))
+                    edges.emplace_back(Left{var_idx}, Right{val_idx});
+    }
 
     // Add a private phantom right-vertex per variable that has any excluded
     // value still in its current domain. The phantom edge represents "this

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -28,7 +28,6 @@
 #include <util/overloaded.hh>
 
 #include <algorithm>
-#include <functional>
 #include <map>
 #include <optional>
 #include <sstream>
@@ -42,7 +41,6 @@ using namespace gcs::innards;
 using std::cmp_not_equal;
 using std::count;
 using std::decay_t;
-using std::function;
 using std::is_same_v;
 using std::make_shared;
 using std::map;
@@ -50,7 +48,6 @@ using std::min;
 using std::move;
 using std::nullopt;
 using std::optional;
-using std::pair;
 using std::shared_ptr;
 using std::string;
 using std::tuple;
@@ -77,25 +74,102 @@ namespace gcs::innards::hints
     }
 }
 
+namespace gcs::innards
+{
+    // Working storage for propagate_gac_all_different, hoisted out so a
+    // propagator can reuse the same buffers on every wake rather than paying
+    // several dozen allocations per call (issue #522). Every buffer is
+    // assign()ed or clear()ed at its point of use, so capacity ratchets up to
+    // the biggest wake seen and stays there. One instance per installed
+    // propagator (per constraint clone), so a search owns its scratch
+    // exclusively -- see dev_docs/propagator-performance.md.
+    struct GacAllDifferentScratch
+    {
+        struct Left
+        {
+            std::vector<IntegerVariableID>::size_type offset;
+
+            [[nodiscard]] auto operator<=>(const Left &) const = default;
+        };
+
+        struct Right
+        {
+            std::vector<Integer>::size_type offset;
+
+            [[nodiscard]] auto operator<=>(const Right &) const = default;
+        };
+
+        using Vertex = std::variant<Left, Right>;
+
+        // the bipartite variable-value graph and its matching
+        std::vector<std::pair<Left, Right>> edges;
+        std::vector<uint8_t> left_covered, right_covered;
+        std::vector<std::optional<Right>> matching;
+
+        // augmenting-path search inside build_matching
+        std::vector<uint8_t> reached_on_the_left, reached_on_the_right;
+        std::vector<Left> how_we_got_to_on_the_right;
+        std::vector<Right> how_we_got_to_on_the_left;
+
+        // the directed matching graph: edges_out_from is offset-indexed
+        // (variables first, then values) and only feeds the SCC pass, so it
+        // stores offsets directly rather than typed vertices
+        std::vector<std::vector<std::size_t>> edges_out_from;
+        std::vector<std::vector<Right>> edges_out_from_variable, edges_in_to_variable;
+        std::vector<std::vector<Left>> edges_out_from_value, edges_in_to_value;
+
+        // Tarjan's algorithm
+        std::vector<int> indices, lowlinks, components;
+        std::vector<std::size_t> tarjan_stack;
+        std::vector<std::pair<std::size_t, std::size_t>> tarjan_frames;
+        std::vector<uint8_t> enstackinated;
+
+        // reachability sweeps: the used-edge marking pass, and Hall set
+        // extraction in the prove_* helpers
+        std::vector<Vertex> to_explore;
+        std::vector<uint8_t> in_to_explore, explored;
+        std::vector<uint8_t> hall_left, hall_right;
+        std::vector<std::optional<Left>> inverse_matching;
+        std::vector<uint8_t> n_of_hall_variables;
+
+        // flat vars.size() * vals.size() bitmap; phantom rights never appear
+        std::vector<uint8_t> used_edges;
+
+        // grouping deletions by the SCC that justifies them
+        std::vector<std::vector<Literal>> deletions_by_scc;
+        std::vector<std::optional<Right>> representatives_for_scc;
+    };
+
+    auto make_gac_all_different_scratch() -> std::shared_ptr<GacAllDifferentScratch>
+    {
+        return make_shared<GacAllDifferentScratch>();
+    }
+}
+
 namespace
 {
-    struct Left
+    using Left = GacAllDifferentScratch::Left;
+    using Right = GacAllDifferentScratch::Right;
+
+    // Clear (not deallocate) the first n inner vectors, growing the outer
+    // vector with fresh empties if this wake needs more than any previous one.
+    // Anything past n is stale from an earlier wake and is never read.
+    template <typename T_>
+    auto clear_inners_to_size(vector<vector<T_>> & vec, size_t n) -> void
     {
-        vector<IntegerVariableID>::size_type offset;
+        if (vec.size() < n)
+            vec.resize(n);
+        for (size_t i = 0; i != n; ++i)
+            vec[i].clear();
+    }
 
-        [[nodiscard]] auto operator<=>(const Left &) const = default;
-    };
-
-    struct Right
+    auto build_matching(const vector<IntegerVariableID> & vars, size_t n_right, GacAllDifferentScratch & scratch) -> void
     {
-        vector<Integer>::size_type offset;
+        const auto & edges = scratch.edges;
+        auto & left_covered = scratch.left_covered;
+        auto & right_covered = scratch.right_covered;
+        auto & matching = scratch.matching;
 
-        [[nodiscard]] auto operator<=>(const Right &) const = default;
-    };
-
-    auto build_matching(const vector<IntegerVariableID> & vars, size_t n_right, const vector<pair<Left, Right>> & edges,
-        vector<uint8_t> & left_covered, vector<uint8_t> & right_covered, vector<optional<Right>> & matching) -> void
-    {
         // start with a greedy matching
         for (const auto & e : edges) {
             if ((! left_covered[e.first.offset]) && (! right_covered[e.second.offset])) {
@@ -107,11 +181,14 @@ namespace
 
         // now augment
         while (true) {
-            vector<uint8_t> reached_on_the_left(vars.size(), 0);
-            vector<uint8_t> reached_on_the_right(n_right, 0);
-
-            vector<Left> how_we_got_to_on_the_right(n_right, Left{});
-            vector<Right> how_we_got_to_on_the_left(vars.size(), Right{});
+            auto & reached_on_the_left = scratch.reached_on_the_left;
+            auto & reached_on_the_right = scratch.reached_on_the_right;
+            auto & how_we_got_to_on_the_right = scratch.how_we_got_to_on_the_right;
+            auto & how_we_got_to_on_the_left = scratch.how_we_got_to_on_the_left;
+            reached_on_the_left.assign(vars.size(), 0);
+            reached_on_the_right.assign(n_right, 0);
+            how_we_got_to_on_the_right.assign(n_right, Left{});
+            how_we_got_to_on_the_left.assign(vars.size(), Right{});
 
             // start from exposed variables
             for (Left v{0}; v.offset != vars.size(); ++v.offset)
@@ -191,21 +268,23 @@ namespace
 
     auto prove_matching_is_too_small(const ConstraintID & constraint_id, const vector<IntegerVariableID> & vars, const vector<Integer> & vals,
         const vector<Integer> & excluded, size_t n_right, map<Integer, ProofLine> & value_am1_constraint_numbers, const State &, ProofLogger * const,
-        const vector<pair<Left, Right>> & edges, const vector<uint8_t> & left_covered, const vector<optional<Right>> & matching)
-        -> std::tuple<hints::AllDifferentHall, Reason>
+        GacAllDifferentScratch & scratch) -> std::tuple<hints::AllDifferentHall, Reason>
     {
-        vector<optional<Left>> inverse_matching(n_right, nullopt);
-        for (const auto & [l, r] : enumerate(matching))
+        auto & inverse_matching = scratch.inverse_matching;
+        inverse_matching.assign(n_right, nullopt);
+        for (const auto & [l, r] : enumerate(scratch.matching))
             if (r)
                 inverse_matching[r->offset] = Left{l};
 
-        vector<uint8_t> hall_variables(vars.size(), 0);
-        vector<uint8_t> hall_values(n_right, 0);
+        auto & hall_variables = scratch.hall_left;
+        auto & hall_values = scratch.hall_right;
+        hall_variables.assign(vars.size(), 0);
+        hall_values.assign(n_right, 0);
 
         // there must be at least one thing uncovered, and this will
         // necessarily participate in a hall violator
         for (Left v{0}; v.offset != vars.size(); ++v.offset)
-            if (! left_covered[v.offset]) {
+            if (! scratch.left_covered[v.offset]) {
                 hall_variables[v.offset] = 1;
                 break;
             }
@@ -213,8 +292,9 @@ namespace
         // either we have found a hall violator, or we have a spare value
         // on the right
         while (true) {
-            vector<uint8_t> n_of_hall_variables(n_right, 0);
-            for (const auto & [l, r] : edges)
+            auto & n_of_hall_variables = scratch.n_of_hall_variables;
+            n_of_hall_variables.assign(n_right, 0);
+            for (const auto & [l, r] : scratch.edges)
                 if (hall_variables[l.offset])
                     n_of_hall_variables[r.offset] = 1;
 
@@ -238,6 +318,8 @@ namespace
             hall_values[not_subset_witness.offset] = 1;
         }
 
+        // these escape into the returned hint and lazy reason, so they are
+        // deliberately fresh vectors, not scratch
         vector<IntegerVariableID> hall_variable_ids;
         for (Left v{0}; v.offset != vars.size(); ++v.offset)
             if (hall_variables[v.offset] && ! is_constant_variable(vars[v.offset]))
@@ -258,7 +340,7 @@ namespace
                 }}}};
     }
 
-    using Vertex = variant<Left, Right>;
+    using Vertex = GacAllDifferentScratch::Vertex;
 
     // The two justification shapes a single SCC deletion can take: a Hall set (real
     // explicit steps) or a single forced value (pure RUP). A typed variant rather
@@ -266,29 +348,49 @@ namespace
     // hint — there is no separate annotation channel.
     using DeletionJustification = variant<hints::AllDifferent, hints::AllDifferentHall>;
 
-    auto vertex_to_offset(const vector<IntegerVariableID> & vars, const vector<Integer> &, Vertex v) -> std::size_t
+    // The concrete overloads let statically-typed call sites (which is most of
+    // them) skip building a Vertex and dispatching on it; the Vertex overload
+    // is only for genuinely variant vertices.
+    auto vertex_to_offset(const vector<IntegerVariableID> &, const vector<Integer> &, const Left & l) -> std::size_t
+    {
+        return l.offset;
+    }
+
+    auto vertex_to_offset(const vector<IntegerVariableID> & vars, const vector<Integer> &, const Right & r) -> std::size_t
+    {
+        return vars.size() + r.offset;
+    }
+
+    auto vertex_to_offset(const vector<IntegerVariableID> & vars, const vector<Integer> & vals, const Vertex & v) -> std::size_t
     {
         return overloaded{
-            [&](const Left & l) { return l.offset; },               //
-            [&](const Right & r) { return vars.size() + r.offset; } //
+            [&](const Left & l) { return vertex_to_offset(vars, vals, l); }, //
+            [&](const Right & r) { return vertex_to_offset(vars, vals, r); } //
         }
             .visit(v);
     }
 
     auto prove_deletion_using_sccs(const ConstraintID & constraint_id, const vector<IntegerVariableID> & vars, const vector<Integer> & vals,
         const vector<Integer> & excluded, size_t n_right, map<Integer, ProofLine> & value_am1_constraint_numbers, const State &, ProofLogger * const,
-        const vector<vector<Right>> & edges_out_from_variable, const vector<vector<Left>> & edges_out_from_value, const Right delete_value,
-        const vector<int> & components) -> tuple<DeletionJustification, Reason>
+        const Right delete_value, GacAllDifferentScratch & scratch) -> tuple<DeletionJustification, Reason>
     {
+        const auto & edges_out_from_variable = scratch.edges_out_from_variable;
+        const auto & edges_out_from_value = scratch.edges_out_from_value;
+        const auto & components = scratch.components;
+
         // we know a hall set exists, but we have to find it. starting
         // from but not including the end of the edge we're deleting,
         // everything reachable forms a hall set.
-        vector<uint8_t> in_to_explore(vars.size() + n_right, 0);
-        vector<Vertex> to_explore;
-
-        vector<uint8_t> explored(vars.size() + n_right, 0);
-        vector<uint8_t> hall_left(vars.size(), 0);
-        vector<uint8_t> hall_right(n_right, 0);
+        auto & in_to_explore = scratch.in_to_explore;
+        auto & to_explore = scratch.to_explore;
+        auto & explored = scratch.explored;
+        auto & hall_left = scratch.hall_left;
+        auto & hall_right = scratch.hall_right;
+        in_to_explore.assign(vars.size() + n_right, 0);
+        to_explore.clear();
+        explored.assign(vars.size() + n_right, 0);
+        hall_left.assign(vars.size(), 0);
+        hall_right.assign(n_right, 0);
 
         in_to_explore[vertex_to_offset(vars, vals, delete_value)] = 1;
         to_explore.push_back(delete_value);
@@ -296,18 +398,20 @@ namespace
         while (! to_explore.empty()) {
             Vertex n = to_explore.back();
             to_explore.pop_back();
-            in_to_explore[vertex_to_offset(vars, vals, n)] = 0;
-            explored[vertex_to_offset(vars, vals, n)] = 1;
+            auto n_offset = vertex_to_offset(vars, vals, n);
+            in_to_explore[n_offset] = 0;
+            explored[n_offset] = 1;
 
             visit(
                 [&](const auto & x) -> void {
                     if constexpr (is_same_v<decay_t<decltype(x)>, Left>) {
                         hall_left[x.offset] = 1;
                         for (const auto & t : edges_out_from_variable[x.offset]) {
-                            if (care_about_scc == components[vertex_to_offset(vars, vals, t)] && ! explored[vertex_to_offset(vars, vals, t)]) {
-                                if (0 == in_to_explore[vertex_to_offset(vars, vals, t)]) {
+                            auto t_offset = vertex_to_offset(vars, vals, t);
+                            if (care_about_scc == components[t_offset] && ! explored[t_offset]) {
+                                if (0 == in_to_explore[t_offset]) {
                                     to_explore.push_back(t);
-                                    in_to_explore[vertex_to_offset(vars, vals, t)] = 1;
+                                    in_to_explore[t_offset] = 1;
                                 }
                             }
                         }
@@ -315,10 +419,11 @@ namespace
                     else {
                         hall_right[x.offset] = 1;
                         for (const auto & t : edges_out_from_value[x.offset]) {
-                            if (care_about_scc == components[vertex_to_offset(vars, vals, t)] && ! explored[vertex_to_offset(vars, vals, t)]) {
-                                if (0 == in_to_explore[vertex_to_offset(vars, vals, t)]) {
+                            auto t_offset = vertex_to_offset(vars, vals, t);
+                            if (care_about_scc == components[t_offset] && ! explored[t_offset]) {
+                                if (0 == in_to_explore[t_offset]) {
                                     to_explore.push_back(t);
-                                    in_to_explore[vertex_to_offset(vars, vals, t)] = 1;
+                                    in_to_explore[t_offset] = 1;
                                 }
                             }
                         }
@@ -327,6 +432,8 @@ namespace
                 n);
         }
 
+        // these escape into the returned hint and lazy reason, so they are
+        // deliberately fresh vectors, not scratch
         vector<IntegerVariableID> hall_variable_ids;
         for (Left v{0}; v.offset != vars.size(); ++v.offset)
             if (hall_left[v.offset] && ! is_constant_variable(vars[v.offset]))
@@ -359,14 +466,97 @@ namespace
                     }}}};
         }
     }
+
+    // Tarjan's algorithm over scratch.edges_out_from, with an explicit stack
+    // of (vertex, next edge index) frames instead of a recursive std::function:
+    // no closure allocation, no type-erased call per visit, and no deep native
+    // recursion on big graphs. This reproduces the recursive formulation's
+    // numbering exactly (including taking min with the lowlink, not the index,
+    // of an on-stack target, as the recursive version did), so component
+    // identifiers -- and hence everything downstream -- are unchanged.
+    auto find_strongly_connected_components(size_t n_vertices, GacAllDifferentScratch & scratch) -> int
+    {
+        const auto & edges_out_from = scratch.edges_out_from;
+        auto & indices = scratch.indices;
+        auto & lowlinks = scratch.lowlinks;
+        auto & components = scratch.components;
+        auto & stack = scratch.tarjan_stack;
+        auto & enstackinated = scratch.enstackinated;
+        auto & frames = scratch.tarjan_frames;
+
+        indices.assign(n_vertices, 0);
+        lowlinks.assign(n_vertices, 0);
+        components.assign(n_vertices, 0);
+        enstackinated.assign(n_vertices, 0);
+        stack.clear();
+        frames.clear();
+
+        int next_index = 1, number_of_components = 0;
+
+        for (size_t root = 0; root != n_vertices; ++root) {
+            if (0 != indices[root])
+                continue;
+
+            frames.emplace_back(root, 0);
+            while (! frames.empty()) {
+                auto [v, next_edge] = frames.back();
+
+                if (0 == next_edge) {
+                    // first arrival at v
+                    indices[v] = next_index;
+                    lowlinks[v] = next_index;
+                    ++next_index;
+                    stack.push_back(v);
+                    enstackinated[v] = 1;
+                }
+
+                bool descended = false;
+                while (next_edge != edges_out_from[v].size()) {
+                    auto w = edges_out_from[v][next_edge];
+                    ++next_edge;
+                    if (0 == indices[w]) {
+                        // descend into w; the min with w's lowlink happens
+                        // when w's frame is popped, below
+                        frames.back().second = next_edge;
+                        frames.emplace_back(w, 0);
+                        descended = true;
+                        break;
+                    }
+                    else if (enstackinated[w])
+                        lowlinks[v] = min(lowlinks[v], lowlinks[w]);
+                }
+
+                if (descended)
+                    continue;
+
+                frames.pop_back();
+                if (lowlinks[v] == indices[v]) {
+                    size_t w;
+                    do {
+                        w = stack.back();
+                        stack.pop_back();
+                        enstackinated[w] = 0;
+                        components[w] = number_of_components;
+                    } while (w != v);
+                    ++number_of_components;
+                }
+
+                if (! frames.empty())
+                    lowlinks[frames.back().first] = min(lowlinks[frames.back().first], lowlinks[v]);
+            }
+        }
+
+        return number_of_components;
+    }
 }
 
 auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_id, const vector<IntegerVariableID> & vars,
-    const vector<Integer> & vals, const vector<Integer> & excluded, map<Integer, ProofLine> & value_am1_constraint_numbers, const State & state,
-    auto & tracker, ProofLogger * const logger) -> void
+    const vector<Integer> & vals, const vector<Integer> & excluded, map<Integer, ProofLine> & value_am1_constraint_numbers,
+    GacAllDifferentScratch & scratch, const State & state, auto & tracker, ProofLogger * const logger) -> void
 {
     // find a matching to check feasibility
-    vector<pair<Left, Right>> edges;
+    auto & edges = scratch.edges;
+    edges.clear();
 
     for (const auto & [var_idx, var] : enumerate(vars))
         for (const auto & [val_idx, val] : enumerate(vals))
@@ -389,17 +579,19 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
                 }
     }
 
-    vector<uint8_t> left_covered(vars.size(), 0);
-    vector<uint8_t> right_covered(n_right, 0);
-    vector<optional<Right>> matching(vars.size(), nullopt);
+    scratch.left_covered.assign(vars.size(), 0);
+    scratch.right_covered.assign(n_right, 0);
+    scratch.matching.assign(vars.size(), nullopt);
 
-    build_matching(vars, n_right, edges, left_covered, right_covered, matching);
+    build_matching(vars, n_right, scratch);
 
-    if (cmp_not_equal(count(left_covered.begin(), left_covered.end(), 1), vars.size())) {
+    const auto & matching = scratch.matching;
+
+    if (cmp_not_equal(count(scratch.left_covered.begin(), scratch.left_covered.end(), 1), vars.size())) {
         // nope. we've got a maximum cardinality matching that leaves at least
         // one thing on the left uncovered.
-        auto [hall, reason] = prove_matching_is_too_small(
-            constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, edges, left_covered, matching);
+        auto [hall, reason] =
+            prove_matching_is_too_small(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, scratch);
         return tracker.infer(logger, FalseLiteral{},
             JustifyExplicitly{[&logger, w = hall](const ReasonLiterals & r) { emit_justification(*logger, w, r); }, ThenRUP::Yes, move(hall)},
             reason);
@@ -408,83 +600,55 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
     // we have a matching that uses every variable. however, some edges may
     // not occur in any maximum cardinality matching, and we can delete
     // these. first we need to build the directed matching graph...
-    vector<vector<Vertex>> edges_out_from(vars.size() + n_right, vector<Vertex>{});
-    vector<vector<Right>> edges_out_from_variable(vars.size()), edges_in_to_variable(vars.size());
-    vector<vector<Left>> edges_out_from_value(n_right), edges_in_to_value(n_right);
+    auto & edges_out_from = scratch.edges_out_from;
+    auto & edges_out_from_variable = scratch.edges_out_from_variable;
+    auto & edges_in_to_variable = scratch.edges_in_to_variable;
+    auto & edges_out_from_value = scratch.edges_out_from_value;
+    auto & edges_in_to_value = scratch.edges_in_to_value;
+    clear_inners_to_size(edges_out_from, vars.size() + n_right);
+    clear_inners_to_size(edges_out_from_variable, vars.size());
+    clear_inners_to_size(edges_in_to_variable, vars.size());
+    clear_inners_to_size(edges_out_from_value, n_right);
+    clear_inners_to_size(edges_in_to_value, n_right);
 
     for (auto & [f, t] : edges)
         if (matching[f.offset] == t) {
-            edges_out_from[vertex_to_offset(vars, vals, t)].push_back(f);
+            edges_out_from[vertex_to_offset(vars, vals, t)].push_back(vertex_to_offset(vars, vals, f));
             edges_out_from_value[t.offset].push_back(f);
             edges_in_to_variable[f.offset].push_back(t);
         }
         else {
-            edges_out_from[vertex_to_offset(vars, vals, f)].push_back(t);
+            edges_out_from[vertex_to_offset(vars, vals, f)].push_back(vertex_to_offset(vars, vals, t));
             edges_out_from_variable[f.offset].push_back(t);
             edges_in_to_value[t.offset].push_back(f);
         }
 
     // now we need to find strongly connected components...
-    vector<int> indices(vars.size() + n_right, 0), lowlinks(vars.size() + n_right, 0), components(vars.size() + n_right, 0);
-    vector<Vertex> stack;
-    vector<uint8_t> enstackinated(vars.size() + n_right);
-    int next_index = 1, number_of_components = 0;
-
-    function<auto(Vertex)->void> scc;
-    scc = [&](Vertex v) -> void {
-        indices[vertex_to_offset(vars, vals, v)] = next_index;
-        lowlinks[vertex_to_offset(vars, vals, v)] = next_index;
-        ++next_index;
-        stack.emplace_back(v);
-        enstackinated[vertex_to_offset(vars, vals, v)] = 1;
-
-        for (auto & w : edges_out_from[vertex_to_offset(vars, vals, v)]) {
-            if (0 == indices[vertex_to_offset(vars, vals, w)]) {
-                scc(w);
-                lowlinks[vertex_to_offset(vars, vals, v)] = min(lowlinks[vertex_to_offset(vars, vals, v)], lowlinks[vertex_to_offset(vars, vals, w)]);
-            }
-            else if (enstackinated[vertex_to_offset(vars, vals, w)]) {
-                lowlinks[vertex_to_offset(vars, vals, v)] = min(lowlinks[vertex_to_offset(vars, vals, v)], lowlinks[vertex_to_offset(vars, vals, w)]);
-            }
-        }
-
-        if (lowlinks[vertex_to_offset(vars, vals, v)] == indices[vertex_to_offset(vars, vals, v)]) {
-            Vertex w;
-            do {
-                w = stack.back();
-                stack.pop_back();
-                enstackinated[vertex_to_offset(vars, vals, w)] = 0;
-                components[vertex_to_offset(vars, vals, w)] = number_of_components;
-            } while (v != w);
-            ++number_of_components;
-        }
-    };
-
-    for (Left v{0}; v.offset != vars.size(); ++v.offset)
-        if (0 == indices[vertex_to_offset(vars, vals, v)])
-            scc(v);
-
-    for (Right v{0}; v.offset != n_right; ++v.offset)
-        if (0 == indices[vertex_to_offset(vars, vals, v)])
-            scc(v);
+    const auto number_of_components = find_strongly_connected_components(vars.size() + n_right, scratch);
+    const auto & components = scratch.components;
 
     // every edge in the original matching is used, and so cannot be
     // deleted. used_edges only tracks real (non-phantom) right offsets;
     // phantom edges are never deletable and are skipped below.
-    vector<vector<uint8_t>> used_edges(vars.size(), vector<uint8_t>(vals.size(), 0));
+    auto & used_edges = scratch.used_edges;
+    used_edges.assign(vars.size() * vals.size(), 0);
+    const auto used_edge_idx = [&](size_t l, size_t r) { return l * vals.size() + r; };
     for (const auto & [l, r] : enumerate(matching))
         if (r && r->offset < vals.size())
-            used_edges[l][r->offset] = 1;
+            used_edges[used_edge_idx(l, r->offset)] = 1;
 
     // for each unmatched vertex, bring in everything that could be updated
     // to take it. Phantom rights participate too (when their owner is
     // matched to a real value, the phantom is unmatched and its presence
     // here marks the owner's edges as redirectable).
     {
-        vector<Vertex> to_explore;
-        vector<uint8_t> in_to_explore(vars.size() + n_right, 0);
+        auto & to_explore = scratch.to_explore;
+        auto & in_to_explore = scratch.in_to_explore;
+        auto & explored = scratch.explored;
+        to_explore.clear();
+        in_to_explore.assign(vars.size() + n_right, 0);
+        explored.assign(vars.size() + n_right, 0);
 
-        vector<uint8_t> explored(vars.size() + n_right, 0);
         for (Right v{0}; v.offset != n_right; ++v.offset)
             in_to_explore[vertex_to_offset(vars, vals, v)] = 1;
 
@@ -503,19 +667,21 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
         while (! to_explore.empty()) {
             Vertex v = to_explore.back();
             to_explore.pop_back();
-            in_to_explore[vertex_to_offset(vars, vals, v)] = 0;
-            explored[vertex_to_offset(vars, vals, v)] = 1;
+            auto v_offset = vertex_to_offset(vars, vals, v);
+            in_to_explore[v_offset] = 0;
+            explored[v_offset] = 1;
 
             visit(
                 [&](const auto & x) {
                     if constexpr (is_same_v<decay_t<decltype(x)>, Left>) {
                         for (auto & t : edges_in_to_variable[x.offset]) {
                             if (t.offset < vals.size())
-                                used_edges[x.offset][t.offset] = 1;
-                            if (! explored[vertex_to_offset(vars, vals, t)]) {
-                                if (! in_to_explore[vertex_to_offset(vars, vals, t)]) {
+                                used_edges[used_edge_idx(x.offset, t.offset)] = 1;
+                            auto t_offset = vertex_to_offset(vars, vals, t);
+                            if (! explored[t_offset]) {
+                                if (! in_to_explore[t_offset]) {
                                     to_explore.push_back(t);
-                                    in_to_explore[vertex_to_offset(vars, vals, t)] = 1;
+                                    in_to_explore[t_offset] = 1;
                                 }
                             }
                         }
@@ -523,11 +689,12 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
                     else {
                         for (auto & t : edges_in_to_value[x.offset]) {
                             if (x.offset < vals.size())
-                                used_edges[t.offset][x.offset] = 1;
-                            if (! explored[vertex_to_offset(vars, vals, t)]) {
-                                if (! in_to_explore[vertex_to_offset(vars, vals, t)]) {
+                                used_edges[used_edge_idx(t.offset, x.offset)] = 1;
+                            auto t_offset = vertex_to_offset(vars, vals, t);
+                            if (! explored[t_offset]) {
+                                if (! in_to_explore[t_offset]) {
                                     to_explore.push_back(t);
-                                    in_to_explore[vertex_to_offset(vars, vals, t)] = 1;
+                                    in_to_explore[t_offset] = 1;
                                 }
                             }
                         }
@@ -541,20 +708,19 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
     // (skipping phantom edges, which never appear in used_edges)
     for (auto & [f, t] : edges)
         if (t.offset < vals.size() && components[vertex_to_offset(vars, vals, f)] == components[vertex_to_offset(vars, vals, t)])
-            used_edges[f.offset][t.offset] = 1;
-
-    // avoid outputting duplicate proof lines
-    vector<uint8_t> sccs_already_done(number_of_components + 1, 0);
+            used_edges[used_edge_idx(f.offset, t.offset)] = 1;
 
     // anything left can be deleted. need to do all of these together if we're doing
     // justifications, to avoid having to figure out an ordering for nested Hall sets.
     // Phantom edges are skipped: they're never deletable.
-    vector<vector<Literal>> deletions_by_scc(number_of_components);
-    vector<optional<Right>> representatives_for_scc(number_of_components);
+    auto & deletions_by_scc = scratch.deletions_by_scc;
+    auto & representatives_for_scc = scratch.representatives_for_scc;
+    clear_inners_to_size(deletions_by_scc, number_of_components);
+    representatives_for_scc.assign(number_of_components, nullopt);
     for (auto & [delete_var_name, delete_value] : edges) {
         if (delete_value.offset >= vals.size())
             continue;
-        if (used_edges[delete_var_name.offset][delete_value.offset])
+        if (used_edges[used_edge_idx(delete_var_name.offset, delete_value.offset)])
             continue;
         auto scc = components[vertex_to_offset(vars, vals, delete_value)];
         deletions_by_scc[scc].emplace_back(vars[delete_var_name.offset] != vals[delete_value.offset]);
@@ -565,8 +731,8 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
         if (! representatives_for_scc[scc])
             continue;
 
-        auto [justification, reason] = prove_deletion_using_sccs(constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state,
-            logger, edges_out_from_variable, edges_out_from_value, *representatives_for_scc[scc], components);
+        auto [justification, reason] = prove_deletion_using_sccs(
+            constraint_id, vars, vals, excluded, n_right, value_am1_constraint_numbers, state, logger, *representatives_for_scc[scc], scratch);
         visit(
             overloaded{
                 [&](hints::AllDifferent & w) { tracker.infer_all(logger, deletions_by_scc[scc], JustifyUsingRUP{w}, reason); }, //
@@ -582,8 +748,8 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
 
 template auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_id, const std::vector<IntegerVariableID> & vars,
     const std::vector<Integer> & vals, const std::vector<Integer> & excluded, std::map<Integer, ProofLine> & value_am1_constraint_numbers,
-    const State & state, SimpleInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
+    GacAllDifferentScratch & scratch, const State & state, SimpleInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
 
 template auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_id, const std::vector<IntegerVariableID> & vars,
     const std::vector<Integer> & vals, const std::vector<Integer> & excluded, std::map<Integer, ProofLine> & value_am1_constraint_numbers,
-    const State & state, EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;
+    GacAllDifferentScratch & scratch, const State & state, EagerProofLoggingInferenceTracker & inference_tracker, ProofLogger * const logger) -> void;

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -167,11 +167,14 @@ namespace
     // or sweep each variable's actual domain and map values through a dense
     // value -> index table. The sweep pays a fixed per-variable cost (bitmap
     // reset, domain iteration, bitmap scan) to avoid a vals.size() in_domain
-    // probe per variable, so it only wins when vals is wide enough:
-    // interleaved measurement showed it 2% faster whole-program at 33 values
-    // (langford --size=11) but 1% slower at 10 values (QWH quasigroup7),
-    // hence this cutoff between them.
-    constexpr std::size_t min_vals_for_domain_sweep = 32;
+    // probe per variable, so it only wins when vals is wide enough. Measured,
+    // interleaved, whole-program: 1% slower at 10 values (QWH quasigroup7 axiom
+    // instances), but 16% faster at 30 values (order-30 balanced latin square
+    // completion, where the edge build was 28% of the profile and the sweep
+    // cut its cycles by 37%) and 2% faster at 33 (langford --size=11) -- so
+    // the crossover is somewhere in 11..29, and this cutoff takes the widest
+    // slice of the win that the measurements support.
+    constexpr std::size_t min_vals_for_domain_sweep = 24;
 
     // The dense table has one slot per value in [min(vals), max(vals)], so it
     // only makes sense if the values aren't too spread out. Allow a fixed

--- a/gcs/constraints/all_different/gac_all_different.cc
+++ b/gcs/constraints/all_different/gac_all_different.cc
@@ -163,6 +163,25 @@ namespace
     using Left = GacAllDifferentScratch::Left;
     using Right = GacAllDifferentScratch::Right;
 
+    // The edges build can either probe every (var, val) pair with in_domain,
+    // or sweep each variable's actual domain and map values through a dense
+    // value -> index table. The sweep pays a fixed per-variable cost (bitmap
+    // reset, domain iteration, bitmap scan) to avoid a vals.size() in_domain
+    // probe per variable, so it only wins when vals is wide enough:
+    // interleaved measurement showed it 2% faster whole-program at 33 values
+    // (langford --size=11) but 1% slower at 10 values (QWH quasigroup7),
+    // hence this cutoff between them.
+    constexpr std::size_t min_vals_for_domain_sweep = 32;
+
+    // The dense table has one slot per value in [min(vals), max(vals)], so it
+    // only makes sense if the values aren't too spread out. Allow a fixed
+    // number of (mostly-empty) slots per distinct value, plus some slack so
+    // that a small value set spanning a modest range still qualifies. With 4
+    // bytes per slot this also bounds the table's memory at ~256 bytes per
+    // distinct value.
+    constexpr std::size_t dense_value_table_slots_per_value = 64;
+    constexpr std::size_t dense_value_table_slots_slack = 1024;
+
     // Clear (not deallocate) the first n inner vectors, growing the outer
     // vector with fresh empties if this wake needs more than any previous one.
     // Anything past n is stale from an earlier wake and is never read.
@@ -571,19 +590,16 @@ auto gcs::innards::propagate_gac_all_different(const ConstraintID & constraint_i
     edges.clear();
 
     if (! scratch.val_lookup_initialised) {
-        // vals is fixed for an installed propagator, so build the value ->
-        // index lookup once. The sweep pays a fixed per-variable cost (bitmap
-        // reset, domain iteration, bitmap scan) to avoid a vals.size()
-        // in_domain probe per variable, so it only wins when vals is wide
-        // enough: measured 2% whole-program faster at 33 values (langford 11)
-        // but 1% slower at 10 values (QWH quasigroup7), hence the 32 cutoff.
-        // A dense table also only makes sense if the values aren't too spread
-        // out; in either failure case we stay with the probe loop below.
+        // vals is fixed for an installed propagator, so decide once whether
+        // to build the value -> index lookup. If the value set is too narrow
+        // for the sweep to pay off, or too sparse for a dense table (see the
+        // constants for both trade-offs), the lookup stays empty and every
+        // wake takes the probe loop below instead.
         scratch.val_lookup_initialised = true;
-        if (vals.size() >= 32) {
+        if (vals.size() >= min_vals_for_domain_sweep) {
             auto [min_it, max_it] = minmax_element(vals);
             auto span = (*max_it - *min_it).as_index() + 1;
-            if (span <= 64 * vals.size() + 1024) {
+            if (span <= dense_value_table_slots_per_value * vals.size() + dense_value_table_slots_slack) {
                 scratch.val_lookup_min = *min_it;
                 scratch.val_to_idx_plus_one.assign(span, 0);
                 for (const auto & [val_idx, val] : enumerate(vals))

--- a/gcs/constraints/all_different/gac_all_different.hh
+++ b/gcs/constraints/all_different/gac_all_different.hh
@@ -9,6 +9,7 @@
 #include <gcs/variable_id.hh>
 
 #include <map>
+#include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -17,9 +18,24 @@ namespace gcs
 {
     namespace innards
     {
+        struct GacAllDifferentScratch;
+
+        /**
+         * \brief Make the reusable working storage for propagate_gac_all_different.
+         *
+         * Create one per installed propagator (a `shared_ptr` captured into the
+         * propagator closure works well) and pass the same object to every call:
+         * the propagator clears rather than reallocates its working buffers, so
+         * the hot path stops paying for dozens of allocations on every wake. The
+         * type is opaque outside gac_all_different.cc.
+         *
+         * \ingroup Innards
+         */
+        [[nodiscard]] auto make_gac_all_different_scratch() -> std::shared_ptr<GacAllDifferentScratch>;
+
         auto propagate_gac_all_different(const ConstraintID & constraint_id, const std::vector<IntegerVariableID> & vars,
             const std::vector<Integer> & vals, const std::vector<Integer> & excluded, std::map<Integer, ProofLine> & value_am1_constraint_numbers,
-            const State & state, auto & inference_tracker, ProofLogger * const logger) -> void;
+            GacAllDifferentScratch & scratch, const State & state, auto & inference_tracker, ProofLogger * const logger) -> void;
     }
 
 }

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -158,7 +158,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
 
     propagators.install(
         constraint_id(),
-        [vars, start, values = move(values), value_am1s = _value_am1s, constraint_id = constraint_id()](
+        [vars, start, values = move(values), value_am1s = _value_am1s, scratch = make_gac_all_different_scratch(), constraint_id = constraint_id()](
             const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
             // Channeling: x_i = v  =>  x_v = i. If i is not in D(x_v), prune
             // v from D(x_i). Single pass — Inverse(x, y) runs this in both
@@ -170,7 +170,7 @@ auto SymmetricAllDifferent::install_propagators(Propagators & propagators) -> vo
                             ExplicitReason{ReasonLiterals{vars.at((v - start).as_index()) != Integer(i) + start}});
             }
 
-            propagate_gac_all_different(constraint_id, vars, values, vector<Integer>{}, *value_am1s.get(), state, inf, logger);
+            propagate_gac_all_different(constraint_id, vars, values, vector<Integer>{}, *value_am1s.get(), *scratch, state, inf, logger);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -166,7 +166,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
     propagators.install(
         constraint_id(),
         [x = _x, y = _y, x_start = _x_start, y_start = _y_start, x_values = move(x_values), x_value_am1s = _x_value_am1s,
-            constraint_id = constraint_id(),
+            scratch = make_gac_all_different_scratch(), constraint_id = constraint_id(),
             owner = constraint_id()](const State & state, auto & inf, ProofLogger * const logger) -> PropagatorState {
             // Channel x<->y and GAC-alldifferent on x feed each other: a GAC
             // removal on x can leave a y value with no back-support (more
@@ -189,7 +189,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
                                 ExplicitReason{ReasonLiterals{x.at((y_i_value - x_start).as_index()) != Integer(i) + y_start}});
                 }
 
-                propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), state, inf, logger);
+                propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), *scratch, state, inf, logger);
             } while (inf.did_anything_since_last_call_inside_propagator());
 
             return PropagatorState::EnableButIdempotent;

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -516,9 +516,9 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
 
     propagators.install(
         constraint_id(),
-        [p = _p, vals = move(p_vals), am1_lines, constraint_id = constraint_id()](
+        [p = _p, vals = move(p_vals), am1_lines, scratch = make_gac_all_different_scratch(), constraint_id = constraint_id()](
             const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            propagate_gac_all_different(constraint_id, p, vals, vector<Integer>{}, *am1_lines, state, inference, logger);
+            propagate_gac_all_different(constraint_id, p, vals, vector<Integer>{}, *am1_lines, *scratch, state, inference, logger);
             // Idempotent for the same reason AllDifferent's GAC propagator is:
             // one call prunes to the closure, and the run is nothing but that
             // call. Triggers are 1:1 with p, so an aliased scope is caught by


### PR DESCRIPTION
Phase 1 of #522: the implementation-hygiene pass over `propagate_gac_all_different`. The propagator's algorithm is unchanged — this removes the per-wake allocation churn and the type-erased recursive SCC that profiling flagged, exactly as scoped in the issue.

## What changed

- **Reusable scratch.** `GacAllDifferentScratch` (opaque outside `gac_all_different.cc`, created via `make_gac_all_different_scratch()`) now owns every working buffer: the edges vector, the five adjacency structures, the matching/augmenting-path buffers, the Tarjan state, the reachability sweeps, the used-edges bitmap, and the per-SCC deletion grouping. Each of the five call sites (`AllDifferent` GAC, `AllDifferentExcept`, `SymmetricAllDifferent`, `Inverse`, `ArgSort`) creates one per installed propagator and captures it into the closure — the bin_packing Stage-3 pattern from dev_docs/propagator-performance.md. Buffers are `assign()`ed or `clear()`ed at point of use, so capacity ratchets up to the biggest wake and the steady-state hot path never allocates. The `vector<vector>` adjacency reuse clears inner vectors without freeing them (`clear_inners_to_size`).
- **Iterative Tarjan.** The recursive `std::function` SCC is now an explicit stack of (vertex, next-edge) frames over offset-indexed adjacency: no closure allocation, no type-erased call per visit, no deep native recursion. It reproduces the recursive formulation's numbering exactly — including the original's min-with-*lowlink* (not index) for on-stack targets — so component identifiers and everything downstream are unchanged.
- **`vertex_to_offset` concrete overloads.** Statically-typed call sites (most of them) no longer build a `variant` and `visit` it just to compute `offset` or `vars.size() + offset`; repeated offset computations in the sweep loops are now computed once per vertex.
- **Smaller things.** `used_edges` is a flat bitmap rather than `vector<vector<uint8_t>>`; the unused `sccs_already_done` vector is deleted.

The Hall-set id vectors that escape into lazy `Reason`s and hints stay per-call fresh allocations, deliberately.

## Neutrality

Search- and proof-neutral by construction and by measurement:

- `recursions`, `propagations`, and solution counts identical on every benchmark below.
- `langford --size=7 --prove`: `.opb` and `.pbp` **byte-identical** to baseline.
- 510/510 ctest (caps on); the nine affected constraint tests (`all_different`, `all_different_except`, `symmetric_all_different`, `inverse`, `sort`, `arg_sort`, plus the view_mixed variants) pass with `GCS_TEST_CAP_DEFAULTS=OFF` full-enumeration checking, four runs with fresh random seeds.

## Measurements

Standard sweep (dev_docs/benchmarking.md; `taskset -c 4`, 3 trials, median solve time), baseline = `domains-intersect-fastpath` (ea135770):

| benchmark | baseline (s) | after (s) | ratio | recursions | propagations |
|---|--:|--:|--:|--:|--:|
| langford_11 | 7.88 | 5.63 | **1.40×** | 256593 | 29805376 |
| ortho_latin_6_all | 24.26 | 24.07 | 1.01× | 1339912 | 343819580 |
| qap_12 | 1.79 | 1.79 | 1.00× | 123333 | 24460415 |
| magic_series_300 | 5.18 | 5.24 | 0.99× | 1193 | 41909926 |
| magic_square_5 | 17.61 | 17.73 | 0.99× | 6042079 | 501848714 |
| tsp_default | 10.65 | 10.66 | 1.00× | 4285745 | 83372056 |
| n_queens_14_all | 12.08 | 12.05 | 1.00× | 6391931 | 264025654 |
| n_queens_88 | 215.85 | 216.21 | 1.00× | 49339390 | 6108047866 |

langford_11 is the only benchmark in the set that exercises GAC AllDifferent (n_queens/qap use pairwise `NotEquals`, and ortho_latin's default all-different mode is pairwise not-equals too). The rest of the set is the no-regression control.

QWH-style MiniZinc workload (mzn-challenge 2008 `quasigroup7`, order 10, unsat; identical search order, 30 s limit, nodes explored = per-node throughput):

| instance | baseline | after | ratio |
|---|--:|--:|--:|
| qg7-10, nodes in 30 s (median of 3) | 177750 | 248511 | **1.40×** |
| qg7-08, full unsat run (4891 nodes, deterministic) | 0.389 s | 0.283 s | **1.37×** |

(`quasigroup7.mzn` flattens to 16 `glasgow_alldifferent` over order-10 rows/columns plus 112 `array_var_int_element` and 56 `int_lin_eq`; node counts at the 30 s cut are the throughput signal since the search order is identical.)

## Second commit: edge build by domain sweep (phase 1.5)

After the scratch pass, the top leaf cost on langford_11 was `State::in_domain` — the edges build probes every (var, val) pair, `vars.size() × vals.size()` probes per wake. The second commit sweeps each variable's actual domain once (`for_each_value_immutable`), maps values through a dense value→index table built on the first wake, marks a bitmap, and emits edges by scanning the bitmap in val-index order — the **same edges in the same order** as the probe loop, so everything downstream (and the proof bytes) is unchanged.

The sweep has a fixed per-variable cost, so it only wins when vals is wide. Interleaved same-session measurement: **2% whole-program faster at 33 values** (langford_11, 5.52s → 5.42s) but **1% slower at 10 values** (QWH qg7). Per the propagator-performance ground rules ("never makes anything slower"), it is gated on a minimum `vals.size()` (and on the value range being dense enough for the table), with the probe loop kept as the fallback — narrow and sparse value sets take exactly the old path. Measured cutoff basis is in the code comment; a third commit lowers the cutoff from 32 to 24 after same-tree Gecode benchmarking on order-30 latin square completion showed the sweep 16% faster whole-program at 30 values (edge-build cycles −37%).

Cumulative langford_11 vs the stack baseline: 7.88 s → 5.42 s (**1.45×**). Proof byte-identity re-verified after this commit; 510/510 caps-on and the nine caps-off enumeration tests re-run green.

## What's next (not this PR)

The issue's phase 2 (staged propagation, reuse the cheap value-removal pass, ~3× in Gent/Miguel/Nightingale) and phase 3 (SCC-incremental, ~10×, a project) remain open on #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARYiwRGLg4vXRtgMr1VKAv
