### PR TITLE
Speed up proof writing (2.6-3x on cheap-constraint problems)

### DIFF
--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -286,30 +286,29 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         return visit([&](auto & v1, auto & v2) { return enforce_equality(logger, v1, v2, state, inference, ReasonLiterals{cond}, owner); }, v1, v2);
     };
 
-    auto v1_scope = std::make_shared<const std::vector<IntegerVariableID>>(std::vector<IntegerVariableID>{_v1});
-    auto v2_scope = std::make_shared<const std::vector<IntegerVariableID>>(std::vector<IntegerVariableID>{_v2});
-    auto v1v2_scope = std::make_shared<const std::vector<IntegerVariableID>>(std::vector<IntegerVariableID>{_v1, _v2});
-    auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2, v1_scope, v2_scope, owner = constraint_id()](const State & state, auto & inference,
+    auto enforce_constraint_must_not_hold = [v1 = _v1, v2 = _v2, owner = constraint_id()](const State & state, auto & inference,
                                                 ProofLogger * const logger, const Literal & cond) -> PropagatorState {
         auto value1 = state.optional_single_value(v1);
         if (value1) {
+            // The reason is stated outright -- the value is already in hand, so
+            // deferring through ExactSingleValue would only re-read the domain
+            // at materialise time, and both literals sit inline.
             if (! inference.infer_not_equal_or_stop(logger, v2, *value1, JustifyUsingRUP{hints::Equals{owner}},
-                    inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v1_scope.get()}}) : Reason{}))
+                    inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{cond, v1 == *value1}}} : Reason{}))
                 return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::DisableUntilBacktrack;
         }
         auto value2 = state.optional_single_value(v2);
         if (value2) {
             if (! inference.infer_not_equal_or_stop(logger, v1, *value2, JustifyUsingRUP{hints::Equals{owner}},
-                    inference.want_reasons() ? concat(singleton_reason(cond), ExactSingleValue{ReasonVars{v2_scope.get()}}) : Reason{}))
+                    inference.want_reasons() ? Reason{ExplicitReason{ReasonLiterals{cond, v2 == *value2}}} : Reason{}))
                 return PropagatorState::Enable; // contradiction: loop sees tracker.contradicted()
             return PropagatorState::DisableUntilBacktrack;
         }
         return PropagatorState::Enable;
     };
 
-    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, v1v2_scope, owner = constraint_id()](const State & state, auto &,
-                                         ProofLogger * const logger,
+    auto infer_cond_when_undecided = [v1 = _v1, v2 = _v2, owner = constraint_id()](const State & state, auto &, ProofLogger * const logger,
                                          const IntegerVariableCondition & cond) -> ReificationVerdictFor<EqualsJustification> {
         // Aliased non-constant operands: equality definitely holds regardless of
         // domain. Returning MustHold here lets the dispatcher pin the cond
@@ -323,7 +322,7 @@ auto ReifiedEquals::install_propagators(Propagators & propagators) -> void
         auto value1 = state.optional_single_value(v1);
         auto value2 = state.optional_single_value(v2);
         if (value1 && value2) {
-            auto reason = Reason{ExactSingleValue{ReasonVars{v1v2_scope.get()}}};
+            auto reason = Reason{ExplicitReason{ReasonLiterals{v1 == *value1, v2 == *value2}}};
             if (*value1 == *value2)
                 return reification_verdict::MustHold<EqualsJustification>{
                     .justification = JustifyUsingRUP{hints::Equals{owner}}, //

--- a/gcs/innards/assertion_hints.hh
+++ b/gcs/innards/assertion_hints.hh
@@ -9,20 +9,10 @@
 #include <gcs/integer.hh>
 
 #include <optional>
-#include <ostream>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
-#include <version>
-
-#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
-#include <format>
-using std::format;
-#else
-#include <fmt/core.h>
-using fmt::format;
-#endif
 
 namespace gcs::innards
 {
@@ -163,23 +153,6 @@ namespace gcs::innards
         std::string_view hint_name = "";
         std::optional<SExpr> hint_fields = std::nullopt;
     };
-
-    /**
-     * \brief An assertion annotation can be written to an ostream.
-     *
-     * \ingroup Innards
-     */
-    inline auto operator<<(std::ostream & s, const AssertionAnnotation & annotation) -> std::ostream &
-    {
-        s << ":";
-        for (const auto & id_or_label : annotation.derivable_from) {
-            s << id_or_label << " ";
-        }
-        s << ":" << annotation.hint_name << ":";
-        if (annotation.hint_fields)
-            s << format("{}", *annotation.hint_fields);
-        return s;
-    }
 
 } // namespace gcs::innards
 #endif

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -28,6 +28,36 @@ namespace gcs::innards
     {
     };
 
+    // A reason with its materialisation timing pinned by snapshot_reason: for
+    // the Lazy kinds, a pointer to the still-declarative reason (materialised
+    // against the post-inference state each time it is asked for, exactly as
+    // before); for everything else, the literals themselves, snapshotted
+    // pre-inference. track/track_explicit consume this directly, so the eager
+    // literals reach the logger without being wrapped back up in an
+    // ExplicitReason and re-materialised (a copy) per inference.
+    struct SnapshottedReason
+    {
+        const Reason * materialise_later = nullptr;
+        ReasonLiterals literals{};
+        // The declarative reason this was snapshotted from, still in its
+        // pre-materialisation form. Only the contradiction path reads it, to
+        // stash the reason for the conflict observers -- and they want it
+        // whether or not proofs are on, so it is recorded on every snapshot
+        // path, including the two that produce no literals at all.
+        const Reason * original = nullptr;
+
+        // The literals to log, against `state` as it is now; `scratch` backs
+        // the lazy case, so a multi-literal inference materialises per
+        // literal, as the old re-entrant path did.
+        [[nodiscard]] auto materialised(const State & state, ReasonLiterals & scratch) const -> const ReasonLiterals &
+        {
+            if (! materialise_later)
+                return literals;
+            scratch = materialise(*materialise_later, state);
+            return scratch;
+        }
+    };
+
     template <typename Actual_>
     class InferenceTrackerBase
     {
@@ -53,11 +83,11 @@ namespace gcs::innards
         // do_throw is forwarded to track_impl: true (the default) keeps the throwing
         // failure path the legacy infer* methods rely on; false is the non-throwing
         // infer_*_or_stop path, which sets _contradicted and returns instead.
-        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason,
+        auto track(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const SnapshottedReason & reason,
             const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt, bool do_throw = true) -> void
         {
             if (inf == Inference::Contradiction)
-                _last_contradiction_reason = reason;
+                _last_contradiction_reason = reason.original ? *reason.original : Reason{};
             return static_cast<Actual_ *>(this)->track_impl(logger, inf, lit, just, reason, assertion_hints, do_throw);
         }
 
@@ -75,22 +105,30 @@ namespace gcs::innards
         //   - the Lazy variants: these used to be evaluated by the logger, after
         //     the inference. Carry the declarative reason unchanged so it
         //     materialises against the (post-inference) state later.
-        [[nodiscard]] static auto snapshot_reason(ProofLogger * const logger, const Reason & reason, State & state) -> Reason
+        [[nodiscard]] static auto snapshot_reason(ProofLogger * const logger, const Reason & reason, State & state) -> SnapshottedReason
         {
-            // The proofs-off (non-materialising) tracker never reads the reason, so
-            // this collapses to a constant NoReason there and the whole call — and
-            // the snapshotted Reason it would have produced — is dead-code eliminated.
+            // The proofs-off (non-materialising) tracker never *logs* the reason, so
+            // this collapses to just recording the handle there: no domain walk, and
+            // the literals the snapshot would have built are never materialised. The
+            // handle itself is still wanted, because a contradiction hands it to the
+            // conflict observers (dom/wdeg), which run with proofs off.
             if constexpr (! Actual_::materialises_reasons)
-                return NoReason{};
+                return SnapshottedReason{.original = &reason};
             else {
                 if (! logger)
-                    return NoReason{};
+                    return SnapshottedReason{.original = &reason};
 
                 return reason.visit(overloaded{
-                    [&](const NoReason &) -> Reason { return NoReason{}; },                            //
-                    [&](const LazyReasonOver &) -> Reason { return reason; },                          //
-                    [&](const NarrowableLazyReasonOver &) -> Reason { return reason; },                //
-                    [&](const auto &) -> Reason { return ExplicitReason{materialise(reason, state)}; } //
+                    [&](const NoReason &) -> SnapshottedReason { return SnapshottedReason{.original = &reason}; }, //
+                    [&](const LazyReasonOver &) -> SnapshottedReason {
+                        return SnapshottedReason{.materialise_later = &reason, .original = &reason};
+                    }, //
+                    [&](const NarrowableLazyReasonOver &) -> SnapshottedReason {
+                        return SnapshottedReason{.materialise_later = &reason, .original = &reason};
+                    }, //
+                    [&](const auto &) -> SnapshottedReason {
+                        return SnapshottedReason{.literals = materialise(reason, state), .original = &reason};
+                    } //
                 });
             }
         }
@@ -131,7 +169,7 @@ namespace gcs::innards
         // _contradicted and returns normally, and the propagate loop detects it.
         template <typename Emit_, typename Hint_>
         auto track_explicit(ProofLogger * const logger, const Inference inf, const Literal & lit, const JustifyExplicitly<Emit_, Hint_> & why,
-            const Reason & reason, const std::optional<AssertionAnnotation> & fallback, bool do_throw = true) -> void
+            const SnapshottedReason & reason, const std::optional<AssertionAnnotation> & fallback, bool do_throw = true) -> void
         {
             switch (inf) {
             case Inference::NoChange: break;
@@ -140,16 +178,20 @@ namespace gcs::innards
             case Inference::BoundsChanged:
             case Inference::Instantiated:
                 if constexpr (Actual_::materialises_reasons)
-                    if (logger)
-                        infer_explicitly(*logger, lit, why.emit, why.then_rup, materialise(reason, _state), why.hint, fallback);
+                    if (logger) {
+                        ReasonLiterals scratch;
+                        infer_explicitly(*logger, lit, why.emit, why.then_rup, reason.materialised(_state, scratch), why.hint, fallback);
+                    }
                 record_firing_inference(inf, lit);
                 break;
 
             [[unlikely]] case Inference::Contradiction:
-                _last_contradiction_reason = reason;
+                _last_contradiction_reason = reason.original ? *reason.original : Reason{};
                 if constexpr (Actual_::materialises_reasons)
-                    if (logger)
-                        infer_explicitly(*logger, lit, why.emit, why.then_rup, materialise(reason, _state), why.hint, fallback);
+                    if (logger) {
+                        ReasonLiterals scratch;
+                        infer_explicitly(*logger, lit, why.emit, why.then_rup, reason.materialised(_state, scratch), why.hint, fallback);
+                    }
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _made_progress_since_last_check = true;
                 _contradicted = true;
@@ -557,7 +599,7 @@ namespace gcs::innards
             // JustifyExplicitly infer_all overload below.
             auto snapshotted = snapshot_reason(logger, reason, _state);
             for (const auto & lit : lits)
-                infer(logger, lit, why, snapshotted, assertion_hints);
+                track(logger, _state.infer(lit), lit, why, snapshotted, assertion_hints);
         }
 
         // The JustifyExplicitly counterpart of infer_all. When the steps end in a
@@ -582,11 +624,11 @@ namespace gcs::innards
                         return;
 
                     auto snapshotted = snapshot_reason(logger, reason, _state);
-                    ReasonLiterals reason_lits = materialise(snapshotted, _state);
+                    ReasonLiterals scratch;
                     auto t = logger->temporary_proof_level();
-                    emit_explicit_steps(*logger, why.emit, reason_lits);
+                    emit_explicit_steps(*logger, why.emit, snapshotted.materialised(_state, scratch));
                     for (const auto & lit : lits)
-                        infer(logger, lit, JustifyUsingRUP{}, snapshotted);
+                        track(logger, _state.infer(lit), lit, JustifyUsingRUP{}, snapshotted);
                     logger->forget_proof_level(t);
                     return;
                 }
@@ -594,7 +636,7 @@ namespace gcs::innards
 
             auto snapshotted = snapshot_reason(logger, reason, _state);
             for (const auto & lit : lits)
-                infer(logger, lit, why, snapshotted, fallback);
+                track_explicit(logger, _state.infer(lit), lit, why, snapshotted, fallback);
         }
 
         // Yields this round's inferences in the order they were made (oldest first). The
@@ -666,7 +708,7 @@ namespace gcs::innards
         // path skips snapshot_reason and every proof-only block compiles out.
         static constexpr bool materialises_reasons = false;
 
-        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const Reason &,
+        auto track_impl(ProofLogger * const, const Inference inf, const Literal & lit, const Justification &, const SnapshottedReason &,
             const std::optional<AssertionAnnotation> &, bool do_throw = true) -> void
         {
             switch (inf) {
@@ -711,8 +753,8 @@ namespace gcs::innards
 
         static constexpr bool materialises_reasons = true;
 
-        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just, const Reason & reason,
-            const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt, bool do_throw = true) -> void
+        auto track_impl(ProofLogger * const logger, const Inference inf, const Literal & lit, const Justification & just,
+            const SnapshottedReason & reason, const std::optional<AssertionAnnotation> & assertion_hints = std::nullopt, bool do_throw = true) -> void
         {
             switch (inf) {
             case Inference::NoChange: break;
@@ -721,13 +763,11 @@ namespace gcs::innards
             case Inference::BoundsChanged:
             case Inference::Instantiated:
                 if (logger) {
-                    // Materialise the reason here, post-inference: snapshot_reason
-                    // already pinned the timing (eager kinds are a fixed
-                    // ExplicitReason snapshot taken pre-inference, Lazy kinds stay
-                    // declarative and materialise against the now-current state),
-                    // so materialising now gives both kinds the literals the logger
-                    // used to compute internally.
-                    logger->infer(lit, just, materialise(reason, _state), assertion_hints);
+                    // The snapshot pinned the timing: eager kinds carry literals
+                    // taken pre-inference, Lazy kinds stay declarative and
+                    // materialise here against the now-current state.
+                    ReasonLiterals scratch;
+                    logger->infer(lit, just, reason.materialised(_state, scratch), assertion_hints);
                 }
 
                 overloaded{
@@ -749,8 +789,10 @@ namespace gcs::innards
                 break;
 
             [[unlikely]] case Inference::Contradiction:
-                if (logger)
-                    logger->infer(lit, just, materialise(reason, _state), assertion_hints);
+                if (logger) {
+                    ReasonLiterals scratch;
+                    logger->infer(lit, just, reason.materialised(_state, scratch), assertion_hints);
+                }
                 _did_anything_since_last_call_by_propagation_queue = true;
                 _made_progress_since_last_check = true;
                 _contradicted = true;

--- a/gcs/innards/proofs/bits_encoding.cc
+++ b/gcs/innards/proofs/bits_encoding.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <bit>
 #include <cstdlib>
+#include <limits>
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -36,4 +37,18 @@ auto gcs::innards::get_bits_encoding_coeffs(Integer lower, Integer upper) -> tup
     Integer highest_bit_coeff = highest_bit_shift >= 0_i ? power2(highest_bit_shift) : 0_i;
     auto negative_bit_coeff = lower < 0_i ? -power2(highest_bit_shift + 1_i) : 0_i;
     return tuple{highest_bit_shift, highest_bit_coeff, negative_bit_coeff};
+}
+
+auto gcs::innards::bits_encoding_fits(Integer lower, Integer upper) -> bool
+{
+    // Mirrors the arithmetic above, which materialises power2(highest_bit_shift)
+    // and, for a negative lower bound, power2(highest_bit_shift + 1); power2
+    // refuses anything that would overflow an Integer. Kept adjacent to
+    // get_bits_encoding_coeffs so the two stay in agreement.
+    if (lower == Integer::min_value())
+        return false;
+    Integer highest_abs_value = lower < 0_i ? max(abs(lower) - 1_i, upper) : upper;
+    Integer highest_bit_shift = Integer{bit_width(static_cast<unsigned long long>(highest_abs_value.raw_value))} - 1_i;
+    Integer highest_needed_power = lower < 0_i ? highest_bit_shift + 1_i : highest_bit_shift;
+    return highest_needed_power < Integer{std::numeric_limits<long long>::digits};
 }

--- a/gcs/innards/proofs/bits_encoding.hh
+++ b/gcs/innards/proofs/bits_encoding.hh
@@ -16,6 +16,19 @@ namespace gcs::innards
      * \ingroup Innards
      */
     [[nodiscard]] auto get_bits_encoding_coeffs(Integer lower, Integer upper) -> std::tuple<Integer, Integer, Integer>;
+
+    /**
+     * \brief Can a variable ranging from lower to upper actually be given a
+     * bits encoding, or would its coefficients overflow an Integer?
+     *
+     * FlatZinc's unbounded ints get bounds of half the Integer range, which
+     * still encodes -- but a view negating such a variable can need one more
+     * bit than exists. Callers introducing a bit vector for a *derived* range
+     * check this first and fall back rather than overflow.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto bits_encoding_fits(Integer lower, Integer upper) -> bool;
 }
 
 #endif

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -21,20 +21,16 @@ namespace
         out += name;
         out += ' ';
     }
-}
 
-auto gcs::innards::emit_inequality_to(NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
-    string & out, EnsureNames ensure_names) -> void
-{
-    // build up the inequality, adjusting as we go for constant terms,
-    // and converting from <= to >=.
-    Integer rhs = -ineq.rhs;
-    for (auto & [w, v] : ineq.lhs.terms) {
-        if (0_i == w)
-            continue;
-
+    // Render one weighted term of a PB inequality being emitted in >= form:
+    // append its literal rendering(s) to `out` with negated weight, or fold a
+    // constant term into `rhs`. Shared by the plain and reified renderers so
+    // there is exactly one spelling of every term.
+    auto append_or_fold_term_to(NamesAndIDsTracker & names_and_ids_tracker, Integer w, const PseudoBooleanTerm & v, string & out, Integer & rhs,
+        EnsureNames ensure_names) -> void
+    {
         overloaded{
-            [&, w = w](const ProofLiteral & lit) {
+            [&](const ProofLiteral & lit) {
                 overloaded{
                     [&](const TrueLiteral &) { rhs += w; }, //
                     [&](const FalseLiteral &) {},           //
@@ -45,9 +41,9 @@ auto gcs::innards::emit_inequality_to(NamesAndIDsTracker & names_and_ids_tracker
                     } //
                 }
                     .visit(simplify_literal(names_and_ids_tracker, lit));
-            },                                                                                                               //
-            [&, w = w](const ProofFlag & flag) { append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(flag)); }, //
-            [&, w = w](const IntegerVariableID & var) {
+            },                                                                                                        //
+            [&](const ProofFlag & flag) { append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(flag)); }, //
+            [&](const IntegerVariableID & var) {
                 overloaded{
                     [&](const SimpleIntegerVariableID & var) {
                         for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(var))
@@ -79,17 +75,62 @@ auto gcs::innards::emit_inequality_to(NamesAndIDsTracker & names_and_ids_tracker
                 }
                     .visit(var);
             }, //
-            [&, w = w](const ProofOnlySimpleIntegerVariableID & var) {
+            [&](const ProofOnlySimpleIntegerVariableID & var) {
                 for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(var))
                     append_term_to(out, -w * bit_value, names_and_ids_tracker.pb_file_string_for(bit_lit));
             }, //
-            [&, w = w](const ProofBitVariable & bit) {
+            [&](const ProofBitVariable & bit) {
                 auto [_, bit_name] = names_and_ids_tracker.get_bit(bit);
                 append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(bit_name));
             }, //
         }
             .visit(v);
     }
+}
+
+auto gcs::innards::emit_inequality_to(NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
+    string & out, EnsureNames ensure_names) -> void
+{
+    // build up the inequality, adjusting as we go for constant terms,
+    // and converting from <= to >=.
+    Integer rhs = -ineq.rhs;
+    for (auto & [w, v] : ineq.lhs.terms) {
+        if (0_i == w)
+            continue;
+        append_or_fold_term_to(names_and_ids_tracker, w, v, out, rhs, ensure_names);
+    }
+
+    out += ">= ";
+    append_number_to(out, rhs);
+}
+
+auto gcs::innards::emit_reified_inequality_to(NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
+    const HalfReifyOnConjunctionOf & half_reif, string & out, EnsureNames ensure_names) -> void
+{
+    // Renders exactly what emit_inequality_to would produce for
+    // reify(ineq, half_reif), without materialising the reified sum: the
+    // base terms, then each negated reifying term with the reification
+    // coefficient, converted from <= to >= as usual.
+    auto shape = names_and_ids_tracker.reification_shape(ineq, half_reif);
+
+    Integer rhs = -shape.effective_rhs;
+    for (auto & [w, v] : ineq.lhs.terms) {
+        if (0_i == w)
+            continue;
+        append_or_fold_term_to(names_and_ids_tracker, w, v, out, rhs, ensure_names);
+    }
+
+    for (auto & r : half_reif)
+        overloaded{
+            [&](const ProofFlag & f) { append_or_fold_term_to(names_and_ids_tracker, shape.reif_coefficient, ! f, out, rhs, ensure_names); }, //
+            [&](const ProofLiteral & lit) {
+                append_or_fold_term_to(names_and_ids_tracker, shape.reif_coefficient, ! lit, out, rhs, ensure_names);
+            }, //
+            [&](const ProofBitVariable & bit) {
+                append_or_fold_term_to(names_and_ids_tracker, shape.reif_coefficient, ! bit, out, rhs, ensure_names);
+            } //
+        }
+            .visit(r);
 
     out += ">= ";
     append_number_to(out, rhs);

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -23,8 +23,8 @@ namespace
     }
 }
 
-auto gcs::innards::emit_inequality_to(
-    NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, string & out) -> void
+auto gcs::innards::emit_inequality_to(NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
+    string & out, EnsureNames ensure_names) -> void
 {
     // build up the inequality, adjusting as we go for constant terms,
     // and converting from <= to >=.
@@ -38,8 +38,11 @@ auto gcs::innards::emit_inequality_to(
                 overloaded{
                     [&](const TrueLiteral &) { rhs += w; }, //
                     [&](const FalseLiteral &) {},           //
-                    [&]<typename T_>(
-                        const VariableConditionFrom<T_> & cond) { append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(cond)); } //
+                    [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
+                        append_term_to(out, -w,
+                            EnsureNames::Yes == ensure_names ? names_and_ids_tracker.pb_file_string_for_ensuring(cond)
+                                                             : names_and_ids_tracker.pb_file_string_for(cond));
+                    } //
                 }
                     .visit(simplify_literal(names_and_ids_tracker, lit));
             },                                                                                                               //
@@ -96,6 +99,6 @@ auto gcs::innards::emit_inequality_to(
     NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ostream & stream) -> void
 {
     string out;
-    emit_inequality_to(names_and_ids_tracker, ineq, out);
+    emit_inequality_to(names_and_ids_tracker, ineq, out, EnsureNames::No);
     stream << out;
 }

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -120,15 +120,29 @@ auto gcs::innards::emit_reified_inequality_to(NamesAndIDsTracker & names_and_ids
         append_or_fold_term_to(names_and_ids_tracker, w, v, out, rhs, ensure_names);
     }
 
+    // Each reifying term appears negated. A flag or bit negation is a cheap
+    // struct copy, but negating a condition literal builds a whole new
+    // variant chain just to name it -- and both polarities of a condition are
+    // always introduced together, so the negated condition's literal IS the
+    // negation of the condition's literal. Look up the condition as given and
+    // flip the XLiteral instead.
+    auto w = shape.reif_coefficient;
     for (auto & r : half_reif)
         overloaded{
-            [&](const ProofFlag & f) { append_or_fold_term_to(names_and_ids_tracker, shape.reif_coefficient, ! f, out, rhs, ensure_names); }, //
+            [&](const ProofFlag & f) { append_or_fold_term_to(names_and_ids_tracker, w, ! f, out, rhs, ensure_names); }, //
             [&](const ProofLiteral & lit) {
-                append_or_fold_term_to(names_and_ids_tracker, shape.reif_coefficient, ! lit, out, rhs, ensure_names);
-            }, //
-            [&](const ProofBitVariable & bit) {
-                append_or_fold_term_to(names_and_ids_tracker, shape.reif_coefficient, ! bit, out, rhs, ensure_names);
-            } //
+                overloaded{
+                    [&](const TrueLiteral &) { /* negated: contributes nothing */ }, //
+                    [&](const FalseLiteral &) { rhs += w; },                         //
+                    [&]<typename T_>(const VariableConditionFrom<T_> & cond) {
+                        auto xlit = EnsureNames::Yes == ensure_names ? names_and_ids_tracker.xliteral_for_ensuring(cond)
+                                                                     : names_and_ids_tracker.xliteral_for(cond);
+                        append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(! xlit));
+                    } //
+                }
+                    .visit(simplify_literal(names_and_ids_tracker, lit));
+            },                                                                                                                     //
+            [&](const ProofBitVariable & bit) { append_or_fold_term_to(names_and_ids_tracker, w, ! bit, out, rhs, ensure_names); } //
         }
             .visit(r);
 

