### PR TITLE
Move the cake_pb_cp measurement probe out of the test-utils header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,9 @@ install(EXPORT GlasgowConstraintSolverTargets
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/gcs/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gcs
         FILES_MATCHING PATTERN "*.hh"
-        REGEX "constraints_test_utils\\.hh$" EXCLUDE)
+        # Test-harness headers, not part of the installed API.
+        REGEX "constraints_test_utils\\.hh$" EXCLUDE
+        REGEX "cake_probe\\.hh$" EXCLUDE)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/util/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/util

--- a/gcs/constraints/innards/cake_probe.hh
+++ b/gcs/constraints/innards/cake_probe.hh
@@ -1,0 +1,135 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_CAKE_PROBE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_CAKE_PROBE_HH
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+/**
+ * \file
+ * \brief Measurement-only probe: run the workflow-2 cake_pb_cp chain over a
+ * proof a test has just written.
+ *
+ * This is instrumentation, not part of the test harness. It is called from
+ * verify_proof_and_dispose() in constraints_test_utils.hh, and does nothing at
+ * all unless GCS_TEST_CAKE is set in the environment; when it is, it drives
+ * cake_pb_cp and veripb through a shell and logs a greppable line per proof,
+ * so the chain-verify rate across the random data-driven instances can be
+ * measured. It never throws and never fails a test.
+ *
+ * It lives in its own header because none of that has anything to do with
+ * writing a constraint test, and constraints_test_utils.hh -- which every
+ * constraint test includes, and which a test author reads to find out how the
+ * harness works -- is the wrong place to meet popen(), std::system() with
+ * interpolated paths, and a hand-rolled output parser.
+ *
+ * \sa verified_encodings/run_scp_chain.bash, which runs the same chain as a
+ * real test over a curated set of .scp cases.
+ */
+
+namespace gcs::test_innards
+{
+    // Runs the full verified-encoding chain on a just-written .scp/.pbp, best
+    // effort, and logs a greppable "CAKECHAIN <name> <OUTCOME>" line. Never
+    // throws: this is for measuring the chain-verify rate across the random
+    // data-driven instances, not for gating the suite. Enabled by GCS_TEST_CAKE;
+    // cake_pb_cp path overridable via CAKE_PB_CP.
+#ifdef _WIN32
+    // The probe drives cake_pb_cp and veripb through popen() and a POSIX shell,
+    // and cake_pb_cp does not run on Windows anyway, so it compiles out to a
+    // no-op there.
+    inline auto cake_probe_chain(const std::string &) -> void
+    {
+    }
+#else
+    inline auto cake_capture(const std::string & cmd) -> std::string
+    {
+        std::string out;
+        if (FILE * p = ::popen((cmd + " 2>/dev/null").c_str(), "r")) {
+            char buf[8192];
+            size_t n;
+            while ((n = std::fread(buf, 1, sizeof buf, p)) > 0)
+                out.append(buf, n);
+            ::pclose(p);
+        }
+        return out;
+    }
+
+    inline auto cake_probe_chain(const std::string & pn) -> void
+    {
+        if (auto e = std::getenv("GCS_TEST_CAKE"); ! (e && *e))
+            return;
+        const char * cakeenv = std::getenv("CAKE_PB_CP");
+        std::string cake = (cakeenv && *cakeenv) ? cakeenv : "cake_pb_cp";
+        auto scp = pn + ".scp", pbp = pn + ".pbp";
+        auto vopb = pn + ".cakeopb", core = pn + ".cakecore";
+
+        auto has = [](const std::string & s, const char * m) { return s.find(m) != std::string::npos; };
+        // A VERIFIED line, or "s NO CONCLUSION": the latter is cake's success
+        // output for a proof whose conclusion is NONE (the init-only tests).
+        auto verified = [&](const std::string & s) { return has(s, "s VERIFIED") || has(s, "s NO CONCLUSION"); };
+        auto lastmeaningful = [](const std::string & s) {
+            std::string best;
+            size_t i = 0;
+            while (i < s.size()) {
+                auto e = s.find('\n', i);
+                auto line = s.substr(i, e == std::string::npos ? std::string::npos : e - i);
+                if (! line.empty() && line.find("Running VeriPB") == std::string::npos)
+                    best = line;
+                if (e == std::string::npos)
+                    break;
+                i = e + 1;
+            }
+            return best;
+        };
+        auto log = [&](const std::string & outcome, const std::string & extra = "") {
+            std::string line = "CAKECHAIN " + pn + " " + outcome;
+            if (! extra.empty())
+                line += " :: " + extra;
+            line += "\n";
+            std::fputs(line.c_str(), stderr);
+        };
+        auto firstline = [](const std::string & s) {
+            auto n = s.find('\n');
+            return n == std::string::npos ? s : s.substr(0, n);
+        };
+
+        // 1. cake_pb_cp re-derives its own OPB from the .scp.
+        std::system((cake + " " + scp + " > " + vopb + " 2>/dev/null").c_str());
+        std::string opb = cake_capture("cat " + vopb);
+        if (opb.find(">=") == std::string::npos && opb.find("<=") == std::string::npos) {
+            log("SKIP_NO_OPB");
+            std::remove(vopb.c_str());
+            return;
+        }
+        // 2. veripb elaborates OUR proof against CAKE's OPB (the divergence gate).
+        // (A domain-{0} variable's zero-bit bound rows print with an EMPTY
+        // left-hand side, which needs a veripb with the labelled-empty-LHS
+        // parser fix of 2026-07-10.)
+        auto elab = cake_capture("veripb " + vopb + " " + pbp + " --elaborate " + core + " 2>&1");
+        if (! verified(elab)) {
+            log("FAIL_ELAB", lastmeaningful(elab));
+            // Preserve the failing triple (scp/pbp + cake's OPB) for inspection.
+            // Uniquely numbered so multiple failures sharing a proof_name don't
+            // overwrite each other.
+            if (auto k = std::getenv("GCS_TEST_CAKE_KEEP"); k && *k) {
+                static int fail_seq = 0;
+                std::string dir{k}, sfx = std::to_string(++fail_seq);
+                for (auto ext : {".scp", ".pbp"})
+                    std::system(("mkdir -p " + dir + " && cp " + pn + ext + " " + dir + "/" + pn + "." + sfx + ext + " 2>/dev/null").c_str());
+                std::system(("cp " + vopb + " " + dir + "/" + pn + "." + sfx + ".cakeopb 2>/dev/null").c_str());
+            }
+            std::remove(vopb.c_str());
+            std::remove(core.c_str());
+            return;
+        }
+        // 3. cake_pb_cp re-checks the elaborated core.
+        auto rc = cake_capture(cake + " " + scp + " " + core);
+        log(verified(rc) ? "OK" : "FAIL_RECHECK", lastmeaningful(rc));
+        std::remove(vopb.c_str());
+        std::remove(core.c_str());
+    }
+#endif
+}
+
+#endif

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -7,6 +7,8 @@
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
 
