### PR TITLE
examples: add rcpsp_max, an RCPSP/max benchmark for difference logic

### DIFF
--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -600,6 +600,92 @@ extra global pass and the presolver's own O(number of constraints) enumeration
 are pure overhead. That is the honest counterweight to the 9.7× on the unlucky
 order, and the reason this ships off by default.
 
+## RCPSP/max: the benchmark this was built for
+
+Per Kletzander, Dekker, Schutt and Stuckey (arXiv:2607.20022), RCPSP/max is
+where a global difference-logic propagator wins most: 550 → 586.55 on their
+scoring, and average unsat-detection time 1.98 s → under 0.01 s. The reason is
+structural. A *maximum* time lag is a negative-weight arc running backwards
+along the precedence network, so the network has cycles, and a nearly-tight one
+is infeasible-or-nearly-so in a way per-constraint bounds propagation can only
+find by crawling.
+
+`examples/rcpsp` reaches it with `--max-lag-density`, and `--variant` posts the
+identical edge list, in the identical order, three ways. `--branch` defaults to
+a static order, so `recursions` is an invariant across variants rather than a
+confound: any row where the three disagree on recursions is a bug.
+
+Measured on fataepyc-10, release, `taskset`-pinned, medians of 3, never with
+`--prove`; proof numbers taken separately below.
+
+### Feasible instances
+
+`recursions` identical in every row, propagations 3–12× lower for the global:
+
+| instance | status | recursions | props (dec) | props (presolved) | props (global) |
+|---|---|---:|---:|---:|---:|
+| `--size 14 --seed 9 --max-lag-density 0.4 --max-lag-slack 0` | optimal 17 | 35 | 447 | 314 | **55** |
+| `--size 12 --seed 3 --max-lag-density 0.3` | optimal 14 | 61 | 749 | 576 | **140** |
+| `--size 18 --seed 11 --max-lag-density 0.3` | optimal 22 | 102 | 2,669 | 1,530 | **227** |
+| `--size 16 --seed 3 --max-lag-density 0.3` | optimal 14 | 296 | 1,271 | 859 | **256** |
+| `--size 22 --seed 4 --max-lag-density 0.25` | optimal 32 | 10,512 | 109,199 | 82,726 | **32,682** |
+| `--size 20 --seed 5 --max-lag-density 0.3` | unsat at root | 1 | 1,155 | 56 | **1** |
+
+The `--size 22` row is the honest one: 3.3× fewer propagations, and **8 % slower**
+in wall time (0.0771 s decomposed against 0.0828 s global). That is the
+non-incrementality caveat under "Deliberately deferred" showing up on a real
+model — every wake re-runs the whole Bellman-Ford pass. The presolved column
+sits between the two throughout because it leaves the donor linears installed
+alongside the lifted global unless they are explicitly retired.
+
+### Negative cycles, against the horizon
+
+The sharp result. A negative cycle of weight -1, resources off, horizon forced,
+so the only thing varying is how far the bounds have to crawl:
+
+| horizon | props (dec) | props (global) | wall dec (s) | wall global (s) |
+|---:|---:|---:|---:|---:|
+| 200 | 1,163 | **1** | 0.00035 | 0.00016 |
+| 800 | 4,763 | **1** | 0.00073 | 0.00010 |
+| 3,200 | 19,163 | **1** | 0.00324 | 0.00011 |
+| 12,800 | 76,763 | **1** | 0.02397 | 0.00010 |
+| 51,200 | 307,163 | **1** | 0.26282 | 0.00011 |
+
+Exactly linear against a constant: 4× the horizon is 4× the propagations
+decomposed, and one propagation regardless for the global.
+
+### Proofs of that refutation
+
+Separate runs, with `--prove`:
+
+| horizon | dec lines | dec `.pbp` | veripb dec | global lines | global `.pbp` | veripb global |
+|---:|---:|---:|---:|---:|---:|---:|
+| 200 | 4,454 | 299,560 B | 0.068 s | **12** | **222 B** | 0.012 s |
+| 800 | 18,254 | 1,417,961 B | 0.95 s | **12** | **222 B** | 0.012 s |
+| 3,200 | 73,454 | 6,578,202 B | 21.0 s | **12** | **222 B** | 0.014 s |
+| 12,800 | 294,254 | 29,769,564 B | **> 600 s, abandoned** | **12** | **222 B** | 0.013 s |
+
+The refutation is 12 lines and 222 bytes whatever the horizon, because it sums
+the cycle's edge rows once (proof shape 1 above). The decomposed proof grows
+with the horizon and its verification grows faster still — the 12,800 row was
+abandoned after ten minutes rather than being left to finish, so that figure is
+a lower bound and is marked as one.
+
+### Where the paper's headline does and does not reproduce
+
+The cost claim reproduces cleanly. The *shape* claim does not: `recursions: 1`
+in **both** columns on the negative-cycle rows, because gcs runs root
+propagation to a fixpoint and a negative cycle always eventually empties a
+domain. So the global propagator does not turn a search into a root refutation
+here; it turns an expensive root refutation into a single propagation.
+
+The paper's baseline searches because its disjunctive resources contribute
+*half-reified* difference constraints, so the cycle only closes after Boolean
+decisions. `examples/rcpsp --machine pairwise` posts exactly that structure —
+`LinearGreaterThanEqualIf` in both directions on a 0/1 ordering variable — but
+half-reified edges are not supported by the propagator yet, so that mechanism is
+absent here by construction rather than by choice.
+
 ## Deliberately deferred
 
 - **Incrementality.** The paper's `IncSat` / `IncLB` / `IncUB` maintain a valid

