### PR TITLE
all_different: stage the GAC propagator behind the cheap value pass (#522 phase 2)

### DIFF
--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -173,20 +173,15 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
                     // for staging to pay; see min_var_val_pairs_for_staged_gac):
                     // push newly assigned values through the clique -- the same
                     // value-consistency pass, over the same backtrackable
-                    // unassigned list, as the VC propagator below. The first
-                    // flag read discards any stale value:
-                    // did_anything_since_last_call_inside_propagator is set by
-                    // every inference from every propagator and only cleared
-                    // when read, and acting on a leftover true after an
-                    // inference-free stage 1 would skip stage 2 with none of
-                    // our own triggers guaranteeing a re-wake.
+                    // unassigned list, as the VC propagator below.
                     if (staged) {
-                        inference.did_anything_since_last_call_inside_propagator();
                         if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, constraint_id,
                                 reasons.table.empty() ? nullptr : &reasons.table, reasons.base))
                             return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
 
-                        // If stage 1 inferred anything, defer the expensive
+                        // If stage 1 inferred anything (the progress flag is
+                        // clean at run start, so it reports exactly our own
+                        // stage 1), defer the expensive
                         // stage: return Enable *without* an idempotence claim,
                         // so the removals just made -- all on our own on_change
                         // trigger variables -- requeue us at the round
@@ -202,7 +197,7 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
                         // not), so the search is unchanged, though propagation
                         // counts and proof shape differ from running GAC on
                         // every wake.
-                        if (inference.did_anything_since_last_call_inside_propagator())
+                        if (inference.made_progress_since_last_check())
                             return PropagatorState::Enable;
                     }
 

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -22,6 +22,7 @@
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::holds_alternative;
 using std::make_shared;
 using std::make_unique;
 using std::map;
@@ -31,6 +32,55 @@ using std::vector;
 using std::ranges::adjacent_find;
 using std::ranges::find;
 using std::ranges::sort;
+
+namespace
+{
+    // Whether the GAC propagator runs the cheap value-consistency pass as a
+    // first stage, deferring the matching/SCC work while that pass is still
+    // finding removals. Deferral splits a wake into two propagator
+    // invocations and adds an unassigned-list scan per wake, so it only pays
+    // when the deferred work is expensive -- that is, when the bipartite
+    // variable-value graph is big. Measured on the (vars x values) product:
+    // 22 x 33 = 726 (langford --size=11) is 1.36x faster staged, while
+    // 10 x 10 = 100 (QWH quasigroup7) is ~2% slower, so the cutoff sits
+    // between them, at the rounded geometric mean.
+    constexpr std::size_t min_var_val_pairs_for_staged_gac = 256;
+
+    // Prebuilt per-variable "v == its single value" reasons for the
+    // value-consistency pass, indexed by the variable's own
+    // SimpleIntegerVariableID index (offset by base). Each is a deferred
+    // ExactSingleValue, so it materialises to v == whatever value v is fixed
+    // to at the point of inference. Constraint-owned (moved into the
+    // propagator closure), not backtracked: the table never changes during
+    // search. Views and constants get no entry and fall back to inline
+    // construction in the propagator.
+    struct SingleValueReasons
+    {
+        unsigned long long base = 0;
+        vector<Reason> table;
+    };
+
+    auto build_single_value_reasons(const vector<IntegerVariableID> & vars) -> SingleValueReasons
+    {
+        SingleValueReasons result;
+        auto lo = ~0ull, hi = 0ull;
+        bool any_simple = false;
+        for (const auto & v : vars)
+            if (auto s = std::get_if<SimpleIntegerVariableID>(&v)) {
+                lo = std::min(lo, s->index);
+                hi = std::max(hi, s->index);
+                any_simple = true;
+            }
+        if (any_simple) {
+            result.base = lo;
+            result.table.resize(hi - lo + 1);
+            for (const auto & v : vars)
+                if (auto s = std::get_if<SimpleIntegerVariableID>(&v))
+                    result.table[s->index - lo] = Reason{ExactSingleValue{ReasonVars{vector<IntegerVariableID>{v}}}};
+        }
+        return result;
+    }
+}
 
 AllDifferent::AllDifferent(vector<IntegerVariableID> v) : _vars(move(v))
 {
@@ -67,23 +117,28 @@ auto AllDifferent::prepare(Propagators &, State & initial_state, ProofModel * co
         return true;
     }
 
-    // Set up only what the requested propagator needs: GAC wants the compressed
-    // value set; VC wants the not-yet-assigned variables as backtrackable state.
-    overloaded{//
-        [&](const consistency::GAC &) {
-            for (auto & var : _sanitised_vars)
-                for (const auto & val : initial_state.each_value_immutable(var))
-                    if (_compressed_vals.end() == find(_compressed_vals, val))
-                        _compressed_vals.push_back(val);
-        },
-        [&](const consistency::VC &) {
-            NonGacAllDifferentUnassigned unassigned{};
-            for (auto & var : _sanitised_vars)
-                if (! initial_state.has_single_value(var))
-                    unassigned.push_back(var);
-            _unassigned_handle = initial_state.add_constraint_state(unassigned);
-        }}
-        .visit(_level);
+    // GAC wants the compressed value set. It has to be built before the
+    // staging decision below, which depends on its size.
+    if (holds_alternative<consistency::GAC>(_level)) {
+        for (auto & var : _sanitised_vars)
+            for (const auto & val : initial_state.each_value_immutable(var))
+                if (_compressed_vals.end() == find(_compressed_vals, val))
+                    _compressed_vals.push_back(val);
+        _gac_staged = _sanitised_vars.size() * _compressed_vals.size() >= min_var_val_pairs_for_staged_gac;
+    }
+
+    // The value-consistency pass needs the not-yet-assigned variables as
+    // backtrackable state: VC runs it as its whole propagator, GAC as the
+    // cheap first stage of its staged propagator when the constraint is big
+    // enough for staging to pay. Skipped otherwise: an unused constraint
+    // state would still be saved and restored at every search node.
+    if (holds_alternative<consistency::VC>(_level) || _gac_staged) {
+        NonGacAllDifferentUnassigned unassigned{};
+        for (auto & var : _sanitised_vars)
+            if (! initial_state.has_single_value(var))
+                unassigned.push_back(var);
+        _unassigned_handle = initial_state.add_constraint_state(unassigned);
+    }
 
     return true;
 }
