### PR TITLE
Resolve the branch callback once per solve, not per node

### DIFF
--- a/dev_docs/propagator-performance.md
+++ b/dev_docs/propagator-performance.md
@@ -166,6 +166,49 @@ position-indexed bitmaps held in per-clone scratch (reset with `fill`, never
 regrown) removed ~50% of its runtime that was pure hash-table allocation and
 rehashing. See [bin-packing.md](bin-packing.md).
 
+### Keep type-erased callables out of per-node and per-inference paths
+
+`std::function` costs in three places: construction heap-allocates whenever
+the callable's captures outgrow the small-buffer optimisation (two pointers,
+typically), copies are deep and silent, and invocation is an indirect call
+the compiler cannot inline through. None of that matters for a callback
+built once and invoked on a cold path; all of it matters per node or per
+inference. Concretely:
+
+- **Take hot callbacks as template parameters**, not `std::function`.
+  `State::for_each_value_immutable` and `JustifyExplicitly`'s `emit` are the
+  patterns to copy: the concrete closure type reaches the call site, so it
+  inlines and nothing allocates. (This also beats C++26 `std::function_ref`,
+  which still costs an indirect call — when the C++26 wrapper types
+  eventually arrive on all our toolchains they will improve the cold-path
+  vocabulary, not change this rule.)
+- **Watch for invisible copies.** Copying a `std::function` deep-copies
+  every capture. The archetype was `solve_with_state`: the expression
+  `callbacks.branch ? callbacks.branch : <default>` materialised a copy of
+  the branch callback — and of everything the composed heuristics captured,
+  including a vector of all the branch variables — at every search node, and
+  rebuilt the entire default heuristic per node when no callback was set.
+  The fix is the shape to reuse: resolve the callback once before search
+  starts, then invoke the lvalue in the recursion.
+- **Copy semantics are part of a closure's interface.** Because a
+  `std::function` may be copied at any time, mutable state captured into one
+  must sit behind a `shared_ptr` so every copy aliases it (the RNG sharing
+  in `search_heuristics.cc` is the documented example). Capturing an RNG or
+  a cache by value looks equivalent and is not: the first silent copy forks
+  its state.
+- An owning wrapper is still correct when the callable is **stored** and
+  outlives the call that created it: `SolveCallbacks`, tabulation's
+  `accept`, deferred proof lines, or a callable parameter a coroutine keeps
+  in its frame across suspensions. A non-owning reference (a raw callable
+  `&`, or an eventual `std::function_ref`) in any of those positions
+  dangles.
+
+`PropagationFunction` is bespoke erasure for a different reason: a
+propagator must be invocable with either inference-tracker type, which means
+two `operator()` signatures — beyond any `std::function`-family type. It is
+constructed once at install time, so per-wake it costs the same single
+virtual call either way.
+
 ### Fast data structures for small collections
 
 `std::set` / `std::map` (red-black trees) and `std::unordered_set` /

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -61,9 +61,7 @@ namespace
             if (optional_abort_flag && optional_abort_flag->load())
                 return false;
 
-            auto create_branch_generator =
-                callbacks.branch ? callbacks.branch : branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
-            auto branch_generator = create_branch_generator(state.current(), propagators);
+            auto branch_generator = callbacks.branch(state.current(), propagators);
             auto branch_iter = branch_generator.begin();
 
             if (branch_iter == branch_generator.end()) {
@@ -161,6 +159,13 @@ auto gcs::solve_with(
         if (auto & fn = optional_proof_options->proof_file_names.s_expr_file)
             write_scp(*fn, problem, optional_proof->model());
     }
+
+    // solve_with_state invokes callbacks.branch unconditionally: an unset
+    // branch callback is filled in with the default heuristic here, once,
+    // rather than testing and copying the std::function (and every closure
+    // the composed heuristics capture) at every node of the recursion.
+    if (! callbacks.branch)
+        callbacks.branch = branch_with(variable_order::dom_then_deg(problem), value_order::smallest_first());
 
     if (callbacks.after_proof_started)
         callbacks.after_proof_started(state.current());


### PR DESCRIPTION
`solve_with_state` named the branch callback through `callbacks.branch ? callbacks.branch : branch_with(...)`, whose result is a prvalue. With a branch callback set, that deep-copies the `std::function` — and every closure the composed heuristics capture, including the branch-variable vector inside `in_order_of` — at **every search node**. With no callback set (which is what all the curated benchmarks do), it instead rebuilt the entire default `dom_then_deg` + `smallest_first` heuristic per node, copying `all_normal_variables()` each time.

This resolves the callback once in `solve_with` before search starts, and invokes the lvalue in the recursion. A second commit codifies the underlying rule in `dev_docs/propagator-performance.md`: no type-erased callables in per-node/per-inference paths, templated callbacks for hot code, `std::function` for stored cold callables — with the invisible-copy and shared-mutable-capture (RNG `shared_ptr`) traps written down. This came out of an audit of our `std::function` usage prompted by the C++26 `copyable_function`/`function_ref` additions; worth keeping for design reasons regardless of the numbers.

## Benchmarks

`dev_docs/benchmarking.md` set, 3 trials per build, medians of `solve time`. **`recursions` and `propagations` are bit-identical between builds on every benchmark** (the change is search-neutral); they are shown once.

| benchmark | recursions | propagations | baseline | after | Δ |
|---|---|---|---|---|---|
| magic_series_300 | 1,193 | 41,909,926 | 5.016s | 5.018s | ±0% |
| magic_square_5 | 6,042,079 | 501,848,714 | 17.572s | 17.141s | −2.5% |
| qap_12 | 123,333 | 24,460,415 | 1.751s | 1.749s | ±0% |
| tsp_default | 4,285,745 | 83,372,056 | 10.527s | 10.316s | −2.0% |
| n_queens_88 | 49,339,390 | 6,108,047,866 | 216.44s | 211.77s | −2.2% |
| langford_11 | 256,593 | 29,805,376 | 5.548s | 5.484s | −1.2% |
| n_queens_14_all | 6,391,931 | 264,025,654 | 12.00s | 11.78s | −1.9% |
| ortho_latin_6_all | 1,339,912 | 343,819,580 | 23.367s | 23.230s | −0.6% |

The improvement tracks node rate, as the mechanism predicts: biggest on high-nodes/second workloads (magic_square, n_queens, tsp), zero on the propagation-dominated ones (magic_series at 1,193 nodes, qap). Caveats for honesty: 1–2% is within the range code-layout noise can produce, the dev VM exposes no cpufreq governor to pin, and all eight benchmarks exercise the default-heuristic (rebuild-per-node) arm rather than the copy-per-node arm — though the consistent direction plus exact flatness where nodes are few supports the numbers being real.

Tests: full ctest suite passes (511/511) on the fixed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG64fM66vNWW4TG1MLXW45