### PR TITLE
Constraint tests: announce the random seed, reproduce any run with --seed

### DIFF
--- a/gcs/constraints/abs/abs_test.cc
+++ b/gcs/constraints/abs/abs_test.cc
@@ -27,7 +27,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -110,6 +109,8 @@ auto run_abs_initialiser_test(const string & label, pair<int, int> v1_range, pai
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 2;
@@ -160,8 +161,7 @@ auto main(int argc, char * argv[]) -> int
         {-6, pair{6, 6}},   // tautology
         {pair{-6, -6}, 7}}; // contradiction
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x)
         generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15));
     for (int x = 0; x < 10; ++x)

--- a/gcs/constraints/all_different/all_different_except_test.cc
+++ b/gcs/constraints/all_different/all_different_except_test.cc
@@ -201,6 +201,8 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 4;

--- a/gcs/constraints/all_different/all_different_test.cc
+++ b/gcs/constraints/all_different/all_different_test.cc
@@ -28,7 +28,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -151,6 +150,8 @@ auto run_alldiff_collection_test(bool proofs, const string & label, const vector
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 6;
@@ -175,8 +176,7 @@ auto main(int argc, char * argv[]) -> int
             {1, 1, 3, 4, 5, 6},  // two equal constants (contradiction)
             {7, 7, 7, 7, 7, 7}}; // all equal constants (contradiction)
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x)
         generate_random_data(rand, data, random_bounds(-10, 10, 2, 5), random_bounds(-10, 10, 2, 5), random_bounds(-10, 10, 2, 5),
             random_bounds(-10, 10, 2, 5), random_bounds(-10, 10, 2, 5), random_bounds(-10, 10, 2, 5));

--- a/gcs/constraints/all_different/symmetric_all_different_test.cc
+++ b/gcs/constraints/all_different/symmetric_all_different_test.cc
@@ -197,8 +197,10 @@ namespace
     }
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;

--- a/gcs/constraints/all_equal/all_equal_test.cc
+++ b/gcs/constraints/all_equal/all_equal_test.cc
@@ -28,7 +28,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -196,6 +195,8 @@ auto run_dup_all_equal_test(bool proofs, const vector<pair<int, int>> & unique_d
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Max vector length across the data is 4; CMake registers up through
@@ -222,8 +223,7 @@ auto main(int argc, char * argv[]) -> int
         {{4, 4}, {4, 4}, {4, 4}}, // three equal constants (tautology)
     };
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     auto random_run = [&](int n_vars) {
         vector<pair<int, int>> doms;
         std::uniform_int_distribution<int> lo_dist{-3, 5};

--- a/gcs/constraints/among/among_test.cc
+++ b/gcs/constraints/among/among_test.cc
@@ -32,7 +32,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -164,6 +163,8 @@ auto run_self_ref_among_test(bool proofs, pair<int, int> shared_range, const vec
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 5;
@@ -191,8 +192,7 @@ auto main(int argc, char * argv[]) -> int
         {3, vector{5, 6}, {5, 6, 7}},               // all-constant array: only 2 match (contradiction)
         {pair{0, 2}, vector{5}, {5, pair{1, 10}}}}; // mixed: one constant match + one variable
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 4);
         auto n_values_1 = n_values_dist(rand);

--- a/gcs/constraints/at_most_one/at_most_one_test.cc
+++ b/gcs/constraints/at_most_one/at_most_one_test.cc
@@ -26,7 +26,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -169,6 +168,8 @@ auto run_all_tests(Variant variant, bool proofs, const ViewWrapConfig & view_cfg
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 5;
@@ -177,8 +178,7 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     bool effectively_bare = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
     bool run_dup = effectively_bare;

--- a/gcs/constraints/bin_packing/bin_packing_test.cc
+++ b/gcs/constraints/bin_packing/bin_packing_test.cc
@@ -147,8 +147,10 @@ namespace
     }
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Each capa case: { item_ranges, sizes, capacities }.
     vector<tuple<vector<pair<int, int>>, vector<int>, vector<int>>> capa_data = {
         // Two items, two bins, capacity covers any single item but not both.

--- a/gcs/constraints/circuit/circuit_disconnected_test.cc
+++ b/gcs/constraints/circuit/circuit_disconnected_test.cc
@@ -20,6 +20,8 @@ using std::nullopt;
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 8;

--- a/gcs/constraints/circuit/circuit_multiple_sccs_test.cc
+++ b/gcs/constraints/circuit/circuit_multiple_sccs_test.cc
@@ -33,6 +33,8 @@ auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes)
 }
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 9;