@@ -105,14 +160,53 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
     Triggers triggers;
     triggers.on_change = {_sanitised_vars.begin(), _sanitised_vars.end()};
 
-    overloaded{//
+    overloaded{
         [&](const consistency::GAC &) {
             auto value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
+            auto reasons = _gac_staged ? build_single_value_reasons(_sanitised_vars) : SingleValueReasons{};
             propagators.install(
                 constraint_id(),
                 [vars = move(_sanitised_vars), vals = move(_compressed_vals), value_am1_constraint_numbers = move(value_am1_constraint_numbers),
-                    scratch = make_gac_all_different_scratch(),
+                    scratch = make_gac_all_different_scratch(), staged = _gac_staged, unassigned_handle = _unassigned_handle, reasons = move(reasons),
                     constraint_id = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                    // Stage 1, cheap (only when the constraint is big enough
+                    // for staging to pay; see min_var_val_pairs_for_staged_gac):
+                    // push newly assigned values through the clique -- the same
+                    // value-consistency pass, over the same backtrackable
+                    // unassigned list, as the VC propagator below. The first
+                    // flag read discards any stale value:
+                    // did_anything_since_last_call_inside_propagator is set by
+                    // every inference from every propagator and only cleared
+                    // when read, and acting on a leftover true after an
+                    // inference-free stage 1 would skip stage 2 with none of
+                    // our own triggers guaranteeing a re-wake.
+                    if (staged) {
+                        inference.did_anything_since_last_call_inside_propagator();
+                        if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, constraint_id,
+                                reasons.table.empty() ? nullptr : &reasons.table, reasons.base))
+                            return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
+
+                        // If stage 1 inferred anything, defer the expensive
+                        // stage: return Enable *without* an idempotence claim,
+                        // so the removals just made -- all on our own on_change
+                        // trigger variables -- requeue us at the round
+                        // boundary. Cheaper propagators react to the removals
+                        // first, and the matching/SCC stage runs once against
+                        // the accumulated state instead of once per wake.
+                        // Stage 2 cannot be starved: a deferral only happens
+                        // when stage 1 strictly shrank a domain, which can only
+                        // happen finitely often, and the engine cannot reach
+                        // its fixpoint while we are still being requeued. The
+                        // per-node fixpoint is therefore still exactly the GAC
+                        // closure (stage 1 never removes anything GAC would
+                        // not), so the search is unchanged, though propagation
+                        // counts and proof shape differ from running GAC on
+                        // every wake.
+                        if (inference.did_anything_since_last_call_inside_propagator())
+                            return PropagatorState::Enable;
+                    }
+
+                    // Stage 2, expensive: full GAC via matching + SCCs.
                     propagate_gac_all_different(
                         constraint_id, vars, vals, vector<Integer>{}, *value_am1_constraint_numbers.get(), *scratch, state, inference, logger);
                     // Idempotent: one call prunes to the GAC closure. The
@@ -120,47 +214,26 @@ auto AllDifferent::install_propagators(Propagators & propagators) -> void
                     // what survives is exactly the union of maximum matchings,
                     // so a re-run deletes nothing (every remaining edge is in
                     // some maximum matching) and a matching still exists (no
-                    // contradiction). Duplicate scope variables never reach here
-                    // (prepare rejects them), and triggers are 1:1 with the
-                    // scope, so view aliasing is caught by the install-time
-                    // downgrade.
+                    // contradiction). Stage 1 cannot break the claim: the
+                    // closure has already removed every value a newly fixed
+                    // variable would push through the clique (an edge (y, v)
+                    // with x fixed to v is in no maximum matching), so a
+                    // re-run's stage 1 infers nothing. Duplicate scope
+                    // variables never reach here (prepare rejects them), and
+                    // triggers are 1:1 with the scope, so view aliasing is
+                    // caught by the install-time downgrade.
                     return PropagatorState::EnableButIdempotent;
                 },
                 triggers);
         },
         [&](const consistency::VC &) {
-            // Prebuild the per-variable "v == its single value" reason once, indexed by the
-            // variable's own SimpleIntegerVariableID index (offset by reason_base). This is a
-            // deferred ExactSingleValue, so it materialises to v == whatever value v is fixed
-            // to at the point of inference. It is constraint-owned (moved into the propagator
-            // closure), not backtracked: the table never changes during search. Views and
-            // constants get no entry and fall back to inline construction in the propagator.
-            unsigned long long reason_base = 0;
-            vector<Reason> reasons;
-            {
-                auto lo = ~0ull, hi = 0ull;
-                bool any_simple = false;
-                for (const auto & v : _sanitised_vars)
-                    if (auto s = std::get_if<SimpleIntegerVariableID>(&v)) {
-                        lo = std::min(lo, s->index);
-                        hi = std::max(hi, s->index);
-                        any_simple = true;
-                    }
-                if (any_simple) {
-                    reason_base = lo;
-                    reasons.resize(hi - lo + 1);
-                    for (const auto & v : _sanitised_vars)
-                        if (auto s = std::get_if<SimpleIntegerVariableID>(&v))
-                            reasons[s->index - lo] = Reason{ExactSingleValue{ReasonVars{vector<IntegerVariableID>{v}}}};
-                }
-            }
-
+            auto reasons = build_single_value_reasons(_sanitised_vars);
             propagators.install(
                 constraint_id(),
-                [unassigned_handle = _unassigned_handle, owner = constraint_id(), reasons = std::move(reasons), reason_base](
+                [unassigned_handle = _unassigned_handle, owner = constraint_id(), reasons = std::move(reasons)](
                     const State & state, auto & tracker, ProofLogger * const logger) -> PropagatorState {
                     if (! propagate_non_gac_alldifferent(
-                            unassigned_handle, state, tracker, logger, owner, reasons.empty() ? nullptr : &reasons, reason_base))
+                            unassigned_handle, state, tracker, logger, owner, reasons.table.empty() ? nullptr : &reasons.table, reasons.base))
                         return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
                     // Idempotent: the to_propagate worklist re-checks
                     // optional_single_value after every removal and processes the

--- a/gcs/constraints/all_different/all_different.hh
+++ b/gcs/constraints/all_different/all_different.hh
@@ -40,7 +40,8 @@ namespace gcs
         const std::vector<IntegerVariableID> _vars;
         std::vector<IntegerVariableID> _sanitised_vars;
         std::vector<Integer> _compressed_vals;             ///< consistency::GAC path
-        innards::ConstraintStateHandle _unassigned_handle; ///< consistency::VC path
+        innards::ConstraintStateHandle _unassigned_handle; ///< VC's whole propagator, staged GAC's cheap first stage
+        bool _gac_staged = false;                          ///< GAC path: big enough to stage? set in prepare()
         bool _has_duplicate_vars = false;
         AllDifferentConsistency _level = consistency::GAC{};
 

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -1174,7 +1174,7 @@ namespace
                         return PropagatorState::Enable;
 
                     propagate_default_product<Hint_>(*data, modulus_r, state, inference, logger, owner);
-                } while (inference.did_anything_since_last_call_inside_propagator());
+                } while (inference.made_progress_since_last_check());
 
                 // Idempotent: the do-while ran the stages (and the default product)
                 // to quiescence, so an immediate re-run is one no-op pass (see

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -190,7 +190,7 @@ auto Inverse::install_propagators(Propagators & propagators) -> void
                 }
 
                 propagate_gac_all_different(constraint_id, x, x_values, vector<Integer>{}, *x_value_am1s.get(), *scratch, state, inf, logger);
