### PR TITLE
MinDistance: ForwardBound and PairSupport propagation with verified justifications

### DIFF
--- a/examples/p_dispersion/p_dispersion.cc
+++ b/examples/p_dispersion/p_dispersion.cc
@@ -17,6 +17,7 @@
 #include <gcs/constraints/all_different.hh>
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/element.hh>
+#include <gcs/constraints/min_distance.hh>
 #include <gcs/constraints/min_max.hh>
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
@@ -94,6 +95,28 @@ namespace
         problem.post(ArrayMin{ys, z});
     }
 
+    // Post the dedicated MinDistance global constraint with the given propagation
+    // mode. The distance matrix is shared (no copy) with the tuple variant's
+    // Element arrays. File-provided r_ij thresholds map to the constraint's R via
+    // the R_ij = r_ij + 1 conversion (D >= r_ij + 1); reqs[i][j] < 0 means "no
+    // requirement for this pair" and leaves R_ij = 0 (vacuous). The access is
+    // bounds-guarded against a ragged/undersized reqs matrix.
+    auto post_min_distance_variant(Problem & problem, const vector<IntegerVariableID> & x, IntegerVariableID z,
+        const std::shared_ptr<const DistanceMatrix> & distance, const vector<vector<long>> & reqs, MinDistancePropagation mode) -> void
+    {
+        auto pp = static_cast<int>(x.size());
+        std::optional<ArrayParam<MinDistance::Matrix>> md_reqs;
+        if (! reqs.empty()) {
+            MinDistance::Matrix r(pp, vector<Integer>(pp, 0_i));
+            for (int i = 0; i < pp; ++i)
+                for (int j = i + 1; j < pp; ++j)
+                    if (i < static_cast<int>(reqs.size()) && j < static_cast<int>(reqs[i].size()) && reqs[i][j] >= 0)
+                        r[i][j] = Integer{reqs[i][j] + 1};
+            md_reqs = ArrayParam<MinDistance::Matrix>{std::move(r)};
+        }
+        problem.post(MinDistance{x, z, ArrayParam<MinDistance::Matrix>{distance}, std::move(md_reqs), mode});
+    }
+
     // Parse "WxH" (or a single "N" meaning N x N) into a (width, height) pair.
     auto parse_grid_spec(const string & spec) -> std::pair<int, int>
     {
@@ -124,10 +147,12 @@ auto main(int argc, char * argv[]) -> int
                 cxxopts::value<double>()->default_value("0"))                     //
             ;
 
-        options.add_options("Model")                                                                    //
-            ("variant", "Constraint variant to post (currently only: tuple)",                           //
-                cxxopts::value<string>()->default_value("tuple"))                                       //
-            ("p,points", "Number of sites to select (>= 2)", cxxopts::value<int>()->default_value("3")) //
+        options.add_options("Model") //
+            ("variant",
+                "Constraint variant to post: tuple (Element+ArrayMin decomposition), or the "                 //
+                "MinDistance global with min-distance-check / min-distance-fb / min-distance-ps propagation", //
+                cxxopts::value<string>()->default_value("tuple"))                                             //
+            ("p,points", "Number of sites to select (>= 2)", cxxopts::value<int>()->default_value("3"))       //
             ("initial-lb",
                 "Initial lower bound on z. Default 1 forbids coincident sites "                           //
                 "(positive separation); use 0 to allow duplicate sites (z can be 0).",                    //
@@ -170,8 +195,8 @@ auto main(int argc, char * argv[]) -> int
     }
 
     auto variant = options_vars["variant"].as<string>();
-    if (variant != "tuple") {
-        println(cerr, "Error: unknown --variant '{}'. Phase 1 supports only 'tuple'.", variant);
+    if (variant != "tuple" && variant != "min-distance-check" && variant != "min-distance-fb" && variant != "min-distance-ps") {
+        println(cerr, "Error: unknown --variant '{}'. Supported: tuple, min-distance-check, min-distance-fb, min-distance-ps.", variant);
         return EXIT_FAILURE;
     }
 
@@ -250,7 +275,14 @@ auto main(int argc, char * argv[]) -> int
     auto z = problem.create_integer_variable(initial_lb, max_dist, "z");
 
     auto distance = make_shared<const DistanceMatrix>(instance.distance);
-    post_tuple_variant(problem, x, z, distance, reqs, max_dist);
+    if (variant == "tuple")
+        post_tuple_variant(problem, x, z, distance, reqs, max_dist);
+    else if (variant == "min-distance-check")
+        post_min_distance_variant(problem, x, z, distance, reqs, MinDistancePropagation::CheckOnly);
+    else if (variant == "min-distance-fb")
+        post_min_distance_variant(problem, x, z, distance, reqs, MinDistancePropagation::ForwardBound);
+    else // min-distance-ps
+        post_min_distance_variant(problem, x, z, distance, reqs, MinDistancePropagation::PairSupport);
 
     if (options_vars.contains("all-different"))
         problem.post(AllDifferent{x});

--- a/examples/p_dispersion/p_dispersion.cc
+++ b/examples/p_dispersion/p_dispersion.cc
@@ -31,6 +31,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <cxxopts.hpp>
@@ -54,6 +55,7 @@ using std::make_shared;
 using std::nullopt;
 using std::optional;
 using std::string;
+using std::string_view;
 using std::to_string;
 using std::vector;
 
@@ -117,6 +119,43 @@ namespace
         problem.post(MinDistance{x, z, ArrayParam<MinDistance::Matrix>{distance}, std::move(md_reqs), mode});
     }
 
