### PR TITLE
difference logic: a global propagator for systems of x - y <= d (#571)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -72,6 +72,16 @@ library. For an introduction to *using* the solver, start with the top-level
   scaffolding at all. Covers the per-blocker push chains, variable
   durations without in-proof end variables, and the same recipe one
   dimension up for `Disjunctive2D`.
+- [Difference logic](difference-logic.md) — design note for
+  `DifferenceConstraints`, the global propagator for systems of `x - y <= d`:
+  the constraint-graph formulation, the two Bellman-Ford directions, why every
+  operand is canonicalised to a bare variable before the OPB row is emitted
+  (representation consistency, without which nothing cancels), the two proof
+  shapes — a negative cycle refuted by one telescoping `pol`, a bound push
+  justified per edge along the predecessor forest — the source paper's
+  pseudocode defects, the measured order-independence and proof-size results,
+  and what is deferred (incrementality, half-reification, presolver, root
+  simplification).
 - [Range ("in") literals](range_literals_spec.md) — the design specification
   for the interval-literal proof layer: reifying `[X∈[a,b]]` to its
   order-chain cuts, the always-covered partition invariant, interval-tree

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -1,0 +1,424 @@
+# Difference logic: `DifferenceConstraints`
+
+`DifferenceConstraints` propagates a whole system of `x - y <= d` at once,
+rather than one propagator per constraint. This note covers the graph
+formulation, the two propagation directions, the round bound and why the
+negative-cycle extraction is total, the canonicalisation rule and why it exists,
+the two proof shapes with worked examples, the defects in the source paper's
+pseudocode, and what is deliberately deferred.
+
+The source is Kletzander, Dekker, Schutt and Stuckey, *Global Difference
+Constraint Propagation for Constraint Programming*, arXiv:2607.20022 — the
+journal expansion of Feydy, Schutt and Stuckey (PPDP 2008). Issue #571 tracks
+the whole effort; this document describes what the first propagator PR actually
+does, which is a deliberately small slice of the paper.
+
+## The graph
+
+A system `C` of difference constraints is a weighted digraph `G_C`: one vertex
+per variable, and one edge `x --d--> y` per constraint `x - y <= d`. Note the
+direction — the tail is the constraint's left hand side.
+
+Two classical facts (the paper's Theorem 1, from the Shostak / Dechter-Meiri-
+Pearl lineage) are all the reasoning we need:
+
+- `C` is satisfiable iff `G_C` has **no negative-weight cycle**;
+- `C ⊨ x - y <= d` iff the **shortest path** from `x` to `y` weighs at most `d`.
+
+The paper encodes variable bounds as edges to a dummy vertex `v0` fixed at 0
+(`x >= l` is `v0 --(-l)--> x`, `x <= u` is `x --u--> v0`), which turns bounds
+propagation into single-source shortest paths from `v0` (their Corollary 1).
+`v0` is never materialised here: the seeding of the two Bellman-Ford passes
+below *is* the `v0` edge set, expressed directly as the initial distance array.
+
+## The two directions
+
+Read one edge `x --d--> y`, i.e. `x - y <= d`, in both directions:
+
+- as `y >= x - d`, so **lower bounds flow forwards**: `lb(y) >= lb(x) - d`;
+- as `x <= y + d`, so **upper bounds flow backwards**: `ub(x) <= ub(y) + d`.
+
+So the propagator runs two Bellman-Ford passes:
+
+1. **Lower bounds**, over the graph as given, seeded with `lb(v)` for every
+   node. Writing `dist(v) = -lb(v)` this is literally shortest paths from `v0`
+   with `w(v0, v) = -lb(v)`.
+2. **Upper bounds**, over the reverse graph, seeded with `ub(v)`.
+
+The two passes are **independent**, which is what makes one pass each a complete
+fixpoint rather than something that has to be iterated: each edge relates only
+`lb(x)` to `lb(y)`, and only `ub(y)` to `ub(x)`, so the lower-bound closure
+depends on nothing but the initial lower bounds and vice versa. Reaching that
+closure is exactly what Bellman-Ford computes.
+
+Infeasibility shows up two ways, and both are handled:
+
+- a **negative cycle**, which is infeasibility of the difference system on its
+  own, refuted directly (below);
+- a pushed bound crossing the opposite bound, which the framework turns into a
+  contradiction when the inference empties the domain.
+
+One caveat on "one pass each is the fixpoint": it is the fixpoint of the
+*bounds abstraction*. gcs domains can have holes, so an inferred bound can snap
+past the value Bellman-Ford computed, which may license a further push. The
+propagator therefore triggers on the bounds of every node it owns, returns plain
+`Enable` rather than `EnableButIdempotent`, and is re-woken by its own
+inferences until the state stops moving.
+
+## Rounds, and why the extraction is total
+
+With `n` nodes, a shortest path from `v0` is simple, and the seeding *is* the
+`v0` edge set, so at most `n - 1` real edges remain and `n - 1` relaxation
+rounds always suffice. The loop runs rounds `0 .. n - 1` — one more than needed
+— and then round `n` purely to detect: a relaxation that still succeeds there is
+sound evidence that the system has a negative cycle.
+
+The extraction then walks `pred` back from the node just relaxed, marking as it
+goes, and both things it needs are true.
+
+**The walk never runs off the end of the forest.** Suppose it did: it visits
+distinct nodes `v, a_1, …, a_k` with `a_k` having no predecessor, so `dist(a_k)`
+has sat at its seeded value since before round 0. Those nodes are distinct, so
+`k <= n - 1`, and `a_k ⇝ v` is a real path of `k` edges out of a source whose
+distance never moved — which after `k <= n` completed rounds forces
+`dist(v) <= dist(a_k) + w(a_k ⇝ v)`. But `pred` gives exactly the reverse:
+`dist(v) = dist(a_1) + w_1` at the instant it was set, and
+`dist(a_i) >= dist(a_{i+1}) + w_{i+1}` throughout (each was an equality when its
+pointer was set, and the tail has only fallen since), so
+`dist(v) >= dist(a_k) + w(a_k ⇝ v)` — *after* the strictly improving relaxation
+that round `n` has just made. The two together say `dist(v) < dist(v)`. So the
+walk must revisit a node, and the first repeat is on a cycle.
+
+**Every cycle in the predecessor graph is a negative cycle.** A cycle comes into
+existence at the moment its last pointer is set, say `pred[v_1] := (v_k, v_1)`,
+the rest already being in place. Chaining the same inequalities from `v_1` round
+to `v_k` gives `dist_new(v_1) = dist(v_k) + w_k >= dist_old(v_1) + W`, and
+setting the pointer at all required `dist_new(v_1) < dist_old(v_1)`, so `W < 0`.
+Its edges and weights never change afterwards — reassigning any of them destroys
+the cycle — so whenever one is found it is still negative. Summing the edge rows
+round it cancels every distance and leaves `0 > W`.
+
+Neither argument is left to trust: the extracted cycle is re-checked
+arithmetically before anything is emitted (below).
+
+## Canonicalisation, and why
+
+Every operand of every edge is reduced at construction to a bare
+`SimpleIntegerVariableID` plus an offset, and the offsets are folded into the
+weight:
+
+```
+V1 - V2 <= d,  V1 = X + c1,  V2 = Y + c2      ⇒      X - Y <= d - c1 + c2
+```
+
+Three cases fall out:
+
+| Operands | Result |
+|---|---|
+| two distinct variables | a graph edge |
+| one variable, one constant | a **static bound** on the variable (`X <= d` or `Y >= -d`) |
+| the same variable twice, or two constants | `0 <= d`: vacuous, or a **root contradiction** |
+| a negated view `-X + c` | **rejected**, `InvalidProblemDefinitionException` |
+
+**Negated views are rejected because accepting them would be unsound, not merely
+incomplete.** `V - W <= d` with `V = -X + c` is `-X - W <= d - c`, which is not
+a difference constraint at all: both coefficients are negative, the graph
+formulation does not describe it, and treating it as an edge would licence
+inferences the constraint does not entail. This is the survey's section 2.6(e).
+
+**The OPB rows are emitted over the canonical form**, not over the operands the
+user handed in, and that is the load-bearing decision of the whole design.
+`dev_docs/view-proof-logging.md` invariant 1: a `pol` only cancels a variable
+when both lines express it in the *same* representation. A registered view `V`
+of `X` has its own bit-vector, related to `BinEnc(X)` only by the link axiom, so
+two edges that meet at "the same variable" through two different views would not
+cancel at all and every derivation below would strand. Both proof shapes here
+are cancellation-driven, so this is not a small risk — the survey ranks it as
+the single most likely thing to go wrong, and it is the historical
+`Abs`/`AllDifferent` bug class.
+
+Emitting the deviewed row removes the problem by construction, and it is still
+definitional: `X - Y <= d - c1 + c2` states exactly the posted `V1 - V2 <= d`,
+just written in the bare variables' bits. Nothing else goes in the OPB — no
+flags, no auxiliaries — and every inference the propagator makes is a
+cutting-planes consequence of those rows alone. (The alternative, which
+`linear/justify.cc` takes, is to emit in the user's operands and switch the
+`PolBuilder` into deview mode. That is strictly more machinery for the same
+result here, because this constraint owns both ends of every cancellation.)
+
+One labelled row per **posted** edge, role `e<i>` with `i` the edge's index in
+the list the user gave, so a proof line traces back to the edge that was
+written. Rows are emitted even for edges that contribute no graph edge: an
+aliased edge leaves the same variable in the sum twice with opposite
+coefficients, and a two-constant edge leaves the sum empty, and both render as a
+row whose left hand side is zero — which is what `0 <= d` says, and which VeriPB
+reads as trivially true or directly false according to `d`'s sign. A false one
+is a root contradiction that RUPs straight from the model, via
+`Propagators::install_initial_contradiction`.
+
+## Proof shape 1: negative cycle ⇒ contradiction
+
+Sum the cycle's edge rows and nothing else. Each variable appears once with `+1`
+(as some edge's head) and once with `-1` (as the next edge's tail), so every
+`BinEnc` term telescopes away and what is left is `0 >= -W` with `W < 0`, i.e. a
+constraint of positive degree over an empty left hand side. All multipliers are
+`1`; there is no multiplication, division or saturation, and (by total
+unimodularity of a node-arc incidence matrix) there never needs to be.
+
+The reason is **empty** — no domain state is used at all.
+
+Worked example, straight out of `examples/difference_chain --mode=refute
+--variant=global -n 10 --prove`, whose model closes a negative cycle of weight
+`-1` round a 13-edge chain. The entire `.pbp` is:
+
+```
+pseudo-Boolean proof version 3.0
+pol @c[_1][e18] @c[_1][e19] + @c[_1][e9] + @c[_1][e75] + @c[_1][e29] + @c[_1][e10] + @c[_1][e11] + @c[_1][e12] + @c[_1][e13] + @c[_1][e14] + @c[_1][e15] + @c[_1][e16] + @c[_1][e17] + ;
+rup >= 1;
+...
+```
+
+12 lines, **independent of the domain size and of `n`**. The same model posted
+as one `LinearLessThanEqual` per edge needs `1760k - 468` lines at `n = 10` for
+`k >= 2`, where `k` is the domain multiplier — the per-constraint propagators
+can only find the contradiction by crawling every bound up one unit at a time.
+At `k = 64` that is 112,172 lines against 12. (`k = 1` is off the line at 294
+lines: the domain `0..10` is too narrow for the crawl to get going before the
+bounds cross.)
+
+## Proof shape 2: bound push ⇒ one `pol` per edge
+
+Inferences are made **per edge along the predecessor forest, not per path**.
+After Bellman-Ford converges, the improved nodes are walked in an order
+consistent with the predecessor relation (the forest's roots are exactly the
+nodes whose bound did not improve), and each node's new bound is inferred citing
+*its predecessor's already-inferred bound*. Each such inference is then a
+single-edge push, and its proof is one `pol`:
+
+```
+pol  <edge row>  <definition row for the predecessor's bound literal>  + ;
+```
+
+For a lower-bound push across `x --d--> y` with the predecessor at `x >= L`:
+
+```
+  (edge row)          -BinEnc(x) + BinEnc(y)                >= -d
+  (D+[x >= L])         BinEnc(x) + M·¬[x >= L]              >= L
+  ────────────────────────────────────────────────────────────────
+                       BinEnc(y) + M·¬[x >= L]              >= L - d
+```
+
+and the framework's closing reason-wrapped RUP then derives
+`[x >= L] → [y >= L - d]`. Upper bounds are the mirror image, citing the
+definition row of `[y < U + 1]` and concluding `[x < U + d + 1]`.
+
+This is `justify_linear_bounds` for a two-term linear, which is no accident: a
+single difference edge *is* a two-term linear, and the global propagator's only
+extra power is that it chains the pushes. It is also the shape verified by hand
+in `boundpush_hand.pbp` (see the survey directory) before any of this was
+written.
+
+Real output, from the four-variable chain in
+`gcs/constraints/difference/difference_constraints_test.cc`:
+
+```
+red 1 i[_2][b0] 2 i[_2][b1] 4 i[_2][b2] 1 ~i[_2][ge1] >= 1 : i[_2][ge1] -> 0;
+red -1 i[_2][b0] -2 i[_2][b1] -4 i[_2][b2] 7 i[_2][ge1] >= 0 : i[_2][ge1] -> 1;
+...
+pol @c[_1][e0] -3 + ;
+rup 1 i[_2][ge1] 1 ~i[_1][ge0] >= 1;
+```
+
+Two properties worth naming:
+
+- **Per-edge is `O(1)` proof lines per inferred bound**, where a per-path
+  justification would be `O(path length)`. It also needs no intermediate atoms
+  beyond the ones the inferences mint anyway.
+- **The reason is already "lifted"** in the paper's section 4.3.3 sense. The
+  weakest antecedent for `y >= L - d` across this one edge is exactly `x >= L`,
+  so the `pol`'s degree comes out at exactly the pushed amount with no wasted
+  slack, and the learned clause is magnitude-invariant. The paper measures its
+  `Simple` explanation (cite the current bounds, whatever they are) as clearly
+  the worst of its three; per-edge inference gets `Lifted` for free, without
+  choosing to.
+
+The `pol` is load-bearing, not decoration. RUP cannot compose across
+constraints: transferring the predecessor's *order atom* into the edge row's
+`BinEnc` terms is a linear addition of two constraints, which unit propagation
+never performs (`view-proof-logging.md` invariant 3, and the same finding
+`dev_docs/disjunctive-proof-logging.md` records for its single-edge pol).
+
+## The self-check
+
+Before emitting a cycle refutation the extracted cycle is verified
+arithmetically: that each edge meets the next at the node it claims to, that the
+walk closes, and that the total weight really is negative. That is `O(cycle)`,
+negligible, and it turns a predecessor-walk bug into an exception at the right
+place rather than a VeriPB failure hundreds of lines later. The same check is
+applied to each bound push (the pushed value must equal the predecessor's bound
+plus the edge weight).
+
+This matters more than usual here because of an asymmetry the survey points out
+(section 2.1): if the algorithm produces a **wrong** inference, the `pol` will
+not verify and proof logging catches it; if it produces a **missing** inference,
+proof logging cannot help at all, because a proof only ever certifies what was
+derived. Hence also the cross-check in the test suite, which posts each system
+twice — once as `DifferenceConstraints`, once as individual two-term
+`LinearLessThanEqual` constraints — and requires the solution sets to be
+identical. A soundness bug shows up there as a missing solution and an
+over-pruning bug as an extra one, neither of which any proof would catch.
+
+Solution-set equality still would not show that the *new* strength ever fired: a
+propagator that inferred nothing at all would pass every one of those cases, just
+by searching harder. So two tests assert behaviour directly rather than counting
+solutions. `run_transitive_test` posts `x - y <= -3` and `y - z <= -4` over
+`0..10`, propagates the root, and requires `z >= 7` and `x <= 3` — bounds that no
+single edge implies, so they can only come from a chained push.
+`run_negated_view_test` requires `InvalidProblemDefinitionException` for each of
+`-x`, `-y` and `-x + 2` as an operand, and fails if no exception is raised rather
+than passing silently. Both were confirmed by mutation: stubbing out
+`infer_along_forest` fails the first, and dropping the `negate_first` check fails
+the second.
+
+## Defects in the paper's pseudocode
+
+Two, catalogued so nobody transcribes them:
+
+- **Algorithm 3 lines 15-16 use `γ(s)` after line 10 has set it to `+∞`.** The
+  value intended is `wSP(v0, s)`, saved on line 9. Transcribed literally the
+  relaxation test is always `+∞ < γ(t)`, which is false, and the algorithm
+  never propagates anything. The paper's own Example 7 arithmetic disambiguates
+  it.
+- **The `δ→` / `δ←` notation is not self-consistent.** Section 3.1 defines
+  `δ←_x(y) = wSP(x, y)` and `δ→_x(y) = wSP(y, x)`; Algorithm 3 line 11 then
+  writes `δ→_{v0}(s) := wSP(v0, s) + π(s) - π(v0)`, which is `δ←` by that
+  definition. Read Algorithm 3 throughout as "distance *from* `v0`". (Line 20
+  also drops its argument, which is merely cosmetic.)
+
+Two more from the paper that bear on this PR even though the algorithms they
+belong to are not implemented yet:
+
+- The `Do` gate in Algorithm 3 is against the *previous run's* bounds, not the
+  current ones, and the paper never says what happens to `Do` on backtracking.
+  Loosening it is always sound, tightening it silently loses propagation — and
+  a lost propagation is invisible to proof logging. Relevant when incrementality
+  lands.
+- Theorem 2 assumes **range** domains. gcs domains have holes. The propagator
+  stays sound (it only reads and writes bounds), but the theorem's completeness
+  half only holds for the bounds abstraction — so this is a bounds-consistent
+  propagator, and its tests use `solve_for_tests`, never
+  `solve_for_tests_checking_gac`.
+
+## Measurements
+
+`examples/difference_chain` builds the paper's Example 8, whose root fixpoint is
+`Θ(n³)` under one-propagator-per-constraint with an unlucky posting order and
+`Θ(n²)` with a lucky one. `--variant=global` posts exactly the same edges as one
+`DifferenceConstraints`. Medians of 3, `k = 2`, release build, no `--prove`:
+
+| n | order | variant | propagations | recursions | time (s) |
+|---:|---|---|---:|---:|---:|
+| 40 | unlucky | decomposed | 37,102 | 43 | 0.00125 |
+| 40 | unlucky | global | **87** | 83 | 0.00055 |
+| 40 | lucky | decomposed | 3,601 | 43 | 0.00064 |
+| 40 | lucky | global | **87** | 83 | 0.00043 |
+| 160 | unlucky | decomposed | 2,126,002 | 163 | 0.0459 |
+| 160 | unlucky | global | **327** | 323 | 0.0081 |
+| 160 | lucky | decomposed | 52,801 | 163 | 0.0088 |
+| 160 | lucky | global | **327** | 323 | 0.0073 |
+| 640 | unlucky | decomposed | 132,305,602 | 643 | 3.542 |
+| 640 | unlucky | global | **1,287** | 1,283 | 0.323 |
+| 640 | lucky | decomposed | 825,601 | 643 | 0.199 |
+| 640 | lucky | global | **1,287** | 1,283 | 0.269 |
+
+The headline is not the speed-up, it is the **column that does not move**: the
+global propagator's count is `2n + 7` for both orders, so the cost stops
+depending on the sequence the edges were handed over in. Bellman-Ford visits
+each edge a fixed number of times whatever order they are stored in; the
+decomposed model's propagation queue does not.
+
+Two honest caveats. First, `recursions` differs between the variants because the
+default `dom_then_deg` brancher sees different variable degrees — one global
+propagator gives every variable degree 1, where the decomposition gives `y_0`
+degree `n + 1` — so this is a search-shape change as well as a propagation
+change and the two columns have to be read together. Second, on the *lucky*
+order at large `n` the global propagator is slightly slower in wall time despite
+doing 640× fewer propagations, because this version is not incremental: every
+wake re-runs the whole `O(rounds × |E|)` pass from the current bounds. That is
+the deferred work below, not a property of the approach.
+
+Proof size, `--mode=refute` (the same system plus one edge closing a
+negative cycle of weight `-1`), `n = 10`:
+
+| k | decomposed `.pbp` lines | global `.pbp` lines |
+|---:|---:|---:|
+| 2 | 3,052 | **12** |
+| 4 | 6,572 | **12** |
+| 8 | 13,612 | **12** |
+| 16 | 27,692 | **12** |
+| 32 | 55,852 | **12** |
+| 64 | 112,172 | **12** |
+
+and against `n` at `k = 2`:
+
+| n | decomposed | global |
+|---:|---:|---:|
+| 5 | 842 | **12** |
+| 10 | 3,052 | **12** |
+| 20 | 11,672 | **12** |
+| 40 | 45,712 | **12** |
+
+The decomposed figure is `1760k - 468` in the domain multiplier for `k >= 2`,
+exactly linear; the global one is a constant, because the refutation is one
+`pol`. (PR #583 reported `1760k - 481` for the decomposed model; the 13-line
+difference is the posting-order change made here, which moves the cycle-closing
+edge in front of the lower-bound bump so that both variants post identical edge
+sequences.)
+
+## Deliberately deferred
+
+- **Incrementality.** The paper's `IncSat` / `IncLB` / `IncUB` maintain a valid
+  potential function `π` and run Dijkstra on the reduced-cost graph, processing
+  all bound changes since the last run in one pass, in `O(n log n + m)`. `π`
+  stays valid when edges are removed — validity is a conjunction over edges — so
+  it needs no trailing, which suits backtracking well. None of that is here: this
+  version recomputes Bellman-Ford from scratch on every wake, which is
+  `O(n·m)` worst case. The wall-time caveat above is entirely this.
+- **Half-reified edges** (`b -> x - y <= d`). These make the edge set change
+  during search, which needs the trailed edge journal and the paper's `E'`
+  machinery. The proof side is already understood and costs nothing extra: a
+  half-reified row contributes `M·¬b` to the sum, the `BinEnc` terms telescope
+  exactly as before, and one `saturate` turns the residuals into the clause
+  `¬b_1 ∨ … ∨ ¬b_k`. `Disjunctive` already does this at `k = 1`.
+- **`IncImp`** (implication checking, to disentail half-reified edges). It needs
+  no new proof machinery — "shortest path `x ⇝ y` of weight `<= d'`" plus the
+  candidate edge `y --(-d'-1)--(b)--> x` is a negative cycle, so it is proof
+  shape 1 with `b` the sole surviving residual — but the paper's own
+  configuration study says to leave it **off**: on RCPSP/max every configuration
+  with it on scored below every configuration with it off.
+- **The presolver** — detecting difference-shaped constraints already posted on
+  a `Problem` and lifting them into a global propagator. This is the half the
+  paper's measurements say is actually valuable (310.00 → 312.94 for the
+  propagator alone on the MiniZinc challenge set, → 320.95 with simplification),
+  and it depends on #546's typed constraint enumeration.
+- **Root simplification** — Johnson's all-pairs shortest paths, then dropping
+  redundant edges, fixing Booleans whose edge would close a negative cycle, and
+  unifying variables on a zero-weight cycle. Note that dropping a redundant edge
+  is a decision about which *propagators run*, not about what the model says: the
+  OPB must always contain every posted constraint, so the removal has no proof
+  obligation at all.
+- **Runtime propagator priorities.** The paper wants bound propagation at the
+  lowest priority and Boolean propagation at the highest, as separate
+  propagators. gcs has no runtime propagator priorities, only
+  `InitialiserPriority`.
+
+## See also
+
+- [Implementing a constraint](constraints.md) — the structural pattern this
+  follows.
+- [View proof-logging support](view-proof-logging.md) — invariant 1 is why the
+  OPB rows are canonicalised; invariant 3 is why the bound push needs an
+  explicit `pol`.
+- [Proof logging for `Disjunctive`](disjunctive-proof-logging.md) — its
+  `before_{i,j} ⇔ s_i + l_i <= s_j` is a half-reified difference constraint, and
+  its pairwise pols are proof shape 2 at chain length 1.