-            } while (inf.did_anything_since_last_call_inside_propagator());
+            } while (inf.made_progress_since_last_check());
 
             return PropagatorState::EnableButIdempotent;
         },

--- a/gcs/constraints/linear/propagate.cc
+++ b/gcs/constraints/linear/propagate.cc
@@ -260,7 +260,7 @@ auto gcs::innards::propagate_linear(const auto & coeff_vars, Integer value, cons
     // from last time, and after a clean inverse the forward's inputs (the
     // inverse's lower bounds) are, so either clean sweep proves the fixpoint. We
     // detect change with the tracker's non-destructive inference count rather
-    // than did_anything_since_last_call_inside_propagator(), because that flag
+    // than made_progress_since_last_check(), because that flag
     // is shared with the propagate_stages callers (multiply/divide/power run
     // their own do-while on it across all stages), so clearing it here would
     // corrupt their loop.
@@ -429,7 +429,7 @@ auto gcs::innards::propagate_linear_incremental(const auto & coeff_vars, Integer
     // idempotence -- see propagate_linear for the read/write reasoning (the
     // inverse writes the lower bounds the forward reads, so it can feed a
     // further forward tightening) and the same non-destructive change detection
-    // (the shared did_anything flag belongs to the propagate_stages callers).
+    // (the shared progress flag belongs to the propagate_stages callers).
     // lower_sum / inv_lower_sum are invariant within a sweep, so each is
     // recomputed at the sweep top from the current active-term bounds plus the
     // folded fixed_lower. An inequality does a single forward sweep, as before.

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -148,7 +148,7 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
         [product_data = product_data, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             do {
                 signed_multiply::propagate(*product_data, state, inference, logger, owner);
-            } while (inference.did_anything_since_last_call_inside_propagator());
+            } while (inference.made_progress_since_last_check());
             // Idempotent: the do-while ran signed_multiply::propagate to quiescence
             // (it exits only when a whole pass inferred nothing), so an immediate
             // re-run is a single no-op pass. This needs no 1:1-trigger / non-aliasing

--- a/gcs/constraints/power/power.cc
+++ b/gcs/constraints/power/power.cc
@@ -228,7 +228,7 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
 
                     for (auto & link : *links)
                         signed_multiply::propagate(link, state, inference, logger, owner);
-                } while (inference.did_anything_since_last_call_inside_propagator());
+                } while (inference.made_progress_since_last_check());
 
                 // Idempotent: the do-while ran the stages and multiply links to
                 // quiescence, so an immediate re-run is one no-op pass (see multiply.cc

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -34,7 +34,7 @@ namespace gcs::innards
     protected:
         State & _state;
         std::deque<std::pair<SimpleIntegerVariableID, Inference>> _inferences;
