### PR TITLE
Give every solver binary a --proof-files-basename (issue #17)

### DIFF
--- a/dev_docs/view-proof-logging.md
+++ b/dev_docs/view-proof-logging.md
@@ -237,14 +237,23 @@ cmake -S . -B build -DGCS_ENABLE_VIEW_WRAP_SWEEP=ON
 The harness and the `--view-wrap=N` / `--view-position=...` flags are always
 built; only the per-wrap ctest registrations are gated.
 
-Single manual run:
+Single manual run. These are data-driven test binaries, not example
+programs: they have no `--prove` flag, and instead prove and run VeriPB
+themselves whenever `veripb` is on the `PATH`, naming each proof after the
+test and its view configuration. So a manual run needs only the view
+flags, and `GCS_PRESERVE_PROOF_FILES=1` to stop the harness deleting each
+proof once it has verified (see `dev_docs/constraints.md`):
 
 ```shell
-./build/equals_test --view-wrap=11 --view-position=all --prove eq_w11
-veripb eq_w11.opb eq_w11.pbp
-./build/lex_test --view-position=mixed --prove lex_mixed   # heterogeneous views
-veripb lex_mixed.opb lex_mixed.pbp
+GCS_PRESERVE_PROOF_FILES=1 ./build/equals_test --view-wrap=11 --view-position=all
+ls equals_test_*.opb            # one per view configuration exercised
+
+GCS_PRESERVE_PROOF_FILES=1 ./build/lex_test --view-position=mixed  # heterogeneous views
+ls lex_test_*.opb
 ```
+
+Use `GCS_PRESERVE_PROOF_FILES=all` instead to keep *every* instance's
+proof rather than the last one per configuration.
 
 ## Status
 

--- a/minicp_benchmarks/magic_series/magic_series.cc
+++ b/minicp_benchmarks/magic_series/magic_series.cc
@@ -28,9 +28,11 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
+        options.add_options("Program Options")                                //
+            ("help", "Display help information")                              //
+            ("prove", "Create a proof")                                       //
+            ("proof-files-basename", "Basename for the .opb and .pbp files",  //
+                cxxopts::value<std::string>()->default_value("magic_series")) //
             ("branch",
                 "Branching heuristic: default, or dom-wdeg[:VARIANT] "               //
                 "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",             //
@@ -130,7 +132,7 @@ auto main(int argc, char * argv[]) -> int
                        },
             .branch = brancher,
             .restarts = restarts},
-        options_vars.contains("prove") ? make_optional<ProofOptions>("magic_series") : nullopt);
+        options_vars.contains("prove") ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<std::string>()) : nullopt);
 
     cout << stats;
 

--- a/minicp_benchmarks/magic_square/magic_square.cc
+++ b/minicp_benchmarks/magic_square/magic_square.cc
@@ -34,9 +34,11 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
+        options.add_options("Program Options")                                //
+            ("help", "Display help information")                              //
+            ("prove", "Create a proof")                                       //
+            ("proof-files-basename", "Basename for the .opb and .pbp files",  //
+                cxxopts::value<std::string>()->default_value("magic_square")) //
             ("branch",
                 "Branching heuristic: default, or dom-wdeg[:VARIANT] "                                               //
                 "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",                                             //
@@ -161,7 +163,7 @@ auto main(int argc, char * argv[]) -> int
     unsigned long long n_solutions = 0;
     auto stats = bench::solve_with_timeout(options_vars["timeout"].as<double>(), p,
         SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return ++n_solutions < 10000; }, .branch = brancher, .restarts = restarts},
-        options_vars.contains("prove") ? make_optional<ProofOptions>("magic_square") : nullopt);
+        options_vars.contains("prove") ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<std::string>()) : nullopt);
 
     cout << stats;
 

--- a/minicp_benchmarks/n_queens/n_queens.cc
+++ b/minicp_benchmarks/n_queens/n_queens.cc
@@ -28,9 +28,11 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
+        options.add_options("Program Options")                               //
+            ("help", "Display help information")                             //
+            ("prove", "Create a proof")                                      //
+            ("proof-files-basename", "Basename for the .opb and .pbp files", //
+                cxxopts::value<string>()->default_value("n_queens"))         //
             ("branch",
                 "Branching heuristic: default, or dom-wdeg[:VARIANT] "               //
                 "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",             //
@@ -112,7 +114,7 @@ auto main(int argc, char * argv[]) -> int
                        },
             .branch = brancher,
             .restarts = restarts},
-        options_vars.contains("prove") ? make_optional<ProofOptions>("n_queens") : nullopt);
+        options_vars.contains("prove") ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>()) : nullopt);
 
     cout << stats;
 