--- a/gcs/constraints/circuit/circuit_no_backedges_test.cc
+++ b/gcs/constraints/circuit/circuit_no_backedges_test.cc
@@ -45,6 +45,8 @@ auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes)
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 8;

--- a/gcs/constraints/circuit/circuit_prune_root_test.cc
+++ b/gcs/constraints/circuit/circuit_prune_root_test.cc
@@ -30,6 +30,8 @@ auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes)
 }
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 6;

--- a/gcs/constraints/circuit/circuit_prune_skip_test.cc
+++ b/gcs/constraints/circuit/circuit_prune_skip_test.cc
@@ -33,6 +33,8 @@ auto post_constraints(Problem & p, vector<IntegerVariableID> & nodes)
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 7;

--- a/gcs/constraints/circuit/circuit_test.cc
+++ b/gcs/constraints/circuit/circuit_test.cc
@@ -94,6 +94,8 @@ auto run_circuit_test(bool proofs, const ViewWrapConfig & view_cfg, int n, Circu
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Instances run at n = 3, 4, 5; positions 0..4 cover the largest fully.

--- a/gcs/constraints/comparison/comparison_test.cc
+++ b/gcs/constraints/comparison/comparison_test.cc
@@ -21,7 +21,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -227,6 +226,8 @@ auto run_dup_reif_binary_comparison_test(
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Mode is the first non-flag positional; --view-* flags may follow. With no
     // mode given (a manual run rather than the ctest harness) run every mode.
     string requested_mode;
@@ -273,8 +274,7 @@ auto main(int argc, char * argv[]) -> int
         {-2, -2} //
     };
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x)
         generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15));
     for (int x = 0; x < 10; ++x)

--- a/gcs/constraints/count/count_test.cc
+++ b/gcs/constraints/count/count_test.cc
@@ -28,7 +28,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -154,6 +153,8 @@ auto run_count_result_in_array_test(bool proofs, pair<int, int> shared_range, in
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 6;
@@ -189,8 +190,7 @@ auto main(int argc, char * argv[]) -> int
         {1, 4, {4, 4, 7}},                  // all-constant array: count is 2, not 1 (contradiction)
         {pair{0, 2}, 5, {5, pair{1, 10}}}}; // mixed: one constant match + one variable
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 4);
         auto n_values = n_values_dist(rand);