--- a/gcs/innards/proofs/emit_inequality_to.cc
+++ b/gcs/innards/proofs/emit_inequality_to.cc
@@ -4,14 +4,27 @@
 
 #include <util/overloaded.hh>
 
+#include <ostream>
+
 using std::ostream;
 using std::string;
 
 using namespace gcs;
 using namespace gcs::innards;
 
+namespace
+{
+    auto append_term_to(string & out, Integer w, const string & name) -> void
+    {
+        append_number_to(out, w);
+        out += ' ';
+        out += name;
+        out += ' ';
+    }
+}
+
 auto gcs::innards::emit_inequality_to(
-    NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ostream & stream) -> void
+    NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, string & out) -> void
 {
     // build up the inequality, adjusting as we go for constant terms,
     // and converting from <= to >=.
@@ -26,16 +39,16 @@ auto gcs::innards::emit_inequality_to(
                     [&](const TrueLiteral &) { rhs += w; }, //
                     [&](const FalseLiteral &) {},           //
                     [&]<typename T_>(
-                        const VariableConditionFrom<T_> & cond) { stream << -w << " " << names_and_ids_tracker.pb_file_string_for(cond) << " "; } //
+                        const VariableConditionFrom<T_> & cond) { append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(cond)); } //
                 }
                     .visit(simplify_literal(names_and_ids_tracker, lit));
-            },                                                                                                                    //
-            [&, w = w](const ProofFlag & flag) { stream << -w << " " << names_and_ids_tracker.pb_file_string_for(flag) << " "; }, //
+            },                                                                                                               //
+            [&, w = w](const ProofFlag & flag) { append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(flag)); }, //
             [&, w = w](const IntegerVariableID & var) {
                 overloaded{
                     [&](const SimpleIntegerVariableID & var) {
                         for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(var))
-                            stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                            append_term_to(out, -w * bit_value, names_and_ids_tracker.pb_file_string_for(bit_lit));
                     },
                     [&](const ViewOfIntegerVariableID & view) {
                         // Emit V's own bits when the view is registered (the
@@ -46,16 +59,16 @@ auto gcs::innards::emit_inequality_to(
                         // proof logging, which the registry doesn't support.
                         if (auto v_id = names_and_ids_tracker.find_view(view)) {
                             for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(*v_id))
-                                stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                                append_term_to(out, -w * bit_value, names_and_ids_tracker.pb_file_string_for(bit_lit));
                         }
                         else if (! view.negate_first) {
                             for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(view.actual_variable))
-                                stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                                append_term_to(out, -w * bit_value, names_and_ids_tracker.pb_file_string_for(bit_lit));
                             rhs += w * view.then_add;
                         }
                         else {
                             for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(view.actual_variable))
-                                stream << w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                                append_term_to(out, w * bit_value, names_and_ids_tracker.pb_file_string_for(bit_lit));
                             rhs += w * view.then_add;
                         }
                     },
@@ -65,15 +78,24 @@ auto gcs::innards::emit_inequality_to(
             }, //
             [&, w = w](const ProofOnlySimpleIntegerVariableID & var) {
                 for (const auto & [bit_value, bit_lit] : names_and_ids_tracker.each_bit(var))
-                    stream << -w * bit_value << " " << names_and_ids_tracker.pb_file_string_for(bit_lit) << " ";
+                    append_term_to(out, -w * bit_value, names_and_ids_tracker.pb_file_string_for(bit_lit));
             }, //
             [&, w = w](const ProofBitVariable & bit) {
                 auto [_, bit_name] = names_and_ids_tracker.get_bit(bit);
-                stream << -w << " " << names_and_ids_tracker.pb_file_string_for(bit_name) << " ";
+                append_term_to(out, -w, names_and_ids_tracker.pb_file_string_for(bit_name));
             }, //
         }
             .visit(v);
     }
 
-    stream << ">= " << rhs;
+    out += ">= ";
+    append_number_to(out, rhs);
+}
+
+auto gcs::innards::emit_inequality_to(
+    NamesAndIDsTracker & names_and_ids_tracker, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ostream & stream) -> void
+{
+    string out;
+    emit_inequality_to(names_and_ids_tracker, ineq, out);
+    stream << out;
 }

--- a/gcs/innards/proofs/emit_inequality_to.hh
+++ b/gcs/innards/proofs/emit_inequality_to.hh
@@ -41,13 +41,33 @@ namespace gcs::innards
     }
 
     /**
+     * \brief Should rendering an inequality introduce proof names for
+     * conditions that do not have one yet?
+     *
+     * `Yes` fuses what would otherwise be a separate need_all_proof_names_in
+     * pass into rendering: an introduction emits its definition lines to the
+     * proof stream mid-render, which is safe precisely because the line being
+     * rendered is being assembled in a buffer and written afterwards. The
+     * model-writing path must use `No` (with an explicit pre-pass), since its
+     * introductions append to the same OPB buffer being rendered into.
+     *
+     * \ingroup Innards
+     */
+    enum class EnsureNames
+    {
+        Yes,
+        No
+    };
+
+    /**
      * \brief Append an inequality, rendered as OPB / proof text, to a string.
      *
      * Only used inside proof innards.
      *
      * \ingroup Innards
      */
