### PR TITLE
Fix cumulative proof-only end proxy for negative start bounds (#553)

### DIFF
--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -30,6 +30,7 @@ using namespace gcs::innards;
 
 using std::make_shared;
 using std::make_unique;
+using std::min;
 using std::move;
 using std::size_t;
 using std::string;
@@ -133,15 +134,18 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     // the possible-active window / contrib domain and to filter tasks that can
     // never raise the profile.
     _length_vals.clear();
+    _length_lb.clear();
     _length_ub.clear();
     _height_vals.clear();
     _height_ub.clear();
     _length_vals.reserve(n);
+    _length_lb.reserve(n);
     _length_ub.reserve(n);
     _height_vals.reserve(n);
     _height_ub.reserve(n);
     for (const auto & l : _lengths) {
         _length_vals.push_back(is_constant_variable(l) ? const_value_of(l) : 0_i);
+        _length_lb.push_back(initial_state.lower_bound(l));
         _length_ub.push_back(initial_state.upper_bound(l));
     }
     for (const auto & h : _heights) {
@@ -205,9 +209,16 @@ auto Cumulative::define_proof_model(ProofModel & model) -> void
         // end = s_i + l_i. Crucially end has NO OPB encoding (cake has no such
         // variable): it is bit-defined inside the proof by the install_initialiser
         // (introduce_bits_of), which also emits the `end ≥ t+1 → after` bridge
-        // lemma per (i,t). nullopt unless both operands vary.
+        // lemma per (i,t). nullopt unless both operands vary. The range must
+        // cover s + l in full or introduce_bits_of's redundancy goals are
+        // unprovable: lb(s) + lb(l) can be negative (a start before time 0,
+        // issue #553), in which case end gets a sign bit; keep 0 as the lower
+        // bound otherwise --- end ≥ 0 is the one unsigned boundary pin that
+        // would be a tautology, and verified instances' tracked bounds stay
+        // untouched.
         if (! is_constant_variable(_starts[i]) && ! is_constant_variable(_lengths[i]))
-            _end[i] = model.create_proof_only_integer_variable_in_proof(0_i, _per_task_t_hi[i] + 1_i, "cumend");
+            _end[i] =
+                model.create_proof_only_integer_variable_in_proof(min(0_i, _per_task_t_lo[i] + _length_lb[i]), _per_task_t_hi[i] + 1_i, "cumend");
 
         for (Integer t = t_lo; t <= t_hi; ++t) {
             // Name the flags to match cake_pb_cp's verified cumulative encoder

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -48,7 +48,11 @@ namespace gcs
         // variable one, where the variable / _contrib_flags is used instead) and
         // _*_ub holds the initial upper bound (used to size the possible-active
         // window / contrib domain and to filter tasks that can never load).
+        // _length_lb holds the initial length lower bound, used with lb(start)
+        // to give the proof-only end = s + l proxy its true lower bound (which
+        // is negative when a start can begin far enough before time 0).
         std::vector<Integer> _length_vals;
+        std::vector<Integer> _length_lb;
         std::vector<Integer> _length_ub;
         std::vector<Integer> _height_vals;
         std::vector<Integer> _height_ub;

--- a/gcs/constraints/cumulative/cumulative_test.cc
+++ b/gcs/constraints/cumulative/cumulative_test.cc
@@ -491,6 +491,10 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 4}}, {1}, {3}, 2},
         // Two tasks of differing lengths, cap 1: gaps matter.
         {{{0, 3}, {0, 3}}, {1, 2}, {1, 1}, 1},
+        // Negative start lower bounds with constant lengths: the per-task
+        // window and the before/after flags span t < 0 (issue #553 shape,
+        // without the end proxy).
+        {{{-2, 1}, {-2, 1}}, {2, 2}, {1, 1}, 1},
         // Degenerate cases (issue #254).
         // Empty active-task list: the only task has zero length and zero height,
         // so no propagator is installed and every start is feasible.