--- a/gcs/constraints/cumulative/cumulative_test.cc
+++ b/gcs/constraints/cumulative/cumulative_test.cc
@@ -31,7 +31,6 @@ using std::min;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -440,6 +439,8 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Negative variable sizes must be rejected at install time (constants are
@@ -506,8 +507,7 @@ auto main(int argc, char * argv[]) -> int
     // and the constraint is enumerated via brute-force over the start
     // domains: a wider horizon multiplies the enumeration cost across all
     // tasks. Sized so total runtime stays under a second even unoptimised.
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     auto random_instance = [&](int n, int max_start, int max_length, int max_height,
                                int max_cap) -> tuple<vector<pair<int, int>>, vector<int>, vector<int>, int> {

--- a/gcs/constraints/disjunctive/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_test.cc
@@ -30,7 +30,6 @@ using std::min;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -281,6 +280,8 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Mode is the first non-flag positional; --view-* flags may follow. With no
     // mode given (a manual run rather than the ctest harness) run every mode.
     string requested_mode;
@@ -340,8 +341,7 @@ auto main(int argc, char * argv[]) -> int
     };
 
     // Random instances for breadth.
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     auto random_instance = [&](int n, int max_start, int max_length) -> pair<vector<pair<int, int>>, vector<int>> {
         uniform_int_distribution<> lo_dist(0, max_start), span_dist(0, max_start), len_dist(0, max_length);

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
@@ -30,7 +30,6 @@ using std::min;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -261,6 +260,8 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Mode is the first non-flag positional. With no mode given (a manual run
     // rather than the ctest harness) run every mode.
     string requested_mode;
@@ -303,8 +304,7 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {1, 1}, {1, 1}},
     };
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     auto random_instance = [&](int n, int max_pos, int max_size) -> tuple<vector<pair<int, int>>, vector<pair<int, int>>, vector<int>, vector<int>> {
         uniform_int_distribution<> lo_dist(0, max_pos), span_dist(0, max_pos), size_dist(0, max_size);

--- a/gcs/constraints/divide_modulus/divide_modulus_test.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus_test.cc
@@ -27,7 +27,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -225,6 +224,8 @@ auto run_divmod_constant_test(bool proofs, bool is_div, const DivideConsistency 
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // The view-wrap sweep: wrap each position per the config and run a
     // focused deterministic subset, proof files suffixed per config.
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -264,8 +265,7 @@ auto main(int argc, char * argv[]) -> int
     // weaker than bounds consistency on the division itself). The first
     // generator's divisor range spans zero, exercising the relational
     // divisor != 0 handling; the second keeps it strictly positive.
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> random_bc_data;
     for (int x = 0; x < 4; ++x) {
         generate_random_data(rand, random_bc_data, random_bounds(-12, 12, 3, 10), random_bounds(-5, 5, 2, 8), random_bounds(-12, 12, 3, 10));

--- a/gcs/constraints/element/element_test.cc
+++ b/gcs/constraints/element/element_test.cc
@@ -31,7 +31,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -231,6 +230,8 @@ auto run_dup_element_test(bool proofs, const string & label, const vector<pair<i
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Mode is the first non-flag positional; --view-* flags may follow. With no
     // mode given (a manual run rather than the ctest harness) run every mode.
     string requested_mode;
@@ -291,8 +292,7 @@ auto main(int argc, char * argv[]) -> int
         // All-fixed 2D.
         {{5, 5}, {0, 0}, {0, 0}, {{{5, 5}}}},  // a[0][0]==5==var (tautology)
         {{4, 4}, {0, 0}, {0, 0}, {{{5, 5}}}}}; // a[0][0]==5 != var 4 (contradiction)
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     uniform_int_distribution n_values_dist(1, 4);
     uniform_int_distribution larger_n_values_dist(1, 8);

--- a/gcs/constraints/equals/equals_test.cc
+++ b/gcs/constraints/equals/equals_test.cc
@@ -23,7 +23,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -190,7 +189,7 @@ auto run_no_overlap_equals_test(bool proofs) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
-    set_seed_from_argv(argc, argv);
+    establish_and_announce_seed(argc, argv);
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Single-position config that names a position the constraint doesn't
@@ -221,8 +220,7 @@ auto main(int argc, char * argv[]) -> int
         {-3, -3} //
     };
 
-    random_device rand_dev;
-    mt19937 rand(get_seed().value_or(rand_dev()));
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x)
         generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15));
     for (int x = 0; x < 10; ++x)

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
@@ -31,7 +31,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -93,8 +92,10 @@ auto run_bgcc_test(bool proofs, const vector<Range> & vars_range, const vector<i
     check_results(proof_name, expected, actual);
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     vector<tuple<vector<Range>, vector<int>, vector<Range>, bool>> data = {
         // Upper-capacity Hall isolated: counts pinned and the fourth variable's
         // escape value (4) is outside the cover, so ONLY the multi-value removal
@@ -133,8 +134,7 @@ auto main(int, char *[]) -> int
         {{pair{1, 2}}, {}, {}, false},                        // empty value set, open: any assignment allowed
     };
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int iteration = 0; iteration < 24; ++iteration) {
         uniform_int_distribution n_vars_dist(2, 3);
         uniform_int_distribution n_values_dist(1, 2);

--- a/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
@@ -31,7 +31,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -101,8 +100,10 @@ auto run_gacgcc_test(bool proofs, const vector<Range> & vars_range, const vector
     check_results(proof_name, expected, actual);
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     vector<tuple<vector<Range>, vector<int>, vector<Range>, bool>> data = {
         // Upper-capacity: first three confined to {1,2}, value 2 capped at 1,
         // so value 1 must take two of them; the fourth is forced off 1 and 2.
@@ -130,8 +131,7 @@ auto main(int, char *[]) -> int
         {{pair{1, 2}}, {}, {}, false},                        // empty value set, open: any assignment allowed
     };
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int iteration = 0; iteration < 24; ++iteration) {
         uniform_int_distribution n_vars_dist(2, 3);
         uniform_int_distribution n_values_dist(1, 2);

--- a/gcs/constraints/in/in_test.cc
+++ b/gcs/constraints/in/in_test.cc
@@ -27,7 +27,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -314,6 +313,8 @@ auto run_random_tests(bool proofs, const ViewWrapConfig & view_cfg, mt19937 & ra
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Only the primary `var` of each In variant is wrapped; the inner
@@ -324,8 +325,7 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())

--- a/gcs/constraints/increasing/increasing_test.cc
+++ b/gcs/constraints/increasing/increasing_test.cc
@@ -27,7 +27,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -205,6 +204,8 @@ auto run_dup_inc_test(bool proofs, const vector<pair<int, int>> & unique_domains
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 5;
@@ -213,8 +214,7 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     auto random_run = [&]<IncVariant V>(bool proofs) {
         // Sizes 2..5 with modest domains. For Increasing and 5 vars over a

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -433,13 +433,16 @@ namespace gcs::test_innards
     }
 
     /**
-     * Singleton holding the --seed argv value, if one was passed.
+     * Singleton holding the run's seed.
      *
-     * Test main()s call set_seed_from_argv(argc, argv) once at startup; the
-     * seed then drives both the test's data RNG (callers read it via
-     * get_seed()) and the harness's branching heuristic
-     * (random_branch_with_optional_seed below). When unset, behaviour is
-     * the historical random_device-based randomness.
+     * Test main()s call establish_and_announce_seed(argc, argv) once at
+     * startup, which fills this from `--seed=N` or a fresh random_device
+     * draw; the seed then drives both the test's data RNG (callers read it
+     * via get_seed()) and the harness's branching heuristic
+     * (random_branch_with_optional_seed below). Unset only in binaries that
+     * never establish a seed (the Catch2-based tests and other
+     * non-randomised probes), where branching falls back to
+     * random_device-based randomness.
      */
     inline auto seed_storage() -> std::optional<std::uint_fast32_t> &
     {
@@ -470,6 +473,32 @@ namespace gcs::test_innards
             }
         }
         seed_storage() = std::nullopt;
+    }
+
+    /**
+     * Like set_seed_from_argv(), but when no `--seed=N` is given, draws a
+     * seed from random_device, stores it as if it had been passed, and
+     * announces it on stderr. Every source of randomness in the run (data
+     * generation via get_seed(), branching via
+     * random_branch_with_optional_seed()) then flows from the announced
+     * seed, so a pathologically slow or failing random instance can be
+     * reproduced by re-running the same command line with `--seed=N`
+     * appended. ctest echoes the output of failing tests, so the seed is in
+     * the CI log exactly when it is most needed.
+     */
+    inline auto establish_and_announce_seed(int argc, char * argv[]) -> void
+    {
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+        using std::println;
+#else
+        using fmt::println;
+#endif
+        using std::cerr;
+
+        set_seed_from_argv(argc, argv);
+        if (! seed_storage())
+            seed_storage() = static_cast<std::uint_fast32_t>(std::random_device{}());
+        println(cerr, "{}: random seed is {} (reproduce with --seed={})", argv[0], *seed_storage(), *seed_storage());
     }
 
     /// Build the random branching pair, honouring --seed if set. Uses

--- a/gcs/constraints/innards/product_justify_test.cc
+++ b/gcs/constraints/innards/product_justify_test.cc
@@ -435,8 +435,10 @@ namespace
     }
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             break;