+    // The --variant names, in help order. A nullopt mode means the tuple
+    // decomposition; every other name posts the MinDistance global under the
+    // named propagation mode. This is the single source of truth: validation,
+    // dispatch and the --variant help text all read it, so adding a variant is
+    // one row here and nothing else.
+    struct Variant
+    {
+        string_view name;
+        optional<MinDistancePropagation> mode;
+    };
+
+    constexpr Variant variants[] = {
+        {"tuple", nullopt},
+        {"min-distance-check", MinDistancePropagation::CheckOnly},
+        {"min-distance-fb", MinDistancePropagation::ForwardBound},
+        {"min-distance-ps", MinDistancePropagation::PairSupport},
+    };
+
+    auto find_variant(const string & name) -> optional<Variant>
+    {
+        for (const auto & v : variants)
+            if (v.name == name)
+                return v;
+        return nullopt;
+    }
+
+    auto variant_names() -> string
+    {
+        string result;
+        for (const auto & v : variants) {
+            if (! result.empty())
+                result += ", ";
+            result += v.name;
+        }
+        return result;
+    }
+
     // Parse "WxH" (or a single "N" meaning N x N) into a (width, height) pair.
     auto parse_grid_spec(const string & spec) -> std::pair<int, int>
     {
@@ -149,10 +188,11 @@ auto main(int argc, char * argv[]) -> int
 
         options.add_options("Model") //
             ("variant",
-                "Constraint variant to post: tuple (Element+ArrayMin decomposition), or the "                 //
-                "MinDistance global with min-distance-check / min-distance-fb / min-distance-ps propagation", //
-                cxxopts::value<string>()->default_value("tuple"))                                             //
-            ("p,points", "Number of sites to select (>= 2)", cxxopts::value<int>()->default_value("3"))       //
+                "Constraint variant to post: tuple (the Element+ArrayMin decomposition), or the "       //
+                "MinDistance global under one propagation mode. Supported: " +                          //
+                    variant_names(),                                                                    //
+                cxxopts::value<string>()->default_value("tuple"))                                       //
+            ("p,points", "Number of sites to select (>= 2)", cxxopts::value<int>()->default_value("3")) //
             ("initial-lb",
                 "Initial lower bound on z. Default 1 forbids coincident sites "                           //
                 "(positive separation); use 0 to allow duplicate sites (z can be 0).",                    //
@@ -195,8 +235,9 @@ auto main(int argc, char * argv[]) -> int
     }
 
     auto variant = options_vars["variant"].as<string>();
