### PR TITLE
infer_all: batch a JustifyExplicitly's steps for ThenRUP::No too

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -366,6 +366,18 @@ proof lines via `logger->emit_rup_proof_line_under_reason`,
 `logger->emit(RUPProofRule{}, ..., ProofLevel::Temporary)`, and similar.
 See `among/among.cc` and `lex/lex.cc` for examples of varying complexity.
 
+**A `JustifyExplicitly` handed to `infer_all` justifies the whole batch,
+once.** The `emit` is never told which literal it is justifying, so it runs
+exactly once per `infer_all` call, before any of the literals are applied,
+with the reason materialised once at that point. What each literal needs
+after the steps is what `ThenRUP` says: with `ThenRUP::Yes` the steps are
+shared scaffolding and every literal is RUPped under it; with
+`ThenRUP::No` the steps must themselves derive **every** literal in the
+batch, at `ProofLevel::Current` so the conclusions outlive the emit's
+temporary scaffolding — nothing further is logged per literal. Never write
+an `emit` that assumes it will be called once per firing literal, and never
+pass a literal the steps do not conclude.
+
 **Assertion hints (optional).** Both `JustifyUsingRUP` and
 `JustifyExplicitly` take an optional trailing *typed assertion hint*, e.g.
 `JustifyUsingRUP{hints::Foo{owner}}` or `JustifyExplicitly{emit,

--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -602,18 +602,38 @@ namespace gcs::innards
                 track(logger, _state.infer(lit), lit, why, snapshotted, assertion_hints);
         }
 
-        // The JustifyExplicitly counterpart of infer_all. When the steps end in a
-        // RUP (ThenRUP::Yes) and proofs are Off, it does the shared-temporary-level
-        // batching: emit the scaffolding once via the emit callable, then RUP each
-        // inference under it. Otherwise (assertion mode, or ThenRUP::No) it falls
-        // through to the per-literal path, where each inference carries the
-        // assertion hint in assert mode.
+        // The JustifyExplicitly counterpart of infer_all. A JustifyExplicitly handed
+        // to infer_all is *one* justification for the whole batch, not one repeated
+        // per literal: the emit callable is never told which literal it is
+        // justifying, so it cannot behave per-literal even if it wanted to, and
+        // re-running it would only re-emit the same lines. So whenever proofs are on
+        // and nothing is being asserted, the steps are emitted exactly once, under a
+        // single temporary level, and then each literal is applied. What a literal
+        // needs after the steps is what ThenRUP says:
+        //
+        //   - ThenRUP::Yes: the steps are shared scaffolding, so each literal is
+        //     RUPped under the reason, inside the temporary bracket the scaffolding
+        //     lives in;
+        //   - ThenRUP::No: the steps conclude the inference themselves, which for a
+        //     batch means they must derive *every* literal in it, at
+        //     ProofLevel::Current so the conclusions outlive the bracket. Nothing
+        //     further is logged per literal, so the scaffolding can be forgotten
+        //     before the domain updates are applied -- which also means a
+        //     contradiction unwinding out of one of them cannot strand the level.
+        //
+        // Either way the reason is materialised once, before any of the inferences:
+        // an eager reason is a pre-inference snapshot regardless, but a lazy one is
+        // pinned here rather than re-evaluated against each intermediate state.
+        //
+        // In assertion mode there is nothing to batch -- no steps are emitted, and
+        // every literal must carry its own assertion and hint -- so that falls
+        // through to the per-literal path below, as does the proofs-off tracker.
         template <typename Emit_, typename Hint_>
         auto infer_all(ProofLogger * const logger, const std::vector<Literal> & lits, const JustifyExplicitly<Emit_, Hint_> & why,
             const Reason & reason, const std::optional<AssertionAnnotation> & fallback = std::nullopt) -> void
         {
             if constexpr (Actual_::materialises_reasons) {
-                if (logger && logger->get_assertion_level() == AssertionLevel::Off && why.then_rup == ThenRUP::Yes) {
+                if (logger && logger->get_assertion_level() == AssertionLevel::Off) {
                     auto any_will_fire = false;
                     for (const auto & lit : lits)
                         if (_state.test_literal(lit) != LiteralIs::DefinitelyTrue) {
@@ -627,9 +647,16 @@ namespace gcs::innards
                     ReasonLiterals scratch;
                     auto t = logger->temporary_proof_level();
                     emit_explicit_steps(*logger, why.emit, snapshotted.materialised(_state, scratch));
-                    for (const auto & lit : lits)
-                        track(logger, _state.infer(lit), lit, JustifyUsingRUP{}, snapshotted);
-                    logger->forget_proof_level(t);
+                    if (why.then_rup == ThenRUP::Yes) {
+                        for (const auto & lit : lits)
+                            track(logger, _state.infer(lit), lit, JustifyUsingRUP{}, snapshotted);
+                        logger->forget_proof_level(t);
+                    }
+                    else {
+                        logger->forget_proof_level(t);
+                        for (const auto & lit : lits)
+                            track(logger, _state.infer(lit), lit, NoJustificationNeeded{}, snapshotted);
+                    }
                     return;
                 }
             }


### PR DESCRIPTION
Replaces the earlier version of this PR, which guarded the multiply justification callback so it ran once per propagate. That was the propagator working around `infer_all`, so fix `infer_all` instead.

A `JustifyExplicitly` handed to `infer_all` is *one* justification for the whole batch: the emit callable is never told which literal it is justifying (`emit_explicit_steps` passes only the reason), so it cannot behave per-literal, and re-running it only re-emits the same lines. `infer_all` batched on that basis for `ThenRUP::Yes` only; `ThenRUP::No` fell through to the per-literal path, so the steps ran once per *firing* literal. For `signed_multiply` that meant deriving the whole Procedure 7.5 grid twice whenever both z bounds moved, even though `justify_z_bounds` emits both closing RUPs, at `ProofLevel::Current`, in a single call.

So take the batching decision on what it actually is — proofs on, nothing being asserted — and let `ThenRUP` pick only what each literal needs afterwards:

- `Yes`: RUP each literal under the shared scaffolding, exactly as before;
- `No`: the steps have already concluded every literal in the batch, so nothing further is logged per literal. The scaffolding is forgotten before the domain updates are applied, which also stops a contradiction unwinding out of one of them from stranding the temporary level.

Assertion mode is untouched: there is nothing to batch when no steps are emitted and every literal needs its own annotated assertion, so it still takes the per-literal path. Keeping `ThenRUP::No` also keeps every closing RUP hinted, unlike a flip to `ThenRUP::Yes`, whose tracker RUPs would be hint-free.

The `ThenRUP::Yes` users (`among`, `lex`, `gac_all_different`'s Hall witness) take the same path they did before and are byte-identical. What tightens is the `ThenRUP::No` contract, now written down in `dev_docs/constraints.md`: the steps must derive **every** literal in the batch, at `ProofLevel::Current`. `signed_multiply` is the only user and it complies; a violation would fail loudly at a later RUP, not silently.

Proof-shape change only: recursions/propagations unchanged; `random_polynomial --seed 42` goes 2758737 -> 2438819 bytes (-11.6%), byte-for-byte the same proof the guarded version produced. Full suite passes with proof verification.

Stacked on this branch: #579 (uses the now-honest batch to derive only the z bound that is actually moving, a further -24%) and #580 (closes the temporary level when a batched inference contradicts). They touch different files and are independent of each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)