--- a/gcs/constraints/innards/tabulation_test.cc
+++ b/gcs/constraints/innards/tabulation_test.cc
@@ -35,7 +35,6 @@ using std::mt19937;
 using std::nullopt;
 using std::optional;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::unique_ptr;
@@ -153,8 +152,10 @@ auto run_tabulated_product_test(bool proofs, bool claim_determined, pair<int, in
     check_results(proof_name, expected, actual);
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> data = {
         {{1, 3}, {1, 3}, {1, 9}},      //
         {{-3, 3}, {-3, 3}, {-9, 9}},   // negatives and zero throughout
@@ -167,8 +168,7 @@ auto main(int, char *[]) -> int
         {{2, 2}, {3, 3}, {7, 7}},      // all fixed, contradiction
     };
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 3; ++x)
         generate_random_data(rand, data, random_bounds(-6, 6, 1, 5), random_bounds(-6, 6, 1, 5), random_bounds(-20, 20, 5, 20));
 

--- a/gcs/constraints/inverse/inverse_test.cc
+++ b/gcs/constraints/inverse/inverse_test.cc
@@ -34,7 +34,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -107,6 +106,8 @@ auto run_inverse_test(bool proofs, const ViewWrapConfig & view_cfg, const vector
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Combined x|y operand positions wrapped by the single-position sweep.
@@ -145,8 +146,7 @@ auto main(int argc, char * argv[]) -> int
         {{1, 0}, {1, 0}},  // swap: x[0]=1<->y[1]=0, x[1]=0<->y[0]=1, consistent (tautology)
         {{1, 0}, {0, 1}}}; // x swapped but y identity: inconsistent (contradiction)
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     // Random sweep: equal-length arrays of length 2..4 with domains over
     // {0..n-1} (occasionally const). Inverse forces a permutation matching,