--- a/examples/difference_chain/CMakeLists.txt
+++ b/examples/difference_chain/CMakeLists.txt
@@ -2,7 +2,10 @@ add_executable(difference_chain difference_chain.cc)
 target_link_libraries(difference_chain PRIVATE glasgow_constraint_solver)
 target_link_libraries(difference_chain PRIVATE cxxopts)
 
-# One entry per mode, each with its own proof basename: without that, a parallel
-# ctest run has both entries writing the same .opb / .pbp pair (issue #562).
+# One entry per mode and variant, each with its own proof basename: without
+# that, a parallel ctest run has several entries writing the same .opb / .pbp
+# pair (issue #562).
 add_test(NAME difference_chain-fixpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-fixpoint $<TARGET_FILE:difference_chain> --mode fixpoint)
 add_test(NAME difference_chain-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-refute $<TARGET_FILE:difference_chain> --mode refute)
+add_test(NAME difference_chain-global-fixpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-global-fixpoint $<TARGET_FILE:difference_chain> --mode fixpoint --variant global)
+add_test(NAME difference_chain-global-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-global-refute $<TARGET_FILE:difference_chain> --mode refute --variant global)

--- a/examples/difference_chain/difference_chain.cc
+++ b/examples/difference_chain/difference_chain.cc
@@ -38,17 +38,20 @@
 // which is a single cutting-planes step whatever the domains are; this mode is
 // the baseline that claim will be measured against.
 //
