### PR TITLE
tests: default to running all modes when none is given

### DIFF
--- a/gcs/constraints/comparison/comparison_test.cc
+++ b/gcs/constraints/comparison/comparison_test.cc
@@ -227,17 +227,20 @@ auto run_dup_reif_binary_comparison_test(
 
 auto main(int argc, char * argv[]) -> int
 {
-    // Mode is the first non-flag positional; --view-* flags may follow.
-    string mode;
+    // Mode is the first non-flag positional; --view-* flags may follow. With no
+    // mode given (a manual run rather than the ctest harness) run every mode.
+    string requested_mode;
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
         if (! a.starts_with("--")) {
-            mode = a;
+            requested_mode = a;
             break;
         }
     }
-    if (mode.empty())
-        throw UnimplementedException{};
+    // Keep in sync with the if-chain below and the comparison_constraint_${mode}
+    // foreach in gcs/CMakeLists.txt.
+    const vector<string> all_modes = {"lt", "lt_if", "lt_iff", "le", "le_if", "le_iff", "gt", "gt_if", "gt_iff", "ge", "ge_if", "ge_iff"};
+    const vector<string> modes = requested_mode.empty() ? all_modes : vector<string>{requested_mode};
 
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
@@ -279,96 +282,98 @@ auto main(int argc, char * argv[]) -> int
     for (int x = 0; x < 10; ++x)
         generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_constant(-10, 10));
 
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
-            continue;
-        for (auto & [r1, r2] : data) {
-            if (mode == "lt") {
-                run_binary_comparison_test<LessThan>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a < b; });
-            }
-            else if (mode == "lt_if") {
-                run_reif_binary_comparison_test<LessThanIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a < b; }, false);
-            }
-            else if (mode == "lt_iff") {
-                run_reif_binary_comparison_test<LessThanIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a < b; }, true);
-            }
-            else if (mode == "le") {
-                run_binary_comparison_test<LessThanEqual>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a <= b; });
-            }
-            else if (mode == "le_if") {
-                run_reif_binary_comparison_test<LessThanEqualIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a <= b; }, false);
-            }
-            else if (mode == "le_iff") {
-                run_reif_binary_comparison_test<LessThanEqualIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a <= b; }, true);
-            }
-            else if (mode == "gt") {
-                run_binary_comparison_test<GreaterThan>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a > b; });
-            }
-            else if (mode == "gt_if") {
-                run_reif_binary_comparison_test<GreaterThanIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a > b; }, false);
-            }
-            else if (mode == "gt_iff") {
-                run_reif_binary_comparison_test<GreaterThanIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a > b; }, true);
-            }
-            else if (mode == "ge") {
-                run_binary_comparison_test<GreaterThanEqual>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a >= b; });
-            }
-            else if (mode == "ge_if") {
-                run_reif_binary_comparison_test<GreaterThanEqualIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a >= b; }, false);
-            }
-            else if (mode == "ge_iff") {
-                run_reif_binary_comparison_test<GreaterThanEqualIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a >= b; }, true);
-            }
-            else
-                throw UnimplementedException{};
-        }
-
-        // Dup-variable cases. lt/gt themselves throw (Bucket A — covered
-        // separately); lt_if/gt_if were Bucket B (propagator weak on alias)
-        // and are now fixed via the alias check in
-        // ReifiedCompareLessThanOrMaybeEqual's infer_cond_when_undecided.
-        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
-            vector<pair<int, int>> dup_data = {{0, 0}, {0, 5}, {-3, 3}, {2, 5}};
-            for (auto & xr : dup_data) {
-                if (mode == "le")
-                    run_dup_binary_comparison_test<LessThanEqual>(proofs, mode, xr, [](int) { return true; });
-                else if (mode == "ge")
-                    run_dup_binary_comparison_test<GreaterThanEqual>(proofs, mode, xr, [](int) { return true; });
-                else if (mode == "le_if")
-                    run_dup_reif_binary_comparison_test<LessThanEqualIf>(proofs, mode, xr, [](int, int) { return true; });
-                else if (mode == "ge_if")
-                    run_dup_reif_binary_comparison_test<GreaterThanEqualIf>(proofs, mode, xr, [](int, int) { return true; });
-                else if (mode == "lt_if")
-                    // LessThanIf(x, x, c) ≡ c → x<x ≡ ¬c.
-                    run_dup_reif_binary_comparison_test<LessThanIf>(proofs, mode, xr, [](int, int c) { return c == 0; });
-                else if (mode == "gt_if")
-                    // GreaterThanIf(x, x, c) ≡ c → x>x ≡ ¬c.
-                    run_dup_reif_binary_comparison_test<GreaterThanIf>(proofs, mode, xr, [](int, int c) { return c == 0; });
-                else if (mode == "lt_iff")
-                    run_dup_reif_binary_comparison_test<LessThanIff>(proofs, mode, xr, [](int, int c) { return c == 0; });
-                else if (mode == "le_iff")
-                    run_dup_reif_binary_comparison_test<LessThanEqualIff>(proofs, mode, xr, [](int, int c) { return c == 1; });
-                else if (mode == "gt_iff")
-                    run_dup_reif_binary_comparison_test<GreaterThanIff>(proofs, mode, xr, [](int, int c) { return c == 0; });
-                else if (mode == "ge_iff")
-                    run_dup_reif_binary_comparison_test<GreaterThanEqualIff>(proofs, mode, xr, [](int, int c) { return c == 1; });
-                // else: lt, gt — Bucket A throw, no dup test
-            }
-
-            // lt, gt on aliased operands are trivially unsat: reject at
-            // construction. Only check once per binary, not per view-cfg.
-            if (mode == "lt" || mode == "gt") {
-                Problem ep;
-                auto x = ep.create_integer_variable(Integer{0}, Integer{3});
-                try {
-                    if (mode == "lt")
-                        ep.post(LessThan{x, x});
-                    else
-                        ep.post(GreaterThan{x, x});
-                    cerr << "expected " << mode << "(x,x) to throw InvalidProblemDefinitionException" << '\n';
-                    return EXIT_FAILURE;
+    for (const auto & mode : modes) {
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            for (auto & [r1, r2] : data) {
+                if (mode == "lt") {
+                    run_binary_comparison_test<LessThan>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a < b; });
                 }
-                catch (const InvalidProblemDefinitionException &) {
+                else if (mode == "lt_if") {
+                    run_reif_binary_comparison_test<LessThanIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a < b; }, false);
+                }
+                else if (mode == "lt_iff") {
+                    run_reif_binary_comparison_test<LessThanIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a < b; }, true);
+                }
+                else if (mode == "le") {
+                    run_binary_comparison_test<LessThanEqual>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a <= b; });
+                }
+                else if (mode == "le_if") {
+                    run_reif_binary_comparison_test<LessThanEqualIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a <= b; }, false);
+                }
+                else if (mode == "le_iff") {
+                    run_reif_binary_comparison_test<LessThanEqualIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a <= b; }, true);
+                }
+                else if (mode == "gt") {
+                    run_binary_comparison_test<GreaterThan>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a > b; });
+                }
+                else if (mode == "gt_if") {
+                    run_reif_binary_comparison_test<GreaterThanIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a > b; }, false);
+                }
+                else if (mode == "gt_iff") {
+                    run_reif_binary_comparison_test<GreaterThanIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a > b; }, true);
+                }
+                else if (mode == "ge") {
+                    run_binary_comparison_test<GreaterThanEqual>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a >= b; });
+                }
+                else if (mode == "ge_if") {
+                    run_reif_binary_comparison_test<GreaterThanEqualIf>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a >= b; }, false);
+                }
+                else if (mode == "ge_iff") {
+                    run_reif_binary_comparison_test<GreaterThanEqualIff>(proofs, mode, view_cfg, r1, r2, [](int a, int b) { return a >= b; }, true);
+                }
+                else
+                    throw UnimplementedException{};
+            }
+
+            // Dup-variable cases. lt/gt themselves throw (Bucket A — covered
+            // separately); lt_if/gt_if were Bucket B (propagator weak on alias)
+            // and are now fixed via the alias check in
+            // ReifiedCompareLessThanOrMaybeEqual's infer_cond_when_undecided.
+            if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+                vector<pair<int, int>> dup_data = {{0, 0}, {0, 5}, {-3, 3}, {2, 5}};
+                for (auto & xr : dup_data) {
+                    if (mode == "le")
+                        run_dup_binary_comparison_test<LessThanEqual>(proofs, mode, xr, [](int) { return true; });
+                    else if (mode == "ge")
+                        run_dup_binary_comparison_test<GreaterThanEqual>(proofs, mode, xr, [](int) { return true; });
+                    else if (mode == "le_if")
+                        run_dup_reif_binary_comparison_test<LessThanEqualIf>(proofs, mode, xr, [](int, int) { return true; });
+                    else if (mode == "ge_if")
+                        run_dup_reif_binary_comparison_test<GreaterThanEqualIf>(proofs, mode, xr, [](int, int) { return true; });
+                    else if (mode == "lt_if")
+                        // LessThanIf(x, x, c) ≡ c → x<x ≡ ¬c.
+                        run_dup_reif_binary_comparison_test<LessThanIf>(proofs, mode, xr, [](int, int c) { return c == 0; });
+                    else if (mode == "gt_if")
+                        // GreaterThanIf(x, x, c) ≡ c → x>x ≡ ¬c.
+                        run_dup_reif_binary_comparison_test<GreaterThanIf>(proofs, mode, xr, [](int, int c) { return c == 0; });
+                    else if (mode == "lt_iff")
+                        run_dup_reif_binary_comparison_test<LessThanIff>(proofs, mode, xr, [](int, int c) { return c == 0; });
+                    else if (mode == "le_iff")
+                        run_dup_reif_binary_comparison_test<LessThanEqualIff>(proofs, mode, xr, [](int, int c) { return c == 1; });
+                    else if (mode == "gt_iff")
+                        run_dup_reif_binary_comparison_test<GreaterThanIff>(proofs, mode, xr, [](int, int c) { return c == 0; });
+                    else if (mode == "ge_iff")
+                        run_dup_reif_binary_comparison_test<GreaterThanEqualIff>(proofs, mode, xr, [](int, int c) { return c == 1; });
+                    // else: lt, gt — Bucket A throw, no dup test
+                }
+
+                // lt, gt on aliased operands are trivially unsat: reject at
+                // construction. Only check once per binary, not per view-cfg.
+                if (mode == "lt" || mode == "gt") {
+                    Problem ep;
+                    auto x = ep.create_integer_variable(Integer{0}, Integer{3});
+                    try {
+                        if (mode == "lt")
+                            ep.post(LessThan{x, x});
+                        else
+                            ep.post(GreaterThan{x, x});
+                        cerr << "expected " << mode << "(x,x) to throw InvalidProblemDefinitionException" << '\n';
+                        return EXIT_FAILURE;
+                    }
+                    catch (const InvalidProblemDefinitionException &) {
+                    }
                 }
             }
         }