--- a/gcs/constraints/knapsack/knapsack_test.cc
+++ b/gcs/constraints/knapsack/knapsack_test.cc
@@ -31,7 +31,6 @@ using std::max;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -167,8 +166,10 @@ auto run_dup_knapsack_test(bool proofs, const string & label, pair<int, int> val
     (void)valrange;
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     vector<tuple<pair<int, int>, vector<vector<int>>, vector<pair<int, int>>>> data = {{{0, 1}, {{2, 3, 4}, {2, 3, 4}}, {{0, 8}, {3, 1000}}}, //
         {{0, 1}, {{2, 3, 4}, {2, 3, 4}}, {{3, 8}, {3, 1000}}},                                                                                //
         {{0, 1}, {{2, 3, 4}, {2, 3, 4}}, {{0, 8}, {3, 5}}},                                                                                   //
@@ -196,8 +197,7 @@ auto main(int, char *[]) -> int
         {{1, 1}, {{2, 3}}, {{5, 5}}},  // all taken 1: sum 5 == total (tautology)
         {{1, 1}, {{2, 3}}, {{4, 4}}}}; // all taken 1: sum 5 != total 4 (contradiction)
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_coeffs_dist(1, 4), size_dist(1, 4), item_dist(0, 8), bound_dist(0, 40), delta_dist(0, 30);
         auto size = size_dist(rand);

--- a/gcs/constraints/knapsack/knapsack_upfront_test.cc
+++ b/gcs/constraints/knapsack/knapsack_upfront_test.cc
@@ -32,7 +32,6 @@ using std::max;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -227,8 +226,10 @@ auto run_knapsack_upfront_regression(pair<int, int> valrange, const vector<vecto
     test_innards::check_results(make_optional(proof_name), expected, actual);
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Deterministic regressions first, so we know fast if the worst-case
     // search paths are broken even though the random tests below would
     // sometimes mask it. Minimal repro for the per-call dead-state RUP
@@ -263,8 +264,7 @@ auto main(int, char *[]) -> int
         {{1, 1}, {{2, 3}}, {{5, 5}}},  // all taken 1: sum 5 == total (tautology)
         {{1, 1}, {{2, 3}}, {{4, 4}}}}; // all taken 1: sum 5 != total 4 (contradiction)
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_coeffs_dist(1, 4), size_dist(1, 4), item_dist(0, 8), bound_dist(0, 40), delta_dist(0, 30);
         auto size = size_dist(rand);

--- a/gcs/constraints/lex/lex_test.cc
+++ b/gcs/constraints/lex/lex_test.cc
@@ -551,6 +551,8 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Positions 0..5 cover the length-3 case fully (both 3-element arrays);

--- a/gcs/constraints/linear/linear_constant_test.cc
+++ b/gcs/constraints/linear/linear_constant_test.cc
@@ -70,8 +70,10 @@ namespace
     }
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -22,7 +22,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -298,6 +297,8 @@ auto run_dup_linear_test(bool proofs, const string & mode, pair<int, int> a_rang
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Mode is the first non-flag positional; --view-* flags may follow. With no
     // mode given (a manual run rather than the ctest harness) run every mode.
     string requested_mode;
@@ -352,8 +353,7 @@ auto main(int argc, char * argv[]) -> int
 
     data.emplace_back(pair{8, 14}, pair{0, 8}, pair{4, 19}, vector{pair{vector{-7, 6, 7}, 69}});
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     uniform_int_distribution nc_dist(1, 5);
     for (int x = 0; x < 5; ++x)
         generate_random_data(rand, data, random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15), random_bounds(-10, 10, 5, 15),

--- a/gcs/constraints/logical/logical_test.cc
+++ b/gcs/constraints/logical/logical_test.cc
@@ -21,7 +21,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -154,6 +153,8 @@ auto run_alias_reif_logical_test(const string & which, bool proofs, const vector
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Operand positions wrapped by the sweep. The fixed data tops out at 4
@@ -187,8 +188,7 @@ auto main(int argc, char * argv[]) -> int
         {{{1, 1}, {1, 1}}, {0, 0}},  // all true but reif pinned false (contradiction for Or; And too)
         {{{0, 0}, {0, 0}}, {1, 1}}}; // all false but reif pinned true (contradiction)
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     uniform_int_distribution n_values_dist(1, 4);
     for (int x = 0; x < 10; ++x) {
         auto n_values = n_values_dist(rand);

--- a/gcs/constraints/mdd/mdd_test.cc
+++ b/gcs/constraints/mdd/mdd_test.cc
@@ -120,8 +120,10 @@ auto run_all_tests(bool proofs) -> void
         {{{{0_i, 0}, {1_i, 1}, {2_i, 1}}}, {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 0}}}, {{{0_i, 0}}, {{1_i, 0}}}}, {1, 2, 2, 1}, {0});
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;

