### PR TITLE
Difference-logic presolver (#571)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -80,8 +80,10 @@ library. For an introduction to *using* the solver, start with the top-level
   shapes — a negative cycle refuted by one telescoping `pol`, a bound push
   justified per edge along the predecessor forest — the source paper's
   pseudocode defects, the measured order-independence and proof-size results,
-  and what is deferred (incrementality, half-reification, presolver, root
-  simplification).
+  the `DifferenceLogic` presolver that lifts an already-posted model into the
+  same propagator (including why `DisableUntilBacktrack` could not be imposed
+  from outside, and why the tests assert on counts rather than on solutions),
+  and what is deferred (incrementality, half-reification, root simplification).
 - [Range ("in") literals](range_literals_spec.md) — the design specification
   for the interval-literal proof layer: reifying `[X∈[a,b]]` to its
   order-chain cuts, the always-covered partition invariant, interval-tree

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -1,11 +1,12 @@
-# Difference logic: `DifferenceConstraints`
+# Difference logic: `DifferenceConstraints` and the `DifferenceLogic` presolver
 
 `DifferenceConstraints` propagates a whole system of `x - y <= d` at once,
 rather than one propagator per constraint. This note covers the graph
 formulation, the two propagation directions, the round bound and why the
 negative-cycle extraction is total, the canonicalisation rule and why it exists,
 the two proof shapes with worked examples, the defects in the source paper's
-pseudocode, and what is deliberately deferred.
+pseudocode, the presolver that lifts an already-posted model into the same
+propagator, and what is deliberately deferred.
 
 The source is Kletzander, Dekker, Schutt and Stuckey, *Global Difference
 Constraint Propagation for Constraint Programming*, arXiv:2607.20022 — the
@@ -375,6 +376,230 @@ difference is the posting-order change made here, which moves the cycle-closing
 edge in front of the lower-bound bump so that both variants post identical edge
 sequences.)
 
+## The presolver
+
+`DifferenceLogic` (`gcs/presolvers/difference_logic.hh`) scans a posted
+`Problem` for difference-shaped constraints and installs the propagator above
+over them, **alongside** the donors' own propagators. A model written as
+ordinary two-term `LinearLessThanEqual`s does not have to be rewritten to get
+the global propagation. It is off by default; the user opts in with
+`problem.add_presolver(DifferenceLogic{})`.
+
+The timing dictates the shape and is worth stating plainly. Presolvers run
+*after* `create_propagators` and *after* the proof model is finalised
+(`solve.cc`), so a presolver **cannot remove** the donors' propagators and
+**cannot add OPB content** — `Presolver::run` is handed no `ProofModel *` at all.
+That is the paper's §4.4 hybrid, and it is also what makes the proof trivial:
+each donor already emitted its own labelled row, so the global propagator cites
+*those* rows and derives nothing that is not a cutting-planes consequence of
+constraints the model already contains.
+
+### What is lifted, and what is not
+
+The paper's **level 1**, restricted to what the propagator supports today: a
+two-term linear with coefficients exactly `+1` and `-1`, an unconditional
+(`reif::MustHold`) condition, and two distinct variable operands, each of which
+may carry a `+X + c` view offset. Two of the exclusions are soundness
+requirements rather than mere incompleteness:
+
+- **Half-reified donors are refused.** `linear_inequality.cc` emits the `If`
+  form's row under `HalfReifyOnConjunctionOf`, so it states `b -> x - y <= d`,
+  not `x - y <= d`. Lifting it as an unconditional edge would licence
+  inferences the model does not entail (and the pol citing it would carry an
+  uncancelled gate term). Since `clone()` returns the family base, the
+  reification condition is the *only* thing distinguishing a
+  `LinearLessThanEqual` from a `LinearLessThanEqualIf` at enumeration time.
+- **Negated views are refused**, for the reason given above.
+
+Degenerate edges — a constant operand, or the same variable at both ends — are
+also skipped, and left to the donor. This is not just tidiness: a `0 <= d` with
+`d < 0` is a root contradiction, which `DifferenceConstraints` reports with
+`install_initial_contradiction`, and **initialisers have already run** by the
+time a presolver is called. Declining to lift such an edge leaves it with the
+donor, which handles it correctly.
+
+**`Comparison` donors are the shape we most want and cannot yet have.**
+`x <= y + d` over an offset view *is* a difference constraint, but
+`ReifiedCompareLessThanOrMaybeEqual::define_proof_model` emits its unconditional
+rows through the `void`-returning `add_constraint`, so they carry no `@label`
+and no proof step can cite them. They are detected, skipped, and **counted**, so
+what a later labelling PR would buy is measured rather than guessed at.
+Labelling them touches the `cake_pb_cp` chain surface, hence the deferral.
+
+### Deview mode is the one thing the shared propagator needed
+
+`DifferenceConstraints` emits its own rows over the canonical bare variables,
+which is why its pols telescope. A donor's row is emitted over the *user's*
+operands, views and all. So the shared propagator cites every edge row through a
+`PolBuilder` in **deview mode**, which substitutes the framework's already-derived
+deview-form line (in `X`-bits) for the `V`-form one. For
+`DifferenceConstraints`'s own rows this is a no-op — no view appears in their
+left-hand sides, so no deview-form is registered and `deviewed_line_for` returns
+the line unchanged — which is why the constraint's OPB and proof output is
+byte-identical to before the sharing refactor. It is load-bearing for the
+presolver: confirmed by mutation, removing it fails VeriPB on the
+`view_negcycle_wide` fixture in the *shipping* hybrid configuration. Same
+situation, and same fix, as `linear/justify.cc`.
+
+### Turning the donors off, and why `DisableUntilBacktrack` could not be reused as is
+
+The hybrid is what the paper measures as best and is the default, but the
+redundant donors should be measurable, so `disabling_lifted_donors()` exists and
+ships off.
+
+gcs already has `PropagatorState::DisableUntilBacktrack`, and its **mechanism**
+is exactly right: the propagator is swapped past `idle_end` in the queue, where
+`enqueue_if_idle` will not find it, so skipping it costs nothing. Its
+**lifetime** is the part that does not transfer, in two places:
+
+- `propagate()` saves `orig_idle_end` on entry and restores it from that call's
+  `on_backtrack`, so the boundary is scoped to one `propagate()` call;
+- more decisively, the no-guesses path *rebuilds* `queue` and `lookup` from
+  scratch and resets `idle_end` to the propagator count.
+
+A presolver acts at the root, before the first root propagation, so a boundary
+it set would be erased before it ever took effect. `Propagators::
+disable_propagators_for_constraints` therefore reuses the partition and adds a
+*second* boundary that nothing restores: the rebuild puts permanently disabled
+propagators at the tail, past `idle_end`, and the enabled count is what
+`enqueued_end` and `idle_end` are set to.
+
+It takes a **batch** of `ConstraintID`s, not one at a time. Finding a
+constraint's propagators means scanning the propagator list, so a per-constraint
+entry point makes disabling `m` donors `O(m · propagators)`; on `difference_chain`
+at `n = 160` that quadratic was 23× the entire rest of the solve.
+
+Disabling is **not** removing. The constraint keeps its OPB row, its scope and
+adjacency entries, and its contribution to every variable's degree, so the
+branching heuristic sees an unchanged problem. That is what makes the option a
+tripwire as well as a knob: the global propagator subsumes every donor's
+single-edge push, so **solutions and recursions must come out identical** with
+the donors on and off. They do, across the whole test corpus; if they ever did
+not, the subsumption claim would be wrong.
+
+### Why the tests assert on counts
+
+The presolver is invisible from the outside. A version that silently lifted
+nothing — because, say, `clone()` stopped flattening a posted
+`LinearLessThanEqual` to `ReifiedLinearInequality`, so
+`each_constraint_of_type<ReifiedLinearInequality>()` no longer matched it —
+would pass **every** validation we would otherwise write: solution-set
+equivalence (a no-op presolver preserves solutions), the OPB byte-diff
+(byte-identical is the *expected* result), and VeriPB (there would be nothing
+new to check).
+
+So the presolver reports what it did in `DifferenceLogicStats`, and three
+things guard it:
+
+- `static_assert`s in `run()` pinning the class relationships the enumeration
+  relies on, so a hierarchy change is a compiler error at the site that needs
+  fixing;
+- a **runtime cross-check** of the typed enumeration against
+  `Constraint::constraint_type()`, which does not depend on the hierarchy at all:
+  if more constraints report `lin_less_equal` than the typed enumeration
+  yielded, the presolver throws;
+- assertions on the counts, and the propagation-count differential below.
+
+Every one of those failure messages names the invariant and says explicitly not
+to update the expectation. Mutation-tested: asking for `LinearLessThanEqual`
+instead of `ReifiedLinearInequality` — the exact regression being defended
+against — trips the cross-check, and with the cross-check also disabled all four
+test modes fail, each naming the presolver.
+
+The cross-check is on unconditionally, rather than being an opt-in strict mode,
+and it is deliberately *not* "throw if nothing was lifted". Lifting nothing is a
+perfectly ordinary outcome — most models contain plenty of `lin_less_equal`
+constraints and no two-term `+1`/`-1` ones — so that version would fire on
+legitimate models and would have to be off by default, which is to say it would
+never be on when it mattered. The condition that cannot legitimately hold is the
+narrower one: a constraint reporting a donor family's `constraint_type()` that
+the typed enumeration did not yield. That is exactly the regression, it is free
+of false positives, and it costs one pass over the posted constraints per
+solve.
+
+### Gating
+
+None, beyond declining to install over a single edge, which is a degeneracy (one
+edge's global propagator computes exactly what that edge's own propagator does)
+rather than a tuning decision. A minimum-edge-count or connectivity threshold was
+considered and **not** shipped: the measurements below give no crossover to site
+it at — the presolver is a large win on the unlucky order at every size measured,
+and its cost on the lucky order is a roughly constant factor rather than
+something that switches sign — and the presolver is opt-in already, so a second
+gate the user cannot reason about would be guessing dressed as tuning.
+
+### Measurements
+
+`examples/difference_chain --variant=presolved`, `-k 2`, release, medians of 3.
+First, **`--mode=refute`**, which is unsatisfiable at the root, so there is no
+search and the columns compare propagation and proof directly:
+
+| n | order | variant | propagations | time (s) | `.pbp` lines |
+|---:|---|---|---:|---:|---:|
+| 40 | unlucky | decomposed | 68,137 | 0.00185 | 45,712 |
+| 40 | unlucky | presolved | 903 | 0.00063 | **40** |
+| 40 | unlucky | presolved + donors off | 2 | 0.00067 | **18** |
+| 40 | unlucky | global | 1 | 0.00013 | **12** |
+| 40 | lucky | decomposed | 38,435 | 0.00132 | 26,935 |
+| 40 | lucky | presolved | 903 | 0.00061 | **40** |
+| 160 | unlucky | decomposed | 4,139,782 | 0.0845 | 720,352 |
+| 160 | unlucky | presolved | 13,203 | 0.0113 | **40** |
+| 160 | unlucky | presolved + donors off | 2 | 0.0108 | **18** |
+| 160 | unlucky | global | 1 | 0.0025 | **12** |
+| 160 | lucky | decomposed | 2,150,495 | 0.0492 | 414,835 |
+| 160 | lucky | presolved | 13,203 | 0.0112 | **40** |
+
+The proof-size result is the headline: the presolver recovers essentially the
+whole of the global route's win, 720,352 lines down to 40, because the
+refutation is one telescoping `pol` over the donors' own rows however big the
+domains are.
+
+Then **`--mode=fixpoint`**, which searches:
+
+| n | order | variant | propagations | recursions | time (s) |
+|---:|---|---|---:|---:|---:|
+| 160 | unlucky | decomposed | 2,126,002 | 163 | 0.0473 |
+| 160 | unlucky | presolved | 52,807 | 163 | 0.0157 |
+| 160 | unlucky | presolved + donors off | 167 | 163 | 0.0148 |
+| 160 | unlucky | global | 327 | 323 | 0.0085 |
+| 160 | lucky | decomposed | 52,801 | 163 | 0.0097 |
+| 160 | lucky | presolved | 52,807 | 163 | 0.0152 |
+| 640 | unlucky | decomposed | 132,305,602 | 643 | 4.460 |
+| 640 | unlucky | presolved | 825,607 | 643 | 0.459 |
+| 640 | unlucky | presolved + donors off | 647 | 643 | 0.452 |
+| 640 | unlucky | global | 1,287 | 1,283 | 0.333 |
+| 640 | lucky | decomposed | 825,601 | 643 | 0.257 |
+| 640 | lucky | presolved | 825,607 | 643 | 0.445 |
+
+Four things to read out of this.
+
+**The presolver buys order-independence, which is what the pathology was.** The
+`presolved` propagation count is identical for both orders at every size, and
+equal to the *lucky* decomposed figure: 132.3M → 825.6k at `n = 640`, a 160×
+reduction and 9.7× in wall time.
+
+**It does not reach the global route, and the reason is registration order.**
+gcs has no runtime propagator priorities (issue #582), and a presolver's
+propagator is registered last, so at every round the donors all run before the
+global one gets its turn — and then the global one's inferences wake them all
+again. The residual is Θ(|E|) per round where the global route is Θ(1), which is
+why `presolved` sits at 825,607 against `global`'s 1,287. Priorities would remove
+the extra sweeps but not the one-run-per-donor-per-round floor; only disabling
+the donors does that, and it takes the count to 647.
+
+**The redundant donors cost almost nothing in wall time here**, 0.459 s against
+0.452 s at `n = 640`, even though they are 1,275× of the propagation count.
+Time is dominated by the non-incremental Bellman-Ford, not by the donors' cheap
+two-term propagations. So on this family the hybrid is nearly free, which
+matches the paper preferring it.
+
+**On the lucky order the presolver is a modest loss**, 0.257 s → 0.445 s at
+`n = 640`: nothing was wrong with the propagation order to begin with, and the
+extra global pass and the presolver's own O(number of constraints) enumeration
+(about 200 ns per constraint per pass, three passes, two of them the tripwire's)
+are pure overhead. That is the honest counterweight to the 9.7× on the unlucky
+order, and the reason this ships off by default.
+
 ## Deliberately deferred
 
 - **Incrementality.** The paper's `IncSat` / `IncLB` / `IncUB` maintain a valid
@@ -396,11 +621,10 @@ sequences.)
   shape 1 with `b` the sole surviving residual — but the paper's own
   configuration study says to leave it **off**: on RCPSP/max every configuration
   with it on scored below every configuration with it off.
-- **The presolver** — detecting difference-shaped constraints already posted on
-  a `Problem` and lifting them into a global propagator. This is the half the
-  paper's measurements say is actually valuable (310.00 → 312.94 for the
-  propagator alone on the MiniZinc challenge set, → 320.95 with simplification),
-  and it depends on #546's typed constraint enumeration.
+- **Lifting `Comparison` donors**, which needs their unconditional OPB rows
+  labelled; see the presolver section above.
+- **Lifting half-reified donors**, which is the same problem as supporting
+  half-reified edges in the propagator.
 - **Root simplification** — Johnson's all-pairs shortest paths, then dropping
   redundant edges, fixing Booleans whose edge would close a negative cycle, and
   unifying variables on a zero-weight cycle. Note that dropping a redundant edge