-    if (variant != "tuple" && variant != "min-distance-check" && variant != "min-distance-fb" && variant != "min-distance-ps") {
-        println(cerr, "Error: unknown --variant '{}'. Supported: tuple, min-distance-check, min-distance-fb, min-distance-ps.", variant);
+    auto selected_variant = find_variant(variant);
+    if (! selected_variant) {
+        println(cerr, "Error: unknown --variant '{}'. Supported: {}.", variant, variant_names());
         return EXIT_FAILURE;
     }
 
@@ -275,14 +316,10 @@ auto main(int argc, char * argv[]) -> int
     auto z = problem.create_integer_variable(initial_lb, max_dist, "z");
 
     auto distance = make_shared<const DistanceMatrix>(instance.distance);
-    if (variant == "tuple")
+    if (selected_variant->mode)
+        post_min_distance_variant(problem, x, z, distance, reqs, *selected_variant->mode);
+    else
         post_tuple_variant(problem, x, z, distance, reqs, max_dist);
-    else if (variant == "min-distance-check")
-        post_min_distance_variant(problem, x, z, distance, reqs, MinDistancePropagation::CheckOnly);
-    else if (variant == "min-distance-fb")
-        post_min_distance_variant(problem, x, z, distance, reqs, MinDistancePropagation::ForwardBound);
-    else // min-distance-ps
-        post_min_distance_variant(problem, x, z, distance, reqs, MinDistancePropagation::PairSupport);
 
     if (options_vars.contains("all-different"))
         problem.post(AllDifferent{x});

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
@@ -29,14 +30,15 @@ using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
-MinDistance::MinDistance(vector<IntegerVariableID> x, IntegerVariableID z, ArrayParam<Matrix> distances, optional<ArrayParam<Matrix>> requirements) :
-    _x(move(x)), _z(z), _distances(move(distances)), _requirements(move(requirements))
+MinDistance::MinDistance(vector<IntegerVariableID> x, IntegerVariableID z, ArrayParam<Matrix> distances, optional<ArrayParam<Matrix>> requirements,
+    MinDistancePropagation propagation) :
+    _x(move(x)), _z(z), _distances(move(distances)), _requirements(move(requirements)), _propagation(propagation)
 {
 }
 
 auto MinDistance::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<MinDistance>(_x, _z, _distances, _requirements);
+    return make_unique<MinDistance>(_x, _z, _distances, _requirements, _propagation);
 }
 
 auto MinDistance::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