--- a/gcs/constraints/min_max/min_max_test.cc
+++ b/gcs/constraints/min_max/min_max_test.cc
@@ -30,7 +30,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -138,6 +137,8 @@ auto run_dup_min_max_test(bool proofs, bool min, const string & label, const vec
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Position 0 = result; positions 1..5 = up to 5 array entries.
@@ -175,8 +176,7 @@ auto main(int argc, char * argv[]) -> int
         {3, {4}},                          // single constant element: result 3 wrong (contradiction both)
         {pair{0, 9}, {3, 5, pair{0, 9}}}}; // mixed: two constants plus a variable
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 5);
         auto n_values = n_values_dist(rand);

--- a/gcs/constraints/multiply/multiply_test.cc
+++ b/gcs/constraints/multiply/multiply_test.cc
@@ -26,7 +26,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -210,6 +209,8 @@ auto run_constant_test(
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // The view-wrap sweep: wrap each operand position per the config and run
     // a focused deterministic subset, with the proof files suffixed so
     // parallel ctest entries never clobber each other.
@@ -250,8 +251,7 @@ auto main(int argc, char * argv[]) -> int
     // completeness are checked against a full enumeration; per-node bounds
     // consistency is deliberately not claimed (interval reasoning leaves
     // unsupported endpoints, as the product_bounds test pins).
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     vector<tuple<pair<int, int>, pair<int, int>, pair<int, int>>> random_bc_data;
     for (int x = 0; x < 4; ++x) {
         generate_random_data(rand, random_bc_data, random_bounds(-10, 10, 3, 12), random_bounds(-10, 10, 3, 12), random_bounds(-80, 80, 10, 60));

--- a/gcs/constraints/n_value/n_value_test.cc
+++ b/gcs/constraints/n_value/n_value_test.cc
@@ -19,7 +19,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -108,6 +107,8 @@ auto run_dup_n_value_test(bool proofs, const vector<pair<int, int>> & unique_dom
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 6;
@@ -141,8 +142,7 @@ auto main(int argc, char * argv[]) -> int
         {2, {7}},                 // single constant element: result can't be 2 (contradiction)
         {2, {5, pair{5, 6}, 6}}}; // mixed: two constants plus a variable
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 5);
         auto n_values = n_values_dist(rand);

--- a/gcs/constraints/parity/parity_test.cc
+++ b/gcs/constraints/parity/parity_test.cc
@@ -30,7 +30,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -112,6 +111,8 @@ auto run_dup_parity_test(bool proofs, const vector<pair<int, int>> & unique_doma
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 4;
@@ -154,8 +155,7 @@ auto main(int argc, char * argv[]) -> int
         {1, 2, 0, -1} //
     };
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         uniform_int_distribution n_values_dist(1, 4);
         auto n_values = n_values_dist(rand);

--- a/gcs/constraints/plus_minus/plus_minus_test.cc
+++ b/gcs/constraints/plus_minus/plus_minus_test.cc
@@ -31,7 +31,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::string;
 using std::tuple;
@@ -193,6 +192,8 @@ auto run_tagged_test(bool proofs, const string & proof_suffix, const PlusConsist
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 3;
@@ -235,8 +236,7 @@ auto main(int argc, char * argv[]) -> int
     // return type (because hand-rolled cases include hole-y vector<int> domains
     // that the random sweep doesn't produce), so visit-widen at insertion.
     auto widen_v12 = [](variant<int, pair<int, int>> v) -> V12 { return visit([](auto x) -> V12 { return x; }, v); };
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {
         auto r1 = generate_random_data_item(rand, random_bounds_or_constant(-10, 10, 5, 15));
         auto r2 = generate_random_data_item(rand, random_bounds_or_constant(-10, 10, 5, 15));

--- a/gcs/constraints/power/power_test.cc
+++ b/gcs/constraints/power/power_test.cc
@@ -232,6 +232,8 @@ auto run_power_alias_test(bool proofs, pair<int, int> x_range) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // The view-wrap sweep over (base, result): a focused constant-exponent
     // battery under wraps, proof files suffixed per config.
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);

--- a/gcs/constraints/regular/regular_bacchus_test.cc
+++ b/gcs/constraints/regular/regular_bacchus_test.cc
@@ -95,8 +95,10 @@ auto run_all_tests(bool proofs) -> void
         {{{0_i, 0}, {1_i, 0}, {2_i, 1}}, {{0_i, 1}, {1_i, 1}, {2_i, 1}}}, {1});
 }
 