@@ -410,7 +634,8 @@ sequences.)
 - **Runtime propagator priorities.** The paper wants bound propagation at the
   lowest priority and Boolean propagation at the highest, as separate
   propagators. gcs has no runtime propagator priorities, only
-  `InitialiserPriority`.
+  `InitialiserPriority`. Issue #582 tracks this, and the presolver measurements
+  above are the concrete cost of not having them.
 
 ## See also
 

--- a/examples/difference_chain/CMakeLists.txt
+++ b/examples/difference_chain/CMakeLists.txt
@@ -9,3 +9,11 @@ add_test(NAME difference_chain-fixpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/
 add_test(NAME difference_chain-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-refute $<TARGET_FILE:difference_chain> --mode refute)
 add_test(NAME difference_chain-global-fixpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-global-fixpoint $<TARGET_FILE:difference_chain> --mode fixpoint --variant global)
 add_test(NAME difference_chain-global-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-global-refute $<TARGET_FILE:difference_chain> --mode refute --variant global)
+
+# The presolved variant reaches the same two conclusions by a third route: the
+# donors are posted as ordinary linears and the presolver lifts them, so the
+# proof cites the donors' own OPB rows rather than rows this example's model
+# emitted. Worth its own entries --- the presolver's unit tests drive it through
+# a Problem built in-process, not through a posted model.
+add_test(NAME difference_chain-presolved-fixpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-presolved-fixpoint $<TARGET_FILE:difference_chain> --mode fixpoint --variant presolved)
+add_test(NAME difference_chain-presolved-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-presolved-refute $<TARGET_FILE:difference_chain> --mode refute --variant presolved)

--- a/examples/difference_chain/difference_chain.cc
+++ b/examples/difference_chain/difference_chain.cc
@@ -50,9 +50,21 @@
 // stops depending on the order the edges were given in; and in --mode=refute it
 // refutes the negative cycle by summing the cycle's edge rows, which is one
 // cutting-planes step whatever the domains are.
+//
+// --variant=presolved posts the decomposed model and then adds the
+// DifferenceLogic presolver, which detects those two-term linears and installs
+// the same global propagator over them without the model being rewritten. The
+// donors' own propagators stay installed (the paper's section 4.4 hybrid), which
+// is what makes this the interesting middle column: it answers whether the
+// presolver route recovers the global route's win while still paying for the
+// redundant propagators, and whether the presolver's propagator running last in
+// registration order (gcs has no propagator priorities, see issue #582) costs
+// anything measurable. --disable-donors additionally retires the lifted donors'
+// propagators, which is the same experiment with that cost removed.
 
 #include <gcs/constraints/difference.hh>
 #include <gcs/constraints/linear.hh>
+#include <gcs/presolvers/difference_logic.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -60,6 +72,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -82,8 +95,10 @@ using namespace gcs;
 using std::cerr;
 using std::cout;
 using std::make_optional;
+using std::make_shared;
 using std::nullopt;
 using std::optional;
+using std::shared_ptr;
 using std::string;
 using std::string_view;
 using std::vector;
@@ -113,6 +128,7 @@ namespace
     enum struct Variant
     {
         Decomposed,
+        Presolved,
         Global
     };
 
@@ -177,20 +193,24 @@ namespace
     // Hand the same edges to the solver, either one propagator each or all at
     // once. Both variants produce the same OPB rows for the same edges (one
     // labelled inequality per edge), so the proofs are directly comparable.
-    auto post_edges(Problem & problem, const vector<DifferenceEdge> & edges, Variant variant) -> void
+    auto post_edges(Problem & problem, const vector<DifferenceEdge> & edges, Variant variant, bool disable_donors,
+        const shared_ptr<DifferenceLogicStats> & presolver_stats) -> void
     {
         switch (variant) {
             using enum Variant;
+        case Presolved:
         case Decomposed:
             for (const auto & e : edges)
                 problem.post(LinearLessThanEqual{WeightedSum{} + 1_i * e.x + -1_i * e.y, e.d});
+            if (variant == Presolved)
+                problem.add_presolver(DifferenceLogic{presolver_stats}.disabling_lifted_donors(disable_donors));
             break;
         case Global: problem.post(DifferenceConstraints{edges}); break;
         }
     }
 
     // The --variant names, in help order.
-    constexpr string_view variants[] = {"decomposed", "global"};
+    constexpr string_view variants[] = {"decomposed", "presolved", "global"};
 
     auto variant_names() -> string
     {
@@ -239,6 +259,9 @@ auto main(int argc, char * argv[]) -> int
                 cxxopts::value<string>()->default_value("fixpoint"))                                     //
             ("variant", "Model variant to post. Supported: " + variant_names(),                          //
                 cxxopts::value<string>()->default_value("decomposed"))                                   //
+            ("disable-donors",                                                                           //
+                "With --variant=presolved, also retire the lifted constraints' own propagators, so "     //
+                "only the global one runs over them")                                                    //
             ("all", "Find all solutions rather than stopping at the first")                              //
             ;
 
@@ -300,6 +323,8 @@ auto main(int argc, char * argv[]) -> int
     optional<Variant> variant;
     if (variant_name_given == "decomposed")
         variant = Variant::Decomposed;
+    else if (variant_name_given == "presolved")
+        variant = Variant::Presolved;
     else if (variant_name_given == "global")
         variant = Variant::Global;
     else {
@@ -320,7 +345,14 @@ auto main(int argc, char * argv[]) -> int
     if (*mode == Mode::Refute)
         edges.push_back(DifferenceEdge{x[n], y[0], -1_i});
 
-    post_edges(problem, edges, *variant);
+    auto disable_donors = options_vars.contains("disable-donors");
+    if (disable_donors && *variant != Variant::Presolved) {
+        println(cerr, "Error: --disable-donors only means anything with --variant=presolved.");
+        return EXIT_FAILURE;
+    }
+
+    auto presolver_stats = make_shared<DifferenceLogicStats>();
+    post_edges(problem, edges, *variant, disable_donors, presolver_stats);
 
     // The lower-bound bump that starts the chase. Posted last, so that the
     // difference constraints are all in the queue ahead of it and the bump wakes
@@ -360,6 +392,12 @@ auto main(int argc, char * argv[]) -> int
     println("order: {}", order_name);
     println("mode: {}", mode_name);
     println("variant: {}", variant_name_given);
+    if (*variant == Variant::Presolved) {
+        println("disable_donors: {}", disable_donors ? "yes" : "no");
+        println("presolver_edges_lifted: {}", presolver_stats->edges_lifted);
+        println("presolver_nodes: {}", presolver_stats->nodes);
+        println("presolver_donors_disabled: {}", presolver_stats->donor_propagators_disabled);
+    }
     println("all: {}", all ? "yes" : "no");
     println("domain: 0..{}", hi.raw_value);
     println("status: {}", status);

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(glasgow_constraint_solver
         innards/state.cc
         innards/variable_id_utils.cc
         presolvers/auto_table.cc
+        presolvers/difference_logic.cc
 )
 
 # The repo root contains both gcs/ and util/, so it must be on the include path.
@@ -178,6 +179,15 @@ if(GCS_BUILD_TESTS)
     add_executable(problem_test problem_test.cc)
     target_link_libraries(problem_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME problem_test COMMAND $<TARGET_FILE:problem_test>)
+
+    add_executable(difference_logic_presolver_test presolvers/difference_logic_test.cc)
+    target_link_libraries(difference_logic_presolver_test PRIVATE glasgow_constraint_solver)
+    foreach(mode detection equivalence tripwire opb)
+        add_test(NAME difference_logic_presolver_${mode}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_logic_presolver_test> ${mode})
+    endforeach()
+    add_test(NAME difference_logic_presolver_proofs
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_logic_presolver_test> proofs)
 
     add_executable(constraint_enumeration_test constraint_enumeration_test.cc)
     target_link_libraries(constraint_enumeration_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(glasgow_constraint_solver
         constraints/count/count.cc
         constraints/cumulative/cumulative.cc
         constraints/difference/difference_constraints.cc
+        constraints/difference/difference_graph.cc
         constraints/disjunctive/disjunctive.cc
         constraints/disjunctive_2d/disjunctive_2d.cc
         constraints/divide_modulus/divide_modulus.cc

--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -1,16 +1,12 @@
 #include <gcs/constraints/difference/difference_constraints.hh>
+#include <gcs/constraints/difference/difference_graph.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
-#include <gcs/innards/proofs/pol_builder.hh>
-#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
-#include <gcs/innards/reason.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
-
-#include <util/overloaded.hh>
 
 #include <map>
 #include <memory>
@@ -24,8 +20,6 @@ using namespace gcs::innards;
 using std::make_unique;
 using std::map;
 using std::move;
-using std::nullopt;
-using std::optional;
 using std::size_t;
 using std::string;
 using std::to_string;
@@ -41,26 +35,16 @@ namespace
     // -X - W <= d - c, which is not a difference constraint (both coefficients
     // are negative). Getting this wrong is unsound rather than merely
     // incomplete, so it is a hard error at construction. See the survey's
-    // section 2.6(e).
-    struct DeviewedOperand
+    // section 2.6(e). The shared helper reports it by returning nullopt,
+    // because a presolver has to skip such a constraint rather than reject the
+    // model it appears in.
+    auto deview_operand(const IntegerVariableID & var, const char * which) -> DeviewedDifferenceOperand
     {
-        optional<SimpleIntegerVariableID> variable;
-        Integer offset;
-    };
-
-    auto deview_operand(const IntegerVariableID & var, const char * which) -> DeviewedOperand
-    {
-        return overloaded{
-            [&](const SimpleIntegerVariableID & v) { return DeviewedOperand{v, 0_i}; },                   //
-            [&](const ConstantIntegerVariableID & v) { return DeviewedOperand{nullopt, v.const_value}; }, //
-            [&](const ViewOfIntegerVariableID & v) {
-                if (v.negate_first)
-                    throw InvalidProblemDefinitionException{
-                        string{"DifferenceConstraints "} + which + " operand is a negated view, which is not a difference constraint"};
-                return DeviewedOperand{v.actual_variable, v.then_add};
-            } //
-        }
-            .visit(var);
+        auto result = deview_difference_operand(var);
+        if (! result)
+            throw InvalidProblemDefinitionException{
+                string{"DifferenceConstraints "} + which + " operand is a negated view, which is not a difference constraint"};
+        return *result;
     }
 }
 
@@ -87,9 +71,9 @@ auto DifferenceConstraints::prepare(Propagators &, State &, ProofModel * const) 
 
     map<SimpleIntegerVariableID, size_t> node_of;
     auto node_index = [&](const SimpleIntegerVariableID & v) -> size_t {
-        auto [it, inserted] = node_of.emplace(v, _nodes.size());
+        auto [it, inserted] = node_of.emplace(v, _graph.nodes.size());
         if (inserted)
-            _nodes.push_back(v);
+            _graph.nodes.push_back(v);
         return it->second;
     };
 
@@ -113,15 +97,15 @@ auto DifferenceConstraints::prepare(Propagators &, State &, ProofModel * const) 
                     _root_contradiction_posted_index = i;
             }
             else
-                _graph_edges.push_back(GraphEdge{from, to, d, i});
+                _graph.edges.push_back(DifferenceGraphEdge{from, to, d, i});
         }
         else if (left.variable) {
             // X - c2 <= d, i.e. X <= d (c2 already folded in above).
-            _static_bounds.push_back(StaticBound{node_index(*left.variable), d, false, i});
+            _graph.static_bounds.push_back(DifferenceStaticBound{node_index(*left.variable), d, false, i});
         }
         else if (right.variable) {
             // c1 - Y <= d, i.e. Y >= -d.
-            _static_bounds.push_back(StaticBound{node_index(*right.variable), -d, true, i});
+            _graph.static_bounds.push_back(DifferenceStaticBound{node_index(*right.variable), -d, true, i});
         }
         else {
             // Two constants: 0 <= d, exactly as for aliasing.
@@ -156,7 +140,7 @@ auto DifferenceConstraints::define_proof_model(ProofModel & model, const State &
     // PolBuilder::enable_deview_mode, as linear/justify.cc does; that is
     // strictly more machinery for the same result here, since this constraint
     // owns both ends of every cancellation.)
-    _edge_lines.reserve(_edges.size());
+    _graph.edge_lines.reserve(_edges.size());
     for (size_t i = 0; i < _edges.size(); ++i) {
         const auto & e = _edges[i];
         auto left = deview_operand(e.x, "left");
@@ -174,7 +158,7 @@ auto DifferenceConstraints::define_proof_model(ProofModel & model, const State &
         // both render as a row whose left hand side is zero, which is exactly
         // what 0 <= d says, and which VeriPB reads as trivially true or
         // directly false according to d's sign.
-        _edge_lines.push_back(model.add_labelled_constraint(constraint_id(), "e" + to_string(i), move(sum) <= d));
+        _graph.edge_lines.push_back(model.add_labelled_constraint(constraint_id(), "e" + to_string(i), move(sum) <= d));
     }
 }
 
@@ -183,261 +167,15 @@ auto DifferenceConstraints::install_propagators(Propagators & propagators) -> vo
     if (_root_contradiction_posted_index) {
         // The edge's own OPB row is `0 >= something positive', so the
         // contradiction is RUP from the model with no state involved at all.
+        // Deliberately not part of install_difference_propagator: this is an
+        // initialiser, and initialisers have already run by the time a
+        // presolver builds a graph, so the presolver must instead decline to
+        // lift a degenerate edge and leave it to its own propagator.
         propagators.install_initial_contradiction("difference constraint x - x <= d with d < 0", JustifyUsingRUP{}, NoReason{});
         return;
     }
 
-    if (_graph_edges.empty() && _static_bounds.empty())
-        return;
-
-    Triggers triggers;
-    for (const auto & v : _nodes)
-        triggers.on_bounds.emplace_back(v);
-
-    propagators.install(
-        constraint_id(),
-        [nodes = move(_nodes), graph_edges = move(_graph_edges), static_bounds = move(_static_bounds), edge_lines = move(_edge_lines)](
-            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            auto n = nodes.size();
-            auto m = graph_edges.size();
-
-            // Static bounds first: an edge with a constant operand is a plain
-            // bound on the other operand, and once applied it is just part of
-            // the state that Bellman-Ford seeds from. These never change, so
-            // after the first call every one of these is a no-op.
-            for (const auto & sb : static_bounds) {
-                if (sb.is_lower) {
-                    if (state.lower_bound(nodes[sb.node]) < sb.value)
-                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, NoReason{});
-                }
-                else {
-                    if (state.upper_bound(nodes[sb.node]) > sb.value)
-                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, NoReason{});
-                }
-            }
-
-            // Both passes walk a predecessor relation, one forwards along the
-            // edges and one backwards, so each is parameterised by which end of
-            // an edge the predecessor sits at. `head_of' is the node whose
-            // bound the edge pushed (so pred[head_of(e)] == e), and `tail_of'
-            // is the node whose bound was cited.
-
-            // The refutation of a negative cycle is the sum of the cycle's edge
-            // rows and nothing else: each variable appears once with +1 (as
-            // some edge's head) and once with -1 (as the next edge's tail), so
-            // every BinEnc term telescopes away and what is left is
-            // `0 >= -(cycle weight)' with the right hand side at least 1. No
-            // domain state is involved, hence the empty reason.
-            //
-            // Before saying anything, verify the extracted cycle
-            // arithmetically: that each edge meets the next, that it closes,
-            // and that the total weight really is negative. That is O(cycle)
-            // and turns a predecessor-walk bug into an exception at the right
-            // place rather than a VeriPB failure hundreds of lines later
-            // (survey section 2.9.4).
-            auto contradict_on_cycle = [&](const vector<size_t> & cycle, auto && tail_of, auto && head_of) -> void {
-                if (cycle.empty())
-                    throw UnexpectedException{"difference logic extracted an empty negative cycle"};
-                Integer weight{0};
-                for (size_t k = 0; k < cycle.size(); ++k) {
-                    const auto & here = graph_edges[cycle[k]];
-                    const auto & next = graph_edges[cycle[(k + 1) % cycle.size()]];
-                    weight += here.d;
-                    if (head_of(next) != tail_of(here))
-                        throw UnexpectedException{"difference logic extracted a disconnected negative cycle"};
-                }
-                if (weight >= 0_i)
-                    throw UnexpectedException{"difference logic extracted a cycle of weight " + weight.to_string() + ", which is not negative"};
-
-                inference.contradiction(logger,
-                    JustifyExplicitly{[&](const ReasonLiterals &) {
-                                          PolBuilder pol;
-                                          for (auto e : cycle)
-                                              pol.add(edge_lines[graph_edges[e].posted_index]);
-                                          pol.emit(*logger, ProofLevel::Temporary);
-                                      },
-                        ThenRUP::Yes},
-                    NoReason{});
-            };
-
-            // Walk predecessors back from `start' looking for a cycle, which is
-            // total: the walk cannot run off the end of the predecessor forest,
-            // and whatever cycle it does reach is a negative one. Both are
-            // proved in dev_docs/difference-logic.md ("Rounds, and why the
-            // extraction is total"); in outline, a walk that reached a
-            // predecessor-less node would exhibit a real path into `start'
-            // whose source has held its seeded distance since before round 0,
-            // and the round bound below says that path has already propagated,
-            // contradicting the strict improvement that just happened.
-            auto extract_cycle = [&](size_t start, const vector<optional<size_t>> & pred, auto && tail_of) -> vector<size_t> {
-                vector<bool> seen(n, false);
-                auto at = start;
-                while (! seen[at]) {
-                    seen[at] = true;
-                    if (! pred[at])
-                        throw UnexpectedException{"difference logic found no negative cycle where one must exist"};
-                    at = tail_of(graph_edges[*pred[at]]);
-                }
-
-                vector<size_t> cycle;
-                auto here = at;
-                do {
-                    cycle.push_back(*pred[here]);
-                    here = tail_of(graph_edges[*pred[here]]);
-                } while (here != at);
-                return cycle;
-            };
-
-            // Infer improved bounds in an order consistent with the predecessor
-            // forest, so that each node's push cites its predecessor's bound
-            // *after* that bound has been applied. Roots of the forest are the
-            // nodes whose bound did not improve, so every node with a
-            // predecessor gets exactly one inference.
-            auto infer_along_forest = [&](const vector<optional<size_t>> & pred, auto && tail_of, auto && infer_one) -> void {
-                vector<bool> done(n, false);
-                vector<size_t> chain;
-                for (size_t v = 0; v < n; ++v) {
-                    if (done[v] || ! pred[v])
-                        continue;
-                    chain.clear();
-                    auto at = v;
-                    while (! done[at] && pred[at]) {
-                        done[at] = true;
-                        chain.push_back(at);
-                        at = tail_of(graph_edges[*pred[at]]);
-                    }
-                    for (auto it = chain.rbegin(); it != chain.rend(); ++it)
-                        infer_one(*it);
-                }
-            };
-
-            // Lower bounds flow forwards. Edge x --d--> y is x - y <= d, i.e.
-            // y >= x - d, so lb(y) >= lb(x) - d. Writing dist(v) = -lb(v) this
-            // is single-source shortest paths from the paper's dummy vertex v0,
-            // whose edge to v weighs -lb(v): that is exactly how the seeding
-            // below encodes the current bounds (Corollary 1).
-            vector<Integer> lb(n, 0_i);
-            vector<optional<size_t>> lb_pred(n, nullopt);
-            for (size_t v = 0; v < n; ++v)
-                lb[v] = state.lower_bound(nodes[v]);
-
-            // A shortest path from v0 is simple, so after the seeding (which is
-            // the v0 edge set) it uses at most n - 1 real edges, and n - 1
-            // relaxation rounds suffice. Rounds 0 .. n - 1 give n of them, one
-            // more than needed; round n relaxes nothing unless the system has a
-            // negative cycle, so a success there is sound evidence of one and
-            // the extraction above is guaranteed to find it.
-            auto lb_tail_of = [](const GraphEdge & g) { return g.from; };
-            auto lb_head_of = [](const GraphEdge & g) { return g.to; };
-
-            for (size_t round = 0; round <= n; ++round) {
-                bool changed = false;
-                for (size_t e = 0; e < m; ++e) {
-                    const auto & edge = graph_edges[e];
-                    auto candidate = lb[edge.from] - edge.d;
-                    if (candidate > lb[edge.to]) {
-                        lb[edge.to] = candidate;
-                        lb_pred[edge.to] = e;
-                        changed = true;
-                        if (round == n)
-                            contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
-                    }
-                }
-                if (! changed)
-                    break;
-            }
-
-            infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) {
-                const auto & edge = graph_edges[*lb_pred[v]];
-                auto source = nodes[edge.from];
-                auto source_lb = lb[edge.from];
-                if (source_lb - edge.d != lb[v])
-                    throw UnexpectedException{"difference logic lower bound does not match its predecessor edge"};
-                if (state.lower_bound(nodes[v]) >= lb[v])
-                    return;
-
-                // One edge, one pol: the edge row plus the definition row
-                // of the predecessor's bound literal cancels BinEnc(source)
-                // and leaves BinEnc(v) >= source_lb - d, which is exactly
-                // what the closing RUP needs. This is justify_linear_bounds
-                // for a two-term linear, and it is the shape verified by
-                // hand in boundpush_hand.pbp. Citing the predecessor's own
-                // bound is already the paper's "lifted" explanation: the
-                // weakest antecedent for v >= L - d across this edge *is*
-                // source >= L, so the pol's degree comes out at exactly the
-                // pushed amount with no wasted slack.
-                inference.infer_greater_than_or_equal(logger, nodes[v], lb[v],
-                    JustifyExplicitly{[&](const ReasonLiterals &) {
-                                          PolBuilder pol;
-                                          pol.add(edge_lines[edge.posted_index]);
-                                          pol.add_for_literal(logger->names_and_ids_tracker(), source >= source_lb);
-                                          pol.emit(*logger, ProofLevel::Temporary);
-                                      },
-                        ThenRUP::Yes},
-                    ExplicitReason{ReasonLiterals{{source >= source_lb}}});
-            });
-
-            // Upper bounds flow backwards along the same edges. Edge
-            // x --d--> y is also x <= y + d, so ub(x) <= ub(y) + d: shortest
-            // paths in the reverse graph, seeded from the current upper bounds.
-            vector<Integer> ub(n, 0_i);
-            vector<optional<size_t>> ub_pred(n, nullopt);
-            for (size_t v = 0; v < n; ++v)
-                ub[v] = state.upper_bound(nodes[v]);
-
-            auto ub_tail_of = [](const GraphEdge & g) { return g.to; };
-            auto ub_head_of = [](const GraphEdge & g) { return g.from; };
-
-            for (size_t round = 0; round <= n; ++round) {
-                bool changed = false;
-                for (size_t e = 0; e < m; ++e) {
-                    const auto & edge = graph_edges[e];
-                    auto candidate = ub[edge.to] + edge.d;
-                    if (candidate < ub[edge.from]) {
-                        ub[edge.from] = candidate;
-                        ub_pred[edge.from] = e;
-                        changed = true;
-                        if (round == n)
-                            contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
-                    }
-                }
-                if (! changed)
-                    break;
-            }
-
-            infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) {
-                const auto & edge = graph_edges[*ub_pred[v]];
-                auto source = nodes[edge.to];
-                auto source_ub = ub[edge.to];
-                if (source_ub + edge.d != ub[v])
-                    throw UnexpectedException{"difference logic upper bound does not match its predecessor edge"};
-                if (state.upper_bound(nodes[v]) <= ub[v])
-                    return;
-
-                inference.infer_less_than(logger, nodes[v], ub[v] + 1_i,
-                    JustifyExplicitly{[&](const ReasonLiterals &) {
-                                          PolBuilder pol;
-                                          pol.add(edge_lines[edge.posted_index]);
-                                          pol.add_for_literal(logger->names_and_ids_tracker(), source < source_ub + 1_i);
-                                          pol.emit(*logger, ProofLevel::Temporary);
-                                      },
-                        ThenRUP::Yes},
-                    ExplicitReason{ReasonLiterals{{source < source_ub + 1_i}}});
-            });
-
-            // Deliberately not EnableButIdempotent, and not merely because the
-            // scope aliases whenever one variable appears in several edges
-            // (which is the normal case here, and which Propagators::install
-            // detects and ignores the claim for anyway). The claim would be
-            // wrong on its own terms: the passes above reach the fixpoint of
-            // the bounds abstraction, but an inferred bound can snap past a
-            // hole in the domain and land strictly above the value computed
-            // here, which seeds the next call higher and lets it push further.
-            // So a second call genuinely can infer more, and the propagator has
-            // to be re-woken by its own inferences until the state settles.
-            return PropagatorState::Enable;
-        },
-        triggers);
+    install_difference_propagator(propagators, constraint_id(), move(_graph));
 }
 
 auto DifferenceConstraints::constraint_type() const -> string