@@ -274,6 +276,15 @@ auto MinDistance::define_proof_model(ProofModel & model) -> void
 
 auto MinDistance::install_propagators(Propagators & propagators) -> void
 {
+    if (_propagation == MinDistancePropagation::CheckOnly) {
+        install_check_only_propagator(propagators);
+        return;
+    }
+    install_forward_propagator(propagators, _propagation == MinDistancePropagation::PairSupport);
+}
+
+auto MinDistance::install_check_only_propagator(Propagators & propagators) -> void
+{
     const auto n = static_cast<long long>((*_distances).size());
 
     Triggers triggers;
@@ -335,6 +346,191 @@ auto MinDistance::install_propagators(Propagators & propagators) -> void
                         if (b < 0 || b >= n)
                             return PropagatorState::Enable;
                         auto dab = D[a][b];
+                        mu = mu ? std::min(*mu, dab) : dab;
+                    }
+                }
+                if (mu) {
+                    inference.infer_greater_than_or_equal(logger, z, *mu, JustifyUsingRUP{}, all_reason);
+                    inference.infer_less_than(logger, z, *mu + 1_i, JustifyUsingRUP{}, all_reason);
+                }
+            }
+
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto MinDistance::install_forward_propagator(Propagators & propagators, bool pair_support) -> void
+{
+    const auto n = static_cast<long long>((*_distances).size());
+
+    // Real propagation reacts to any domain change of a selected point (a value
+    // removed from x_j can lose a support) and to a rise in z's lower bound
+    // (which raises the T_ij threshold and invalidates supports); on_bounds on z
+    // covers the lower-bound wake.
+    Triggers triggers;
+    for (const auto & x : _x)
+        triggers.on_change.emplace_back(x);
+    triggers.on_bounds.emplace_back(_z);
+
+    auto all_reason = generic_reason(_x);
+
+    propagators.install(
+        constraint_id(),
+        [x = _x, z = _z, distances = _distances, requirements = _requirements, n, pair_support, all_reason = std::move(all_reason)](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            const auto & D = *distances;
+            const auto p = x.size();
+            const bool has_reqs = requirements.has_value();
+
+            auto in_range = [&](Integer v) { return v.raw_value >= 0 && v.raw_value < n; };
+            auto r_at = [&](std::size_t i, std::size_t j) -> Integer { return has_reqs ? (**requirements)[i][j] : 0_i; };
+            auto d_at = [&](Integer a, Integer b) -> Integer { return D[a.raw_value][b.raw_value]; };
+
+            // z's lower bound at the top of this wake feeds every threshold. If a
+            // later inference here raises it (the full-assignment pin does), the
+            // on_bounds trigger re-queues us and we recompute with the new value.
+            const auto z_min = state.lower_bound(z);
+
+            for (std::size_t i = 0; i < p; ++i)
+                for (std::size_t j = i + 1; j < p; ++j) {
+                    const auto rij = r_at(i, j);
+                    const auto tij = std::max(rij, z_min);
+
+                    // (1) Assigned-endpoint forward prune (paper Section 4.1). When
+                    // one endpoint is fixed to a, remove every b from the other
+                    // endpoint's domain with D[a,b] < T_ij. Plain RUP: {x_i = a},
+                    // plus z >= z_min when the z part of the threshold binds (the R
+                    // forbidden-pair clause carries the R part on its own).
+                    auto forward_prune = [&](std::size_t assigned_pos, std::size_t other_pos) {
+                        auto av = state.optional_single_value(x[assigned_pos]);
+                        if (! av || ! in_range(*av))
+                            return;
+                        auto a = *av;
+                        vector<Integer> other_dom;
+                        state.for_each_value_immutable(x[other_pos], [&](Integer b) { other_dom.push_back(b); });
+                        for (auto b : other_dom) {
+                            if (! in_range(b) || d_at(a, b) >= tij)
+                                continue;
+                            ReasonLiterals rlits{x[assigned_pos] == a};
+                            if (! (has_reqs && d_at(a, b) < rij))
+                                rlits.push_back(z >= z_min);
+                            inference.infer_not_equal(logger, x[other_pos], b, JustifyUsingRUP{}, ExplicitReason{std::move(rlits)});
+                        }
+                    };
+                    forward_prune(i, j);
+                    forward_prune(j, i);
+
+                    // (2) Pairwise objective upper bound (paper Section 4.1):
+                    //   u_ij = max{ D[a,b] : a in dom(x_i), b in dom(x_j), D[a,b] >= R_ij }.
+                    // If the set is empty (or its max is below z_min) the pair cannot
+                    // be satisfied and the node fails; otherwise tighten z <= u_ij.
+                    optional<Integer> u;
+                    state.for_each_value_immutable(x[i], [&](Integer a) {
+                        if (! in_range(a))
+                            return;
+                        state.for_each_value_immutable(x[j], [&](Integer b) {
+                            if (! in_range(b))
+                                return;
+                            auto dab = d_at(a, b);
+                            if (dab >= rij)
+                                u = u ? std::max(*u, dab) : dab;
+                        });
+                    });
+
+                    // Loop the smaller endpoint domain in the explicit per-value
+                    // derivation (both work by symmetry; the smaller one is cheaper).
+                    auto loop_pos = state.domain_size(x[i]) <= state.domain_size(x[j]) ? i : j;
+
+                    if (! u || *u < z_min) {
+                        // Pair infeasible. For each a in dom(x_loop), every b in the
+                        // other domain dies (R clause when D[a,b] < R_ij; else the
+                        // pair clause with z >= z_min), so ~[x_loop = a]; then x_loop's
+                        // at-least-one closes the contradiction. Item 4 of the spec.
+                        const bool z_guards = u.has_value(); // empty set is pure-R, no z role
+                        auto emit_infeasible = [&, loop_pos](const ReasonLiterals & reason) {
+                            state.for_each_value_immutable(x[loop_pos], [&](Integer a) {
+                                if (! in_range(a))
+                                    return;
+                                logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (x[loop_pos] != a) >= 1_i, ProofLevel::Temporary);
+                            });
+                        };
+                        Reason reason = generic_reason(vector<IntegerVariableID>{x[i], x[j]});
+                        if (z_guards)
+                            reason = with_extra(std::move(reason), ReasonLiterals{z >= z_min});
+                        inference.contradiction(logger, JustifyExplicitly{emit_infeasible, ThenRUP::Yes}, reason);
+                    }
+                    else if (*u < state.upper_bound(z)) {
+                        auto uu = *u;
+                        // Item 3 of the spec: for each a in dom(x_loop) derive
+                        // ~[x_loop = a] \/ [z <= u_ij]; the z bound needed to kill each
+                        // partner b comes free from negating [z <= u_ij], so the reason
+                        // is just the two endpoint domains.
+                        auto emit_ub = [&, loop_pos, uu](const ReasonLiterals & reason) {
+                            state.for_each_value_immutable(x[loop_pos], [&](Integer a) {
+                                if (! in_range(a))
+                                    return;
+                                logger->emit_rup_proof_line_under_reason(
+                                    reason, WPBSum{} + 1_i * (x[loop_pos] != a) + 1_i * (z <= uu) >= 1_i, ProofLevel::Temporary);
+                            });
+                        };
+                        inference.infer_less_than(
+                            logger, z, uu + 1_i, JustifyExplicitly{emit_ub, ThenRUP::Yes}, generic_reason(vector<IntegerVariableID>{x[i], x[j]}));
+                    }
+
+                    // (3) Pair-support scan (paper Section 4.2), PairSupport only.
+                    // Remove a from an endpoint's domain when no value of the other
+                    // endpoint supports it (D[a,b] >= T_ij). Plain RUP: assuming
+                    // [x_from = a], every b in dom(x_to) dies, and x_to's
+                    // at-least-one closes it. Item 2 of the spec.
+                    if (pair_support) {
+                        const bool z_binds = z_min > rij;
+                        auto support_scan = [&](std::size_t from_pos, std::size_t to_pos) {
+                            vector<Integer> from_dom;
+                            state.for_each_value_immutable(x[from_pos], [&](Integer a) { from_dom.push_back(a); });
+                            for (auto a : from_dom) {
+                                if (! in_range(a) || ! state.in_domain(x[from_pos], a))
+                                    continue;
+                                bool supported = false;
+                                state.for_each_value_immutable(x[to_pos], [&](Integer b) {
+                                    if (in_range(b) && d_at(a, b) >= tij) {
+                                        supported = true;
+                                        return false;
+                                    }
+                                    return true;
+                                });
+                                if (! supported) {
+                                    Reason reason = generic_reason(vector<IntegerVariableID>{x[to_pos]});
+                                    if (z_binds)
+                                        reason = with_extra(std::move(reason), ReasonLiterals{z >= z_min});
+                                    inference.infer_not_equal(logger, x[from_pos], a, JustifyUsingRUP{}, reason);
+                                }
+                            }
+                        };
+                        support_scan(i, j);
+                        support_scan(j, i);
+                    }
+                }
+
+            // Once every endpoint is fixed, pin z to the exact minimum pairwise
+            // distance. The forward bounds above supply z <= mu; z >= mu is the
+            // min-attained ladder (plain RUP, reasoned over all of x). This is what
+            // makes a full assignment with z < mu unacceptable.
+            bool all_assigned = true;
+            for (std::size_t i = 0; i < p; ++i)
+                if (! state.optional_single_value(x[i]))
+                    all_assigned = false;
+            if (all_assigned) {
+                optional<Integer> mu;
+                for (std::size_t i = 0; i < p; ++i) {
+                    auto a = state.optional_single_value(x[i]).value();
+                    if (! in_range(a))
+                        return PropagatorState::Enable;
+                    for (std::size_t j = i + 1; j < p; ++j) {
+                        auto b = state.optional_single_value(x[j]).value();
+                        if (! in_range(b))
+                            return PropagatorState::Enable;
+                        auto dab = d_at(a, b);
                         mu = mu ? std::min(*mu, dab) : dab;
                     }
                 }

--- a/gcs/constraints/min_distance/min_distance.hh
+++ b/gcs/constraints/min_distance/min_distance.hh
@@ -12,6 +12,33 @@
 namespace gcs
 {
     /**
+     * \brief Propagation strength for the MinDistance constraint.
+     *
+     * These select propagation strength only and never change the OPB encoding
+     * (define_proof_model is identical for all three). Following Lagerkvist,
+     * "Propagation Algorithms for the Minimum-Distance Constraint over Selected
+     * Points" (ModRef 2026), Sections 4.1-4.2:
+     *
+     * - \c CheckOnly: the constraint only acts once the endpoints of a pair are
+     *   assigned (the phase-2 baseline; the encoding regression check).
+     * - \c ForwardBound: the paper's global-forward-bound. When one endpoint of
+     *   a pair is assigned it prunes unsupported values from the other, and it
+     *   maintains a pairwise objective upper bound on \c z (the \c pair-forward-bound
+     *   filtering, aggregated into one global propagator).
+     * - \c PairSupport: the paper's global-pair-support. ForwardBound plus a full
+     *   per-pair support scan that can delete unsupported values from either
+     *   endpoint before it is assigned.
+     *
+     * \ingroup Constraints
+     */
+    enum class MinDistancePropagation
+    {
+        CheckOnly,
+        ForwardBound,
+        PairSupport
+    };
+
+    /**
      * \brief Constrain \c z to be the minimum, over all pairs of selected-point
      * variables, of the distance between the sites they select.
      *
@@ -36,10 +63,9 @@ namespace gcs
      * present, must be \f$p \times p\f$ with non-negative entries above the
      * diagonal. Violations are rejected at post time.
      *
-     * This propagator is deliberately check-only: it updates \c z (and detects a
-     * requirement violation) only once the endpoints of a pair are assigned.
-     * Every inference it makes is plain reverse unit propagation from the proof
-     * encoding.
+     * The \c propagation argument selects the propagation strength (see
+     * MinDistancePropagation); it never changes the proof encoding. The default
+     * is \c ForwardBound.
      *
      * \ingroup Constraints
      */
@@ -54,6 +80,7 @@ namespace gcs
         const IntegerVariableID _z;
         ArrayParam<Matrix> _distances;
         std::optional<ArrayParam<Matrix>> _requirements;
+        MinDistancePropagation _propagation;
 
         // Filled in by prepare() for use by define_proof_model(): the site
         // values each position can take (visible-frame, one list per position),
@@ -66,10 +93,12 @@ namespace gcs
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
+        auto install_check_only_propagator(innards::Propagators &) -> void;
+        auto install_forward_propagator(innards::Propagators &, bool pair_support) -> void;
 
     public:
         explicit MinDistance(std::vector<IntegerVariableID> x, IntegerVariableID z, ArrayParam<Matrix> distances,
-            std::optional<ArrayParam<Matrix>> requirements = std::nullopt);
+            std::optional<ArrayParam<Matrix>> requirements = std::nullopt, MinDistancePropagation propagation = MinDistancePropagation::ForwardBound);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/min_distance/min_distance_test.cc
+++ b/gcs/constraints/min_distance/min_distance_test.cc
@@ -10,6 +10,7 @@
 #include <optional>
 #include <random>
 #include <set>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 #include <variant>
@@ -132,18 +133,62 @@ namespace
         }
         return result;
     }
+
+    auto mode_label(MinDistancePropagation mode) -> const char *
+    {
+        switch (mode) {
+            using enum MinDistancePropagation;
+        case CheckOnly: return "check";
+        case ForwardBound: return "fb";
+        case PairSupport: return "ps";
+        }
+        return "?";
+    }
+
+    // The pair-support invariant (paper Section 4.2), checked at every search node
+    // once PairSupport propagation has reached fixpoint: for every ordered pair
+    // (i, j) and every site a still in dom(x_i), some site b in dom(x_j) has
+    // D[a,b] >= max(R_ij, z_min). This is deliberately weaker than joint GAC. The
+    // logical (post-view) values of the variables are the site indices, so reading
+    // them via the CurrentState is view-safe.
+    auto check_pair_support(
+        const CurrentState & s, const vector<IntegerVariableID> & xs, IntegerVariableID z, const IntMatrix & d, const optional<IntMatrix> & r) -> void
+    {
+        const int p = static_cast<int>(xs.size());
+        const int zmin = s.lower_bound(z).raw_value;
+        for (int i = 0; i < p; ++i)
+            for (int j = 0; j < p; ++j) {
+                if (i == j)
+                    continue;
+                const int rij = r ? (*r)[std::min(i, j)][std::max(i, j)] : 0;
+                const int t = std::max(rij, zmin);
+                for (auto a : s.each_value(xs[i])) {
+                    bool supported = false;
+                    for (auto b : s.each_value(xs[j]))
+                        if (d[a.raw_value][b.raw_value] >= t) {
+                            supported = true;
+                            break;
+                        }
+                    if (! supported) {
+                        println(cerr, "pair-support invariant violated: position {} value {} has no partner in position {} at threshold {}", i,
+                            a.raw_value, j, t);
+                        throw std::runtime_error{"pair-support invariant violated"};
+                    }
+                }
+            }
+    }
 }
 