-auto main(int, char *[]) -> int
+auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;

--- a/gcs/constraints/regular/regular_legacy_test.cc
+++ b/gcs/constraints/regular/regular_legacy_test.cc
@@ -290,6 +290,8 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Sequence positions wrapped by the single-position sweep. The fixed

--- a/gcs/constraints/regular/regular_test.cc
+++ b/gcs/constraints/regular/regular_test.cc
@@ -290,6 +290,8 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     // Sequence positions wrapped by the single-position sweep. The fixed

--- a/gcs/constraints/seq_precede_chain/seq_precede_chain_test.cc
+++ b/gcs/constraints/seq_precede_chain/seq_precede_chain_test.cc
@@ -30,7 +30,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -236,6 +235,8 @@ auto run_dup_seq_precede_chain_test(bool proofs, const vector<pair<int, int>> & 
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 5;
@@ -250,8 +251,7 @@ auto main(int argc, char * argv[]) -> int
     // under non-baseline view configs.
     bool run_scale = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())

--- a/gcs/constraints/smart_table/smart_table_test.cc
+++ b/gcs/constraints/smart_table/smart_table_test.cc
@@ -431,6 +431,8 @@ auto run_degenerate_test(bool proofs, const string & mode) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     // Mode is the first non-flag positional. With no mode given (a manual run
     // rather than the ctest harness) run every mode.
     string requested_mode;