--- a/gcs/constraints/difference/difference_constraints.hh
+++ b/gcs/constraints/difference/difference_constraints.hh
@@ -2,7 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_CONSTRAINTS_HH
 
 #include <gcs/constraint.hh>
-#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/constraints/difference/difference_graph.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
@@ -72,32 +72,15 @@ namespace gcs
         // propagator works off the canonical form below.
         std::vector<DifferenceEdge> _edges;
 
-        // The canonical graph, built by prepare(). Every operand is reduced to
-        // a bare SimpleIntegerVariableID plus an offset, and the offsets are
-        // folded into the weight, so that every edge's OPB row speaks the same
-        // representation and the telescoping pol cancels exactly.
-        std::vector<SimpleIntegerVariableID> _nodes;
-
-        struct GraphEdge
-        {
-            std::size_t from;
-            std::size_t to;
-            Integer d;
-            std::size_t posted_index;
-        };
-
-        // A constant operand does not give a graph edge, it gives a static
-        // bound on the other operand.
-        struct StaticBound
-        {
-            std::size_t node;
-            Integer value;
-            bool is_lower;
-            std::size_t posted_index;
-        };
-
-        std::vector<GraphEdge> _graph_edges;
-        std::vector<StaticBound> _static_bounds;
+        // The canonical graph, built by prepare() and filled in with one
+        // labelled OPB row per posted edge by define_proof_model(). Every
+        // operand is reduced to a bare SimpleIntegerVariableID plus an offset,
+        // and the offsets are folded into the weight, so that every edge's OPB
+        // row speaks the same representation and the telescoping pol cancels
+        // exactly. The propagator itself is shared with the difference-logic
+        // presolver, which builds one of these out of constraints somebody else
+        // posted; see innards::install_difference_propagator.
+        innards::DifferenceGraph _graph;
 
         // An edge whose two operands canonicalise to the same thing (aliasing,
         // or two constants) says 0 <= d. Harmless when d >= 0; a root
@@ -106,10 +89,6 @@ namespace gcs
         // Only whether this is engaged is acted on; the index identifies the
         // first offending edge, for a future assertion hint to name.
         std::optional<std::size_t> _root_contradiction_posted_index;
-
-        // One labelled OPB row per posted edge, indexed by posted position.
-        // Empty when proofs are off.
-        std::vector<innards::ProofLine> _edge_lines;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -190,6 +190,47 @@ namespace
             throw UnexpectedException{"difference did not push x's upper bound transitively to 3"};
     }
 
+    // The hole snap, which is why this propagator returns PropagatorState::Enable
+    // rather than EnableButIdempotent. One Bellman-Ford pass each way reaches the
+    // fixpoint of the *bounds abstraction*, but an inferred bound can land
+    // strictly above the value the pass computed, because the state snaps it past
+    // a hole in the domain -- and that higher bound seeds the next call, which
+    // then pushes further. So a second call genuinely infers more, and the
+    // propagator must be re-woken by its own inferences.
+    //
+    // y has the hole {3, 4, 5}. First call: lb(y) >= lb(x) + 3 = 3, which snaps
+    // to 6; lb(z) >= lb(y) + 2, but the *pass* computed lb(y) = 3, so it only
+    // pushes z to 5. Second call, seeded from the snapped lb(y) = 6: z >= 8.
+    // Nothing else is in the model, so if the propagator claimed idempotence the
+    // engine would not re-wake it from its own inferences and z would be left at
+    // 5. Confirmed by mutation: switching the return to EnableButIdempotent makes
+    // this fail (and also trips the harness's GCS_CHECK_IDEMPOTENT_CLAIMS re-run).
+    auto run_hole_snap_test() -> void
+    {
+        print(cerr, "difference hole snap:");
+        cerr << flush;
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 10_i, "x");
+        auto y = p.create_integer_variable(vector<Integer>{0_i, 1_i, 2_i, 6_i, 7_i, 8_i, 9_i, 10_i}, "y");
+        auto z = p.create_integer_variable(0_i, 10_i, "z");
+        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -3_i}, DifferenceEdge{y, z, -2_i}}});
+
+        optional<Integer> y_lower, z_lower;
+        solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
+            y_lower = s.lower_bound(y);
+            z_lower = s.lower_bound(z);
+            return false;
+        }});
+
+        println(cerr, " y >= {}, z >= {}", y_lower ? y_lower->raw_value : -1, z_lower ? z_lower->raw_value : -1);
+        if (y_lower != make_optional(6_i))
+            throw UnexpectedException{"difference did not snap y's lower bound past the hole to 6"};
+        if (z_lower != make_optional(8_i))
+            throw UnexpectedException{"difference stopped at the first pass's lower bound for z instead of re-running from the snapped bound: "
+                                      "the propagator must not claim idempotence"};
+    }
+
     // A negated view operand is not a difference constraint at all, and
     // accepting one would be unsound rather than merely incomplete, so it is
     // rejected at construction.
@@ -335,8 +376,10 @@ auto main(int argc, char * argv[]) -> int
     string mode{argv[1]};
 
     run_negated_view_test();
