### PR TITLE
dev_docs: catch up with the signed end proxy and SnapshottedReason

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -328,6 +328,28 @@ and the pol differently:
   variable-duration encoding **chain-verifies** against `cake_pb_cp`
   (`scp_chain_cumulative_var_duration_sat`).
 
+  **The proxy is signed when a start can precede time 0.** Its range must
+  cover `s + l` in full, or `introduce_bits_of`'s redundancy goals are
+  unprovable — so its lower bound is `min(0, lb(s_i) + lb(l_i))`, not a
+  hard-coded `0`, and it carries a sign bit whenever that is negative.
+  This was issue #553: mznc2023 `unison` parks its inactive tasks at
+  `s = -1, l = 0`, and with a `0` lower bound the first `le` step's
+  proofgoal `s + l ≥ 0` is simply false, so veripb rejected the proof
+  there. Zero stays the lower bound otherwise, because `end ≥ 0` is then
+  the one boundary pin that is a tautology.
+
+  `introduce_bits_of` grew the signed path to match: the same
+  construction shifted by `2^S`, with `¬sign` as the top bit of the
+  unsigned sum `BinEnc + 2^S`, so after veripb's literal normalisation
+  the emitted lines *are* the unsigned lines of the shifted form. It also
+  now derives the form's own bound lines by `pol` over the operands' OPB
+  bound rows before the top step, so the two top-step redundancy goals
+  discharge by veripb's implication check for any operand shape. Leaning
+  on unit propagation for those, as it used to, stalls whenever an
+  operand's bit encoding overhangs the target's — a start in `[-17, -16]`
+  spanning `[-32, 31]` against a proxy spanning `[-8, 7]`, say — which
+  was a latent failure in the unsigned case too.
+
 The `pin_contributor` / `pin_pushed` helpers in
 `cumulative/cumulative.cc` package the (a)/(b) emission so the overflow
 and both push inferences share one shape across all constant/variable

--- a/dev_docs/reasons-improvement.md
+++ b/dev_docs/reasons-improvement.md
@@ -14,12 +14,20 @@ This is built on the `302-then-347` branch. As built: the `Reason` variant
 `{Generic,BothBounds,Lazy}ReasonOver` + `Narrowable*`) and `materialise()`
 live in `gcs/innards/reason.hh`; the
 materialise is deferred inside the inference tracker (`snapshot_reason` pins the
-eager-vs-lazy timing so eager reasons snapshot pre-inference into an
-`ExplicitReason` and lazy ones materialise post-inference). The old
+eager-vs-lazy timing so eager reasons snapshot pre-inference into a
+`SnapshottedReason` and lazy ones materialise post-inference). The old
 `ReasonFunction` thunk, its `LegacyReasonFunction` bridge, and the `Reason(F&&)`
 ctor are all gone — no `std::function` is built on the reason path. Every step was
 byte-identical to the prior proofs. The justification layer that builds on this is
 implemented too; see the "IMPLEMENTED" note in `infer-redesign.md`.
+
+As built on 2026-06-19 `snapshot_reason` returned an `ExplicitReason`; #534
+replaced that with `SnapshottedReason` (`gcs/innards/inference_tracker.hh`),
+which carries `literals` / `materialise_later` / `original` and reaches the
+logger without being wrapped back up and re-materialised per inference. The
+`original` handle exists for the dom/wdeg conflict observers, which read the
+contradicting reason and run with proofs off — where the snapshot deliberately
+materialises nothing. The eager-versus-lazy timing described above is unchanged.
 
 ## Motivation
 

--- a/dev_docs/variable-encodings.md
+++ b/dev_docs/variable-encodings.md
@@ -104,6 +104,19 @@ The two in-proof rows share a rule — the variable is meaningless until introdu
   them, register the variable's bounds as not-trivially-derivable
   (`note_bounds_not_trivially_derivable`, as ArgSort's free signed bit-sums do) and
   derive the bounds once, explicitly, from the introduction.
+- **The target's range must cover the form in full.** `introduce_bits_of` defines
+  the target *equal* to the linear form, so a target that cannot represent every
+  value the form can take leaves the top-step redundancy goals plain false, and
+  veripb rejects the proof at the first `le` step. Give the target
+  `[min over the form, max over the form]` and let it be **signed** when the lower
+  end is negative — do not floor it at `0` because the modelled quantity "obviously"
+  cannot be negative. It is the *form's* range that matters, not the quantity's:
+  issue #553 was exactly this, Cumulative's `end = s + l` proxy pinned to a lower
+  bound of `0` while `unison`'s inactive tasks sit at `s = -1, l = 0`, making the
+  first proofgoal `s + l >= 0` genuinely false. See
+  [cumulative-proof-logging.md](cumulative-proof-logging.md) for that case written
+  out. A signed target is fully supported: the construction is the same one shifted
+  by `2^S`, with `¬sign` as the top bit.
 
 ## Rule of thumb
 


### PR DESCRIPTION
Closes #570. Documentation only; no code touched.

Two `dev_docs/` files describe proof-side machinery that changed under the batch merged on 2026-07-27 and were not updated to match.

### `dev_docs/cumulative-proof-logging.md` — the end proxy can be signed

The "Variable durations" bullet predates #555. Nothing in it is false, but a reader would reasonably conclude the proof-only `end_i = s_i + l_i` proxy is always non-negative. It is not: its lower bound is `min(0, lb(s_i) + lb(l_i))`, so it is signed and carries a sign bit whenever a start can precede time 0.

That was the #553 bug — mznc2023 `unison` parks its inactive tasks at `s = -1, l = 0`, where the first `le` redundancy step's proofgoal `s + l >= 0` is genuinely false, and veripb rejected the proof there. The bullet now records that, along with the two halves of the `introduce_bits_of` fix it needed:

- the signed path (the same construction shifted by `2^S`, with `~sign` as the top bit of `BinEnc + 2^S`);
- the `pol` derivation of the form's own bound lines before the top step, which discharges the two top-step redundancy goals for any operand shape instead of relying on unit propagation — which stalls when an operand's bit encoding overhangs the target's, a latent failure in the unsigned case too.

### `dev_docs/reasons-improvement.md` — `snapshot_reason`'s return type

The **IMPLEMENTED (2026-06-19)** section names `ExplicitReason` as what `snapshot_reason` yields. Since #534 it yields `SnapshottedReason` (`gcs/innards/inference_tracker.hh`), which carries `literals` / `materialise_later` / `original`.

Since that section is an explicitly dated record of what was built on the `302-then-347` branch, this both fixes the name in the sentence and adds a short note dating the change and saying why `original` exists (the dom/wdeg conflict observers read the contradicting reason and run with proofs off, where the snapshot deliberately materialises nothing). The eager-versus-lazy *timing* the sentence describes was always right and is unchanged.

### Not included

`dev_docs/disjunctive-proof-logging.md` was checked and is still accurate — #556 removed only the `>= 1` order-atom aliasing for `{0,1}` `DirectOnly` variables, so `need_pol_item_defining_literal` still returns a bare `XLiteral` for eq/ne atoms there and the `emit_before_pol` workaround remains load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)