--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -51,3 +51,18 @@ add_test(NAME rcpsp_all COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_ver
 # covers the Disjunctive proof path over a resource rather than over the machine.
 add_test(NAME rcpsp_unary COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_unary
     $<TARGET_FILE:rcpsp> --size 10 --seed 4 --resources 1 --capacity 1 --max-demand 1 --unary disjunctive)
+
+# The temporal network through the global propagator, and through the presolver
+# that lifts it back out of the decomposition, on the same maximum-lag instance
+# rcpsp_max_lags posts decomposed. All three reach makespan 14 in 61 recursions
+# --- --branch is a static order, so the search is an invariant across variants
+# --- and differ only in propagations, which is the point of the comparison.
+add_test(NAME rcpsp_global COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_global
+    $<TARGET_FILE:rcpsp> --size 12 --seed 3 --max-lag-density 0.3 --variant global)
+add_test(NAME rcpsp_presolved COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_presolved
+    $<TARGET_FILE:rcpsp> --size 12 --seed 3 --max-lag-density 0.3 --variant presolved)
+
+# The negative cycle through the global propagator: refuted at the root, with a
+# refutation that sums the cycle's edge rows rather than crawling bounds.
+add_test(NAME rcpsp_global_infeasible COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_global_infeasible
+    $<TARGET_FILE:rcpsp> --size 8 --seed 1 --infeasible --variant global)

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -75,8 +75,10 @@
 
 #include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/difference.hh>
 #include <gcs/constraints/disjunctive.hh>
 #include <gcs/constraints/linear.hh>
+#include <gcs/presolvers/difference_logic.hh>
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
@@ -88,6 +90,7 @@
 #include <cstdlib>
 #include <exception>
 #include <iostream>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -193,13 +196,33 @@ namespace
 
     // One difference constraint, s_from + d <= s_to, over the model's variables
     // rather than over task indices, so that the makespan bounds are the same
-    // kind of thing as the time lags. Posted below as a two-term linear.
+    // kind of thing as the time lags.
     struct ModelEdge
     {
         IntegerVariableID from;
         IntegerVariableID to;
         Integer d;
     };
+
+    // How the temporal network reaches the solver. All three say exactly the
+    // same thing, over the same edges in the same order.
+    enum struct Variant
+    {
+        Decomposed, ///< One two-term LinearGreaterThanEqual per edge.
+        Presolved,  ///< As Decomposed, plus the DifferenceLogic presolver, which lifts them back.
+        Global      ///< The whole network as one DifferenceConstraints.
+    };
+
+    auto variant_from_string(const string & spec) -> optional<Variant>
+    {
+        if (spec == "decomposed")
+            return Variant::Decomposed;
+        if (spec == "presolved")
+            return Variant::Presolved;
+        if (spec == "global")
+            return Variant::Global;
+        return nullopt;
+    }
 
     // Every difference constraint in the model, in one list and in posting
     // order: the plain precedences, then any generalised lags, then the
@@ -310,6 +333,13 @@ auto main(int argc, char * argv[]) -> int
             ("all",
                 "Enumerate every feasible schedule instead of minimising the makespan, posting " //
                 "no objective")                                                                  //
+            ("variant",
+                "How to post the temporal network --- the precedences, the time lags and the "     //
+                "makespan bounds, which are all difference constraints. decomposed (the default) " //
+                "posts one two-term LinearGreaterThanEqual per edge; global posts the whole "      //
+                "network as one DifferenceConstraints; presolved posts it decomposed and lets "    //
+                "the DifferenceLogic presolver lift it back",                                      //
+                cxxopts::value<string>()->default_value("decomposed"))                             //
             ;
 
         options_vars = options.parse(argc, argv);
@@ -423,12 +453,46 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_FAILURE;
     }
 