-    auto emit_inequality_to(NamesAndIDsTracker &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, std::string & out) -> void;
+    auto emit_inequality_to(
+        NamesAndIDsTracker &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, std::string & out, EnsureNames ensure_names) -> void;
 
     /**
      * \brief Write an inequality out to an ostream.

--- a/gcs/innards/proofs/emit_inequality_to.hh
+++ b/gcs/innards/proofs/emit_inequality_to.hh
@@ -7,10 +7,48 @@
 #include <gcs/innards/proofs/pseudo_boolean.hh>
 #include <gcs/innards/proofs/reification.hh>
 
+#include <charconv>
 #include <iosfwd>
+#include <limits>
+#include <string>
 
 namespace gcs::innards
 {
+    /**
+     * \brief Append a number to a string being built up as proof text,
+     * without the locale machinery or allocation that streams and
+     * to_string bring. Proof lines are assembled with this rather than
+     * ostream insertion because it is on the hot path of every logged
+     * inference.
+     *
+     * \ingroup Innards
+     */
+    inline auto append_number_to(std::string & out, long long v) -> void
+    {
+        // digits10 is the largest number of decimal digits that is guaranteed to
+        // round-trip, so the widest representable value takes one more than that,
+        // and a negative one takes a further character for the sign. The buffer is
+        // therefore always big enough and to_chars cannot fail, so there is no
+        // errc to check.
+        char buf[std::numeric_limits<long long>::digits10 + 2];
+        auto r = std::to_chars(buf, buf + sizeof(buf), v);
+        out.append(buf, r.ptr);
+    }
+
+    inline auto append_number_to(std::string & out, Integer v) -> void
+    {
+        append_number_to(out, v.raw_value);
+    }
+
+    /**
+     * \brief Append an inequality, rendered as OPB / proof text, to a string.
+     *
+     * Only used inside proof innards.
+     *
+     * \ingroup Innards
+     */
+    auto emit_inequality_to(NamesAndIDsTracker &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, std::string & out) -> void;
+
     /**
      * \brief Write an inequality out to an ostream.
      *

--- a/gcs/innards/proofs/emit_inequality_to.hh
+++ b/gcs/innards/proofs/emit_inequality_to.hh
@@ -70,6 +70,21 @@ namespace gcs::innards
         NamesAndIDsTracker &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, std::string & out, EnsureNames ensure_names) -> void;
 
     /**
+     * \brief Append the half-reified form of an inequality, rendered as proof
+     * text, to a string: byte-for-byte what emit_inequality_to produces for
+     * reify(ineq, half_reif), but without materialising the reified sum.
+     * The per-inference emission path, where the materialisation is
+     * measurable, uses this; anything that wants the reified sum as a value
+     * still goes through NamesAndIDsTracker::reify.
+     *
+     * Only used inside proof innards.
+     *
+     * \ingroup Innards
+     */
+    auto emit_reified_inequality_to(NamesAndIDsTracker &, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq,
+        const HalfReifyOnConjunctionOf & half_reif, std::string & out, EnsureNames ensure_names) -> void;
+
+    /**
      * \brief Write an inequality out to an ostream.
      *
      * Only used inside proof innards.

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -96,15 +96,16 @@ namespace
         }
     };
 
-    struct HashVariableCondition
+    // A variable's atoms, one table per condition family, storing only the
+    // positive polarity (the negative-op condition is the flipped literal:
+    // every allocation registers the pair together). Read on every condition
+    // rendered into every proof line, hence value-keyed tables per variable
+    // rather than one big map over whole condition objects.
+    struct VariableAtoms
     {
-        [[nodiscard]] auto operator()(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> std::size_t
-        {
-            auto h = HashSimpleOrProofOnlyVariable{}(cond.var);
-            h = hash_combine(h, static_cast<std::size_t>(cond.op));
-            h = hash_combine(h, static_cast<std::size_t>(cond.value.raw_value));
-            return hash_combine(h, static_cast<std::size_t>(cond.upper_value.raw_value));
-        }
+        std::unordered_map<long long, XLiteral> eq; // Equal; NotEqual is the flip
+        std::unordered_map<long long, XLiteral> ge; // GreaterEqual; Less is the flip
+        map<pair<Integer, Integer>, XLiteral> in;   // InRange by (lo, hi); NotInRange is the flip
     };
 
     struct HashView
@@ -131,7 +132,80 @@ struct NamesAndIDsTracker::Imp
     ProofLogger * logger = nullptr;
 
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
-    unordered_map<VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID>, XLiteral, HashVariableCondition> variable_conditions_to_x;
+    // Indexed by variable index (variables are allocated with sequential
+    // indices, so these stay dense), one per id kind.
+    vector<VariableAtoms> simple_variable_atoms;
+    vector<VariableAtoms> proof_only_variable_atoms;
+
+    [[nodiscard]] auto atoms_for(const SimpleOrProofOnlyIntegerVariableID & id) -> VariableAtoms &
+    {
+        auto & table = visit(overloaded{//
+                                 [&](const SimpleIntegerVariableID &) -> vector<VariableAtoms> & { return simple_variable_atoms; },
+                                 [&](const ProofOnlySimpleIntegerVariableID &) -> vector<VariableAtoms> & { return proof_only_variable_atoms; }},
+            id);
+        auto idx = visit([&](const auto & i) { return static_cast<vector<VariableAtoms>::size_type>(i.index); }, id);
+        if (table.size() <= idx)
+            table.resize(idx + 1);
+        return table[idx];
+    }
+
+    [[nodiscard]] auto find_atoms(const SimpleOrProofOnlyIntegerVariableID & id) const -> const VariableAtoms *
+    {
+        const auto & table =
+            visit(overloaded{//
+                      [&](const SimpleIntegerVariableID &) -> const vector<VariableAtoms> & { return simple_variable_atoms; },
+                      [&](const ProofOnlySimpleIntegerVariableID &) -> const vector<VariableAtoms> & { return proof_only_variable_atoms; }},
+                id);
+        auto idx = visit([&](const auto & i) { return static_cast<vector<VariableAtoms>::size_type>(i.index); }, id);
+        return idx < table.size() ? &table[idx] : nullptr;
+    }
+
+    // The single lookup behind xliteral_for and friends: resolve a condition
+    // to its literal, flipping polarity for the negative ops.
+    [[nodiscard]] auto find_condition(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> optional<XLiteral>
+    {
+        const auto * atoms = find_atoms(cond.var);
+        if (! atoms)
+            return nullopt;
+        auto flip_if = [&](const XLiteral & x, bool negate) { return negate ? ! x : x; };
+        switch (cond.op) {
+            using enum VariableConditionOperator;
+        case Equal:
+        case NotEqual:
+            if (auto it = atoms->eq.find(cond.value.raw_value); it != atoms->eq.end())
+                return flip_if(it->second, NotEqual == cond.op);
+            return nullopt;
+        case GreaterEqual:
+        case Less:
+            if (auto it = atoms->ge.find(cond.value.raw_value); it != atoms->ge.end())
+                return flip_if(it->second, Less == cond.op);
+            return nullopt;
+        case InRange:
+        case NotInRange:
+            if (auto it = atoms->in.find(pair{cond.value, cond.upper_value}); it != atoms->in.end())
+                return flip_if(it->second, NotInRange == cond.op);
+            return nullopt;
+        }
+        throw NonExhaustiveSwitch{};
+    }
+
+    // Record a condition's literal, normalised to the positive op so both
+    // polarities are answerable from one entry. First store wins, matching
+    // the emplace semantics this replaces.
+    auto store_condition(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond, const XLiteral & x) -> void
+    {
+        auto & atoms = atoms_for(cond.var);
+        switch (cond.op) {
+            using enum VariableConditionOperator;
+        case Equal: atoms.eq.try_emplace(cond.value.raw_value, x); return;
+        case NotEqual: atoms.eq.try_emplace(cond.value.raw_value, ! x); return;
+        case GreaterEqual: atoms.ge.try_emplace(cond.value.raw_value, x); return;
+        case Less: atoms.ge.try_emplace(cond.value.raw_value, ! x); return;
+        case InRange: atoms.in.try_emplace(pair{cond.value, cond.upper_value}, x); return;
+        case NotInRange: atoms.in.try_emplace(pair{cond.value, cond.upper_value}, ! x); return;
+        }
+        throw NonExhaustiveSwitch{};
+    }
     unordered_map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, vector<pair<Integer, XLiteral>>>, HashSimpleOrProofOnlyVariable>
         integer_variable_bits_to_size_and_proof_vars;
     unordered_map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, Integer>, HashSimpleOrProofOnlyVariable> integer_variable_definition_bounds;
@@ -159,7 +233,7 @@ struct NamesAndIDsTracker::Imp
         eqvars_that_exist;
     // Range ("in") literals [lo, hi], keyed by (lo, hi): the forward and reverse
     // lines of the reification against the variable's two order cuts. The literal
-    // itself lives in variable_conditions_to_x, keyed by the InRange / NotInRange
+    // itself lives in the per-variable atom tables, keyed by the InRange / NotInRange
     // conditions, just like the eq and order atoms. A width-1 interval is its eq
     // atom and is never entered here.
     unordered_map<SimpleOrProofOnlyIntegerVariableID, map<pair<Integer, Integer>, pair<ProofLine, ProofLine>>, HashSimpleOrProofOnlyVariable>
@@ -292,7 +366,7 @@ auto NamesAndIDsTracker::start_writing_model(ProofModel * const model) -> void
 auto NamesAndIDsTracker::associate_condition_with_xliteral(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond, const XLiteral & x)
     -> void
 {
-    _imp->variable_conditions_to_x.emplace(cond, x);
+    _imp->store_condition(cond, x);
 }
 
 auto NamesAndIDsTracker::track_variable_takes_at_least_one_value(const SimpleOrProofOnlyIntegerVariableID & id, ProofLine line) -> void
@@ -413,8 +487,7 @@ auto NamesAndIDsTracker::create_literals_for_introduced_variable_value(SimpleInt
     // literal can ever be defined over it.
     track_variable_name(id, to_string(id.index) + "intr_" + name); // hack!
     auto x = allocate_xliteral_meaning(id, EqualsOrGreaterEqual::Equals, val);
-    _imp->variable_conditions_to_x.emplace(id == val, x);
-    _imp->variable_conditions_to_x.emplace(id != val, ! x);
+    _imp->store_condition(id == val, x);
 }
 
 auto NamesAndIDsTracker::need_proof_name(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) -> void
@@ -427,7 +500,7 @@ auto NamesAndIDsTracker::need_proof_name(const VariableConditionFrom<SimpleOrPro
     case GreaterEqual: need_gevar(cond.var, cond.value); break;
     case InRange:
     case NotInRange:
-        if (! _imp->variable_conditions_to_x.contains(cond))
+        if (! _imp->find_condition(cond))
             static_cast<void>(need_invar(cond.var, cond.value, cond.upper_value));
         break;
     }
@@ -558,12 +631,11 @@ auto NamesAndIDsTracker::track_eqvar(
 
 auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
 {
-    if (_imp->variable_conditions_to_x.contains(id == v))
+    if (_imp->find_condition(id == v))
         return;
 
     auto eqvar = allocate_xliteral_meaning(id, EqualsOrGreaterEqual::Equals, v);
-    _imp->variable_conditions_to_x.emplace(id == v, eqvar);
-    _imp->variable_conditions_to_x.emplace(id != v, ! eqvar);
+    _imp->store_condition(id == v, eqvar);
 
     auto bounds = _imp->integer_variable_definition_bounds.find(id);
     ProofLine forwards_line, reverse_line;
@@ -745,12 +817,11 @@ auto NamesAndIDsTracker::definitional_label_base(const SimpleOrProofOnlyIntegerV
 
 auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
 {
-    if (_imp->variable_conditions_to_x.contains(id >= v))
+    if (_imp->find_condition(id >= v))
         return;
 
     auto gevar = allocate_xliteral_meaning(id, EqualsOrGreaterEqual::GreaterEqual, v);
-    _imp->variable_conditions_to_x.emplace(id >= v, gevar);
-    _imp->variable_conditions_to_x.emplace(id < v, ! gevar);
+    _imp->store_condition(id >= v, gevar);
 
     // gevar -> bits
     if (_imp->logger && _imp->assertion_level > AssertionLevel::Definitions) {
@@ -1083,8 +1154,7 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     need_gevar(id, hi + 1_i);
 
     auto x = allocate_xliteral_meaning(id, lo, hi);
-    _imp->variable_conditions_to_x.emplace(in_range(id, lo, hi), x);
-    _imp->variable_conditions_to_x.emplace(not_in_range(id, lo, hi), ! x);
+    _imp->store_condition(in_range(id, lo, hi), x);
 
     auto will_define = _imp->logger->get_assertion_level() <= AssertionLevel::Links;
     // Struggling to get clang-format to behave here...
@@ -1588,14 +1658,14 @@ auto NamesAndIDsTracker::pb_file_string_for_ensuring(const VariableConditionFrom
 
 auto NamesAndIDsTracker::xliteral_for_ensuring(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) -> XLiteral
 {
-    auto f = _imp->variable_conditions_to_x.find(cond);
-    if (f == _imp->variable_conditions_to_x.end()) {
+    auto f = _imp->find_condition(cond);
+    if (! f) {
         need_proof_name(cond);
-        f = _imp->variable_conditions_to_x.find(cond);
-        if (f == _imp->variable_conditions_to_x.end())
+        f = _imp->find_condition(cond);
+        if (! f)
             throw ProofError{"still can't find literals for cond after introducing it"};
     }
-    return f->second;
+    return *f;
 }
 
 auto NamesAndIDsTracker::bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> string
@@ -1638,18 +1708,18 @@ auto NamesAndIDsTracker::find_xliteral_for(const ProofFlag & flag) const -> opti
 
 auto NamesAndIDsTracker::xliteral_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> const XLiteral
 {
-    auto f = _imp->variable_conditions_to_x.find(cond);
-    if (f == _imp->variable_conditions_to_x.end())
+    auto f = _imp->find_condition(cond);
+    if (! f)
         throw ProofError{"can't find literals for cond"};
-    return f->second;
+    return *f;
 }
 
 auto NamesAndIDsTracker::find_xliteral_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> optional<XLiteral>
 {
-    auto f = _imp->variable_conditions_to_x.find(cond);
-    if (f == _imp->variable_conditions_to_x.end())
-        return nullopt;
-    return f->second;
+    // Same lookup as xliteral_for, which is the point: this is its non-throwing
+    // twin, so it must see exactly the same atoms (recover_am1 uses it to spot a
+    // complementary {~b0, b0} pair over a bit-aliased {0,1} variable, issue #557).
+    return _imp->find_condition(cond);
 }
 
 auto NamesAndIDsTracker::pb_file_string_for(const ProofFlag & flag) const -> const string &

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -101,11 +101,20 @@ namespace
     // every allocation registers the pair together). Read on every condition
     // rendered into every proof line, hence value-keyed tables per variable
     // rather than one big map over whole condition objects.
+    // The two halves of an atom's defining reification: forward and reverse
+    // lines (or, for a direct-encoded 0/1 variable, the literal itself).
+    using AtomDefs = pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>;
+
     struct VariableAtoms
     {
         std::unordered_map<long long, XLiteral> eq; // Equal; NotEqual is the flip
         std::unordered_map<long long, XLiteral> ge; // GreaterEqual; Less is the flip
         map<pair<Integer, Integer>, XLiteral> in;   // InRange by (lo, hi); NotInRange is the flip
+        // The defining lines for the eq and ge atoms that have them (an atom
+        // can exist in eq/ge above without defs, e.g. an introduced
+        // variable's values). Value-keyed like the literal tables.
+        std::unordered_map<long long, AtomDefs> eq_defs;
+        std::unordered_map<long long, AtomDefs> ge_defs;
     };
 
     struct HashView
@@ -225,12 +234,11 @@ struct NamesAndIDsTracker::Imp
     // permutation variables, whose eq atoms are OPB constraint terms/guards (matching
     // cake) and so are forced model-time under @i labels.
     std::set<SimpleOrProofOnlyIntegerVariableID> vars_recover_labels;
-    unordered_map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>,
-        HashSimpleOrProofOnlyVariable>
-        gevars_that_exist;
-    unordered_map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>,
-        HashSimpleOrProofOnlyVariable>
-        eqvars_that_exist;
+    // The values with ge atoms, per variable, in value order: need_gevar's
+    // order-encoding chain links join each new atom to its neighbours, which
+    // needs ordered iteration. The atoms' literals and defining lines live in
+    // the per-variable atom tables.
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, std::set<Integer>, HashSimpleOrProofOnlyVariable> gevar_values;
     // Range ("in") literals [lo, hi], keyed by (lo, hi): the forward and reverse
     // lines of the reification against the variable's two order cuts. The literal
     // itself lives in the per-variable atom tables, keyed by the InRange / NotInRange
@@ -427,10 +435,10 @@ auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCon
         [&](const SimpleIntegerVariableID & var) -> variant<ProofLine, XLiteral> {
             switch (cond.op) {
                 using enum VariableConditionOperator;
-            case GreaterEqual: need_gevar(var, cond.value); return _imp->gevars_that_exist.at(var).at(cond.value).first;
-            case Less: need_gevar(var, cond.value); return _imp->gevars_that_exist.at(var).at(cond.value).second;
-            case Equal: need_direct_encoding_for(var, cond.value); return _imp->eqvars_that_exist.at(var).at(cond.value).first;
-            case NotEqual: need_direct_encoding_for(var, cond.value); return _imp->eqvars_that_exist.at(var).at(cond.value).second;
+            case GreaterEqual: need_gevar(var, cond.value); return _imp->atoms_for(var).ge_defs.at(cond.value.raw_value).first;
+            case Less: need_gevar(var, cond.value); return _imp->atoms_for(var).ge_defs.at(cond.value.raw_value).second;
+            case Equal: need_direct_encoding_for(var, cond.value); return _imp->atoms_for(var).eq_defs.at(cond.value.raw_value).first;
+            case NotEqual: need_direct_encoding_for(var, cond.value); return _imp->atoms_for(var).eq_defs.at(cond.value.raw_value).second;
             case InRange:
                 static_cast<void>(need_invar(var, cond.value, cond.upper_value));
                 return _imp->invars_that_exist.at(var).at(pair{cond.value, cond.upper_value}).first;
@@ -448,10 +456,10 @@ auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCon
             if (auto v_id = find_view(var)) {
                 switch (cond.op) {
                     using enum VariableConditionOperator;
-                case GreaterEqual: need_gevar(*v_id, cond.value); return _imp->gevars_that_exist.at(*v_id).at(cond.value).first;
-                case Less: need_gevar(*v_id, cond.value); return _imp->gevars_that_exist.at(*v_id).at(cond.value).second;
-                case Equal: need_direct_encoding_for(*v_id, cond.value); return _imp->eqvars_that_exist.at(*v_id).at(cond.value).first;
-                case NotEqual: need_direct_encoding_for(*v_id, cond.value); return _imp->eqvars_that_exist.at(*v_id).at(cond.value).second;
+                case GreaterEqual: need_gevar(*v_id, cond.value); return _imp->atoms_for(*v_id).ge_defs.at(cond.value.raw_value).first;
+                case Less: need_gevar(*v_id, cond.value); return _imp->atoms_for(*v_id).ge_defs.at(cond.value.raw_value).second;
+                case Equal: need_direct_encoding_for(*v_id, cond.value); return _imp->atoms_for(*v_id).eq_defs.at(cond.value.raw_value).first;
+                case NotEqual: need_direct_encoding_for(*v_id, cond.value); return _imp->atoms_for(*v_id).eq_defs.at(cond.value.raw_value).second;
                 case InRange:
                 case NotInRange: throw UnimplementedException{};
                 }
@@ -482,7 +490,7 @@ auto NamesAndIDsTracker::need_pol_item_defining_literal(const IntegerVariableCon
 
 auto NamesAndIDsTracker::create_literals_for_introduced_variable_value(SimpleIntegerVariableID id, Integer val, const string & name) -> void
 {
-    // These literals bypass eqvars_that_exist and the containment structures, which
+    // These literals bypass the eq-atom defs table and the containment structures, which
     // is safe because an introduced variable has no bits encoding, so no range
     // literal can ever be defined over it.
     track_variable_name(id, to_string(id.index) + "intr_" + name); // hack!
@@ -626,7 +634,7 @@ auto NamesAndIDsTracker::allocate_flag_index() -> unsigned long long
 auto NamesAndIDsTracker::track_eqvar(
     SimpleIntegerVariableID id, Integer val, const pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>> & names) -> void
 {
-    _imp->eqvars_that_exist[id].emplace(val, names);
+    _imp->atoms_for(id).eq_defs.try_emplace(val.raw_value, names);
 }
 
 auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
@@ -723,7 +731,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         }
     }
 
-    _imp->eqvars_that_exist[id].emplace(v, pair{forwards_line, reverse_line});
+    _imp->atoms_for(id).eq_defs.try_emplace(v.raw_value, pair{forwards_line, reverse_line});
 
     // If `id` is a view's proof-only var, eagerly emit the
     // eq-atom-level link `V=v <=> X=k_x` as two RUP lines. The GE-atom
@@ -825,12 +833,13 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
 
     // gevar -> bits
     if (_imp->logger && _imp->assertion_level > AssertionLevel::Definitions) {
-        _imp->gevars_that_exist[id].emplace(v, make_pair(ProofLine{}, ProofLine{})); // Don't output geqvar definitions if using assertions
+        _imp->atoms_for(id).ge_defs.try_emplace(
+            v.raw_value, make_pair(ProofLine{}, ProofLine{})); // Don't output geqvar definitions if using assertions
     }
     else if (_imp->logger) {
         auto def_lines = visit(
             [&](const auto & id) { return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Top); }, id);
-        _imp->gevars_that_exist[id].emplace(v, def_lines);
+        _imp->atoms_for(id).ge_defs.try_emplace(v.raw_value, def_lines);
     }
     else {
         // Label the two halves @<base>[ge<v>][r]/[f]: the base is @i[name] for a
@@ -839,7 +848,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // ~ge..) is cake's [r]; the second is [f]. v may be negative -- veripb
         // 3.0.2 allows `-` in @labels.
         string ge_label = definitional_label_base(id) + "[ge" + to_string(v.raw_value) + "]";
-        _imp->gevars_that_exist[id].emplace(v,
+        _imp->atoms_for(id).ge_defs.try_emplace(v.raw_value,
             visit(
                 [&](const auto & vid) -> pair<ProofLine, ProofLine> {
                     return pair{_imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
@@ -915,8 +924,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         fix_bound(true);
     }
 
-    auto & other_gevars = _imp->gevars_that_exist.at(id);
-    auto this_gevar = other_gevars.find(v);
+    auto & other_gevars = _imp->gevar_values[id];
+    auto this_gevar = other_gevars.insert(v).first;
     auto higher_gevar = next(this_gevar);
 
     // Returns a shared PolBuilder (rather than a rendered string) so the line
@@ -936,7 +945,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     if (higher_gevar != other_gevars.end()) {
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
-                auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
+                auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= *higher_gevar)) >= 1_i;
                 emit_proof_line_now_or_at_start([c = chain_con, link_hint](ProofLogger * const logger) {
                     if (logger->get_assertion_level() > AssertionLevel::Links)
                         return;
@@ -950,12 +959,12 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                     return;
                 }
                 else if (_imp->assertion_level == AssertionLevel::Links) {
-                    auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= higher_gevar->first)) >= 1_i;
+                    auto chain_con = WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id >= *higher_gevar)) >= 1_i;
                     emit_proof_line_now_or_at_start(
                         [c = chain_con, link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
                 }
                 else {
-                    auto pol = make_pol_chain_line(id >= v, ! (id >= higher_gevar->first));
+                    auto pol = make_pol_chain_line(id >= v, ! (id >= *higher_gevar));
                     emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
                 }
             } //
@@ -967,7 +976,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     if (this_gevar != other_gevars.begin()) {
         overloaded{
             [&](const ProofOnlySimpleIntegerVariableID & id) {
-                auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
+                auto chain_con = WPBSum{} + (1_i * (id >= *prev(this_gevar))) + (1_i * ! (id >= v)) >= 1_i;
                 emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) {
                     if (logger->get_assertion_level() > AssertionLevel::Links)
                         return;
@@ -981,13 +990,13 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                     return;
                 }
                 else if (_imp->assertion_level == AssertionLevel::Links) {
-                    auto chain_con = WPBSum{} + (1_i * (id >= prev(this_gevar)->first)) + (1_i * ! (id >= v)) >= 1_i;
+                    auto chain_con = WPBSum{} + (1_i * (id >= *prev(this_gevar))) + (1_i * ! (id >= v)) >= 1_i;
                     emit_proof_line_now_or_at_start([c = chain_con, link_hint = link_hint](ProofLogger * const logger) {
                         logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint);
                     });
                 }
                 else {
-                    auto pol = make_pol_chain_line(id >= prev(this_gevar)->first, ! (id >= v));
+                    auto pol = make_pol_chain_line(id >= *prev(this_gevar), ! (id >= v));
                     emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
                 }
             } //
@@ -1040,8 +1049,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 return;
             }
 
-            auto v_defs = _imp->gevars_that_exist[id].at(v);
-            auto x_defs = _imp->gevars_that_exist[SimpleOrProofOnlyIntegerVariableID{view.actual_variable}].at(x_threshold);
+            auto v_defs = _imp->atoms_for(id).ge_defs.at(v.raw_value);
+            auto x_defs = _imp->atoms_for(SimpleOrProofOnlyIntegerVariableID{view.actual_variable}).ge_defs.at(x_threshold.raw_value);
             auto link = _imp->view_link_ids.at(*pid_ptr);
             auto * v_fwd_line = std::get_if<ProofLine>(&v_defs.first);
             auto * v_rev_line = std::get_if<ProofLine>(&v_defs.second);
@@ -1179,9 +1188,9 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     // the eq atoms that already exist.
     if (! _imp->containment_trees.contains(id)) {
         auto & tree = _imp->containment_trees[id];
-        if (auto eqit = _imp->eqvars_that_exist.find(id); eqit != _imp->eqvars_that_exist.end())
-            for (const auto & [v, _] : eqit->second)
-                tree.insert(v, v);
+        if (const auto * atoms = _imp->find_atoms(id))
+            for (const auto & [v, _] : atoms->eq_defs)
+                tree.insert(Integer{v}, Integer{v});
     }
     link_immediate_containment(id, lo, hi);
     _imp->containment_trees[id].insert(lo, hi);
@@ -1248,9 +1257,9 @@ auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariabl
 
     // Every pre-existing eq atom becomes a singleton cell, so that coverings can
     // reach conclusions already logged over those atoms.
-    if (auto eqit = _imp->eqvars_that_exist.find(id); eqit != _imp->eqvars_that_exist.end())
-        for (const auto & [v, _] : eqit->second)
-            if (lb <= v && v <= ub) {
+    if (const auto * atoms = _imp->find_atoms(id))
+        for (const auto & [raw_v, _] : atoms->eq_defs)
+            if (Integer v{raw_v}; lb <= v && v <= ub) {
                 boundaries.insert(v);
                 boundaries.insert(v + 1_i);
             }
@@ -1386,17 +1395,23 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
     // recurse back through need_gevar(X, ...), which is a no-op for
     // already-existing atoms but would invalidate iterators if it weren't.
     SimpleOrProofOnlyIntegerVariableID x_key{view.actual_variable};
-    if (auto it = _imp->gevars_that_exist.find(x_key); it != _imp->gevars_that_exist.end()) {
+    if (auto it = _imp->gevar_values.find(x_key); it != _imp->gevar_values.end()) {
         auto x_atoms = it->second;
-        for (const auto & [k, _] : x_atoms) {
+        for (const auto & k : x_atoms) {
             Integer v_value = view.negate_first ? view.then_add - k + 1_i : k + view.then_add;
             need_gevar(v_id, v_value);
         }
     }
-    if (auto it = _imp->eqvars_that_exist.find(x_key); it != _imp->eqvars_that_exist.end()) {
-        auto x_atoms = it->second;
-        for (const auto & [k, _] : x_atoms) {
-            Integer v_value = view.negate_first ? view.then_add - k : k + view.then_add;
+    if (const auto * atoms = _imp->find_atoms(x_key); atoms && ! atoms->eq_defs.empty()) {
+        // Ascending, so the backfilled V atoms are emitted in the same
+        // order the ordered map this replaces produced.
+        vector<long long> x_atom_values;
+        x_atom_values.reserve(atoms->eq_defs.size());
+        for (const auto & [k, _] : atoms->eq_defs)
+            x_atom_values.push_back(k);
+        sort(x_atom_values);
+        for (const auto & k : x_atom_values) {
+            Integer v_value = view.negate_first ? view.then_add - Integer{k} : Integer{k} + view.then_add;
             need_direct_encoding_for(v_id, v_value);
         }
     }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -143,7 +143,10 @@ struct NamesAndIDsTracker::Imp
     map<ProofFlag, XLiteral> flags;
 
     map<SimpleOrProofOnlyIntegerVariableID, string> id_names;
-    map<XLiteral, string> xlits_to_verbose_names;
+    // The PB-file rendering of every allocated XLiteral, indexed 2 * id +
+    // negated (ids are allocated sequentially from 1). Populated in both
+    // naming modes, so rendering a literal is an index, not a lookup.
+    vector<string> xlit_names;
     map<ProofFlag, string> flag_names;
 
     list<function<auto(ProofLogger * const)->void>> delayed_proof_steps;
@@ -1497,23 +1500,25 @@ auto NamesAndIDsTracker::make_proof_flag_named(const string & full_name) -> Proo
     return result;
 }
 
-auto NamesAndIDsTracker::pb_file_string_for(const XLiteral & lit) const -> string
+auto NamesAndIDsTracker::store_xlit_names(const XLiteral & lit, string name) -> void
 {
-    if (_imp->verbose_names) {
-        auto it = _imp->xlits_to_verbose_names.find(lit);
-        if (it == _imp->xlits_to_verbose_names.end())
-            throw ProofError("missing verbose name for xliteral " + to_string(lit.id) + " " + to_string(lit.negated));
-        return it->second;
-    }
-    else {
-        if (lit.negated)
-            return "~x" + to_string(lit.id);
-        else
-            return "x" + to_string(lit.id);
-    }
+    // `name` renders the positive polarity; the negation is always `~name`.
+    auto idx = static_cast<vector<string>::size_type>(lit.id) * 2;
+    if (_imp->xlit_names.size() < idx + 2)
+        _imp->xlit_names.resize(idx + 2);
+    _imp->xlit_names[idx + 1] = "~" + name;
+    _imp->xlit_names[idx] = move(name);
 }
 
-auto NamesAndIDsTracker::pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> string
+auto NamesAndIDsTracker::pb_file_string_for(const XLiteral & lit) const -> const string &
+{
+    auto idx = static_cast<vector<string>::size_type>(lit.id) * 2 + (lit.negated ? 1 : 0);
+    if (idx >= _imp->xlit_names.size() || _imp->xlit_names[idx].empty())
+        throw ProofError("missing name for xliteral " + to_string(lit.id) + " " + to_string(lit.negated));
+    return _imp->xlit_names[idx];
+}
+
+auto NamesAndIDsTracker::pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> const string &
 {
     return pb_file_string_for(xliteral_for(cond));
 }
@@ -1572,7 +1577,7 @@ auto NamesAndIDsTracker::find_xliteral_for(const VariableConditionFrom<SimpleOrP
     return f->second;
 }
 
-auto NamesAndIDsTracker::pb_file_string_for(const ProofFlag & flag) const -> string
+auto NamesAndIDsTracker::pb_file_string_for(const ProofFlag & flag) const -> const string &
 {
     return pb_file_string_for(xliteral_for(flag));
 }
@@ -1603,17 +1608,17 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
         overloaded{
             [&](const SimpleIntegerVariableID & id) -> void {
                 string name = format("i[{}][{}{}]", name_of(id), (op == EqualsOrGreaterEqual::Equals ? "eq" : "ge"), value_name);
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
+                store_xlit_names(result, name);
             }, //
             [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
                 string name = format("p[{}_{}][{}{}]", id.index, name_of(id), (op == EqualsOrGreaterEqual::Equals ? "eq" : "ge"), value_name);
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
+                store_xlit_names(result, name);
             } //
         }
             .visit(id);
     }
+    else
+        store_xlit_names(result, "x" + to_string(result.id));
 
     if (_imp->variables_map_file) {
         try {
@@ -1657,17 +1662,17 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning(SimpleOrProofOnlyIntegerVaria
         overloaded{
             [&](const SimpleIntegerVariableID & id) -> void {
                 string name = format("i[{}][in{}_{}]", name_of(id), value_name(lo), value_name(hi));
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
+                store_xlit_names(result, name);
             }, //
             [&](const ProofOnlySimpleIntegerVariableID & id) -> void {
                 string name = format("p[{}_{}][in{}_{}]", id.index, name_of(id), value_name(lo), value_name(hi));
-                _imp->xlits_to_verbose_names.emplace(result, name);
-                _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
+                store_xlit_names(result, name);
             } //
         }
             .visit(id);
     }
+    else
+        store_xlit_names(result, "x" + to_string(result.id));
 
     if (_imp->variables_map_file) {
         try {
@@ -1705,9 +1710,10 @@ auto NamesAndIDsTracker::allocate_flag_xliteral(ProofFlag flag, const string & v
     auto result = XLiteral{++_imp->next_xliteral_nr, false};
 
     if (_imp->verbose_names) {
-        _imp->xlits_to_verbose_names.emplace(result, verbose_name);
-        _imp->xlits_to_verbose_names.emplace(! result, "~" + verbose_name);
+        store_xlit_names(result, verbose_name);
     }
+    else
+        store_xlit_names(result, "x" + to_string(result.id));
 
     if (_imp->variables_map_file) {
         try {
@@ -1742,9 +1748,10 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning_negative_bit_of(
                         [&](const SimpleIntegerVariableID & id) { return format("i[{}][sign]", name_of(id)); }, //
                         [&](const ProofOnlySimpleIntegerVariableID & id) { return format("p[{}_{}][sign]", id.index, name_of(id)); }},
                   id);
-        _imp->xlits_to_verbose_names.emplace(result, name);
-        _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
+        store_xlit_names(result, name);
     }
+    else
+        store_xlit_names(result, "x" + to_string(result.id));
 
     if (_imp->variables_map_file) {
         try {
@@ -1789,9 +1796,10 @@ auto NamesAndIDsTracker::allocate_xliteral_meaning_bit_of(
                         [&](const SimpleIntegerVariableID & id) { return format("i[{}][b{}]", name_of(id), power); }, //
                         [&](const ProofOnlySimpleIntegerVariableID & id) { return format("p[{}_{}][b{}]", id.index, name_of(id), power); }},
                   id);
-        _imp->xlits_to_verbose_names.emplace(result, name);
-        _imp->xlits_to_verbose_names.emplace(! result, "~" + name);
+        store_xlit_names(result, name);
     }
+    else
+        store_xlit_names(result, "x" + to_string(result.id));
 
     if (_imp->variables_map_file) {
         try {

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -2018,14 +2018,7 @@ auto NamesAndIDsTracker::s_expr_term_of(ReificationCondition cond) const -> opti
     return parse_s_expr(name);
 }
 
-auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif) -> WPBSumLE
-{
-    WPBSumLE result{{}, 0_i};
-    reify_into(ineq, half_reif, result);
-    return result;
-}
-
-auto NamesAndIDsTracker::reify_into(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif, WPBSumLE & out) -> void
+auto NamesAndIDsTracker::reification_shape(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif) -> ReificationShape
 {
     // so what happens if there's a false literal in the left hand term? conceptually,
     // this means the constraint will always hold, but it's probably useful to have
@@ -2108,22 +2101,27 @@ auto NamesAndIDsTracker::reify_into(const WPBSumLE & ineq, const HalfReifyOnConj
     // to always be there.
     auto clamped_reif_const = min(-max_contribution_from_positive_terms + ineq.rhs, -1_i);
 
-    auto & new_lhs = out.lhs;
-    new_lhs.terms.clear();
+    // if we have a false literal on the left hand side, adjusting the degree of falsity
+    // up by the sum of positive terms is enough that it will be trivially true.
+    auto effective_rhs = contains_false_literal ? ineq.rhs + max_contribution_from_positive_terms : ineq.rhs;
+
+    return ReificationShape{.reif_coefficient = clamped_reif_const, .effective_rhs = effective_rhs};
+}
+
+auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif) -> WPBSumLE
+{
+    auto shape = reification_shape(ineq, half_reif);
+
+    WPBSum new_lhs;
     new_lhs.terms.reserve(ineq.lhs.terms.size() + half_reif.size());
     new_lhs.terms.insert(new_lhs.terms.end(), ineq.lhs.terms.begin(), ineq.lhs.terms.end());
     for (auto & r : half_reif)
         overloaded{
-            [&](const ProofFlag & f) { new_lhs += clamped_reif_const * ! f; },           //
-            [&](const ProofLiteral & lit) { new_lhs += clamped_reif_const * ! lit; },    //
-            [&](const ProofBitVariable & bit) { new_lhs += clamped_reif_const * ! bit; } //
+            [&](const ProofFlag & f) { new_lhs += shape.reif_coefficient * ! f; },           //
+            [&](const ProofLiteral & lit) { new_lhs += shape.reif_coefficient * ! lit; },    //
+            [&](const ProofBitVariable & bit) { new_lhs += shape.reif_coefficient * ! bit; } //
         }
             .visit(r);
 
-    // if we have a false literal on the left hand side, adjusting the degree of falsity
-    // up by the sum of positive terms is enough that it will be trivially true.
-    if (contains_false_literal)
-        out.rhs = ineq.rhs + max_contribution_from_positive_terms;
-    else
-        out.rhs = ineq.rhs;
+    return move(new_lhs) <= shape.effective_rhs;
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -85,14 +85,22 @@ namespace
         return seed ^ (v + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
     }
 
+    struct HashSimpleOrProofOnlyVariable
+    {
+        [[nodiscard]] auto operator()(const SimpleOrProofOnlyIntegerVariableID & id) const -> std::size_t
+        {
+            return visit(overloaded{//
+                             [&](const SimpleIntegerVariableID & v) { return hash_combine(1, v.index); },
+                             [&](const ProofOnlySimpleIntegerVariableID & v) { return hash_combine(2, v.index); }},
+                id);
+        }
+    };
+
     struct HashVariableCondition
     {
         [[nodiscard]] auto operator()(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> std::size_t
         {
-            auto h = visit(overloaded{//
-                               [&](const SimpleIntegerVariableID & v) { return hash_combine(1, v.index); },
-                               [&](const ProofOnlySimpleIntegerVariableID & v) { return hash_combine(2, v.index); }},
-                cond.var);
+            auto h = HashSimpleOrProofOnlyVariable{}(cond.var);
             h = hash_combine(h, static_cast<std::size_t>(cond.op));
             h = hash_combine(h, static_cast<std::size_t>(cond.value.raw_value));
             return hash_combine(h, static_cast<std::size_t>(cond.upper_value.raw_value));
@@ -122,11 +130,12 @@ struct NamesAndIDsTracker::Imp
     ProofModel * model = nullptr;
     ProofLogger * logger = nullptr;
 
-    map<SimpleOrProofOnlyIntegerVariableID, ProofLine> variable_at_least_one_constraints;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     unordered_map<VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID>, XLiteral, HashVariableCondition> variable_conditions_to_x;
-    map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, vector<pair<Integer, XLiteral>>>> integer_variable_bits_to_size_and_proof_vars;
-    map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, Integer>> integer_variable_definition_bounds;
-    map<SimpleOrProofOnlyIntegerVariableID, pair<ProofLine, ProofLine>> integer_variable_bound_rows;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, vector<pair<Integer, XLiteral>>>, HashSimpleOrProofOnlyVariable>
+        integer_variable_bits_to_size_and_proof_vars;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, Integer>, HashSimpleOrProofOnlyVariable> integer_variable_definition_bounds;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, pair<ProofLine, ProofLine>, HashSimpleOrProofOnlyVariable> integer_variable_bound_rows;
     // Variables (e.g. ArgSort's cake-named free-bit-sum sorted values) whose [lo, hi]
     // domain is NOT a trivial consequence of the OPB -- cake emits no bound line for
     // them and the bounds are only entailed through conditional channels -- so
@@ -142,14 +151,19 @@ struct NamesAndIDsTracker::Imp
     // permutation variables, whose eq atoms are OPB constraint terms/guards (matching
     // cake) and so are forced model-time under @i labels.
     std::set<SimpleOrProofOnlyIntegerVariableID> vars_recover_labels;
-    map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> gevars_that_exist;
-    map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>> eqvars_that_exist;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>,
+        HashSimpleOrProofOnlyVariable>
+        gevars_that_exist;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, map<Integer, pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>>>,
+        HashSimpleOrProofOnlyVariable>
+        eqvars_that_exist;
     // Range ("in") literals [lo, hi], keyed by (lo, hi): the forward and reverse
     // lines of the reification against the variable's two order cuts. The literal
     // itself lives in variable_conditions_to_x, keyed by the InRange / NotInRange
     // conditions, just like the eq and order atoms. A width-1 interval is its eq
     // atom and is never entered here.
-    map<SimpleOrProofOnlyIntegerVariableID, map<pair<Integer, Integer>, pair<ProofLine, ProofLine>>> invars_that_exist;
+    unordered_map<SimpleOrProofOnlyIntegerVariableID, map<pair<Integer, Integer>, pair<ProofLine, ProofLine>>, HashSimpleOrProofOnlyVariable>
+        invars_that_exist;
 
     // Every range and eq literal on each variable, as intervals, for finding a new
     // literal's immediate neighbours in the containment order.
@@ -1994,6 +2008,13 @@ auto NamesAndIDsTracker::s_expr_term_of(ReificationCondition cond) const -> opti
 
 auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif) -> WPBSumLE
 {
+    WPBSumLE result{{}, 0_i};
+    reify_into(ineq, half_reif, result);
+    return result;
+}
+
+auto NamesAndIDsTracker::reify_into(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & half_reif, WPBSumLE & out) -> void
+{
     // so what happens if there's a false literal in the left hand term? conceptually,
     // this means the constraint will always hold, but it's probably useful to have
     // something that syntactically contains all the right variables. so, we can just
@@ -2075,7 +2096,8 @@ auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjuncti
     // to always be there.
     auto clamped_reif_const = min(-max_contribution_from_positive_terms + ineq.rhs, -1_i);
 
-    WPBSum new_lhs;
+    auto & new_lhs = out.lhs;
+    new_lhs.terms.clear();
     new_lhs.terms.reserve(ineq.lhs.terms.size() + half_reif.size());
     new_lhs.terms.insert(new_lhs.terms.end(), ineq.lhs.terms.begin(), ineq.lhs.terms.end());
     for (auto & r : half_reif)
@@ -2089,7 +2111,7 @@ auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjuncti
     // if we have a false literal on the left hand side, adjusting the degree of falsity
     // up by the sum of positive terms is enough that it will be trivially true.
     if (contains_false_literal)
-        return new_lhs <= ineq.rhs + max_contribution_from_positive_terms;
+        out.rhs = ineq.rhs + max_contribution_from_positive_terms;
     else
-        return new_lhs <= ineq.rhs;
+        out.rhs = ineq.rhs;
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -60,6 +60,7 @@ using std::shared_ptr;
 using std::string;
 using std::stringstream;
 using std::to_string;
+using std::unordered_map;
 using std::variant;
 using std::vector;
 using std::visit;
@@ -73,13 +74,56 @@ using fmt::format;
 using fmt::print;
 #endif
 
+namespace
+{
+    // These three tables are read on every literal rendered into every proof
+    // line, so they are hashed rather than tree-ordered. Nothing iterates
+    // them. The hashes just have to spread structured small integers; the
+    // magic constant is the usual 64-bit golden-ratio mix.
+    constexpr auto hash_combine(std::size_t seed, std::size_t v) -> std::size_t
+    {
+        return seed ^ (v + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
+    }
+
+    struct HashVariableCondition
+    {
+        [[nodiscard]] auto operator()(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> std::size_t
+        {
+            auto h = visit(overloaded{//
+                               [&](const SimpleIntegerVariableID & v) { return hash_combine(1, v.index); },
+                               [&](const ProofOnlySimpleIntegerVariableID & v) { return hash_combine(2, v.index); }},
+                cond.var);
+            h = hash_combine(h, static_cast<std::size_t>(cond.op));
+            h = hash_combine(h, static_cast<std::size_t>(cond.value.raw_value));
+            return hash_combine(h, static_cast<std::size_t>(cond.upper_value.raw_value));
+        }
+    };
+
+    struct HashView
+    {
+        [[nodiscard]] auto operator()(const ViewOfIntegerVariableID & view) const -> std::size_t
+        {
+            auto h = hash_combine(view.negate_first ? 3 : 4, view.actual_variable.index);
+            return hash_combine(h, static_cast<std::size_t>(view.then_add.raw_value));
+        }
+    };
+
+    struct HashProofFlag
+    {
+        [[nodiscard]] auto operator()(const ProofFlag & flag) const -> std::size_t
+        {
+            return hash_combine(flag.positive ? 5 : 6, flag.index);
+        }
+    };
+}
+
 struct NamesAndIDsTracker::Imp
 {
     ProofModel * model = nullptr;
     ProofLogger * logger = nullptr;
 
     map<SimpleOrProofOnlyIntegerVariableID, ProofLine> variable_at_least_one_constraints;
-    map<VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID>, XLiteral> variable_conditions_to_x;
+    unordered_map<VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID>, XLiteral, HashVariableCondition> variable_conditions_to_x;
     map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, vector<pair<Integer, XLiteral>>>> integer_variable_bits_to_size_and_proof_vars;
     map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, Integer>> integer_variable_definition_bounds;
     map<SimpleOrProofOnlyIntegerVariableID, pair<ProofLine, ProofLine>> integer_variable_bound_rows;
@@ -119,7 +163,7 @@ struct NamesAndIDsTracker::Imp
     // adjacent cells. Absent until the first interval request.
     map<SimpleOrProofOnlyIntegerVariableID, std::set<Integer>> interval_partitions;
 
-    map<ViewOfIntegerVariableID, ProofOnlySimpleIntegerVariableID> view_proof_only_vars;
+    unordered_map<ViewOfIntegerVariableID, ProofOnlySimpleIntegerVariableID, HashView> view_proof_only_vars;
     map<ProofOnlySimpleIntegerVariableID, ViewOfIntegerVariableID> view_proof_only_to_view;
     // For each registered view, the (LE-half, GE-half) ProofLine IDs of the
     // bit-vector link constraint emitted in need_view. The LE half is
@@ -140,7 +184,7 @@ struct NamesAndIDsTracker::Imp
     // corresponding deview-form line. Lookup via deviewed_line_for.
     map<ProofLine, ProofLine> deviewed_line_by_v_form;
 
-    map<ProofFlag, XLiteral> flags;
+    unordered_map<ProofFlag, XLiteral, HashProofFlag> flags;
 
     map<SimpleOrProofOnlyIntegerVariableID, string> id_names;
     // The PB-file rendering of every allocated XLiteral, indexed 2 * id +

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1348,6 +1348,15 @@ auto NamesAndIDsTracker::has_bit_representation(const SimpleOrProofOnlyIntegerVa
     return _imp->integer_variable_bits_to_size_and_proof_vars.contains(id);
 }
 
+auto NamesAndIDsTracker::view_bounds(const ViewOfIntegerVariableID & view) const -> pair<Integer, Integer>
+{
+    auto bounds_it = _imp->integer_variable_definition_bounds.find(view.actual_variable);
+    if (bounds_it == _imp->integer_variable_definition_bounds.end())
+        throw ProofError{"view_bounds: underlying variable's bounds are not registered"};
+    auto [x_lo, x_hi] = bounds_it->second;
+    return view.negate_first ? pair{-x_hi + view.then_add, -x_lo + view.then_add} : pair{x_lo + view.then_add, x_hi + view.then_add};
+}
+
 auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> ProofOnlySimpleIntegerVariableID
 {
     if (auto it = _imp->view_proof_only_vars.find(view); it != _imp->view_proof_only_vars.end())
@@ -1356,12 +1365,7 @@ auto NamesAndIDsTracker::need_view(const ViewOfIntegerVariableID & view) -> Proo
     if (! _imp->model)
         throw UnimplementedException{"need_view: view introduction during proof-logging phase is not yet supported"};
 
-    auto bounds_it = _imp->integer_variable_definition_bounds.find(view.actual_variable);
-    if (bounds_it == _imp->integer_variable_definition_bounds.end())
-        throw ProofError{"need_view: underlying variable's bounds are not registered"};
-    auto [x_lo, x_hi] = bounds_it->second;
-
-    auto [v_lo, v_hi] = view.negate_first ? pair{-x_hi + view.then_add, -x_lo + view.then_add} : pair{x_lo + view.then_add, x_hi + view.then_add};
+    auto [v_lo, v_hi] = view_bounds(view);
 
     string name = "view_of_" + name_of(view.actual_variable);
     if (view.negate_first)

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1581,6 +1581,18 @@ auto NamesAndIDsTracker::pb_file_string_for(const VariableConditionFrom<SimpleOr
     return pb_file_string_for(xliteral_for(cond));
 }
 
+auto NamesAndIDsTracker::pb_file_string_for_ensuring(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) -> const string &
+{
+    auto f = _imp->variable_conditions_to_x.find(cond);
+    if (f == _imp->variable_conditions_to_x.end()) {
+        need_proof_name(cond);
+        f = _imp->variable_conditions_to_x.find(cond);
+        if (f == _imp->variable_conditions_to_x.end())
+            throw ProofError{"still can't find literals for cond after introducing it"};
+    }
+    return pb_file_string_for(f->second);
+}
+
 auto NamesAndIDsTracker::bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> string
 {
     auto it = _imp->integer_variable_bits_to_size_and_proof_vars.find(var);

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -2075,7 +2075,9 @@ auto NamesAndIDsTracker::reify(const WPBSumLE & ineq, const HalfReifyOnConjuncti
     // to always be there.
     auto clamped_reif_const = min(-max_contribution_from_positive_terms + ineq.rhs, -1_i);
 
-    WPBSum new_lhs = ineq.lhs;
+    WPBSum new_lhs;
+    new_lhs.terms.reserve(ineq.lhs.terms.size() + half_reif.size());
+    new_lhs.terms.insert(new_lhs.terms.end(), ineq.lhs.terms.begin(), ineq.lhs.terms.end());
     for (auto & r : half_reif)
         overloaded{
             [&](const ProofFlag & f) { new_lhs += clamped_reif_const * ! f; },           //

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1583,6 +1583,11 @@ auto NamesAndIDsTracker::pb_file_string_for(const VariableConditionFrom<SimpleOr
 
 auto NamesAndIDsTracker::pb_file_string_for_ensuring(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) -> const string &
 {
+    return pb_file_string_for(xliteral_for_ensuring(cond));
+}
+
+auto NamesAndIDsTracker::xliteral_for_ensuring(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) -> XLiteral
+{
     auto f = _imp->variable_conditions_to_x.find(cond);
     if (f == _imp->variable_conditions_to_x.end()) {
         need_proof_name(cond);
@@ -1590,7 +1595,7 @@ auto NamesAndIDsTracker::pb_file_string_for_ensuring(const VariableConditionFrom
         if (f == _imp->variable_conditions_to_x.end())
             throw ProofError{"still can't find literals for cond after introducing it"};
     }
-    return pb_file_string_for(f->second);
+    return f->second;
 }
 
 auto NamesAndIDsTracker::bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> string

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -206,6 +206,15 @@ namespace gcs::innards
         [[nodiscard]] auto find_view(const ViewOfIntegerVariableID & view) const -> std::optional<ProofOnlySimpleIntegerVariableID>;
 
         /**
+         * The [lo, hi] a view's visible values span, from the underlying
+         * variable's registered definition bounds. What need_view sizes a
+         * view's proof-only bit vector by; exposed so the objective path can
+         * first ask whether that bit vector is representable at all
+         * (bits_encoding_fits) before registering the view.
+         */
+        [[nodiscard]] auto view_bounds(const ViewOfIntegerVariableID & view) const -> std::pair<Integer, Integer>;
+
+        /**
          * Record that `deviewed_line` is the deview-form of `v_form_line`.
          * Lookup is via `deviewed_line_for`.
          */

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -348,6 +348,15 @@ namespace gcs::innards
         [[nodiscard]] auto pb_file_string_for_ensuring(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) -> const std::string &;
 
         /**
+         * As xliteral_for, but introduce the condition's proof name first if
+         * it does not exist yet, like pb_file_string_for_ensuring. Both
+         * polarities are always introduced together, so negating the result
+         * is the negated condition's literal; the reified-line renderer uses
+         * this to avoid negating whole condition objects.
+         */
+        [[nodiscard]] auto xliteral_for_ensuring(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) -> XLiteral;
+
+        /**
          * Return a string form of the exact literals specifying a bit assignment for var == val, an alternative way to witness solutions.
          */
         [[nodiscard]] auto bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> std::string;

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -546,17 +546,26 @@ namespace gcs::innards
         [[nodiscard]] auto create_proof_flag_for_constant(Integer k, const std::string & atom) -> ProofFlag;
 
         /**
+         * The numbers that determine a half-reification of a PB constraint:
+         * the (negative) coefficient each negated reifying term is given, and
+         * the constraint's effective right-hand side (adjusted if the
+         * conjunction contains a statically-false literal). The reified
+         * constraint is `lhs + reif_coefficient * (each ~term) <=
+         * effective_rhs`; reify() materialises exactly that, and
+         * emit_reified_inequality_to renders it directly.
+         */
+        struct ReificationShape
+        {
+            Integer reif_coefficient;
+            Integer effective_rhs;
+        };
+
+        [[nodiscard]] auto reification_shape(const WPBSumLE &, const HalfReifyOnConjunctionOf &) -> ReificationShape;
+
+        /**
          * Reify a PB constraint on a conjunction of ProofFlags or ProofLiterals
          */
         [[nodiscard]] auto reify(const WPBSumLE &, const HalfReifyOnConjunctionOf &) -> WPBSumLE;