-        bool _did_anything_since_last_call_by_propagation_queue, _did_anything_since_last_call_inside_propagator;
+        bool _did_anything_since_last_call_by_propagation_queue, _made_progress_since_last_check;
         // Set when an inference yields a contradiction on the non-throwing
         // (infer_*_or_stop) path. The throwing infer* methods unwind instead, so
         // this is the signal the propagate loop checks for propagators that opt
@@ -106,7 +106,7 @@ namespace gcs::innards
                 .visit(lit);
 
             _did_anything_since_last_call_by_propagation_queue = true;
-            _did_anything_since_last_call_inside_propagator = true;
+            _made_progress_since_last_check = true;
         }
 
         // The JustifyExplicitly counterpart of track_impl. Lives in the base class
@@ -140,7 +140,7 @@ namespace gcs::innards
                     if (logger)
                         infer_explicitly(*logger, lit, why.emit, why.then_rup, materialise(reason, _state), why.hint, fallback);
                 _did_anything_since_last_call_by_propagation_queue = true;
-                _did_anything_since_last_call_inside_propagator = true;
+                _made_progress_since_last_check = true;
                 _contradicted = true;
                 if (do_throw)
                     throw TrackedPropagationFailed{};
@@ -150,7 +150,7 @@ namespace gcs::innards
 
     public:
         explicit InferenceTrackerBase(State & s) :
