### PR TITLE
Consistent proof-file disposal policy, via GCS_PRESERVE_PROOF_FILES

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -719,6 +719,42 @@ GCS_TEST_MAX_SOLUTIONS= GCS_TEST_MAX_RECURSIONS= ./build/foo_test
 The capped defaults are for keeping the *routine* parallel suite fast;
 correctness work wants the full enumeration check.
 
+### What happens to the proof files
+
+`verify_proof_and_clean_up` runs VeriPB and then, **by default, deletes**
+the `.opb`, `.pbp`, `.scp` and `.varmap` it just checked. This is not
+merely tidiness: a `.pbp` for an enumeration test can reach hundreds of
+megabytes, and a full parallel `ctest` that kept them all would hold
+gigabytes at once — enough to exhaust the disk mid-run and make an
+*unrelated* lane's proof write fail. Deleting each proof as it verifies
+bounds the footprint to the lanes running concurrently.
+
+Files are **always kept when verification fails**, whatever the policy.
+Since a failed verification throws, and no test catches
+`UnexpectedException`, the run stops at the first bad proof — so the
+files left under the bare proof name are exactly the failing instance's,
+identified by the test's own log line just above them. That is why the
+default needs no counter.
+
+`GCS_PRESERVE_PROOF_FILES` overrides the policy:
+
+| Value | Behaviour |
+|-------|-----------|
+| unset, empty, `0` | delete once verified (the default) |
+| any other value, e.g. `1` | keep, letting the next instance overwrite in place |
+| `all` | keep every instance, renamed with a zero-padded per-basename counter |
+
+Use `1` to inspect the proof a test just produced. Use `all` only when
+harvesting proofs across instances — comparing proof bytes before and
+after a change, say. A single test can write hundreds of proofs under one
+basename (`equals_test` writes 284), so `all` combined with
+`-DGCS_TEST_CAP_DEFAULTS=OFF` can fill a disk.
+
+```shell
+GCS_PRESERVE_PROOF_FILES=1 ./build/equals_test     # keep the last of each
+GCS_PRESERVE_PROOF_FILES=all ./build/equals_test   # equals_test.0001.pbp, ...
+```
+
 ## Adding a new constraint: checklist
 
 1. Header file with class declaration, Doxygen comments, the standard

--- a/gcs/constraints/circuit/circuit_disconnected_test.cc
+++ b/gcs/constraints/circuit/circuit_disconnected_test.cc
@@ -64,7 +64,7 @@ auto main(int argc, char * argv[]) -> int
     cout << stats;
 
     if (proof_name)
-        if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
+        if (! verify_proof_and_dispose(*proof_name))
             return EXIT_FAILURE;
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/circuit/circuit_multiple_sccs_test.cc
+++ b/gcs/constraints/circuit/circuit_multiple_sccs_test.cc
@@ -78,7 +78,7 @@ auto main(int argc, char * argv[]) -> int
     cout << stats;
 
     if (proof_name)
-        if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
+        if (! verify_proof_and_dispose(*proof_name))
             return EXIT_FAILURE;
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/circuit/circuit_no_backedges_test.cc
+++ b/gcs/constraints/circuit/circuit_no_backedges_test.cc
@@ -90,7 +90,7 @@ auto main(int argc, char * argv[]) -> int
     cout << stats;
 
     if (proof_name)
-        if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
+        if (! verify_proof_and_dispose(*proof_name))
             return EXIT_FAILURE;
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/circuit/circuit_prune_root_test.cc
+++ b/gcs/constraints/circuit/circuit_prune_root_test.cc
@@ -75,7 +75,7 @@ auto main(int argc, char * argv[]) -> int
     cout << stats;
 
     if (proof_name)
-        if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
+        if (! verify_proof_and_dispose(*proof_name))
             return EXIT_FAILURE;
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/circuit/circuit_prune_skip_test.cc
+++ b/gcs/constraints/circuit/circuit_prune_skip_test.cc
@@ -78,7 +78,7 @@ auto main(int argc, char * argv[]) -> int
     cout << stats;
 
     if (proof_name)