-
-        /**
-         * As reify(), but writing the result into `out`, reusing its term
-         * storage. For per-inference emission, where a freshly allocated
-         * reified sum per proof line is measurable; `out` must not alias the
-         * input.
-         */
-        auto reify_into(const WPBSumLE &, const HalfReifyOnConjunctionOf &, WPBSumLE & out) -> void;
 
         /*
          * Allocate an XLiteral with the given semantic meaning.

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -340,6 +340,14 @@ namespace gcs::innards
         [[nodiscard]] auto pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> const std::string &;
 
         /**
+         * As pb_file_string_for, but introduce the condition's proof name
+         * first if it does not exist yet (need_proof_name), in one lookup for
+         * the common already-known case. Only for use while assembling a
+         * proof line in a buffer: an introduction emits definition lines.
+         */
+        [[nodiscard]] auto pb_file_string_for_ensuring(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) -> const std::string &;
+
+        /**
          * Return a string form of the exact literals specifying a bit assignment for var == val, an alternative way to witness solutions.
          */
         [[nodiscard]] auto bit_assignment_string_for(const SimpleOrProofOnlyIntegerVariableID & var, const Integer & value) const -> std::string;

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -74,6 +74,11 @@ namespace gcs::innards
 
         [[nodiscard]] auto allocate_flag_index() -> unsigned long long;
 