--- a/gcs/constraints/sort/arg_sort_test.cc
+++ b/gcs/constraints/sort/arg_sort_test.cc
@@ -26,7 +26,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -110,7 +109,7 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
-    set_seed_from_argv(argc, argv);
+    establish_and_announce_seed(argc, argv);
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
@@ -176,8 +175,7 @@ auto main(int argc, char * argv[]) -> int
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
-        auto seed = get_seed();
-        mt19937 rng(seed ? *seed : random_device{}());
+        mt19937 rng(*get_seed());
         for (int t = 0; t < 8; ++t) {
             auto xd = random_x_domains(rng);
             run_arg_sort_test(proofs, t % 2, xd);

--- a/gcs/constraints/sort/sort_test.cc
+++ b/gcs/constraints/sort/sort_test.cc
@@ -28,7 +28,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::set;
 using std::tuple;
 using std::uniform_int_distribution;
@@ -127,7 +126,7 @@ namespace
 
 auto main(int argc, char * argv[]) -> int
 {
-    set_seed_from_argv(argc, argv);
+    establish_and_announce_seed(argc, argv);
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
@@ -229,8 +228,7 @@ auto main(int argc, char * argv[]) -> int
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
-        auto seed = get_seed();
-        mt19937 rng(seed ? *seed : random_device{}());
+        mt19937 rng(*get_seed());
         for (int t = 0; t < 8; ++t) {
             auto [xd, yd] = random_instance(rng);
             run_sort_test(proofs, xd, yd);

--- a/gcs/constraints/table/negative_table_test.cc
+++ b/gcs/constraints/table/negative_table_test.cc
@@ -226,6 +226,8 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 3;

--- a/gcs/constraints/table/table_test.cc
+++ b/gcs/constraints/table/table_test.cc
@@ -208,6 +208,8 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 3;

--- a/gcs/constraints/value_precede/value_precede_test.cc
+++ b/gcs/constraints/value_precede/value_precede_test.cc
@@ -31,7 +31,6 @@ using std::make_optional;
 using std::mt19937;
 using std::nullopt;
 using std::pair;
-using std::random_device;
 using std::sample;
 using std::set;
 using std::tuple;
@@ -194,6 +193,8 @@ auto run_dup_value_precede_test(bool proofs, const vector<int> & chain, const ve
 
 auto main(int argc, char * argv[]) -> int
 {
+    establish_and_announce_seed(argc, argv);
+
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
 
     constexpr int n_positions = 5;
@@ -202,8 +203,7 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_SUCCESS;
     }
 
-    random_device rand_dev;
-    mt19937 rand(rand_dev());
+    mt19937 rand(*get_seed());
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())


### PR DESCRIPTION
Every constraint test draws fresh randomness on every run — data generation in about thirty of them, branching order in all of them via `random_branch_with_optional_seed()` — and nothing ever records what was drawn. So a pathologically slow or failing random instance is unreproducible after the fact. (The immediate prompt: a reified-linear Sanitize CI lane spent 767 seconds on one draw, roughly 3× the family's typical worst case, and there was no way to look at what it had drawn.)

This adds `establish_and_announce_seed()` to the test utilities: take `--seed=N` if given, otherwise draw a seed from `random_device`, store it in the existing `seed_storage()` singleton, and announce it on stderr as `<binary>: random seed is N (reproduce with --seed=N)`. Every constraint test `main()` now calls it, and the tests that seeded their data RNG from `random_device` directly now seed from the stored value instead, so the whole run — data and branching both — flows from the one announced seed. Re-running the same command line with `--seed=N` appended reproduces the run; verified byte-identical stderr (which includes every generated instance description) for `linear_test`, `circuit_test`, and `sort_test`. ctest echoes the output of failing tests, so the seed lands in the CI log exactly when it is most needed.

Mechanics: the eleven `main(int, char *[])` signatures gain parameter names; the 28 `random_device rand_dev; mt19937 rand(rand_dev());` pairs become `mt19937 rand(*get_seed());`; `sort`/`arg_sort`/`equals`, which were already wired to `--seed`, switch from `set_seed_from_argv()` to the announcing variant and drop their now-redundant fallback ternaries; the orphaned `using std::random_device;` declarations go.

One behavioural consequence to be aware of: where a test previously drew independently in several places (`sort` and friends constructed a fresh RNG per proofs mode), those constructions now start from the same seed, so the proof and non-proof passes see the same random instances. That is exactly how `--seed=N` already behaved for the wired tests; instance diversity across CI runs is unchanged, and the proof lane now checks precisely the instances the enumeration lane enumerated.

Not wired, deliberately: the Catch2-based tests and the deterministic dup/probe binaries (`circuit_dup_test`, `smart_table_dup_test`, `product_bounds_test`), which have no per-run randomness to announce.

All 511 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG64fM66vNWW4TG1MLXW45