--- a/minicp_benchmarks/qap/qap.cc
+++ b/minicp_benchmarks/qap/qap.cc
@@ -33,9 +33,11 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
+        options.add_options("Program Options")                               //
+            ("help", "Display help information")                             //
+            ("prove", "Create a proof")                                      //
+            ("proof-files-basename", "Basename for the .opb and .pbp files", //
+                cxxopts::value<std::string>()->default_value("qap"))         //
             ("branch",
                 "Branching heuristic: default, or dom-wdeg[:VARIANT] "               //
                 "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",             //
@@ -176,7 +178,7 @@ auto main(int argc, char * argv[]) -> int
                        },
             .branch = brancher,
             .restarts = restarts},
-        options_vars.contains("prove") ? make_optional<ProofOptions>("qap") : nullopt);
+        options_vars.contains("prove") ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<std::string>()) : nullopt);
 
     cout << stats << endl;
 

--- a/minicp_benchmarks/tsp/tsp.cc
+++ b/minicp_benchmarks/tsp/tsp.cc
@@ -28,9 +28,11 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::ParseResult options_vars;
 
     try {
-        options.add_options()                    //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
+        options.add_options()                                                //
+            ("help", "Display help information")                             //
+            ("prove", "Create a proof")                                      //
+            ("proof-files-basename", "Basename for the .opb and .pbp files", //
+                cxxopts::value<string>()->default_value("tsp"))              //
             ("branch",
                 "Branching heuristic: default, or dom-wdeg[:VARIANT] "               //
                 "(VARIANT = classic/ia/ca/id/cd/ca.cd/chs; bare = chs)",             //
@@ -144,7 +146,7 @@ auto main(int argc, char * argv[]) -> int
                        },
             .branch = brancher,
             .restarts = restarts},
-        options_vars.contains("prove") ? make_optional<ProofOptions>("tsp") : nullopt);
+        options_vars.contains("prove") ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>()) : nullopt);
 
     cout << stats;
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -249,8 +249,10 @@ auto main(int argc, char * argv[]) -> int
             // --prove is a bare flag here as it is everywhere else, with the
             // basename supplied separately. `--prove=NAME` is kept as a
             // deprecated alias for the old value-taking spelling; the
-            // space-separated `--prove NAME` is gone, so the .msc configs
-            // declare the basename as its own extraFlag.
+            // space-separated `--prove NAME` cannot be (a flag with an implicit
+            // value does not consume the following token), so it is diagnosed
+            // after parsing instead, and the .msc configs declare the basename
+            // as its own extraFlag.
             ("prove", "Create a proof", cxxopts::value<string>()->implicit_value("")) //
             ("proof-files-basename", "Basename for the .opb and .pbp files",          //
                 cxxopts::value<string>()->default_value("fzn-glasgow"))               //
@@ -271,6 +273,19 @@ auto main(int argc, char * argv[]) -> int
         cout << options.help() << std::endl;
         return EXIT_SUCCESS;
     }
+
+    // Positional arguments beyond the one --file consumes land in unmatched(),
+    // where nothing reads them: silently ignoring them turns a mistyped command
+    // line into a successful-looking run. The case that matters is the old
+    // `--prove NAME` spelling. --prove is now a bare flag, and a flag with an
+    // implicit value does not consume the following token, so `model.fzn --prove
+    // NAME` solves the model, strands NAME here, and writes the proof under the
+    // default basename -- exit 0, no diagnostic, and the mistake only surfaces
+    // when veripb is pointed at files that were never written.
+    for (const auto & arg : options_vars.unmatched())
+        println(cerr, "warning: ignoring unexpected argument '{}'", arg);
+    if (! options_vars.unmatched().empty() && options_vars.contains("prove") && options_vars["prove"].as<string>().empty())
+        println(cerr, "warning: --prove NAME is no longer accepted, use --prove --proof-files-basename NAME");
 
     bool all_solutions = options_vars.contains("all-solutions");
     bool free_search = options_vars.contains("free-search");

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -243,10 +243,17 @@ auto main(int argc, char * argv[]) -> int
             ("statistics,s", "Print statistics")                                                       //
             ("timeout,t", "Timeout in ms", cxxopts::value<unsigned long long>())                       //
             ("restarts",
-                "Restart on a Luby schedule with the given conflict scale (find-one / "      //
-                "optimisation only); learns nogoods across restarts",                        //
-                cxxopts::value<unsigned long long>())                                        //
-            ("prove", "Write proofs to this file (.opb and .pbp)", cxxopts::value<string>()) //
+                "Restart on a Luby schedule with the given conflict scale (find-one / " //
+                "optimisation only); learns nogoods across restarts",                   //
+                cxxopts::value<unsigned long long>())                                   //
+            // --prove is a bare flag here as it is everywhere else, with the
+            // basename supplied separately. `--prove=NAME` is kept as a
+            // deprecated alias for the old value-taking spelling; the
+            // space-separated `--prove NAME` is gone, so the .msc configs
+            // declare the basename as its own extraFlag.
+            ("prove", "Create a proof", cxxopts::value<string>()->implicit_value("")) //
+            ("proof-files-basename", "Basename for the .opb and .pbp files",          //
+                cxxopts::value<string>()->default_value("fzn-glasgow"))               //
             ("file", "FlatZinc file used as input", cxxopts::value<string>());
 
         options.parse_positional({"file"});