-auto run_min_distance_test(bool proofs, const ViewWrapConfig & view_cfg, const vector<DomainSpec> & x_specs, const DomainSpec & z_spec,
-    const IntMatrix & d, const optional<IntMatrix> & r) -> void
+auto run_min_distance_test(bool proofs, MinDistancePropagation mode, const ViewWrapConfig & view_cfg, const vector<DomainSpec> & x_specs,
+    const DomainSpec & z_spec, const IntMatrix & d, const optional<IntMatrix> & r) -> void
 {
     const int n = static_cast<int>(d.size());
     const int p = static_cast<int>(x_specs.size());
     // Positions 0..p-1 are the selected-point variables; position p is z.
     auto wraps = wraps_for_positions(view_cfg, p + 1);
 
-    print(cerr, "min_distance [{}] p={} n={} x={} z={} r={}{}", view_wrap_config_label(view_cfg), p, n, x_specs, z_spec, r.has_value(),
-        proofs ? " with proofs:" : ":");
+    print(cerr, "min_distance [{}/{}] p={} n={} x={} z={} r={}{}", mode_label(mode), view_wrap_config_label(view_cfg), p, n, x_specs, z_spec,
+        r.has_value(), proofs ? " with proofs:" : ":");
     cerr << flush;
 
     // Brute-force the expected (x-assignment, z) solution set directly from the
@@ -182,12 +227,28 @@ auto run_min_distance_test(bool proofs, const ViewWrapConfig & view_cfg, const v
     auto z = visit([&](const auto & s) { return create_integer_variable_or_constant_with_view(problem, s, wraps.at(p)); }, z_spec);
 
     if (r)
-        problem.post(MinDistance{xs, z, to_integer_matrix(d), ArrayParam<MinDistance::Matrix>{to_integer_matrix(*r)}});
+        problem.post(MinDistance{xs, z, to_integer_matrix(d), ArrayParam<MinDistance::Matrix>{to_integer_matrix(*r)}, mode});
     else
-        problem.post(MinDistance{xs, z, to_integer_matrix(d)});
+        problem.post(MinDistance{xs, z, to_integer_matrix(d), nullopt, mode});
 
-    auto proof_name = proofs ? make_optional("min_distance_test_" + view_wrap_config_label(view_cfg)) : nullopt;
-    solve_for_tests(problem, proof_name, actual, tuple{xs, z});
+    auto proof_name = proofs ? make_optional("min_distance_test_" + std::string{mode_label(mode)} + "_" + view_wrap_config_label(view_cfg)) : nullopt;
+
+    if (mode == MinDistancePropagation::PairSupport) {
+        // Same solution collection as solve_for_tests, plus a per-node check that
+        // PairSupport really reaches pair-support fixpoint at every node.
+        solve_for_tests_with_callbacks(
+            problem, proof_name,
+            [&](const CurrentState & s) -> bool {
+                actual.emplace(extract_from_state(s, xs), extract_from_state(s, z));
+                return true;
+            },
+            [&](const CurrentState & s) -> bool {
+                check_pair_support(s, xs, z, d, r);
+                return true;
+            });
+    }
+    else
+        solve_for_tests(problem, proof_name, actual, tuple{xs, z});
     check_results(proof_name, expected, actual);
 }
 
@@ -228,8 +289,19 @@ auto run_rejection_tests() -> void
     expect_rejected(IntMatrix{{0, 1}, {1, 0}}, make_optional(IntMatrix{{0}}), "requirements matrix not p x p");
 }
 