-    if (mode == "basic")
+    if (mode == "basic") {
         run_transitive_test();
+        run_hole_snap_test();
+    }
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -1,0 +1,309 @@
+#include <gcs/constraints/difference/difference_graph.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/inference_tracker.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/innards/state.hh>
+
+#include <util/overloaded.hh>
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::size_t;
+using std::vector;
+
+auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> optional<DeviewedDifferenceOperand>
+{
+    return overloaded{
+        [&](const SimpleIntegerVariableID & v) { return optional<DeviewedDifferenceOperand>{{v, 0_i}}; },                   //
+        [&](const ConstantIntegerVariableID & v) { return optional<DeviewedDifferenceOperand>{{nullopt, v.const_value}}; }, //
+        [&](const ViewOfIntegerVariableID & v) {
+            if (v.negate_first)
+                return optional<DeviewedDifferenceOperand>{nullopt};
+            return optional<DeviewedDifferenceOperand>{{v.actual_variable, v.then_add}};
+        } //
+    }
+        .visit(var);
+}
+
+auto gcs::innards::install_difference_propagator(Propagators & propagators, const ConstraintID & constraint_id, DifferenceGraph graph) -> void
+{
+    if (graph.edges.empty() && graph.static_bounds.empty())
+        return;
+
+    Triggers triggers;
+    for (const auto & v : graph.nodes)
+        triggers.on_bounds.emplace_back(v);
+
+    propagators.install(
+        constraint_id,
+        [nodes = move(graph.nodes), graph_edges = move(graph.edges), static_bounds = move(graph.static_bounds), edge_lines = move(graph.edge_lines)](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            auto n = nodes.size();
+            auto m = graph_edges.size();
+
+            // Every pol below cites an edge row in deview mode. For rows this
+            // constraint emitted itself that is a no-op: they are already over
+            // bare variables, so no deview-form is registered for them and
+            // deviewed_line_for hands the line straight back. It matters for a
+            // presolver-built graph, whose rows belong to somebody else's
+            // constraint and are therefore in the user's views' bits, while the
+            // arithmetic here (and the reason literals) is over the canonical
+            // bare variables. Same reasoning, and the same fix, as
+            // linear/justify.cc.
+            auto edge_line_pol = [&]() {
+                PolBuilder pol;
+                pol.enable_deview_mode(logger->names_and_ids_tracker());
+                return pol;
+            };
+
+            // Static bounds first: an edge with a constant operand is a plain
+            // bound on the other operand, and once applied it is just part of
+            // the state that Bellman-Ford seeds from. These never change, so
+            // after the first call every one of these is a no-op.
+            for (const auto & sb : static_bounds) {
+                if (sb.is_lower) {
+                    if (state.lower_bound(nodes[sb.node]) < sb.value)
+                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, NoReason{});
+                }
+                else {
+                    if (state.upper_bound(nodes[sb.node]) > sb.value)
+                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, NoReason{});
+                }
+            }
+
+            // Both passes walk a predecessor relation, one forwards along the
+            // edges and one backwards, so each is parameterised by which end of
+            // an edge the predecessor sits at. `head_of' is the node whose
+            // bound the edge pushed (so pred[head_of(e)] == e), and `tail_of'
+            // is the node whose bound was cited.
+
+            // The refutation of a negative cycle is the sum of the cycle's edge
+            // rows and nothing else: each variable appears once with +1 (as
+            // some edge's head) and once with -1 (as the next edge's tail), so
+            // every BinEnc term telescopes away and what is left is
+            // `0 >= -(cycle weight)' with the right hand side at least 1. No
+            // domain state is involved, hence the empty reason.
+            //
+            // Before saying anything, verify the extracted cycle
+            // arithmetically: that each edge meets the next, that it closes,
+            // and that the total weight really is negative. That is O(cycle)
+            // and turns a predecessor-walk bug into an exception at the right
+            // place rather than a VeriPB failure hundreds of lines later
+            // (survey section 2.9.4).
+            auto contradict_on_cycle = [&](const vector<size_t> & cycle, auto && tail_of, auto && head_of) -> void {
+                if (cycle.empty())
+                    throw UnexpectedException{"difference logic extracted an empty negative cycle"};
+                Integer weight{0};
+                for (size_t k = 0; k < cycle.size(); ++k) {
+                    const auto & here = graph_edges[cycle[k]];
+                    const auto & next = graph_edges[cycle[(k + 1) % cycle.size()]];
+                    weight += here.d;
+                    if (head_of(next) != tail_of(here))
+                        throw UnexpectedException{"difference logic extracted a disconnected negative cycle"};
+                }
+                if (weight >= 0_i)
+                    throw UnexpectedException{"difference logic extracted a cycle of weight " + weight.to_string() + ", which is not negative"};
+
+                inference.contradiction(logger,
+                    JustifyExplicitly{[&](const ReasonLiterals &) {
+                                          auto pol = edge_line_pol();
+                                          for (auto e : cycle)
+                                              pol.add(edge_lines[graph_edges[e].posted_index]);
+                                          pol.emit(*logger, ProofLevel::Temporary);
+                                      },
+                        ThenRUP::Yes},
+                    NoReason{});
+            };
+
+            // Walk predecessors back from `start' looking for a cycle, which is
+            // total: the walk cannot run off the end of the predecessor forest,
+            // and whatever cycle it does reach is a negative one. Both are
+            // proved in dev_docs/difference-logic.md ("Rounds, and why the
+            // extraction is total"); in outline, a walk that reached a
+            // predecessor-less node would exhibit a real path into `start'
+            // whose source has held its seeded distance since before round 0,
+            // and the round bound below says that path has already propagated,
+            // contradicting the strict improvement that just happened.
+            auto extract_cycle = [&](size_t start, const vector<optional<size_t>> & pred, auto && tail_of) -> vector<size_t> {
+                vector<bool> seen(n, false);
+                auto at = start;
+                while (! seen[at]) {
+                    seen[at] = true;
+                    if (! pred[at])
+                        throw UnexpectedException{"difference logic found no negative cycle where one must exist"};
+                    at = tail_of(graph_edges[*pred[at]]);
+                }
+
+                vector<size_t> cycle;
+                auto here = at;
+                do {
+                    cycle.push_back(*pred[here]);
+                    here = tail_of(graph_edges[*pred[here]]);
+                } while (here != at);
+                return cycle;
+            };
+
+            // Infer improved bounds in an order consistent with the predecessor
+            // forest, so that each node's push cites its predecessor's bound
+            // *after* that bound has been applied. Roots of the forest are the
+            // nodes whose bound did not improve, so every node with a
+            // predecessor gets exactly one inference.
+            auto infer_along_forest = [&](const vector<optional<size_t>> & pred, auto && tail_of, auto && infer_one) -> void {
+                vector<bool> done(n, false);
+                vector<size_t> chain;
+                for (size_t v = 0; v < n; ++v) {
+                    if (done[v] || ! pred[v])
+                        continue;
+                    chain.clear();
+                    auto at = v;
+                    while (! done[at] && pred[at]) {
+                        done[at] = true;
+                        chain.push_back(at);
+                        at = tail_of(graph_edges[*pred[at]]);
+                    }
+                    for (auto it = chain.rbegin(); it != chain.rend(); ++it)
+                        infer_one(*it);
+                }
+            };
+
+            // Lower bounds flow forwards. Edge x --d--> y is x - y <= d, i.e.
+            // y >= x - d, so lb(y) >= lb(x) - d. Writing dist(v) = -lb(v) this
+            // is single-source shortest paths from the paper's dummy vertex v0,
+            // whose edge to v weighs -lb(v): that is exactly how the seeding
+            // below encodes the current bounds (Corollary 1).
+            vector<Integer> lb(n, 0_i);
+            vector<optional<size_t>> lb_pred(n, nullopt);
+            for (size_t v = 0; v < n; ++v)
+                lb[v] = state.lower_bound(nodes[v]);
+
+            // A shortest path from v0 is simple, so after the seeding (which is
+            // the v0 edge set) it uses at most n - 1 real edges, and n - 1
+            // relaxation rounds suffice. Rounds 0 .. n - 1 give n of them, one
+            // more than needed; round n relaxes nothing unless the system has a
+            // negative cycle, so a success there is sound evidence of one and
+            // the extraction above is guaranteed to find it.
+            auto lb_tail_of = [](const DifferenceGraphEdge & g) { return g.from; };
+            auto lb_head_of = [](const DifferenceGraphEdge & g) { return g.to; };
+
+            for (size_t round = 0; round <= n; ++round) {
+                bool changed = false;
+                for (size_t e = 0; e < m; ++e) {
+                    const auto & edge = graph_edges[e];
+                    auto candidate = lb[edge.from] - edge.d;
+                    if (candidate > lb[edge.to]) {
+                        lb[edge.to] = candidate;
+                        lb_pred[edge.to] = e;
+                        changed = true;
+                        if (round == n)
+                            contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
+                    }
+                }
+                if (! changed)
+                    break;
+            }
+
+            infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) {
+                const auto & edge = graph_edges[*lb_pred[v]];
+                auto source = nodes[edge.from];
+                auto source_lb = lb[edge.from];
+                if (source_lb - edge.d != lb[v])
+                    throw UnexpectedException{"difference logic lower bound does not match its predecessor edge"};
+                if (state.lower_bound(nodes[v]) >= lb[v])
+                    return;
+
+                // One edge, one pol: the edge row plus the definition row
+                // of the predecessor's bound literal cancels BinEnc(source)
+                // and leaves BinEnc(v) >= source_lb - d, which is exactly
+                // what the closing RUP needs. This is justify_linear_bounds
+                // for a two-term linear, and it is the shape verified by
+                // hand in boundpush_hand.pbp. Citing the predecessor's own
+                // bound is already the paper's "lifted" explanation: the
+                // weakest antecedent for v >= L - d across this edge *is*
+                // source >= L, so the pol's degree comes out at exactly the
+                // pushed amount with no wasted slack.
+                inference.infer_greater_than_or_equal(logger, nodes[v], lb[v],
+                    JustifyExplicitly{[&](const ReasonLiterals &) {
+                                          auto pol = edge_line_pol();
+                                          pol.add(edge_lines[edge.posted_index]);
+                                          pol.add_for_literal(logger->names_and_ids_tracker(), source >= source_lb);
+                                          pol.emit(*logger, ProofLevel::Temporary);
+                                      },
+                        ThenRUP::Yes},
+                    ExplicitReason{ReasonLiterals{{source >= source_lb}}});
+            });
+
+            // Upper bounds flow backwards along the same edges. Edge
+            // x --d--> y is also x <= y + d, so ub(x) <= ub(y) + d: shortest
+            // paths in the reverse graph, seeded from the current upper bounds.
+            vector<Integer> ub(n, 0_i);
+            vector<optional<size_t>> ub_pred(n, nullopt);
+            for (size_t v = 0; v < n; ++v)
+                ub[v] = state.upper_bound(nodes[v]);
+
+            auto ub_tail_of = [](const DifferenceGraphEdge & g) { return g.to; };
+            auto ub_head_of = [](const DifferenceGraphEdge & g) { return g.from; };
+
+            for (size_t round = 0; round <= n; ++round) {
+                bool changed = false;
+                for (size_t e = 0; e < m; ++e) {
+                    const auto & edge = graph_edges[e];
+                    auto candidate = ub[edge.to] + edge.d;
+                    if (candidate < ub[edge.from]) {
+                        ub[edge.from] = candidate;
+                        ub_pred[edge.from] = e;
+                        changed = true;
+                        if (round == n)
+                            contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
+                    }
+                }
+                if (! changed)
+                    break;
+            }
+
+            infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) {
+                const auto & edge = graph_edges[*ub_pred[v]];
+                auto source = nodes[edge.to];
+                auto source_ub = ub[edge.to];
+                if (source_ub + edge.d != ub[v])
+                    throw UnexpectedException{"difference logic upper bound does not match its predecessor edge"};
+                if (state.upper_bound(nodes[v]) <= ub[v])
+                    return;
+
+                inference.infer_less_than(logger, nodes[v], ub[v] + 1_i,
+                    JustifyExplicitly{[&](const ReasonLiterals &) {
+                                          auto pol = edge_line_pol();
+                                          pol.add(edge_lines[edge.posted_index]);
+                                          pol.add_for_literal(logger->names_and_ids_tracker(), source < source_ub + 1_i);
+                                          pol.emit(*logger, ProofLevel::Temporary);
+                                      },
+                        ThenRUP::Yes},
+                    ExplicitReason{ReasonLiterals{{source < source_ub + 1_i}}});
+            });
+
+            // Deliberately not EnableButIdempotent, and not merely because the
+            // scope aliases whenever one variable appears in several edges
+            // (which is the normal case here, and which Propagators::install
+            // detects and ignores the claim for anyway). The claim would be
+            // wrong on its own terms: the passes above reach the fixpoint of
+            // the bounds abstraction, but an inferred bound can snap past a
+            // hole in the domain and land strictly above the value computed
+            // here, which seeds the next call higher and lets it push further.
+            // So a second call genuinely can infer more, and the propagator has
+            // to be re-woken by its own inferences until the state settles.
+            // (run_hole_snap_test in difference_constraints_test.cc pins this.)
+            return PropagatorState::Enable;
+        },
+        triggers);
+}

--- a/gcs/constraints/difference/difference_graph.hh
+++ b/gcs/constraints/difference/difference_graph.hh
@@ -1,0 +1,128 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_GRAPH_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_GRAPH_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/propagators-fwd.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief One edge of a canonicalised difference system: `nodes[from] -
+     * nodes[to] <= d`, derived from the `posted_index`th constraint the caller
+     * handed over.
+     *
+     * \sa DifferenceGraph
+     * \ingroup Innards
+     */
+    struct DifferenceGraphEdge
+    {
+        std::size_t from;
+        std::size_t to;
+        Integer d;
+        std::size_t posted_index;
+    };
+
+    /**
+     * \brief An edge with a constant operand, which is not a graph edge at all
+     * but a plain bound on the other operand: `nodes[node] >= value` when
+     * `is_lower`, `nodes[node] <= value` otherwise.
+     *
+     * \sa DifferenceGraph
+     * \ingroup Innards
+     */
+    struct DifferenceStaticBound
+    {
+        std::size_t node;
+        Integer value;
+        bool is_lower;
+        std::size_t posted_index;
+    };
+
+    /**
+     * \brief An operand reduced to (bare variable, offset), so that the operand
+     * equals `*variable + offset`. A constant operand has no variable, just the
+     * offset.
+     *
+     * \sa deview_difference_operand
+     * \ingroup Innards
+     */
+    struct DeviewedDifferenceOperand
+    {
+        std::optional<SimpleIntegerVariableID> variable;
+        Integer offset;
+    };
+
+    /**
+     * \brief Reduce an operand to a bare variable plus an offset, or fail on a
+     * negated view.
+     *
+     * Returns `nullopt` for a negated view (`-X + c`): `V - W <= d` with
+     * `V = -X + c` is `-X - W <= d - c`, which is not a difference constraint at
+     * all --- both coefficients are negative, the graph formulation does not
+     * describe it, and treating it as an edge would licence inferences the
+     * constraint does not entail. Callers must reject rather than approximate;
+     * getting this wrong is unsound, not merely incomplete.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto deview_difference_operand(const IntegerVariableID &) -> std::optional<DeviewedDifferenceOperand>;
+
+    /**
+     * \brief A canonicalised system of difference constraints, ready to be
+     * propagated: the node list, the edge list over node indices, any static
+     * bounds, and one OPB row per contributing constraint.
+     *
+     * Every operand has been reduced to a bare SimpleIntegerVariableID and the
+     * view offsets folded into the weights, so that consecutive edges meeting at
+     * "the same variable" really do share a representation and the telescoping
+     * `pol` cancels exactly (see `dev_docs/difference-logic.md`).
+     *
+     * \c edge_lines is indexed by \c posted_index and holds the *already
+     * emitted* OPB row stating each edge. It is empty when proofs are off. The
+     * propagator only ever cites these rows, never adds any: it derives
+     * cutting-planes consequences of constraints the model already contains,
+     * which is what lets a presolver build one of these out of other people's
+     * constraints after the proof model has been finalised.
+     *
+     * \ingroup Innards
+     */
+    struct DifferenceGraph
+    {
+        std::vector<SimpleIntegerVariableID> nodes;
+        std::vector<DifferenceGraphEdge> edges;
+        std::vector<DifferenceStaticBound> static_bounds;
+        std::vector<ProofLine> edge_lines;
+    };
+
+    /**
+     * \brief Install the global difference-logic propagator over a canonicalised
+     * system, attributed to the given constraint.
+     *
+     * The propagator runs Bellman-Ford from the current lower bounds over the
+     * graph and from the current upper bounds over its reverse, pushing every
+     * bound the system implies, and refutes a negative cycle by summing the
+     * cycle's rows. It is shared between DifferenceConstraints, which builds the
+     * graph from the edges it was posted with, and the difference-logic
+     * presolver, which builds it out of donor constraints already posted to the
+     * Problem: the algorithm cares only about the node list, the edge list and
+     * the rows, never about where they came from.
+     *
+     * A no-op if the system has neither edges nor static bounds. Detecting a
+     * root-level contradiction (an edge saying `0 <= d` with `d < 0`) is *not*
+     * this function's job --- see DifferenceConstraints::install_propagators,
+     * which handles it with an initialiser, a door that has closed by the time a
+     * presolver runs.
+     *
+     * \ingroup Innards
+     */
+    auto install_difference_propagator(Propagators &, const ConstraintID &, DifferenceGraph) -> void;
+}
+
+#endif

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -169,6 +169,20 @@ struct Propagators::Imp : RefinedWatchSink
     // (see the run loop); a member so it isn't reallocated on every propagate() call.
     vector<int> to_disable;
 
