### PR TITLE
Make split_random actually pick a random half

### DIFF
--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -447,8 +447,8 @@ namespace
                 auto mid = s.domain_size(var) / 2_i;
                 auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
                 if (uniform_int_distribution(0, 1)(*rand) == 0) {
-                    co_yield var > v;
                     co_yield var <= v;
+                    co_yield var > v;
                 }
                 else {
                     co_yield var > v;

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraint.hh>
+#include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/equals.hh>
 #include <gcs/current_state.hh>
 #include <gcs/innards/propagators.hh>
@@ -13,9 +14,12 @@
 #include <catch2/generators/catch_generators.hpp>
 
 #include <optional>
+#include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
+
+using std::vector;
 
 namespace
 {
@@ -117,6 +121,77 @@ TEST_CASE("dom_wdeg tie-breaks on degree")
     auto picked = selector(state.current(), propagators);
     REQUIRE(picked.has_value());
     CHECK(*picked == IntegerVariableID{a});
+}
+
+// split_random's coin flip used to yield the same pair of conditions in both
+// arms, so it always took the upper half first: split_largest_first plus a
+// wasted RNG draw (issue #568). Both orderings must appear, and every node
+// must still offer exactly the complementary pair, or search stops being
+// complete.
+TEST_CASE("split_random takes each half first sometimes")
+{
+    State state;
+    auto x = IntegerVariableID{state.allocate_integer_variable_with_state(1_i, 4_i)};
+    Propagators propagators;
+
+    // The split point does not depend on the coin flip: domain size 4 gives
+    // mid = 2, and dropping mid - 1 = 1 value lands on 2 either way.
+    const auto lower_half = x <= 2_i, upper_half = x > 2_i;
+
+    // A fixed seed keeps this deterministic run to run. The exact sequence is
+    // not portable --- uniform_int_distribution's algorithm is unspecified ---
+    // but 100 draws from a fair coin see both arms on any implementation.
+    auto generate = value_order::split_random(1234);
+
+    bool saw_lower_first = false, saw_upper_first = false;
+    for (int draw = 0; draw < 100; ++draw) {
+        vector<IntegerVariableCondition> yielded;
+        for (auto && cond : generate(state.current(), propagators, x))
+            yielded.push_back(cond);
+
+        REQUIRE(yielded.size() == 2);
+        if (yielded[0] == lower_half) {
+            CHECK(yielded[1] == upper_half);
+            saw_lower_first = true;
+        }
+        else {
+            CHECK(yielded[0] == upper_half);
+            CHECK(yielded[1] == lower_half);
+            saw_upper_first = true;
+        }
+    }
+
+    CHECK(saw_lower_first);
+    CHECK(saw_upper_first);
+}
+
+TEST_CASE("split_random wired into solve_with finds every solution")
+{
+    // The 24 permutations of 1..4, restricted to the 12 with x[0] < x[3].
+    // Which half of a domain is tried first only changes the order in which
+    // the tree is explored, so a complete search must find all of them
+    // whatever the coin flips do -- checked over several seeds, since each
+    // seed gives a different sequence of branch orderings.
+    auto seed = GENERATE(1, 2, 3, 4, 5);
+
+    Problem problem;
+    vector<IntegerVariableID> xs;
+    for (int i = 0; i < 4; ++i)
+        xs.push_back(problem.create_integer_variable(1_i, 4_i));
+    for (unsigned i = 0; i < xs.size(); ++i)
+        for (unsigned j = i + 1; j < xs.size(); ++j)
+            problem.post(NotEquals{xs[i], xs[j]});
+    problem.post(LessThan{xs[0], xs[3]});
+
+    int solutions = 0;
+    solve_with(problem,
+        SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                           ++solutions;
+                           return true;
+                       },
+            .branch = branch_with(variable_order::dom(problem), value_order::split_random(seed))});
+
+    CHECK(solutions == 12);
 }
 
 TEST_CASE("dom_wdeg wired into solve_with finds every solution")

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -193,6 +193,9 @@ set_tests_properties(minizinc-sort PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-argsort COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ argsorttest true true)
 set_tests_properties(minizinc-argsort PROPERTIES SKIP_RETURN_CODE 66)
 
+add_test(NAME minizinc-splitrandom COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ splitrandom true true)
+set_tests_properties(minizinc-splitrandom PROPERTIES SKIP_RETURN_CODE 66)
+
 add_test(NAME minizinc-strictlydecreasing COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ strictlydecreasing true true)
 set_tests_properties(minizinc-strictlydecreasing PROPERTIES SKIP_RETURN_CODE 66)
 

--- a/minizinc/tests/splitrandom.mzn
+++ b/minizinc/tests/splitrandom.mzn
@@ -1,0 +1,17 @@
+include "alldifferent.mzn";
+
+% Bound-split branching where each node flips a coin for which half to try
+% first. Issue #568: both arms of that coin flip used to yield the same pair
+% of conditions, so indomain_split_random silently behaved as "upper half
+% first, always" and never exercised the randomised ordering at all. A
+% complete search must enumerate the same solutions whichever way each coin
+% lands, and the proof must still verify with the two split branches emitted
+% in either order.
+array[1..4] of var 1..4: x;
+
+constraint alldifferent(x);
+constraint x[1] < x[4];
+
+solve :: int_search(x, first_fail, indomain_split_random) satisfy;
+
+output ["ENUMSOL: x=\(x)\n"];


### PR DESCRIPTION
Fixes #568.

`split_random_value_generator` drew a coin flip and then yielded **the same pair of conditions in both arms**, so it always took the upper half first: `split_largest_first` plus one wasted RNG draw per branch node, despite the header documenting it as "taking a random half first". The fix is the two-line swap in one arm that the issue suggested.

### On the re-baselining risk

The issue flagged that this changes search trajectories for every `split_random` seed. In practice there was nothing to re-baseline: the only caller anywhere in the tree is the MiniZinc frontend's `indomain_split_random`, and no test, example, benchmark, or bundled model used it. That is also why an inert coin flip survived — the heuristic had no coverage at all. Both branch directions were already exercised individually by `split_smallest_first` / `split_largest_first`, so the machinery (nogood reduction's negative-flip detection, proof logging of the two split branches) handles either order; what was new was the same generator alternating between them.

### Tests

- `search_heuristics_test`: drives the generator directly over a fixed seed and requires both orderings to appear, each as the complementary pair. Verified this fails on the unfixed code (`CHECK(saw_lower_first)` false) and passes after.
- `search_heuristics_test`: `solve_with` enumeration over five seeds — branch order must not change the solution set.
- `minizinc-splitrandom`: a model annotated `int_search(x, first_fail, indomain_split_random)`, run through the differential harness. The frontend leaves the RNG unseeded here, so each run takes a different tree; solutions are diffed against MiniZinc's default solver and the proof is checked by VeriPB. Ran it four times over and above the suite — 12 solutions and `s VERIFIED COMPLETE ENUMERATION OF 12 SOLUTIONS` every time.

Full `ctest`: 532/532 pass. clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)