-            _state(s), _did_anything_since_last_call_by_propagation_queue(false), _did_anything_since_last_call_inside_propagator(false)
+            _state(s), _did_anything_since_last_call_by_propagation_queue(false), _made_progress_since_last_check(false)
         {
         }
 
@@ -590,10 +590,11 @@ namespace gcs::innards
         }
 
         // How many firing inferences have been recorded since the last reset().
-        // Unlike the did_anything_since_last_call_* flags, this is a
+        // Unlike the destructive progress-flag reads below, this is a
         // non-destructive read: the propagation queue brackets each propagator
         // run with it to attribute the run's (contiguous) inference range back
-        // to that propagator.
+        // to that propagator, and nested helpers use it for change detection
+        // without stealing anyone else's flag (see propagate_linear).
         [[nodiscard]] auto count_inferences() const -> std::size_t
         {
             return _inferences.size();
@@ -602,7 +603,7 @@ namespace gcs::innards
         auto reset() -> void
         {
             _inferences.clear();
-            _did_anything_since_last_call_inside_propagator = false;
+            _made_progress_since_last_check = false;
             _did_anything_since_last_call_by_propagation_queue = false;
         }
 
@@ -611,9 +612,27 @@ namespace gcs::innards
             return std::exchange(_did_anything_since_last_call_by_propagation_queue, false);
         }
 
-        auto did_anything_since_last_call_inside_propagator() -> bool
+        // Has this propagator inferred anything (or hit a contradiction) since
+        // its current run began, or since it last asked? A destructive read:
+        // asking clears the flag, so consecutive checks partition the run into
+        // windows. The propagation queue clears the flag before every run (via
+        // begin_propagator_run), so the first check never reports another
+        // propagator's leftovers -- everything the flag says is the caller's
+        // own work. There is only one flag per run, though: a helper that
+        // consumes it steals the edge from a check loop further up the same
+        // call stack, so a helper that may run under someone else's loop must
+        // bracket with count_inferences() instead (see propagate_linear).
+        [[nodiscard]] auto made_progress_since_last_check() -> bool
         {
-            return std::exchange(_did_anything_since_last_call_inside_propagator, false);
+            return std::exchange(_made_progress_since_last_check, false);
+        }
+
+        // Called by the propagation queue before each propagator run (including
+        // an idempotence-recheck re-run), so made_progress_since_last_check()
+        // starts every run with a clean window.
+        auto begin_propagator_run() -> void
+        {
+            _made_progress_since_last_check = false;
         }
     };
 
@@ -650,12 +669,12 @@ namespace gcs::innards
                     .visit(lit);
 
                 _did_anything_since_last_call_by_propagation_queue = true;
-                _did_anything_since_last_call_inside_propagator = true;
+                _made_progress_since_last_check = true;
                 break;
 
             [[unlikely]] case Inference::Contradiction:
                 _did_anything_since_last_call_by_propagation_queue = true;