@@ -599,6 +603,23 @@ auto main(int argc, char * argv[]) -> int
             run_cumulative_full_test(proofs, "mrcpsp", {{0, 4}, {0, 4}}, {{1, 3}, {2, 3}}, {{1, 2}, {1, 2}}, {2, 2});
             // Full: durations, heights AND capacity all variable.
             run_cumulative_full_test(proofs, "full", {{0, 3}, {0, 3}}, {{1, 2}, {1, 2}}, {{1, 2}, {1, 2}}, {2, 3});
+
+            // Negative start lower bounds with variable durations: s + l
+            // reaches below 0, so the proof-only end = s + l proxy must be
+            // signed (issue #553; unison's inactive tasks sit at s = -1,
+            // l = 0, exactly this shape).
+            run_cumulative_full_test(proofs, "neg_start", {{-1, 2}, {-1, 2}}, {{0, 2}, {0, 2}}, {{1, 1}, {1, 1}}, {1, 1});
+            // Mixed: one signed-end task, one constant-length task (no end).
+            run_cumulative_full_test(proofs, "neg_start_mixed", {{-2, 1}, {0, 2}}, {{1, 2}, {2, 2}}, {{1, 1}, {1, 1}}, {1, 1});
+            // Deep negative start: s's own sign bit reaches -16, below
+            // end's -8 (end spans [-8, 3]), so the top redundancy goals
+            // need the derived form-bound pol lines (s's lower-bound row
+            // is out of slack's reach).
+            run_cumulative_full_test(proofs, "neg_start_deep", {{-10, 0}}, {{2, 3}}, {{1, 1}}, {1, 1});
+            // All-negative window whose top redundancy goals stall at a
+            // unit-propagation fixpoint without the derived form-bound
+            // lines: s's encoding spans [-32, 31] against end's [-8, 7].
+            run_cumulative_full_test(proofs, "neg_start_stall", {{-17, -16}}, {{9, 16}}, {{1, 1}}, {1, 1});
         }
     }
 

--- a/gcs/innards/proofs/introduce_bits_test.cc
+++ b/gcs/innards/proofs/introduce_bits_test.cc
@@ -24,6 +24,59 @@ auto main() -> int
     // the proof below as end = s + l.
     auto end = model.create_proof_only_integer_variable_in_proof(0_i, 6_i, "end");
 