@@ -1052,8 +1059,11 @@ auto main(int argc, char * argv[]) -> int
 
         optional<ProofOptions> proof_options;
         if (options_vars.contains("prove")) {
-            string basename = options_vars["prove"].as<string>();
-            proof_options.emplace(basename);
+            // A non-empty --prove value is the deprecated `--prove=NAME` form.
+            string legacy_basename = options_vars["prove"].as<string>();
+            if (! legacy_basename.empty())
+                println(cerr, "warning: --prove=NAME is deprecated, use --prove --proof-files-basename NAME");
+            proof_options.emplace(legacy_basename.empty() ? options_vars["proof-files-basename"].as<string>() : legacy_basename);
         }
 
         optional<RestartSchedule> restart_schedule;

--- a/minizinc/glasgow-for-debugging.msc
+++ b/minizinc/glasgow-for-debugging.msc
@@ -7,6 +7,6 @@
     "executable": "false",
     "tags": ["cp", "int"],
     "stdFlags": ["-a", "-f", "-i", "-n", "-p", "-r", "-s", "-t", "-v"],
-    "extraFlags": [["--prove", "Write a proof to this file (suffix .opb and .pbp will be added)", "string", ""], ["--restarts", "Restart search on a Luby schedule with this conflict scale (find-one / optimisation only; 0 = off)", "int", "0"]]
+    "extraFlags": [["--prove", "Create a proof", "bool", "false"], ["--proof-files-basename", "Basename for the .opb and .pbp files (suffix .opb and .pbp will be added)", "string", "fzn-glasgow"], ["--restarts", "Restart search on a Luby schedule with this conflict scale (find-one / optimisation only; 0 = off)", "int", "0"]]
 }
 

--- a/minizinc/glasgow-for-tests.msc
+++ b/minizinc/glasgow-for-tests.msc
@@ -7,6 +7,6 @@
     "executable": "fzn-glasgow",
     "tags": ["cp", "int"],
     "stdFlags": ["-a", "-f", "-i", "-n", "-p", "-r", "-s", "-t", "-v"],
-    "extraFlags": [["--prove", "Write a proof to this file (suffix .opb and .pbp will be added)", "string", ""], ["--restarts", "Restart search on a Luby schedule with this conflict scale (find-one / optimisation only; 0 = off)", "int", "0"]],
+    "extraFlags": [["--prove", "Create a proof", "bool", "false"], ["--proof-files-basename", "Basename for the .opb and .pbp files (suffix .opb and .pbp will be added)", "string", "fzn-glasgow"], ["--restarts", "Restart search on a Luby schedule with this conflict scale (find-one / optimisation only; 0 = off)", "int", "0"]],
     "inputType": "JSON"
 }

--- a/minizinc/glasgow.msc
+++ b/minizinc/glasgow.msc
@@ -7,6 +7,6 @@
     "executable": "minizinc/../build/fzn-glasgow",
     "tags": ["cp", "int"],
     "stdFlags": ["-a", "-f", "-i", "-n", "-p", "-r", "-s", "-t", "-v"],
-    "extraFlags": [["--prove", "Write a proof to this file (suffix .opb and .pbp will be added)", "string", ""], ["--restarts", "Restart search on a Luby schedule with this conflict scale (find-one / optimisation only; 0 = off)", "int", "0"]],
+    "extraFlags": [["--prove", "Create a proof", "bool", "false"], ["--proof-files-basename", "Basename for the .opb and .pbp files (suffix .opb and .pbp will be added)", "string", "fzn-glasgow"], ["--restarts", "Restart search on a Luby schedule with this conflict scale (find-one / optimisation only; 0 = off)", "int", "0"]],
     "inputType": "JSON"
 }

--- a/minizinc/run_fzn_json_test.bash
+++ b/minizinc/run_fzn_json_test.bash
@@ -32,7 +32,7 @@ if ! diff -u <(sort < "$jsondir/$testname.expected") "$testname.fzn.sols" ; then
 fi
 
 if veripb --help >/dev/null 2>&1 ; then
-    "$fznglasgow" -a --prove "$testname" "$infile" || exit 3
+    "$fznglasgow" -a --prove --proof-files-basename "$testname" "$infile" || exit 3
     if ! veripb "$testname.opb" "$testname.pbp" ; then
         echo "Rerunning last 100 lines of proof verification in trace mode..."
         echo '$ ' veripb --trace "$(readlink -f "$testname.opb")" "$(readlink -f "$testname.pbp")"