+// The three propagation modes every data-driven spec is run under.
+constexpr MinDistancePropagation all_modes[] = {
+    MinDistancePropagation::CheckOnly, MinDistancePropagation::ForwardBound, MinDistancePropagation::PairSupport};
+
 auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
 {
+    // Run each spec under all three propagation modes: identical solution sets,
+    // proofs verified for each.
+    auto go = [&](const vector<DomainSpec> & x_specs, const DomainSpec & z_spec, const IntMatrix & d, const optional<IntMatrix> & r) {
+        for (auto mode : all_modes)
+            run_min_distance_test(proofs, mode, view_cfg, x_specs, z_spec, d, r);
+    };
+
     // A handful of small symmetric distance matrices to draw on.
     const IntMatrix d2{{0, 3}, {3, 0}};
     const IntMatrix d3{{0, 2, 5}, {2, 0, 4}, {5, 4, 0}};
@@ -239,50 +311,50 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg) -> void
     const IntMatrix d4_ties{{0, 4, 4, 7}, {4, 0, 7, 4}, {4, 7, 0, 4}, {7, 4, 4, 0}};
 
     // p = 2, basic.
-    run_min_distance_test(proofs, view_cfg, {pair{0, 1}, pair{0, 1}}, pair{0, 5}, d2, nullopt);
+    go({pair{0, 1}, pair{0, 1}}, pair{0, 5}, d2, nullopt);
     // p = 2, z domain excludes 0 (duplicates ruled out by z >= 1).
