### PR TITLE
Fix inverted eq-atom pol-item polarity for value 0 of aliased {0,1} variables (#559)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -480,6 +480,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(proof_model_tautology_test PRIVATE glasgow_constraint_solver)
     add_test(NAME proof_model_tautology_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:proof_model_tautology_test>)
 
+    add_executable(eqvar_polarity_test innards/proofs/eqvar_polarity_test.cc)
+    target_link_libraries(eqvar_polarity_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME eqvar_polarity_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eqvar_polarity_test>)
+
     add_executable(introduce_bits_test innards/proofs/introduce_bits_test.cc)
     target_link_libraries(introduce_bits_test PRIVATE glasgow_constraint_solver)
     add_test(NAME introduce_bits_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:introduce_bits_test>)

--- a/gcs/innards/proofs/eqvar_polarity_test.cc
+++ b/gcs/innards/proofs/eqvar_polarity_test.cc
@@ -1,0 +1,63 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <optional>
+#include <variant>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::get_if;
+using std::nullopt;
+
+// Regression for issue #559. A real (state) {0,1} variable takes the
+// direct-only single-bit encoding, so its eq/ne atoms are primitive bit
+// literals: id == 1 and id != 0 are the bit eqvar, id == 0 and id != 1 are
+// ~eqvar. For such a primitive atom the pol item that
+// need_pol_item_defining_literal returns (and that add_for_literal would push
+// as a term) must be the atom's own literal, i.e. xliteral_for(atom). Before
+// the fix, track_eqvar stored value 1's (eqvar, ~eqvar) pair for value 0 as
+// well, so need_pol_item_defining_literal(id == 0) returned eqvar where
+// id == 0 is ~eqvar -- the opposite polarity -- silently corrupting any pol
+// that cited the value-0 eq/ne atom.
+auto main() -> int
+{
+    ProofOptions proof_options{"eqvar_polarity_test"};
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+
+    SimpleIntegerVariableID x{0};
+    model.set_up_integer_variable(x, 0_i, 1_i, "x", nullopt);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    // The pol-defining item of each aliased eq/ne atom must be a raw XLiteral
+    // equal to that atom's own literal.
+    auto consistent = [&](const VariableConditionFrom<SimpleIntegerVariableID> & cond) -> bool {
+        auto item = tracker.need_pol_item_defining_literal(cond);
+        auto * xlit = get_if<XLiteral>(&item);
+        return xlit && *xlit == tracker.xliteral_for(cond);
+    };
+
+    int rc = 0;
+    if (! consistent(x == 0_i))
+        rc = 1;
+    if (! consistent(x == 1_i))
+        rc = 1;
+    if (! consistent(x != 0_i))
+        rc = 1;
+    if (! consistent(x != 1_i))
+        rc = 1;
+
+    logger.conclude_none();
+    tracker.finalise();
+
+    return rc;
+}

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -382,9 +382,16 @@ auto ProofModel::set_up_direct_only_variable_encoding(SimpleOrProofOnlyIntegerVa
                 names_and_ids_tracker().associate_condition_with_xliteral(id != 1_i, ! eqvar);
                 names_and_ids_tracker().associate_condition_with_xliteral(id == 0_i, ! eqvar);
                 names_and_ids_tracker().associate_condition_with_xliteral(id != 0_i, eqvar);
-                pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>> names{eqvar, ! eqvar};
-                names_and_ids_tracker().track_eqvar(id, 1_i, names);
-                names_and_ids_tracker().track_eqvar(id, 0_i, names);
+                // track_eqvar stores the (== v, != v) pol-item pair that
+                // need_pol_item_defining_literal returns. For value 1 the eq atom
+                // is eqvar and the disequality is !eqvar; for value 0 the polarity
+                // is flipped (id == 0 is !eqvar, id != 0 is eqvar), so value 0 gets
+                // the swapped pair -- otherwise need_pol_item_defining_literal(id ==
+                // 0) / (id != 0) would return the opposite-polarity bit (issue #559).
+                pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>> names_1{eqvar, ! eqvar};
+                names_and_ids_tracker().track_eqvar(id, 1_i, names_1);
+                pair<variant<ProofLine, XLiteral>, variant<ProofLine, XLiteral>> names_0{! eqvar, eqvar};
+                names_and_ids_tracker().track_eqvar(id, 0_i, names_0);
             }, //
             [](const ProofOnlySimpleIntegerVariableID &) {
                 // currently there's no API for asking for literals for these


### PR DESCRIPTION
Fixes #559.

## The bug

A real (state) `{0,1}` variable takes the direct-only single-bit encoding (`set_up_direct_only_variable_encoding`), so its eq/ne atoms are primitive bit literals:

| condition | literal |
|---|---|
| `id == 1` / `id != 0` | `eqvar` (`b0`) |
| `id == 0` / `id != 1` | `~eqvar` (`~b0`) |

The condition→literal associations were registered correctly, but `track_eqvar` stored value 1's `(eqvar, ~eqvar)` pol-item pair for value **0** as well:

```cpp
pair<...> names{eqvar, ! eqvar};
track_eqvar(id, 1_i, names);
track_eqvar(id, 0_i, names);   // <-- value 0 reuses value 1's pair
```

`need_pol_item_defining_literal` returns `.first` for `Equal` and `.second` for `NotEqual`, so for value 0 it returned the **opposite-polarity** bit:
- `need_pol_item_defining_literal(id == 0)` → `eqvar` (`b0`), but `id == 0` is `~b0`
- `need_pol_item_defining_literal(id != 0)` → `~eqvar` (`~b0`), but `id != 0` is `b0`

## Impact

Latent. No current caller consumes the returned item for a value-0 eq atom: `product_justify` and `disjunctive` discard the `XLiteral` case and only cite `ProofLine` definitions, and `add_for_literal` — the one consumer that would push the item as a pol term — is only ever called with bound (`>=`/`<`) literals. But `add_for_literal(id == 0)` / `(id != 0)` on such a variable would silently push the wrong-polarity bit and corrupt the pol. It's the same `{0,1}`-aliasing family as #554 and #557, found while fixing the latter.

## The fix

Store the swapped `(~eqvar, eqvar)` pair for value 0, so the pol item matches `xliteral_for` for both values. One-liner plus a comment.

## Testing

- New `eqvar_polarity_test` (a tracker-level test, in the style of `invar_test`): for a real `{0,1}` variable it asserts `need_pol_item_defining_literal(cond)` is a raw `XLiteral` equal to `xliteral_for(cond)` for `cond ∈ {== 0, == 1, != 0, != 1}`. It **fails without** the fix (returns non-zero) and **passes with** it (and veripb verifies the trivial proof).
- Full suite: **417/417**, caps off (`GCS_TEST_CAP_DEFAULTS=OFF`). The fix changes no existing proof, since nothing cites the value-0 eq pol-item today.

Found by Claude Code (proof consultant) during the #557 fix (#560).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
