### PR TITLE
Fix invalid GCC proof from loose at-most-one over aliased {0,1} variables (#557)

### DIFF
--- a/gcs/constraints/among/among_test.cc
+++ b/gcs/constraints/among/among_test.cc
@@ -182,15 +182,23 @@ auto main(int argc, char * argv[]) -> int
         {pair{1, 5}, vector{2, 3, 2, 3, 3}, {pair{1, 5}, pair{1, 5}, pair{1, 5}}}, //
         // Degenerate cases (issue #254): empty array, empty value set,
         // single element, all-constant. Result is a genuine constant.
-        {0, vector{2, 3}, {}},                      // empty array: 0 in set (tautology)
-        {1, vector{2, 3}, {}},                      // empty array: can't be 1 (contradiction)
-        {0, vector<int>{}, {5, 5, 5}},              // empty value set: nothing matches (tautology)
-        {1, vector<int>{}, {5, 5, 5}},              // empty value set: can't be 1 (contradiction)
-        {1, vector{5}, {5}},                        // single element matches (tautology)
-        {1, vector{5}, {6}},                        // single element, no match (contradiction)
-        {2, vector{5, 6}, {5, 6, 7}},               // all-constant array: 2 match (tautology)
-        {3, vector{5, 6}, {5, 6, 7}},               // all-constant array: only 2 match (contradiction)
-        {pair{0, 2}, vector{5}, {5, pair{1, 10}}}}; // mixed: one constant match + one variable
+        {0, vector{2, 3}, {}},                     // empty array: 0 in set (tautology)
+        {1, vector{2, 3}, {}},                     // empty array: can't be 1 (contradiction)
+        {0, vector<int>{}, {5, 5, 5}},             // empty value set: nothing matches (tautology)
+        {1, vector<int>{}, {5, 5, 5}},             // empty value set: can't be 1 (contradiction)
+        {1, vector{5}, {5}},                       // single element matches (tautology)
+        {1, vector{5}, {6}},                       // single element, no match (contradiction)
+        {2, vector{5, 6}, {5, 6, 7}},              // all-constant array: 2 match (tautology)
+        {3, vector{5, 6}, {5, 6, 7}},              // all-constant array: only 2 match (contradiction)
+        {pair{0, 2}, vector{5}, {5, pair{1, 10}}}, // mixed: one constant match + one variable
+        // Bit-aliased {0,1}-domain array variables with a value-of-interest set
+        // that contains both 0 and 1 plus another value, ordered so the
+        // complementary pair (var != 0 = b0, var != 1 = ~b0) is NOT first in the
+        // per-variable at-most-one. Among tolerates the loose pre-#557 line, so
+        // this does not fail without the fix, but it exercises the fixed
+        // recover_am1 block scheme on the Top-level (cached-initialiser) path that
+        // the GlobalCardinality demand aggregate shares at Temporary level.
+        {pair{0, 3}, vector{5, 0, 1}, {pair{0, 1}, pair{0, 5}, pair{0, 1}}}};
 
     mt19937 rand(*get_seed());
     for (int x = 0; x < 10; ++x) {

--- a/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/bounds_global_cardinality_test.cc
@@ -119,6 +119,20 @@ auto main(int argc, char * argv[]) -> int
         {{pair{1, 2}, pair{1, 2}}, {1, 2}, {pair{0, 2}, pair{0, 2}}, false},
         // Closed.
         {{pair{1, 3}, pair{1, 3}, pair{2, 3}}, {1, 2, 3}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
+        // Cover values spanning zero, with a bit-aliased {0,1}-domain variable in
+        // the Hall set (issue #557): the aliased variable's (== 0)/(== 1) atoms are
+        // ~b0/b0, a complementary pair, which made the demand-aggregate at-most-one
+        // loose and broke the proof. These faithful negative mirrors of the
+        // positive cases above exercise the fixed recover_am1 block scheme. Closed
+        // span-zero (the primary reproducer): fails ~half the branching seeds
+        // before the fix.
+        {{pair{-1, 1}, pair{-1, 1}, pair{0, 1}}, {-1, 0, 1}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
+        // Upper-capacity Hall, all-negative-plus-zero domains: three vars confined
+        // to {-2,-1} with capacity 2+1 force the fourth off value -1.
+        {{pair{-2, -1}, pair{-2, -1}, pair{-2, -1}, pair{-2, 0}}, {-2, -1}, {pair{0, 2}, pair{0, 1}}, false},
+        // Lower-demand Hall over a span-zero cover: value -1 demanded twice with a
+        // {0,1}-aliased supplier among the potential vars.
+        {{pair{-2, 1}, pair{-2, 1}, pair{-1, 2}}, {-2, -1}, {pair{2, 3}, pair{0, 3}}, false},
         // Bounded form, value absent from a domain.
         {{pair{1, 3}, pair{1, 3}, pair{1, 3}}, {1, 2}, {pair{1, 3}, pair{0, 1}}, false},
         // Degenerate cases (issue #254): empty vars, empty value set, single

--- a/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
+++ b/gcs/constraints/global_cardinality/gac_global_cardinality_test.cc
@@ -116,6 +116,15 @@ auto main(int argc, char * argv[]) -> int
         {{pair{1, 2}, pair{1, 2}}, {1, 2}, {pair{0, 2}, pair{0, 2}}, false},
         // Closed.
         {{pair{1, 3}, pair{1, 3}, pair{2, 3}}, {1, 2, 3}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
+        // Cover values spanning zero, with a bit-aliased {0,1}-domain variable in
+        // the Hall set (issue #557): its (== 0)/(== 1) atoms are the complementary
+        // pair ~b0/b0, which made the demand-aggregate at-most-one loose and broke
+        // the proof (emit_gcc_demand_pol). Exercises the fixed recover_am1 block
+        // scheme; the closed span-zero case fails a fraction of branching seeds
+        // before the fix.
+        {{pair{-1, 1}, pair{-1, 1}, pair{0, 1}}, {-1, 0, 1}, {pair{0, 3}, pair{0, 3}, pair{0, 3}}, true},
+        // Lower-demand Hall over a span-zero cover with a {0,1}-aliased supplier.
+        {{pair{-2, 1}, pair{-2, 1}, pair{-1, 2}}, {-2, -1}, {pair{2, 3}, pair{0, 3}}, false},
         // A GAC-only pruning: AllDifferent-style Hall set (each value once).
         {{pair{1, 2}, pair{1, 2}, pair{1, 3}}, {1, 2, 3}, {pair{0, 1}, pair{0, 1}, pair{0, 1}}, false},
         // Degenerate cases (issue #254): empty vars, empty value set, single

--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -1,13 +1,17 @@
 #include <gcs/constraints/innards/recover_am1.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 
 #include <gcs/proof.hh>
 #include <util/enumerate.hh>
+#include <util/overloaded.hh>
 
+#include <optional>
 #include <sstream>
 #include <type_traits>
+#include <utility>
 #include <variant>
 
 using namespace gcs;
@@ -16,6 +20,9 @@ using namespace gcs::innards;
 using std::function;
 using std::holds_alternative;
 using std::is_same_v;
+using std::nullopt;
+using std::optional;
+using std::pair;
 using std::vector;
 
 template <typename Literal_>
@@ -57,6 +64,46 @@ template <typename Literal_>
         }
     }
 
+    // Detect a complementary literal pair among the atoms: two atoms that are the
+    // same underlying proof literal with opposite polarity. This arises when a
+    // bit-aliased two-value variable contributes two of the atoms -- e.g. a
+    // {0,1}-domain variable whose (== 1)/(== 0) atoms *are* the single bit b0 /
+    // ~b0, so an at-most-one over {var == 0, var == 1, ...} contains {~b0, b0}.
+    // The generic pairwise->global fold below is not tight in that case: the
+    // tautological pair line (b0 + ~b0 >= 1) normalises to a constant
+    // mid-derivation, and the ceiling-division renormalisation then discards a
+    // unit, yielding a loose at-most-one that leaves a residual literal in any pol
+    // that sums it (issue #557; a sibling of the #554 gevar-aliasing bug). Only
+    // GlobalCardinality passes several value-conditions on the *same* variable, so
+    // it is the only caller that can hit this; every other caller passes
+    // conditions over distinct variables, finds no pair, and takes the generic
+    // path with byte-identical output. A "not found" lookup means the literal is
+    // unaliased/fresh and so cannot be half of a pair, which is the safe default.
+    auto atom_xliteral = [&](const Literal_ & atom) -> optional<XLiteral> {
+        if constexpr (is_same_v<Literal_, ProofFlag>)
+            return logger.names_and_ids_tracker().find_xliteral_for(atom);
+        else
+            return overloaded{//
+                [](const TrueLiteral &) -> optional<XLiteral> { return nullopt; }, [](const FalseLiteral &) -> optional<XLiteral> { return nullopt; },
+                [&](const auto & cond) -> optional<XLiteral> { return logger.names_and_ids_tracker().find_xliteral_for(cond); }}
+                .visit(simplify_literal(logger.names_and_ids_tracker(), atom));
+    };
+
+    optional<pair<unsigned, unsigned>> complementary_pair;
+    {
+        vector<optional<XLiteral>> xs;
+        xs.reserve(atoms.size());
+        for (const auto & atom : atoms)
+            xs.push_back(atom_xliteral(atom));
+        for (unsigned i = 0; i < atoms.size() && ! complementary_pair; ++i)
+            if (xs[i])
+                for (unsigned j = i + 1; j < atoms.size(); ++j)
+                    if (xs[j] && *xs[i] == ! *xs[j]) {
+                        complementary_pair = pair<unsigned, unsigned>{i, j};
+                        break;
+                    }
+    }
+
     // pair_ne callbacks typically emit intermediate proof lines at Temporary
     // level. Without isolation, those lines would share the caller's
     // Temporary depth (active_proof_level + 1) — and our cleanup at that
@@ -89,12 +136,43 @@ template <typename Literal_>
     // workflow-2 when cake_pb_cp re-derives the OPB with a different constraint
     // count.
     PolBuilder am1;
-    for (unsigned i1 = 1; i1 < atoms.size(); ++i1) {
-        if (i1 != 1)
-            am1.multiply_by(Integer{static_cast<long long>(i1 + 1)});
-        for (unsigned i2 = 0; i2 < i1; ++i2)
-            am1.add(pair_ne(atoms[i1], atoms[i2]));
-        am1.divide_by(Integer{static_cast<long long>(i1 + 2)});
+    if (complementary_pair && atoms.size() >= 3) {
+        // Block scheme for the degenerate complementary-pair case (issue #557).
+        // With a pair (p, q) where atoms[q] == !atoms[p], every other atom a_k is
+        // forced false: pair_ne(a_k, a_p) + pair_ne(a_k, a_q) = 2 ~a_k + (~a_p +
+        // ~a_q), and because the pair is complementary the bracket folds to the
+        // constant 1, so dividing by 2 gives exactly ~a_k >= 1. Accumulating each
+        // further other atom the same way (multiply the running sum by 2, add its
+        // two pair lines, divide by 2) keeps every coefficient at exactly the
+        // divisor and never rounds a unit away -- the property the generic fold
+        // loses. The result is the tight Sum_{k != p, q} ~a_k >= n - 2, which is
+        // the PB-normal form of the global at-most-one Sum ~a >= n - 1 (the pair
+        // itself contributes the folded-away +1). With n >= 3 there is at least
+        // one other atom, so the builder is never empty. (n == 2 with a pair is
+        // left to the generic fold below, which already yields the correct trivial
+        // 0 >= 0.) Two or more pairs -- unreachable from in-tree callers -- still
+        // come out exactly, as the infeasible-strength 0 >= 1.
+        auto [p, q] = *complementary_pair;
+        bool first = true;
+        for (unsigned k = 0; k < atoms.size(); ++k) {
+            if (k == p || k == q)
+                continue;
+            if (! first)
+                am1.multiply_by(2_i);
+            am1.add(pair_ne(atoms[k], atoms[p]));
+            am1.add(pair_ne(atoms[k], atoms[q]));
+            am1.divide_by(2_i);
+            first = false;
+        }
+    }
+    else {
+        for (unsigned i1 = 1; i1 < atoms.size(); ++i1) {
+            if (i1 != 1)
+                am1.multiply_by(Integer{static_cast<long long>(i1 + 1)});
+            for (unsigned i2 = 0; i2 < i1; ++i2)
+                am1.add(pair_ne(atoms[i1], atoms[i2]));
+            am1.divide_by(Integer{static_cast<long long>(i1 + 2)});
+        }
     }
 
     // Restore the caller's level, then emit the result there (its level is

--- a/gcs/constraints/innards/recover_am1.cc
+++ b/gcs/constraints/innards/recover_am1.cc
@@ -83,8 +83,9 @@ template <typename Literal_>
         if constexpr (is_same_v<Literal_, ProofFlag>)
             return logger.names_and_ids_tracker().find_xliteral_for(atom);
         else
-            return overloaded{//
-                [](const TrueLiteral &) -> optional<XLiteral> { return nullopt; }, [](const FalseLiteral &) -> optional<XLiteral> { return nullopt; },
+            return overloaded{                                                      //
+                [](const TrueLiteral &) -> optional<XLiteral> { return nullopt; },  //
+                [](const FalseLiteral &) -> optional<XLiteral> { return nullopt; }, //
                 [&](const auto & cond) -> optional<XLiteral> { return logger.names_and_ids_tracker().find_xliteral_for(cond); }}
                 .visit(simplify_literal(logger.names_and_ids_tracker(), atom));
     };

--- a/gcs/constraints/innards/recover_am1.hh
+++ b/gcs/constraints/innards/recover_am1.hh
@@ -31,6 +31,18 @@ namespace gcs::innards
      * using division to renormalise coefficients to 1. The result is a PB
      * normal-form line whose literal coefficients are all 1.
      *
+     * If two atoms are a complementary literal pair (the same underlying proof
+     * literal with opposite polarity, e.g. <em>b</em> and <em>&not;b</em> from a
+     * bit-aliased two-value variable), the generic fold is not tight, so the
+     * helper switches to a dedicated derivation. Its result is then the PB
+     * normal form of the at-most-one after the pair folds to a constant:
+     * <em>&Sigma;<sub>k not in pair</sub> &not;a_k &ge; n - 2</em>, which is
+     * equivalent to <em>&Sigma; &not;a_k &ge; n - 1</em>. (See issue #557: the
+     * loose generic result left a residual literal that broke aggregating pols in
+     * <code>GlobalCardinality</code> — the only caller that passes several
+     * conditions on one variable and so the only one that can produce such a
+     * pair.)
+     *
      * The result line is emitted at the requested <code>ProofLevel</code>
      * (typically <code>Top</code> when the helper is called from an
      * initialiser and the result is cached for reuse, or

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -1540,11 +1540,27 @@ auto NamesAndIDsTracker::xliteral_for(const ProofFlag & flag) const -> const XLi
     return f->second;
 }
 
+auto NamesAndIDsTracker::find_xliteral_for(const ProofFlag & flag) const -> optional<XLiteral>
+{
+    auto f = _imp->flags.find(flag);
+    if (f == _imp->flags.end())
+        return nullopt;
+    return f->second;
+}
+
 auto NamesAndIDsTracker::xliteral_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> const XLiteral
 {
     auto f = _imp->variable_conditions_to_x.find(cond);
     if (f == _imp->variable_conditions_to_x.end())
         throw ProofError{"can't find literals for cond"};
+    return f->second;
+}
+
+auto NamesAndIDsTracker::find_xliteral_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> & cond) const -> optional<XLiteral>
+{
+    auto f = _imp->variable_conditions_to_x.find(cond);
+    if (f == _imp->variable_conditions_to_x.end())
+        return nullopt;
     return f->second;
 }
 

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -321,6 +321,15 @@ namespace gcs::innards
         [[nodiscard]] auto xliteral_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> const XLiteral;
 
         /**
+         * Like xliteral_for, but returns nullopt instead of throwing when the
+         * condition has no registered XLiteral. A condition is registered iff it
+         * (or its negation) has been introduced --- so "not found" means the
+         * literal is fresh/unaliased, which callers can use to reason about
+         * whether two atoms could be the same underlying bit.
+         */
+        [[nodiscard]] auto find_xliteral_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> std::optional<XLiteral>;
+
+        /**
          * Return a string form of a raw proof literal, for writing to a model or log.
          */
         [[nodiscard]] auto pb_file_string_for(const VariableConditionFrom<SimpleOrProofOnlyIntegerVariableID> &) const -> std::string;
@@ -334,6 +343,12 @@ namespace gcs::innards
          * Return the raw proof literal representing a proof flag, for writing to a model or log.
          */
         [[nodiscard]] auto xliteral_for(const ProofFlag &) const -> const XLiteral;
+
+        /**
+         * Like xliteral_for, but returns nullopt instead of throwing when the flag
+         * has no registered XLiteral.
+         */
+        [[nodiscard]] auto find_xliteral_for(const ProofFlag &) const -> std::optional<XLiteral>;
 
         /**
          * Return a string form of a proof flag, for writing to a model or log. Same as calling


### PR DESCRIPTION
Fixes #557.

## The bug

`GlobalCardinality` (bounds **and** GAC) in closed mode with a cover set spanning zero emits a proof VeriPB rejects with a RUP failure. The solve is correct; only the proof is invalid, and it is branch-order dependent (~15/30 random BC seeds, ~1/30 GAC).

## Root cause

The demand-side Hall aggregates build a per-variable at-most-one `Σ_{v∈cut} [var==v] ≤ 1` via `recover_am1`. A bit-aliased two-value variable — e.g. a `{0,1}` domain, encoded as a single bit `b0` so `var==0 ≡ ~b0` and `var==1 ≡ b0` — contributes two atoms that are a **complementary literal pair** `{~b0, b0}`. `recover_am1`'s incremental multiply/divide fold is not tight there: the tautological pair line normalises to a constant mid-derivation, and the ceiling division then discards a unit, producing a **loose** at-most-one. Summed into the demand `pol` this leaves a residual bit term (`i3b0`), so the wrapping RUP is not implied.

The "cover spans zero" framing in the issue is a proxy: the real trigger is a bit-aliased `{2k,2k+1}` domain in the Hall cut, which the issue's positive-shift control (`{0,1}→{1,2}`) accidentally removed by giving that variable a second bit.

This is a sibling of #554 — the `{0,1}` single-bit aliasing interfering with a `pol` construction. The encoding is deliberately matched to `cake_pb_cp` (workflow 2), so the fix makes the pol helper **alias-robust** rather than changing the encoding.

## The fix

`recover_am1` now detects a complementary literal pair among its atoms (via a new non-throwing `NamesAndIDsTracker::find_xliteral_for`, since complementarity is an `XLiteral`-level fact) and, for ≥3 atoms, derives the tight at-most-one with a dedicated **block scheme**: for each non-pair atom `a_k`, `pair_ne(a_k, a_p) + pair_ne(a_k, a_q) = 2·~a_k + (~a_p + ~a_q)`; the complementary bracket folds to the constant 1, so dividing by 2 gives exactly `~a_k ≥ 1`. Every coefficient stays at the divisor and no unit is ever rounded away, so the result is the tight `Σ_{k∉pair} ~a_k ≥ n−2` (the PB normal form of `Σ~a ≥ n−1`).

- **Byte-identical for non-degenerate inputs** — they take the unchanged generic fold.
- Only `GlobalCardinality` passes several value-conditions on one variable, so it is the only caller that can produce a pair. `among`, `inverse`, `symmetric_all_different`, and `sort` pass conditions over distinct variables and are unaffected (verified: full suite green).
- The degenerate line is *strictly stronger*, so nothing that verified before can break.

## Testing

- All 6 reproducer shapes × {BC, GAC} × 30 seeds now verify (0/360 failures; the closed span-zero shape was 15/30 BC before).
- Regression cases added to `bounds_global_cardinality_test` and `gac_global_cardinality_test` (faithful spanning-zero mirrors; the closed case fails ~6/20 BC and 1/20 GAC seeds **without** the fix, 0 **with**), plus an `among` case exercising the Top-level block scheme.
- Full suite: **416/416**, caps off (`GCS_TEST_CAP_DEFAULTS=OFF`), veripb + MiniZinc.

## Follow-up

A separate latent aliasing corner found during this work — `need_pol_item_defining_literal` returns the wrong-polarity item for value 0 of an aliased `{0,1}` variable — is filed as #559 (latent, no live caller; not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