-// Everything is posted as a two-term LinearLessThanEqual, i.e.
-// 1*a + -1*b <= d, which is the shape the presolver planned in issue #571 will
-// detect. Deliberately not LessThanEqual/Comparison over an offset view: those
-// are emitted unlabelled in the OPB, so a later global propagator could not
-// cite them in a proof.
+// --variant=decomposed posts every constraint as its own two-term
+// LinearLessThanEqual, i.e. 1*a + -1*b <= d, which is the shape the presolver
+// planned in issue #571 will detect. Deliberately not LessThanEqual/Comparison
+// over an offset view: those are emitted unlabelled in the OPB, so a global
+// propagator could not cite them in a proof.
 //
-// --variant currently accepts only "decomposed", the model above with one
-// propagator per constraint. A later PR in this stack adds --variant=global,
-// which posts the same system as a single global difference-logic constraint;
-// the dispatch below is the seam for it.
+// --variant=global posts exactly the same edges, in exactly the same order, as
+// a single DifferenceConstraints. That runs one Bellman-Ford pass over the
+// whole graph per wake instead of one propagator per edge, so the fixpoint cost
+// stops depending on the order the edges were given in; and in --mode=refute it
+// refutes the negative cycle by summing the cycle's edge rows, which is one
+// cutting-planes step whatever the domains are.
 
+#include <gcs/constraints/difference.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
@@ -95,13 +98,6 @@ using fmt::println;
 
 namespace
 {
-    // Post the difference constraint a - b <= d. Always as a two-term linear
-    // inequality: see the file-top comment for why not Comparison.
-    auto post_difference(Problem & problem, IntegerVariableID a, IntegerVariableID b, Integer d) -> void
-    {
-        problem.post(LinearLessThanEqual{WeightedSum{} + 1_i * a + -1_i * b, d});
-    }
-
     enum struct Order
     {
         Unlucky,
@@ -114,32 +110,43 @@ namespace
         Refute
     };
 
-    // Post Example 8's constraints over y and x. The two orders contain exactly
-    // the same constraints and differ only in the sequence they are handed to
-    // the solver in, which is what seeds the propagation queue.
-    auto post_example_8(Problem & problem, const vector<IntegerVariableID> & y, const vector<IntegerVariableID> & x, int n, Order order) -> void
+    enum struct Variant
     {
+        Decomposed,
+        Global
+    };
+
+    // Build Example 8's constraints over y and x. The two orders contain
+    // exactly the same edges and differ only in the sequence they come out in,
+    // which is what seeds the propagation queue for --variant=decomposed (and
+    // which --variant=global is designed not to care about).
+    auto example_8_edges(const vector<IntegerVariableID> & y, const vector<IntegerVariableID> & x, int n, Order order) -> vector<DifferenceEdge>
+    {
+        vector<DifferenceEdge> edges;
+
+        auto edge = [&](IntegerVariableID a, IntegerVariableID b, Integer d) { edges.push_back(DifferenceEdge{a, b, d}); };
+
         auto chain_ascending = [&] {
             for (int i = 2; i <= n; ++i)
-                post_difference(problem, y[i - 1], y[i], 0_i);
+                edge(y[i - 1], y[i], 0_i);
         };
         auto chain_descending = [&] {
             for (int i = n; i >= 2; --i)
-                post_difference(problem, y[i - 1], y[i], 0_i);
+                edge(y[i - 1], y[i], 0_i);
         };
         auto jumps_ascending = [&] {
             for (int i = 1; i <= n; ++i)
-                post_difference(problem, y[0], y[i], Integer{i - 1});
+                edge(y[0], y[i], Integer{i - 1});
         };
         auto jumps_descending = [&] {
             for (int i = n; i >= 1; --i)
-                post_difference(problem, y[0], y[i], Integer{i - 1});
+                edge(y[0], y[i], Integer{i - 1});
         };
-        auto bridge = [&] { post_difference(problem, y[n], x[0], 0_i); };
+        auto bridge = [&] { edge(y[n], x[0], 0_i); };
         auto x_pairs = [&] {
             for (int i = 0; i <= n; ++i)
                 for (int j = i + 1; j <= n; ++j)
-                    post_difference(problem, x[i], x[j], 0_i);
+                    edge(x[i], x[j], 0_i);
         };
 
         switch (order) {
@@ -163,12 +170,27 @@ namespace
             x_pairs();
             break;
         }
+
+        return edges;
     }
 
-    // The --variant names, in help order. Only the decomposition exists in this
-    // PR; --variant=global (one global difference-logic constraint over the same
-    // system) arrives in a later PR of the issue #571 stack.
-    constexpr string_view variants[] = {"decomposed"};
+    // Hand the same edges to the solver, either one propagator each or all at
+    // once. Both variants produce the same OPB rows for the same edges (one
+    // labelled inequality per edge), so the proofs are directly comparable.
+    auto post_edges(Problem & problem, const vector<DifferenceEdge> & edges, Variant variant) -> void
+    {
+        switch (variant) {
+            using enum Variant;
+        case Decomposed:
+            for (const auto & e : edges)
+                problem.post(LinearLessThanEqual{WeightedSum{} + 1_i * e.x + -1_i * e.y, e.d});
+            break;
+        case Global: problem.post(DifferenceConstraints{edges}); break;
+        }
+    }
+
+    // The --variant names, in help order.
+    constexpr string_view variants[] = {"decomposed", "global"};
 
     auto variant_names() -> string
     {
@@ -274,9 +296,14 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_FAILURE;
     }
 
-    auto variant = options_vars["variant"].as<string>();
-    if (variant != "decomposed") {
-        println(cerr, "Error: unknown --variant '{}'. Supported: {}.", variant, variant_names());
+    auto variant_name_given = options_vars["variant"].as<string>();
+    optional<Variant> variant;
+    if (variant_name_given == "decomposed")
+        variant = Variant::Decomposed;
+    else if (variant_name_given == "global")
+        variant = Variant::Global;
+    else {
+        println(cerr, "Error: unknown --variant '{}'. Supported: {}.", variant_name_given, variant_names());
         return EXIT_FAILURE;
     }
 
@@ -285,18 +312,22 @@ auto main(int argc, char * argv[]) -> int
     auto y = problem.create_integer_variable_vector(n + 1, 0_i, hi, "y");
     auto x = problem.create_integer_variable_vector(n + 1, 0_i, hi, "x");
 
-    post_example_8(problem, y, x, n, *order);
-
-    // The lower-bound bump that starts the chase. Posted last, so that the
-    // difference constraints are all in the queue ahead of it and the bump wakes
-    // them exactly as the paper describes.
-    problem.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * y[0], Integer{n}});
+    auto edges = example_8_edges(y, x, n, *order);
 
     // One extra difference constraint closing a negative cycle of weight -1
     // around y_0 <= ... <= y_n <= x_0 <= ... <= x_n, which the chain makes
     // reachable at cost 0. Nothing about it is locally violated.
     if (*mode == Mode::Refute)
