### PR TITLE
Fix objective-bound proof for {0,1} DirectOnly variables (#554)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -484,6 +484,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(introduce_bits_test PRIVATE glasgow_constraint_solver)
     add_test(NAME introduce_bits_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:introduce_bits_test>)
 
+    add_executable(direct_only_gevar_bound_test innards/proofs/direct_only_gevar_bound_test.cc)
+    target_link_libraries(direct_only_gevar_bound_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME direct_only_gevar_bound_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:direct_only_gevar_bound_test>)
+
     add_executable(invar_test innards/proofs/invar_test.cc)
     target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
     add_test(NAME invar_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)

--- a/gcs/innards/proofs/direct_only_gevar_bound_test.cc
+++ b/gcs/innards/proofs/direct_only_gevar_bound_test.cc
@@ -1,0 +1,49 @@
+#include <gcs/constraints/linear.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+using namespace gcs;
+
+// Regression for issue #554: a {0,1} DirectOnly variable's `>= 1` order atom
+// must be a genuine reified ge-atom line, not the bare bit literal.
+//
+// A weighted `pol` that substitutes a lower-bound atom (justify_linear_bounds,
+// for the objective-bound derivation here) adds `coeff * (x >= L)`'s defining
+// row to cancel the base constraint's `coeff * x` term, leaving `coeff * ~g`
+// and `coeff * L` of degree behind. If `x >= 1` is aliased to the encoding bit
+// b0 (the old {0,1} encoding), `need_pol_item_defining_literal` returns a bare
+// literal, `add_for_literal` pushes the degree-0 axiom `b0 coeff *`, and that
+// axiom CANCELS the base's own `~b0` term outright -- the derived bound comes
+// out `coeff` short and the objective-bound RUP fails to verify.
+//
+// The failure only surfaces when at least two wide, only-lower-bounded bits
+// variables share the objective sum: with one, VeriPB's bitwise unit
+// propagation binary-searches the true bound back out of the raw constraint;
+// with two, every constraint's slack spans the other variable's full range, no
+// bit propagates, and the short bound stands. So: x forced to 1 (coeff 200),
+// z1, z2 in [0, 1023] lower-bounded to 300 (slack 723 > 512, bit-opaque),
+// obj = 200x + z1 + z2. Root propagation infers obj >= 800; the buggy pol
+// derives only obj >= 600, and veripb rejects the bound RUP. (Distilled from
+// the mznc2023 unit-commitment instance, whose objective sum has 59 such
+// terms.) The solve is trivially satisfiable; the proof obligation is the whole
+// point, so run under run_test_and_verify.bash.
+auto main() -> int
+{
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 1_i, "x");
+    auto z1 = p.create_integer_variable(0_i, 1023_i, "z1");
+    auto z2 = p.create_integer_variable(0_i, 1023_i, "z2");
+    auto obj = p.create_integer_variable(0_i, 4095_i, "obj");
+
+    p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * x, 1_i});
+    p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * z1, 300_i});
+    p.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * z2, 300_i});
+    p.post(LinearEquality{WeightedSum{} + 200_i * x + 1_i * z1 + 1_i * z2 + -1_i * obj, 0_i});
+
+    p.minimise(obj);
+
+    solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }}, ProofOptions{"direct_only_gevar_bound_test"});
+
+    return 0;
+}

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -494,12 +494,6 @@ auto NamesAndIDsTracker::track_eqvar(
     _imp->eqvars_that_exist[id].emplace(val, names);
 }
 