+    // Indexed by propagator id: 1 if disable_propagators_for_constraint has
+    // retired this propagator for the whole search. This is the *permanent*
+    // counterpart of PropagatorState::DisableUntilBacktrack, and it needs to be
+    // separate from it because the "until backtrack" lifetime is scoped to a
+    // propagate() call --- idle_end is saved on entry and restored by that
+    // call's on_backtrack, and the no-guesses path rebuilds queue and lookup
+    // from scratch --- so a boundary set before search starts would be erased
+    // by the first root propagation. The mechanism, though, is the same one:
+    // the rebuild below partitions the queue so that disabled propagators sit
+    // beyond idle_end, exactly where a to_disable swap puts them, which is what
+    // makes enqueue_if_idle skip them for free.
+    vector<uint8_t> permanently_disabled;
+    int permanently_disabled_count = 0;
+
     // One entry per run this round that returned EnableButIdempotent (and whose
     // claim is not ignored): runs are serial and the store applies inferences
     // immediately, so a run whose end left the tracker holding
@@ -373,6 +387,7 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
 {
     int id = _imp->propagation_functions.size();
     _imp->propagation_functions.emplace_back(move(f));
+    _imp->permanently_disabled.push_back(0);
 
     auto [it, inserted] = _imp->constraint_index_of_id.try_emplace(constraint_id, static_cast<int>(_imp->constraint_ids.size()));
     if (inserted)
@@ -484,6 +499,28 @@ auto Propagators::install(const ConstraintID & constraint_id, PropagationFunctio
         trigger_on_instantiated(v, id);
     for (const auto & [literal, payload] : triggers.refined)
         _imp->register_refined_watch(id, literal, payload, false);
+}
+
+auto Propagators::disable_propagators_for_constraints(std::span<const ConstraintID> constraint_ids) -> std::size_t
+{
+    // Plural, and deliberately so: a per-constraint entry point would have to
+    // scan every propagator per call, and a presolver disabling m donors would
+    // then pay O(m * propagators). Mark the constraint indices first, then make
+    // one pass.
+    vector<uint8_t> wanted(_imp->constraint_ids.size(), 0);
+    for (const auto & constraint_id : constraint_ids)
+        if (auto it = _imp->constraint_index_of_id.find(constraint_id); it != _imp->constraint_index_of_id.end())
+            wanted[it->second] = 1;
+
+    std::size_t disabled = 0;
+    for (std::size_t p = 0; p < _imp->propagator_constraint_index.size(); ++p)
+        if (wanted[_imp->propagator_constraint_index[p]] && ! _imp->permanently_disabled[p]) {
+            _imp->permanently_disabled[p] = 1;
+            ++_imp->permanently_disabled_count;
+            ++disabled;
+        }
+
+    return disabled;
 }
 
 auto Propagators::install_initialiser(InitialisationFunction && f, InitialiserPriority priority) -> void
@@ -629,17 +666,33 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
 
     if (guesses.empty()) {
         // On the first pass, walk propagators in registration order. The queue runs
-        // oldest-first, so push them forwards.
+        // oldest-first, so push them forwards. Permanently disabled propagators
+        // (disable_propagators_for_constraint) go to the tail instead, past
+        // idle_end, which is the same place a DisableUntilBacktrack swap puts
+        // one --- so they are neither run now nor woken later --- except that
+        // this boundary is not restored by anything, which is the whole point.
         _imp->queue.resize(_imp->propagation_functions.size());
         _imp->lookup.resize(_imp->propagation_functions.size());
-        for (unsigned i = 0; i != _imp->propagation_functions.size(); ++i) {
-            _imp->queue[i] = i;
-            _imp->lookup[i] = i;
+        int enabled_end = 0;
+        for (unsigned i = 0; i != _imp->propagation_functions.size(); ++i)
+            if (! _imp->permanently_disabled[i]) {
+                _imp->queue[enabled_end] = i;
+                _imp->lookup[i] = enabled_end;
+                ++enabled_end;
+            }
+        if (0 != _imp->permanently_disabled_count) {
+            int at = enabled_end;
+            for (unsigned i = 0; i != _imp->propagation_functions.size(); ++i)
+                if (_imp->permanently_disabled[i]) {
+                    _imp->queue[at] = i;
+                    _imp->lookup[i] = at;
+                    ++at;
+                }
         }
 
         _imp->enqueued_begin = 0;
-        _imp->enqueued_end = _imp->propagation_functions.size();
-        _imp->idle_end = _imp->propagation_functions.size();
+        _imp->enqueued_end = enabled_end;
+        _imp->idle_end = enabled_end;
     }
     else {
         // Seed the queue from every supplied guess. A propagator already enqueued by an
@@ -742,6 +795,15 @@ auto Propagators::propagate(const Literals & guesses, State & state, ProofLogger
                 break;
 
             int propagator_id = _imp->queue[_imp->enqueued_begin++];
+            // A propagator disabled between two propagate() calls can still be
+            // sitting inside the enqueued region of a queue built before the
+            // disable; the partition above only takes effect at the next
+            // rebuild. Skipping it here means disable_propagators_for_constraint
+            // takes effect immediately whenever it is called, at the cost of one
+            // predictable branch that is not even reached unless something has
+            // been disabled.
+            if (0 != _imp->permanently_disabled_count && _imp->permanently_disabled[propagator_id]) [[unlikely]]
+                continue;
             try {
                 ++_imp->total_propagations;
                 tracker.begin_propagator_run();

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -14,6 +14,7 @@
 #include <gcs/problem.hh>
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -471,6 +472,38 @@ namespace gcs::innards
          * state so it cannot be mis-sequenced.
          */
         auto install(const ConstraintID & constraint_id, PropagationFunction &&, const Triggers & trigger_vars) -> void;
+
+        /**
+         * Retire every propagator belonging to any of the given constraints for
+         * the rest of the search, returning how many were retired (a constraint
+         * that installed none, or whose propagators were already disabled,
+         * contributes nothing). Ids this Propagators has never seen are ignored.
+         *
+         * This is for a Presolver that has installed something strictly stronger
+         * than a set of already-installed propagators and wants to measure what
+         * the redundant ones cost --- see the difference-logic presolver, whose
+         * global propagator subsumes every donor's single-edge bound push.
+         * Disabling is *not* removing: the constraint keeps its OPB row, its
+         * entry in the scope and adjacency tables, and its contribution to every
+         * variable's degree, so a branching heuristic sees exactly the same
+         * problem and the search tree is unchanged. Consequently the caller is
+         * responsible for the soundness argument --- disabling a propagator
+         * whose inferences are not all made by something else loses propagation
+         * silently, and no proof will complain, because a proof only certifies
+         * what was derived.
+         *
+         * The effect is permanent, deliberately unlike
+         * PropagatorState::DisableUntilBacktrack, whose lifetime is scoped to a
+         * propagate() call. Intended to be called before search starts (a
+         * Presolver runs at the root); calling it later is safe but only ever
+         * takes effect from the next propagator dequeue onwards.
+         *
+         * Takes a whole batch rather than one constraint at a time because it
+         * has to scan the propagators to find them: one call per constraint
+         * would make disabling m of them quadratic, which for a difference-logic
+         * model with a dense edge set is the dominant cost.
+         */
+        auto disable_propagators_for_constraints(std::span<const ConstraintID> constraint_ids) -> std::size_t;
 
         /**
          * Install an initialiser, which will be called once just before search

--- a/gcs/presolvers/difference_logic.cc
+++ b/gcs/presolvers/difference_logic.cc
@@ -1,0 +1,254 @@
+#include <gcs/constraints/comparison/comparison.hh>
+#include <gcs/constraints/difference/difference_graph.hh>
+#include <gcs/constraints/linear/linear_greater_than_equal.hh>
+#include <gcs/constraints/linear/linear_inequality.hh>
+#include <gcs/constraints/linear/linear_less_than_equal.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/presolvers/difference_logic.hh>
+#include <gcs/problem.hh>
+#include <gcs/reification.hh>
+
+#include <concepts>
+#include <map>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::holds_alternative;
+using std::make_unique;
+using std::map;
+using std::move;
+using std::optional;
+using std::shared_ptr;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+namespace
+{
+    // The type strings the two donor families report. Constraint::constraint_type()
+    // is total and independent of the C++ class hierarchy, which is exactly what
+    // makes it usable as a cross-check on the hierarchy: see check_enumeration_is_working.
+    const string linear_inequality_type = "lin_less_equal";
+
+    auto is_comparison_type(const string & t) -> bool
+    {
+        return t == "less_than" || t == "less_equal" || t == "greater_than" || t == "greater_equal";
+    }
+
+    // The failure this exists to catch is a silent one, so it says so at length.
+    // Problem stores what Constraint::clone() returns, and every member of these
+    // families currently clones to its family base, which is why asking for the
+    // base is what finds a posted LinearLessThanEqual. If that ever stops being
+    // true, each_constraint_of_type<ReifiedLinearInequality>() yields nothing, the
+    // presolver lifts nothing, and *every* validation still passes: a presolver
+    // that does nothing preserves the solution set, adds no OPB content and leaves
+    // every proof verifying. So cross-check the typed enumeration against
+    // constraint_type(), which does not depend on the hierarchy at all, and fail
+    // loudly rather than quietly doing nothing.
+    auto check_enumeration_is_working(const Problem & problem, size_t linears_seen, size_t comparisons_seen) -> void
+    {
+        size_t linears_by_type = 0, comparisons_by_type = 0;
+        for (const auto & c : problem.each_constraint()) {
+            auto type = c.constraint_type();
+            if (type == linear_inequality_type)
+                ++linears_by_type;
+            else if (is_comparison_type(type))
+                ++comparisons_by_type;
+        }
+
+        auto complain = [&](const string & family, const string & base, size_t by_type, size_t seen) {
+            throw UnexpectedException{"the difference-logic presolver's constraint enumeration is broken: " + to_string(by_type) +
+                " posted constraints report a " + family + " constraint_type(), but Problem::each_constraint_of_type<" + base + ">() yielded only " +
+                to_string(seen) +
+                " of them. DETECTION is what needs fixing here, not this check. The likely cause is a change to Constraint::clone() or to the class "
+                "hierarchy, so that a posted constraint is no longer stored as its family base (see PR #585). Do NOT relax this check: a presolver "
+                "that lifts nothing still passes every solution-equivalence, OPB byte-diff and VeriPB check, so this is the only thing standing "
+                "between a silent regression and shipping. Fix gcs/presolvers/difference_logic.cc."};
+        };
+
+        if (linears_by_type > linears_seen)
+            complain(linear_inequality_type, "ReifiedLinearInequality", linears_by_type, linears_seen);
+        if (comparisons_by_type > comparisons_seen)
+            complain(
+                "less_than / less_equal / greater_than / greater_equal", "ReifiedCompareLessThanOrMaybeEqual", comparisons_by_type, comparisons_seen);
+    }
+}
+
+DifferenceLogic::DifferenceLogic(shared_ptr<DifferenceLogicStats> stats) : _stats(move(stats)), _disable_lifted_donors(false)
+{
+}
+
+auto DifferenceLogic::disabling_lifted_donors(bool disable) -> DifferenceLogic &
+{
+    _disable_lifted_donors = disable;
+    return *this;
+}
+
+auto DifferenceLogic::clone() const -> unique_ptr<Presolver>
+{
+    auto result = make_unique<DifferenceLogic>(_stats);
+    result->disabling_lifted_donors(_disable_lifted_donors);
+    return result;
+}
+
+auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &, ProofLogger * const logger) -> bool
+{
+    // Compile-time pins on the contract the enumeration below relies upon. The
+    // helper matches the type Problem *stores*, which is what clone() returns,
+    // and for both of these families that is the base; asking for the derived
+    // user-facing type is not a compile error, it simply matches nothing. If a
+    // future refactor breaks these relationships, this is the place that needs
+    // to change, so fail here rather than at runtime. (The base being a base is
+    // necessary but not sufficient --- clone() must also still return it --- so
+    // check_enumeration_is_working covers the rest.)
+    static_assert(std::derived_from<LinearLessThanEqual, ReifiedLinearInequality>);
+    static_assert(std::derived_from<LinearLessThanEqualIf, ReifiedLinearInequality>);
+    static_assert(std::derived_from<LinearGreaterThanEqual, ReifiedLinearInequality>);
+    static_assert(std::derived_from<LessThan, ReifiedCompareLessThanOrMaybeEqual>);
+    static_assert(std::derived_from<LessThanEqual, ReifiedCompareLessThanOrMaybeEqual>);
+    static_assert(std::derived_from<GreaterThanEqual, ReifiedCompareLessThanOrMaybeEqual>);
+
+    DifferenceLogicStats stats;
+
+    DifferenceGraph graph;
+    map<SimpleIntegerVariableID, size_t> node_of;
+    auto node_index = [&](const SimpleIntegerVariableID & v) -> size_t {
+        auto [it, inserted] = node_of.emplace(v, graph.nodes.size());
+        if (inserted)
+            graph.nodes.push_back(v);
+        return it->second;
+    };
+
+    // The donors whose edges were lifted, for the optional disable below. Kept
+    // as ids rather than pointers because that is what Propagators indexes by.
+    vector<ConstraintID> lifted_donors;
+
+    size_t linears_seen = 0;
+    for (const auto & c : problem.each_constraint_of_type<ReifiedLinearInequality>()) {
+        ++linears_seen;
+
+        // Unconditional only. This is not a nicety: comparison.cc and
+        // linear_inequality.cc emit the `If` form's row *half-reified* under
+        // HalfReifyOnConjunctionOf, so treating it as an unconditional edge
+        // would licence inferences the model does not entail, and the pol
+        // citing it would carry an uncancelled gate term. Half-reified edges
+        // need the paper's E' machinery and a trailed edge journal; a later PR.
+        if (! holds_alternative<reif::MustHold>(c.reification_condition())) {
+            ++stats.skipped_reified;
+            continue;
+        }
+
+        const auto & terms = c.coefficients_and_variables().terms;
+        if (2 != terms.size()) {
+            ++stats.skipped_not_two_terms;
+            continue;
+        }
+
+        optional<IntegerVariableID> positive, negative;
+        for (const auto & t : terms) {
+            if (1_i == t.coefficient && ! positive)
+                positive = t.variable;
+            else if (-1_i == t.coefficient && ! negative)
+                negative = t.variable;
+        }
+        if (! positive || ! negative) {
+            ++stats.skipped_coefficients;
+            continue;
+        }
+
+        auto left = deview_difference_operand(*positive);
+        auto right = deview_difference_operand(*negative);
+        if (! left || ! right) {
+            // A negated view: `-X - Y <= d` has both coefficients negative and
+            // is not a difference constraint at all. Unsound to lift, not
+            // merely unhelpful.
+            ++stats.skipped_negated_view;
+            continue;
+        }
+
+        // A constant operand makes this a plain bound, which the donor's own
+        // propagator applies once and which adds nothing to the graph; and
+        // aliasing says 0 <= d, which is vacuous or else a root contradiction
+        // that would need an initialiser --- and initialisers have already run
+        // by the time a presolver is called. Leave both to the donor, which
+        // handles them. Checked before node_index is called, so a skipped edge
+        // never leaves an isolated node behind to be triggered on.
+        if (! left->variable || ! right->variable || *left->variable == *right->variable) {
+            ++stats.skipped_degenerate;
+            continue;
+        }
+
+        // (X + c1) - (Y + c2) <= d becomes X - Y <= d - c1 + c2, matching
+        // DifferenceConstraints exactly. The donor's OPB row is still in the
+        // user's views' bits; the propagator cites it in deview mode, which is
+        // what puts it in the same representation as this arithmetic.
+        auto d = c.value() - left->offset + right->offset;
+        auto from = node_index(*left->variable);
+        auto to = node_index(*right->variable);
+
+        auto posted_index = graph.edges.size();
+        graph.edges.push_back(DifferenceGraphEdge{from, to, d, posted_index});
+        if (logger) {
+            // The donor's own row, which linear_inequality.cc labelled
+            // @c[<id>] with an empty role. Nothing new goes into the OPB ---
+            // Presolver::run has no ProofModel * precisely because that door has
+            // closed --- and nothing needs to: every inference the propagator
+            // makes is a cutting-planes consequence of these rows.
+            graph.edge_lines.push_back(ProofLineLabel{"c[" + as_string(c.constraint_id()) + "]"});
+        }
+        lifted_donors.push_back(c.constraint_id());
+    }
+
+    // Comparisons are difference constraints too --- `x <= y + d` is a view, not
+    // a separate constraint kind --- but ReifiedCompareLessThanOrMaybeEqual
+    // emits its unconditional rows through the void-returning add_constraint, so
+    // they carry no @label and no proof step can cite them. Count what that
+    // costs us rather than silently ignoring it; labelling those rows touches
+    // the cake_pb_cp chain surface and is deliberately a later PR.
+    size_t comparisons_seen = 0;
+    for (const auto & c : problem.each_constraint_of_type<ReifiedCompareLessThanOrMaybeEqual>()) {
+        ++comparisons_seen;
+        if (! holds_alternative<reif::MustHold>(c.reification_condition()))
+            continue;
+        auto left = deview_difference_operand(c.left_variable());
+        auto right = deview_difference_operand(c.right_variable());
+        if (left && right && left->variable && right->variable && *left->variable != *right->variable)
+            ++stats.skipped_unlabelled_comparison;
+    }
+
+    check_enumeration_is_working(problem, linears_seen, comparisons_seen);
+
+    stats.edges_lifted = graph.edges.size();
+    stats.nodes = graph.nodes.size();
+
+    // Fewer than two edges is not a threshold, it is a degeneracy: over a single
+    // edge the global propagator computes exactly what that edge's own
+    // propagator computes, so installing it buys nothing and costs a wake. No
+    // further gating is applied --- see dev_docs/difference-logic.md for why a
+    // real threshold is not shipped.
+    if (graph.edges.size() >= 2) {
+        // A presolver-derived propagator has no posted-constraint identity of
+        // its own, exactly as for AutoTable.
+        install_difference_propagator(propagators, CurrentlyUnnamedConstraint{}, move(graph));
+        stats.propagator_installed = true;
+
+        if (_disable_lifted_donors)
+            stats.donor_propagators_disabled = propagators.disable_propagators_for_constraints(lifted_donors);
+    }
+
+    if (_stats)
+        *_stats = stats;
+
+    return true;
+}

--- a/gcs/presolvers/difference_logic.hh
+++ b/gcs/presolvers/difference_logic.hh
@@ -1,0 +1,153 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_DIFFERENCE_LOGIC_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_DIFFERENCE_LOGIC_HH
+
+#include <gcs/presolver.hh>
+
+#include <cstddef>
+#include <memory>
+
+namespace gcs
+{
+    /**
+     * \brief What the difference-logic presolver did, filled in when it runs.
+     *
+     * The presolver's whole job is invisible from the outside: it adds no OPB
+     * content, changes no solution, and leaves proofs verifying whether it fired
+     * or not. A presolver that silently lifted nothing --- because, say,
+     * Constraint::clone() stopped flattening a posted LinearLessThanEqual to
+     * ReifiedLinearInequality --- would pass every solution-equivalence, OPB
+     * byte-diff and VeriPB check there is. So the counts are not decoration:
+     * they are how the tests, and the measurements, tell "working" from
+     * "no-op". \sa DifferenceLogic
+     *
+     * \ingroup Presolvers
+     */
+    struct DifferenceLogicStats
+    {
+        /// Donors turned into graph edges: the number that matters.
+        std::size_t edges_lifted = 0;
+
+        /// Distinct variables those edges span.
+        std::size_t nodes = 0;
+
+        /// True if a global propagator was actually installed.
+        bool propagator_installed = false;
+
+        /// Propagators retired by the donors-off option.
+        std::size_t donor_propagators_disabled = 0;
+
+        /**
+         * \name Why a candidate was not lifted.
+         *
+         * Every posted linear inequality the presolver looked at falls into
+         * exactly one of edges_lifted or one of the first five buckets, so those
+         * six numbers account for every ReifiedLinearInequality in the model.
+         * @{
+         */
+
+        /// A linear that is not exactly two terms.
+        std::size_t skipped_not_two_terms = 0;
+
+        /// A two-term linear whose coefficients are not exactly +1 and -1.
+        std::size_t skipped_coefficients = 0;
+
+        /// A linear whose reification condition is not reif::MustHold. Lifting
+        /// one of these as though it were unconditional would be unsound: the
+        /// `If` form's row is emitted half-reified.
+        std::size_t skipped_reified = 0;
+
+        /// An operand that is a negated view (`-X + c`), which is not a
+        /// difference constraint at all.
+        std::size_t skipped_negated_view = 0;
+
+        /// An edge that canonicalises to `0 <= d` (both operands the same
+        /// variable, or both constants), or to a plain bound on one variable
+        /// (one constant operand). Nothing is gained by lifting these and the
+        /// `d < 0` case would need an initialiser, a door that has closed by
+        /// the time a presolver runs, so they are left to their own propagator.
+        std::size_t skipped_degenerate = 0;
+
+        /// A Comparison (`x < y`, `x <= y + d`, ...) that *is* difference
+        /// shaped but whose OPB row is emitted unlabelled, so no proof step can
+        /// cite it. This is the measure of what a later PR that labels those
+        /// rows would gain. \sa DifferenceLogic
+        std::size_t skipped_unlabelled_comparison = 0;
+
+        ///@}
+    };
+
+    /**
+     * \brief Scan a posted Problem for difference-shaped constraints and install
+     * a global difference-logic propagator over them, alongside the constraints'
+     * own propagators.
+     *
+     * A model does not have to be rewritten against DifferenceConstraints to get
+     * the global propagation: post `1*x + -1*y <= d` as an ordinary
+     * LinearLessThanEqual, add this presolver, and the edges are lifted into one
+     * Bellman-Ford pass over the whole graph. This is the hybrid of section 4.4
+     * of Kletzander, Dekker, Schutt and Stuckey, "Global Difference Constraint
+     * Propagation for Constraint Programming" (arXiv:2607.20022) --- and it is
+     * what the timing forces in any case, since presolvers run after
+     * create_propagators and after the proof model has been finalised, so the
+     * donors' propagators cannot be removed and no new OPB content can be added.
+     *
+     * That timing is not a limitation, it is what makes the proofs trivial. Each
+     * donor already emitted its own labelled OPB row; the global propagator
+     * simply cites those rows in its `pol`s, and derives nothing that is not a
+     * cutting-planes consequence of constraints the model already contains.
+     *
+     * Off by default: the paper's own MiniZinc-wide result is near-noise, so
+     * this is opted into with Problem::add_presolver, not applied automatically.
+     *
+     * \par What is lifted
+     *
+     * The paper's "level 1", restricted to what the propagator supports today: a
+     * two-term LinearLessThanEqual with coefficients exactly `+1` and `-1`, an
+     * unconditional (reif::MustHold) reification condition, and two distinct
+     * variable operands, each of which may carry a `+X + c` view offset (folded
+     * into the weight). Everything else is skipped and counted --- see
+     * DifferenceLogicStats, and note in particular that Comparison donors are
+     * skipped only because their unconditional OPB rows are emitted *unlabelled*
+     * and so cannot be cited, not because they are the wrong shape.
+     *
+     * Equalities (level 2) and disequalities (level 3) are not chased at all;
+     * the paper measures both as losing to level 1.
+     *
+     * \ingroup Presolvers
+     */
+    class DifferenceLogic : public Presolver
+    {
+    private:
+        std::shared_ptr<DifferenceLogicStats> _stats;
+        bool _disable_lifted_donors;
+
+    public:
+        /**
+         * \brief Construct the presolver, optionally sharing a stats block that
+         * will be filled in when it runs.
+         *
+         * The block is shared, not copied, so it survives Problem::add_presolver
+         * cloning the presolver and can be read after solving.
+         */
+        explicit DifferenceLogic(std::shared_ptr<DifferenceLogicStats> stats = nullptr);
+
+        /**
+         * \brief Also retire the propagators of every donor whose edge was
+         * lifted, so only the global propagator runs over them.
+         *
+         * Ships off, because the hybrid is what the paper measures as best; this
+         * exists so the alternative can be measured rather than assumed. It is
+         * also a soundness tripwire, and a strong one: the global propagator
+         * subsumes every donor's single-edge bound push, and disabling a
+         * propagator changes neither degrees nor adjacency, so the search tree
+         * must come out *identical* either way. It differing means the
+         * subsumption claim is wrong.
+         */
+        auto disabling_lifted_donors(bool = true) -> DifferenceLogic &;
+
+        [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
+        [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;
+    };
+}
+
+#endif

--- a/gcs/presolvers/difference_logic_test.cc
+++ b/gcs/presolvers/difference_logic_test.cc
@@ -1,0 +1,608 @@
+// Tests for the difference-logic presolver.
+//
+// READ THIS BEFORE "FIXING" A FAILURE HERE.
+//
+// This presolver is invisible from the outside by design. It adds no OPB
+// content, changes no solution, and leaves every proof verifying. That means a
+// presolver which silently lifted *nothing* -- because, say, Constraint::clone()
+// stopped flattening a posted LinearLessThanEqual down to
+// ReifiedLinearInequality, so that
+// Problem::each_constraint_of_type<ReifiedLinearInequality>() no longer matched
+// it -- would pass:
+//
+//   * every solution-set equivalence check (a no-op presolver preserves them);
+//   * the OPB byte-identical check (byte-identical is the *expected* result);
+//   * every VeriPB run (there would be nothing new to verify).
+//
+// So the assertions on DifferenceLogicStats below, and the propagation-count
+// differential in the `differential` mode, are the only things standing between
+// a silent regression and shipping. If one of them fails, DETECTION IS BROKEN.
+// Do not update the expected numbers to match what the code now does. Fix
+// gcs/presolvers/difference_logic.cc.
+
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/exception.hh>
+#include <gcs/presolvers/difference_logic.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::ifstream;
+using std::istreambuf_iterator;
+using std::make_optional;
+using std::make_shared;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::shared_ptr;
+using std::string;
+using std::to_string;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // Boilerplate every failure message here shares. Naming the invariant is not
+    // enough on its own: the whole hazard is that "just update the number" looks
+    // like a reasonable response to one of these.
+    const string detection_is_broken = "\n\nThis means the presolver's DETECTION is broken, not that this expectation is stale.\n"
+                                       "The most likely cause is a change to Constraint::clone() or to the Linear class\n"
+                                       "hierarchy, such that Problem::each_constraint_of_type<ReifiedLinearInequality>()\n"
+                                       "no longer yields posted LinearLessThanEqual constraints (clone() currently returns\n"
+                                       "the family base -- see PR #585).\n\n"
+                                       "Fix gcs/presolvers/difference_logic.cc. Do NOT update the expected count here: a\n"
+                                       "presolver that lifts nothing still passes every solution-equivalence, OPB byte-diff\n"
+                                       "and VeriPB check, so this assertion is the only thing standing between a silent\n"
+                                       "regression and shipping.";
+
+    auto check_count(const string & what, size_t expected, size_t actual, const string & fixture) -> void
+    {
+        if (expected != actual)
+            throw UnexpectedException{"the difference-logic presolver reported " + to_string(actual) + " for " + what + " on fixture '" + fixture +
+                "', expected " + to_string(expected) + "." + detection_is_broken};
+    }
+
+    // One end of an edge: variable `var` offset by `offset` (a bare variable
+    // when the offset is zero, a `+X + c` view otherwise), or, when `var` is
+    // unset, the constant `offset`.
+    struct Operand
+    {
+        optional<size_t> var;
+        int offset;
+        bool negated = false;
+    };
+
+    auto v(size_t i) -> Operand
+    {
+        return Operand{i, 0};
+    }
+
+    auto v(size_t i, int offset) -> Operand
+    {
+        return Operand{i, offset};
+    }
+
+    auto neg(size_t i) -> Operand
+    {
+        return Operand{i, 0, true};
+    }
+
+    auto c(int value) -> Operand
+    {
+        return Operand{nullopt, value};
+    }
+
+    struct EdgeSpec
+    {
+        Operand x;
+        Operand y;
+        int d;
+    };
+
+    auto operand_value(const Operand & o, const vector<int> & vals) -> int
+    {
+        auto base = o.var ? vals.at(*o.var) : 0;
+        return (o.negated ? -base : base) + o.offset;
+    }
+
+    auto operand_id(const Operand & o, const vector<IntegerVariableID> & vars) -> IntegerVariableID
+    {
+        if (! o.var)
+            return constant_variable(Integer(o.offset));
+        auto base = o.negated ? -vars.at(*o.var) : vars.at(*o.var);
+        return o.offset == 0 ? base : base + Integer(o.offset);
+    }
+
+    auto satisfied(const vector<int> & vals, const vector<EdgeSpec> & edges) -> bool
+    {
+        for (const auto & e : edges)
+            if (operand_value(e.x, vals) - operand_value(e.y, vals) > e.d)
+                return false;
+        return true;
+    }
+
+    // How the presolver is (or is not) attached. The hybrid is what ships; the
+    // third exists so the redundant donors can be measured, and because a search
+    // tree that moves when they are switched off would mean the global
+    // propagator does not in fact subsume them.
+    enum class Config
+    {
+        NoPresolver,
+        Hybrid,
+        DonorsDisabled
+    };
+
+    auto config_name(Config config) -> string
+    {
+        switch (config) {
+            using enum Config;
+        case NoPresolver: return "no-presolver";
+        case Hybrid: return "hybrid";
+        case DonorsDisabled: return "donors-disabled";
+        }
+        throw UnimplementedException{};
+    }
+
+    // Post the system as one two-term LinearLessThanEqual per edge -- the shape
+    // the presolver detects -- and attach the presolver as asked.
+    auto build(Problem & p, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges, Config config,
+        const shared_ptr<DifferenceLogicStats> & stats) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> vars;
+        for (const auto & [lo, hi] : domains)
+            vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
+
+        for (const auto & e : edges)
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars), Integer(e.d)});
+
+        switch (config) {
+            using enum Config;
+        case NoPresolver: break;
+        case Hybrid: p.add_presolver(DifferenceLogic{stats}); break;
+        case DonorsDisabled: p.add_presolver(DifferenceLogic{stats}.disabling_lifted_donors()); break;
+        }
+
+        return vars;
+    }
+
+    // Solution-set equivalence across all three configurations, against an
+    // independent C++ oracle. Sound and complete, in both directions: an
+    // over-pruning presolver loses a solution and an unsound one gains one, and
+    // no proof would catch either, since a proof only certifies what was
+    // derived.
+    auto run_equivalence_test(bool proofs, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges,
+        size_t expected_edges_lifted) -> void
+    {
+        print(cerr, "difference presolver equivalence {} domains={} edges={}{}", name, domains, edges.size(), proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<tuple<vector<int>>> expected;
+        build_expected(expected, [&](const vector<int> & vals) { return satisfied(vals, edges); }, domains);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        for (auto config : {Config::NoPresolver, Config::Hybrid, Config::DonorsDisabled}) {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto vars = build(p, domains, edges, config, stats);
+
+            set<tuple<vector<int>>> actual;
+            // The presolver only reads and writes bounds, so bounds consistent,
+            // not GAC.
+            auto proof_name = proofs ? make_optional("difference_presolver_" + name + "_" + config_name(config)) : nullopt;
+            solve_for_tests(p, proof_name, actual, tuple{vars});
+            check_results(proof_name, expected, actual);
+
+            if (config != Config::NoPresolver)
+                check_count("edges lifted", expected_edges_lifted, stats->edges_lifted, name);
+        }
+    }
+
+    // The tripwire. Disabling the donors' own propagators must not change the
+    // search tree at all: the global propagator subsumes every single-edge bound
+    // push, and disabling changes neither degrees nor adjacency, so the
+    // branching heuristic sees an unchanged problem. Solutions *and* recursions
+    // must match exactly. (Propagation counts of course do not, and are the
+    // point of the option.)
+    auto run_tripwire_test(const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges) -> void
+    {
+        print(cerr, "difference presolver tripwire {}:", name);
+        cerr << flush;
+
+        Stats results[2];
+        for (auto [index, config] : {pair{0, Config::Hybrid}, pair{1, Config::DonorsDisabled}}) {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            static_cast<void>(build(p, domains, edges, config, stats));
+            results[index] = solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return true; }});
+            if (config == Config::DonorsDisabled && 0 == stats->donor_propagators_disabled)
+                throw UnexpectedException{"the difference-logic presolver disabled no donor propagators on fixture '" + name +
+                    "', so the tripwire compared two identical configurations." + detection_is_broken};
+        }
+
+        println(cerr, " hybrid {} solutions / {} recursions / {} propagations, donors off {} / {} / {}", results[0].solutions, results[0].recursions,
+            results[0].propagations, results[1].solutions, results[1].recursions, results[1].propagations);
+
+        if (results[0].solutions != results[1].solutions)
+            throw UnexpectedException{"difference presolver fixture '" + name + "' found " + to_string(results[0].solutions) +
+                " solutions with the donors enabled but " + to_string(results[1].solutions) +
+                " with them disabled: the global propagator does not subsume them and disabling is unsound"};
+
+        if (results[0].recursions != results[1].recursions)
+            throw UnexpectedException{"difference presolver fixture '" + name + "' searched " + to_string(results[0].recursions) +
+                " nodes with the donors enabled but " + to_string(results[1].recursions) +
+                " with them disabled: the search tree moved, so the global propagator does not reach the same fixpoint as the donors do"};
+    }
+
+    // The corpus: views on either end and shared between edges, aliasing,
+    // constant operands, negative cycles, zero-weight cycles, and a negated view
+    // that must be refused rather than mis-lifted.
+    struct Fixture
+    {
+        string name;
+        vector<pair<int, int>> domains;
+        vector<EdgeSpec> edges;
+        size_t expected_edges_lifted;
+    };
+
+    auto corpus() -> vector<Fixture>
+    {
+        return {{"chain", {{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(2), v(3), -1}}, 3},
+            {"tree", {{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(1), v(3), -2}}, 3},
+            {"negative_domain", {{-4, 2}, {-3, 3}, {-2, 4}}, {{v(0), v(1), -1}, {v(1), v(2), 2}, {v(2), v(0), 3}}, 3},
+            {"negcycle", {{0, 6}, {0, 6}, {0, 6}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), -1}}, 3},
+            {"zerocycle", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), 0}}, 3},
+            {"zerocycle_offset", {{0, 6}, {0, 6}}, {{v(0), v(1), -2}, {v(1), v(0), 2}}, 2},
+            {"views", {{0, 5}, {0, 5}, {0, 5}}, {{v(0, 4), v(1, -1), 1}, {v(1, 2), v(2, 2), 0}}, 2},
+            // The same variable reached through two different offset views, which
+            // only cancels in the proof because the pol cites the donors' rows in
+            // deview mode.
+            {"view_shared_node", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1, 2), -1}, {v(1, -3), v(2), -1}}, 2},
+            {"view_negcycle", {{0, 5}, {0, 5}}, {{v(0, 2), v(1), 0}, {v(1, 1), v(0), 0}}, 2},
+            // The same negative cycle over domains too wide for the donors to
+            // have crawled anywhere much before the global propagator fires, so
+            // the refutation has to be made from loose bounds. That is what
+            // forces the telescoping pol to do real work in the *hybrid*
+            // configuration too, and with views in play it only telescopes
+            // because the pol cites the donors' rows in deview mode. Confirmed
+            // by mutation: dropping enable_deview_mode fails VeriPB here.
+            {"view_negcycle_wide", {{0, 60}, {0, 60}}, {{v(0, 2), v(1), 0}, {v(1, 1), v(0), 0}}, 2},
+            // Aliasing and constant operands are left to their own propagators,
+            // so only the two real edges are lifted.
+            {"alias_and_constants", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(0), 0}, {v(0), c(4), 1}, {c(1), v(1), 0}, {v(0), v(1), -1}, {v(1), v(2), -1}},
+                2},
+            // A negated view is not a difference constraint at all, and must be
+            // refused rather than lifted: -x - y <= d has both coefficients
+            // negative. The other two edges still lift.
+            {"negated_view", {{-3, 3}, {-3, 3}, {-3, 3}}, {{neg(0), v(1), 1}, {v(0), v(2), -1}, {v(2), v(1), -1}}, 2}};
+    }
+
+    auto run_equivalence_tests(bool proofs) -> void
+    {
+        for (const auto & f : corpus())
+            run_equivalence_test(proofs, f.name, f.domains, f.edges, f.expected_edges_lifted);
+    }
+
+    auto run_tripwire_tests() -> void
+    {
+        for (const auto & f : corpus())
+            run_tripwire_test(f.name, f.domains, f.edges);
+    }
+
+    // Every donor shape, with the count it must land in. A donor migrating from
+    // one bucket to another -- most dangerously from "lifted" to any of the
+    // skips -- is caught here and nowhere else.
+    auto run_detection_tests() -> void
+    {
+        auto check = [](const string & fixture, const DifferenceLogicStats & stats, const DifferenceLogicStats & expected) {
+            println(cerr,
+                "difference presolver detection {}: lifted {} over {} nodes, skipped {} not-two-terms, {} coefficients, {} reified, {} "
+                "negated-view, {} degenerate, {} unlabelled-comparison",
+                fixture, stats.edges_lifted, stats.nodes, stats.skipped_not_two_terms, stats.skipped_coefficients, stats.skipped_reified,
+                stats.skipped_negated_view, stats.skipped_degenerate, stats.skipped_unlabelled_comparison);
+            check_count("edges lifted", expected.edges_lifted, stats.edges_lifted, fixture);
+            check_count("nodes", expected.nodes, stats.nodes, fixture);
+            check_count("skipped: not two terms", expected.skipped_not_two_terms, stats.skipped_not_two_terms, fixture);
+            check_count("skipped: coefficients", expected.skipped_coefficients, stats.skipped_coefficients, fixture);
+            check_count("skipped: reified", expected.skipped_reified, stats.skipped_reified, fixture);
+            check_count("skipped: negated view", expected.skipped_negated_view, stats.skipped_negated_view, fixture);
+            check_count("skipped: degenerate", expected.skipped_degenerate, stats.skipped_degenerate, fixture);
+            check_count("skipped: unlabelled comparison", expected.skipped_unlabelled_comparison, stats.skipped_unlabelled_comparison, fixture);
+            if (expected.propagator_installed != stats.propagator_installed)
+                throw UnexpectedException{"the difference-logic presolver " + string{stats.propagator_installed ? "did" : "did not"} +
+                    " install a propagator on fixture '" + fixture + "', but it should " + (expected.propagator_installed ? "have" : "not have") +
+                    "." + detection_is_broken};
+        };
+
+        // Five plain two-term +1/-1 linears over four variables: the base case,
+        // and the one whose failure means detection has stopped working
+        // altogether.
+        {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable_vector(4, 0_i, 6_i, "x");
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[1] + -1_i * x[2], -1_i});
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[2] + -1_i * x[3], -1_i});
+            // Written the other way round, and with a view: still an edge.
+            p.post(LinearLessThanEqual{WeightedSum{} + -1_i * x[0] + 1_i * x[3], 5_i});
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * (x[0] + 2_i) + -1_i * x[2], 0_i});
+            p.add_presolver(DifferenceLogic{stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
+            check("five_plain_linears", *stats, DifferenceLogicStats{.edges_lifted = 5, .nodes = 4, .propagator_installed = true});
+        }
+
+        // Everything that must be skipped, one of each, plus two real edges so
+        // that a propagator is still installed.
+        {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable_vector(4, 0_i, 6_i, "x");
+            auto b = p.create_integer_variable(0_i, 1_i, "b");
+
+            // Three terms.
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1] + 1_i * x[2], 4_i});
+            // Two terms, wrong coefficients.
+            p.post(LinearLessThanEqual{WeightedSum{} + 2_i * x[0] + -1_i * x[1], 4_i});
+            // Two terms, both positive.
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + 1_i * x[1], 9_i});
+            // Half-reified: the row is emitted under HalfReifyOnConjunctionOf, so
+            // lifting it as unconditional would be unsound.
+            p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -2_i, b == 1_i});
+            // Fully reified, likewise.
+            p.post(LinearLessThanEqualIff{WeightedSum{} + 1_i * x[1] + -1_i * x[2], -2_i, b == 1_i});
+            // A negated view.
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * (-x[0]) + -1_i * x[1], 1_i});
+            // Aliasing, and a constant operand.
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[0], 0_i});
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * constant_variable(4_i), 1_i});
+            // A Comparison, which *is* difference shaped but whose OPB row is
+            // emitted unlabelled, so no proof step could cite it.
+            p.post(LessThanEqual{x[2], x[3] + 2_i});
+            p.post(GreaterThan{x[3], x[2]});
+            // ... and one that is not, so it is not counted as a missed
+            // opportunity either.
+            p.post(LessThan{x[2], constant_variable(5_i)});
+
+            // The two real edges.
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[1] + -1_i * x[2], -1_i});
+
+            p.add_presolver(DifferenceLogic{stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
+            check("every_skip", *stats,
+                DifferenceLogicStats{.edges_lifted = 2,
+                    .nodes = 3,
+                    .propagator_installed = true,
+                    .skipped_not_two_terms = 1,
+                    .skipped_coefficients = 2,
+                    .skipped_reified = 2,
+                    .skipped_negated_view = 1,
+                    .skipped_degenerate = 2,
+                    .skipped_unlabelled_comparison = 2});
+        }
+
+        // A single edge is a degeneracy, not a threshold: over one edge the
+        // global propagator computes exactly what that edge's own propagator
+        // computes, so nothing is installed.
+        {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable_vector(2, 0_i, 6_i, "x");
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
+            p.add_presolver(DifferenceLogic{stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
+            check("single_edge", *stats, DifferenceLogicStats{.edges_lifted = 1, .nodes = 2, .propagator_installed = false});
+        }
+
+        // A model with nothing difference shaped in it: the presolver must stay
+        // completely silent.
+        {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable_vector(4, 0_i, 3_i, "x");
+            p.post(AllDifferent{x});
+            p.add_presolver(DifferenceLogic{stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
+            check("nothing_to_lift", *stats, DifferenceLogicStats{.edges_lifted = 0, .nodes = 0, .propagator_installed = false});
+        }
+
+        println(cerr, "difference presolver detection: ok");
+    }
+
+    auto read_file(const string & name) -> string
+    {
+        ifstream f{name, std::ios::binary};
+        if (! f)
+            throw UnexpectedException{"could not read back " + name};
+        return string{istreambuf_iterator<char>{f}, istreambuf_iterator<char>{}};
+    }
+
+    // The defining property: a presolver adds no OPB content. Presolver::run has
+    // no ProofModel * at all, so this should be true by construction; check it
+    // anyway, since it is the entire licence for lifting other people's
+    // constraints after the model has been finalised.
+    auto run_opb_tests() -> void
+    {
+        auto solve_and_read = [](const string & basename, Config config, auto && post) -> pair<string, string> {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            post(p);
+            switch (config) {
+                using enum Config;
+            case NoPresolver: break;
+            case Hybrid: p.add_presolver(DifferenceLogic{stats}); break;
+            case DonorsDisabled: p.add_presolver(DifferenceLogic{stats}.disabling_lifted_donors()); break;
+            }
+            // Default branching, deliberately: the .pbp comparison below needs
+            // determinism, and the point of the negative control is that the
+            // presolver installing nothing leaves the search identical too.
+            static_cast<void>(solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }},
+                make_optional<ProofOptions>(ProofFileNames{basename})));
+            auto opb = read_file(basename + ".opb"), pbp = read_file(basename + ".pbp");
+            for (auto ext : proof_file_extensions)
+                std::remove((basename + ext).c_str());
+            return {opb, pbp};
+        };
+
+        // Positive case: a system the presolver does lift.
+        {
+            auto post = [](Problem & p) {
+                auto x = p.create_integer_variable_vector(4, 0_i, 5_i, "x");
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[1] + -1_i * (x[2] + 1_i), -1_i});
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[2] + -1_i * x[3], -1_i});
+            };
+            auto [off_opb, off_pbp] = solve_and_read("difference_presolver_opb_off", Config::NoPresolver, post);
+            auto [on_opb, on_pbp] = solve_and_read("difference_presolver_opb_on", Config::Hybrid, post);
+            if (off_opb != on_opb)
+                throw UnexpectedException{"the difference-logic presolver changed the .opb. It must not: Presolver::run is handed no ProofModel, "
+                                          "and the whole design rests on the global propagator citing rows the donors already emitted"};
+            if (off_pbp == on_pbp)
+                throw UnexpectedException{"the difference-logic presolver left the .pbp byte-identical on a fixture it is supposed to lift three "
+                                          "edges from, so it evidently propagated nothing." +
+                    detection_is_broken};
+            println(cerr, "difference presolver opb: lifted fixture .opb identical ({} bytes), .pbp differs ({} vs {} bytes)", off_opb.size(),
+                off_pbp.size(), on_pbp.size());
+        }
+
+        // Negative control: nothing is difference shaped, so the presolver posts
+        // nothing, installs nothing, and does not even perturb the branching.
+        // Both files must be byte-identical.
+        {
+            auto post = [](Problem & p) {
+                auto x = p.create_integer_variable_vector(4, 0_i, 3_i, "x");
+                p.post(AllDifferent{x});
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + 1_i * x[1] + 1_i * x[2], 4_i});
+            };
+            auto [off_opb, off_pbp] = solve_and_read("difference_presolver_control_off", Config::NoPresolver, post);
+            auto [on_opb, on_pbp] = solve_and_read("difference_presolver_control_on", Config::Hybrid, post);
+            if (off_opb != on_opb || off_pbp != on_pbp)
+                throw UnexpectedException{"the difference-logic presolver changed the proof of a model containing nothing difference shaped"};
+            println(cerr, "difference presolver opb: control .opb and .pbp both identical ({} and {} bytes)", off_opb.size(), off_pbp.size());
+        }
+    }
+
+    // The behavioural differential a no-op presolver cannot pass. This is the
+    // paper's Example 1: x - y <= 0 and y - x <= -2 are trivially unsatisfiable,
+    // but no individual constraint is violated by the initial domains, so
+    // per-constraint propagation can only find it by crawling both bounds two
+    // units at a time -- Theta(domain size) propagations. The global propagator
+    // sums the two edges round the cycle and refutes at once.
+    auto run_differential_test() -> void
+    {
+        print(cerr, "difference presolver differential:");
+        cerr << flush;
+
+        const int n = 500;
+        auto solve_it = [&](Config config) -> pair<Stats, DifferenceLogicStats> {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable(0_i, Integer(n), "x");
+            auto y = p.create_integer_variable(0_i, Integer(n), "y");
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x + -1_i * y, 0_i});
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * y + -1_i * x, -2_i});
+            switch (config) {
+                using enum Config;
+            case NoPresolver: break;
+            case Hybrid: p.add_presolver(DifferenceLogic{stats}); break;
+            case DonorsDisabled: p.add_presolver(DifferenceLogic{stats}.disabling_lifted_donors()); break;
+            }
+            return {solve_with(p, SolveCallbacks{}), *stats};
+        };
+
+        auto [without, without_stats] = solve_it(Config::NoPresolver);
+        auto [with, with_stats] = solve_it(Config::Hybrid);
+        auto [disabled, disabled_stats] = solve_it(Config::DonorsDisabled);
+
+        println(cerr, " propagations {} without, {} with, {} with donors off ({} solutions each)", without.propagations, with.propagations,
+            disabled.propagations, without.solutions);
+
+        if (0 != without.solutions || 0 != with.solutions || 0 != disabled.solutions)
+            throw UnexpectedException{"difference presolver differential fixture is supposed to be unsatisfiable"};
+
+        check_count("edges lifted", 2, with_stats.edges_lifted, "differential");
+        check_count("edges lifted", 2, disabled_stats.edges_lifted, "differential");
+
+        // A factor of ten is far inside the margin: the measured numbers are
+        // around 500 against 3. Equality is what a no-op presolver would give.
+        if (with.propagations * 10 >= without.propagations)
+            throw UnexpectedException{"the difference-logic presolver made no measurable difference on the paper's Example 1: " +
+                to_string(without.propagations) + " propagations without it against " + to_string(with.propagations) +
+                " with it, where the global propagator should refute the negative cycle in one step." + detection_is_broken};
+
+        if (disabled.propagations >= with.propagations)
+            throw UnexpectedException{"disabling the donors did not reduce propagations on the paper's Example 1: " + to_string(with.propagations) +
+                " with them against " + to_string(disabled.propagations) + " without"};
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    if (argc < 2)
+        throw UnimplementedException{};
+
+    string mode{argv[1]};
+
+    if (mode == "detection") {
+        run_detection_tests();
+        run_differential_test();
+    }
+    else if (mode == "equivalence")
+        run_equivalence_tests(false);
+    else if (mode == "proofs") {
+        if (! can_run_veripb()) {
+            println(cerr, "veripb not available, skipping");
+            return EXIT_SUCCESS;
+        }
+        run_equivalence_tests(true);
+    }
+    else if (mode == "tripwire")
+        run_tripwire_tests();
+    else if (mode == "opb")
+        run_opb_tests();
+    else
+        throw UnimplementedException{};
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Part 2 of #571: a presolver that scans a posted `Problem` for
difference-shaped constraints and installs the global difference-logic
propagator over them, so a model does not have to be rewritten against
`DifferenceConstraints` to benefit.