-    // The temporal network, as one two-term linear per edge. Spelled
-    // GreaterThanEqual with the head first, which is the direction a precedence
-    // reads in, and which every one of these has been posted in since this
-    // example landed.
-    for (const auto & e : model_edges(instance, starts, makespan))
-        problem.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * e.to + -1_i * e.from, e.d});
+    auto variant_name = options_vars["variant"].as<string>();
+    auto variant = variant_from_string(variant_name);
+    if (! variant) {
+        println(cerr, "Error: unknown --variant value '{}'. Supported: decomposed, presolved, global.", variant_name);
+        return EXIT_FAILURE;
+    }
+
+    // The temporal network. --variant decides how it reaches the solver, over
+    // the identical edge list in the identical order, so a comparison between
+    // the three is between the handling and nothing else.
+    auto edges = model_edges(instance, starts, makespan);
+    auto presolver_stats = std::make_shared<DifferenceLogicStats>();
+
+    switch (*variant) {
+        using enum Variant;
+    case Presolved:
+    case Decomposed:
+        // One two-term linear per edge, spelled GreaterThanEqual with the head
+        // first, which is the direction a precedence reads in and the spelling
+        // every one of these has been posted in since this example landed.
+        // Changing it would give the same constraint a different WeightedSum
+        // term order, and so a different OPB row, for no reason.
+        for (const auto & e : edges)
+            problem.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * e.to + -1_i * e.from, e.d});
+        if (*variant == Presolved)
+            problem.add_presolver(DifferenceLogic{presolver_stats});
+        break;
+
+    case Global:
+        // The whole network as one propagator. A ModelEdge is s_from + d <= s_to,
+        // and a DifferenceEdge is x - y <= d, so the weight flips sign.
+        {
+            vector<DifferenceEdge> difference_edges;
+            difference_edges.reserve(edges.size());
+            for (const auto & e : edges)
+                difference_edges.push_back(DifferenceEdge{e.from, e.to, -e.d});
+            problem.post(DifferenceConstraints{difference_edges});
+        }
+        break;
+    }
 
     // A .sch instance's dummy source is pinned at time zero: the file's arc
     // weights are all relative to it.
@@ -566,6 +630,11 @@ auto main(int argc, char * argv[]) -> int
     println("machine tasks: {}", instance.machine_tasks.size());
     println("machine posted as: {}", machine_variant);
     println("unary posted as: {}", unary_variant);
+    println("variant: {}", variant_name);
+    if (*variant == Variant::Presolved) {
+        println("presolver_edges_lifted: {}", presolver_stats->edges_lifted);
+        println("presolver_nodes: {}", presolver_stats->nodes);
+    }
     println("critical path: {}", critical_path);
     println("horizon: {}", horizon);
     println("all: {}", all ? "yes" : "no");


### PR DESCRIPTION
Adds `--variant=global` and `--variant=presolved` to `examples/rcpsp`, and the
measurements that make it the benchmark for the difference-logic work in #571.

**Based on #588** (`difflogic-04-presolver`), which is this PR's base branch, so
the diff shown here is only this PR's two commits.

> [!NOTE]
> This PR used to add `examples/rcpsp_max`, a second RCPSP model, ~900 lines.
> That example is gone: everything in it that needs no difference-logic
> propagator — maximum lags, the ProGen/max `.sch` reader, `--horizon`, `--all`,
> `--infeasible` — has been folded into `examples/rcpsp` by the `rcpsp-unify`
> prep PR, which lands on `main` before this stack. What is left here is the
> `--variant` flag, which is the part that actually needs the propagator.
>
> Consequences worth knowing while reviewing: the branch no longer touches
> `examples/CMakeLists.txt`, which is what used to make it `CONFLICTING`; it now
> sits *after* #588 in a linear chain rather than forking off #584 and being
> merged back in at #590; and **every measurement below has been re-taken** on
> `examples/rcpsp`, because the instances the old tables were measured on no
> longer exist. They are not the old numbers rescaled.

## Why this example

Per Kletzander, Dekker, Schutt and Stuckey (arXiv:2607.20022), RCPSP/max is
where a global difference-logic propagator wins most: 550 → 586.55 on their
scoring, and average unsat-detection time 1.98 s → under 0.01 s. The reason is
structural — a *maximum* time lag is a negative-weight arc running backwards
along the precedence network, so the network has cycles, and a nearly-tight one
is infeasible-or-nearly-so in a way per-constraint bounds propagation can only
find by crawling.