-                _did_anything_since_last_call_inside_propagator = true;
+                _made_progress_since_last_check = true;
                 _contradicted = true;
                 if (do_throw)
                     throw TrackedPropagationFailed{};
@@ -705,14 +724,14 @@ namespace gcs::innards
                     .visit(lit);
 
                 _did_anything_since_last_call_by_propagation_queue = true;
-                _did_anything_since_last_call_inside_propagator = true;
+                _made_progress_since_last_check = true;
                 break;
 
             [[unlikely]] case Inference::Contradiction:
                 if (logger)
                     logger->infer(lit, just, materialise(reason, _state), assertion_hints);
                 _did_anything_since_last_call_by_propagation_queue = true;
-                _did_anything_since_last_call_inside_propagator = true;
+                _made_progress_since_last_check = true;
                 _contradicted = true;
                 if (do_throw)
                     throw TrackedPropagationFailed{};

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -66,6 +66,7 @@ namespace
         PropagationFunction & f, const State & state, Tracker_ & tracker, ProofLogger * const logger, const ConstraintID & id) -> void
     {
         const auto inferences_before_recheck = tracker.count_inferences();
+        tracker.begin_propagator_run();
         try {
             (void)f(state, tracker, logger);
         }
@@ -414,6 +415,7 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
             int propagator_id = _imp->queue[_imp->enqueued_begin++];
             try {
                 ++_imp->total_propagations;
+                tracker.begin_propagator_run();
                 auto propagator_state = _imp->propagation_functions[propagator_id](state, tracker, logger);
                 if (tracker.contradicted()) {
                     // A propagator that opted into the non-throwing failure path


### PR DESCRIPTION
Phase 2 of #522, stacked on #523: **staged propagation**. On each wake, a big-enough `AllDifferent` GAC propagator now runs the cheap value-consistency pass first — the same `propagate_non_gac_alldifferent` worklist, over the same backtrackable unassigned list, that the `consistency::VC` level uses — and only builds the matching/SCC state when that pass has reached its own fixpoint without inferring anything. This is the "staged" optimisation from Gent, Miguel & Nightingale's AIJ 2008 survey, adapted to this engine's round-based queue.

## Why the propagator still always runs to completion

This is the part that needs care: a staged propagator that skips the expensive stage must never let the engine reach a "fixpoint" that isn't actually GAC. The discipline:

- **A deferral always leads to another run.** When stage 1 infers anything, the propagator returns `Enable` with **no idempotence claim**, so the removals it just made — all on its own `on_change` trigger variables — requeue it at the round boundary. Other, cheaper propagators react to the removals first; the matching/SCC stage then runs once against the accumulated state instead of once per wake.
- **Deferrals are finite.** Each one strictly shrank a domain, so only finitely many can happen before a run falls through to stage 2. The engine cannot declare a fixpoint while the propagator keeps being requeued, so at every node's fixpoint the constraint is fully GAC — and stage 1 never removes anything GAC wouldn't, so the fixpoint (and hence the search) is exactly what it was before. This is the same fixpoint-uniqueness argument the engine itself documents for idempotence-claim replays (`propagators.cc`, round-boundary comment).
- **The progress flag.** Stage 2 is skipped only when stage 1 made no inference, detected via the tracker's progress flag. Originally the flag was a latch set by every inference from every propagator and cleared only when read, so this propagator had to open with a discarding read to avoid acting on another propagator's leftover `true` (which would have skipped stage 2 with no re-wake guaranteed). A later commit in this PR removes that trap at the source: the propagation queue now clears the flag before every propagator run, the read is renamed `made_progress_since_last_check()`, and the discard idiom is gone — the flag reports exactly the running propagator's own work. Search, propagation counts, and proofs unchanged.
- **The idempotence claim survives staging.** `EnableButIdempotent` stays on the stage-2 path only. A re-run's stage 1 infers nothing after a GAC run: the closure has already removed every value a newly fixed variable would push through the clique (an edge (y, v) with x fixed to v is in no maximum matching). Verified empirically with `GCS_CHECK_IDEMPOTENT_CLAIMS` (which re-runs every honoured claim and aborts if it infers) over the all_different/inverse/symmetric/arg_sort tests and langford.

## Gated by constraint size, like #523's sweep cutoff

A deferral splits one wake into two propagator invocations and adds an unassigned-list scan per wake, so it only pays when the deferred matching/SCC work is expensive. Measured on the vars × values product: **726** (langford_11, 22×33) is **1.35× faster** staged, while **100** (QWH qg7, 10×10) was ~2% *slower* (+2.4% propagator invocations for nothing — a 10×10 matching is too cheap to be worth deferring). Staging is therefore gated on `vars × values >= 256` (`min_var_val_pairs_for_staged_gac`, rounded geometric mean of the measured points). Below the gate the propagator body and behaviour are exactly as on the base branch — qg7's propagation counts match to the last digit — and no unassigned constraint state is registered either, so small alldifferents don't even pay trailing costs.

## Scope

Only `AllDifferent`'s GAC arm is staged. `AllDifferentExcept` is deliberately excluded — its excluded values are shareable, so the clique pass is unsound there. `Inverse`/`SymmetricAllDifferent`/`ArgSort` already run their own cheap channelling stages ahead of the GAC call and have bespoke idempotence claims; left alone. The per-variable single-value reasons table the VC arm built inline is factored into `build_single_value_reasons` and shared by both arms.

## What changes and what doesn't

Unlike #523 (byte-identical proofs), staging changes *when* inferences happen and *which* justification they carry, by design: some deletions that used to be GAC trivial-SCC RUPs are now cheap-pass RUPs (same reason shape, "other variable == value"), and propagation counts differ on staged constraints. What must not change is the search:

- `recursions` and `solutions` identical on every benchmark below (langford_11: 256593 / 35584; qg7-08: 4891 nodes).
- The all_different test's **per-node GAC checking** (`solve_for_tests_checking_gac`) passes with `GCS_TEST_CAP_DEFAULTS=OFF` (3 runs, fresh seeds) — direct verification that every search node still reaches the full GAC closure.
- 510/510 ctest (includes the veripb-verified proof tests). `langford --size=8 --prove` (16×16 = 256, so genuinely staged) verifies end-to-end — "VERIFIED COMPLETE ENUMERATION OF 300 SOLUTIONS" — with the staged proof 6% smaller (3.91 MB vs 4.17 MB).

## Measurements

Baseline = #523 tip (`31dfce7f`); `taskset -c 4`, 3 trials, median solve time. langford_11 is the only benchmark in the set that posts a big-enough GAC AllDifferent (ortho_latin's default mode is pairwise not-equals; n_queens/qap likewise; magic_series/magic_square/tsp post none), so the other seven rows are no-regression controls — all with bit-identical propagation counts.

| benchmark | baseline (s) | after (s) | ratio | recursions/solutions | propagations (total/effectful) |
|---|--:|--:|--:|---|---|
| langford_11 | 5.62 | 4.14 | **1.36×** | identical | 29.8M/4.50M → 29.2M/4.01M |
| ortho_latin_6_all | 23.41 | 23.28 | 1.01× | identical | identical |
| qap_12 | 1.74 | 1.74 | 1.00× | identical | identical |
| magic_series_300 | 4.94 | 4.99 | 0.99× | identical | identical |
| magic_square_5 | 17.22 | 17.20 | 1.00× | identical | identical |
| tsp_default | 10.52 | 10.37 | 1.01× | identical | identical |
| n_queens_14_all | 11.97 | 11.99 | 1.00× | identical | identical |
| n_queens_88 | 215.43 | 215.74 | 1.00× | identical | identical |

QWH (below the gate — checks the gate removes the regression; interleaved, median of 3):

| instance | baseline | after | note |
|---|--:|--:|---|
| qg7-08 full run | 0.282 s | 0.281 s | nodes and propagation counts identical (gate off) |
| qg7-10, nodes in 30 s | 253346 | 252680 | −0.3%, noise |

Post-gate langford_11 re-measurement (interleaved): 5.64 s → 4.17 s, consistent with the sweep.

Cumulative over the whole #522 stack (#523 + this), against the original `domains-intersect-fastpath` baseline: langford_11 **7.88 s → 4.17 s (1.89×)**.

## What's next (not this PR)

Phase 3 of #522 (SCC-incremental processing across the search, ~10× in the survey) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARYiwRGLg4vXRtgMr1VKAv