**Based on #585** (`difflogic-03-enumeration`), which is this PR's base branch,
so the diff shown here is only this PR's six commits. This is the second
consumer of #546's typed constraint enumeration, and the first one to ship ---
including the clone-flattening trap that issue documents, which is what most of
the validation below is defending against.

Also fixes an omission from #584's review, as a deliberately separate first
commit: the hole-snapping second call was documented but not tested.

## The design in one paragraph

Presolvers run after `create_propagators` and after the proof model is finalised,
so this one cannot remove the donors' propagators and cannot add OPB content —
`Presolver::run` is handed no `ProofModel *` at all. That is not a limitation, it
is the paper's §4.4 hybrid *and* what makes the proof trivial: each donor
`LinearLessThanEqual` already emitted its own labelled row (`@c[<id>]`,
`linear_inequality.cc:118`), so the global propagator cites those rows in its
`pol`s and derives nothing that is not a cutting-planes consequence of
constraints the model already contains.

## Sharing the propagator

`innards::install_difference_propagator` takes a `DifferenceGraph` — node list,
canonicalised edge list, static bounds, one `ProofLine` per edge — and installs
the Bellman-Ford propagator over it. `DifferenceConstraints` builds one from the
edges it was posted with; the presolver builds one out of other people's
constraints. Two changes beyond the move:

* the deviewing helper reports a negated view by returning `nullopt` rather than
  throwing, because a presolver has to *skip* such a constraint rather than
  reject the model containing it (`DifferenceConstraints` keeps its throwing
  wrapper, same message);
* every `pol` that cites an edge row runs the `PolBuilder` in **deview mode**.
  For rows `DifferenceConstraints` emits itself that is a no-op — they are
  already over bare variables, so no deview-form is registered and
  `deviewed_line_for` hands the line straight back — but it is load-bearing for
  a presolver-built graph, whose rows are in the user's views' bits. Same
  situation and same fix as `linear/justify.cc`.

Root-contradiction detection stays in `DifferenceConstraints`: it installs an
*initialiser*, and initialisers have already run by presolve time, so the
presolver declines to lift degenerate edges instead.

The posted-constraint path is unchanged, checked empirically rather than by
inspection: `difference_test views` (fixed seed) and `difference_chain -n 6` in
both `--mode=fixpoint` and `--mode=refute`, run with `--prove` before and after,
give byte-identical `.opb`, `.pbp`, `.scp` and `.varmap`.

## What could and could not be lifted

The paper's **level 1**, restricted to what the propagator supports: two-term
linears with coefficients exactly `+1`/`-1`, `reif::MustHold`, two distinct
variable operands, each optionally carrying a `+X + c` view offset. Two
exclusions are soundness requirements, not incompleteness:

* **half-reified donors** — `linear_inequality.cc` emits the `If` form's row
  under `HalfReifyOnConjunctionOf`, so it says `b -> x - y <= d`; and since
  `clone()` returns the family base, the reification condition is the *only*
  thing that distinguishes a `LinearLessThanEqual` from a
  `LinearLessThanEqualIf` at enumeration time;
* **negated views** — `-X - Y <= d` is not a difference constraint at all.

**`Comparison` donors are the shape we most want and cannot yet have.**
`x <= y + d` over an offset view *is* a difference constraint, but
`ReifiedCompareLessThanOrMaybeEqual::define_proof_model` emits its unconditional
rows through the `void`-returning `add_constraint` (`comparison.cc:98`), so they
carry no `@label` and no `pol` can cite them. They are detected, skipped, and
**counted**, so what a later labelling PR would buy is measured rather than
guessed at. Equalities (level 2) and disequalities (level 3) are not chased at
all; the paper measures both as losing.

On `examples/difference_chain` every edge lifts (13,201 of 13,201 at n = 160).

## Turning the donors off: what happened to `DisableUntilBacktrack`

Asked for explicitly, so: the **mechanism** transfers and is reused, the
**lifetime** does not.

`DisableUntilBacktrack` swaps the propagator past `idle_end` in the queue, where
`enqueue_if_idle` will not find it. That partition is exactly right. But "until
backtrack" is scoped to a `propagate()` call — `orig_idle_end` is saved on entry
and restored by that call's `on_backtrack` — and, decisively, the **no-guesses
path rebuilds `queue` and `lookup` from scratch and resets `idle_end` to the
propagator count**. A presolver acts before the first root propagation, so a
boundary it set would be erased before it ever took effect. So
`Propagators::disable_propagators_for_constraints` reuses the partition and adds
a *second* boundary that nothing restores: the rebuild puts disabled propagators
at the tail and sets `enqueued_end`/`idle_end` to the enabled count.

It takes a **batch**, because finding a constraint's propagators means scanning
the propagator list: a per-constraint entry point made disabling m donors
`O(m · propagators)`, which on this model at n = 160 was 23× the entire rest of
the solve. (Found by measurement, not by inspection.)

Disabling is not removing — the constraint keeps its OPB row, its scope and
adjacency entries, and its degree contribution — which is what makes the
default-off `disabling_lifted_donors()` a **tripwire** as well as a knob:
solutions *and* recursions must come out identical with the donors on and off,
and they do across the whole corpus.

## Making a no-op presolver impossible to ship

This presolver is invisible from the outside, so a version that silently lifted
nothing — say because `clone()` stopped flattening posted `LinearLessThanEqual`s
— would pass solution-set equivalence, the OPB byte-diff (byte-identical being
the *expected* result) and VeriPB. Three guards:

* `static_assert`s in `run()` pinning the class relationships;
* a **runtime cross-check** of the typed enumeration against
  `Constraint::constraint_type()`, which does not depend on the hierarchy at all;
* `DifferenceLogicStats` — edges lifted, nodes, and skips bucketed by reason —
  which the tests assert on exactly.

Every one of those messages names the invariant and says explicitly not to update
the expectation. Mutation-tested: asking for `LinearLessThanEqual` instead of
`ReifiedLinearInequality` trips the cross-check; with the cross-check disabled
too, all four test modes fail, each naming the presolver as the thing to fix.
Dropping `enable_deview_mode` fails VeriPB on `view_negcycle_wide` in the
shipping hybrid configuration.

## Validation

`gcs/presolvers/difference_logic_test.cc`, five ctest lanes:

* **equivalence** / **proofs** — a twelve-fixture corpus (views, a shared view
  node, aliases, constants, negative cycles, zero-weight cycles, a negated view)
  solved with no presolver, with the hybrid, and with the donors disabled, all
  three against an independent C++ oracle, with VeriPB verifying every proof;
* **tripwire** — identical solutions *and* recursions, donors on versus off,
  across the same corpus;
* **opb** — `.opb` byte-identical with the presolver off and on for a lifted
  fixture (with a paired assertion that the `.pbp` *did* change), and both `.opb`
  and `.pbp` byte-identical for a negative control containing nothing difference
  shaped;
* **detection** — every donor shape against the bucket it must land in, plus the
  paper's Example 1 as a behavioural differential: 252 propagations without the
  presolver, 3 with it, 1 with the donors also off.

The runtime caps are ctest environment variables, so running these binaries
directly — as the corpus runs above were — is caps-off, i.e. full-enumeration
checking rather than the soundness-only partial check.

`ctest --preset release -j 12`: **547/547 pass**. Built and tested under the
`sanitize` preset as well.

## Measurements

Full tables are in `dev_docs/difference-logic.md` and posted to #582. Headlines,
`-k 2`, medians of 3:

| | decomposed | presolved | presolved, donors off | global |
|---|---:|---:|---:|---:|
| n=640 fixpoint unlucky, propagations | 132,305,602 | 825,607 | 647 | 1,287 |
| n=640 fixpoint unlucky, time (s) | 4.460 | 0.459 | 0.452 | 0.333 |
| n=640 fixpoint **lucky**, time (s) | 0.257 | 0.445 | 0.447 | 0.281 |
| n=160 refute, `.pbp` lines | 720,352 | **40** | 18 | 12 |

* The presolver buys **order-independence**, which is what the pathology was: its
  propagation count is identical for both posting orders and equal to the lucky
  decomposed figure. 160× fewer propagations and 9.7× faster on the unlucky
  order at n = 640.
* It recovers **essentially the whole proof-size win**: 720,352 lines → 40,
  because the refutation is one telescoping `pol` over the donors' rows however
  big the domains are.
* It does **not** reach the global route's propagation count, and running last is
  why — but only by a constant factor, not asymptotically; see #582 for the
  breakdown. The residual sweeps cost about 1.5% of wall time here.
* On the **lucky** order it is a modest loss (0.257 s → 0.445 s): nothing was
  wrong with the propagation order to begin with, so the extra global pass and
  the presolver's own O(constraints) enumeration are pure overhead. That is why
  it ships off.

## Gating

None beyond declining to install over a single edge, which is a degeneracy rather
than a threshold. A minimum-edge-count or connectivity gate was considered and
**not** shipped: the measurements give no crossover to site it at — the presolver
wins at every size measured on the unlucky order and loses by a roughly constant
factor on the lucky one — and it is opt-in already, so a second gate the user
cannot reason about would be guessing dressed as tuning.

## Not done

* Half-reified donors, and `Comparison` donors (which need their unconditional
  OPB rows labelled, touching the `cake_pb_cp` chain surface).
* Root simplification (Johnson's, redundant-edge removal, zero-cycle unification).
* Incrementality, which is what the remaining wall-time gap to `global` is.