+    // Signed targets (issue #553): when the form's lower bound is negative the
+    // target carries a sign bit and the construction runs shifted by 2^S.
+    // The issue's own shape: s2 + l2 reaches -1.
+    auto s2 = model.create_proof_only_integer_variable(-1_i, 2_i, "s2", IntegerVariableProofRepresentation::Bits);
+    auto l2 = model.create_proof_only_integer_variable(0_i, 2_i, "l2", IntegerVariableProofRepresentation::Bits);
+    auto end2 = model.create_proof_only_integer_variable_in_proof(-1_i, 4_i, "end2");
+    // Operand sign reaching below the target's: s3's encoding spans [-16, 15]
+    // but end3's only [-8, 7], so the top le redundancy goal (s3 + l3 >= -8)
+    // closes only through propagation of s3's lower-bound row, not by slack.
+    auto s3 = model.create_proof_only_integer_variable(-10_i, 0_i, "s3", IntegerVariableProofRepresentation::Bits);
+    auto l3 = model.create_proof_only_integer_variable(2_i, 3_i, "l3", IntegerVariableProofRepresentation::Bits);
+    auto end3 = model.create_proof_only_integer_variable_in_proof(-8_i, 3_i, "end3");
+    // Sign-only target (no value bits) over a zero-width operand ({0}, the
+    // empty sum).
+    auto s4 = model.create_proof_only_integer_variable(-1_i, 0_i, "s4", IntegerVariableProofRepresentation::Bits);
+    auto l4 = model.create_proof_only_integer_variable(0_i, 0_i, "l4", IntegerVariableProofRepresentation::Bits);
+    auto end4 = model.create_proof_only_integer_variable_in_proof(-1_i, 0_i, "end4");
+    // A negative form coefficient: end5 = s5 - l5 spans [-3, 3].
+    auto s5 = model.create_proof_only_integer_variable(0_i, 3_i, "s5", IntegerVariableProofRepresentation::Bits);
+    auto l5 = model.create_proof_only_integer_variable(0_i, 3_i, "l5", IntegerVariableProofRepresentation::Bits);
+    auto end5 = model.create_proof_only_integer_variable_in_proof(-3_i, 3_i, "end5");
+
+    // Shapes whose top-step redundancy goals unit propagation alone cannot
+    // close (they stall at a propagation fixpoint), so they check the derived
+    // form-bound pol lines specifically.
+    // s6's encoding spans [-32, 31], far overhanging end6's [-8, 7]: the
+    // issue #553 review's counterexample.
+    auto s6 = model.create_proof_only_integer_variable(-17_i, -16_i, "s6", IntegerVariableProofRepresentation::Bits);
+    auto l6 = model.create_proof_only_integer_variable(9_i, 16_i, "l6", IntegerVariableProofRepresentation::Bits);
+    auto end6 = model.create_proof_only_integer_variable_in_proof(-8_i, 0_i, "end6");
+    // Three signed operands, unit coefficients.
+    auto s7a = model.create_proof_only_integer_variable(-5_i, 0_i, "s7a", IntegerVariableProofRepresentation::Bits);
+    auto s7b = model.create_proof_only_integer_variable(-5_i, 0_i, "s7b", IntegerVariableProofRepresentation::Bits);
+    auto s7c = model.create_proof_only_integer_variable(-5_i, 0_i, "s7c", IntegerVariableProofRepresentation::Bits);
+    auto end7 = model.create_proof_only_integer_variable_in_proof(-15_i, 0_i, "end7");
+    // Three negated non-negative operands.
+    auto x8a = model.create_proof_only_integer_variable(0_i, 5_i, "x8a", IntegerVariableProofRepresentation::Bits);
+    auto x8b = model.create_proof_only_integer_variable(0_i, 5_i, "x8b", IntegerVariableProofRepresentation::Bits);
+    auto x8c = model.create_proof_only_integer_variable(0_i, 5_i, "x8c", IntegerVariableProofRepresentation::Bits);
+    auto end8 = model.create_proof_only_integer_variable_in_proof(-15_i, 0_i, "end8");
+    // A ge-side stall: the operands' encodings reach 25 but end9 tops out
+    // at 24, over a signed target.
+    auto s9 = model.create_proof_only_integer_variable(-1_i, 0_i, "s9", IntegerVariableProofRepresentation::Bits);
+    auto x9a = model.create_proof_only_integer_variable(0_i, 8_i, "x9a", IntegerVariableProofRepresentation::Bits);
+    auto x9b = model.create_proof_only_integer_variable(0_i, 8_i, "x9b", IntegerVariableProofRepresentation::Bits);
+    auto x9c = model.create_proof_only_integer_variable(0_i, 8_i, "x9c", IntegerVariableProofRepresentation::Bits);
+    auto end9 = model.create_proof_only_integer_variable_in_proof(-1_i, 24_i, "end9");
+    // The unsigned analogue of the stall (pre-existing, not issue #553).
+    auto x10a = model.create_proof_only_integer_variable(0_i, 8_i, "x10a", IntegerVariableProofRepresentation::Bits);
+    auto x10b = model.create_proof_only_integer_variable(0_i, 8_i, "x10b", IntegerVariableProofRepresentation::Bits);
+    auto x10c = model.create_proof_only_integer_variable(0_i, 8_i, "x10c", IntegerVariableProofRepresentation::Bits);
+    auto end10 = model.create_proof_only_integer_variable_in_proof(0_i, 24_i, "end10");
+
     model.finalise();
 
     ProofLogger logger(proof_options, tracker);