+        // Record the PB-file rendering of a freshly-allocated XLiteral (and its
+        // negation, as `~name`). Every allocate_* path calls this exactly once,
+        // in both naming modes, so pb_file_string_for is a plain index.
+        auto store_xlit_names(const XLiteral &, std::string name) -> void;
+
         // Allocate the XLiteral backing a flag, registering `verbose_name` (and
         // its negation) as the PB-file rendering. Shared by create_proof_flag
         // (which passes the `f[index][stem]` form) and make_proof_flag_named
@@ -313,7 +318,7 @@ namespace gcs::innards
         /**
          * Return the string used in PB files for a given XLiteral.
          */
-        [[nodiscard]] auto pb_file_string_for(const XLiteral &) const -> std::string;
+        [[nodiscard]] auto pb_file_string_for(const XLiteral &) const -> const std::string &;
 
         /**
          * Return the raw proof literal representing a variable condition, for writing to a model or log.
@@ -332,7 +337,7 @@ namespace gcs::innards
         /**
          * Return a string form of a raw proof literal, for writing to a model or log.
          */
-        [[nodiscard]] auto pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> std::string;
+        [[nodiscard]] auto pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> const std::string &;
 
         /**
          * Return a string form of the exact literals specifying a bit assignment for var == val, an alternative way to witness solutions.
@@ -354,7 +359,7 @@ namespace gcs::innards
          * Return a string form of a proof flag, for writing to a model or log. Same as calling
          * raw_literal_as_string(raw_proof_literal(flag)).
          */
-        [[nodiscard]] auto pb_file_string_for(const ProofFlag &) const -> std::string;
+        [[nodiscard]] auto pb_file_string_for(const ProofFlag &) const -> const std::string &;
 
         /**
          * Call the supplied function for each bit making up the given variable, specifying

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -542,6 +542,14 @@ namespace gcs::innards
          */
         [[nodiscard]] auto reify(const WPBSumLE &, const HalfReifyOnConjunctionOf &) -> WPBSumLE;
 
+        /**
+         * As reify(), but writing the result into `out`, reusing its term
+         * storage. For per-inference emission, where a freshly allocated
+         * reified sum per proof line is measurable; `out` must not alias the
+         * input.
+         */
+        auto reify_into(const WPBSumLE &, const HalfReifyOnConjunctionOf &, WPBSumLE & out) -> void;
+
         /*
          * Allocate an XLiteral with the given semantic meaning.
          */

--- a/gcs/innards/proofs/pol_builder.cc
+++ b/gcs/innards/proofs/pol_builder.cc
@@ -1,4 +1,5 @@
 #include <gcs/exception.hh>