--- a/minizinc/run_minizinc_test.bash
+++ b/minizinc/run_minizinc_test.bash
@@ -59,7 +59,7 @@ else
 fi
 
 if [[ "$doproofs" == "true" ]] && veripb --help >/dev/null ; then
-    minizinc --solver "$solver_msc" -a "$minizincdir/tests/$testname.mzn" --prove "$testname" | tee "$testname.glasgow.out" || exit 7
+    minizinc --solver "$solver_msc" -a "$minizincdir/tests/$testname.mzn" --prove --proof-files-basename "$testname" | tee "$testname.glasgow.out" || exit 7
     if ! veripb "$testname.opb" "$testname.pbp" ; then
         echo "Rerunning last 100 lines of proof verification in trace mode..."
         echo '$ ' veripb --trace "$(readlink -f "$testname.opb")" "$(readlink -f "$testname.pbp")"

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -1727,10 +1727,12 @@ auto main(int argc, char * argv[]) -> int
     cxxopts::Options options("XCSP Glasgow Constraint Solver", "Get started by using option --help");
 
     try {
-        options.add_options("Program Options")   //
-            ("help", "Display help information") //
-            ("prove", "Create a proof")          //
-            ("all", "Find all solutions")        //
+        options.add_options("Program Options")                               //
+            ("help", "Display help information")                             //
+            ("prove", "Create a proof")                                      //
+            ("proof-files-basename", "Basename for the .opb and .pbp files", //
+                cxxopts::value<string>()->default_value("xcsp"))             //
+            ("all", "Find all solutions")                                    //
             ("branch",
                 "Branching heuristic: dom-then-deg, or dom-wdeg[:VARIANT] "          //
                 "(VARIANT one of classic, ia, ca, id, cd, ca.cd, chs)",              //
@@ -1850,7 +1852,7 @@ auto main(int argc, char * argv[]) -> int
             },
             .branch = *brancher,
             .restarts = restarts},
-        options_vars.contains("prove") ? make_optional<ProofOptions>("xcsp") : nullopt, &abort_flag);
+        options_vars.contains("prove") ? make_optional<ProofOptions>(options_vars["proof-files-basename"].as<string>()) : nullopt, &abort_flag);
 
     if (timeout_thread.joinable()) {
         {


### PR DESCRIPTION
Second of a four-PR stack. **Stacked on #563** — review that first; this PR's diff is against it.

Towards #17.

## The problem

Four incompatible ways of asking for a proof had grown up across the binaries:

| Family | Spelling | Can you name the proof? |
|---|---|---|
| `examples/*` (33) | `--prove` + `--proof-files-basename NAME` | yes, defaults to the program name |
| `minicp_benchmarks/*` (5) | `--prove` | no — hardcoded in C++ |
| `xcsp` | `--prove` | no — hardcoded as `"xcsp"` |
| `fzn-glasgow` | `--prove NAME` | yes, but as the flag's value |

Only the first can express "put this run's proof here". That is why the proof-basename collisions in `examples/` and `xcsp/` are currently papered over with `RESOURCE_LOCK` rather than fixed: for three of the four families there was no flag to pass. **This PR is what unblocks #562**, handled in PR 3 of the stack.

## The change

Standardise on the `examples/` spelling — `--prove` as a bare flag, the name supplied by `--proof-files-basename`, defaulting to the program name. 35 binaries were already correct; 7 needed changing.

`fzn-glasgow` is the awkward one, since `--prove` took the basename as its value. It keeps working as `--prove=NAME`, which now warns. The space-separated `--prove NAME` cannot coexist with a bare `--prove` in cxxopts — an option with an implicit value does not consume the following token — so the three `.msc` solver configs now declare `--prove` as a bool extraFlag alongside a string `--proof-files-basename`, and the two bash runners pass the new spelling.

## Also

Fixes a manual-run recipe in `dev_docs/view-proof-logging.md` that told you to pass `--prove eq_w11` to `equals_test` / `lex_test`. Those are data-driven test binaries with **no `--prove` flag at all**: they prove and run VeriPB themselves whenever `veripb` is on the `PATH`. The recipe now uses the view flags plus `GCS_PRESERVE_PROOF_FILES=1`, and names the proof files the harness actually writes.

## Scope

Deliberately limited to the *proof* CLI. The broader #17 asks — converging `--stats` / `--branch` / `--restarts`, and grouping examples into MiniCP / features / other — are untouched, and #17 should stay open. Directory reshuffling on top of a wide mechanical edit is what would make this risky rather than routine.

No behaviour change for any existing invocation except `fzn-glasgow`'s `--prove NAME`. Suite green: 525/525, including all 73 MiniZinc tests (72 of which exercise the proof lane through the updated `.msc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDQsidr7oKDfCVnDcetf3j