### PR TITLE
infer_all: close the temporary level when a batched inference contradicts

### DIFF
--- a/gcs/innards/inference_tracker.hh
+++ b/gcs/innards/inference_tracker.hh
@@ -648,8 +648,27 @@ namespace gcs::innards
                     auto t = logger->temporary_proof_level();
                     emit_explicit_steps(*logger, why.emit, snapshotted.materialised(_state, scratch));
                     if (why.then_rup == ThenRUP::Yes) {
-                        for (const auto & lit : lits)
-                            track(logger, _state.infer(lit), lit, JustifyUsingRUP{}, snapshotted);
+                        // One of these inferences can wipe a domain, and a
+                        // contradiction unwinds out of track() -- so the forget has to
+                        // happen on the way out as well. The temporary level is this
+                        // function's to close: whoever catches TrackedPropagationFailed
+                        // is several frames up with no idea a level was opened here,
+                        // and the backtrack that follows forgets the *search* level,
+                        // which is one shallower than this one. Stranding it is not
+                        // unsound -- nothing references the scaffolding once the steps
+                        // are emitted, and the lines are swept by whichever forget of
+                        // this level comes next -- but "the code that opens a temporary
+                        // level closes it" is the invariant the emit-then-forget
+                        // pattern rests on, and the single-literal path
+                        // (infer_explicitly) has always closed before it throws.
+                        try {
+                            for (const auto & lit : lits)
+                                track(logger, _state.infer(lit), lit, JustifyUsingRUP{}, snapshotted);
+                        }
+                        catch (const TrackedPropagationFailed &) {
+                            logger->forget_proof_level(t);
+                            throw;
+                        }
                         logger->forget_proof_level(t);
                     }
                     else {


### PR DESCRIPTION
Sibling of #579, both stacked on #551 (they touch different files, so they can land in either order once #551 does).

The `ThenRUP::Yes` batch in `infer_all` emits its scaffolding under a temporary level, RUPs each literal under it, then forgets the level. But one of those inferences can wipe a domain, and a contradiction unwinds out of `track()`, skipping the forget.

**It isn't wiped by the backtrack.** Search at depth *d* runs with the active proof level at *d+1* (`solve.cc`), so a `JustifyExplicitly`'s temporary lines land at *d+2* — while the backtrack out of that node forgets *d+1*. The stranded lines are only swept if the search later re-enters that depth and forgets *d+2*. When it doesn't, they stay live to the end of the proof: on `verified_encodings/scp_cases/lex_less_than_unsat.scp` the proof ends with four orphan constraints still in VeriPB's database, and this PR's extra `del range` is the only thing that removes them.

So: not a bug — no later step references the scaffolding once the steps are emitted, and an orphan constraint costs only checker memory and a little hint-free RUP time. This is for the invariant. "The code that opens a temporary level closes it" is what makes the emit-then-forget pattern safe to reason about locally (`ProofLogger::temporary_proof_level`'s own documentation warns about nesting on that basis), and the single-literal path in `infer_explicitly` has always closed before it throws. `#551`'s `ThenRUP::No` branch already can't strand, because it forgets before applying the updates; this makes the `Yes` branch match.

How often: across the whole test suite, **26 of 5763** batched `ThenRUP::Yes` `infer_all` calls end in a contradiction, all of them in `lex` (`lex_test` plus the four `scp_chain_lex_*_unsat` cases). `ortho_latin`, `langford` and `crystal_maze` produce byte-identical proofs.

`lex_less_than_unsat`: 2009 -> 2026 bytes, one added `del range`, still `s VERIFIED UNSATISFIABLE`. Full suite passes with proof verification, 422/422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)