-        post_difference(problem, x[n], y[0], -1_i);
+        edges.push_back(DifferenceEdge{x[n], y[0], -1_i});
+
+    post_edges(problem, edges, *variant);
+
+    // The lower-bound bump that starts the chase. Posted last, so that the
+    // difference constraints are all in the queue ahead of it and the bump wakes
+    // them exactly as the paper describes. Not a difference constraint, and
+    // posted identically in both variants, so the comparison is between the two
+    // ways of handling the edges and nothing else.
+    problem.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * y[0], Integer{n}});
 
     auto all = options_vars.contains("all");
     bool proven = false;
@@ -328,7 +359,7 @@ auto main(int argc, char * argv[]) -> int
     println("k: {}", k);
     println("order: {}", order_name);
     println("mode: {}", mode_name);
-    println("variant: {}", variant);
+    println("variant: {}", variant_name_given);
     println("all: {}", all ? "yes" : "no");
     println("domain: 0..{}", hi.raw_value);
     println("status: {}", status);

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(glasgow_constraint_solver
         constraints/comparison/comparison.cc
         constraints/count/count.cc
         constraints/cumulative/cumulative.cc
+        constraints/difference/difference_constraints.cc
         constraints/disjunctive/disjunctive.cc
         constraints/disjunctive_2d/disjunctive_2d.cc
         constraints/divide_modulus/divide_modulus.cc

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -221,6 +221,7 @@ if(GCS_BUILD_TESTS)
     add_executable(comparison_test constraints/comparison/comparison_test.cc)
     add_executable(count_test constraints/count/count_test.cc)
     add_executable(cumulative_test constraints/cumulative/cumulative_test.cc)
+    add_executable(difference_test constraints/difference/difference_constraints_test.cc)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
     add_executable(divide_modulus_test constraints/divide_modulus/divide_modulus_test.cc)
@@ -268,7 +269,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -290,6 +291,10 @@ if(GCS_BUILD_TESTS)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
+    foreach(mode basic cycles views alias random)
+        add_test(NAME difference_constraint_${mode}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_test> ${mode})
+    endforeach()
     foreach(mode strict nonstrict)
         add_test(NAME disjunctive_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:disjunctive_test> ${mode})

--- a/gcs/constraints/difference.hh
+++ b/gcs/constraints/difference.hh
@@ -1,0 +1,6 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_HH
+
+#include <gcs/constraints/difference/difference_constraints.hh>
+
+#endif

--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -1,0 +1,457 @@
+#include <gcs/constraints/difference/difference_constraints.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/s_expr.hh>
+#include <gcs/innards/state.hh>
+
+#include <util/overloaded.hh>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_unique;
+using std::map;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+namespace
+{
+    // Reduce an operand to (bare variable, offset), so that V = *variable +
+    // offset. A constant operand has no variable, just the offset.
+    //
+    // A negated view is rejected outright: V - W <= d with V = -X + c is
+    // -X - W <= d - c, which is not a difference constraint (both coefficients
+    // are negative). Getting this wrong is unsound rather than merely
+    // incomplete, so it is a hard error at construction. See the survey's
+    // section 2.6(e).
+    struct DeviewedOperand
+    {
+        optional<SimpleIntegerVariableID> variable;
+        Integer offset;
+    };
+
+    auto deview_operand(const IntegerVariableID & var, const char * which) -> DeviewedOperand
+    {
+        return overloaded{
+            [&](const SimpleIntegerVariableID & v) { return DeviewedOperand{v, 0_i}; },                   //
+            [&](const ConstantIntegerVariableID & v) { return DeviewedOperand{nullopt, v.const_value}; }, //
+            [&](const ViewOfIntegerVariableID & v) {
+                if (v.negate_first)
+                    throw InvalidProblemDefinitionException{
+                        string{"DifferenceConstraints "} + which + " operand is a negated view, which is not a difference constraint"};
+                return DeviewedOperand{v.actual_variable, v.then_add};
+            } //
+        }
+            .visit(var);
+    }
+}
+
+DifferenceConstraints::DifferenceConstraints(vector<DifferenceEdge> edges) : _edges(move(edges))
+{
+    // Reject negated views up front, so a bad model is a post-time error rather
+    // than a mysterious proof failure much later. prepare() redoes the
+    // deviewing; this is a cheap guard, not the canonicalisation itself.
+    for (const auto & e : _edges) {
+        static_cast<void>(deview_operand(e.x, "left"));
+        static_cast<void>(deview_operand(e.y, "right"));
+    }
+}
+
+auto DifferenceConstraints::clone() const -> unique_ptr<Constraint>
+{
+    return make_unique<DifferenceConstraints>(_edges);
+}
+
+auto DifferenceConstraints::prepare(Propagators &, State &, ProofModel * const) -> bool
+{
+    if (_edges.empty())
+        return false;
+
+    map<SimpleIntegerVariableID, size_t> node_of;
+    auto node_index = [&](const SimpleIntegerVariableID & v) -> size_t {
+        auto [it, inserted] = node_of.emplace(v, _nodes.size());
+        if (inserted)
+            _nodes.push_back(v);
+        return it->second;
+    };
+
+    for (size_t i = 0; i < _edges.size(); ++i) {
+        const auto & e = _edges[i];
+        auto left = deview_operand(e.x, "left");
+        auto right = deview_operand(e.y, "right");
+
+        // (X + c1) - (Y + c2) <= d  becomes  X - Y <= d - c1 + c2, so every
+        // edge's weight is expressed over bare variables and nothing else.
+        auto d = e.d - left.offset + right.offset;
+
+        if (left.variable && right.variable) {
+            auto from = node_index(*left.variable);
+            auto to = node_index(*right.variable);
+            if (from == to) {
+                // Aliasing: X - X <= d, i.e. 0 <= d. Vacuous when d >= 0, a
+                // root contradiction when d < 0 (the OPB row is directly
+                // false, so the contradiction RUPs from it).
+                if (d < 0_i && ! _root_contradiction_posted_index)
+                    _root_contradiction_posted_index = i;
+            }
+            else
+                _graph_edges.push_back(GraphEdge{from, to, d, i});
+        }
+        else if (left.variable) {
+            // X - c2 <= d, i.e. X <= d (c2 already folded in above).
+            _static_bounds.push_back(StaticBound{node_index(*left.variable), d, false, i});
+        }
+        else if (right.variable) {
+            // c1 - Y <= d, i.e. Y >= -d.
+            _static_bounds.push_back(StaticBound{node_index(*right.variable), -d, true, i});
+        }
+        else {
+            // Two constants: 0 <= d, exactly as for aliasing.
+            if (d < 0_i && ! _root_contradiction_posted_index)
+                _root_contradiction_posted_index = i;
+        }
+    }
+
+    return true;
+}
+
+auto DifferenceConstraints::define_proof_model(ProofModel & model, const State &) -> void
+{
+    // One labelled row per posted edge, role e<i> with i the edge's position in
+    // the posted list, so a proof line can be traced back to the edge the user
+    // wrote. Nothing else goes in: no flags, no auxiliaries. Every inference
+    // this constraint makes is a cutting-planes consequence of these rows.
+    //
+    // The row is emitted over the *canonical* (deviewed) operands, with the
+    // views' offsets folded into the right hand side, rather than over the
+    // user's operands. This is deliberate, and it is what makes the proofs
+    // work: the negative-cycle refutation and the bound pushes both rely on
+    // consecutive edges' shared variable cancelling exactly, and
+    // dev_docs/view-proof-logging.md invariant 1 says that only happens when
+    // both rows express it in the same representation. A registered view V of X
+    // has its own bit-vector, related to BinEnc(X) only by the link axiom, so
+    // two edges meeting at "the same variable" through different views would
+    // not cancel at all. Emitting the deviewed form removes the problem by
+    // construction, and it is still definitional: X - Y <= d - c1 + c2 states
+    // exactly the posted V1 - V2 <= d, just written in the bare variables'
+    // bits. (The alternative would be to emit in the user's operands and use
+    // PolBuilder::enable_deview_mode, as linear/justify.cc does; that is
+    // strictly more machinery for the same result here, since this constraint
+    // owns both ends of every cancellation.)
+    _edge_lines.reserve(_edges.size());
+    for (size_t i = 0; i < _edges.size(); ++i) {
+        const auto & e = _edges[i];
+        auto left = deview_operand(e.x, "left");
+        auto right = deview_operand(e.y, "right");
+        auto d = e.d - left.offset + right.offset;
+
+        WPBSum sum;
+        if (left.variable)
+            sum += 1_i * IntegerVariableID{*left.variable};
+        if (right.variable)
+            sum += -1_i * IntegerVariableID{*right.variable};
+
+        // An aliased edge leaves the same variable in the sum twice with
+        // opposite coefficients, and a two-constant edge leaves the sum empty:
+        // both render as a row whose left hand side is zero, which is exactly
+        // what 0 <= d says, and which VeriPB reads as trivially true or
+        // directly false according to d's sign.
+        _edge_lines.push_back(model.add_labelled_constraint(constraint_id(), "e" + to_string(i), move(sum) <= d));
+    }
+}
+
+auto DifferenceConstraints::install_propagators(Propagators & propagators) -> void
+{
+    if (_root_contradiction_posted_index) {
+        // The edge's own OPB row is `0 >= something positive', so the
+        // contradiction is RUP from the model with no state involved at all.
+        propagators.install_initial_contradiction("difference constraint x - x <= d with d < 0", JustifyUsingRUP{}, NoReason{});
+        return;
+    }
+
+    if (_graph_edges.empty() && _static_bounds.empty())
+        return;
+
+    Triggers triggers;
+    for (const auto & v : _nodes)
+        triggers.on_bounds.emplace_back(v);
+
+    propagators.install(
+        constraint_id(),
+        [nodes = move(_nodes), graph_edges = move(_graph_edges), static_bounds = move(_static_bounds), edge_lines = move(_edge_lines)](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            auto n = nodes.size();
+            auto m = graph_edges.size();
+
+            // Static bounds first: an edge with a constant operand is a plain
+            // bound on the other operand, and once applied it is just part of
+            // the state that Bellman-Ford seeds from. These never change, so
+            // after the first call every one of these is a no-op.
+            for (const auto & sb : static_bounds) {
+                if (sb.is_lower) {
+                    if (state.lower_bound(nodes[sb.node]) < sb.value)
+                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, NoReason{});
+                }
+                else {
+                    if (state.upper_bound(nodes[sb.node]) > sb.value)
+                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, NoReason{});
+                }
+            }
+
+            // Both passes walk a predecessor relation, one forwards along the
+            // edges and one backwards, so each is parameterised by which end of
+            // an edge the predecessor sits at. `head_of' is the node whose
+            // bound the edge pushed (so pred[head_of(e)] == e), and `tail_of'
+            // is the node whose bound was cited.
+
+            // The refutation of a negative cycle is the sum of the cycle's edge
+            // rows and nothing else: each variable appears once with +1 (as
+            // some edge's head) and once with -1 (as the next edge's tail), so
+            // every BinEnc term telescopes away and what is left is
+            // `0 >= -(cycle weight)' with the right hand side at least 1. No
+            // domain state is involved, hence the empty reason.
+            //
+            // Before saying anything, verify the extracted cycle
+            // arithmetically: that each edge meets the next, that it closes,
+            // and that the total weight really is negative. That is O(cycle)
+            // and turns a predecessor-walk bug into an exception at the right
+            // place rather than a VeriPB failure hundreds of lines later
+            // (survey section 2.9.4).
+            auto contradict_on_cycle = [&](const vector<size_t> & cycle, auto && tail_of, auto && head_of) -> void {
+                if (cycle.empty())
+                    throw UnexpectedException{"difference logic extracted an empty negative cycle"};
+                Integer weight{0};
+                for (size_t k = 0; k < cycle.size(); ++k) {
+                    const auto & here = graph_edges[cycle[k]];
+                    const auto & next = graph_edges[cycle[(k + 1) % cycle.size()]];
+                    weight += here.d;
+                    if (head_of(next) != tail_of(here))
+                        throw UnexpectedException{"difference logic extracted a disconnected negative cycle"};
+                }
+                if (weight >= 0_i)
+                    throw UnexpectedException{"difference logic extracted a cycle of weight " + weight.to_string() + ", which is not negative"};
+
+                inference.contradiction(logger,
+                    JustifyExplicitly{[&](const ReasonLiterals &) {
+                                          PolBuilder pol;
+                                          for (auto e : cycle)
+                                              pol.add(edge_lines[graph_edges[e].posted_index]);
+                                          pol.emit(*logger, ProofLevel::Temporary);
+                                      },
+                        ThenRUP::Yes},
+                    NoReason{});
+            };
+
+            // Walk predecessors back from `start' looking for a cycle, which is
+            // total: the walk cannot run off the end of the predecessor forest,
+            // and whatever cycle it does reach is a negative one. Both are
+            // proved in dev_docs/difference-logic.md ("Rounds, and why the
+            // extraction is total"); in outline, a walk that reached a
+            // predecessor-less node would exhibit a real path into `start'
+            // whose source has held its seeded distance since before round 0,
+            // and the round bound below says that path has already propagated,
+            // contradicting the strict improvement that just happened.
+            auto extract_cycle = [&](size_t start, const vector<optional<size_t>> & pred, auto && tail_of) -> vector<size_t> {
+                vector<bool> seen(n, false);
+                auto at = start;
+                while (! seen[at]) {
+                    seen[at] = true;
+                    if (! pred[at])
+                        throw UnexpectedException{"difference logic found no negative cycle where one must exist"};
+                    at = tail_of(graph_edges[*pred[at]]);
+                }
+
+                vector<size_t> cycle;
+                auto here = at;
+                do {
+                    cycle.push_back(*pred[here]);
+                    here = tail_of(graph_edges[*pred[here]]);
+                } while (here != at);
+                return cycle;
+            };
+
+            // Infer improved bounds in an order consistent with the predecessor
+            // forest, so that each node's push cites its predecessor's bound
+            // *after* that bound has been applied. Roots of the forest are the
+            // nodes whose bound did not improve, so every node with a
+            // predecessor gets exactly one inference.
+            auto infer_along_forest = [&](const vector<optional<size_t>> & pred, auto && tail_of, auto && infer_one) -> void {
+                vector<bool> done(n, false);
+                vector<size_t> chain;
+                for (size_t v = 0; v < n; ++v) {
+                    if (done[v] || ! pred[v])
+                        continue;
+                    chain.clear();
+                    auto at = v;
+                    while (! done[at] && pred[at]) {
+                        done[at] = true;
+                        chain.push_back(at);
+                        at = tail_of(graph_edges[*pred[at]]);
+                    }
+                    for (auto it = chain.rbegin(); it != chain.rend(); ++it)
+                        infer_one(*it);
+                }
+            };
+
+            // Lower bounds flow forwards. Edge x --d--> y is x - y <= d, i.e.
+            // y >= x - d, so lb(y) >= lb(x) - d. Writing dist(v) = -lb(v) this
+            // is single-source shortest paths from the paper's dummy vertex v0,
+            // whose edge to v weighs -lb(v): that is exactly how the seeding
+            // below encodes the current bounds (Corollary 1).
+            vector<Integer> lb(n, 0_i);
+            vector<optional<size_t>> lb_pred(n, nullopt);
+            for (size_t v = 0; v < n; ++v)
+                lb[v] = state.lower_bound(nodes[v]);
+
+            // A shortest path from v0 is simple, so after the seeding (which is
+            // the v0 edge set) it uses at most n - 1 real edges, and n - 1
+            // relaxation rounds suffice. Rounds 0 .. n - 1 give n of them, one
+            // more than needed; round n relaxes nothing unless the system has a
+            // negative cycle, so a success there is sound evidence of one and
+            // the extraction above is guaranteed to find it.
+            auto lb_tail_of = [](const GraphEdge & g) { return g.from; };
+            auto lb_head_of = [](const GraphEdge & g) { return g.to; };
+
+            for (size_t round = 0; round <= n; ++round) {
+                bool changed = false;
+                for (size_t e = 0; e < m; ++e) {
+                    const auto & edge = graph_edges[e];
+                    auto candidate = lb[edge.from] - edge.d;
+                    if (candidate > lb[edge.to]) {
+                        lb[edge.to] = candidate;
+                        lb_pred[edge.to] = e;
+                        changed = true;
+                        if (round == n)
+                            contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
+                    }
+                }
+                if (! changed)
+                    break;
+            }
+
+            infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) {
+                const auto & edge = graph_edges[*lb_pred[v]];
+                auto source = nodes[edge.from];
+                auto source_lb = lb[edge.from];
+                if (source_lb - edge.d != lb[v])
+                    throw UnexpectedException{"difference logic lower bound does not match its predecessor edge"};
+                if (state.lower_bound(nodes[v]) >= lb[v])
+                    return;
+
+                // One edge, one pol: the edge row plus the definition row
+                // of the predecessor's bound literal cancels BinEnc(source)
+                // and leaves BinEnc(v) >= source_lb - d, which is exactly
+                // what the closing RUP needs. This is justify_linear_bounds
+                // for a two-term linear, and it is the shape verified by
+                // hand in boundpush_hand.pbp. Citing the predecessor's own
+                // bound is already the paper's "lifted" explanation: the
+                // weakest antecedent for v >= L - d across this edge *is*
+                // source >= L, so the pol's degree comes out at exactly the
+                // pushed amount with no wasted slack.
+                inference.infer_greater_than_or_equal(logger, nodes[v], lb[v],
+                    JustifyExplicitly{[&](const ReasonLiterals &) {
+                                          PolBuilder pol;
+                                          pol.add(edge_lines[edge.posted_index]);
+                                          pol.add_for_literal(logger->names_and_ids_tracker(), source >= source_lb);
+                                          pol.emit(*logger, ProofLevel::Temporary);
+                                      },
+                        ThenRUP::Yes},
+                    ExplicitReason{ReasonLiterals{{source >= source_lb}}});
+            });
+
+            // Upper bounds flow backwards along the same edges. Edge
+            // x --d--> y is also x <= y + d, so ub(x) <= ub(y) + d: shortest
+            // paths in the reverse graph, seeded from the current upper bounds.
+            vector<Integer> ub(n, 0_i);
+            vector<optional<size_t>> ub_pred(n, nullopt);
+            for (size_t v = 0; v < n; ++v)
+                ub[v] = state.upper_bound(nodes[v]);
+
+            auto ub_tail_of = [](const GraphEdge & g) { return g.to; };
+            auto ub_head_of = [](const GraphEdge & g) { return g.from; };
+
+            for (size_t round = 0; round <= n; ++round) {
+                bool changed = false;
+                for (size_t e = 0; e < m; ++e) {
+                    const auto & edge = graph_edges[e];
+                    auto candidate = ub[edge.to] + edge.d;
+                    if (candidate < ub[edge.from]) {
+                        ub[edge.from] = candidate;
+                        ub_pred[edge.from] = e;
+                        changed = true;
+                        if (round == n)
+                            contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
+                    }
+                }
+                if (! changed)
+                    break;
+            }
+
+            infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) {
+                const auto & edge = graph_edges[*ub_pred[v]];
+                auto source = nodes[edge.to];
+                auto source_ub = ub[edge.to];
+                if (source_ub + edge.d != ub[v])
+                    throw UnexpectedException{"difference logic upper bound does not match its predecessor edge"};
+                if (state.upper_bound(nodes[v]) <= ub[v])
+                    return;
+
+                inference.infer_less_than(logger, nodes[v], ub[v] + 1_i,
+                    JustifyExplicitly{[&](const ReasonLiterals &) {
+                                          PolBuilder pol;
+                                          pol.add(edge_lines[edge.posted_index]);
+                                          pol.add_for_literal(logger->names_and_ids_tracker(), source < source_ub + 1_i);
+                                          pol.emit(*logger, ProofLevel::Temporary);
+                                      },
+                        ThenRUP::Yes},
+                    ExplicitReason{ReasonLiterals{{source < source_ub + 1_i}}});
+            });
+
+            // Deliberately not EnableButIdempotent, and not merely because the
+            // scope aliases whenever one variable appears in several edges
+            // (which is the normal case here, and which Propagators::install
+            // detects and ignores the claim for anyway). The claim would be
+            // wrong on its own terms: the passes above reach the fixpoint of
+            // the bounds abstraction, but an inferred bound can snap past a
+            // hole in the domain and land strictly above the value computed
+            // here, which seeds the next call higher and lets it push further.
+            // So a second call genuinely can infer more, and the propagator has
+            // to be re-woken by its own inferences until the state settles.
+            return PropagatorState::Enable;
+        },
+        triggers);
+}
+
+auto DifferenceConstraints::constraint_type() const -> string
+{
+    return "difference";
+}
+
+auto DifferenceConstraints::s_expr(const ProofModel * const model) const -> SExpr
+{
+    auto & tracker = model->names_and_ids_tracker();
+
+    vector<SExpr> edges;
+    for (const auto & e : _edges)
+        edges.push_back(SExpr::list({tracker.s_expr_term_of(e.x), tracker.s_expr_term_of(e.y), SExpr::atom(e.d.to_string())}));
+
+    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(move(edges))});
+}

