### PR TITLE
Add negative-number coverage to constraint tests

### DIFF
--- a/gcs/constraints/all_different/all_different_except_test.cc
+++ b/gcs/constraints/all_different/all_different_except_test.cc
@@ -151,6 +151,21 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
     run_alldiffexcept_test(proofs, view_cfg, {{1, 1}, {2, 2}}, {0}); // distinct constants (tautology)
     run_alldiffexcept_test(proofs, view_cfg, {{3, 3}, {3, 3}}, {});  // dup, empty excluded set (contradiction)
 
+    // Negative values and a negative exempt value: the excluded value is cited
+    // value-dependently in the clique !=, the duplicate-forcing initialiser, and
+    // the GAC/phantom-edge reasons, so a negative one drives all of those onto
+    // the negative side of the encoding (the issue #553 class of value citation).
+    // Hall pruning over negative domains with -1 excluded.
+    run_alldiffexcept_test(proofs, view_cfg, {{-2, 2}, {-2, 2}, {-2, 2}}, {-1});
+    // Domains spanning zero, 0 excluded: phantom edges sit on a negative-inclusive domain.
+    run_alldiffexcept_test(proofs, view_cfg, {{-2, 1}, {-2, 1}, {-2, 1}}, {0});
+    // Multiple negative excluded values.
+    run_alldiffexcept_test(proofs, view_cfg, {{-3, 0}, {-3, 0}, {-3, 0}}, {-1, -2});
+    // Infeasible via fixed negative duplicates: -1, -1 with 0 excluded forces -1 != -1.
+    run_alldiffexcept_test(proofs, view_cfg, {{-1, -1}, {-1, -1}}, {0});
+    // All-fixed dup of a negative excluded value: allowed (tautology).
+    run_alldiffexcept_test(proofs, view_cfg, {{-2, -2}, {-2, -2}}, {-2});
+
     if (run_dup) {
         // Same variable in two positions: forces it into the excluded set.
         run_alldiffexcept_dup_test(proofs, {{0, 3}}, {0, 0}, {0});
@@ -159,6 +174,12 @@ auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, bool run_dup) -
         // Same variable in two positions but no value in `excluded` available:
         // infeasible.
         run_alldiffexcept_dup_test(proofs, {{1, 3}}, {0, 0}, {0});
+
+        // Same variable duplicated, forced into a NEGATIVE excluded value: the
+        // initialiser infers x != v for every non-excluded v over a negative-
+        // inclusive domain (issue #553 class).
+        run_alldiffexcept_dup_test(proofs, {{-3, 0}}, {0, 0}, {-1});
+        run_alldiffexcept_dup_test(proofs, {{-2, 1}, {-2, 1}}, {0, 0, 1}, {-1});
 
         // Two unique variables, one duplicated, one not, with two excluded values.
         run_alldiffexcept_dup_test(proofs, {{0, 3}, {0, 3}}, {0, 0, 1}, {0});

--- a/gcs/constraints/disjunctive/disjunctive_test.cc
+++ b/gcs/constraints/disjunctive/disjunctive_test.cc
@@ -338,6 +338,13 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 0}, {1, 1}}, {1, 1}},
         // All-fixed starts that overlap: both span [0,2) (contradiction).
         {{{0, 0}, {1, 1}}, {2, 2}},
+        // Negative start times (issue #553 analog: start times are legitimately
+        // signed, and the before-pol's order-literal / bit-alignment reasoning
+        // rides the operands' sign-bit encoding). Constant lengths here;
+        // variable-length negatives are in var_data below.
+        {{{-2, 1}, {-2, 1}}, {2, 2}},
+        {{{-4, 0}, {-4, 0}}, {1, 3}},
+        {{{-3, -1}, {-3, -1}, {-3, -1}}, {1, 1, 1}},
     };
 
     // Random instances for breadth.
@@ -386,6 +393,14 @@ auto main(int argc, char * argv[]) -> int
         // contradiction-pruned (exercises emit_chain_step's end-proxy).
         {{{0, 6}, {0, 6}}, {{2, 3}, {2, 3}}},
         {{{0, 6}, {0, 6}, {0, 6}}, {{1, 3}, {1, 3}, {1, 3}}},
