### PR TITLE
gitignore the tmp/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ perf.data
 perf.data.old
 html
 build*
+# scratch area for local experiments; contents must never be committed
+/tmp/
 Doxyfile
 *.a
 *.log


### PR DESCRIPTION
The root `tmp/` directory is a scratch area for local experiments, but it is not ignored, so an over-broad `git add` can sweep its contents into a commit — which is exactly how an 8MB benchmark tarball recently ended up inside a feature commit on the `reasons-hoist` branch (since excised by a history rewrite).

One line: ignore `/tmp/`, anchored to the repository root so a nested directory that happens to be called `tmp` is unaffected. Nothing under `tmp/` is tracked on `main`, so the entry changes nothing retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARYiwRGLg4vXRtgMr1VKAv