+#include <gcs/constraints/innards/cake_probe.hh>
+
 #include <gcs/innards/variable_id_utils.hh>
 
 #include <util/enumerate.hh>
@@ -69,109 +71,6 @@ namespace gcs::test_innards
     {
         return run_veripb("--help", ">/dev/null");
     }
-
-    // ---- PROBE (measurement only): workflow-2 cake_pb_cp chain -----------------
-    // Runs the full verified-encoding chain on a just-written .scp/.pbp, best
-    // effort, and logs a greppable "CAKECHAIN <name> <OUTCOME>" line. Never
-    // throws: this is for measuring the chain-verify rate across the random
-    // data-driven instances, not for gating the suite. Enabled by GCS_TEST_CAKE;
-    // cake_pb_cp path overridable via CAKE_PB_CP.
-#ifdef _WIN32
-    // The probe drives cake_pb_cp and veripb through popen() and a POSIX shell,
-    // and cake_pb_cp does not run on Windows anyway, so it compiles out to a
-    // no-op there.
-    inline auto cake_probe_chain(const std::string &) -> void
-    {
-    }
-#else
-    inline auto cake_capture(const std::string & cmd) -> std::string
-    {
-        std::string out;
-        if (FILE * p = ::popen((cmd + " 2>/dev/null").c_str(), "r")) {
-            char buf[8192];
-            size_t n;
-            while ((n = std::fread(buf, 1, sizeof buf, p)) > 0)
-                out.append(buf, n);
-            ::pclose(p);
-        }
-        return out;
-    }
-
-    inline auto cake_probe_chain(const std::string & pn) -> void
-    {
-        if (auto e = std::getenv("GCS_TEST_CAKE"); ! (e && *e))
-            return;
-        const char * cakeenv = std::getenv("CAKE_PB_CP");
-        std::string cake = (cakeenv && *cakeenv) ? cakeenv : "cake_pb_cp";
-        auto scp = pn + ".scp", pbp = pn + ".pbp";
-        auto vopb = pn + ".cakeopb", core = pn + ".cakecore";
-
-        auto has = [](const std::string & s, const char * m) { return s.find(m) != std::string::npos; };
-        // A VERIFIED line, or "s NO CONCLUSION": the latter is cake's success
-        // output for a proof whose conclusion is NONE (the init-only tests).
-        auto verified = [&](const std::string & s) { return has(s, "s VERIFIED") || has(s, "s NO CONCLUSION"); };
-        auto lastmeaningful = [](const std::string & s) {
-            std::string best;
-            size_t i = 0;
-            while (i < s.size()) {
-                auto e = s.find('\n', i);
-                auto line = s.substr(i, e == std::string::npos ? std::string::npos : e - i);
-                if (! line.empty() && line.find("Running VeriPB") == std::string::npos)
-                    best = line;
-                if (e == std::string::npos)
-                    break;
-                i = e + 1;
-            }
-            return best;
-        };
-        auto log = [&](const std::string & outcome, const std::string & extra = "") {
-            std::string line = "CAKECHAIN " + pn + " " + outcome;
-            if (! extra.empty())
-                line += " :: " + extra;
-            line += "\n";
-            std::fputs(line.c_str(), stderr);
-        };
-        auto firstline = [](const std::string & s) {
-            auto n = s.find('\n');
-            return n == std::string::npos ? s : s.substr(0, n);
-        };
-
-        // 1. cake_pb_cp re-derives its own OPB from the .scp.
-        std::system((cake + " " + scp + " > " + vopb + " 2>/dev/null").c_str());
-        std::string opb = cake_capture("cat " + vopb);
-        if (opb.find(">=") == std::string::npos && opb.find("<=") == std::string::npos) {
-            log("SKIP_NO_OPB");
-            std::remove(vopb.c_str());
-            return;
-        }
-        // 2. veripb elaborates OUR proof against CAKE's OPB (the divergence gate).
-        // (A domain-{0} variable's zero-bit bound rows print with an EMPTY
-        // left-hand side, which needs a veripb with the labelled-empty-LHS
-        // parser fix of 2026-07-10.)
-        auto elab = cake_capture("veripb " + vopb + " " + pbp + " --elaborate " + core + " 2>&1");
-        if (! verified(elab)) {
-            log("FAIL_ELAB", lastmeaningful(elab));
-            // Preserve the failing triple (scp/pbp + cake's OPB) for inspection.
-            // Uniquely numbered so multiple failures sharing a proof_name don't
-            // overwrite each other.
-            if (auto k = std::getenv("GCS_TEST_CAKE_KEEP"); k && *k) {
-                static int fail_seq = 0;
-                std::string dir{k}, sfx = std::to_string(++fail_seq);
-                for (auto ext : {".scp", ".pbp"})
-                    std::system(("mkdir -p " + dir + " && cp " + pn + ext + " " + dir + "/" + pn + "." + sfx + ext + " 2>/dev/null").c_str());
-                std::system(("cp " + vopb + " " + dir + "/" + pn + "." + sfx + ".cakeopb 2>/dev/null").c_str());
-            }
-            std::remove(vopb.c_str());
-            std::remove(core.c_str());
-            return;
-        }
-        // 3. cake_pb_cp re-checks the elaborated core.
-        auto rc = cake_capture(cake + " " + scp + " " + core);
-        log(verified(rc) ? "OK" : "FAIL_RECHECK", lastmeaningful(rc));
-        std::remove(vopb.c_str());
-        std::remove(core.c_str());
-    }
-#endif
 
     /**
      * The file extensions a proving run can leave beside its proof. Only .opb


### PR DESCRIPTION
Closes #576.

`gcs/constraints/innards/constraints_test_utils.hh` is included by every constraint test in the tree, and roughly a hundred lines of it were a measurement probe that no test uses: a best-effort run of the workflow-2 `cake_pb_cp` chain over a proof that has just verified, logging a greppable `CAKECHAIN` line, no-op unless `GCS_TEST_CAKE` is set.

The objection is location, not quality — the banner is honest about what it is and the code is careful within its own terms. But #566 has just made the case that measurement-only programs should not sit beside material people are meant to read, and this is the same class of thing somewhere considerably more central: someone opening this header to work out how to write a constraint test has to scroll past `popen()`, `std::system()` with interpolated paths, a hand-rolled last-non-empty-line parser and a `mkdir -p && cp`, none of which has anything to do with writing a constraint test.

Moved verbatim to `gcs/constraints/innards/cake_probe.hh`, included by `constraints_test_utils.hh` for its single call site, with a file comment saying what it is and why it is not in there.

**No behaviour change.** With `GCS_TEST_CAKE=1`, `equals_test` still logs all 284 `CAKECHAIN` lines, and none without it.

**Also excluded from install**, alongside `constraints_test_utils.hh` — the install rule now says why both are excluded. Checked by installing into a prefix and looking: 222 headers installed, neither of these among them.

This deliberately does not decide whether the probe still earns its keep now that #432 reports all non-cake-blocked constraints chain-verifying. That is a separate question, and moving it does not foreclose either answer.

**Based on #566**, which is where the argument for it comes from; the review comment in #576 suggested `main`, but #563 rewrites the surrounding part of the same header, so a `main`-based branch would only conflict on rebase.

Suite: 368/368. The 157 `scp_chain` tests are excluded — they fail on this machine before and after any of this work, on a `cake_pb_cp` that predates the current `.scp` format and rejects the input at step [2].

🤖 Generated with [Claude Code](https://claude.com/claude-code)