@@ -34,6 +87,15 @@ auto main() -> int
     // The 2m reds. The returned pair is BinEnc(end) >= s + l / <= s + l; we don't
     // need to reference them here --- VeriPB has already verified each step.
     [[maybe_unused]] auto [ge, le] = logger.introduce_bits_of(WPBSum{} + 1_i * s + 1_i * l, end, ProofLevel::Top);
+    [[maybe_unused]] auto [ge2, le2] = logger.introduce_bits_of(WPBSum{} + 1_i * s2 + 1_i * l2, end2, ProofLevel::Top);
+    [[maybe_unused]] auto [ge3, le3] = logger.introduce_bits_of(WPBSum{} + 1_i * s3 + 1_i * l3, end3, ProofLevel::Top);
+    [[maybe_unused]] auto [ge4, le4] = logger.introduce_bits_of(WPBSum{} + 1_i * s4 + 1_i * l4, end4, ProofLevel::Top);
+    [[maybe_unused]] auto [ge5, le5] = logger.introduce_bits_of(WPBSum{} + 1_i * s5 + (-1_i) * l5, end5, ProofLevel::Top);
+    [[maybe_unused]] auto [ge6, le6] = logger.introduce_bits_of(WPBSum{} + 1_i * s6 + 1_i * l6, end6, ProofLevel::Top);
+    [[maybe_unused]] auto [ge7, le7] = logger.introduce_bits_of(WPBSum{} + 1_i * s7a + 1_i * s7b + 1_i * s7c, end7, ProofLevel::Top);
+    [[maybe_unused]] auto [ge8, le8] = logger.introduce_bits_of(WPBSum{} + (-1_i) * x8a + (-1_i) * x8b + (-1_i) * x8c, end8, ProofLevel::Top);
+    [[maybe_unused]] auto [ge9, le9] = logger.introduce_bits_of(WPBSum{} + 1_i * s9 + 1_i * x9a + 1_i * x9b + 1_i * x9c, end9, ProofLevel::Top);
+    [[maybe_unused]] auto [ge10, le10] = logger.introduce_bits_of(WPBSum{} + 1_i * x10a + 1_i * x10b + 1_i * x10c, end10, ProofLevel::Top);
 
     logger.conclude_none();
     tracker.finalise();

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -82,6 +82,7 @@ struct NamesAndIDsTracker::Imp
     map<VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID>, XLiteral> variable_conditions_to_x;
     map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, vector<pair<Integer, XLiteral>>>> integer_variable_bits_to_size_and_proof_vars;
     map<SimpleOrProofOnlyIntegerVariableID, pair<Integer, Integer>> integer_variable_definition_bounds;
+    map<SimpleOrProofOnlyIntegerVariableID, pair<ProofLine, ProofLine>> integer_variable_bound_rows;
     // Variables (e.g. ArgSort's cake-named free-bit-sum sorted values) whose [lo, hi]
     // domain is NOT a trivial consequence of the OPB -- cake emits no bound line for
     // them and the bounds are only entailed through conditional channels -- so