--- a/gcs/constraints/disjunctive/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_test.cc
@@ -281,17 +281,20 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
-    if (argc < 2)
-        throw UnimplementedException{};
-
-    string mode{argv[1]};
-    bool strict;
-    if (mode == "strict")
-        strict = true;
-    else if (mode == "nonstrict")
-        strict = false;
-    else
-        throw UnimplementedException{};
+    // Mode is the first non-flag positional; --view-* flags may follow. With no
+    // mode given (a manual run rather than the ctest harness) run every mode.
+    string requested_mode;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (! a.starts_with("--")) {
+            requested_mode = a;
+            break;
+        }
+    }
+    // Keep in sync with the strict/nonstrict dispatch below and the matching
+    // foreach(mode ...) in gcs/CMakeLists.txt.
+    const vector<string> all_modes = {"strict", "nonstrict"};
+    const vector<string> modes = requested_mode.empty() ? all_modes : vector<string>{requested_mode};
 
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
@@ -417,33 +420,43 @@ auto main(int argc, char * argv[]) -> int
         {{1, 0}, {{0, 2}, {2, 2}}},
     };
 
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
-            continue;
-        for (auto & [sr, lens] : data)
-            run_disjunctive_test(proofs, mode, strict, view_cfg, sr, lens);
+    for (const auto & mode : modes) {
+        bool strict;
+        if (mode == "strict")
+            strict = true;
+        else if (mode == "nonstrict")
+            strict = false;
+        else
+            throw UnimplementedException{};
 
-        // Variable-duration cases run in both modes, only when not view-wrapping
-        // (these runners create bare variables), to avoid duplicating coverage
-        // under every wrap.
-        if (run_dup) {
-            for (auto & [sr, ls] : var_data)
-                run_var_disjunctive_test(proofs, mode, strict, sr, ls);
-            for (auto & [cs, ls] : cstart_data)
-                run_const_start_var_len_test(proofs, mode, strict, cs, ls);
-        }
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            for (auto & [sr, lens] : data)
+                run_disjunctive_test(proofs, mode, strict, view_cfg, sr, lens);
 
-        // Dup tests use bare variables (the harness duplicates a handle into
-        // several task positions); only run them when no wrapping is in
-        // effect, to avoid duplicating the bare coverage under every wrap.
-        if (run_dup) {
-            // Two tasks sharing a start var: positive lengths ⇒ UNSAT,
-            // zero lengths ⇒ depends on strict.
-            run_dup_disjunctive_test(proofs, mode, strict, {{0, 3}}, {0, 0}, {2, 2});
-            // {x, x, y} — first two share, third independent.
-            run_dup_disjunctive_test(proofs, mode, strict, {{0, 3}, {0, 3}}, {0, 0, 1}, {1, 1, 2});
-            // Zero-length dup pair — non-strict OK, strict edge case.
-            run_dup_disjunctive_test(proofs, mode, strict, {{0, 2}}, {0, 0}, {0, 0});
+            // Variable-duration cases run in both modes, only when not view-wrapping
+            // (these runners create bare variables), to avoid duplicating coverage
+            // under every wrap.
+            if (run_dup) {
+                for (auto & [sr, ls] : var_data)
+                    run_var_disjunctive_test(proofs, mode, strict, sr, ls);
+                for (auto & [cs, ls] : cstart_data)
+                    run_const_start_var_len_test(proofs, mode, strict, cs, ls);
+            }
+
+            // Dup tests use bare variables (the harness duplicates a handle into
+            // several task positions); only run them when no wrapping is in
+            // effect, to avoid duplicating the bare coverage under every wrap.
+            if (run_dup) {
+                // Two tasks sharing a start var: positive lengths ⇒ UNSAT,
+                // zero lengths ⇒ depends on strict.
+                run_dup_disjunctive_test(proofs, mode, strict, {{0, 3}}, {0, 0}, {2, 2});
+                // {x, x, y} — first two share, third independent.
+                run_dup_disjunctive_test(proofs, mode, strict, {{0, 3}, {0, 3}}, {0, 0, 1}, {1, 1, 2});
+                // Zero-length dup pair — non-strict OK, strict edge case.
+                run_dup_disjunctive_test(proofs, mode, strict, {{0, 2}}, {0, 0}, {0, 0});
+            }
         }
     }
 

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
@@ -261,17 +261,20 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
-    if (argc != 2)
-        throw UnimplementedException{};
-
-    string mode{argv[1]};
-    bool strict;
-    if (mode == "strict")
-        strict = true;
-    else if (mode == "nonstrict")
-        strict = false;
-    else
-        throw UnimplementedException{};
+    // Mode is the first non-flag positional. With no mode given (a manual run
+    // rather than the ctest harness) run every mode.
+    string requested_mode;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (! a.starts_with("--")) {
+            requested_mode = a;
+            break;
+        }
+    }
+    // Keep in sync with the strict/nonstrict dispatch below and the matching
+    // foreach(mode ...) in gcs/CMakeLists.txt.
+    const vector<string> all_modes = {"strict", "nonstrict"};
+    const vector<string> modes = requested_mode.empty() ? all_modes : vector<string>{requested_mode};
 
     // Each test: { x_ranges, y_ranges, widths, heights }
     vector<tuple<vector<pair<int, int>>, vector<pair<int, int>>, vector<int>, vector<int>>> data = {
@@ -327,39 +330,49 @@ auto main(int argc, char * argv[]) -> int
     for (int k = 0; k < 10; ++k)
         data.push_back(random_instance(3, 3, 3));
 
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
-            continue;
-        int idx = 0;
-        for (auto & [xr, yr, w, h] : data)
-            run_disjunctive_2d_test(proofs, mode, strict, "d" + std::to_string(idx++), xr, yr, w, h);
+    for (const auto & mode : modes) {
+        bool strict;
+        if (mode == "strict")
+            strict = true;
+        else if (mode == "nonstrict")
+            strict = false;
+        else
+            throw UnimplementedException{};
 
-        // Two rectangles share an x handle: they may still separate in y.
-        run_dup_disjunctive_2d_test(proofs, mode, strict, {{0, 2}}, {{0, 2}, {0, 2}}, {0, 0}, {2, 2}, {1, 1});
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            int idx = 0;
+            for (auto & [xr, yr, w, h] : data)
+                run_disjunctive_2d_test(proofs, mode, strict, "d" + std::to_string(idx++), xr, yr, w, h);
 
-        // Variable rectangle sizes (rotation-style). {lo, hi} with lo < hi is a
-        // variable size; lo == hi a constant.
-        // Two squares with variable side 1..2.
-        run_disjunctive_2d_var_test(proofs, mode, strict, "sq", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{1, 2}, {1, 2}}, {{1, 2}, {1, 2}});
-        // Rotation: a 1x2 / 2x1 rectangle whose orientation varies (width and
-        // height swap), alongside a fixed unit square.
-        run_disjunctive_2d_var_test(proofs, mode, strict, "rot", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{1, 2}, {1, 1}}, {{1, 2}, {1, 1}});
-        // Mixed: one fixed rectangle, one with variable width only.
-        run_disjunctive_2d_var_test(proofs, mode, strict, "mixed", {{0, 3}, {0, 3}}, {{0, 2}, {0, 2}}, {{2, 2}, {1, 3}}, {{1, 1}, {2, 2}});
-        // Forced overlap: two rectangles pinned to the origin with variable
-        // sizes >= 1 always overlap -> UNSAT, exercising the variable-size
-        // contradiction proof.
-        run_disjunctive_2d_var_test(proofs, mode, strict, "clash", {{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {{1, 2}, {1, 2}}, {{1, 2}, {1, 2}});
-        // Near-clash: small position freedom with variable sizes, forcing both
-        // contradictions and pushes.
-        run_disjunctive_2d_var_test(proofs, mode, strict, "tight", {{0, 1}, {0, 1}}, {{0, 1}, {0, 1}}, {{2, 2}, {1, 2}}, {{2, 2}, {1, 2}});
-        // Wider value ranges so we exercise the end-proxy bit encoding.
-        run_disjunctive_2d_var_test(proofs, mode, strict, "wide", {{0, 4}, {0, 4}}, {{0, 3}, {0, 3}}, {{2, 4}, {1, 3}}, {{1, 3}, {2, 4}});
-        // A possibly-zero variable size (strict: the size==0 rect still respects
-        // the clause; non-strict: it escapes via the zero-size disjunct).
-        run_disjunctive_2d_var_test(proofs, mode, strict, "zero", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {2, 2}}, {{2, 2}, {1, 2}});
-        // Both rectangles can be zero-area on either axis.
-        run_disjunctive_2d_var_test(proofs, mode, strict, "zero2", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}});
+            // Two rectangles share an x handle: they may still separate in y.
+            run_dup_disjunctive_2d_test(proofs, mode, strict, {{0, 2}}, {{0, 2}, {0, 2}}, {0, 0}, {2, 2}, {1, 1});
+
+            // Variable rectangle sizes (rotation-style). {lo, hi} with lo < hi is a
+            // variable size; lo == hi a constant.
+            // Two squares with variable side 1..2.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "sq", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{1, 2}, {1, 2}}, {{1, 2}, {1, 2}});
+            // Rotation: a 1x2 / 2x1 rectangle whose orientation varies (width and
+            // height swap), alongside a fixed unit square.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "rot", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{1, 2}, {1, 1}}, {{1, 2}, {1, 1}});
+            // Mixed: one fixed rectangle, one with variable width only.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "mixed", {{0, 3}, {0, 3}}, {{0, 2}, {0, 2}}, {{2, 2}, {1, 3}}, {{1, 1}, {2, 2}});
+            // Forced overlap: two rectangles pinned to the origin with variable
+            // sizes >= 1 always overlap -> UNSAT, exercising the variable-size
+            // contradiction proof.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "clash", {{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {{1, 2}, {1, 2}}, {{1, 2}, {1, 2}});
+            // Near-clash: small position freedom with variable sizes, forcing both
+            // contradictions and pushes.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "tight", {{0, 1}, {0, 1}}, {{0, 1}, {0, 1}}, {{2, 2}, {1, 2}}, {{2, 2}, {1, 2}});
+            // Wider value ranges so we exercise the end-proxy bit encoding.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "wide", {{0, 4}, {0, 4}}, {{0, 3}, {0, 3}}, {{2, 4}, {1, 3}}, {{1, 3}, {2, 4}});
+            // A possibly-zero variable size (strict: the size==0 rect still respects
+            // the clause; non-strict: it escapes via the zero-size disjunct).
+            run_disjunctive_2d_var_test(proofs, mode, strict, "zero", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {2, 2}}, {{2, 2}, {1, 2}});
+            // Both rectangles can be zero-area on either axis.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "zero2", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}});
+        }
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/element/element_test.cc
+++ b/gcs/constraints/element/element_test.cc
@@ -231,21 +231,22 @@ auto run_dup_element_test(bool proofs, const string & label, const vector<pair<i
 
 auto main(int argc, char * argv[]) -> int
 {
-    if (argc < 2)
-        throw UnimplementedException{};
-
-    string mode{argv[1]};
-    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
-
-    // Position layout per mode: var, then the index variable(s), then the
-    // array entries (only when the array is itself made of variables). The
-    // skip bound matches the registered n_positions for each mode.
-    int n_positions = (mode == "const") ? 2 : (mode == "const2d") ? 3 : (mode == "var2d") ? 5 : 6;
-    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
-        println(cerr, "element view sweep: position {} out of range for n_positions = {}; skipping", *view_cfg.single_position, n_positions);
-        return EXIT_SUCCESS;
+    // Mode is the first non-flag positional; --view-* flags may follow. With no
+    // mode given (a manual run rather than the ctest harness) run every mode.
+    string requested_mode;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (! a.starts_with("--")) {
+            requested_mode = a;
+            break;
+        }
     }
-    bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+    // Keep in sync with the mode dispatch below and the matching foreach(mode ...)
+    // in gcs/CMakeLists.txt.
+    const vector<string> all_modes = {"var", "const", "const2d", "var2d"};
+    const vector<string> modes = requested_mode.empty() ? all_modes : vector<string>{requested_mode};
+
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     vector<tuple<pair<int, int>, pair<int, int>, vector<pair<int, int>>>> var_data = {{{1, 2}, {0, 1}, {{1, 2}, {1, 2}}}, //
         {{1, 2}, {-2, 2}, {{1, 2}, {1, 2}}},                                                                              //
@@ -324,40 +325,52 @@ auto main(int argc, char * argv[]) -> int
             vector{size_t(n_values_1), vector{size_t(n_values_2), random_bounds(-3, 3, 0, 3)}});
     }
 
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
+    for (const auto & mode : modes) {
+        // Position layout per mode: var, then the index variable(s), then the
+        // array entries (only when the array is itself made of variables). The
+        // skip bound matches the registered n_positions for each mode.
+        int n_positions = (mode == "const") ? 2 : (mode == "const2d") ? 3 : (mode == "var2d") ? 5 : 6;
+        if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+            println(cerr, "element view sweep: position {} out of range for n_positions = {}; skipping", *view_cfg.single_position, n_positions);
             continue;
-        if (mode == "var") {
-            for (auto & [r1, r2, r3] : var_data)
-                run_element_test(proofs, mode, view_cfg, r1, r2, r3);
+        }
+        bool run_dup = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
 
-            if (run_dup) {
-                // Dup-variable cases.
-                // [x, y, x] — same handle at non-adjacent positions.
-                run_dup_element_test(proofs, "xyx", {{1, 3}, {1, 3}}, {0, 1, 0}, {0, 2}, -1);
-                // [x, x] — same handle at adjacent positions.
-                run_dup_element_test(proofs, "xx", {{1, 3}}, {0, 0}, {0, 1}, -1);
-                // [x, y, x] but result is x — forces idx-selected value = x.
-                run_dup_element_test(proofs, "xyx_resx", {{1, 3}, {1, 3}}, {0, 1, 0}, {0, 2}, 0);
-                // [x, y] with result = x — forces array[idx] = x, i.e. either
-                // idx=0 (trivial) or idx=1 and y = x.
-                run_dup_element_test(proofs, "xy_resx", {{1, 3}, {1, 3}}, {0, 1}, {0, 1}, 0);
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            if (mode == "var") {
+                for (auto & [r1, r2, r3] : var_data)
+                    run_element_test(proofs, mode, view_cfg, r1, r2, r3);
+
+                if (run_dup) {
+                    // Dup-variable cases.
+                    // [x, y, x] — same handle at non-adjacent positions.
+                    run_dup_element_test(proofs, "xyx", {{1, 3}, {1, 3}}, {0, 1, 0}, {0, 2}, -1);
+                    // [x, x] — same handle at adjacent positions.
+                    run_dup_element_test(proofs, "xx", {{1, 3}}, {0, 0}, {0, 1}, -1);
+                    // [x, y, x] but result is x — forces idx-selected value = x.
+                    run_dup_element_test(proofs, "xyx_resx", {{1, 3}, {1, 3}}, {0, 1, 0}, {0, 2}, 0);
+                    // [x, y] with result = x — forces array[idx] = x, i.e. either
+                    // idx=0 (trivial) or idx=1 and y = x.
+                    run_dup_element_test(proofs, "xy_resx", {{1, 3}, {1, 3}}, {0, 1}, {0, 1}, 0);
+                }
             }
+            else if (mode == "const") {
+                for (auto & [r1, r2, r3] : const_data)
+                    run_element_constant_test(proofs, mode, view_cfg, r1, r2, r3);
+            }
+            else if (mode == "const2d") {
+                for (auto & [r1, r2, r3, r4] : const2d_data)
+                    run_element2d_constant_test(proofs, mode, view_cfg, r1, r2, r3, r4);
+            }
+            else if (mode == "var2d") {
+                for (auto & [r1, r2, r3, r4] : var2d_data)
+                    run_element2d_test(proofs, mode, view_cfg, r1, r2, r3, r4);
+            }
+            else
+                throw UnimplementedException{};
         }
-        else if (mode == "const") {
-            for (auto & [r1, r2, r3] : const_data)
-                run_element_constant_test(proofs, mode, view_cfg, r1, r2, r3);
-        }
-        else if (mode == "const2d") {
-            for (auto & [r1, r2, r3, r4] : const2d_data)
-                run_element2d_constant_test(proofs, mode, view_cfg, r1, r2, r3, r4);
-        }
-        else if (mode == "var2d") {
-            for (auto & [r1, r2, r3, r4] : var2d_data)
-                run_element2d_test(proofs, mode, view_cfg, r1, r2, r3, r4);
-        }
-        else
-            throw UnimplementedException{};
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -298,16 +298,20 @@ auto run_dup_linear_test(bool proofs, const string & mode, pair<int, int> a_rang
 
 auto main(int argc, char * argv[]) -> int
 {
-    string mode;
+    // Mode is the first non-flag positional; --view-* flags may follow. With no
+    // mode given (a manual run rather than the ctest harness) run every mode.
+    string requested_mode;
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
         if (! a.starts_with("--")) {
-            mode = a;
+            requested_mode = a;
             break;
         }
     }
-    if (mode.empty())
-        throw UnimplementedException{};
+    // Keep in sync with the if-chain below and the matching foreach(mode ...) in
+    // gcs/CMakeLists.txt.
+    const vector<string> all_modes = {"eq", "eq_if", "eq_iff", "ne", "ne_if", "ne_iff", "le", "le_if", "le_iff", "ge", "ge_if", "ge_iff"};
+    const vector<string> modes = requested_mode.empty() ? all_modes : vector<string>{requested_mode};
 
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
@@ -355,80 +359,86 @@ auto main(int argc, char * argv[]) -> int
         generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15),
             vector(nc_dist(rand), pair{vector(3, uniform_int_distribution(-10, 10)), uniform_int_distribution(-200, 200)}));
 
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
-            continue;
-        for (auto & [r1, r2, r3, constraints] : data) {
-            if (mode == "eq") {
-                run_linear_test<LinearEquality>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
-                run_linear_test_gac<LinearEquality>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
+    for (const auto & mode : modes) {
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            for (auto & [r1, r2, r3, constraints] : data) {
+                if (mode == "eq") {
+                    run_linear_test<LinearEquality>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
+                    run_linear_test_gac<LinearEquality>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
+                }
+                else if (mode == "eq_if") {
+                    run_linear_reif_test<LinearEqualityIf>(
+                        false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
+                    run_linear_reif_test_gac<LinearEqualityIf>(
+                        false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
+                }
+                else if (mode == "eq_iff") {
+                    run_linear_reif_test<LinearEqualityIff>(
+                        true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
+                    run_linear_reif_test_gac<LinearEqualityIff>(
+                        true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
+                }
+                else if (mode == "ne") {
+                    run_linear_test<LinearNotEquals>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
+                    run_linear_test_gac<LinearNotEquals>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
+                }
+                else if (mode == "ne_if") {
+                    run_linear_reif_test<LinearNotEqualsIf>(
+                        false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
+                    run_linear_reif_test_gac<LinearNotEqualsIf>(
+                        false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
+                }
+                else if (mode == "ne_iff") {
+                    run_linear_reif_test<LinearNotEqualsIff>(
+                        true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
+                    run_linear_reif_test_gac<LinearNotEqualsIff>(
+                        true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
+                }
+                else if (mode == "le") {
+                    run_linear_test<LinearLessThanEqual>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a <= b; });
+                }
+                else if (mode == "le_if") {
+                    run_linear_reif_test<LinearLessThanEqualIf>(
+                        false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a <= b; });
+                }
+                else if (mode == "le_iff") {
+                    run_linear_reif_test<LinearLessThanEqualIff>(
+                        true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a <= b; });
+                }
+                else if (mode == "ge") {
+                    run_linear_test<LinearGreaterThanEqual>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a >= b; });
+                }
+                else if (mode == "ge_if") {
+                    run_linear_reif_test<LinearGreaterThanEqualIf>(
+                        false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a >= b; });
+                }
+                else if (mode == "ge_iff") {
+                    run_linear_reif_test<LinearGreaterThanEqualIff>(
+                        true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a >= b; });
+                }
+                else
+                    throw UnimplementedException{};
             }
-            else if (mode == "eq_if") {
-                run_linear_reif_test<LinearEqualityIf>(false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
-                run_linear_reif_test_gac<LinearEqualityIf>(
-                    false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
-            }
-            else if (mode == "eq_iff") {
-                run_linear_reif_test<LinearEqualityIff>(true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
-                run_linear_reif_test_gac<LinearEqualityIff>(
-                    true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a == b; });
-            }
-            else if (mode == "ne") {
-                run_linear_test<LinearNotEquals>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
-                run_linear_test_gac<LinearNotEquals>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
-            }
-            else if (mode == "ne_if") {
-                run_linear_reif_test<LinearNotEqualsIf>(false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
-                run_linear_reif_test_gac<LinearNotEqualsIf>(
-                    false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
-            }
-            else if (mode == "ne_iff") {
-                run_linear_reif_test<LinearNotEqualsIff>(true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
-                run_linear_reif_test_gac<LinearNotEqualsIff>(
-                    true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a != b; });
-            }
-            else if (mode == "le") {
-                run_linear_test<LinearLessThanEqual>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a <= b; });
-            }
-            else if (mode == "le_if") {
-                run_linear_reif_test<LinearLessThanEqualIf>(
-                    false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a <= b; });
-            }
-            else if (mode == "le_iff") {
-                run_linear_reif_test<LinearLessThanEqualIff>(
-                    true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a <= b; });
-            }
-            else if (mode == "ge") {
-                run_linear_test<LinearGreaterThanEqual>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a >= b; });
-            }
-            else if (mode == "ge_if") {
-                run_linear_reif_test<LinearGreaterThanEqualIf>(
-                    false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a >= b; });
-            }
-            else if (mode == "ge_iff") {
-                run_linear_reif_test<LinearGreaterThanEqualIff>(
-                    true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a >= b; });
-            }
-            else
-                throw UnimplementedException{};
-        }
 