## What this adds

`examples/rcpsp`'s `model_edges()` already builds every difference constraint —
precedences, generalised lags, makespan bounds — as one list in posting order,
precisely so that a `--variant` flag can hand that identical list, in that
identical order, somewhere else. This PR adds the flag:

* **`decomposed`** (the default) is exactly what the example already did: one
  two-term `LinearGreaterThanEqual` per edge, head first. **Unchanged, and that
  is the contract** — this example is in the proof benchmark set (#632, #633).
* **`global`** posts one `DifferenceConstraints`. A `ModelEdge` is
  `s_from + d <= s_to` and a `DifferenceEdge` is `x - y <= d`, so the weight
  flips sign; nothing else about the list changes.
* **`presolved`** posts it decomposed and lets the `DifferenceLogic` presolver
  lift it back — the route a model not written with the global in mind takes.

`--branch` defaults to a static order, so `recursions` is an invariant across
the three variants rather than a confound: any row where they disagree on
recursions is a bug, not a trade-off.

## The default path is byte-identical

* `tools/opb_snapshot.bash` gives an empty diff for `rcpsp`, `rcpsp_deadline`
  and `rcpsp_split` against `main`.
* All ten published rows of #638's tables reproduce their `horizon`, `status`,
  `makespan`, `recursions` and `propagations` exactly.

Both are re-run at every later stage of the stack, not just here.

## Measured

Measured on fataepyc-10, release, `taskset -c 4`-pinned with boost disabled,
medians of 3, never with `--prove`; proof numbers taken separately. Full tables
in `dev_docs/difference-logic.md`.

Feasible instances — `recursions` identical in every row, propagations 3–12×
lower for the global:

| instance | status | recursions | props (dec) | props (presolved) | props (global) |
|---|---|---:|---:|---:|---:|
| `--size 14 --seed 9 --max-lag-density 0.4 --max-lag-slack 0` | optimal 17 | 35 | 447 | 314 | **55** |
| `--size 12 --seed 3 --max-lag-density 0.3` | optimal 14 | 61 | 749 | 576 | **140** |
| `--size 18 --seed 11 --max-lag-density 0.3` | optimal 22 | 102 | 2,669 | 1,530 | **227** |
| `--size 16 --seed 3 --max-lag-density 0.3` | optimal 14 | 296 | 1,271 | 859 | **256** |
| `--size 22 --seed 4 --max-lag-density 0.25` | optimal 32 | 10,512 | 109,199 | 82,726 | **32,682** |
| `--size 20 --seed 5 --max-lag-density 0.3` | unsat at root | 1 | 1,155 | 56 | **1** |

The `--size 22` row is the honest one: 3.3× fewer propagations and **8 % slower**
in wall time (0.0771 s decomposed against 0.0828 s global). That is the
non-incrementality caveat showing up on a real model — every wake re-runs the
whole Bellman-Ford pass. It is fixed by #593, not here.

Negative-cycle instances, resources off, horizon forced — exactly linear against
a constant:

| horizon | props (dec) | props (global) | wall dec (s) | wall global (s) |
|---:|---:|---:|---:|---:|
| 200 | 1,163 | **1** | 0.00035 | 0.00016 |
| 3,200 | 19,163 | **1** | 0.00324 | 0.00011 |
| 51,200 | 307,163 | **1** | 0.26282 | 0.00011 |

Proofs of that refutation (separate `--prove` runs): **12 lines / 222 bytes
whatever the horizon**, against 4,454 → 294,254 lines for decomposed, whose
VeriPB time goes 0.068 s → 0.95 s → 21.0 s → **abandoned after 600 s**. That
last figure is recorded as a lower bound rather than dropped.

## Where the paper's headline does and does not reproduce

The cost claim reproduces cleanly. The *shape* claim does not, and the dev note
says so: `recursions: 1` in **both** columns on the negative-cycle rows, because
gcs runs root propagation to a fixpoint and a negative cycle always eventually
empties a domain. So the global propagator does not turn a search into a root
refutation here; it turns an expensive root refutation into a single
propagation. The paper's baseline searches because its disjunctive resources
contribute *half-reified* difference constraints, so the cycle only closes after
Boolean decisions. Ours do not at this point in the stack — that is #590 — so
the mechanism is absent by construction.

## Testing

Four new ctest registrations with distinct proof basenames (#562): both new
variants on a max-lag instance, and the negative-cycle instance through the
global propagator, which refutes at the root. Full `ctest` green at this tip.

Refs #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb9fgE3SAiASdwREZVrU3p
