### PR TITLE
Docs and umbrella-header catch-ups for the refined-triggers stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ To use the XCSP solver on an XCSP3 instance, run:
 Useful options:
 
 - `--all` — enumerate every solution (CSP only; ignored on COP).
+- `--branch <heuristic>` — branching heuristic: `dom-then-deg` (the default), or `dom-wdeg[:VARIANT]` with `VARIANT` one of `classic`, `ia`, `ca`, `id`, `cd`, `ca.cd`, `chs`.
 - `--prove` — emit OPB and VeriPB proof artefacts under `xcsp.{opb,pbp}` for external verification.
+- `--restarts [<scale>]` — restart on a Luby schedule with the given conflict scale (`100` if given bare), learning nogoods across restarts. Sound for finding one solution or optimising, not with `--all`.
 - `--timeout <seconds>` — abort search after the given wall-clock time and report `s UNKNOWN` (or `s SATISFIABLE` for a partial COP solution).
 
 For developer documentation on the XCSP3 frontend (the callbacks layer,

--- a/dev_docs/refined-triggers.md
+++ b/dev_docs/refined-triggers.md
@@ -48,6 +48,14 @@ The context offers:
 - `ctx.is_watching(var)` — whether this propagator currently watches any literal
   on `var`. Reads the (backtrack-consistent) index, so a propagator can recompute
   a watched set without tracking it itself.
+- `ctx.clear_watches()` — remove every watch this propagator owns, trailed like
+  `ctx.watch` so backtrack restores exactly the pre-wake set. For a
+  clear-and-recompute client that re-arms a fresh watched set each wake rather
+  than moving watches individually. Only variables in the propagator's declared
+  scope (its triggers and `scope_only`) are searched, so watch only variables
+  declared in scope — the intended usage in any case. `watch_state` is
+  independent and left untouched; reset any of it the new watch set no longer
+  matches.
 - `ctx.watch_state(key)` / `ctx.set_watch_state(key, value)` — a per-propagator
   **backtrackable scratch** `uint64`, keyed by a small integer. See *Backtrackable
   bookkeeping* below.
@@ -59,6 +67,7 @@ coarse triggers:
 struct Triggers {
     std::vector<IntegerVariableID> on_change, on_bounds, on_instantiated;
     std::vector<std::pair<Literal, std::uint32_t>> refined;   // (literal, payload)
+    std::vector<IntegerVariableID> scope_only;                // in scope, arms no wake
 };
 ```
 
@@ -66,6 +75,13 @@ struct Triggers {
 (not undone on backtrack); watches armed later via `ctx.watch` are restored on
 backtrack. (The `Nogoods` 2WL client arms everything at runtime via `ctx.watch`
 and leaves `Triggers` empty — see below.)
+
+`Triggers::scope_only` declares variables as part of the propagator's *scope* —
+they raise variable degree (for dom_then_deg / dom-wdeg), appear in the
+variable→constraint adjacency, and count for the idempotence-aliasing check —
+without arming any wake. A propagator woken only by refined watches it arms
+dynamically would otherwise have an empty scope and be invisible to degree-based
+heuristics; list its variables here (as `NegativeTable` does).
 
 ## The engine mechanism
 

--- a/gcs/gcs.hh
+++ b/gcs/gcs.hh
@@ -13,11 +13,13 @@
 #include <gcs/problem.hh>
 #include <gcs/proof.hh>
 #include <gcs/reification.hh>
+#include <gcs/restarts.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 #include <gcs/stats.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
+#include <gcs/variable_weighting.hh>
 
 #include <gcs/constraints/abs.hh>
 #include <gcs/constraints/all_different.hh>


### PR DESCRIPTION
Post-review QA nits from across the #502–#512 stack, gathered into one commit on top of #512. None are functional changes:

- **#502 — README not updated:** the XCSP "Useful options" list gains the new user-facing `--branch` and `--restarts` flags, with the same soundness caveat as the `SolveCallbacks::restarts` API docs (restarts are for finding one solution or optimising, not `--all`).
- **#502 — umbrella header:** `gcs/gcs.hh` now includes `gcs/restarts.hh` and `gcs/variable_weighting.hh` explicitly. Both were already reachable transitively via `solve.hh` / `search_heuristics.hh`, so this is for the umbrella's completeness as the public-API index rather than a fix.
- **#510 — dev_doc lag:** the `Triggers` snippet in `dev_docs/refined-triggers.md` shows the `scope_only` field, with a short paragraph on what scope drives (degree, adjacency, aliasing) and why a watch-only propagator needs it.
- **#511 — dev_doc lag:** `clear_watches()` joins the `RefinedWatchContext` method list in the same document, with its trailing/scope-search/`watch_state` caveats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG64fM66vNWW4TG1MLXW45