+        // Negative start times with variable durations: s + l crosses below 0,
+        // so the reified before-sum and its bit-alignment pol run over the
+        // operands' negative / sign-bit encoding (the direct issue #553 analog).
+        // Wide and all-negative windows force bound-pushes (the end-proxy path),
+        // not just contradictions.
+        {{{-3, 1}, {-3, 1}}, {{1, 2}, {1, 2}}},
+        {{{-6, 0}, {-6, 0}}, {{2, 3}, {2, 3}}},
+        {{{-8, -4}, {-8, -4}}, {{2, 3}, {2, 3}}},
     };
 
     // Variable-duration random cases (n=2 or 3, narrow horizons, durations 0-2).

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d_test.cc
@@ -302,6 +302,12 @@ auto main(int argc, char * argv[]) -> int
         {{{0, 0}, {2, 2}}, {{0, 0}, {0, 0}}, {1, 1}, {1, 1}},
         // All-fixed positions overlapping at the origin (contradiction).
         {{{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {1, 1}, {1, 1}},
+        // Negative positions (issue #553 analog: origins are legitimately signed
+        // and the before-pol's bit reasoning rides the operands' sign bits).
+        // Both axes negative, then x-only negative; constant sizes here,
+        // variable-size negatives are in the var calls below.
+        {{{-2, 1}, {-2, 1}}, {{-2, 1}, {-2, 1}}, {2, 2}, {2, 2}},
+        {{{-3, 0}, {-3, 0}}, {{0, 3}, {0, 3}}, {2, 2}, {2, 2}},
     };
 
     mt19937 rand(*get_seed());
@@ -372,6 +378,12 @@ auto main(int argc, char * argv[]) -> int
             run_disjunctive_2d_var_test(proofs, mode, strict, "zero", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {2, 2}}, {{2, 2}, {1, 2}});
             // Both rectangles can be zero-area on either axis.
             run_disjunctive_2d_var_test(proofs, mode, strict, "zero2", {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}}, {{0, 2}, {0, 2}});
+            // Negative origins with variable sizes: pos + size crosses below 0 on
+            // both axes, so the reified before-sum and its end-proxy bit encoding
+            // run over the operands' negative / sign-bit encoding (the direct
+            // issue #553 analog). "neg" is tight; "neg_wide" forces bound-pushes.
+            run_disjunctive_2d_var_test(proofs, mode, strict, "neg", {{-2, 1}, {-2, 1}}, {{-2, 1}, {-2, 1}}, {{1, 2}, {1, 2}}, {{1, 2}, {1, 2}});
+            run_disjunctive_2d_var_test(proofs, mode, strict, "neg_wide", {{-4, 0}, {-4, 0}}, {{-3, 0}, {-3, 0}}, {{2, 4}, {1, 3}}, {{1, 3}, {2, 4}});
         }
     }
 

--- a/gcs/constraints/linear/linear_constant_test.cc
+++ b/gcs/constraints/linear/linear_constant_test.cc
@@ -98,6 +98,32 @@ auto main(int argc, char * argv[]) -> int
             auto y = p.create_integer_variable(5_i, 5_i, "y");
             p.post(LinearEquality{WeightedSum{} + 1_i * y + 1_i * 3_c, 8_i});
         });