-    run_min_distance_test(proofs, view_cfg, {pair{0, 1}, pair{0, 1}}, pair{1, 5}, d2, nullopt);
+    go({pair{0, 1}, pair{0, 1}}, pair{1, 5}, d2, nullopt);
     // p = 2, z domain forces a small window (BC through a hole is exercised by the harness).
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+    go({pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
 
     // p = 3, duplicates possible (z can be 0), full domains.
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
     // p = 3, duplicates excluded (z >= 1), so this is effectively all-different sites.
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{1, 6}, d3, nullopt);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{1, 6}, d3, nullopt);
     // p = 3, all distances tied.
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 4}, d3_ties, nullopt);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 4}, d3_ties, nullopt);
     // p = 3, matrix with an off-diagonal zero (sites 0 and 1 are distance 0 apart).
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 5}, d3_zero, nullopt);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 5}, d3_zero, nullopt);
 
     // z domain with a hole: {0, 2, 4} (offset/holes tested together elsewhere).
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, vector<int>{0, 2, 4}, d3, nullopt);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, vector<int>{0, 2, 4}, d3, nullopt);
     // z domain offset above zero: [2, 6].
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{2, 6}, d3, nullopt);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{2, 6}, d3, nullopt);
     // z domain including negatives: forces z >= 0 via the ladder base clause.
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{-2, 6}, d3, nullopt);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{-2, 6}, d3, nullopt);
 
     // x domains with holes / not covering all sites.