--- a/gcs/constraints/difference/difference_constraints.hh
+++ b/gcs/constraints/difference/difference_constraints.hh
@@ -1,0 +1,127 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_CONSTRAINTS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_CONSTRAINTS_HH
+
+#include <gcs/constraint.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief One edge of a DifferenceConstraints system: \f$x - y \le d\f$.
+     *
+     * Either operand may be a view or a constant. A negated view (`-X + c`) is
+     * rejected: `V - W <= d` with `V = -X + c` is `-X - W <= d - c`, which is
+     * not a difference constraint at all.
+     *
+     * \sa DifferenceConstraints
+     * \ingroup Constraints
+     */
+    struct DifferenceEdge
+    {
+        IntegerVariableID x;
+        IntegerVariableID y;
+        Integer d;
+    };
+
+    /**
+     * \brief Constrain that \f$x - y \le d\f$ for every edge in a set of
+     * difference constraints, propagated globally rather than one edge at a
+     * time.
+     *
+     * The system is a weighted digraph with a vertex per variable and an edge
+     * \f$x \xrightarrow{d} y\f$ per constraint. The system is satisfiable iff
+     * that graph has no negative-weight cycle, and it entails
+     * \f$x - y \le d\f$ exactly when the shortest path from \c x to \c y weighs
+     * at most \c d (Dechter, Meiri and Pearl; see Kletzander, Dekker, Schutt and
+     * Stuckey, "Global Difference Constraint Propagation for Constraint
+     * Programming", arXiv:2607.20022, Theorem 1). Posting the same system as
+     * individual two-term LinearLessThanEqual constraints gives the same
+     * solutions, but reaching the bounds fixpoint can take asymptotically more
+     * work, because bounds crawl along the graph one propagator wake at a time
+     * (the paper's Example 8, measured in `examples/difference_chain`).
+     *
+     * This propagator is bounds consistent for the system as a whole: it runs
+     * Bellman-Ford from the current lower bounds over the graph and from the
+     * current upper bounds over its reverse, and pushes every bound the system
+     * implies in one pass. It reads and writes bounds only, so it never removes
+     * an interior value, and gcs domains may have holes where the paper's
+     * Theorem 2 assumes ranges.
+     *
+     * This version handles unconditional edges only. Half-reified edges
+     * (`b -> x - y <= d`), which make the graph change during search, are not
+     * supported yet. Neither is incremental propagation: every wake recomputes
+     * from scratch.
+     *
+     * See `dev_docs/difference-logic.md` for the design, the proof shapes and
+     * what is deferred.
+     *
+     * \ingroup Constraints
+     */
+    class DifferenceConstraints : public Constraint
+    {
+    private:
+        // The edges exactly as posted. Kept for s_expr() and clone(); the
+        // propagator works off the canonical form below.
+        std::vector<DifferenceEdge> _edges;
+
+        // The canonical graph, built by prepare(). Every operand is reduced to
+        // a bare SimpleIntegerVariableID plus an offset, and the offsets are
+        // folded into the weight, so that every edge's OPB row speaks the same
+        // representation and the telescoping pol cancels exactly.
+        std::vector<SimpleIntegerVariableID> _nodes;
+
+        struct GraphEdge
+        {
+            std::size_t from;
+            std::size_t to;
+            Integer d;
+            std::size_t posted_index;
+        };
+
+        // A constant operand does not give a graph edge, it gives a static
+        // bound on the other operand.
+        struct StaticBound
+        {
+            std::size_t node;
+            Integer value;
+            bool is_lower;
+            std::size_t posted_index;
+        };
+
+        std::vector<GraphEdge> _graph_edges;
+        std::vector<StaticBound> _static_bounds;
+
+        // An edge whose two operands canonicalise to the same thing (aliasing,
+        // or two constants) says 0 <= d. Harmless when d >= 0; a root
+        // contradiction when d < 0, in which case its OPB row is directly
+        // false, so the contradiction RUPs from the model with nothing cited.
+        // Only whether this is engaged is acted on; the index identifies the
+        // first offending edge, for a future assertion hint to name.
+        std::optional<std::size_t> _root_contradiction_posted_index;
+
+        // One labelled OPB row per posted edge, indexed by posted position.
+        // Empty when proofs are off.
+        std::vector<innards::ProofLine> _edge_lines;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
+    public:
+        explicit DifferenceConstraints(std::vector<DifferenceEdge> edges);
+
+        [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> override;
+        [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
+        [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+}
+
+#endif

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -1,0 +1,348 @@
+#include <gcs/constraints/difference.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::make_optional;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::to_string;
+using std::tuple;
+using std::uniform_int_distribution;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // One end of an edge: either variable `var` offset by `offset` (a bare
+    // variable when the offset is zero, a `+X + c` view otherwise), or, when
+    // `var` is unset, the constant `offset`.
+    struct Operand
+    {
+        optional<size_t> var;
+        int offset;
+    };
+
+    auto v(size_t i) -> Operand
+    {
+        return Operand{i, 0};
+    }
+
+    auto v(size_t i, int offset) -> Operand
+    {
+        return Operand{i, offset};
+    }
+
+    auto c(int value) -> Operand
+    {
+        return Operand{nullopt, value};
+    }
+
+    struct EdgeSpec
+    {
+        Operand x;
+        Operand y;
+        int d;
+    };
+
+    auto operand_value(const Operand & o, const vector<int> & vals) -> int
+    {
+        return (o.var ? vals.at(*o.var) : 0) + o.offset;
+    }
+
+    auto operand_id(const Operand & o, const vector<IntegerVariableID> & vars) -> IntegerVariableID
+    {
+        if (! o.var)
+            return constant_variable(Integer(o.offset));
+        if (o.offset == 0)
+            return vars.at(*o.var);
+        return vars.at(*o.var) + Integer(o.offset);
+    }
+
+    auto make_vars(Problem & p, const vector<pair<int, int>> & domains) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> vars;
+        for (const auto & [lo, hi] : domains)
+            vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
+        return vars;
+    }
+
+    auto satisfied(const vector<int> & vals, const vector<EdgeSpec> & edges) -> bool
+    {
+        for (const auto & e : edges)
+            if (operand_value(e.x, vals) - operand_value(e.y, vals) > e.d)
+                return false;
+        return true;
+    }
+
+    // Post the same system as one DifferenceConstraints, and separately as one
+    // two-term LinearLessThanEqual per edge. Both are checked against an
+    // independent C++ oracle, and against each other: a soundness failure in
+    // the propagator shows up as a missing solution, over-pruning as an extra
+    // one, and proof logging can catch neither of those (it only ever catches a
+    // wrong inference). See the survey's section 5.2, item 11.
+    auto run_test(bool proofs, const string & mode, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges)
+        -> void
+    {
+        print(cerr, "difference {} {} domains={} edges={}{}", mode, name, domains, edges.size(), proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<tuple<vector<int>>> expected, actual, decomposed;
+        build_expected(expected, [&](const vector<int> & vals) { return satisfied(vals, edges); }, domains);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        {
+            Problem p;
+            auto vars = make_vars(p, domains);
+            vector<DifferenceEdge> posted;
+            for (const auto & e : edges)
+                posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d)});
+            p.post(DifferenceConstraints{posted});
+
+            auto proof_name = proofs ? make_optional("difference_test_" + mode + "_" + name) : nullopt;
+            // Bounds consistent, not GAC: the propagator only reads and writes
+            // bounds, and gcs domains can have holes where the paper's Theorem
+            // 2 assumes ranges.
+            solve_for_tests(p, proof_name, actual, tuple{vars});
+            check_results(proof_name, expected, actual);
+        }
+
+        {
+            Problem p;
+            auto vars = make_vars(p, domains);
+            for (const auto & e : edges)
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars), Integer(e.d)});
+            solve_for_tests(p, nullopt, decomposed, tuple{vars});
+        }
+
+        if (actual != decomposed) {
+            println(cerr, "difference {} {}: global and decomposed models disagree", mode, name);
+            println(cerr, "global has {} solutions, decomposed has {}", actual.size(), decomposed.size());
+            throw UnexpectedException{"difference global and decomposed models disagree"};
+        }
+    }
+
+    // The transitive push: two edges whose combined bound is strictly stronger
+    // than either edge on its own. x - y <= -3 gives y >= x + 3, y - z <= -4
+    // gives z >= y + 4, so the system entails z >= x + 7 -- a bound no single
+    // edge implies. Solve as far as the first complete propagation and read the
+    // bounds off, so this asserts the propagator actually fires rather than
+    // merely that the solution set is right.
+    auto run_transitive_test() -> void
+    {
+        print(cerr, "difference transitive push:");
+        cerr << flush;
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 10_i, "x");
+        auto y = p.create_integer_variable(0_i, 10_i, "y");
+        auto z = p.create_integer_variable(0_i, 10_i, "z");
+        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -3_i}, DifferenceEdge{y, z, -4_i}}});
+
+        optional<Integer> z_lower, x_upper;
+        solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
+            z_lower = s.lower_bound(z);
+            x_upper = s.upper_bound(x);
+            return false;
+        }});
+
+        println(cerr, " z >= {}, x <= {}", z_lower ? z_lower->raw_value : -1, x_upper ? x_upper->raw_value : -1);
+        if (z_lower != make_optional(7_i))
+            throw UnexpectedException{"difference did not push z's lower bound transitively to 7"};
+        if (x_upper != make_optional(3_i))
+            throw UnexpectedException{"difference did not push x's upper bound transitively to 3"};
+    }
+
+    // A negated view operand is not a difference constraint at all, and
+    // accepting one would be unsound rather than merely incomplete, so it is
+    // rejected at construction.
+    auto run_negated_view_test() -> void
+    {
+        print(cerr, "difference negated view rejection:");
+        cerr << flush;
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 5_i, "x");
+        auto y = p.create_integer_variable(0_i, 5_i, "y");
+
+        for (auto [lhs, rhs] : vector<pair<IntegerVariableID, IntegerVariableID>>{{-x, y}, {x, -y}, {-x + 2_i, y}}) {
+            bool threw = false;
+            try {
+                DifferenceConstraints rejected{{DifferenceEdge{lhs, rhs, 0_i}}};
+                static_cast<void>(rejected);
+            }
+            catch (const InvalidProblemDefinitionException &) {
+                threw = true;
+            }
+            if (! threw)
+                throw UnexpectedException{"difference accepted a negated view operand"};
+        }
+
+        println(cerr, " ok");
+    }
+
+    auto run_all_tests(bool proofs, const string & mode) -> void
+    {
+        if (mode == "basic") {
+            // A single edge, both signs of d.
+            run_test(proofs, mode, "single_neg", {{0, 6}, {0, 6}}, {{v(0), v(1), -2}});
+            run_test(proofs, mode, "single_pos", {{0, 6}, {0, 6}}, {{v(0), v(1), 2}});
+            run_test(proofs, mode, "single_zero", {{0, 6}, {0, 6}}, {{v(0), v(1), 0}});
+
+            // A chain: bounds have to travel the whole way in one pass.
+            run_test(proofs, mode, "chain", {{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(2), v(3), -1}});
+
+            // A tree: one source, two branches, so the predecessor forest has
+            // more than one leaf.
+            run_test(proofs, mode, "tree", {{0, 5}, {0, 5}, {0, 5}, {0, 5}, {0, 5}},
+                {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(1), v(3), -2}, {v(0), v(4), 1}});
+
+            // Negative domains, and a mixture of edge weights.
+            run_test(proofs, mode, "negative_domain", {{-4, 2}, {-3, 3}, {-2, 4}}, {{v(0), v(1), -1}, {v(1), v(2), 2}, {v(2), v(0), 3}});
+
+            // Duplicate edges between the same pair, one strictly stronger.
+            run_test(proofs, mode, "duplicate_edges", {{0, 6}, {0, 6}}, {{v(0), v(1), 1}, {v(0), v(1), -2}, {v(0), v(1), 3}});
+        }
+        else if (mode == "cycles") {
+            // A negative cycle: unsatisfiable, and refuted by summing the cycle.
+            run_test(proofs, mode, "negcycle3", {{0, 6}, {0, 6}, {0, 6}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), -1}});
+            run_test(proofs, mode, "negcycle2", {{0, 8}, {0, 8}}, {{v(0), v(1), 0}, {v(1), v(0), -2}});
+            run_test(proofs, mode, "negcycle_weighted", {{0, 5}, {0, 5}, {0, 5}, {0, 5}},
+                {{v(0), v(1), 2}, {v(1), v(2), -3}, {v(2), v(3), 1}, {v(3), v(0), -1}});
+
+            // A zero-weight cycle: satisfiable, and it forces equalities all
+            // the way round.
+            run_test(proofs, mode, "zerocycle", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), 0}});
+            run_test(proofs, mode, "zerocycle_offset", {{0, 6}, {0, 6}}, {{v(0), v(1), -2}, {v(1), v(0), 2}});
+
+            // A negative cycle sitting inside a bigger graph, so the
+            // predecessor walk has to skip the nodes hanging off it.
+            run_test(proofs, mode, "negcycle_with_tail", {{0, 4}, {0, 4}, {0, 4}, {0, 4}},
+                {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(1), -1}, {v(2), v(3), 1}});
+        }
+        else if (mode == "views") {
+            // Offset views on either or both ends. The offsets fold into the
+            // weight, so the OPB row is over the bare variables and every
+            // edge's row speaks the same representation.
+            run_test(proofs, mode, "view_left", {{0, 6}, {0, 6}}, {{v(0, 3), v(1), 0}});
+            run_test(proofs, mode, "view_right", {{0, 6}, {0, 6}}, {{v(0), v(1, -2), 1}});
+            run_test(proofs, mode, "view_both", {{0, 5}, {0, 5}, {0, 5}}, {{v(0, 4), v(1, -1), -1}, {v(1, 2), v(2, 2), 0}});
+            run_test(proofs, mode, "view_chain", {{0, 5}, {0, 5}, {0, 5}}, {{v(0, 1), v(1, 1), -1}, {v(1, -3), v(2, 3), 0}});
+
+            // The same variable reached through two different offset views in
+            // two edges: the graph joins them at one node, which only cancels
+            // because both rows are emitted over the bare variable.
+            run_test(proofs, mode, "view_shared_node", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1, 2), -1}, {v(1, -3), v(2), -1}});
+
+            // A negative cycle whose edges are all expressed through views.
+            run_test(proofs, mode, "view_negcycle", {{0, 5}, {0, 5}}, {{v(0, 2), v(1), 0}, {v(1, 1), v(0, 4), 0}});
+
+            // Constant operands, which are static bounds on the other end.
+            run_test(proofs, mode, "constant_upper", {{0, 8}}, {{v(0), c(2), 3}});
+            run_test(proofs, mode, "constant_lower", {{0, 8}}, {{c(7), v(0), 2}});
+            run_test(proofs, mode, "constant_both_true", {{0, 3}}, {{c(1), c(4), 0}, {v(0), c(0), 2}});
+            run_test(proofs, mode, "constant_both_false", {{0, 3}}, {{c(4), c(1), 0}});
+            run_test(proofs, mode, "constant_and_edge", {{0, 8}, {0, 8}}, {{c(4), v(0), 0}, {v(0), v(1), -2}});
+        }
+        else if (mode == "alias") {
+            // The same variable in both slots, once vacuous and once a root
+            // contradiction. Handled, not thrown: x - x <= d is 0 <= d.
+            run_test(proofs, mode, "alias_ok", {{0, 5}, {0, 5}}, {{v(0), v(0), 0}, {v(0), v(1), -1}});
+            run_test(proofs, mode, "alias_ok_pos", {{0, 5}}, {{v(0), v(0), 3}});
+            run_test(proofs, mode, "alias_bad", {{0, 5}, {0, 5}}, {{v(0), v(0), -1}, {v(0), v(1), 0}});
+            // Aliasing through views, where the offsets decide the sign.
+            run_test(proofs, mode, "alias_view_ok", {{0, 5}}, {{v(0, 2), v(0), 3}});
+            run_test(proofs, mode, "alias_view_bad", {{0, 5}}, {{v(0, 2), v(0), 1}});
+            // An empty system, and one with nothing but a vacuous edge.
+            run_test(proofs, mode, "empty", {{0, 3}}, {});
+        }
+        else if (mode == "random") {
+            mt19937 rand(*get_seed());
+            for (int iteration = 0; iteration < 12; ++iteration) {
+                uniform_int_distribution n_vars_dist{2, 4};
+                auto n_vars = n_vars_dist(rand);
+                vector<pair<int, int>> domains;
+                for (int i = 0; i < n_vars; ++i) {
+                    uniform_int_distribution lo_dist{-3, 2};
+                    auto lo = lo_dist(rand);
+                    uniform_int_distribution width_dist{0, 4};
+                    domains.emplace_back(lo, lo + width_dist(rand));
+                }
+
+                uniform_int_distribution n_edges_dist{1, 6};
+                auto n_edges = n_edges_dist(rand);
+                vector<EdgeSpec> edges;
+                for (int e = 0; e < n_edges; ++e) {
+                    uniform_int_distribution var_dist{0, n_vars - 1};
+                    uniform_int_distribution offset_dist{-2, 2};
+                    uniform_int_distribution d_dist{-3, 3};
+                    edges.push_back(EdgeSpec{v(static_cast<size_t>(var_dist(rand)), offset_dist(rand)),
+                        v(static_cast<size_t>(var_dist(rand)), offset_dist(rand)), d_dist(rand)});
+                }
+
+                run_test(proofs, mode, "random" + to_string(iteration), domains, edges);
+            }
+        }
+        else
+            throw UnimplementedException{};
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    if (argc < 2)
+        throw UnimplementedException{};
+
+    string mode{argv[1]};
+
+    run_negated_view_test();
+    if (mode == "basic")
+        run_transitive_test();
+
+    for (bool proofs : {false, true}) {
+        if (proofs && ! can_run_veripb())
+            continue;
+        run_all_tests(proofs, mode);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/gcs.hh
+++ b/gcs/gcs.hh
@@ -30,6 +30,7 @@
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/count.hh>
 #include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/difference.hh>
 #include <gcs/constraints/disjunctive.hh>
 #include <gcs/constraints/disjunctive_2d.hh>
 #include <gcs/constraints/divide.hh>


### PR DESCRIPTION
Towards #571. **Based on #583** (`difflogic-01-example8`), which is this PR's
base branch, so the diff shown here is only this PR's four commits.

`DifferenceConstraints` takes a whole set of `x - y <= d` constraints and
propagates them as one graph rather than one propagator per constraint. The
system is a weighted digraph with an edge `x --d--> y` per constraint; it is
satisfiable iff that graph has no negative-weight cycle, and it entails
`x - y <= d` exactly when the shortest path from `x` to `y` weighs at most `d`
(Dechter, Meiri and Pearl; Theorem 1 of Kletzander, Dekker, Schutt and Stuckey,
*Global Difference Constraint Propagation for Constraint Programming*,
arXiv:2607.20022).

Each wake runs Bellman-Ford twice — forwards from the current lower bounds,
backwards over the reverse graph from the current upper bounds — and pushes
every bound the system implies in one pass, instead of letting bounds crawl
along the graph one propagator wake at a time. It reads and writes bounds only,
so it is bounds consistent and safe over domains with holes, where the paper's
Theorem 2 assumes ranges.

`dev_docs/difference-logic.md` is the design note: graph formulation, the
canonicalisation rule and why it is load-bearing, the round bound with proofs of
the two facts the code would otherwise be trusting, both proof shapes with real
output, two defects in the paper's pseudocode, and what is deferred.

## Proofs

One labelled OPB row per posted edge, and nothing else — no flags, no
auxiliaries. Every inference is a cutting-planes consequence of those rows.

**A negative cycle is refuted by summing the cycle's edge rows.** Each variable
appears once as some edge's head and once as the next edge's tail, so every
`BinEnc` term telescopes and what is left is `0 >= -W` with `W < 0`. The whole
refutation of `difference_chain --mode=refute --variant=global -n 10` is one
`pol`:

```
pseudo-Boolean proof version 3.0
pol @c[_1][e18] @c[_1][e19] + @c[_1][e9] + @c[_1][e75] + @c[_1][e29] + @c[_1][e10] + @c[_1][e11] + @c[_1][e12] + @c[_1][e13] + @c[_1][e14] + @c[_1][e15] + @c[_1][e16] + @c[_1][e17] + ;
rup >= 1;
...
```

12 lines, 373 bytes, and no domain state involved, so the reason is empty.

**A bound push is inferred per edge along the predecessor forest**, not per path,
so each is one `pol`: the edge row plus the definition row of the predecessor's
bound literal. Citing the predecessor's own bound makes the reason "lifted" in
the paper's section 4.3.3 sense for free, with no wasted slack in the `pol`'s
degree.

Every operand is canonicalised to a bare `SimpleIntegerVariableID` plus an
offset before its row is emitted, with the offsets folded into the weight. That
is the load-bearing decision: a `pol` only cancels a variable when both lines
express it in the same representation, and a registered view has its own
bit-vector related to `BinEnc(X)` only by the link axiom, so two edges meeting
at "the same variable" through different views would not cancel at all. Both
proof shapes here are cancellation-driven.

A negated view operand (`-X + c`) is rejected at construction rather than
handled: `V - W <= d` with `V = -X + c` is `-X - W <= d - c`, which is not a
difference constraint at all, and treating it as an edge would be unsound rather
than merely incomplete.

## Measured: propagation

Example 8's root fixpoint, `--order=unlucky`, `k = 2`, release build, `taskset -c 4`:

| n | global props | global time (s) | decomposed props | decomposed time (s) |
|---:|---:|---:|---:|---:|
| 40 | 87 | 0.000443 | 37,102 | 0.001174 |
| 80 | 167 | 0.001744 | 275,802 | 0.007109 |
| 160 | 327 | 0.008484 | 2,126,002 | 0.044466 |
| 320 | 647 | 0.049595 | 16,693,602 | 0.373881 |
| 480 | 967 | 0.147168 | 55,990,802 | 1.345550 |

The global propagator's invocation count is exactly `2n + 7` — linear — against
`Θ(n³)` for the decomposition. The headline is not really the speed-up, it is
that the count stops depending on the order the edges were posted in: the same
figures come out under `--order=lucky`, where the decomposed model needs 3,601
propagations at `n = 40` instead of 37,102.

**Honest caveat on the time column.** The *time* ratio (2.7× at `n = 40`, 9.1×
at `n = 480`) is far smaller than the propagation ratio (426× to 57,902×),
because at these sizes the decomposed model's cost is dominated by
per-propagator wake overhead rather than by work inside each propagator, while
the global propagator is not incremental and re-runs the whole
`O(rounds × |E|)` pass from scratch on every wake. On the *lucky* order at large
`n` the global propagator is in fact slightly slower in wall time despite doing
640× fewer propagations. Read the two columns together, and note that
`recursions` also differs between the variants because the default
`dom_then_deg` brancher sees different variable degrees (one global propagator
gives every variable degree 1, the decomposition gives `y_0` degree `n + 1`), so
this is a search-shape change as well as a propagation change.

## Measured: proof size

`--mode=refute`, `n = 10`, varying `-k` (domain `0..10k`). Every proof VeriPB-verified:

| k | domain | global `.pbp` lines | global bytes | decomposed lines | decomposed bytes |
|---:|---:|---:|---:|---:|---:|
| 1 | 0..10 | 12 | 373 | 294 | 13,560 |
| 4 | 0..40 | 12 | 373 | 6,572 | 333,797 |
| 16 | 0..160 | 12 | 373 | 27,692 | 1,644,383 |
| 64 | 0..640 | 12 | 373 | 112,172 | 7,651,986 |

The global proof is **constant in the domain size** — 20,515× smaller by bytes
at `k = 64`, and the gap is unbounded — because the refutation is one `pol`
whatever the domains are, where the per-constraint propagators can only find the
contradiction by crawling every bound up one unit at a time. The decomposed
figure is `1760k - 468` for `k >= 2`, exactly linear. It is constant in `n` too:
842 / 3,052 / 11,672 / 45,712 decomposed lines at `n` = 5 / 10 / 20 / 40, against
12 throughout.

## Testing

Five modes (`basic cycles views alias random`), each enumerating every solution
against a pure C++ oracle, every case VeriPB-verified — full enumeration or
`VERIFIED UNSATISFIABLE`. No `AssertRatherThanJustifying` anywhere.

Each system is also posted a second time as one two-term `LinearLessThanEqual`
per edge, and the two solution sets are required to be identical. That is what
catches the failure mode proof logging cannot: a proof only certifies inferences
that *were* made, so a wrong inference fails VeriPB but a missing one is
invisible.

Solution-set equality still would not show that the new strength ever fired, so
two tests assert behaviour directly rather than counting solutions:

- `run_transitive_test` posts `x - y <= -3` and `y - z <= -4` over `0..10`,
  propagates the root, and requires `z >= 7` and `x <= 3` — bounds no single
  edge implies.
- `run_negated_view_test` requires `InvalidProblemDefinitionException` for each
  of `-x`, `-y` and `-x + 2` as an operand, and fails when no exception is
  raised rather than passing silently.

Both were confirmed by mutation: stubbing out `infer_along_forest` fails the
first, dropping the `negate_first` check fails the second.

Verification run for this PR:

- full release suite with `GCS_TEST_CAP_DEFAULTS=OFF`: **541/541 passed**;
- all five difference modes re-run with the caps explicitly cleared, VeriPB on
  every case;
- Sanitize (ASan + UBSan) build: the difference entries plus a 66-test subset,
  all passing, plus `difference_chain --variant=global` at `n = 30` and `60` in
  both modes;
- the two `difference_chain-global-*` ctest entries run under
  `run_test_and_verify.bash` and pass.

## Deferred

- **Incrementality.** The paper's `IncSat` / `IncLB` / `IncUB` maintain a
  potential function and run Dijkstra on the reduced-cost graph in
  `O(n log n + m)`. This version recomputes Bellman-Ford from scratch on every
  wake, which is `O(n·m)` worst case. The wall-time caveat above is entirely
  this.
- **Half-reified edges** (`b -> x - y <= d`), which make the edge set change
  during search and need a trailed edge journal. The proof side already works
  out: a half-reified row contributes `M·¬b` to the sum, the `BinEnc` terms
  telescope as before, and one `saturate` leaves the clause `¬b_1 ∨ … ∨ ¬b_k`.
- **The presolver** — detecting difference-shaped constraints already posted on
  a `Problem` and lifting them into a global propagator. This is the half the
  paper's own measurements say is actually valuable, and it depends on #546's
  typed constraint enumeration.
- **Root simplification** — Johnson's all-pairs shortest paths, then dropping
  redundant edges and unifying variables on zero-weight cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lx8KBTVNSg44EEcVYcBoN