+#include <gcs/innards/proofs/emit_inequality_to.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -29,13 +30,14 @@ auto PolBuilder::enable_deview_mode(const NamesAndIDsTracker & tracker) -> PolBu
 auto PolBuilder::separator_if_not_first() -> void
 {
     if (! _empty)
-        _tokens.emplace_back(string{" +"});
+        _text += " +";
 }
 
 auto PolBuilder::add(ProofLine line) -> PolBuilder &
 {
     ProofLine resolved = _deview_tracker ? _deview_tracker->deviewed_line_for(line) : line;
-    _tokens.emplace_back(resolved);
+    _text += ' ';
+    _refs.emplace_back(_text.size(), move(resolved));
     separator_if_not_first();
     _empty = false;
     return *this;
@@ -46,9 +48,13 @@ auto PolBuilder::add(ProofLine line, Integer coeff) -> PolBuilder &
     if (coeff == 0_i)
         throw UnexpectedException{"PolBuilder::add called with zero coefficient"};
     ProofLine resolved = _deview_tracker ? _deview_tracker->deviewed_line_for(line) : line;
-    _tokens.emplace_back(resolved);
-    if (coeff != 1_i)
-        _tokens.emplace_back(" " + std::to_string(coeff.raw_value) + " *");
+    _text += ' ';
+    _refs.emplace_back(_text.size(), move(resolved));
+    if (coeff != 1_i) {
+        _text += ' ';
+        append_number_to(_text, coeff);
+        _text += " *";
+    }
     separator_if_not_first();
     _empty = false;
     return *this;
@@ -56,7 +62,8 @@ auto PolBuilder::add(ProofLine line, Integer coeff) -> PolBuilder &
 
 auto PolBuilder::add(const XLiteral & lit, const NamesAndIDsTracker & tracker) -> PolBuilder &
 {
-    _tokens.emplace_back(" " + tracker.pb_file_string_for(lit));
+    _text += ' ';
+    _text += tracker.pb_file_string_for(lit);
     separator_if_not_first();
     _empty = false;
     return *this;
@@ -66,9 +73,13 @@ auto PolBuilder::add(const XLiteral & lit, Integer coeff, const NamesAndIDsTrack
 {
     if (coeff == 0_i)
         throw UnexpectedException{"PolBuilder::add called with zero coefficient"};
-    _tokens.emplace_back(" " + tracker.pb_file_string_for(lit));
-    if (coeff != 1_i)
-        _tokens.emplace_back(" " + std::to_string(coeff.raw_value) + " *");
+    _text += ' ';
+    _text += tracker.pb_file_string_for(lit);
+    if (coeff != 1_i) {
+        _text += ' ';
+        append_number_to(_text, coeff);
+        _text += " *";
+    }
     separator_if_not_first();
     _empty = false;
     return *this;
@@ -96,25 +107,31 @@ auto PolBuilder::add_for_literal(NamesAndIDsTracker & tracker, const IntegerVari
 
 auto PolBuilder::saturate() -> PolBuilder &
 {
-    _tokens.emplace_back(string{" s"});
+    _text += " s";
     return *this;
 }
 
 auto PolBuilder::multiply_by(Integer n) -> PolBuilder &
 {
-    _tokens.emplace_back(" " + std::to_string(n.raw_value) + " *");
+    _text += ' ';
+    append_number_to(_text, n);
+    _text += " *";
     return *this;
 }
 
 auto PolBuilder::divide_by(Integer n) -> PolBuilder &
 {
-    _tokens.emplace_back(" " + std::to_string(n.raw_value) + " d");
+    _text += ' ';
+    append_number_to(_text, n);
+    _text += " d";
     return *this;
 }
 
 auto PolBuilder::weaken(const ProofFlag & flag, const NamesAndIDsTracker & tracker) -> PolBuilder &
 {
-    _tokens.emplace_back(" " + tracker.pb_file_string_for(flag) + " w");
+    _text += ' ';
+    _text += tracker.pb_file_string_for(flag);
+    _text += " w";
     return *this;
 }
 
@@ -126,19 +143,20 @@ auto PolBuilder::empty() const -> bool
 auto PolBuilder::render(optional<long long> current_max) const -> string
 {
     string out = "pol";
-    for (const auto & t : _tokens)
-        out += visit(overloaded{
-                         [&](const string & s) -> string { return s; }, //
-                         [&](const ProofLine & l) -> string {
-                             if (current_max)
-                                 return " " + relative_proof_line(l, *current_max);
-                             else if (auto n = std::get_if<ProofLineNumber>(&l))
-                                 return " " + std::to_string(n->number);
-                             else
-                                 return " @" + std::get<ProofLineLabel>(l).label;
-                         } //
-                     },
-            t);
+    std::size_t done = 0;
+    for (const auto & [offset, line] : _refs) {
+        out.append(_text, done, offset - done);
+        done = offset;
+        if (current_max)
+            out += relative_proof_line(line, *current_max);
+        else if (const auto * n = std::get_if<ProofLineNumber>(&line))
+            append_number_to(out, n->number);
+        else {
+            out += '@';
+            out += std::get<ProofLineLabel>(line).label;
+        }
+    }
+    out.append(_text, done, string::npos);
     return out + " ;";
 }
 
@@ -156,6 +174,7 @@ auto PolBuilder::emit(ProofLogger & logger, ProofLevel level) -> ProofLine
 
 auto PolBuilder::clear() -> void
 {
-    _tokens.clear();
+    _text.clear();
+    _refs.clear();
     _empty = true;
 }

--- a/gcs/innards/proofs/pol_builder.hh
+++ b/gcs/innards/proofs/pol_builder.hh
@@ -67,15 +67,16 @@ namespace gcs::innards
     class PolBuilder
     {
     private:
-        // A pol line is built as a sequence of tokens: verbatim string fragments
-        // (coefficients, operators, literal names) interleaved with constraint
-        // references (ProofLine). The references are only resolved to text at
-        // render time, because emitting them as VeriPB *relative* (negative)
-        // indices needs the current proof-line counter, which is known at emit
-        // (not at add). str() renders them absolutely (for tests/debugging);
-        // emit() renders them relatively against the logger's current line.
-        using Token = std::variant<std::string, ProofLine>;
-        std::vector<Token> _tokens;
+        // A pol line is verbatim text (coefficients, operators, literal names)
+        // interleaved with constraint references (ProofLine). The text
+        // accumulates in one buffer; each reference records the offset it
+        // splices in at, because emitting it as a VeriPB *relative* (negative)
+        // index needs the current proof-line counter, which is known at emit
+        // (not at add). str() renders references absolutely (for
+        // tests/debugging); emit() renders them relatively against the
+        // logger's current line.
+        std::string _text;
+        std::vector<std::pair<std::size_t, ProofLine>> _refs;
         bool _empty = true;
         const NamesAndIDsTracker * _deview_tracker = nullptr;
 

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -155,6 +155,11 @@ struct ProofLogger::Imp
     // before assembly starts may itself emit (and so clobber this).
     string line_buffer;
 
+    // Scratch for the reified form of an inference under its reason, reused
+    // across emissions for the same reason (a reified linear sum can run to
+    // hundreds of terms, and a fresh allocation per line is measurable).
+    WPBSumLE reify_buffer{{}, 0_i};
+
     Imp(NamesAndIDsTracker & t) : tracker(t)
     {
     }
@@ -502,7 +507,8 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
         .visit(rule);
 
     if (! reason.empty()) {
-        emit_inequality_to(names_and_ids_tracker(), reify(ineq, reason), rule_line);
+        names_and_ids_tracker().reify_into(ineq, reason, _imp->reify_buffer);
+        emit_inequality_to(names_and_ids_tracker(), _imp->reify_buffer, rule_line);
     }
     else {
         emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -195,6 +195,19 @@ struct ProofLogger::Imp
     deque<string> line_buffers;
     std::size_t line_buffer_depth = 0;
 
+    // Scratch for the ubiquitous `1 * lit >= 1` inference shape, in its
+    // rendered LE form (one -1 term, rhs -1), so infer() does not allocate a
+    // one-term sum per logged inference. Safe to reuse because nothing
+    // reachable from an emission re-enters infer().
+    WPBSumLE unit_buffer{{}, -1_i};
+
+    [[nodiscard]] auto unit_holds(const Literal & lit) -> const WPBSumLE &
+    {
+        unit_buffer.lhs.terms.clear();
+        unit_buffer.lhs.terms.emplace_back(-1_i, ProofLiteral{lit});
+        return unit_buffer;
+    }
+
     Imp(NamesAndIDsTracker & t) : tracker(t)
     {
     }
@@ -305,12 +318,17 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
 auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
 {
     _imp->proof << "% backtracking\n";
-    WPBSum backtrack;
-    backtrack.terms.reserve(guesses.size());
+    // The backtrack clause is `at least one guess is false': exactly a
+    // reason-only reified line over the guesses, so route it through the
+    // reified renderer, which negates each guess at the XLiteral level
+    // rather than as a condition object.
+    ReasonLiterals guesses_as_reason;
+    guesses_as_reason.reserve(guesses.size());
     for (const auto & guess : guesses)
-        backtrack += 1_i * ! guess;
+        guesses_as_reason.emplace_back(ProofLiteral{guess});
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-    emit(assert_or_rup, move(backtrack) >= 1_i, ProofLevel::Current, AssertionAnnotation{.hint_name = hints::Backtrack::hint_name});
+    emit_under_reason(
+        assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Current, guesses_as_reason, AssertionAnnotation{.hint_name = hints::Backtrack::hint_name});
 }
 
 auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions) -> ProofLine
@@ -414,7 +432,7 @@ auto ProofLogger::infer(
         // infer_explicitly(); this variant only carries the plain ones, so the
         // annotation is just the one passed in.
         if (! is_literally_true(lit) && ! std::holds_alternative<NoJustificationNeeded>(why)) {
-            emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason, annotation);
+            emit_under_reason(AssertProofRule{}, _imp->unit_holds(lit), ProofLevel::Current, reason, annotation);
         }
         return;
     }
@@ -422,12 +440,12 @@ auto ProofLogger::infer(
     overloaded{
         [&]([[maybe_unused]] const JustifyUsingRUP<NoHint> & j) {
             if (! is_literally_true(lit)) {
-                emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current);
+                emit_rup_proof_line_under_reason(reason, _imp->unit_holds(lit), ProofLevel::Current);
             }
         }, //
         [&]([[maybe_unused]] const AssertRatherThanJustifying & j) {
             if (! is_literally_true(lit)) {
-                emit_under_reason(AssertProofRule{}, WPBSum{} + 1_i * lit >= 1_i, ProofLevel::Current, reason);
+                emit_under_reason(AssertProofRule{}, _imp->unit_holds(lit), ProofLevel::Current, reason);
             }
         },                                    //
         [&](const NoJustificationNeeded &) {} //

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -195,11 +195,6 @@ struct ProofLogger::Imp
     deque<string> line_buffers;
     std::size_t line_buffer_depth = 0;
 
-    // Scratch for the reified form of an inference under its reason, reused
-    // across emissions for the same reason (a reified linear sum can run to
-    // hundreds of terms, and a fresh allocation per line is measurable).
-    WPBSumLE reify_buffer{{}, 0_i};
-
     Imp(NamesAndIDsTracker & t) : tracker(t)
     {
     }
@@ -539,12 +534,9 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     }
         .visit(rule);
 
-    // EnsureNames::Yes: see emit() above. The nested emissions this can
-    // trigger never come back through here with a reason, so the single
-    // reify buffer is safe.
+    // EnsureNames::Yes: see emit() above.
     if (! reason.empty()) {
-        names_and_ids_tracker().reify_into(ineq, reason, _imp->reify_buffer);
-        emit_inequality_to(names_and_ids_tracker(), _imp->reify_buffer, rule_line, EnsureNames::Yes);
+        emit_reified_inequality_to(names_and_ids_tracker(), ineq, reason, rule_line, EnsureNames::Yes);
     }
     else {
         emit_inequality_to(names_and_ids_tracker(), ineq, rule_line, EnsureNames::Yes);

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -277,7 +277,15 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             }, //
             [&](const ViewOfIntegerVariableID & var) {
                 if (_imp->assertion_level > AssertionLevel::Definitions) {
-                    _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(*names_and_ids_tracker().find_view(var), val);
+                    // An unregistered view (e.g. an objective too wide to
+                    // host its own bit vector) is witnessed through the
+                    // underlying's bits at the deviewed value instead.
+                    if (auto v_id = names_and_ids_tracker().find_view(var))
+                        _imp->proof << " " << names_and_ids_tracker().bit_assignment_string_for(*v_id, val);
+                    else
+                        _imp->proof << " "
+                                    << names_and_ids_tracker().bit_assignment_string_for(
+                                           var.actual_variable, var.negate_first ? var.then_add - val : val - var.then_add);
                 }
                 else
                     _imp->proof << " " << names_and_ids_tracker().pb_file_string_for(deview(var == val));

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -95,6 +95,43 @@ namespace
         throw NonExhaustiveSwitch{};
     }
 
+    // Scoped hold on one of the logger's line-assembly buffers: takes the
+    // buffer at the current nesting depth, cleared, and releases it on the
+    // way out. See the line_buffers member for why this is a stack.
+    class LineBufferLease
+    {
+    private:
+        std::size_t & _depth;
+        std::string & _buffer;
+
+        [[nodiscard]] static auto buffer_at_depth(deque<string> & buffers, std::size_t depth) -> string &
+        {
+            if (buffers.size() <= depth)
+                buffers.resize(depth + 1);
+            return buffers[depth];
+        }
+
+    public:
+        explicit LineBufferLease(deque<string> & buffers, std::size_t & depth) : _depth(depth), _buffer(buffer_at_depth(buffers, depth))
+        {
+            _buffer.clear();
+            ++_depth;
+        }
+
+        ~LineBufferLease()
+        {
+            --_depth;
+        }
+
+        LineBufferLease(const LineBufferLease &) = delete;
+        auto operator=(const LineBufferLease &) -> LineBufferLease & = delete;
+
+        [[nodiscard]] auto buffer() -> string &
+        {
+            return _buffer;
+        }
+    };
+
     // The only rendering of an AssertionAnnotation: `:@label ...:name:fields`,
     // the tail of an assertion line. This replaced an ostream operator on the
     // type itself, which is gone rather than kept as a second spelling to hold
@@ -149,11 +186,14 @@ struct ProofLogger::Imp
     int current_indent = 0;
     AssertionLevel assertion_level;
 
-    // Scratch for assembling a single proof line before it is written out,
+    // Scratch buffers for assembling proof lines before they are written out,
     // reused across emissions to avoid a stringstream per logged inference.
-    // Only valid within one emit call: the name-introduction phase that runs
-    // before assembly starts may itself emit (and so clobber this).
-    string line_buffer;
+    // A stack, indexed by line_buffer_depth: rendering a line can introduce a
+    // proof name whose definitions are emitted (to the stream, ahead of the
+    // buffered line) through a nested emit, which needs its own buffer. A
+    // deque so nested growth never invalidates an outer buffer reference.
+    deque<string> line_buffers;
+    std::size_t line_buffer_depth = 0;
 
     // Scratch for the reified form of an inference under its reason, reused
     // across emissions for the same reason (a reified linear sum can run to
@@ -424,13 +464,10 @@ auto ProofLogger::emit_proof_comment(const string & s) -> void
 auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level,
     const std::optional<AssertionAnnotation> & assertion_hint, const std::optional<ProofLineLabel> & label) -> ProofLine
 {
-    // Any names introduced here can emit their own proof lines, so this must
-    // finish before line assembly starts in the shared buffer.
-    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     log_stacktrace();
 
-    auto & rule_line = _imp->line_buffer;
-    rule_line.clear();
+    LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
+    auto & rule_line = lease.buffer();
 
     overloaded{
         [&](const RUPProofRule &) { rule_line += "rup "; },    //
@@ -439,7 +476,10 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
     }
         .visit(rule);
 
-    emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);
+    // EnsureNames::Yes: a condition without a proof name yet gets introduced
+    // as it is rendered, and its definition lines go out to the proof stream
+    // ahead of this line, which is still sitting in the buffer.
+    emit_inequality_to(names_and_ids_tracker(), ineq, rule_line, EnsureNames::Yes);
 
     overloaded{
         [&](const RUPProofRule & rule) {
@@ -487,17 +527,10 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
 auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level,
     const ReasonLiterals & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
-    // Names introduced here can emit their own proof lines, so both of these
-    // must finish before line assembly starts in the shared buffer.
-    if (! reason.empty())
-        names_and_ids_tracker().need_all_proof_names_in(reason);
-
-    names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
-
     log_stacktrace();
 
-    auto & rule_line = _imp->line_buffer;
-    rule_line.clear();
+    LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
+    auto & rule_line = lease.buffer();
 
     overloaded{
         [&](const RUPProofRule &) { rule_line += "rup "; },    //
@@ -506,12 +539,15 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     }
         .visit(rule);
 
+    // EnsureNames::Yes: see emit() above. The nested emissions this can
+    // trigger never come back through here with a reason, so the single
+    // reify buffer is safe.
     if (! reason.empty()) {
         names_and_ids_tracker().reify_into(ineq, reason, _imp->reify_buffer);
-        emit_inequality_to(names_and_ids_tracker(), _imp->reify_buffer, rule_line);
+        emit_inequality_to(names_and_ids_tracker(), _imp->reify_buffer, rule_line, EnsureNames::Yes);
     }
     else {
-        emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);
+        emit_inequality_to(names_and_ids_tracker(), ineq, rule_line, EnsureNames::Yes);
     }
 
     overloaded{

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -142,6 +142,10 @@ struct ProofLogger::Imp
 
     string proof_file;
     fstream proof;
+    // A proof is many short lines; the default stream buffer makes for a
+    // write syscall every few KB, which shows up at this volume. Installed
+    // via pubsetbuf before open in start_proof.
+    vector<char> proof_stream_buffer;
     int current_indent = 0;
     AssertionLevel assertion_level;
 
@@ -262,6 +266,7 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
 {
     _imp->proof << "% backtracking\n";
     WPBSum backtrack;
+    backtrack.terms.reserve(guesses.size());
     for (const auto & guess : guesses)
         backtrack += 1_i * ! guess;
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
@@ -618,6 +623,8 @@ auto ProofLogger::start_proof(const ProofModel & model) -> void
 {
     try {
         _imp->proof.exceptions(ios::failbit | ios::badbit);
+        _imp->proof_stream_buffer.resize(1024 * 1024);
+        _imp->proof.rdbuf()->pubsetbuf(_imp->proof_stream_buffer.data(), _imp->proof_stream_buffer.size());
         _imp->proof.open(_imp->proof_file, ios::out);
         _imp->proof << "pseudo-Boolean proof version 3.0\n";
         // No `f` rule: VeriPB 3.0 loads the formula implicitly, and omitting the

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -29,6 +29,14 @@
 #include <stacktrace>
 #endif
 
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <format>
+using std::format;
+#else
+#include <fmt/core.h>
+using fmt::format;
+#endif
+
 #include <util/overloaded.hh>
 
 using std::cmp_less_equal;
@@ -87,6 +95,25 @@ namespace
         throw NonExhaustiveSwitch{};
     }
 
+    // The only rendering of an AssertionAnnotation: `:@label ...:name:fields`,
+    // the tail of an assertion line. This replaced an ostream operator on the
+    // type itself, which is gone rather than kept as a second spelling to hold
+    // in step -- the two assert sites below were its only callers.
+    auto append_annotation_to(string & out, const AssertionAnnotation & annotation) -> void
+    {
+        out += ':';
+        for (const auto & id_or_label : annotation.derivable_from) {
+            out += '@';
+            out += id_or_label.label;
+            out += ' ';
+        }
+        out += ':';
+        out += annotation.hint_name;
+        out += ':';
+        if (annotation.hint_fields)
+            out += format("{}", *annotation.hint_fields);
+    }
+
     [[nodiscard]] auto witness_literal(NamesAndIDsTracker & names_and_ids_tracker, const ProofLiteralOrFlag & lit) -> string
     {
         return overloaded{
@@ -117,6 +144,12 @@ struct ProofLogger::Imp
     fstream proof;
     int current_indent = 0;
     AssertionLevel assertion_level;
+
+    // Scratch for assembling a single proof line before it is written out,
+    // reused across emissions to avoid a stringstream per logged inference.
+    // Only valid within one emit call: the name-introduction phase that runs
+    // before assembly starts may itself emit (and so clobber this).
+    string line_buffer;
 
     Imp(NamesAndIDsTracker & t) : tracker(t)
     {
@@ -381,54 +414,57 @@ auto ProofLogger::emit_proof_comment(const string & s) -> void
 auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level,
     const std::optional<AssertionAnnotation> & assertion_hint, const std::optional<ProofLineLabel> & label) -> ProofLine
 {
+    // Any names introduced here can emit their own proof lines, so this must
+    // finish before line assembly starts in the shared buffer.
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     log_stacktrace();
 
-    stringstream rule_line;
+    auto & rule_line = _imp->line_buffer;
+    rule_line.clear();
 
-    rule_line << overloaded{
-                     [&](const RUPProofRule &) -> string { return "rup"; },    //
-                     [&](const ImpliesProofRule &) -> string { return "ia"; }, //
-                     [&](const AssertProofRule &) -> string { return "a"; }    //
-                 }
-                     .visit(rule)
-              << " ";
+    overloaded{
+        [&](const RUPProofRule &) { rule_line += "rup "; },    //
+        [&](const ImpliesProofRule &) { rule_line += "ia "; }, //
+        [&](const AssertProofRule &) { rule_line += "a "; }    //
+    }
+        .visit(rule);
 
     emit_inequality_to(names_and_ids_tracker(), ineq, rule_line);
 
     overloaded{
         [&](const RUPProofRule & rule) {
             if (rule.lines) {
-                rule_line << ": ";
+                rule_line += ": ";
                 for (auto & line : *rule.lines) {
-                    rule_line << relative_proof_line(line, _imp->proof_line.number) << ' ';
+                    rule_line += relative_proof_line(line, _imp->proof_line.number);
+                    rule_line += ' ';
                 }
-                rule_line << " ;";
+                rule_line += " ;";
             }
             else {
-                rule_line << ";";
+                rule_line += ";";
             }
         }, //
         [&](const ImpliesProofRule & rule) {
             if (rule.line) {
-                rule_line << ": ";
-                rule_line << relative_proof_line(*rule.line, _imp->proof_line.number) << ' ';
-                rule_line << " ;";
+                rule_line += ": ";
+                rule_line += relative_proof_line(*rule.line, _imp->proof_line.number);
+                rule_line += "  ;";
             }
             else {
-                rule_line << ";";
+                rule_line += ";";
             }
         }, //
         [&](const AssertProofRule &) {
             if (assertion_hint) {
-                rule_line << *assertion_hint;
+                append_annotation_to(rule_line, *assertion_hint);
             }
-            rule_line << ";";
+            rule_line += ";";
         } //
     }
         .visit(rule);
 
-    auto line = emit_proof_line(rule_line.str(), level, label);
+    auto line = emit_proof_line(rule_line, level, label);
     // Note: no automatic deview-derivation here. Runtime RUP/red emissions
     // happen many times per propagator inference and per-call deview
     // derivation explodes proof size on tests with many view-using
@@ -441,21 +477,24 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
 auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level,
     const ReasonLiterals & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
+    // Names introduced here can emit their own proof lines, so both of these
+    // must finish before line assembly starts in the shared buffer.
     if (! reason.empty())
         names_and_ids_tracker().need_all_proof_names_in(reason);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
 
     log_stacktrace();
-    stringstream rule_line;
 
-    rule_line << overloaded{
-                     [&](const RUPProofRule &) -> string { return "rup"; },    //
-                     [&](const ImpliesProofRule &) -> string { return "ia"; }, //
-                     [&](const AssertProofRule &) -> string { return "a"; }    //
-                 }
-                     .visit(rule)
-              << " ";
+    auto & rule_line = _imp->line_buffer;
+    rule_line.clear();
+
+    overloaded{
+        [&](const RUPProofRule &) { rule_line += "rup "; },    //
+        [&](const ImpliesProofRule &) { rule_line += "ia "; }, //
+        [&](const AssertProofRule &) { rule_line += "a "; }    //
+    }
+        .visit(rule);
 
     if (! reason.empty()) {
         emit_inequality_to(names_and_ids_tracker(), reify(ineq, reason), rule_line);
@@ -467,37 +506,38 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     overloaded{
         [&](const RUPProofRule & rule) {
             if (rule.lines) {
-                rule_line << ": ";
+                rule_line += ": ";
                 for (const auto & line : *rule.lines) {
-                    rule_line << relative_proof_line(line, _imp->proof_line.number) << " ";
+                    rule_line += relative_proof_line(line, _imp->proof_line.number);
+                    rule_line += ' ';
                 }
-                rule_line << " ;";
+                rule_line += " ;";
             }
             else {
-                rule_line << ";";
+                rule_line += ";";
             }
         }, //
         [&](const ImpliesProofRule & rule) {
             if (rule.line) {
-                rule_line << ": ";
-                rule_line << relative_proof_line(*rule.line, _imp->proof_line.number) << " ";
-                rule_line << " ;";
+                rule_line += ": ";
+                rule_line += relative_proof_line(*rule.line, _imp->proof_line.number);
+                rule_line += "  ;";
             }
             else {
-                rule_line << ";";
+                rule_line += ";";
             }
         }, //
         [&](const AssertProofRule &) {
             if (assertion_hint) {
-                rule_line << *assertion_hint;
+                append_annotation_to(rule_line, *assertion_hint);
             }
 
-            rule_line << ";";
+            rule_line += ";";
         } //
     }
         .visit(rule);
 
-    auto line = emit_proof_line(rule_line.str(), level);
+    auto line = emit_proof_line(rule_line, level);
     // Note: see comment in `emit()` about why no auto-deview-derivation.
     return line;
 }

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -1,3 +1,4 @@
+#include <gcs/exception.hh>
 #include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/bits_encoding.hh>
 #include <gcs/innards/proofs/emit_inequality_to.hh>
@@ -13,10 +14,8 @@
 #include <cstdlib>
 #include <exception>
 #include <fstream>
-#include <iterator>
 #include <map>
 #include <set>
-#include <sstream>
 
 #include <version>
 
@@ -32,19 +31,15 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-using std::fstream;
 using std::ios;
 using std::ios_base;
-using std::istreambuf_iterator;
 using std::make_unique;
 using std::map;
 using std::nullopt;
 using std::ofstream;
 using std::optional;
-using std::ostreambuf_iterator;
 using std::pair;
 using std::string;
-using std::stringstream;
 using std::variant;
 using std::vector;
 using std::ranges::sort;
@@ -57,11 +52,22 @@ using std::print;
 using fmt::print;
 #endif
 
+namespace
+{
+    // The string-append twin of ProofLineLabel's ostream operator (a leading
+    // `@`, then the label), plus the trailing space the OPB sites all want.
+    auto append_label_to(string & out, const ProofLineLabel & label) -> void
+    {
+        out += '@';
+        out += label.label;
+        out += ' ';
+    }
+}
+
 struct ProofModel::Imp
 {
     NamesAndIDsTracker & tracker;
 
-    unsigned long long model_variables = 0;
     ProofLineNumber number_of_constraints{0};
 
     optional<IntegerVariableID> optional_minimise_variable;
@@ -71,7 +77,12 @@ struct ProofModel::Imp
     map<Integer, ProofModel::CakeConstantAtoms> cake_constant_atoms;
 
     string opb_file;
-    stringstream opb;
+    // Text not yet written out. Until write_preamble() runs this holds
+    // everything emitted so far (the variable set-up rows); afterwards each
+    // emitting method sends it straight on to the file.
+    string opb;
+    ofstream opb_stream;
+    bool streaming = false;
 
     bool always_use_full_encoding = false;
     bool finalised = false;
@@ -108,7 +119,12 @@ auto ProofModel::emit_constraint_label(const string & constraint_id, const strin
 
 auto ProofModel::begin_constraint_block_comment(const string & constraint_type, const ConstraintID & constraint_id) -> void
 {
-    _imp->opb << "* constraint " << constraint_type << ' ' << as_string(constraint_id) << '\n';
+    _imp->opb += "* constraint ";
+    _imp->opb += constraint_type;
+    _imp->opb += ' ';
+    _imp->opb += as_string(constraint_id);
+    _imp->opb += '\n';
+    write_out_pending();
 }
 
 auto ProofModel::add_constraint(const Literals & lits) -> void
@@ -143,8 +159,9 @@ auto ProofModel::add_constraint(const WPBSumLE & ineq, const optional<HalfReifyO
     if (half_reif)
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
-    _imp->opb << ";\n";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb, EnsureNames::No);
+    _imp->opb += ";\n";
+    write_out_pending();
     auto line = advance_constraint_counter();
     // emit_inequality_to negates the LE inequality to land in PB >= form.
     names_and_ids_tracker().derive_deviewed_form_for(line, ineq.lhs, /*le_half=*/true);
@@ -156,16 +173,17 @@ auto ProofModel::add_constraint(const WPBSumEq & eq, const optional<HalfReifyOnC
     if (half_reif)
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
-    emit_inequality_to(
-        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
-    _imp->opb << ";\n";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb,
+        EnsureNames::No);
+    _imp->opb += ";\n";
     auto first = advance_constraint_counter();
     // LE half: emit_inequality_to negates coefficients on emit.
     names_and_ids_tracker().derive_deviewed_form_for(first, eq.lhs, /*le_half=*/true);
 
-    emit_inequality_to(
-        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
-    _imp->opb << ";\n";
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb,
+        EnsureNames::No);
+    _imp->opb += ";\n";
+    write_out_pending();
     auto second = advance_constraint_counter();
     // GE half: the >= operator in expression.hh negates the sum once before
     // emit_inequality_to negates it again, so OPB-form coefficients match
@@ -188,19 +206,20 @@ auto ProofModel::add_labelled_constraint(const string & label_le, const string &
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
     ProofLineLabel le{label_le};
-    _imp->opb << le << " ";
-    emit_inequality_to(
-        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb);
-    _imp->opb << ";\n";
+    append_label_to(_imp->opb, le);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs <= eq.rhs, *half_reif) : eq.lhs <= eq.rhs, _imp->opb,
+        EnsureNames::No);
+    _imp->opb += ";\n";
     advance_constraint_counter();
     // LE half: emit_inequality_to negates coefficients on emit.
     names_and_ids_tracker().derive_deviewed_form_for(le, eq.lhs, /*le_half=*/true);
 
     ProofLineLabel ge{label_ge};
-    _imp->opb << ge << " ";
-    emit_inequality_to(
-        names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb);
-    _imp->opb << ";\n";
+    append_label_to(_imp->opb, ge);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(eq.lhs >= eq.rhs, *half_reif) : eq.lhs >= eq.rhs, _imp->opb,
+        EnsureNames::No);
+    _imp->opb += ";\n";
+    write_out_pending();
     advance_constraint_counter();
     // GE half: see the unlabelled add_constraint above for the double-negation note.
     names_and_ids_tracker().derive_deviewed_form_for(ge, eq.lhs, /*le_half=*/false);
@@ -216,9 +235,10 @@ auto ProofModel::add_labelled_constraint(const string & label, const WPBSumLE & 
         names_and_ids_tracker().need_all_proof_names_in(*half_reif);
 
     ProofLineLabel l{label};
-    _imp->opb << l << " ";
-    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb);
-    _imp->opb << ";\n";
+    append_label_to(_imp->opb, l);
+    emit_inequality_to(names_and_ids_tracker(), half_reif ? names_and_ids_tracker().reify(ineq, *half_reif) : ineq, _imp->opb, EnsureNames::No);
+    _imp->opb += ";\n";
+    write_out_pending();
     advance_constraint_counter();
     // As the (constraint_id, role) overload: a labelled constraint over a view
     // still needs its deviewed form, so a proof-only view variable's encoding
@@ -389,8 +409,10 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
         // bits-encoded variable. (The two `red` lines are created in-proof on
         // first use, so the OPB is unchanged.)
         auto eqvar = names_and_ids_tracker().allocate_xliteral_meaning_bit_of(id, 0_i);
-        _imp->opb << "1 " << names_and_ids_tracker().pb_file_string_for(eqvar) << " >= 0 ;\n";
-        ++_imp->model_variables;
+        _imp->opb += "1 ";
+        _imp->opb += names_and_ids_tracker().pb_file_string_for(eqvar);
+        _imp->opb += " >= 0 ;\n";
+        write_out_pending();
         advance_constraint_counter();
 
         overloaded{
@@ -422,8 +444,9 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
         for (auto v = lower; v <= upper; ++v) {
             names_and_ids_tracker().track_variable_name(id, name);
             auto eqvar = names_and_ids_tracker().allocate_xliteral_meaning(id, EqualsOrGreaterEqual::Equals, v);
-            _imp->opb << "1 " << names_and_ids_tracker().pb_file_string_for(eqvar) << " ";
-            ++_imp->model_variables;
+            _imp->opb += "1 ";
+            _imp->opb += names_and_ids_tracker().pb_file_string_for(eqvar);
+            _imp->opb += ' ';
 
             visit(
                 [&](const auto & id) {
@@ -432,13 +455,16 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
                 },
                 id);
         }
-        _imp->opb << ">= 1 ;\n";
+        _imp->opb += ">= 1 ;\n";
         names_and_ids_tracker().track_variable_takes_at_least_one_value(id, advance_constraint_counter());
 
         for (auto v = lower; v <= upper; ++v) {
-            _imp->opb << "-1 " << names_and_ids_tracker().pb_file_string_for(id == v) << " ";
+            _imp->opb += "-1 ";
+            _imp->opb += names_and_ids_tracker().pb_file_string_for(id == v);
+            _imp->opb += ' ';
         }
-        _imp->opb << ">= -1 ;\n";
+        _imp->opb += ">= -1 ;\n";
+        write_out_pending();
         advance_constraint_counter();
     }
 }
@@ -538,7 +564,6 @@ auto ProofModel::set_up_bits_variable_encoding(
     vector<pair<Integer, XLiteral>> bits;
     for (auto b : names_and_ids_tracker().each_bit(id))
         bits.push_back(b);
-    _imp->model_variables += bits.size();
 
     // @i[name][lb]/[ub] labels match cake_pb_cp, for a real variable; a vector
     // name like box[0] is fine (veripb's @label parser accepts the nested
@@ -548,18 +573,31 @@ auto ProofModel::set_up_bits_variable_encoding(
 
     // lower bound
     if (labelled)
-        _imp->opb << ProofLineLabel{"i[" + name + "][lb]"} << " ";
-    for (auto & [coeff, var] : bits)
-        _imp->opb << coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
-    _imp->opb << ">= " << lower << " ;\n";
+        append_label_to(_imp->opb, ProofLineLabel{"i[" + name + "][lb]"});
+    for (auto & [coeff, var] : bits) {
+        append_number_to(_imp->opb, coeff);
+        _imp->opb += ' ';
+        _imp->opb += names_and_ids_tracker().pb_file_string_for(var);
+        _imp->opb += ' ';
+    }
+    _imp->opb += ">= ";
+    append_number_to(_imp->opb, lower);
+    _imp->opb += " ;\n";
     auto lower_row = advance_constraint_counter();
 
     // upper bound
     if (labelled)
-        _imp->opb << ProofLineLabel{"i[" + name + "][ub]"} << " ";
-    for (auto & [coeff, var] : bits)
-        _imp->opb << -coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
-    _imp->opb << ">= " << -upper << " ;\n";
+        append_label_to(_imp->opb, ProofLineLabel{"i[" + name + "][ub]"});
+    for (auto & [coeff, var] : bits) {
+        append_number_to(_imp->opb, -coeff);
+        _imp->opb += ' ';
+        _imp->opb += names_and_ids_tracker().pb_file_string_for(var);
+        _imp->opb += ' ';
+    }
+    _imp->opb += ">= ";
+    append_number_to(_imp->opb, -upper);
+    _imp->opb += " ;\n";
+    write_out_pending();
     auto upper_row = advance_constraint_counter();
 
     // Track the two rows so proof steps can combine them by pol (e.g.
@@ -631,43 +669,58 @@ auto ProofModel::cake_constant_atoms(Integer k) -> CakeConstantAtoms
     return result;
 }
 
-auto ProofModel::finalise() -> void
+auto ProofModel::write_out_pending() -> void
 {
-    _imp->finalised = true;
+    if (! _imp->streaming)
+        return;
     try {
-        ofstream full_opb;
-        full_opb.exceptions(ios::failbit | ios::badbit);
-        full_opb.open(_imp->opb_file);
-        full_opb << "* #variable= " << _imp->model_variables << " #constraint= " << _imp->number_of_constraints.number << '\n';
+        _imp->opb_stream << _imp->opb;
+    }
+    catch (const ios_base::failure &) {
+        throw ProofError{"Error writing opb file to '" + _imp->opb_file + "'"};
+    }
+    _imp->opb.clear();
+}
+
+auto ProofModel::write_preamble() -> void
+{
+    if (_imp->streaming)
+        throw UnexpectedException{"proof model preamble has already been written"};
+
+    // A view objective is rendered over its own proof-only bit vector, so
+    // register it now (this appends BinEnc(V)'s set-up rows to the pending
+    // text, where they land just after the variable rows). This also
+    // guarantees find_view succeeds for the objective later, e.g. in the
+    // solution-logging soli path.
+    if (_imp->optional_minimise_variable)
+        if (auto * view = std::get_if<ViewOfIntegerVariableID>(&*_imp->optional_minimise_variable))
+            static_cast<void>(names_and_ids_tracker().need_view(*view));
+
+    try {
+        _imp->opb_stream.exceptions(ios::failbit | ios::badbit);
+        _imp->opb_stream.open(_imp->opb_file, ios::out);
+        // No `* #variable= .. #constraint= ..` counts comment: VeriPB 3 does
+        // not need it, and not writing it is what lets everything stream out
+        // as it is produced instead of being buffered until the counts are
+        // known.
 
         if (_imp->optional_minimise_variable) {
-            full_opb << "min: ";
+            _imp->opb_stream << "min: ";
             overloaded{
                 [&](const SimpleIntegerVariableID & v) {
                     for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(v))
-                        full_opb << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                        _imp->opb_stream << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
                 },                                                                          //
                 [&](const ConstantIntegerVariableID &) { throw UnimplementedException{}; }, //
                 [&](const ViewOfIntegerVariableID & v) {
-                    // If the view's been registered (used in a constraint
-                    // body during model writing), emit V's own bits.
-                    // Otherwise fall back to deviewing through the underlying
-                    // (objective constant offset still doesn't matter for
-                    // optimisation order).
-                    if (auto v_id = names_and_ids_tracker().find_view(v)) {
-                        for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(*v_id))
-                            full_opb << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
-                    }
-                    else {
-                        for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(v.actual_variable))
-                            full_opb << (v.negate_first ? -bit_value : bit_value) << " " << names_and_ids_tracker().pb_file_string_for(bit_name)
-                                     << " ";
-                    }
+                    // Registered just above, so this always renders V's own bits.
+                    for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(*names_and_ids_tracker().find_view(v)))
+                        _imp->opb_stream << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
                 } //
             }
                 .visit(*_imp->optional_minimise_variable);
 
-            full_opb << ";\n";
+            _imp->opb_stream << ";\n";
         }
 
         if (_imp->preserved_variables) {
@@ -679,12 +732,12 @@ auto ProofModel::finalise() -> void
             // side fixed to the other). Dedup so that X and a view of X (or
             // two views of the same X) in the preserve list don't emit X's
             // bits twice.
-            full_opb << "preserved: ";
+            _imp->opb_stream << "preserved: ";
             std::set<SimpleIntegerVariableID> already_emitted;
             auto emit_underlying = [&](const SimpleIntegerVariableID & v) {
                 if (already_emitted.insert(v).second)
                     for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(v))
-                        full_opb << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                        _imp->opb_stream << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
             };
             for (const auto & var : *_imp->preserved_variables) {
                 overloaded{
@@ -695,11 +748,31 @@ auto ProofModel::finalise() -> void
                     .visit(var);
             }
 
-            full_opb << ";\n";
+            _imp->opb_stream << ";\n";
         }
+    }
+    catch (const ios_base::failure &) {
+        throw ProofError{"Error writing opb file to '" + _imp->opb_file + "'"};
+    }
 
-        copy(istreambuf_iterator<char>{_imp->opb}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{full_opb});
-        _imp->opb = stringstream{};
+    _imp->streaming = true;
+    write_out_pending();
+}
+
+auto ProofModel::finalise() -> void
+{
+    _imp->finalised = true;
+    // Anything built without going through write_preamble (tests that drive a
+    // ProofModel directly) has everything still pending; writing the preamble
+    // now flushes it too, giving the old write-everything-at-the-end
+    // behaviour.
+    if (! _imp->streaming)
+        write_preamble();
+    else
+        write_out_pending();
+    try {
+        _imp->opb_stream << std::flush;
+        _imp->opb_stream.close();
     }
     catch (const ios_base::failure &) {
         throw ProofError{"Error writing opb file to '" + _imp->opb_file + "'"};
@@ -713,10 +786,14 @@ auto ProofModel::number_of_constraints() const -> ProofLineNumber
 
 auto ProofModel::minimise(const IntegerVariableID & var) -> void
 {
+    if (_imp->streaming)
+        throw UnexpectedException{"objective must be set before the OPB preamble is written"};
     _imp->optional_minimise_variable = var;
 }
 
 auto ProofModel::preserve(vector<IntegerVariableID> vars) -> void
 {
+    if (_imp->streaming)
+        throw UnexpectedException{"preserved variables must be set before the OPB preamble is written"};
     _imp->preserved_variables = move(vars);
 }

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -691,10 +691,16 @@ auto ProofModel::write_preamble() -> void
     // register it now (this appends BinEnc(V)'s set-up rows to the pending
     // text, where they land just after the variable rows). This also
     // guarantees find_view succeeds for the objective later, e.g. in the
-    // solution-logging soli path.
+    // solution-logging soli path. The exception is a view whose bit vector
+    // cannot be represented at all -- negating a FlatZinc unbounded-int
+    // objective spans one more bit than an Integer holds -- which stays
+    // unregistered, and min: falls back to deviewing through the underlying.
     if (_imp->optional_minimise_variable)
-        if (auto * view = std::get_if<ViewOfIntegerVariableID>(&*_imp->optional_minimise_variable))
-            static_cast<void>(names_and_ids_tracker().need_view(*view));
+        if (auto * view = std::get_if<ViewOfIntegerVariableID>(&*_imp->optional_minimise_variable)) {
+            auto [v_lo, v_hi] = names_and_ids_tracker().view_bounds(*view);
+            if (bits_encoding_fits(v_lo, v_hi))
+                static_cast<void>(names_and_ids_tracker().need_view(*view));
+        }
 
     try {
         _imp->opb_stream.exceptions(ios::failbit | ios::badbit);
@@ -713,9 +719,19 @@ auto ProofModel::write_preamble() -> void
                 },                                                                          //
                 [&](const ConstantIntegerVariableID &) { throw UnimplementedException{}; }, //
                 [&](const ViewOfIntegerVariableID & v) {
-                    // Registered just above, so this always renders V's own bits.
-                    for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(*names_and_ids_tracker().find_view(v)))
-                        _imp->opb_stream << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                    // Registered just above whenever its bit vector is
+                    // representable; otherwise fall back to deviewing through
+                    // the underlying (the objective's constant offset doesn't
+                    // matter for optimisation order).
+                    if (auto v_id = names_and_ids_tracker().find_view(v)) {
+                        for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(*v_id))
+                            _imp->opb_stream << bit_value << " " << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                    }
+                    else {
+                        for (const auto & [bit_value, bit_name] : names_and_ids_tracker().each_bit(v.actual_variable))
+                            _imp->opb_stream << (v.negate_first ? -bit_value : bit_value) << " "
+                                             << names_and_ids_tracker().pb_file_string_for(bit_name) << " ";
+                    }
                 } //
             }
                 .visit(*_imp->optional_minimise_variable);

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -77,6 +77,12 @@ namespace gcs::innards
 
         auto set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVariableID, Integer, Integer, const std::string &) -> void;
 
+        // Send any pending OPB text on to the file. A no-op until
+        // write_preamble has run; emitting methods call it when they finish,
+        // and a missed call is harmless (the text simply rides along until
+        // the next one).
+        auto write_out_pending() -> void;
+
     public:
         /**
          * \name Constructors, destructors, and the like.
@@ -335,6 +341,24 @@ namespace gcs::innards
         auto preserve(std::vector<IntegerVariableID> vars) -> void;
 
         ///@}
+
+        /**
+         * Open the OPB file and write everything that must precede the
+         * constraints: the objective (min:) line and the preserved:
+         * projection line. Everything emitted afterwards goes straight to the
+         * file rather than accumulating in memory, so call this as soon as
+         * the objective and preserve list are known and every variable they
+         * mention has been set up -- in a solve, after
+         * Problem::create_state_for_new_search and before
+         * Problem::create_propagators. Calling minimise or preserve after
+         * this throws. A view objective's proof-only bit vector is registered
+         * here, so `min:` is always rendered over BinEnc(V).
+         *
+         * Optional: finalise() does it on your behalf (with everything still
+         * buffered, and the objective and preserve list set at any point) if
+         * nothing called it earlier.
+         */
+        auto write_preamble() -> void;
 
         /**
          * Finish writing the model. Must be called once, immediately before

--- a/gcs/innards/proofs/simplify_literal.cc
+++ b/gcs/innards/proofs/simplify_literal.cc
@@ -45,6 +45,15 @@ namespace
 
 auto gcs::innards::simplify_literal(const NamesAndIDsTracker & tracker, const ProofLiteral & lit) -> SimpleLiteral
 {
+    // Fast path for by far the most common shape: a non-range condition on a
+    // plain variable, which passes through unchanged. This is just a shortcut
+    // for what the general visit below produces; keep the two in agreement.
+    if (const auto * inner = std::get_if<Literal>(&lit))
+        if (const auto * cond = std::get_if<IntegerVariableCondition>(inner))
+            if (const auto * simple = std::get_if<SimpleIntegerVariableID>(&cond->var))
+                if (! is_range_op(cond->op))
+                    return VariableConditionFrom<SimpleIntegerVariableID>{*simple, cond->op, cond->value, cond->upper_value};
+
     return overloaded{
         [&](const TrueLiteral & t) -> SimpleLiteral { return t; },  //
         [&](const FalseLiteral & f) -> SimpleLiteral { return f; }, //

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -283,13 +283,28 @@ auto gcs::solve_with(
     }
 
     auto state = problem.create_state_for_new_search(optional_proof ? optional_proof->model() : nullptr);
+
+    if (optional_proof) {
+        if (problem.optional_minimise_variable())
+            optional_proof->model()->minimise(*problem.optional_minimise_variable());
+
+        optional_proof->model()->preserve(problem.all_normal_variables());
+
+        // Every variable the objective and preserve list mention now exists,
+        // so the OPB front matter can go out; the constraint definitions that
+        // follow stream straight to the file.
+        optional_proof->model()->write_preamble();
+    }
+
     auto propagators = problem.create_propagators(state, optional_proof ? optional_proof->model() : nullptr);
 
     // With restarts on, search learns nogoods from refuted regions. Install an
     // (initially empty) Nogoods over a store the restart loop grows, subscribed
     // to every variable since a later-learned nogood may mention any. This is
     // engine-owned, not user-posted --- restart nogoods are internal (and, under
-    // parallel search, per-thread). Must precede the model finalise below.
+    // parallel search, per-thread). Must follow create_propagators (it installs
+    // into them) and precede the model finalise below; any model definitions it
+    // adds land after the preamble, like every other constraint's.
     shared_ptr<NogoodStore> nogood_store;
     if (callbacks.restarts) {
         nogood_store = make_shared<NogoodStore>();
@@ -306,11 +321,6 @@ auto gcs::solve_with(
     }
 
     if (optional_proof) {
-        if (problem.optional_minimise_variable())
-            optional_proof->model()->minimise(*problem.optional_minimise_variable());
-
-        optional_proof->model()->preserve(problem.all_normal_variables());
-
         optional_proof->model()->finalise();
         optional_proof->model()->names_and_ids_tracker().switch_from_model_to_proof(optional_proof->logger());
         optional_proof->logger()->start_proof(*optional_proof->model());


### PR DESCRIPTION
Performance work on `gcs/innards/proofs/`, one measured commit per change. Rebased onto `3db5786e`; every figure and byte-comparison below was re-measured on that base.

## Result

Whole-solve wall time with `--prove`, all-solutions / full search, median of 5:

| benchmark | before | after | speedup | proof-logging overhead |
|---|---|---|---|---|
| minicp n_queens 12 (not-equals + views), 208 MB proof | 2.65s | 0.97s | 2.7× | 7.2× → 2.7× |
| minicp magic_series 100 (linear), 149 MB proof | 2.41s | 0.81s | 3.0× | 17.2× → 5.8× |
| minicp magic_square 4 (vc-alldiff), 166 MB proof | 2.25s | 0.86s | 2.6× | 10.7× → 4.3× |

"Overhead" is `--prove` time over the same run without proof logging (0.36s / 0.14s / 0.20s, unchanged by this branch). Entirely CPU-side: proof text now renders at roughly 200 MB/s, where the baseline managed about 90, and disk (~2 GB/s here) was never the bottleneck. An I/O ladder (`/dev/null`, tmpfs, real fs) puts ~92% of the remaining proof cost in user time.

## What changed

- **Representation swaps, invisible outside the tracker:** rendered literal names cached in an id-indexed vector (`const string &`, both naming modes); condition→literal lookup becomes dense per-variable atom tables keyed by value, with the ordered structure kept only where the order-encoding chain walk needs it (`need_gevar`'s next/prev walk over the ge-atom value set).
- **Text assembly:** lines are appended into reused buffers with `to_chars` number rendering instead of a fresh `stringstream` + locale-aware `ostream <<` per line; 1 MB `pubsetbuf` on the proof stream; `simplify_literal` fast path for plain non-range conditions; `PolBuilder` builds one text buffer with spliced line references instead of a `vector<variant<string, ProofLine>>`.
- **Structural:** the `need_all_proof_names_in` pre-pass is fused into rendering (`EnsureNames::Yes`; definitions emitted mid-render land ahead of the buffered line, nested emissions take their own buffer from a lease stack; the model-writing path keeps its explicit pre-pass). Reified lines render directly via `emit_reified_inequality_to` — no materialised reified sum, reason conditions negated at the XLiteral level — with the reification arithmetic single-sourced in `reification_shape()` shared with `reify()`. `backtrack()` uses the same renderer; `infer()` reuses a unit-sum scratch.
- **Model writing:** the OPB streams to disk instead of accumulating in a `stringstream`. `solve()` sets the objective and preserve list between `create_state_for_new_search` and `create_propagators` and calls the new `write_preamble()`, after which every constraint goes straight to the file (peak RSS drops by about the OPB size). Driving a `ProofModel` directly without `write_preamble()` still works — `finalise()` writes the preamble late, buffered as before.
- **Inference side:** reasons are snapshotted once and handed to the logger rather than re-materialised through an `ExplicitReason` round-trip; `equals` states its not-equals reason outright instead of building a `ConcatReason` per inference (the only hot user of that pattern — `vc_all_different` already states reasons explicitly, `regex`'s two uses are cold).

## Proof output compatibility

Re-established commit by commit against `775e5853`, regenerating `.opb`/`.pbp`/`.varmap`/`.scp` for three problem families at each commit:

- **14 of the 16 commits are byte-identical** to the commit before them, on all four output files.
- `6353554f` (fusing the name pre-pass into rendering) emits the same number of proof lines, but a `red` definition line now lands immediately ahead of the line that first uses it rather than in a batch, and the relative `pol` references shift to match (`pol -2 -6` → `pol -1 -6`). The `.varmap` holds the same entries in a different order. VeriPB verifies the result, including a full-size 208 MB enumeration proof.
- `efd013c6` (OPB streaming) changes the `.opb` by exactly one line: the `* #variable= ... #constraint= ...` counts header, which VeriPB 3 does not require and nothing here consumes. The `.pbp` is untouched.

If that definition ordering matters to anything downstream, `6353554f` can be dropped and the rest reworked onto the two-pass shape.

## Validation

- 491/491 ctest, configured with `GCS_ENABLE_MINIZINC=ON` so the frontend tests actually run
- per-commit byte-comparison as described above, all 16 commits building and running standalone
- VeriPB 3.0.2 verification with complete-enumeration conclusions: the three small proofs, plus the full-size 208 MB n_queens 12 enumeration
- clang-format 21 clean

## Rebase notes

Four proof fixes landed on main after this branch was written, in the files it rewrites. Each was reconciled deliberately rather than textually:

- **#554** stops aliasing the `>= 1` gevar to the encoding bit for `{0,1}` DirectOnly variables and deletes `track_gevar`. This branch had rewritten `track_gevar` to feed the dense tables; that rewrite is dropped rather than revived, since the atom is now built lazily by `need_gevar`.
- **#559** fixes the inverted value-0 eq pol-item polarity. The fix lives in `set_up_direct_only_variable_encoding` and carries through the dense-table rewrite unchanged.
- **#557** adds `find_xliteral_for`, the non-throwing twin of `xliteral_for`, which `recover_am1` uses to spot a complementary `{~b0, b0}` pair over a bit-aliased `{0,1}` variable. It landed as a direct probe of `variable_conditions_to_x` — which is exactly the map the dense-atom-tables commit stops putting eq/ge/in atoms in, so the merge was clean but would have made the lookup silently miss every pair it exists to find. It now goes through the same `find_condition` as `xliteral_for`. The `among` and both global-cardinality tests were run 12 times over fresh seeds (the failure #557 fixes is branch-order dependent, ~6/20 seeds) with no failures.
- **#553** added `track_bound_rows` and the `introduce_bits_of` path; the new per-variable table it introduces is hashed like its neighbours (point lookups only, never iterated in order).

`SnapshottedReason` also had to keep a handle on the still-declarative reason: the conflict observers behind dom/wdeg read the contradicting reason, and they run with proofs off, where the snapshot deliberately materialises nothing. `eqvar_polarity_test`, `direct_only_gevar_bound_test`, `introduce_bits_test` and `conflict_observer_test` all pass, and each covers exactly the machinery involved.

## Not done, recommended next (measured residuals)

Remaining tail on these benchmarks is tracker probes ~15%, `memmove` ~10%, and solver-proper work; the constraint-side sweep is done, in the sense that what is left is genuine proof content (linear's wide reasons *are* the emitted lines), cheaper only by changing what gets proved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG64fM66vNWW4TG1MLXW45