-    run_min_distance_test(proofs, view_cfg, {vector<int>{0, 2}, pair{0, 2}, vector<int>{1, 2}}, pair{0, 6}, d3, nullopt);
-    run_min_distance_test(proofs, view_cfg, {pair{0, 1}, pair{1, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+    go({vector<int>{0, 2}, pair{0, 2}, vector<int>{1, 2}}, pair{0, 6}, d3, nullopt);
+    go({pair{0, 1}, pair{1, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
     // One position pinned to a constant site.
-    run_min_distance_test(proofs, view_cfg, {0, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
+    go({0, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, nullopt);
 
     // p = 4.
-    run_min_distance_test(proofs, view_cfg, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{0, 10}, d4, nullopt);
-    run_min_distance_test(proofs, view_cfg, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{1, 10}, d4_ties, nullopt);
+    go({pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{0, 10}, d4, nullopt);
+    go({pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{1, 10}, d4_ties, nullopt);
 
     // With requirements R (only i<j entries read).
     // Feasible requirement: every selected pair at least distance 3 apart.
     const IntMatrix r3_feasible{{0, 3, 3}, {0, 0, 3}, {0, 0, 0}};
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, r3_feasible);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, r3_feasible);
     // Requirement forbids duplicates (R_ij > 0 rules out same-site pairs).
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3_ties, r3_feasible);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3_ties, r3_feasible);
     // Infeasible requirement: demand distance >= 6 where the max distance is 5.
     const IntMatrix r3_infeasible{{0, 6, 6}, {0, 0, 6}, {0, 0, 0}};
-    run_min_distance_test(proofs, view_cfg, {pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, r3_infeasible);
+    go({pair{0, 2}, pair{0, 2}, pair{0, 2}}, pair{0, 6}, d3, r3_infeasible);
     // Heterogeneous requirement per position pair.
     const IntMatrix r4_mixed{{0, 2, 4, 5}, {0, 0, 3, 4}, {0, 0, 0, 3}, {0, 0, 0, 0}};
-    run_min_distance_test(proofs, view_cfg, {pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{0, 10}, d4, r4_mixed);
+    go({pair{0, 3}, pair{0, 3}, pair{0, 3}, pair{0, 3}}, pair{0, 10}, d4, r4_mixed);
 }
 
 // Random symmetric distance matrix: zero diagonal, non-negative, entries in
@@ -382,7 +454,9 @@ auto main(int argc, char * argv[]) -> int
                 r = rr;
             }
 
-            run_min_distance_test(proofs, view_cfg, x_specs, z_spec, d, r);
+            // Same random instance under all three propagation modes.
+            for (auto mode : all_modes)
+                run_min_distance_test(proofs, mode, view_cfg, x_specs, z_spec, d, r);
         }
     }
 


### PR DESCRIPTION
Third PR of the min-distance stack (on #537). Replaces the check-only propagator with real propagation per the paper's §4.1–4.2, selected by a `MinDistancePropagation` enum (CheckOnly kept as the encoding-regression baseline; default ForwardBound):

- **ForwardBound**: assigned-endpoint pruning with incumbent-aware thresholds T_ij = max(R_ij, z_min); pairwise objective upper bound u_ij tightening z; node failure on infeasible pairs.
- **PairSupport**: adds the per-pair support scan (prunes unsupported values before assignment).

Every inference is fully justified and VeriPB-verifies — plain RUP for the prunes, `JustifyExplicitly{ThenRUP::Yes}` per-value derivations for the objective UB and pair-infeasibility, **zero unchecked assertions**, and no changes to the (frozen, previously validated) proof encoding or to proofs innards. Verification: 6 seeds uncapped × 3 modes + mixed view-wrap runs, all 81/81 proofs green per run, with a per-node pair-support invariant check; ctest 419/419.

Benchmarks (examples/p_dispersion gains `min-distance-{check,fb,ps}` variants): `min-distance-ps` reproduces the tuple decomposition's search tree node-for-node (as GAC-per-pair should) at ~1.6× faster wall clock; `min-distance-fb` is often fastest overall with ~30–90× fewer propagations; with proofs on, the global constraint writes **12–14× smaller proofs** that veripb checks **~11–13× faster** than the tuple decomposition. On 60s-timeout instances the global variants find better incumbents.

Next in the stack: the conflict-matching upper bound (§4.4) with its counting-argument proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141nkWU9yZRxKoPoPRG1xfc