+
+        // Negative constant terms / RHS: the empty-sum shortcut compares the
+        // folded constant against the RHS with everything crossing zero, so a
+        // sign error in the fold surfaces only here. (Constant terms are formed
+        // with a negative coefficient, since `_c` literals are non-negative.)
+        run_constant_linear_test(
+            proofs, "-1*1 == -1 (tautology)", true, [](Problem & p) { p.post(LinearEquality{WeightedSum{} + -1_i * 1_c, -1_i}); });
+        run_constant_linear_test(
+            proofs, "-1*1 == 0 (contradiction)", false, [](Problem & p) { p.post(LinearEquality{WeightedSum{} + -1_i * 1_c, 0_i}); });
+        run_constant_linear_test(
+            proofs, "-2*3 == -6 (tautology, coeff != 1)", true, [](Problem & p) { p.post(LinearEquality{WeightedSum{} + -2_i * 3_c, -6_i}); });
+        run_constant_linear_test(
+            proofs, "-2*3 == -5 (contradiction, coeff != 1)", false, [](Problem & p) { p.post(LinearEquality{WeightedSum{} + -2_i * 3_c, -5_i}); });
+
+        // LinearNotEquals with negatives.
+        run_constant_linear_test(
+            proofs, "-1*1 != -1 (contradiction)", false, [](Problem & p) { p.post(LinearNotEquals{WeightedSum{} + -1_i * 1_c, -1_i}); });
+        run_constant_linear_test(
+            proofs, "-1*1 != 0 (tautology)", true, [](Problem & p) { p.post(LinearNotEquals{WeightedSum{} + -1_i * 1_c, 0_i}); });
+
+        // Mixed with a negative variable value and a negative folded constant:
+        // y(=-5) + (-3) == -8 leaves a non-empty sum whose modifier is negative.
+        run_constant_linear_test(proofs, "y(=-5) + (-3) == -8 (tautology, constant folded)", true, [](Problem & p) {
+            auto y = p.create_integer_variable(-5_i, -5_i, "y");
+            p.post(LinearEquality{WeightedSum{} + 1_i * y + -1_i * 3_c, -8_i});
+        });
     }
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -349,6 +349,18 @@ auto main(int argc, char * argv[]) -> int
 
     data.emplace_back(pair{0, 1}, pair{0, 1}, pair{0, 1}, vector{pair{vector{1, 1, 1}, 2}});
 
+    // {0,1}-domain variables carrying NEGATIVE coefficients, alongside a wider
+    // variable so a bound is actually pushed: the bound justification
+    // (justify_linear_bounds) then substitutes a negative-coefficient lower/upper
+    // bound atom on a {0,1} variable -- the shape issue #554 was about, where a
+    // bit-aliased >= 1 atom cancelled its term in the bound pol. The random
+    // generator never produces width-1 domains, so this is only reached here.
+    data.emplace_back(pair{0, 1}, pair{0, 1}, pair{0, 5}, vector{pair{vector{-2, -3, 1}, 0}});
+
+    data.emplace_back(pair{0, 1}, pair{0, 1}, pair{-5, 0}, vector{pair{vector{-2, 3, -1}, 0}});
+
+    data.emplace_back(pair{0, 1}, pair{2, 6}, pair{0, 1}, vector{pair{vector{-4, 1, -2}, -1}});
+
     data.emplace_back(pair{-7, 5}, pair{7, 12}, pair{-3, 12}, vector{pair{vector{4, -8, 10}, 94}});
 
     data.emplace_back(pair{8, 14}, pair{0, 8}, pair{4, 19}, vector{pair{vector{-7, 6, 7}, 69}});


### PR DESCRIPTION
## What

Adds negative-number cases to five constraint tests. Motivated by #553 and #554 — both proof-logging bugs that a negative test value would have caught — this is the coverage half of an audit of all 60 constraint tests: adding negatives on the paths where a negative value is meaningful **and** the propagator or its proof logging is sign-dependent.

## Cases added

- **`disjunctive` / `disjunctive_2d`** — negative start times / positions (constant and variable length/size, including all-negative windows). Start times are the direct #553 role. These constraints fold `s + l` into reified sums over the *real* start variables (no proof-only `end` proxy, unlike `cumulative`), so they verify cleanly — the negative coverage confirms that.
- **`linear_constant`** — negative constant terms, RHS, and modifier, so the empty-sum constant-folding shortcut is exercised with the comparison crossing zero.
- **`all_different_except`** — negative exempt values: Hall pruning over negative domains, and a variable forced into a negative excluded value. A negative exempt value drives the value-dependent citations (`vars[i] != s`, phantom edges, GAC reasons) onto the negative side of the encoding.
- **`linear`** — `{0,1}`-domain variables carrying **negative coefficients**, so the bound justification (`justify_linear_bounds`) substitutes a negative-coefficient bound atom on a `{0,1}` variable — the #554 shape, which the width≥5 random generator never produces.

## Validation

Full suite passes (489/489). Each added case verifies under veripb.

## Note

The audit also turned up a real proof bug — a closed-mode `global_cardinality` RUP failure on cover sets that span zero — filed separately as #557. Negative `global_cardinality` coverage is deliberately **not** included here: it would be flaky against that bug, so it's deferred to the #557 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDQsidr7oKDfCVnDcetf3j