-        // Dup-variable cases. Cover the non-reified Linear variants;
-        // reified forms share the same coalescing infrastructure.
-        if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
-            // 2*a + 3*a + 1*b coalesces to 5*a + 1*b.
-            if (mode == "eq")
-                run_dup_linear_test<LinearEquality>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a == b; });
-            else if (mode == "ne")
-                run_dup_linear_test<LinearNotEquals>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a != b; });
-            else if (mode == "le")
-                run_dup_linear_test<LinearLessThanEqual>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a <= b; });
-            else if (mode == "ge")
-                run_dup_linear_test<LinearGreaterThanEqual>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a >= b; });
-            // 1*a + (-1)*a + 2*b coalesces to 0*a + 2*b = 2*b — exercises
-            // the zero-coefficient-after-coalescing path.
-            if (mode == "eq")
-                run_dup_linear_test<LinearEquality>(proofs, mode, {0, 5}, {0, 5}, {1, -1, 2}, 4, [](int a, int b) { return a == b; });
+            // Dup-variable cases. Cover the non-reified Linear variants;
+            // reified forms share the same coalescing infrastructure.
+            if (view_wrap_config_is_effectively_bare(view_cfg, n_positions)) {
+                // 2*a + 3*a + 1*b coalesces to 5*a + 1*b.
+                if (mode == "eq")
+                    run_dup_linear_test<LinearEquality>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a == b; });
+                else if (mode == "ne")
+                    run_dup_linear_test<LinearNotEquals>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a != b; });
+                else if (mode == "le")
+                    run_dup_linear_test<LinearLessThanEqual>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a <= b; });
+                else if (mode == "ge")
+                    run_dup_linear_test<LinearGreaterThanEqual>(proofs, mode, {0, 5}, {-5, 5}, {2, 3, 1}, 10, [](int a, int b) { return a >= b; });
+                // 1*a + (-1)*a + 2*b coalesces to 0*a + 2*b = 2*b — exercises
+                // the zero-coefficient-after-coalescing path.
+                if (mode == "eq")
+                    run_dup_linear_test<LinearEquality>(proofs, mode, {0, 5}, {0, 5}, {1, -1, 2}, 4, [](int a, int b) { return a == b; });
+            }
         }
     }
 