@@ -1394,6 +1395,19 @@ auto NamesAndIDsTracker::track_bounds(const SimpleOrProofOnlyIntegerVariableID &
 auto NamesAndIDsTracker::tracked_bounds(const SimpleOrProofOnlyIntegerVariableID & id) const -> pair<Integer, Integer>
 {
     return _imp->integer_variable_definition_bounds.at(id);
+}
+
+auto NamesAndIDsTracker::track_bound_rows(const SimpleOrProofOnlyIntegerVariableID & id, ProofLine lower_row, ProofLine upper_row) -> void
+{
+    _imp->integer_variable_bound_rows.emplace(id, pair{lower_row, upper_row});
+}
+
+auto NamesAndIDsTracker::bound_rows(const SimpleOrProofOnlyIntegerVariableID & id) const -> optional<pair<ProofLine, ProofLine>>
+{
+    auto it = _imp->integer_variable_bound_rows.find(id);
+    if (it == _imp->integer_variable_bound_rows.end())
+        return nullopt;
+    return it->second;
 }
 
 auto NamesAndIDsTracker::note_bounds_not_trivially_derivable(const SimpleOrProofOnlyIntegerVariableID & id) -> void

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -417,6 +417,25 @@ namespace gcs::innards
         [[nodiscard]] auto tracked_bounds(const SimpleOrProofOnlyIntegerVariableID & id) const -> std::pair<Integer, Integer>;
 
         /**
+         * Track the OPB bound-row references (lower row, upper row) for a
+         * bits-encoded variable, so that proof steps can combine them by pol
+         * (ProofLogger::introduce_bits_of derives a linear form's own bound
+         * lines this way). A state variable's rows are referenced by their
+         * `i[name][lb]` / `i[name][ub]` labels (count-robust under
+         * cake_pb_cp's re-derived OPB); a proof-only variable's unlabelled
+         * rows by constraint number (it never appears in a cake chain).
+         */
+        auto track_bound_rows(const SimpleOrProofOnlyIntegerVariableID & id, ProofLine lower_row, ProofLine upper_row) -> void;
+
+        /**
+         * The bound-row references recorded by track_bound_rows, or nullopt
+         * for a variable with no OPB bound rows (one made by
+         * ProofModel::create_proof_only_integer_variable_in_proof, whose
+         * meaning lives entirely inside the proof).
+         */
+        [[nodiscard]] auto bound_rows(const SimpleOrProofOnlyIntegerVariableID & id) const -> std::optional<std::pair<ProofLine, ProofLine>>;
+
+        /**
          * Note that this variable's [lo, hi] bounds are not a trivial consequence of
          * the OPB (cake emits no bound line for it, and its bounds are only entailed
          * through conditional channels), so need_gevar must not pin its boundary order

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/emit_inequality_to.hh>
 #include <gcs/innards/proofs/hints.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
@@ -680,36 +681,128 @@ auto ProofLogger::introduce_bits_of(
 {
     // Wietze Koops's construction: walk target's bits from the top, defining each
     // bit e_k as the reified `running-remainder >= 2^k` via a single red whose
-    // witness is just e_k -> 1 (upper half) / e_k -> 0 (lower half). Every
-    // redundancy goal closes by RUP, and the final (k = 0) pair is
-    // BinEnc(target) >= form (end_ge) / BinEnc(target) <= form (end_le).
+    // witness is just e_k -> 1 (upper half) / e_k -> 0 (lower half). The final
+    // (k = 0) pair is BinEnc(target) >= form (end_ge) / BinEnc(target) <= form
+    // (end_le).
+    //
+    // A signed target (negative bit coefficient -2^S) is the same construction
+    // shifted by 2^S: BinEnc + 2^S = 2^S * ~sign + Sigma 2^j e_j is an unsigned
+    // bit sum whose top bit is the negated sign literal, so define ITS bits as
+    // equal to form + 2^S. Every inequality just gains the constant 2^S on the
+    // form side, and after veripb's literal normalisation the emitted lines ARE
+    // the unsigned lines of the shifted form (issue #553). The returned pair
+    // still reads BinEnc(target) >= form / <= form.
+    //
+    // Why every redundancy goal discharges: veripb autoproves a proofgoal by a
+    // single-constraint implication check against the database before trying
+    // RUP. Each middle step's goal is the previous step's line (or, for a le
+    // red's extra goal on that step's ge line, implied by ~C with the current
+    // bit weakened away), so only the two TOP-step goals --- form <= (top-half
+    // max) for the first ge and form >= (0, or -2^S when signed) for the first
+    // le --- have no earlier line to lean on. Unit propagation alone does NOT
+    // reliably close those two (it stalls whenever an operand's bit encoding
+    // overhangs the target's, e.g. a start in [-17, -16] whose encoding spans
+    // [-32, 31] against an end proxy spanning [-8, 7]), so we first derive the
+    // form's own bound lines by pol over the operands' OPB bound rows; the
+    // implication check then discharges the top goals from those, making the
+    // construction shape-independent.
     auto m = names_and_ids_tracker().num_bits(target).raw_value;
 
     // A [0, 0] target now has zero bits (the empty sum, identically zero), for
     // which the construction below would return default-constructed lines. No
-    // caller can currently supply one (every end proxy spans [0, t_hi + 1]),
-    // and the degenerate pair it would need (`form <= 0` / `form >= 0`, RUP
-    // from the operands' bound rows) should be written and tested when a real
-    // caller appears, not speculatively.
+    // caller can currently supply one (cumulative's end proxy could only span
+    // [0, 0] if both operands were constant, and then no proxy is made), and
+    // the degenerate pair it would need (`form <= 0` / `form >= 0`, exactly
+    // the two pol-derived bound lines below) should be written and tested when
+    // a real caller appears, not speculatively.
     if (0 == m)
         throw ProofError{"introduce_bits_of does not support a zero-width target"};
+
+    // The form's own bound lines: Sigma c_i * (operand's lower row) for the
+    // lower (using the upper row where c_i < 0), and symmetrically for the
+    // upper. Terms without tracked bound rows (views, flags, literals ---
+    // none of which any current caller passes) leave the top goals to plain
+    // RUP as before; constants fold into the goals' right-hand sides and
+    // need no row.
+    PolBuilder form_lower_bound, form_upper_bound;
+    bool have_bound_rows = false, bound_rows_derivable = true;
+    for (const auto & term : linear_form.terms) {
+        auto add_rows_for = [&](const SimpleOrProofOnlyIntegerVariableID & id) {
+            auto rows = names_and_ids_tracker().bound_rows(id);
+            if ((! rows) || 0_i == term.coefficient) {
+                bound_rows_derivable = bound_rows_derivable && rows.has_value();
+                return;
+            }
+            auto & [lower_row, upper_row] = *rows;
+            if (term.coefficient > 0_i) {
+                form_lower_bound.add(lower_row, term.coefficient);
+                form_upper_bound.add(upper_row, term.coefficient);
+            }
+            else {
+                form_lower_bound.add(upper_row, -term.coefficient);
+                form_upper_bound.add(lower_row, -term.coefficient);
+            }
+            have_bound_rows = true;
+        };
+        overloaded{
+            [&](const ProofLiteral &) { bound_rows_derivable = false; },            //
+            [&](const ProofFlag &) { bound_rows_derivable = false; },               //
+            [&](const ProofBitVariable &) { bound_rows_derivable = false; },        //
+            [&](const ProofOnlySimpleIntegerVariableID & id) { add_rows_for(id); }, //
+            [&](const IntegerVariableID & var) {
+                overloaded{
+                    [&](const SimpleIntegerVariableID & id) { add_rows_for(id); },         //
+                    [&](const ConstantIntegerVariableID &) {},                             //
+                    [&](const ViewOfIntegerVariableID &) { bound_rows_derivable = false; } //
+                }
+                    .visit(var);
+            } //
+        }
+            .visit(term.variable);
+    }
+    if (bound_rows_derivable && have_bound_rows) {
+        form_lower_bound.emit(*this, level);
+        form_upper_bound.emit(*this, level);
+    }
+
+    // 2^S for a signed target (whose sign bit occupies position 0 of the bits
+    // vector, with the value bit of weight 2^j at position j + 1), else 0.
+    auto shift = -names_and_ids_tracker().negative_bit_coefficient(target);
+    if (0_i != shift && shift != power2(Integer{m - 1}))
+        throw ProofError{"introduce_bits_of: signed target's negative bit coefficient does not match its bit count"};
+
+    // The bit of weight 2^k in the (shifted) sum.
+    auto bit_of_weight = [&](Integer k) -> ProofBitVariable {
+        if (0_i == shift)
+            return ProofBitVariable{target, k, true};
+        else if (k.raw_value == m - 1)
+            return ProofBitVariable{target, 0_i, false}; // ~sign as the top bit
+        else
+            return ProofBitVariable{target, k + 1_i, true};
+    };
 
     pair<ProofLine, ProofLine> bounds;
     SumOf<Weighted<PseudoBooleanTerm>> bitsum; // Sigma_{j > k} 2^j e_j, grows as k descends
     for (long long kk = m - 1; kk >= 0; --kk) {
         Integer k{kk};
-        bitsum += power2(k) * ProofBitVariable{target, k, true}; // now Sigma_{j >= k}
+        auto bit = bit_of_weight(k);
+        bitsum += power2(k) * bit; // now Sigma_{j >= k}
 
         // expr = (running bit sum) - (linear form)
         auto expr = bitsum;
         for (const auto & term : linear_form.terms)
             expr += Weighted<PseudoBooleanTerm>{-term.coefficient, term.variable};
 
-        ProofBitVariable bit{target, k, true};
-        // upper: Sigma_{j >= k} 2^j e_j + (2^k - 1) >= form  <=>  expr >= 1 - 2^k
-        auto ge = emit_red_proof_line(expr >= 1_i - power2(k), {{bit, TrueLiteral{}}}, level);
-        // lower: Sigma_{j >= k} 2^j e_j <= form  <=>  expr <= 0
-        auto le = emit_red_proof_line(expr <= 0_i, {{bit, FalseLiteral{}}}, level);
+        // The witness must map the underlying proof variable, so when the top
+        // bit is ~sign, setting it means mapping sign to the complement.
+        ProofBitVariable witness_var{target, bit.position, true};
+        ProofLiteralOrFlag bit_on = bit.positive ? ProofLiteralOrFlag{TrueLiteral{}} : ProofLiteralOrFlag{FalseLiteral{}};
+        ProofLiteralOrFlag bit_off = bit.positive ? ProofLiteralOrFlag{FalseLiteral{}} : ProofLiteralOrFlag{TrueLiteral{}};
+
+        // upper: Sigma_{j >= k} 2^j e_j + (2^k - 1) >= form + shift  <=>  expr >= 1 - 2^k + shift
+        auto ge = emit_red_proof_line(expr >= 1_i - power2(k) + shift, {{witness_var, bit_on}}, level);
+        // lower: Sigma_{j >= k} 2^j e_j <= form + shift  <=>  expr <= shift
+        auto le = emit_red_proof_line(expr <= shift, {{witness_var, bit_off}}, level);
         if (kk == 0)
             bounds = {ge, le};
     }

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -320,9 +320,19 @@ namespace gcs::innards
          * normalized linear form, as a conservative extension --- Wietze Koops's
          * decomposition of the form into bits in 2m redundancy steps (top-down,
          * each bit `e_k <-> running-remainder >= 2^k` as a single-literal-witness
-         * red). \c target must have been created with
-         * ProofModel::create_proof_only_integer_variable_in_proof, be non-negative,
-         * and wide enough that `2^m` exceeds the form's maximum value.
+         * red), prefixed by two pol lines deriving the form's own bounds from
+         * its operands' OPB bound rows (which is what lets veripb discharge the
+         * two top-step redundancy goals for any operand shape). \c target must
+         * have been created with
+         * ProofModel::create_proof_only_integer_variable_in_proof, with a range
+         * covering the form's: its value bits must reach the form's maximum, and
+         * if the form's minimum is negative the target must be signed with
+         * `-2^S` at most that minimum (a signed target runs the same
+         * construction shifted by `2^S`, with `~sign` as the top bit). The
+         * form's terms should be integer variables and constants: terms without
+         * OPB bound rows (views, flags, literals) forfeit the derived bound
+         * lines, leaving the top goals to unit propagation, which stalls for
+         * some operand shapes.
          *
          * Returns `{BinEnc(target) >= form, BinEnc(target) <= form}` --- the last
          * two reds --- so the caller can reference the variable's bound-defining

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -345,6 +345,12 @@ auto ProofModel::create_proof_only_integer_variable_in_proof(Integer lower, Inte
     // direct-encoding create_literals_for_introduced_variable_value, in bits.
     ProofOnlySimpleIntegerVariableID id{_imp->proof_only_integer_variable_nr++};
     register_bits_variable_encoding(id, lower, upper, name);
+    // No OPB rows means the [lo, hi] bounds are NOT a trivial consequence of
+    // the model: a need_gevar boundary pin (a top-of-proof RUP line) would
+    // have nothing to propagate from, and would be queued before the caller's
+    // in-proof definition lines even exist. Nothing creates gevars over such
+    // a variable today, so this is a trap-removal, not a behaviour change.
+    names_and_ids_tracker().note_bounds_not_trivially_derivable(id);
     return id;
 }
 
@@ -541,7 +547,7 @@ auto ProofModel::set_up_bits_variable_encoding(
     for (auto & [coeff, var] : bits)
         _imp->opb << coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
     _imp->opb << ">= " << lower << " ;\n";
-    advance_constraint_counter();
+    auto lower_row = advance_constraint_counter();
 
     // upper bound
     if (labelled)
@@ -549,7 +555,17 @@ auto ProofModel::set_up_bits_variable_encoding(
     for (auto & [coeff, var] : bits)
         _imp->opb << -coeff << " " << names_and_ids_tracker().pb_file_string_for(var) << " ";
     _imp->opb << ">= " << -upper << " ;\n";
-    advance_constraint_counter();
+    auto upper_row = advance_constraint_counter();
+
+    // Track the two rows so proof steps can combine them by pol (e.g.
+    // ProofLogger::introduce_bits_of deriving a linear form's own bound
+    // lines): by label for a state variable, so the references stay
+    // count-robust under cake_pb_cp's re-derived OPB, and by constraint
+    // number for a proof-only variable, which never appears in a cake chain.
+    if (labelled)
+        names_and_ids_tracker().track_bound_rows(id, ProofLineLabel{"i[" + name + "][lb]"}, ProofLineLabel{"i[" + name + "][ub]"});
+    else
+        names_and_ids_tracker().track_bound_rows(id, lower_row, upper_row);
 
     if (_imp->always_use_full_encoding)
         overloaded{


### PR DESCRIPTION
## Problem

On the mznc2023 code-generator / unison instance (#553), `fzn-glasgow` completed the solve and wrote the proof, but veripb rejected it: a proofgoal in `introduce_bits_of` could not be autoproven.

The proof-only `end = start + length` proxy in `Cumulative` was created with a hard-coded lower bound of 0. When a task's start can begin before time 0 and has a variable length (unison's inactive tasks sit at `start = -1, length = 0`), the first `le` redundancy step's proofgoal is `start + length >= 0`, which is genuinely false.

## Fix

- **`introduce_bits_of` supports a signed target** via the shift identity `BinEnc + 2^S = 2^S·~sign + Σ 2^j e_j`, and first **derives the linear form's own bound lines by `pol`** over the operands' OPB bound rows, so veripb's implication check discharges the two top-step redundancy goals for any operand shape. Unit propagation alone stalls when an operand's bit encoding overhangs the target's — an adversarial review turned up shapes like `s ∈ [-17,-16], l ∈ [9,16]` that a naïve signed-only fix still failed. This also repairs a pre-existing unsigned stall.
- `Cumulative` gives the end proxy its true lower bound `min(0, lb(s) + lb(l))`.
- `NamesAndIDsTracker` tracks each bits variable's OPB bound-row references (labels for state variables, constraint numbers for proof-only ones).

## Validation

- Full test suite passes (489/489).
- `introduce_bits_test` extended with signed / stall shapes; `cumulative_test` gains negative-start cases (all fail before this change, pass after).
- A 2500-case randomised sweep over cumulative operand shapes: 0 failures.
- **The full 1 GB unison proof now verifies end-to-end**: `s VERIFIED BOUNDS 6340 <= obj <= 6340` (veripb 3.0.2, 4h42m) — the first complete check of this instance.

Fixes #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDQsidr7oKDfCVnDcetf3j