-        if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
+        if (! verify_proof_and_dispose(*proof_name))
             return EXIT_FAILURE;
 
     return EXIT_SUCCESS;

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -257,12 +257,20 @@ namespace gcs::test_innards
      * \brief Verify a proof with VeriPB and, on success, dispose of it.
      *
      * Returns whether verification succeeded. The proof files are left in place
-     * when it did not, so a failing proof is always on disk to inspect.
+     * when it did not, so a failing proof can be inspected.
      *
      * This is the non-throwing form, for tests that report the outcome
      * themselves (a Catch2 `CHECK`, or a bool returned to a caller that prints
      * its own diagnostic). Tests that should stop dead at the first bad proof
      * want verify_proof_and_clean_up() instead.
+     *
+     * Note that not stopping is what makes preservation the caller's problem
+     * rather than a guarantee this can make: files kept here survive only until
+     * something writes that basename again. Callers that abandon the run on
+     * failure (the circuit and smart_table tests, which `return EXIT_FAILURE`)
+     * get preservation for free; callers that carry on need a basename per
+     * proving instance, which is why gcs/solve_test.cc gives each of its cases
+     * its own.
      */
     [[nodiscard]] inline auto verify_proof_and_dispose(const std::string & proof_name) -> bool
     {

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <optional>
 #include <random>
 #include <string>
@@ -173,29 +174,130 @@ namespace gcs::test_innards
 #endif
 
     /**
-     * Verify a test's proof with VeriPB, then, on success, delete its .opb/.pbp
-     * files.
+     * The file extensions a proving run can leave beside its proof. Only .opb
+     * and .pbp are always written; .scp and .varmap appear for the runs that ask
+     * for them. std::remove and std::rename on an absent file are harmless
+     * no-ops, so every extension can be handled unconditionally.
+     */
+    inline constexpr std::array proof_file_extensions{".opb", ".pbp", ".scp", ".varmap"};
+
+    /**
+     * \brief What to do with a proof once it has verified successfully.
      *
-     * Every proving test instance writes its proof into the working directory,
-     * and VeriPB .pbp files for enumeration tests routinely reach hundreds of
-     * megabytes. Left in place they accumulate over a run: a full parallel
-     * `ctest` otherwise holds gigabytes of proofs at once, which can exhaust the
-     * disk mid-run and make an *unrelated* lane's proof write fail (an uncaught
-     * std::ios_failure that terminates that test). Deleting each proof as soon as
-     * it verifies bounds the footprint to the lanes running concurrently.
+     * \sa proof_file_preservation(), which reads this from the environment.
+     */
+    enum class ProofFilePreservation
+    {
+        Delete, ///< Delete the proof (the default).
+        Keep,   ///< Keep it, letting the next instance overwrite it in place.
+        KeepAll ///< Keep every instance, uniquified with a per-basename counter.
+    };
+
+    /**
+     * \brief Read the proof-file preservation policy from GCS_PRESERVE_PROOF_FILES.
      *
-     * The files are kept when verification fails, so a failing proof is still on
-     * disk to inspect. std::remove of an already-absent file is a harmless no-op.
+     * Unset, empty, or `0` selects ProofFilePreservation::Delete; `all` selects
+     * ProofFilePreservation::KeepAll; any other value selects
+     * ProofFilePreservation::Keep.
+     */
+    [[nodiscard]] inline auto proof_file_preservation() -> ProofFilePreservation
+    {
+        const char * e = std::getenv("GCS_PRESERVE_PROOF_FILES");
+        if (! (e && *e) || std::string{e} == "0")
+            return ProofFilePreservation::Delete;
+        return std::string{e} == "all" ? ProofFilePreservation::KeepAll : ProofFilePreservation::Keep;
+    }
+
+    /**
+     * \brief Dispose of a proof that has served its purpose, per the
+     * GCS_PRESERVE_PROOF_FILES policy.
+     *
+     * Call this once a proof has been verified, or once a test that reads its
+     * own proof back has finished with it. Call it only on the success path:
+     * leaving the files behind on failure is what makes a failure debuggable.
+     *
+     * By default the files are deleted. Every proving test instance writes its
+     * proof into the working directory, and VeriPB .pbp files for enumeration
+     * tests routinely reach hundreds of megabytes. Left in place they accumulate
+     * over a run: a full parallel `ctest` otherwise holds gigabytes of proofs at
+     * once, which can exhaust the disk mid-run and make an *unrelated* lane's
+     * proof write fail (an uncaught std::ios_failure that terminates that test).
+     * Deleting each proof as soon as it verifies bounds the footprint to the
+     * lanes running concurrently.
+     *
+     * Under ProofFilePreservation::KeepAll the files are instead renamed out of
+     * the way with a zero-padded per-basename counter, so an instance's proof
+     * survives the next instance reusing the basename. Renaming after the fact
+     * keeps the uniquification entirely here: tests go on choosing whatever
+     * basename they like.
+     */
+    inline auto dispose_of_proof_files(const std::string & proof_name) -> void
+    {
+        switch (proof_file_preservation()) {
+            using enum ProofFilePreservation;
+        case Delete:
+            for (auto ext : proof_file_extensions)
+                std::remove((proof_name + ext).c_str());
+            break;
+
+        case Keep: break;
+
+        case KeepAll: {
+            static std::map<std::string, int> counters;
+            auto suffix = std::to_string(++counters[proof_name]);
+            if (suffix.size() < 4)
+                suffix.insert(0, 4 - suffix.size(), '0');
+            for (auto ext : proof_file_extensions)
+                std::rename((proof_name + ext).c_str(), (proof_name + "." + suffix + ext).c_str());
+        } break;
+        }
+    }
+
+    /**
+     * \brief Verify a proof with VeriPB and, on success, dispose of it.
+     *
+     * Returns whether verification succeeded. The proof files are left in place
+     * when it did not, so a failing proof is always on disk to inspect.
+     *
+     * This is the non-throwing form, for tests that report the outcome
+     * themselves (a Catch2 `CHECK`, or a bool returned to a caller that prints
+     * its own diagnostic). Tests that should stop dead at the first bad proof
+     * want verify_proof_and_clean_up() instead.
+     */
+    [[nodiscard]] inline auto verify_proof_and_dispose(const std::string & proof_name) -> bool
+    {
+        if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
+            return false;
+        cake_probe_chain(proof_name); // PROBE: measure workflow-2 chain (no-op unless GCS_TEST_CAKE)
+        dispose_of_proof_files(proof_name);
+        return true;
+    }
+
+    /**
+     * \brief Verify a test's proof with VeriPB, throwing if it does not verify,
+     * and otherwise disposing of it per the GCS_PRESERVE_PROOF_FILES policy.
+     *
+     * Because this throws — and no test catches UnexpectedException — the run
+     * stops at the first bad proof, so the files left under the bare
+     * `proof_name` are exactly the failing instance's. That is why the default
+     * policy needs no counter: overwriting in place still leaves the
+     * interesting proof behind, identified by the test's own log line just
+     * above it.
+     *
+     * `GCS_PRESERVE_PROOF_FILES=all` is for the other use case: harvesting every
+     * instance's proof (byte-comparison across a change, say) rather than
+     * debugging one failure. Note that a single test can write hundreds of
+     * proofs under one basename, so combining that with
+     * -DGCS_TEST_CAP_DEFAULTS=OFF can fill a disk.
+     *
+     * (The cake probe above has its own GCS_TEST_CAKE_KEEP, which names a
+     * *directory* to copy failing triples into rather than being a policy
+     * switch, so it stays separate.)
      */
     inline auto verify_proof_and_clean_up(const std::string & proof_name) -> void
     {
-        if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
+        if (! verify_proof_and_dispose(proof_name))
             throw UnexpectedException{"veripb verification failed"};
-        cake_probe_chain(proof_name); // PROBE: measure workflow-2 chain (no-op unless GCS_TEST_CAKE)
-        std::remove((proof_name + ".opb").c_str());
-        std::remove((proof_name + ".pbp").c_str());
-        std::remove((proof_name + ".scp").c_str());
-        std::remove((proof_name + ".varmap").c_str());
     }
 
     /**

--- a/gcs/constraints/power/power_test.cc
+++ b/gcs/constraints/power/power_test.cc
@@ -186,8 +186,7 @@ auto run_power_pinned_test(
     }
 
     if (proof_name)
-        if (! run_veripb(*proof_name + ".opb", *proof_name + ".pbp"))
-            throw UnexpectedException{"veripb verification failed"};
+        verify_proof_and_clean_up(*proof_name);
 }
 
 // A constant base with a view exponent still goes through PowerTable, and

--- a/gcs/constraints/seq_precede_chain/seq_precede_chain_test.cc
+++ b/gcs/constraints/seq_precede_chain/seq_precede_chain_test.cc
@@ -151,7 +151,7 @@ auto run_scale_test(bool proofs) -> void
 
     if (proofs) {
         auto verify_start = steady_clock::now();
-        if (! run_veripb("seq_precede_chain_test.opb", "seq_precede_chain_test.pbp"))
+        if (! verify_proof_and_dispose("seq_precede_chain_test"))
             throw UnexpectedException{"veripb verification failed on scale test"};
         auto verify_elapsed = duration<double>(steady_clock::now() - verify_start).count();
         println(cerr, "  veripb verification: {:.2f}s", verify_elapsed);

--- a/gcs/constraints/smart_table/smart_table_test.cc
+++ b/gcs/constraints/smart_table/smart_table_test.cc
@@ -162,7 +162,7 @@ auto run_lex_test(bool proofs, const string & mode, int length, vector<pair<int,
 
     if (lex_violated)
         return false;
-    return ! proofs || run_veripb(proof_basename + ".opb", proof_basename + ".pbp");
+    return ! proofs || verify_proof_and_dispose(proof_basename);
 }
 
 auto run_at_most_1_test(bool proofs, const string & mode, int length, vector<pair<int, int>> & ranges, bool at_least, bool in_set) -> bool
@@ -223,7 +223,7 @@ auto run_at_most_1_test(bool proofs, const string & mode, int length, vector<pai
 
     if (at_most_1_violated)
         return false;
-    return ! proofs || run_veripb(proof_basename + ".opb", proof_basename + ".pbp");
+    return ! proofs || verify_proof_and_dispose(proof_basename);
 }
 
 // One tuple using the same variable in several entries at once, mixing

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -43,8 +43,17 @@ namespace
     }
 }
 
+// Every proving case below uses its own proof basename rather than a shared
+// one. verify_proof_and_dispose() keeps the files when a proof fails to verify,
+// but Catch2's CHECK is non-fatal, so the run carries on into the next case: a
+// shared basename would have that case's solve() overwrite the failing proof
+// microseconds later, leaving artifacts belonging to whichever case ran last.
+// Distinct names also make GCS_PRESERVE_PROOF_FILES=1 yield a usable set from
+// this binary rather than a single file.
 TEST_CASE("Solve unsat")
 {
+    const auto proof_name = "solve_test_unsat";
+
     Problem p;
     auto v = p.create_integer_variable(0_i, 100_i);
     p.post(WeightedSum{} + 1_i * v >= 200_i);
@@ -56,14 +65,16 @@ TEST_CASE("Solve unsat")
             found_solution = true;
             return false;
         },
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 TEST_CASE("Solve unsat by model optimisation")
 {
+    const auto proof_name = "solve_test_unsat_model_optimisation";
+
     Problem p;
     auto v = p.create_integer_variable(0_i, 100_i);
     p.post(LessThan{1_c, 0_c});
@@ -76,10 +87,10 @@ TEST_CASE("Solve unsat by model optimisation")
             found_solution = true;
             return false;
         },
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 // Four variables over three values, pairwise different: unsatisfiable, and
@@ -90,6 +101,8 @@ TEST_CASE("Solve unsat by model optimisation")
 // restart loop and that the proof stays balanced across many restarts.
 TEST_CASE("Solve unsat with restarts")
 {
+    const auto proof_name = "solve_test_unsat_restarts";
+
     Problem p;
     vector<IntegerVariableID> xs;
     for (int i = 0; i < 4; ++i)
@@ -105,14 +118,14 @@ TEST_CASE("Solve unsat with restarts")
                            return false;
                        },
             .restarts = RestartSchedule::luby(1)},
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
     // Restarts learn nogoods from the refuted regions, and the proof verifies
     // those learned clauses (an unsound one would fail RUP).
     CHECK(stats.learned_nogoods > 0);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 // As "Solve unsat with restarts" but with binary (2-way) branching:
@@ -123,6 +136,8 @@ TEST_CASE("Solve unsat with restarts")
 // unsound reduction (dropping a literal that is not re-derivable) fails RUP.
 TEST_CASE("Solve unsat with restarts and binary branching")
 {
+    const auto proof_name = "solve_test_unsat_restarts_binary";
+
     Problem p;
     vector<IntegerVariableID> xs;
     for (int i = 0; i < 5; ++i)
@@ -139,12 +154,12 @@ TEST_CASE("Solve unsat with restarts and binary branching")
                        },
             .branch = branch_with(variable_order::dom(p), value_order::smallest_in()),
             .restarts = RestartSchedule::luby(4)},
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
     CHECK(stats.learned_nogoods > 0);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 // As above but with interval (bound-split) branching: value_order::
@@ -154,6 +169,8 @@ TEST_CASE("Solve unsat with restarts and binary branching")
 // extraction and the entailment 2WL. The proof still verifies.
 TEST_CASE("Solve unsat with restarts and interval branching")
 {
+    const auto proof_name = "solve_test_unsat_restarts_interval";
+
     Problem p;
     vector<IntegerVariableID> xs;
     for (int i = 0; i < 5; ++i)
@@ -170,12 +187,12 @@ TEST_CASE("Solve unsat with restarts and interval branching")
                        },
             .branch = branch_with(variable_order::dom(p), value_order::split_smallest_first()),
             .restarts = RestartSchedule::luby(4)},
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
     CHECK(stats.learned_nogoods > 0);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 // As above but with reject-interval branching: value_order::reject_random_interval
@@ -188,6 +205,8 @@ TEST_CASE("Solve unsat with restarts and interval branching")
 // operator-agnostic. The proof must still verify.
 TEST_CASE("Solve unsat with restarts and reject-interval branching")
 {
+    const auto proof_name = "solve_test_unsat_restarts_reject_interval";
+
     Problem p;
     vector<IntegerVariableID> xs;
     for (int i = 0; i < 5; ++i)
@@ -204,12 +223,12 @@ TEST_CASE("Solve unsat with restarts and reject-interval branching")
                        },
             .branch = branch_with(variable_order::dom(p), value_order::reject_random_interval(1)),
             .restarts = RestartSchedule::luby(4)},
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
     CHECK(stats.learned_nogoods > 0);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 // Optimisation with restarts: the incumbent bound persists across restarts, so
@@ -218,6 +237,8 @@ TEST_CASE("Solve unsat with restarts and reject-interval branching")
 // schedule restarts here too.
 TEST_CASE("Optimise with restarts")
 {
+    const auto proof_name = "solve_test_optimise_restarts";
+
     Problem p;
     auto x = p.create_integer_variable(0_i, 2_i);
     auto y = p.create_integer_variable(0_i, 2_i);
@@ -234,11 +255,11 @@ TEST_CASE("Optimise with restarts")
                            return true;
                        },
             .restarts = RestartSchedule::luby(1)},
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(best == optional<Integer>{2_i});
     CHECK(stats.restarts > 0);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 // Scan-vs-refined differential for the engine-owned learned-nogood store (issue
@@ -291,6 +312,8 @@ TEST_CASE("Learned nogoods: refined matches scan under restarts")
 // growing cutoff exhausts the tree.
 TEST_CASE("Solve unsat with restarts and root propagation")
 {
+    const auto proof_name = "solve_test_unsat_restarts_root_propagation";
+
     Problem p;
     const int k = 5;
     vector<IntegerVariableID> position, solution;
@@ -313,11 +336,11 @@ TEST_CASE("Solve unsat with restarts and root propagation")
                            return false;
                        },
             .restarts = RestartSchedule::luby(10)},
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 // Enumerate every solution while restarting. b, c, d are a pairwise-distinct
@@ -331,6 +354,8 @@ TEST_CASE("Solve unsat with restarts and root propagation")
 // conclude a complete enumeration of six.
 TEST_CASE("Enumerate all solutions with restarts")
 {
+    const auto proof_name = "solve_test_enumerate_restarts";
+
     Problem p;
     auto a = p.create_integer_variable(1_i, 4_i);
     auto b = p.create_integer_variable(1_i, 3_i);
@@ -353,18 +378,20 @@ TEST_CASE("Enumerate all solutions with restarts")
                        },
             .branch = branch_with(variable_order::random(p, 1234), value_order::random_out(5678)),
             .restarts = RestartSchedule::luby(1)},
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(solutions.size() == 6);
     CHECK(callbacks == 6); // each solution reported exactly once, no re-counting
     CHECK(stats.solutions == 6);
     CHECK(stats.restarts > 0); // restarts actually fired during enumeration
     CHECK(stats.learned_nogoods > 0);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }
 
 TEST_CASE("Solve unsat optimisation presolving")
 {
+    const auto proof_name = "solve_test_unsat_optimisation_presolving";
+
     Problem p;
     auto v = p.create_integer_variable(0_i, 100_i);
     p.post(WeightedSum{} + 1_i * v >= 200_i);
@@ -377,8 +404,8 @@ TEST_CASE("Solve unsat optimisation presolving")
             found_solution = true;
             return false;
         },
-        ProofOptions{"solve_test"});
+        ProofOptions{proof_name});
 
     CHECK(! found_solution);
-    CHECK(verify_proof_and_dispose("solve_test"));
+    CHECK(verify_proof_and_dispose(proof_name));
 }

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -59,7 +59,7 @@ TEST_CASE("Solve unsat")
         ProofOptions{"solve_test"});
 
     CHECK(! found_solution);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 TEST_CASE("Solve unsat by model optimisation")
@@ -79,7 +79,7 @@ TEST_CASE("Solve unsat by model optimisation")
         ProofOptions{"solve_test"});
 
     CHECK(! found_solution);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 // Four variables over three values, pairwise different: unsatisfiable, and
@@ -112,7 +112,7 @@ TEST_CASE("Solve unsat with restarts")
     // Restarts learn nogoods from the refuted regions, and the proof verifies
     // those learned clauses (an unsound one would fail RUP).
     CHECK(stats.learned_nogoods > 0);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 // As "Solve unsat with restarts" but with binary (2-way) branching:
@@ -144,7 +144,7 @@ TEST_CASE("Solve unsat with restarts and binary branching")
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
     CHECK(stats.learned_nogoods > 0);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 // As above but with interval (bound-split) branching: value_order::
@@ -175,7 +175,7 @@ TEST_CASE("Solve unsat with restarts and interval branching")
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
     CHECK(stats.learned_nogoods > 0);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 // As above but with reject-interval branching: value_order::reject_random_interval
@@ -209,7 +209,7 @@ TEST_CASE("Solve unsat with restarts and reject-interval branching")
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
     CHECK(stats.learned_nogoods > 0);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 // Optimisation with restarts: the incumbent bound persists across restarts, so
@@ -238,7 +238,7 @@ TEST_CASE("Optimise with restarts")
 
     CHECK(best == optional<Integer>{2_i});
     CHECK(stats.restarts > 0);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 // Scan-vs-refined differential for the engine-owned learned-nogood store (issue
@@ -317,7 +317,7 @@ TEST_CASE("Solve unsat with restarts and root propagation")
 
     CHECK(! found_solution);
     CHECK(stats.restarts > 0);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 // Enumerate every solution while restarting. b, c, d are a pairwise-distinct
@@ -360,7 +360,7 @@ TEST_CASE("Enumerate all solutions with restarts")
     CHECK(stats.solutions == 6);
     CHECK(stats.restarts > 0); // restarts actually fired during enumeration
     CHECK(stats.learned_nogoods > 0);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }
 
 TEST_CASE("Solve unsat optimisation presolving")
@@ -380,5 +380,5 @@ TEST_CASE("Solve unsat optimisation presolving")
         ProofOptions{"solve_test"});
 
     CHECK(! found_solution);
-    CHECK(run_veripb("solve_test.opb", "solve_test.pbp"));
+    CHECK(verify_proof_and_dispose("solve_test"));
 }

--- a/gcs/stacktrace_logging_test.cc
+++ b/gcs/stacktrace_logging_test.cc
@@ -73,5 +73,10 @@ TEST_CASE("Verbose logging names gcs stack frames in the proof")
     // No <stacktrace> here (e.g. macOS libc++): log_stacktrace() is compiled out,
     // so there is nothing to assert. Recorded as a pass on those platforms.
     SUCCEED("<stacktrace> unavailable on this toolchain; verbose frame logging is compiled out");
+
+    // The solve above runs on every platform, so its proof needs disposing of on
+    // every platform. Unconditionally here: this branch asserts nothing, so there
+    // is no failure state whose files are worth preserving.
+    gcs::test_innards::dispose_of_proof_files("stacktrace_logging_test");
 #endif
 }

--- a/gcs/stacktrace_logging_test.cc
+++ b/gcs/stacktrace_logging_test.cc
@@ -3,6 +3,8 @@
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdlib>
@@ -59,6 +61,14 @@ TEST_CASE("Verbose logging names gcs stack frames in the proof")
     // named at least one gcs frame. If it did not, either the feature broke or
     // the build dropped the debug info that source_file() resolution depends on.
     CHECK(saw_gcs_frame);
+
+    // Unlike most proving tests this one reads its own proof rather than handing
+    // it to VeriPB, but the same disposal policy applies once it is finished
+    // with. Keep it when the check failed, so the missing frames can be
+    // inspected; close it first so the removal also works on Windows.
+    proof.close();
+    if (saw_gcs_frame)
+        gcs::test_innards::dispose_of_proof_files("stacktrace_logging_test");
 #else
     // No <stacktrace> here (e.g. macOS libc++): log_stacktrace() is compiled out,
     // so there is nothing to assert. Recorded as a pass on those platforms.


### PR DESCRIPTION
First of a four-PR stack tidying up how tests generate, name and dispose of proof files. Fixes #562, #17 and #292 between them; this PR is the shared groundwork the other three build on.

## The problem

Proof files were disposed of inconsistently. The data-driven constraint harness deleted them on success and kept them on failure — the behaviour we want — but nine other test binaries verified their proofs by calling `run_veripb()` directly and simply left the files behind, and `stacktrace_logging_test` wrote a proof, read it back, and never cleaned up at all. A full `ctest` run left **136 stale proof artifacts** under `build/gcs/`.

## The policy

Three layers, so every caller has the right shape available:

- `dispose_of_proof_files()` applies the policy to a proof that has served its purpose;
- `verify_proof_and_dispose()` is the non-throwing form, for tests that report the outcome themselves (a Catch2 `CHECK`, or a bool returned to a caller that prints its own diagnostic);
- `verify_proof_and_clean_up()` keeps its throwing behaviour, now expressed in terms of the other two.

**The default is unchanged**: delete once verified, always keep on failure.

That default needs no uniquifying counter, and it is worth saying why. A failed verification throws, and no test catches `UnexpectedException`, so the run stops at the first bad proof — the files left under the bare basename are exactly the failing instance's, identified by the test's own log line just above them. Verified by shimming a `veripb` that always fails: the test aborts with `SIGABRT` and leaves precisely those four files.

`GCS_PRESERVE_PROOF_FILES` overrides it:

| Value | Behaviour |
|-------|-----------|
| unset, empty, `0` | delete once verified (the default) |
| any other value, e.g. `1` | keep, letting the next instance overwrite in place |
| `all` | keep every instance, renamed with a zero-padded per-basename counter |

`all` is for harvesting proofs across instances — byte-comparing before and after a change — rather than debugging one failure. It is deliberately opt-in: `equals_test` alone writes 284 proofs under one basename, so combining it with `-DGCS_TEST_CAP_DEFAULTS=OFF` can fill a disk. Uniquification happens by renaming *after* verification, which keeps it entirely inside the helper: tests go on choosing whatever basenames they like.

## Call sites routed through it

`solve_test`, `smart_table_test`, `seq_precede_chain_test`, `power_test` and the five circuit scenario tests. `stacktrace_logging_test` disposes of its proof once it has finished reading it, keeping it when the check failed.

## Result

Leftover artifacts under `build/gcs/` after a full run: **136 → 36**. The remainder belong to the tests verified by `run_test_and_verify.bash`, whose disposal is the wrapper's job — that is PR 3 in this stack.

Suite green: 525/525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDQsidr7oKDfCVnDcetf3j