-auto NamesAndIDsTracker::track_gevar(
-    SimpleIntegerVariableID id, Integer val, const pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>> & names) -> void
-{
-    _imp->gevars_that_exist[id].emplace(val, names);
-}
-
 auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
 {
     if (_imp->variable_conditions_to_x.contains(id == v))

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -387,13 +387,6 @@ namespace gcs::innards
             -> void;
 
         /**
-         * Track that a given greater-or-equal variable exists, and has a string name
-         * and associated defining constraints.
-         */
-        auto track_gevar(SimpleIntegerVariableID, Integer, const std::pair<std::variant<ProofLine, XLiteral>, std::variant<ProofLine, XLiteral>> &)
-            -> void;
-
-        /**
          * Track that an at-least-one constraint exists for a given variable.
          */
         auto track_variable_takes_at_least_one_value(const SimpleOrProofOnlyIntegerVariableID &, ProofLine) -> void;

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -367,10 +367,21 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
         names_and_ids_tracker().track_variable_name(id, name);
         // Name the single PB variable as bit 0 (`i[name][b0]`), matching how
         // cake_pb_cp encodes a {0,1} variable. For a {0,1} variable the bit-0
-        // literal *is* the (== 1)/(>= 1) literal, so the condition associations
-        // below are unchanged; only the name differs. We still emit just the one
+        // literal *is* the (== 1)/(== 0) literal, so those eq associations below
+        // alias it directly; only the name differs. We still emit just the one
         // (tautological) line -- cake additionally emits an upper-bound line, but
         // VeriPB no longer pins the constraint count, and references are relative.
+        //
+        // The (>= 1)/(< 1) ORDER atom is deliberately NOT aliased to the bit
+        // here (issue #554). A weighted pol that substitutes a lower-bound atom
+        // needs a genuine reified line (`b0 + 1 ~g1 >= 1`, g1 a fresh reif
+        // literal), whose degree and gate term survive the combination; a bare
+        // bit-literal axiom pushed in its place has no degree and cancels the
+        // base constraint's own `~b0` term outright, silently weakening the
+        // derived bound. So leave the >= 1 gevar unset and let need_gevar build
+        // it lazily as the standard reified pair over the bit, exactly as for a
+        // bits-encoded variable. (The two `red` lines are created in-proof on
+        // first use, so the OPB is unchanged.)
         auto eqvar = names_and_ids_tracker().allocate_xliteral_meaning_bit_of(id, 0_i);
         _imp->opb << "1 " << names_and_ids_tracker().pb_file_string_for(eqvar) << " >= 0 ;\n";
         ++_imp->model_variables;
@@ -393,19 +404,6 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
             .visit(id);
 
         names_and_ids_tracker().track_bits(id, 0_i, {{1_i, eqvar}});
-
-        overloaded{
-            [&](const SimpleIntegerVariableID & id) {
-                names_and_ids_tracker().associate_condition_with_xliteral(id >= 1_i, eqvar);
-                names_and_ids_tracker().associate_condition_with_xliteral(id < 1_i, ! eqvar);
-                pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>> names{eqvar, ! eqvar};
-                names_and_ids_tracker().track_gevar(id, 1_i, names);
-            }, //
-            [](const ProofOnlySimpleIntegerVariableID &) {
-                // currently there's no API for asking for literals for these
-            } //
-        }
-            .visit(id);
     }
     else {
         for (auto v = lower; v <= upper; ++v) {


### PR DESCRIPTION
## Problem

On the mznc2023 unit-commitment instance (#554), veripb rejected the proof at a RUP concluding the objective lower bound.

A `{0,1}` DirectOnly variable aliased its `>= 1` order atom to the single encoding bit `b0`. A weighted `pol` that substitutes a lower-bound atom (`justify_linear_bounds`, for the objective-bound derivation) then pushed a bare degree-0 literal axiom `b0 c *`. That axiom cancels the base constraint's own `~b0` term outright, leaving the derived objective bound `c` short — so the bound RUP was not implied.

## Fix

Stop aliasing the `>= 1` gevar to the bit; let `need_gevar` build it lazily as the standard reified ge-atom over the bit (a fresh reification literal), exactly as for a bits-encoded variable. The OPB is **byte-identical** — the ge-atom lines are created in-proof on first use. Removes the now-unused `track_gevar`.

This is the same failure `disjunctive` already carries a local workaround for; fixing the encoding heals all such sites (`global_cardinality`, `abs`) at the choke point instead of one propagator at a time.

## Validation

- Full test suite passes (490/490).
- New `direct_only_gevar_bound_test` fails before this change (RUP not implied) and passes after (`VERIFIED BOUNDS 800 <= obj <= 800`). It needs ≥2 wide, only-lower-bounded companion variables in the objective sum, or veripb's bitwise unit propagation recovers the dropped bound on its own.
- The unit-commitment instance now verifies; OPB byte-identical pre/post.

Fixes #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDQsidr7oKDfCVnDcetf3j