--- a/gcs/constraints/smart_table/smart_table_test.cc
+++ b/gcs/constraints/smart_table/smart_table_test.cc
@@ -431,8 +431,21 @@ auto run_degenerate_test(bool proofs, const string & mode) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
-    if (argc != 2)
-        throw UnimplementedException{};
+    // Mode is the first non-flag positional. With no mode given (a manual run
+    // rather than the ctest harness) run every mode.
+    string requested_mode;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (! a.starts_with("--")) {
+            requested_mode = a;
+            break;
+        }
+    }
+    // Keep in sync with the mode dispatch below and the matching foreach(mode ...)
+    // in gcs/CMakeLists.txt.
+    const vector<string> all_modes = {"lex_gt", "lex_ge", "lex_lt", "lex_le", "lex_gt_fixed", "lex_ge_fixed", "lex_lt_fixed", "lex_le_fixed",
+        "am1_eq", "am1_in_set", "al1_eq", "al1_in_set", "mixed_same_var", "stacked_unary", "wide_constants", "degenerate"};
+    const vector<string> modes = requested_mode.empty() ? all_modes : vector<string>{requested_mode};
 
     vector<pair<int, vector<pair<int, int>>>> data = {
         // Length    //Ranges
@@ -444,92 +457,92 @@ auto main(int argc, char * argv[]) -> int
         {5, {{1, 1}, {2, 2}, {3, 3}, {4, 4}, {1, 10}}}  //
     };
 
