### PR TITLE
Add MinDistance constraint: definitional PB encoding, check-only propagation

### DIFF
--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -73,6 +73,7 @@ addressed.
 | half-reified comparisons (`LessThanEqualIf`, …) | partially via `Comparison` + reif | ? | n/a | gap (#61) | |
 | half-reified `And` / `Or` | – | ? | n/a | gap (#61) | |
 | `Among` | `Among` | ✓ | n/a (use count) | ? | |
+| `MinDistance` | `MinDistance` | unsupported | n/a | unsupported | Glasgow-specific extension; no frontend vocabulary for it |
 | `SmartTable` | `SmartTable` | ✓ | n/a | ? | Glasgow-specific extension |
 
 ## Solver gaps tracked elsewhere

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -224,6 +224,7 @@ if(GCS_BUILD_TESTS)
     add_executable(linear_constant_test constraints/linear/linear_constant_test.cc)
     add_executable(logical_test constraints/logical/logical_test.cc)
     add_executable(mdd_test constraints/mdd/mdd_test.cc)
+    add_executable(min_distance_test constraints/min_distance/min_distance_test.cc)
     add_executable(min_max_test constraints/min_max/min_max_test.cc)
     add_executable(mini_linear_test constraints/mini_linear_test.cc)
     add_executable(multiply_test constraints/multiply/multiply_test.cc)
@@ -253,7 +254,7 @@ if(GCS_BUILD_TESTS)
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
             count_test cumulative_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
-            logical_test mdd_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
+            logical_test mdd_test min_distance_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
         target_link_libraries(${test_target} PRIVATE glasgow_constraint_solver)
@@ -355,6 +356,7 @@ if(GCS_BUILD_TESTS)
     add_view_tests(at_most_one_constraint at_most_one_test 5)
     add_view_tests(parity_constraint parity_test 4)
     add_view_tests(n_value_constraint n_value_test 6)
+    add_view_tests(min_distance_constraint min_distance_test 6)
     add_view_tests(seq_precede_chain_constraint seq_precede_chain_test 5)
     add_view_tests(count_constraint count_test 6)
     add_view_tests(among_constraint among_test 5)
@@ -406,6 +408,7 @@ if(GCS_BUILD_TESTS)
     endforeach()
     add_test(NAME logical_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:logical_test>)
     add_test(NAME mdd_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:mdd_test>)
+    add_test(NAME min_distance_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:min_distance_test>)
     add_test(NAME min_max_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:min_max_test>)
     add_test(NAME divide_modulus_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:divide_modulus_test>)
     add_test(NAME power_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:power_test>)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(glasgow_constraint_solver
         constraints/linear/utils.cc
         constraints/logical/logical.cc
         constraints/mdd/mdd.cc
+        constraints/min_distance/min_distance.cc
         constraints/min_max/min_max.cc
         constraints/plus_minus/minus.cc
         constraints/multiply/multiply.cc

--- a/gcs/constraints/min_distance.hh
+++ b/gcs/constraints/min_distance.hh
@@ -1,0 +1,6 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MIN_DISTANCE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MIN_DISTANCE_HH
+
+#include <gcs/constraints/min_distance/min_distance.hh>
+
+#endif

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -1,0 +1,375 @@
+#include <gcs/constraints/min_distance/min_distance.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/innards/state.hh>
+
+#include <algorithm>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_unique;
+using std::map;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+MinDistance::MinDistance(vector<IntegerVariableID> x, IntegerVariableID z, ArrayParam<Matrix> distances, optional<ArrayParam<Matrix>> requirements) :
+    _x(move(x)), _z(z), _distances(move(distances)), _requirements(move(requirements))
+{
+}
+
+auto MinDistance::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<MinDistance>(_x, _z, _distances, _requirements);
+}
+
+auto MinDistance::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model);
+
+    install_propagators(propagators);
+}
+
+auto MinDistance::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    const auto p = _x.size();
+    if (p < 2)
+        throw InvalidProblemDefinitionException{"min_distance requires at least two selected-point variables"};
+
+    const auto & D = *_distances;
+    const auto n = D.size();
+    if (n == 0)
+        throw InvalidProblemDefinitionException{"min_distance distance matrix must be non-empty"};
+    for (std::size_t a = 0; a < n; ++a) {
+        if (D[a].size() != n)
+            throw InvalidProblemDefinitionException{"min_distance distance matrix must be square"};
+        if (D[a][a] != 0_i)
+            throw InvalidProblemDefinitionException{"min_distance distance matrix must have a zero diagonal"};
+        for (std::size_t b = 0; b < n; ++b) {
+            if (D[a][b] < 0_i)
+                throw InvalidProblemDefinitionException{"min_distance distances must be non-negative"};
+            if (D[a][b] != D[b][a])
+                throw InvalidProblemDefinitionException{"min_distance distance matrix must be symmetric"};
+        }
+    }
+    if (_requirements) {
+        const auto & R = **_requirements;
+        if (R.size() != p)
+            throw InvalidProblemDefinitionException{"min_distance requirements matrix must be p x p"};
+        for (std::size_t i = 0; i < p; ++i) {
+            if (R[i].size() != p)
+                throw InvalidProblemDefinitionException{"min_distance requirements matrix must be p x p"};
+            for (std::size_t j = i + 1; j < p; ++j)
+                if (R[i][j] < 0_i)
+                    throw InvalidProblemDefinitionException{"min_distance requirements must be non-negative"};
+        }
+    }
+
+    // Restrict every selected-point variable to the site index range [0, n-1]
+    // (mirroring how Element clamps its index variables to the array bounds),
+    // emitting the definitional OPB bounds and a RUP initialiser to prune
+    // anything outside. A no-op when the variable is already within range.
+    for (const auto & x : _x) {
+        propagators.define_bound(initial_state, optional_model, x, Bound::Lower, 0_i);
+        propagators.define_bound(initial_state, optional_model, x, Bound::Upper, Integer(static_cast<long long>(n) - 1));
+    }
+
+    // Record, per position, which site indices it can still take (within the
+    // site range), the union of those, and z's initial bounds, for the proof
+    // model (which does not receive the State).
+    _position_sites.assign(p, {});
+    vector<bool> is_site(n, false);
+    for (std::size_t i = 0; i < p; ++i)
+        for (std::size_t a = 0; a < n; ++a) {
+            auto site = Integer(static_cast<long long>(a));
+            if (initial_state.in_domain(_x[i], site)) {
+                _position_sites[i].push_back(site);
+                is_site[a] = true;
+            }
+        }
+    for (std::size_t a = 0; a < n; ++a)
+        if (is_site[a])
+            _sites.push_back(Integer(static_cast<long long>(a)));
+
+    auto z_bounds = initial_state.bounds(_z);
+    _z_lower = z_bounds.first;
+    _z_upper = z_bounds.second;
+
+    return true;
+}
+
+auto MinDistance::define_proof_model(ProofModel & model) -> void
+{
+    const auto p = _x.size();
+    const auto & D = *_distances;
+    const auto z_lo = _z_lower, z_hi = _z_upper;
+    const auto pbig = Integer(static_cast<long long>(p));
+
+    auto d_at = [&](Integer a, Integer b) -> Integer { return D[a.raw_value][b.raw_value]; };
+
+    // Positions that can take each candidate site.
+    map<Integer, vector<std::size_t>> positions_at;
+    for (std::size_t i = 0; i < p; ++i)
+        for (const auto & a : _position_sites[i])
+            positions_at[a].push_back(i);
+
+    // u_a <-> OR_i [x_i == a]  (arc-consistent full reif).
+    map<Integer, ProofFlag> u;
+    for (const auto & a : _sites) {
+        WPBSum orsum;
+        for (auto i : positions_at[a])
+            orsum += 1_i * (_x[i] == a);
+        u.emplace(a, model.create_proof_flag_fully_reifying("mindist_u_" + to_string(a.raw_value), orsum >= 1_i));
+    }
+
+    // Per-site count: count_a <= 1 + (p-1)[z<=0]. This is the diagonal pair
+    // upper bound: two positions on the same site witness the distance
+    // D[a,a] = 0, forcing z <= 0. Handle the constant-literal cases explicitly.
+    for (const auto & a : _sites) {
+        const auto & pos = positions_at[a];
+        if (pos.size() < 2)
+            continue; // no duplicate possible: constraint is vacuous
+        if (z_hi <= 0_i)
+            continue; // [z<=0] is forced true: constraint is vacuous
+        WPBSum count;
+        for (auto i : pos)
+            count += 1_i * (_x[i] == a);
+        if (z_lo >= 1_i)
+            model.add_constraint(count <= 1_i); // [z<=0] impossible: plain at-most-one
+        else {
+            count += (pbig - 1_i) * (_z >= 1_i); // count_a + (p-1)[z>=1] <= p
+            model.add_constraint(count <= pbig);
+        }
+    }
+
+    // Pair clauses: ~u_a \/ ~u_b \/ [z <= D[a,b]] for candidate a < b. Omitted
+    // only when tautological for z's whole initial domain (z_max <= D[a,b]).
+    for (std::size_t ia = 0; ia < _sites.size(); ++ia)
+        for (std::size_t ib = ia + 1; ib < _sites.size(); ++ib) {
+            auto a = _sites[ia], b = _sites[ib];
+            auto dab = d_at(a, b);
+            if (z_hi <= dab)
+                continue;
+            model.add_constraint(WPBSum{} + 1_i * (! u.at(a)) + 1_i * (! u.at(b)) + 1_i * (_z <= dab) >= 1_i);
+        }
+
+    // Requirement clauses: forbid x_i = a and x_j = b whenever D[a,b] < R_ij
+    // (this includes the a == b diagonal, D[a,a] = 0 < R_ij, when R_ij > 0).
+    if (_requirements) {
+        const auto & R = **_requirements;
+        for (std::size_t i = 0; i < p; ++i)
+            for (std::size_t j = i + 1; j < p; ++j) {
+                auto rij = R[i][j];
+                if (rij <= 0_i)
+                    continue;
+                for (const auto & a : _position_sites[i])
+                    for (const auto & b : _position_sites[j])
+                        if (d_at(a, b) < rij)
+                            model.add_constraint(WPBSum{} + 1_i * (_x[i] != a) + 1_i * (_x[j] != b) >= 1_i);
+            }
+    }
+
+    // Min-attained ladder (the lower bound on z). Levels are the distinct
+    // values { 0 } union { D[a,b] : candidate a < b }, sorted ascending. For
+    // each level t_k we emit [z >= t_k] \/ m_k, where m_k says "some pair with a
+    // strictly smaller distance is already attained"; so z is forced up to t_k
+    // unless a smaller distance witness fires.
+    set<Integer> level_set{0_i};
+    for (std::size_t ia = 0; ia < _sites.size(); ++ia)
+        for (std::size_t ib = ia + 1; ib < _sites.size(); ++ib)
+            level_set.insert(d_at(_sites[ia], _sites[ib]));
+    vector<Integer> levels(level_set.begin(), level_set.end());
+    const auto num_levels = levels.size();
+
+    if (! levels.empty() && z_lo < levels.back()) {
+        map<Integer, ProofFlag> d;                // duplicate (distance-0) witnesses
+        map<pair<Integer, Integer>, ProofFlag> w; // off-diagonal pair witnesses
+
+        auto d_flag = [&](Integer a) -> ProofFlag {
+            if (auto it = d.find(a); it != d.end())
+                return it->second;
+            WPBSum count;
+            for (auto i : positions_at[a])
+                count += 1_i * (_x[i] == a);
+            auto f = model.create_proof_flag_fully_reifying("mindist_d_" + to_string(a.raw_value), count >= 2_i);
+            d.emplace(a, f);
+            return f;
+        };
+        auto w_flag = [&](Integer a, Integer b) -> ProofFlag {
+            auto key = pair{a, b};
+            if (auto it = w.find(key); it != w.end())
+                return it->second;
+            auto f = model.create_proof_flag_fully_reifying(
+                "mindist_w_" + to_string(a.raw_value) + "_" + to_string(b.raw_value), WPBSum{} + 1_i * u.at(a) + 1_i * u.at(b) >= 2_i);
+            w.emplace(key, f);
+            return f;
+        };
+        auto witnesses_at = [&](Integer v) -> vector<ProofFlag> {
+            vector<ProofFlag> ws;
+            if (v == 0_i)
+                for (const auto & a : _sites)
+                    if (positions_at[a].size() >= 2)
+                        ws.push_back(d_flag(a));
+            for (std::size_t ia = 0; ia < _sites.size(); ++ia)
+                for (std::size_t ib = ia + 1; ib < _sites.size(); ++ib) {
+                    auto a = _sites[ia], b = _sites[ib];
+                    if (d_at(a, b) == v)
+                        ws.push_back(w_flag(a, b));
+                }
+            return ws;
+        };
+
+        optional<ProofFlag> m_acc; // m_k: some witness strictly below t_k fires; nullopt = definitely false
+        for (std::size_t k = 0; k < num_levels; ++k) {
+            auto t = levels[k];
+            if (z_lo < t) {
+                WPBSum clause;
+                clause += 1_i * (_z >= t);
+                if (m_acc)
+                    clause += 1_i * (*m_acc);
+                model.add_constraint(clause >= 1_i);
+            }
+            // Fold this level's witnesses into the accumulator for higher levels
+            // (only needed while there is still a higher level to guard).
+            if (k + 1 < num_levels) {
+                auto ws = witnesses_at(t);
+                if (! ws.empty()) {
+                    WPBSum s;
+                    if (m_acc)
+                        s += 1_i * (*m_acc);
+                    for (auto & f : ws)
+                        s += 1_i * f;
+                    m_acc = model.create_proof_flag_fully_reifying("mindist_m_" + to_string(t.raw_value), s >= 1_i);
+                }
+            }
+        }
+    }
+}
+
+auto MinDistance::install_propagators(Propagators & propagators) -> void
+{
+    const auto n = static_cast<long long>((*_distances).size());
+
+    Triggers triggers;
+    for (const auto & x : _x)
+        triggers.on_instantiated.emplace_back(x);
+    triggers.scope_only.emplace_back(_z);
+
+    auto all_reason = generic_reason(_x);
+
+    propagators.install(
+        constraint_id(),
+        [x = _x, z = _z, distances = _distances, requirements = _requirements, n, all_reason = std::move(all_reason)](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            const auto & D = *distances;
+            const auto p = x.size();
+
+            vector<optional<Integer>> value(p);
+            bool all_assigned = true;
+            for (std::size_t i = 0; i < p; ++i) {
+                value[i] = state.optional_single_value(x[i]);
+                if (! value[i])
+                    all_assigned = false;
+            }
+
+            // For every pair whose endpoints are both fixed: check the pairwise
+            // requirement, then tighten z <= D[a,b]. Both are plain RUP from the
+            // encoding, reasoned over just the two fixed endpoints.
+            for (std::size_t i = 0; i < p; ++i) {
+                if (! value[i])
+                    continue;
+                auto a = value[i]->raw_value;
+                if (a < 0 || a >= n)
+                    continue; // defensive: the site-range initialiser keeps x within [0, n-1]
+                for (std::size_t j = i + 1; j < p; ++j) {
+                    if (! value[j])
+                        continue;
+                    auto b = value[j]->raw_value;
+                    if (b < 0 || b >= n)
+                        continue;
+                    auto dab = D[a][b];
+                    auto reason = generic_reason(vector<IntegerVariableID>{x[i], x[j]});
+                    if (requirements && dab < (**requirements)[i][j])
+                        inference.contradiction(logger, JustifyUsingRUP{}, reason);
+                    inference.infer_less_than(logger, z, dab + 1_i, JustifyUsingRUP{}, reason);
+                }
+            }
+
+            // Once every endpoint is fixed, z is exactly the minimum pairwise
+            // distance: pin it from both sides (z <= mu is already covered above,
+            // z >= mu is the min-attained ladder).
+            if (all_assigned) {
+                optional<Integer> mu;
+                for (std::size_t i = 0; i < p; ++i) {
+                    auto a = value[i]->raw_value;
+                    if (a < 0 || a >= n)
+                        return PropagatorState::Enable;
+                    for (std::size_t j = i + 1; j < p; ++j) {
+                        auto b = value[j]->raw_value;
+                        if (b < 0 || b >= n)
+                            return PropagatorState::Enable;
+                        auto dab = D[a][b];
+                        mu = mu ? std::min(*mu, dab) : dab;
+                    }
+                }
+                if (mu) {
+                    inference.infer_greater_than_or_equal(logger, z, *mu, JustifyUsingRUP{}, all_reason);
+                    inference.infer_less_than(logger, z, *mu + 1_i, JustifyUsingRUP{}, all_reason);
+                }
+            }
+
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto MinDistance::constraint_type() const -> string
+{
+    return "min_distance";
+}
+
+auto MinDistance::s_expr(const ProofModel * const model) const -> SExpr
+{
+    auto & tracker = model->names_and_ids_tracker();
+
+    vector<SExpr> xs;
+    for (const auto & x : _x)
+        xs.push_back(tracker.s_expr_term_of(x));
+
+    auto matrix_expr = [](const Matrix & m) -> SExpr {
+        vector<SExpr> rows;
+        for (const auto & row : m) {
+            vector<SExpr> entries;
+            for (const auto & e : row)
+                entries.push_back(SExpr::atom(e.to_string()));
+            rows.push_back(SExpr::list(std::move(entries)));
+        }
+        return SExpr::list(std::move(rows));
+    };
+
+    vector<SExpr> term{SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(xs)), tracker.s_expr_term_of(_z),
+        matrix_expr(*_distances)};
+    if (_requirements)
+        term.push_back(matrix_expr(**_requirements));
+    return SExpr::list(std::move(term));
+}

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -60,12 +60,18 @@ auto MinDistance::prepare(Propagators & propagators, State & initial_state, Proo
     const auto n = D.size();
     if (n == 0)
         throw InvalidProblemDefinitionException{"min_distance distance matrix must be non-empty"};
-    for (std::size_t a = 0; a < n; ++a) {
-        if (D[a].size() != n)
+    // Squareness first, as its own pass: the symmetry test below reads D[b][a]
+    // for b > a, which is only in bounds once every row is known to be n wide.
+    for (const auto & row : D)
+        if (row.size() != n)
             throw InvalidProblemDefinitionException{"min_distance distance matrix must be square"};
+    // Then the entry-wise conditions over the strict upper triangle: symmetry
+    // carries non-negativity to the lower triangle, and the diagonal is pinned
+    // to zero, so every entry is covered.
+    for (std::size_t a = 0; a < n; ++a) {
         if (D[a][a] != 0_i)
             throw InvalidProblemDefinitionException{"min_distance distance matrix must have a zero diagonal"};
-        for (std::size_t b = 0; b < n; ++b) {
+        for (std::size_t b = a + 1; b < n; ++b) {
             if (D[a][b] < 0_i)
                 throw InvalidProblemDefinitionException{"min_distance distances must be non-negative"};
             if (D[a][b] != D[b][a])
@@ -201,7 +207,7 @@ auto MinDistance::define_proof_model(ProofModel & model) -> void
     vector<Integer> levels(level_set.begin(), level_set.end());
     const auto num_levels = levels.size();
 
-    if (! levels.empty() && z_lo < levels.back()) {
+    if (z_lo < levels.back()) {
         map<Integer, ProofFlag> d;                // duplicate (distance-0) witnesses
         map<pair<Integer, Integer>, ProofFlag> w; // off-diagonal pair witnesses
 

--- a/gcs/constraints/min_distance/min_distance.hh
+++ b/gcs/constraints/min_distance/min_distance.hh
@@ -1,0 +1,81 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MIN_DISTANCE_MIN_DISTANCE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_MIN_DISTANCE_MIN_DISTANCE_HH
+
+#include <gcs/array_param.hh>
+#include <gcs/constraint.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief Constrain \c z to be the minimum, over all pairs of selected-point
+     * variables, of the distance between the sites they select.
+     *
+     * The selected-point variables \f$x_0, \ldots, x_{p-1}\f$ each range over
+     * candidate site indices \f$\{0, \ldots, n-1\}\f$, and \c D is a symmetric
+     * \f$n \times n\f$ integer distance matrix with a zero diagonal and
+     * non-negative entries. The constraint enforces
+     * \f[ z = \min_{0 \le i < j < p} D[x_i, x_j]. \f]
+     * Duplicate selections are permitted: assigning two positions to the same
+     * site \c a contributes the diagonal distance \f$D[a,a] = 0\f$, so \c z is
+     * at most zero in that case.
+     *
+     * The optional requirements matrix \c R (a \f$p \times p\f$ matrix, of which
+     * only the entries with \f$i < j\f$ are read) additionally imposes the
+     * pairwise lower bounds \f$D[x_i, x_j] \ge R_{ij}\f$ for every \f$i < j\f$.
+     * This is the p-dispersion "distance requirements" variant; see Lagerkvist,
+     * "Propagation Algorithms for the Minimum-Distance Constraint over Selected
+     * Points", ModRef 2026.
+     *
+     * \c p must be at least two. The distance matrix must be square, symmetric,
+     * have a zero diagonal, and non-negative entries; the requirements matrix, if
+     * present, must be \f$p \times p\f$ with non-negative entries above the
+     * diagonal. Violations are rejected at post time.
+     *
+     * This propagator is deliberately check-only: it updates \c z (and detects a
+     * requirement violation) only once the endpoints of a pair are assigned.
+     * Every inference it makes is plain reverse unit propagation from the proof
+     * encoding.
+     *
+     * \ingroup Constraints
+     */
+    class MinDistance : public Constraint
+    {
+    public:
+        /// A symmetric distance matrix or a requirements matrix.
+        using Matrix = std::vector<std::vector<Integer>>;
+
+    private:
+        const std::vector<IntegerVariableID> _x;
+        const IntegerVariableID _z;
+        ArrayParam<Matrix> _distances;
+        std::optional<ArrayParam<Matrix>> _requirements;
+
+        // Filled in by prepare() for use by define_proof_model(): the site
+        // values each position can take (visible-frame, one list per position),
+        // their union, and z's initial bounds. These flow from prepare() to the
+        // proof model per the split-install pattern.
+        std::vector<std::vector<Integer>> _position_sites;
+        std::vector<Integer> _sites;
+        Integer _z_lower = 0_i, _z_upper = 0_i;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit MinDistance(std::vector<IntegerVariableID> x, IntegerVariableID z, ArrayParam<Matrix> distances,
+            std::optional<ArrayParam<Matrix>> requirements = std::nullopt);
+
+        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
+        virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
+        [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/min_distance/min_distance_test.cc
+++ b/gcs/constraints/min_distance/min_distance_test.cc
@@ -1,0 +1,348 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/min_distance.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <random>
+#include <set>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::min;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::tuple;
+using std::uniform_int_distribution;
+using std::variant;
+using std::vector;
+using std::visit;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+namespace
+{
+    using DomainSpec = variant<int, pair<int, int>, vector<int>>;
+    using IntMatrix = vector<vector<int>>;
+
+    // The visible values a domain spec offers, clipped to the site range
+    // [0, n-1] (matching the constraint's own site-range restriction).
+    auto site_values(const DomainSpec & spec, int n) -> vector<int>
+    {
+        vector<int> vs;
+        visit(
+            [&](const auto & s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, int>)
+                    vs.push_back(s);
+                else if constexpr (std::is_same_v<T, pair<int, int>>) {
+                    for (int v = s.first; v <= s.second; ++v)
+                        vs.push_back(v);
+                }
+                else
+                    vs = s;
+            },
+            spec);
+        vector<int> clipped;
+        for (auto v : vs)
+            if (v >= 0 && v < n)
+                clipped.push_back(v);
+        return clipped;
+    }
+
+    // The visible values a z domain spec offers (no clipping: z is not a site).
+    auto plain_values(const DomainSpec & spec) -> vector<int>
+    {
+        vector<int> vs;
+        visit(
+            [&](const auto & s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, int>)
+                    vs.push_back(s);
+                else if constexpr (std::is_same_v<T, pair<int, int>>) {
+                    for (int v = s.first; v <= s.second; ++v)
+                        vs.push_back(v);
+                }
+                else
+                    vs = s;
+            },
+            spec);
+        return vs;
+    }
+
+    auto min_pairwise(const vector<int> & xs, const IntMatrix & d) -> int
+    {
+        int mu = std::numeric_limits<int>::max();
+        for (std::size_t i = 0; i < xs.size(); ++i)
+            for (std::size_t j = i + 1; j < xs.size(); ++j)
+                mu = min(mu, d[xs[i]][xs[j]]);
+        return mu;
+    }
+
+    auto requirements_ok(const vector<int> & xs, const optional<IntMatrix> & r, const IntMatrix & d) -> bool
+    {
+        if (! r)
+            return true;
+        for (std::size_t i = 0; i < xs.size(); ++i)
+            for (std::size_t j = i + 1; j < xs.size(); ++j)
+                if (d[xs[i]][xs[j]] < (*r)[i][j])
+                    return false;
+        return true;
+    }
+
+    auto to_integer_matrix(const IntMatrix & m) -> MinDistance::Matrix
+    {
+        MinDistance::Matrix result;
+        for (const auto & row : m) {
+            vector<Integer> r;
+            for (auto e : row)
+                r.push_back(Integer(e));
+            result.push_back(std::move(r));
+        }
+        return result;
+    }
+}
+
+auto run_min_distance_test(bool proofs, const ViewWrapConfig & view_cfg, const vector<DomainSpec> & x_specs, const DomainSpec & z_spec,
+    const IntMatrix & d, const optional<IntMatrix> & r) -> void
+{
+    const int n = static_cast<int>(d.size());
+    const int p = static_cast<int>(x_specs.size());
+    // Positions 0..p-1 are the selected-point variables; position p is z.
+    auto wraps = wraps_for_positions(view_cfg, p + 1);
+
+    print(cerr, "min_distance [{}] p={} n={} x={} z={} r={}{}", view_wrap_config_label(view_cfg), p, n, x_specs, z_spec, r.has_value(),
+        proofs ? " with proofs:" : ":");
+    cerr << flush;
+
+    // Brute-force the expected (x-assignment, z) solution set directly from the
+    // definition: z is the minimum pairwise distance, and every requirement holds.
+    vector<vector<int>> x_domains;
+    for (const auto & s : x_specs)
+        x_domains.push_back(site_values(s, n));
+    auto z_domain = plain_values(z_spec);
+
+    set<tuple<vector<int>, int>> expected, actual;
+    {
+        vector<int> xs(p);
+        auto recurse = [&](auto && self, int pos) -> void {
+            if (pos == p) {
+                if (! requirements_ok(xs, r, d))
+                    return;
+                auto mu = min_pairwise(xs, d);
+                for (auto z : z_domain)
+                    if (z == mu)
+                        expected.emplace(xs, z);
+                return;
+            }
+            for (auto v : x_domains[pos]) {
+                xs[pos] = v;
+                self(self, pos + 1);
+            }
+        };
+        recurse(recurse, 0);
+    }
+    println(cerr, " expecting {} solutions", expected.size());
+
+    Problem problem;
+    vector<IntegerVariableID> xs;
+    for (int i = 0; i < p; ++i)
+        xs.push_back(visit([&](const auto & s) { return create_integer_variable_or_constant_with_view(problem, s, wraps.at(i)); }, x_specs[i]));
+    auto z = visit([&](const auto & s) { return create_integer_variable_or_constant_with_view(problem, s, wraps.at(p)); }, z_spec);
+
+    if (r)
+        problem.post(MinDistance{xs, z, to_integer_matrix(d), ArrayParam<MinDistance::Matrix>{to_integer_matrix(*r)}});
+    else
+        problem.post(MinDistance{xs, z, to_integer_matrix(d)});
+
+    auto proof_name = proofs ? make_optional("min_distance_test_" + view_wrap_config_label(view_cfg)) : nullopt;
+    solve_for_tests(problem, proof_name, actual, tuple{xs, z});
+    check_results(proof_name, expected, actual);
+}
+
+auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
+{
+    // A handful of small symmetric distance matrices to draw on.
+    const IntMatrix d2{{0, 3}, {3, 0}};
+    const IntMatrix d3{{0, 2, 5}, {2, 0, 4}, {5, 4, 0}};
+    const IntMatrix d3_ties{{0, 3, 3}, {3, 0, 3}, {3, 3, 0}}; // all off-diagonal distances tied
+    const IntMatrix d3_zero{{0, 0, 4}, {0, 0, 4}, {4, 4, 0}}; // an off-diagonal zero (sites 0,1)
+    const IntMatrix d4{{0, 2, 5, 9}, {2, 0, 4, 6}, {5, 4, 0, 3}, {9, 6, 3, 0}};
+    const IntMatrix d4_ties{{0, 4, 4, 7}, {4, 0, 7, 4}, {4, 7, 0, 4}, {7, 4, 4, 0}};
+
+    // p = 2, basic.
+    run_min_distance_test(proofs, view_cfg, {pair{0, 1}, pair{0, 1}}, pair{0, 5}, d2, nullopt);
+    // p = 2, z domain excludes 0 (duplicates ruled out by z >= 1).
+    run_min_distance_test(proofs, view_cfg, {pair{0, 1}, pair{0, 1}}, pair{1, 5}, d2, nullopt);
+    // p = 2, z domain forces a small window (BC through a hole is exercised by the harness).
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+
+    // p = 3, duplicates possible (z can be 0), full domains.
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+    // p = 3, duplicates excluded (z >= 1), so this is effectively all-different sites.
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{1, 6}, d3, nullopt);
+    // p = 3, all distances tied.
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 4}, d3_ties, nullopt);
+    // p = 3, matrix with an off-diagonal zero (sites 0 and 1 are distance 0 apart).
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 5}, d3_zero, nullopt);
+
+    // z domain with a hole: {0, 2, 4} (offset/holes tested together elsewhere).
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, vector<int>{0, 2, 4}, d3, nullopt);
+    // z domain offset above zero: [2, 6].
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{2, 6}, d3, nullopt);
+    // z domain including negatives: forces z >= 0 via the ladder base clause.
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{-2, 6}, d3, nullopt);
+
+    // x domains with holes / not covering all sites.
+    run_min_distance_test(proofs, view_cfg, {vector<int>{0, 2}, pair{0, 2}, vector<int>{1, 2}}, pair{0, 6}, d3, nullopt);
+    run_min_distance_test(proofs, view_cfg, {pair{0, 1}, pair{1, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+    // One position pinned to a constant site.
+    run_min_distance_test(proofs, view_cfg, {0, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+
+    // p = 4.
+    run_min_distance_test(proofs, view_cfg, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{0, 10}, d4, nullopt);
+    run_min_distance_test(proofs, view_cfg, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{1, 10}, d4_ties, nullopt);
+
+    // With requirements R (only i<j entries read).
+    // Feasible requirement: every selected pair at least distance 3 apart.
+    const IntMatrix r3_feasible{{0, 3, 3}, {0, 0, 3}, {0, 0, 0}};
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, r3_feasible);
+    // Requirement forbids duplicates (R_ij > 0 rules out same-site pairs).
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3_ties, r3_feasible);
+    // Infeasible requirement: demand distance >= 6 where the max distance is 5.
+    const IntMatrix r3_infeasible{{0, 6, 6}, {0, 0, 6}, {0, 0, 0}};
+    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, r3_infeasible);
+    // Heterogeneous requirement per position pair.
+    const IntMatrix r4_mixed{{0, 2, 4, 5}, {0, 0, 3, 4}, {0, 0, 0, 3}, {0, 0, 0, 0}};
+    run_min_distance_test(proofs, view_cfg, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{0, 10}, d4, r4_mixed);
+}
+
+// Random symmetric distance matrix: zero diagonal, non-negative, entries in
+// [0, max_d].
+auto random_distance_matrix(mt19937 & rand, int n, int max_d) -> IntMatrix
+{
+    IntMatrix d(n, vector<int>(n, 0));
+    uniform_int_distribution<int> dist{0, max_d};
+    for (int a = 0; a < n; ++a)
+        for (int b = a + 1; b < n; ++b) {
+            int v = dist(rand);
+            d[a][b] = v;
+            d[b][a] = v;
+        }
+    return d;
+}
+
+auto random_site_domain(mt19937 & rand, int n) -> DomainSpec
+{
+    // Either a contiguous range or an explicit (possibly holey) subset of [0, n-1].
+    uniform_int_distribution<int> choice{0, 2};
+    if (choice(rand) == 0) {
+        // constant
+        uniform_int_distribution<int> v{0, n - 1};
+        return v(rand);
+    }
+    if (choice(rand) == 1) {
+        uniform_int_distribution<int> lo{0, n - 1};
+        int a = lo(rand);
+        uniform_int_distribution<int> hi{a, n - 1};
+        return pair{a, hi(rand)};
+    }
+    vector<int> subset;
+    for (int a = 0; a < n; ++a) {
+        uniform_int_distribution<int> keep{0, 1};
+        if (keep(rand))
+            subset.push_back(a);
+    }
+    if (subset.empty())
+        subset.push_back(uniform_int_distribution<int>{0, n - 1}(rand));
+    return subset;
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+
+    // Largest instance below wraps 5 selected points + z.
+    constexpr int n_positions = 6;
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        println(cerr, "min_distance view sweep: position {} out of range for n_positions = {}; skipping", *view_cfg.single_position, n_positions);
+        return EXIT_SUCCESS;
+    }
+
+    mt19937 rand(*get_seed());
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+
+        run_all_tests(proofs, view_cfg);
+
+        // Random sweep: small symmetric matrices, small p, random site domains,
+        // random z domains, half of them with a random feasible-ish requirement.
+        for (int iter = 0; iter < 8; ++iter) {
+            uniform_int_distribution<int> n_dist{2, 5};
+            uniform_int_distribution<int> p_dist{2, 4};
+            int n = n_dist(rand);
+            int p = p_dist(rand);
+            auto d = random_distance_matrix(rand, n, 4);
+
+            vector<DomainSpec> x_specs;
+            for (int i = 0; i < p; ++i)
+                x_specs.push_back(random_site_domain(rand, n));
+
+            // z domain: a random window that sometimes dips below zero and
+            // sometimes starts above it, wide enough to admit the true minimum.
+            uniform_int_distribution<int> zlo{-1, 2};
+            uniform_int_distribution<int> zwidth{2, 6};
+            int lo = zlo(rand);
+            DomainSpec z_spec = pair{lo, lo + zwidth(rand)};
+
+            optional<IntMatrix> r;
+            uniform_int_distribution<int> want_r{0, 1};
+            if (want_r(rand)) {
+                IntMatrix rr(p, vector<int>(p, 0));
+                uniform_int_distribution<int> rq{0, 3};
+                for (int i = 0; i < p; ++i)
+                    for (int j = i + 1; j < p; ++j)
+                        rr[i][j] = rq(rand);
+                r = rr;
+            }
+
+            run_min_distance_test(proofs, view_cfg, x_specs, z_spec, d, r);
+        }
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/min_distance/min_distance_test.cc
+++ b/gcs/constraints/min_distance/min_distance_test.cc
@@ -264,14 +264,16 @@ auto random_distance_matrix(mt19937 & rand, int n, int max_d) -> IntMatrix
 
 auto random_site_domain(mt19937 & rand, int n) -> DomainSpec
 {
-    // Either a contiguous range or an explicit (possibly holey) subset of [0, n-1].
+    // A constant, a contiguous range, or an explicit (possibly holey) subset of
+    // [0, n-1], each a third of the time --- so one draw, reused.
     uniform_int_distribution<int> choice{0, 2};
-    if (choice(rand) == 0) {
+    const auto which = choice(rand);
+    if (which == 0) {
         // constant
         uniform_int_distribution<int> v{0, n - 1};
         return v(rand);
     }
-    if (choice(rand) == 1) {
+    if (which == 1) {
         uniform_int_distribution<int> lo{0, n - 1};
         int a = lo(rand);
         uniform_int_distribution<int> hi{a, n - 1};

--- a/gcs/constraints/min_distance/min_distance_test.cc
+++ b/gcs/constraints/min_distance/min_distance_test.cc
@@ -33,6 +33,7 @@ using std::nullopt;
 using std::optional;
 using std::pair;
 using std::set;
+using std::string;
 using std::tuple;
 using std::uniform_int_distribution;
 using std::variant;
@@ -190,6 +191,43 @@ auto run_min_distance_test(bool proofs, const ViewWrapConfig & view_cfg, const v
     check_results(proof_name, expected, actual);
 }
 
+// Post a deliberately malformed instance and require it to be rejected with an
+// InvalidProblemDefinitionException rather than accepted or read out of bounds.
+auto expect_rejected(const IntMatrix & d, const optional<IntMatrix> & r, const string & what) -> void
+{
+    Problem problem;
+    auto xs = problem.create_integer_variable_vector(2, 0_i, Integer{static_cast<long long>(d.size()) - 1}, "x");
+    auto z = problem.create_integer_variable(0_i, 9_i, "z");
+
+    try {
+        if (r)
+            problem.post(MinDistance{xs, z, to_integer_matrix(d), ArrayParam<MinDistance::Matrix>{to_integer_matrix(*r)}});
+        else
+            problem.post(MinDistance{xs, z, to_integer_matrix(d)});
+        solve(problem, [](const CurrentState &) -> bool { return false; });
+    }
+    catch (const InvalidProblemDefinitionException &) {
+        return;
+    }
+    throw UnexpectedException{"min_distance accepted a malformed definition: " + what};
+}
+
+// The ragged case is the pointed one: its first row is full width, so a
+// validator that checks squareness row by row while already comparing D[a][b]
+// against D[b][a] reads a short row before ever size-checking it. Under the
+// sanitize preset that is a diagnosed overread, not a silent one.
+auto run_rejection_tests() -> void
+{
+    println(cerr, "min_distance: malformed definitions are rejected");
+    expect_rejected(IntMatrix{{0, 1, 2}, {}, {}}, nullopt, "ragged distance matrix, full first row");
+    expect_rejected(IntMatrix{{0, 1}, {1, 0}, {0, 0}}, nullopt, "non-square distance matrix");
+    expect_rejected(IntMatrix{{0, 1}, {2, 0}}, nullopt, "asymmetric distance matrix");
+    expect_rejected(IntMatrix{{0, -1}, {-1, 0}}, nullopt, "negative distance");
+    expect_rejected(IntMatrix{{1, 1}, {1, 1}}, nullopt, "non-zero diagonal");
+    expect_rejected(IntMatrix{{0, 1}, {1, 0}}, make_optional(IntMatrix{{0, -1}, {-1, 0}}), "negative requirement");
+    expect_rejected(IntMatrix{{0, 1}, {1, 0}}, make_optional(IntMatrix{{0}}), "requirements matrix not p x p");
+}
+
 auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
 {
     // A handful of small symmetric distance matrices to draw on.
@@ -304,6 +342,8 @@ auto main(int argc, char * argv[]) -> int
     }
 
     mt19937 rand(*get_seed());
+
+    run_rejection_tests();
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())

--- a/gcs/gcs.hh
+++ b/gcs/gcs.hh
@@ -44,6 +44,7 @@
 #include <gcs/constraints/linear.hh>
 #include <gcs/constraints/logical.hh>
 #include <gcs/constraints/mdd.hh>
+#include <gcs/constraints/min_distance.hh>
 #include <gcs/constraints/min_max.hh>
 #include <gcs/constraints/minus.hh>
 #include <gcs/constraints/modulus.hh>


### PR DESCRIPTION
Second PR of the min-distance stack (on #536). Adds `MinDistance(x, z, D, R?)`: z = min pairwise distance over selected sites, with optional PDDP per-pair requirements.

The propagator in this PR is deliberately **check-only** (pair-check semantics: acts only on assigned endpoints, pins z when all are assigned), and makes exclusively plain-RUP inferences. That is the point: it validates that the definitional OPB encoding is complete and strong enough on its own, before any bespoke justifications exist. The encoding (O(n²)): used-site flags `u_a ↔ ⋁ᵢ[xᵢ=a]`, per-site counts `Σᵢ[xᵢ=a] ≤ 1+(p−1)[z≤0]` (diagonal/duplicate handling), pair clauses `¬u_a ∨ ¬u_b ∨ [z ≤ D[a,b]]`, and a telescoping min-attained ladder `[z ≥ t_k] ∨ m_k` over the distinct distance levels with duplicate (`d_a`) and pair (`w_ab`) witness flags — all flags fully reified and UP-determined at complete assignments. Requirement clauses are sparse forbidden pairs.

Validation: data-driven test with a brute-force oracle (p=2..4, ties, off-diagonal zeros, z domains including/excluding 0/offset/holey, duplicates possible and excluded, heterogeneous and infeasible R, holey x domains); full-enumeration runs across 8+ seeds all VeriPB-verified, plus offset/negation/mixed view-wrap runs; ctest suite 418/418.

Later PRs add real propagation (forward-bound, pair-support, pairwise objective UB) and the conflict-matching upper bound with its counting proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141nkWU9yZRxKoPoPRG1xfc