### PR TITLE
Scale debug info by build config, keeping verbose stacktrace logging working

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build Commands
 
 Three build types are supported: `Release` (default), `Debug`, and `Sanitize`.
-Use named presets from `CMakePresets.json` for convenience:
+All keep debug information, but scaled to purpose: `Release` uses `-g1` (`/Z7`
+on MSVC) — function names plus line tables, enough for backtraces and the
+`GCS_VERBOSE_LOGGING` stacktrace annotation — while `Debug` and `Sanitize` use
+`-g3` for full interactive debugging. Use named presets from
+`CMakePresets.json` for convenience:
 
 ```shell
 cmake --preset release  && cmake --build --preset release   # optimised (default)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,20 @@ if(PROJECT_IS_TOP_LEVEL)
         add_compile_options(/Zc:preprocessor)  # standards-conformant preprocessor
         # We deliberately use getenv/std::system; silence the CRT "unsafe" deprecations.
         add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+
+        # Emit debug info in Release too, mirroring the -g1 the GCC/Clang side keeps,
+        # so std::stacktrace can resolve function names and source lines for the
+        # GCS_VERBOSE_LOGGING proof annotation (Debug already gets /Zi by default).
+        # /Z7 embeds CodeView in each .obj -- unlike /Zi it needs no shared compiler
+        # PDB, so Ninja's parallel compiles can't collide on one (fatal error C1041).
+        # The linker's /DEBUG then gathers it into a program PDB that DbgHelp reads at
+        # runtime; the debug info lives in that PDB, not the .exe, so Release binaries
+        # stay lean. /DEBUG disables /OPT:REF and /OPT:ICF, so re-enable them to keep
+        # Release free of unreferenced/duplicate functions.
+        add_compile_options($<$<CONFIG:Release>:/Z7>)
+        add_link_options($<$<CONFIG:Release>:/DEBUG>)
+        add_link_options($<$<CONFIG:Release>:/OPT:REF>)
+        add_link_options($<$<CONFIG:Release>:/OPT:ICF>)
     else()
         add_compile_options(-W)
         add_compile_options(-Wall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,10 +116,27 @@ if(PROJECT_IS_TOP_LEVEL)
             add_compile_options(-Wno-unqualified-std-cast-call)
         endif()
 
-        # Always include full debug info, even in release builds, so crash reports are useful.
-        add_compile_options(-g)
-        add_compile_options(-g3)
+        # Debug information, scaled to each configuration's purpose rather than
+        # emitting the very heavy -g3 everywhere (which alone inflated
+        # libglasgow_constraint_solver.a to ~340 MB, ~91% of it DWARF).
+        #
+        #   Release  -> -g1: function names + line-number tables only, no local
+        #               variables (-g2) or macros (-g3). This is the level GCC
+        #               documents as "enough for making backtraces", which is all
+        #               ProofLogger::log_stacktrace (the GCS_VERBOSE_LOGGING proof
+        #               annotation) needs: it filters frames on source_file() and
+        #               prints name + file:line. Keeping it in Release means crash
+        #               reports and verbose proofs stay useful in optimised builds.
+        #   Debug    -> -g3: full information, including macros, for interactive
+        #               debugging.
+        #   Sanitize -> -g3: fully-annotated ASan/UBSan stack traces.
+        #
+        # Anything other than Debug/Sanitize (Release, or an unset build type)
+        # gets -g1 so it always carries at least backtrace-quality debug info.
+        # stacktrace_logging_test guards the Release end of this: it fails if a
+        # build ever drops the debug info the verbose proof logging relies on.
         add_compile_options(-gdwarf-3)
+        add_compile_options($<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:Sanitize>>,-g3,-g1>)
         add_compile_options(-pthread)
         add_link_options(-pthread)
 

--- a/README.md
+++ b/README.md
@@ -333,8 +333,11 @@ autotuner) without recompiling. Each is read once, on first use.
 
 * ``GCS_VERBOSE_LOGGING``: if set to anything, every proof log line is preceded by comment lines
   giving a C++ stacktrace of the solver code that emitted it, which is very useful for figuring
-  out where an unexpected line in a ``.pbp`` file came from. Only available when the compiler
-  provides ``<stacktrace>``.
+  out where an unexpected line in a ``.pbp`` file came from. Only the solver's own frames are
+  shown, and resolving their names and source locations needs debug information, so the build
+  keeps enough of it even in release builds (``-g1`` on GCC/Clang, ``/Z7`` plus linker ``/DEBUG``
+  on MSVC) to keep this useful. Only available when the compiler provides ``<stacktrace>`` (so not
+  on Apple's libc++, for example).
 
 * ``GCS_LINEAR_INCREMENTAL_THRESHOLD``: the number of terms at or above which a linear equality
   uses the incremental propagator, which folds instantiated terms out of the sum at the cost of

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -442,7 +442,11 @@ environment before running a test. Every line written to the `.pbp`
 will be preceded by a C++ stacktrace as comment lines (`% ...`), so a
 VeriPB failure at `foo_test.pbp:N` can be traced back to the exact
 emit site. Cheap to use and often faster than narrowing the failure by
-inspection.
+inspection. Only frames in the solver's own source are shown, and
+resolving them relies on the debug info the build keeps even in release
+(`-g1` on GCC/Clang, `/Z7` on MSVC); `stacktrace_logging_test` guards
+against a build dropping it. Not available where the standard library
+lacks `<stacktrace>` (e.g. macOS libc++), where it silently does nothing.
 
 ## The OPB encoding
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -148,16 +148,13 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(solve_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME solve_test COMMAND $<TARGET_FILE:solve_test>)
 
-    # Checks that GCS_VERBOSE_LOGGING proof annotation resolves gcs source frames,
-    # which depends on the debug info the Release build keeps (see -g1 in the top
-    # CMakeLists.txt). It self-skips where <stacktrace> is unavailable (macOS
-    # libc++). Excluded on MSVC: setenv() is POSIX-only and MSVC's <stacktrace>
-    # resolves frames from a PDB, which this build does not ship (a separate task).
-    if(NOT MSVC)
-        add_executable(stacktrace_logging_test stacktrace_logging_test.cc)
-        target_link_libraries(stacktrace_logging_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
-        add_test(NAME stacktrace_logging_test COMMAND $<TARGET_FILE:stacktrace_logging_test>)
-    endif()
+    # Checks that the GCS_VERBOSE_LOGGING proof annotation resolves gcs source
+    # frames, which depends on the debug info the Release build keeps (-g1 on
+    # GCC/Clang, /Z7 + /DEBUG on MSVC; see the top-level CMakeLists.txt). It
+    # self-skips where <stacktrace> is unavailable (macOS libc++).
+    add_executable(stacktrace_logging_test stacktrace_logging_test.cc)
+    target_link_libraries(stacktrace_logging_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME stacktrace_logging_test COMMAND $<TARGET_FILE:stacktrace_logging_test>)
 
     add_executable(problem_test problem_test.cc)
     target_link_libraries(problem_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -148,6 +148,17 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(solve_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME solve_test COMMAND $<TARGET_FILE:solve_test>)
 
+    # Checks that GCS_VERBOSE_LOGGING proof annotation resolves gcs source frames,
+    # which depends on the debug info the Release build keeps (see -g1 in the top
+    # CMakeLists.txt). It self-skips where <stacktrace> is unavailable (macOS
+    # libc++). Excluded on MSVC: setenv() is POSIX-only and MSVC's <stacktrace>
+    # resolves frames from a PDB, which this build does not ship (a separate task).
+    if(NOT MSVC)
+        add_executable(stacktrace_logging_test stacktrace_logging_test.cc)
+        target_link_libraries(stacktrace_logging_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+        add_test(NAME stacktrace_logging_test COMMAND $<TARGET_FILE:stacktrace_logging_test>)
+    endif()
+
     add_executable(problem_test problem_test.cc)
     target_link_libraries(problem_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME problem_test COMMAND $<TARGET_FILE:problem_test>)

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -139,7 +139,10 @@ auto ProofLogger::log_stacktrace() -> void
     using std::stacktrace;
     if (do_logging) [[unlikely]] {
         for (const auto & entry : stacktrace::current()) {
-            if (entry.source_file().contains("/gcs/"))
+            // source_file() uses the host path separator, so match either form:
+            // "/gcs/" on POSIX, "\gcs\" from MSVC's PDB paths.
+            const auto & file = entry.source_file();
+            if (file.contains("/gcs/") || file.contains("\\gcs\\"))
                 _imp->proof << "% " << to_string(entry) << '\n';
         }
     }

--- a/gcs/stacktrace_logging_test.cc
+++ b/gcs/stacktrace_logging_test.cc
@@ -30,7 +30,11 @@ TEST_CASE("Verbose logging names gcs stack frames in the proof")
 {
     // do_logging inside log_stacktrace() is read once, on the first call, so the
     // environment has to be set before the first solve in this process.
+#ifdef _WIN32
+    _putenv_s("GCS_VERBOSE_LOGGING", "1");
+#else
     setenv("GCS_VERBOSE_LOGGING", "1", 1);
+#endif
 
     Problem p;
     auto v = p.create_integer_variable(0_i, 100_i);
@@ -45,7 +49,8 @@ TEST_CASE("Verbose logging names gcs stack frames in the proof")
     bool saw_gcs_frame = false;
     string line;
     while (getline(proof, line))
-        if (line.starts_with("% ") && line.find("/gcs/") != string::npos) {
+        // Match either separator: "/gcs/" on POSIX, "\gcs\" in MSVC's PDB paths.
+        if (line.starts_with("% ") && (line.find("/gcs/") != string::npos || line.find("\\gcs\\") != string::npos)) {
             saw_gcs_frame = true;
             break;
         }

--- a/gcs/stacktrace_logging_test.cc
+++ b/gcs/stacktrace_logging_test.cc
@@ -1,0 +1,62 @@
+#include <gcs/current_state.hh>
+#include <gcs/expression.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <version>
+
+using namespace gcs;
+
+using std::getline;
+using std::ifstream;
+using std::string;
+
+// GCS_VERBOSE_LOGGING makes ProofLogger::log_stacktrace() prefix each emitted
+// proof line with comment lines naming the gcs source frames that produced it
+// (see README.md and dev_docs/constraints.md). Resolving those frames needs at
+// least line-number debug info in the binary; the Release build ships -g1
+// precisely so this stays useful in optimised builds.
+//
+// The frame filter keys on source_file().contains("/gcs/"), so with no debug
+// info source_file() is empty and *nothing* is logged. This test guards against
+// exactly that on the platforms where <stacktrace> exists: it catches both the
+// feature silently breaking and a build that strips the debug info it needs.
+TEST_CASE("Verbose logging names gcs stack frames in the proof")
+{
+    // do_logging inside log_stacktrace() is read once, on the first call, so the
+    // environment has to be set before the first solve in this process.
+    setenv("GCS_VERBOSE_LOGGING", "1", 1);
+
+    Problem p;
+    auto v = p.create_integer_variable(0_i, 100_i);
+    p.post(WeightedSum{} + 1_i * v >= 200_i); // unsat: forces inference + proof lines
+
+    solve(p, [&](const CurrentState &) -> bool { return true; }, ProofOptions{"stacktrace_logging_test"});
+
+#ifdef __cpp_lib_stacktrace
+    ifstream proof{"stacktrace_logging_test.pbp"};
+    REQUIRE(proof);
+
+    bool saw_gcs_frame = false;
+    string line;
+    while (getline(proof, line))
+        if (line.starts_with("% ") && line.find("/gcs/") != string::npos) {
+            saw_gcs_frame = true;
+            break;
+        }
+
+    // <stacktrace> is available on this toolchain, so verbose logging must have
+    // named at least one gcs frame. If it did not, either the feature broke or
+    // the build dropped the debug info that source_file() resolution depends on.
+    CHECK(saw_gcs_frame);
+#else
+    // No <stacktrace> here (e.g. macOS libc++): log_stacktrace() is compiled out,
+    // so there is nothing to assert. Recorded as a pass on those platforms.
+    SUCCEED("<stacktrace> unavailable on this toolchain; verbose frame logging is compiled out");
+#endif
+}


### PR DESCRIPTION
## Motivation

The GCC/Clang builds emitted `-g -g3 -gdwarf-3` unconditionally, so even a
Release build carried full DWARF-3 debug info (including macros). That alone
inflated `libglasgow_constraint_solver.a` to **~340 MB (~91% of it DWARF)** for
no runtime benefit — on macOS the executables don't even embed it (ld64 uses a
debug map), and a Release build has no reason to ship local-variable and macro
debug info. But we do want *enough* debug info in Release for the
`GCS_VERBOSE_LOGGING` proof annotation (`ProofLogger::log_stacktrace`) to keep
naming solver frames.

## What changed

**1. Scale debug info by configuration** (`39b639f9`)
- Release (and any unset build type) → `-g1`: function names + line tables, the level GCC documents as "enough for making backtraces" — exactly what the stacktrace annotation needs. Archive drops to **~106 MB**.
- Debug / Sanitize → `-g3`: full info for interactive debugging.
- New `stacktrace_logging_test` guards the Release end: with no debug info `source_file()` is empty, the `/gcs/` frame filter matches nothing, and verbose logging silently produces zero output. It runs a tiny solve with `GCS_VERBOSE_LOGGING` set and asserts the proof names at least one gcs frame; self-skips where `<stacktrace>` is unavailable (macOS libc++).

**2. Make it work — and get checked — on MSVC** (`36774dbb`)
- The frame filter keyed on `"/gcs/"`; MSVC resolves PDB paths with backslashes, so `\gcs\` never matched. Now accepts either separator (filter + test scan).
- MSVC Release emitted no debug info. Added `/Z7` + `/DEBUG` on Release (debug info lands in the PDB, not the `.exe`; `/Z7` avoids Ninja parallel-build PDB contention; `/OPT:REF`/`/OPT:ICF` re-enabled so Release stays lean).
- Test uses `_putenv_s` on Windows and is registered on MSVC, so the `windows-2022` lane (Release + full ctest) verifies the feature end to end.

**3. Documentation** (`4e93bc7e`) — README env var, dev_docs proof-debugging workflow, and CLAUDE.md per-config debug levels.

## Verification

- Full `-g1` Release build compiles; `stacktrace_logging_test` passes (skip-branch on macOS libc++).
- clang-format 21 clean; CMake configure clean; archive **339 MB → 106 MB**.
- The MSVC path can't be exercised off-Windows (no `<stacktrace>` on macOS libc++); the `windows-2022` CI lane is its verification — that's the intent of commit 2.