-    string mode{argv[1]};
+    for (const auto & mode : modes) {
+        // These modes carry their own instances rather than using the
+        // length/ranges table below.
+        if (mode == "mixed_same_var" || mode == "stacked_unary" || mode == "wide_constants" || mode == "degenerate") {
+            for (bool proofs : {false, true}) {
+                if (proofs && ! can_run_veripb())
+                    continue;
+                if (mode == "mixed_same_var")
+                    run_mixed_same_var_test(proofs, mode);
+                else if (mode == "stacked_unary")
+                    run_stacked_unary_test(proofs, mode);
+                else if (mode == "wide_constants")
+                    run_wide_constants_test(proofs, mode);
+                else
+                    run_degenerate_test(proofs, mode);
+            }
+            continue;
+        }
 
-    // These modes carry their own instances rather than using the
-    // length/ranges table below.
-    if (mode == "mixed_same_var" || mode == "stacked_unary" || mode == "wide_constants" || mode == "degenerate") {
         for (bool proofs : {false, true}) {
             if (proofs && ! can_run_veripb())
                 continue;
-            if (mode == "mixed_same_var")
-                run_mixed_same_var_test(proofs, mode);
-            else if (mode == "stacked_unary")
-                run_stacked_unary_test(proofs, mode);
-            else if (mode == "wide_constants")
-                run_wide_constants_test(proofs, mode);
-            else
-                run_degenerate_test(proofs, mode);
-        }
-        return EXIT_SUCCESS;
-    }
-
-    for (bool proofs : {false, true}) {
-        if (proofs && ! can_run_veripb())
-            continue;
-        for (auto & [length, ranges] : data) {
-            if (mode == "lex_gt") {
-                // x > y
-                if (! run_lex_test(proofs, mode, length, ranges, false, false, false))
-                    return EXIT_FAILURE;
+            for (auto & [length, ranges] : data) {
+                if (mode == "lex_gt") {
+                    // x > y
+                    if (! run_lex_test(proofs, mode, length, ranges, false, false, false))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "lex_ge") {
+                    // x >= y
+                    if (! run_lex_test(proofs, mode, length, ranges, false, true, false))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "lex_lt") {
+                    // x < y
+                    if (! run_lex_test(proofs, mode, length, ranges, true, false, false))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "lex_le") {
+                    // x <= y
+                    if (! run_lex_test(proofs, mode, length, ranges, true, true, false))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "lex_gt_fixed") {
+                    // x > [1,..,n]
+                    if (! run_lex_test(proofs, mode, length, ranges, false, false, true))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "lex_ge_fixed") {
+                    // x >= [1,..,n]
+                    if (! run_lex_test(proofs, mode, length, ranges, false, true, true))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "lex_lt_fixed") {
+                    // x < [1,..,n]
+                    if (! run_lex_test(proofs, mode, length, ranges, true, false, true))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "lex_le_fixed") {
+                    // x <= [1,..,n]
+                    if (! run_lex_test(proofs, mode, length, ranges, true, true, true))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "am1_eq") {
+                    // at most one var in x == length
+                    if (! run_at_most_1_test(proofs, mode, length, ranges, false, false))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "am1_in_set") {
+                    // at most one var in x one of {1, length}
+                    if (! run_at_most_1_test(proofs, mode, length, ranges, false, true))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "al1_eq") {
+                    // at least one var in x == length
+                    if (! run_at_most_1_test(proofs, mode, length, ranges, true, false))
+                        return EXIT_FAILURE;
+                }
+                else if (mode == "al1_in_set") {
+                    // at least one var in x one of {1, length}
+                    if (! run_at_most_1_test(proofs, mode, length, ranges, true, true))
+                        return EXIT_FAILURE;
+                }
+                else
+                    throw UnimplementedException{};
             }
-            else if (mode == "lex_ge") {
-                // x >= y
-                if (! run_lex_test(proofs, mode, length, ranges, false, true, false))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "lex_lt") {
-                // x < y
-                if (! run_lex_test(proofs, mode, length, ranges, true, false, false))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "lex_le") {
-                // x <= y
-                if (! run_lex_test(proofs, mode, length, ranges, true, true, false))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "lex_gt_fixed") {
-                // x > [1,..,n]
-                if (! run_lex_test(proofs, mode, length, ranges, false, false, true))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "lex_ge_fixed") {
-                // x >= [1,..,n]
-                if (! run_lex_test(proofs, mode, length, ranges, false, true, true))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "lex_lt_fixed") {
-                // x < [1,..,n]
-                if (! run_lex_test(proofs, mode, length, ranges, true, false, true))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "lex_le_fixed") {
-                // x <= [1,..,n]
-                if (! run_lex_test(proofs, mode, length, ranges, true, true, true))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "am1_eq") {
-                // at most one var in x == length
-                if (! run_at_most_1_test(proofs, mode, length, ranges, false, false))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "am1_in_set") {
-                // at most one var in x one of {1, length}
-                if (! run_at_most_1_test(proofs, mode, length, ranges, false, true))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "al1_eq") {
-                // at least one var in x == length
-                if (! run_at_most_1_test(proofs, mode, length, ranges, true, false))
-                    return EXIT_FAILURE;
-            }
-            else if (mode == "al1_in_set") {
-                // at least one var in x one of {1, length}
-                if (! run_at_most_1_test(proofs, mode, length, ranges, true, true))
-                    return EXIT_FAILURE;
-            }
-            else
-                throw UnimplementedException{};
         }
     }
 


### PR DESCRIPTION
## What

Six constraint tests take a positional **mode** argument selecting which subset of configurations to run, and threw `UnimplementedException` when none was supplied. The ctest harness always passes an explicit mode via its `foreach(mode ...)` registrations, so this only bit when running a test binary by hand.

Each `main()` now scans argv for the first non-flag positional; **with no mode it runs every mode in turn**, otherwise just the one requested — making e.g. `./comparison_test` a one-shot "check everything" command.

Affected: `comparison`, `linear`, `disjunctive`, `disjunctive_2d`, `element`, `smart_table` constraint tests.

## How

- Unify the mode parse on the "first argv element not starting with `--`" scan across all six (relaxes the strict `argc != 2` in the two that take no flags — harmless).
- Build a local `all_modes` literal (mirroring the if-chain and the CMake `foreach`, with a keep-in-sync comment) and iterate `modes = requested_mode.empty() ? all_modes : {requested_mode}`.
- Wrap the mode-dependent dispatch in `for (const auto & mode : modes)`, hoisting mode-independent data/RNG above it and keeping mode-dependent setup (element's `n_positions`/`run_dup`, disjunctive's `strict`) inside. `element` needed a small reorder; its view-position skip becomes `continue`, and smart_table's special-block early `return` becomes `continue`.
- A supplied but unknown mode still reaches the existing `else throw`, so it errors exactly as before.

No CMake changes. Formatted with clang-format 21.

## Why it's safe

- **Harness path unchanged**: it always supplies a mode, so `modes` is a single element and the loop runs once — behaviour is identical. Verified by running the affected ctest suite on both this branch and pristine `main`: the pass/fail set is identical.
- **Unknown mode still errors** (`comparison_test bogus` → `UnimplementedException`).
- No-arg runs verified to iterate all modes and exit 0 (comparison, linear, disjunctive, disjunctive_2d, element).

A no-arg run now generates one random dataset shared across all modes in a single process, rather than a fresh seed per process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)