### PR TITLE
Half-reified difference edges (#571)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -80,10 +80,16 @@ library. For an introduction to *using* the solver, start with the top-level
   shapes — a negative cycle refuted by one telescoping `pol`, a bound push
   justified per edge along the predecessor forest — the source paper's
   pseudocode defects, the measured order-independence and proof-size results,
-  the `DifferenceLogic` presolver that lifts an already-posted model into the
-  same propagator (including why `DisableUntilBacktrack` could not be imposed
-  from outside, and why the tests assert on counts rather than on solutions),
-  and what is deferred (incrementality, half-reification, root simplification).
+  half-reified edges `b -> x - y <= d` (the one extra `saturate`, why the reason
+  must name every conditional edge used, and why the round bound survives an
+  edge set that changes between calls), the `DifferenceLogic` presolver that
+  lifts an already-posted model into the same propagator (including why
+  `DisableUntilBacktrack` could not be imposed from outside, and why a
+  half-reified donor is never retired), the RCPSP/max benchmark tables
+  (including where the non-incremental propagator loses, and why "detected at
+  the root" belongs to the paper's root simplification stage rather than to its
+  propagator), and what is deferred (incrementality, `IncImp`, root
+  simplification).
 - [Range ("in") literals](range_literals_spec.md) — the design specification
   for the interval-literal proof layer: reifying `[X∈[a,b]]` to its
   order-chain cuts, the always-covered partition invariant, interval-tree

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -4,9 +4,11 @@
 rather than one propagator per constraint. This note covers the graph
 formulation, the two propagation directions, the round bound and why the
 negative-cycle extraction is total, the canonicalisation rule and why it exists,
-the two proof shapes with worked examples, the defects in the source paper's
-pseudocode, the presolver that lifts an already-posted model into the same
-propagator, and what is deliberately deferred.
+the two proof shapes with worked examples, half-reified edges
+(`b -> x - y <= d`) and what they cost in the reason and in the proof, the
+defects in the source paper's pseudocode, the presolver that lifts an
+already-posted model into the same propagator, and what is deliberately
+deferred.
 
 The source is Kletzander, Dekker, Schutt and Stuckey, *Global Difference
 Constraint Propagation for Constraint Programming*, arXiv:2607.20022 — the
@@ -249,6 +251,170 @@ constraints: transferring the predecessor's *order atom* into the edge row's
 never performs (`view-proof-logging.md` invariant 3, and the same finding
 `dev_docs/disjunctive-proof-logging.md` records for its single-edge pol).
 
+## Half-reified edges: `b -> x - y <= d`
+
+An edge may carry a reification condition. The semantics are deliberately
+one-directional:
+
+> **An edge with a condition participates in the graph exactly while that
+> condition currently holds.** Nothing is ever inferred the other way — the
+> propagator never fixes a condition because of what the graph says.
+
+That second half is the paper's `IncImp`, and leaving it out is not laziness: it
+is the paper's own most strongly supported configuration finding. On RCPSP/max
+*every* configuration with `IncImp` on scored below *every* configuration with
+it off. The proof shape for it is already understood (below), so it is a small
+addition if it is ever wanted; the measurements say not to want it.
+
+Three shapes fall out of the same canonicalisation as before:
+
+| Canonical form | Unconditional | With condition `b` |
+|---|---|---|
+| two distinct variables | graph edge | graph edge, active while `b` holds |
+| one constant operand | static bound | bound applied while `b` holds, citing `b` |
+| `0 <= d`, `d < 0` | root contradiction | **`!b` is inferred** |
+
+The last row is a soundness obligation, not a nicety. `b -> 0 <= -1` says `!b`,
+and an implementation that quietly dropped the edge would return solutions in
+which `b` holds and the constraint is violated. It is handled in the propagator
+rather than by an initialiser (which is how the unconditional case is done),
+because the row `M·¬b >= 1` saturates directly to the unit clause `¬b`, so plain
+RUP against it suffices — and because a presolver has no initialiser available.
+
+### The reason, which is the whole soundness question
+
+**A negative cycle** cites the conditions of every conditional edge on it, and
+nothing else. The unconditional case keeps its empty reason. The conditions are
+deduplicated, because the same Boolean legitimately appears on more than one
+edge — a disjunctive encoding makes that the normal case — and a reason listing
+it twice would render a proof line with a repeated literal.
+
+**A bound push** cites the predecessor's bound and *this edge's* condition, and
+that is the part worth being careful about. It is not "every condition along the
+path", and it does not need to be, because the inference is made **per edge
+along the predecessor forest**, never per path (see proof shape 2). The
+predecessor's bound was either already there when the call started, or was itself
+inferred moments earlier carrying its own edge's condition in its own reason. So
+the conditions along a whole path are cited by the *chain* of inferences, and
+each individual link is a standalone entailment of exactly one OPB row — which
+is what makes each link's RUP check on its own.
+
+### The proof: one extra `saturate`, and that is all
+
+A row emitted under `HalfReifyOnConjunctionOf` carries a big-M term on `¬b`. It
+does not telescope. Everything else does, exactly as before, so summing a cycle
+whose edges are conditional on `b_1 … b_k` leaves
+
+```
+    Σ M_i·¬b_i  >=  -W        (with -W >= 1)
+```
+
+and one `saturate` turns that into the clause `¬b_1 ∨ … ∨ ¬b_k` — the learned
+clause. The emitted line is
+
+```
+pol  <edge row>  <edge row> +  <edge row> +  s ;
+rup 1 ~b_1 1 ~b_2 >= 1;
+```
+
+which is verbatim the shape hand-verified against real gcs OPB output in
+`reified.opb` / `reified_hand.pbp` (survey section 2.0a case 3) before any of
+this was written, and verbatim what the propagator now emits — from
+`difference_test reified negcycle_two_conds`:
+
+```
+pol @c[_1][e0] @c[_1][e2] + @c[_1][e1] + s ;
+rup 1 ~i[_4][b0] 1 ~i[_5][b0] >= 1;
+```
+
+With one Boolean shared between all three edges the same line closes with
+`rup 1 ~i[_4][b0] >= 1;`, which is the deduplication above showing up in the
+proof.
+
+Two honest notes on that `s`:
+
+- **The reason is load-bearing; the `saturate` is not.** Dropping a condition
+  from the reason fails VeriPB on the reified fixtures (confirmed by mutation).
+  Removing the `saturate` does **not** — the closing RUP assumes every condition,
+  which drives each `M·¬b` to zero and falsifies the unsaturated line just as
+  well (also confirmed by mutation, every reified fixture still verifies). It is
+  emitted anyway because it makes the derived line *be* the clause rather than a
+  big-M encoding of it, which is what a reader, an assertion hint, or a
+  longer-lived `ProofLevel` would want.
+- **The bound push does not saturate.** Its residual is harmless under the
+  closing RUP for the same reason, while saturating would clamp `BinEnc(v)`'s own
+  coefficients against the degree for no gain.
+
+Everything else is unchanged: no new OPB content, no flags, no auxiliaries. The
+unconditional path is byte-identical — `.opb`, `.pbp`, `.scp` and `.varmap` all
+compare equal before and after across `difference_test views`,
+`difference_chain -n 6` in both modes and all three variants, and `rcpsp` in all
+three variants. `tools/opb_snapshot.bash` also still matches `main` byte for byte
+on the three `rcpsp` entries in the proof benchmark set.
+
+### Triggers
+
+The propagator already woke on every node's bounds. It now also takes
+`on_change` on each distinct condition variable. That is the coarsest trigger gcs
+offers that is guaranteed to catch a condition *becoming true*:
+
+- `on_bounds` is not enough — `x != v` becomes true the instant `v` leaves the
+  domain, which can be an interior removal;
+- `on_instantiated` fires strictly less often still — `x >= v` can become true
+  long before `x` is fixed.
+
+There is no "becomes entailed" coarse trigger, and the refined per-literal
+watches would need one arming per condition, so `on_change` is both the cheapest
+correct choice and the simplest. Waking when a condition becomes *false* is not
+needed at all — an inactive edge simply does not participate, and no inference is
+lost by finding that out later — but `on_change` cannot distinguish the two
+directions, and the extra wake is cheaper than machinery to avoid it. Condition
+variables are deliberately not deduplicated against the node list: a variable
+that is both a node and somebody's condition would otherwise have to give up one
+of the two trigger kinds, and a duplicate wake is merely wasted work.
+
+### The termination and extraction arguments still hold, verbatim
+
+Both arguments above — the `n - 1` round bound, and the totality of the
+predecessor walk — are statements about **one Bellman-Ford run over one fixed
+edge set**. Neither mentions where the edges came from or whether the same set
+will be there next time. So the only obligation half-reification adds is that the
+edge set really is fixed for the duration of a call, and that is arranged
+directly: the active edges are **snapshotted once** at the top of the call,
+rather than re-tested as the passes go.
+
+The snapshot also stays *correct* as inferences land during the call, which is
+what licenses citing a snapshotted condition in a reason later on. A literal that
+is definitely true holds for every value in the current domain, so it holds for
+every value in any subset of that domain; all this propagator does is shrink
+domains, and a domain shrunk to empty is a contradiction, which ends the call. So
+a condition true at snapshot time is still true at every inference made from it.
+
+Across calls the edge set does change — it grows as conditions become true down a
+branch and shrinks on backtrack — and nothing needs to be trailed for that,
+because nothing about the graph is stored between calls. This version recomputes
+from scratch every wake anyway.
+
+### The completeness caveat, which is the paper's and not ours
+
+The paper's section 4.1 claims its propagator is a *domain* propagator only
+"under the assumptions that the domain `D` is a range domain and **no Boolean
+variable appears twice** in the set of difference, bounds, and half-reified
+difference constraints".
+
+A disjunctive encoding violates that by construction: `b -> i before j` and
+`!b -> j before i` put the same Boolean in two difference constraints, and that
+is precisely the modelling this feature exists to support. So the claim does not
+apply to the most important use case. Two things follow, and they are worth
+keeping apart:
+
+- **Soundness is unaffected.** Nothing above depends on a Boolean appearing at
+  most once; each inference is an entailment of the rows it cites.
+- **Completeness is not claimed.** This is a bounds-consistent propagator for the
+  active sub-system, nothing more — which it already was, since gcs domains have
+  holes where the paper's Theorem 2 assumes ranges (its section 4.1 caveat (vi)).
+  `difference_test reified negcycle_shared_cond` pins the sound-regardless part.
+
 ## The self-check
 
 Before emitting a cycle refutation the extracted cycle is verified
@@ -397,19 +563,48 @@ constraints the model already contains.
 ### What is lifted, and what is not
 
 The paper's **level 1**, restricted to what the propagator supports today: a
-two-term linear with coefficients exactly `+1` and `-1`, an unconditional
-(`reif::MustHold`) condition, and two distinct variable operands, each of which
-may carry a `+X + c` view offset. Two of the exclusions are soundness
-requirements rather than mere incompleteness:
+two-term linear with coefficients exactly `+1` and `-1` and two distinct variable
+operands, each of which may carry a `+X + c` view offset. The reification
+condition may be either of two kinds:
 
-- **Half-reified donors are refused.** `linear_inequality.cc` emits the `If`
-  form's row under `HalfReifyOnConjunctionOf`, so it states `b -> x - y <= d`,
-  not `x - y <= d`. Lifting it as an unconditional edge would licence
-  inferences the model does not entail (and the pol citing it would carry an
-  uncancelled gate term). Since `clone()` returns the family base, the
-  reification condition is the *only* thing distinguishing a
-  `LinearLessThanEqual` from a `LinearLessThanEqualIf` at enumeration time.
+- **`reif::MustHold`**, giving a plain edge;
+- **`reif::If`**, giving a half-reified one, `b -> x - y <= d`.
+
+**Both forms are citable, and this was checked rather than assumed.**
+`linear_inequality.cc` labels them identically — `add_labelled_constraint(id, "",
+…)`, i.e. `@c[<id>]` with an *empty* role — and differs only in passing
+`HalfReifyOnConjunctionOf{cond.cond}` for the `If` form. So the `If` row is
+exactly the shape the propagator's proofs assume, unlike `Comparison`'s
+unconditional rows, which go through the `void`-returning `add_constraint` and
+carry no label at all.
+
+The other three reification kinds are *also* difference constraints, and are
+skipped only because each needs a **different row** of the donor's output than
+the two above:
+
+- `reif::MustNotHold` and `reif::NotIf` state the integer negation,
+  `y - x <= -d-1`;
+- `reif::Iff` emits its two halves under the roles `r` and `f` rather than under
+  the empty role — and both halves are edges, one on `cond` and one on `¬cond`.
+
+They are counted in `skipped_reified` rather than guessed at. Two exclusions
+remain soundness requirements rather than mere incompleteness:
+
 - **Negated views are refused**, for the reason given above.
+- **Degenerate conditional donors are left to the donor.** A conditional
+  `x - x <= -1` says `!b`, which the donor already infers from its own bounds;
+  lifting it would duplicate that, and the presolver skips all degenerate shapes
+  anyway.
+
+**Half-reified donors are never retired**, however many of their edges were
+lifted, and that is a rule rather than a preference. `disabling_lifted_donors()`
+rests on the global propagator subsuming the donor, and for a half-reified donor
+subsumption fails in one direction: `LinearLessThanEqualIf` also infers `!cond`
+when its own bounds make the inequality impossible, and the global propagator
+makes no inference about a condition at all. Retiring one would silently lose
+that. Only unconditional donors go on the retirement list; the tripwire test
+asserts both halves of this (something must be disabled when there is an
+unconditional edge, nothing may be when there is not).
 
 Degenerate edges — a constant operand, or the same variable at both ends — are
 also skipped, and left to the donor. This is not just tidiness: a `0 <= d` with
@@ -681,10 +876,57 @@ here; it turns an expensive root refutation into a single propagation.
 
 The paper's baseline searches because its disjunctive resources contribute
 *half-reified* difference constraints, so the cycle only closes after Boolean
-decisions. `examples/rcpsp --machine pairwise` posts exactly that structure —
-`LinearGreaterThanEqualIf` in both directions on a 0/1 ordering variable — but
-half-reified edges are not supported by the propagator yet, so that mechanism is
-absent here by construction rather than by choice.
+decisions.
+
+### Switching that mechanism on: `--machine=difference`
+
+`examples/rcpsp --machine=difference` posts the machine as the pairwise
+disjunctive decomposition in conditional edges — one ordering Boolean per pair,
+the two disjuncts as edges under it and its negation — so the network's edge set
+now changes during search, which is the paper's modelling rather than ours.
+
+Two things follow, and the second is not the flattering one.
+
+**The search mechanism does reproduce.** On an infeasible instance the
+refutation now genuinely requires Boolean decisions rather than falling out of
+root propagation:
+
+| instance | `--machine` | variant | recursions | propagations |
+|---|---|---|---:|---:|
+| `--size 10 --seed 5 --machine-fraction 0.7 --deadline 17` | pairwise | decomposed | 836 | 45,777 |
+| | difference | decomposed | 689 | 36,145 |
+| | difference | **global** | **6,353** | **11,321** |
+| `--size 12 --seed 2 --machine-fraction 0.8 --deadline 18` | pairwise | decomposed | 316 | 11,498 |
+| | difference | decomposed | 47 | 2,355 |
+| | difference | **global** | **329** | **720** |
+
+**And the global propagator loses that search.** Nine times the nodes on the
+first instance, seven on the second, for a third of the propagations. The cause
+is `IncImp`'s absence, stated above and now measured: the reified linear forms
+infer their own condition — a violated `LinearGreaterThanEqualIf` fixes its
+Boolean false — and `DifferenceConstraints` infers nothing about a condition at
+all, so it explores orderings the decomposition has already refuted. Propagations
+are the wrong metric here; nodes are what the model is paying.
+
+This is the concrete argument for reconsidering `IncImp` for gcs specifically,
+against the paper's own configuration study, which found every configuration with
+it on scoring below every configuration with it off. Their baseline is a
+lazy-clause-generation solver that learns from a failed ordering; gcs is not, so
+what `IncImp` would buy here is not what it bought there.
+
+Two consequences worth stating for anyone writing a model against this
+propagator:
+
+- **The condition variables must be branched on.** An edge whose Boolean is
+  unfixed does not constrain, so leaving them out of the branch list does not
+  merely slow the search down — it lets the solver report a schedule that
+  violates the resource. `examples/rcpsp` puts them first in the branch list, and
+  the cross-check that catches getting this wrong is that all four `--machine`
+  spellings must agree on the optimum.
+- **`recursions` stops being a cross-variant invariant.** On the unconditional
+  temporal network the three variants search identically, which is what makes the
+  tables above a clean comparison. With conditional edges they do not, and a
+  table that reports only propagations would hide the regression above.
 
 ## Deliberately deferred
 
@@ -695,28 +937,29 @@ absent here by construction rather than by choice.
   it needs no trailing, which suits backtracking well. None of that is here: this
   version recomputes Bellman-Ford from scratch on every wake, which is
   `O(n·m)` worst case. The wall-time caveat above is entirely this.
-- **Half-reified edges** (`b -> x - y <= d`). These make the edge set change
-  during search, which needs the trailed edge journal and the paper's `E'`
-  machinery. The proof side is already understood and costs nothing extra: a
-  half-reified row contributes `M·¬b` to the sum, the `BinEnc` terms telescope
-  exactly as before, and one `saturate` turns the residuals into the clause
-  `¬b_1 ∨ … ∨ ¬b_k`. `Disjunctive` already does this at `k = 1`.
 - **`IncImp`** (implication checking, to disentail half-reified edges). It needs
   no new proof machinery — "shortest path `x ⇝ y` of weight `<= d'`" plus the
   candidate edge `y --(-d'-1)--(b)--> x` is a negative cycle, so it is proof
-  shape 1 with `b` the sole surviving residual — but the paper's own
-  configuration study says to leave it **off**: on RCPSP/max every configuration
-  with it on scored below every configuration with it off.
+  shape 1 with `b` the sole surviving residual, and the `saturate` already in
+  place produces exactly that unit clause — but the paper's own configuration
+  study says to leave it **off**: on RCPSP/max every configuration with it on
+  scored below every configuration with it off. **This is the one deferral the
+  RCPSP/max measurement below now costs something visible**: without it, a system
+  whose infeasibility depends on edges nobody has fixed yet is invisible at the
+  root.
 - **Lifting `Comparison` donors**, which needs their unconditional OPB rows
   labelled; see the presolver section above.
-- **Lifting half-reified donors**, which is the same problem as supporting
-  half-reified edges in the propagator.
+- **Lifting `Iff`, `NotIf` and `MustNotHold` linear donors**, which need the `r`
+  and `f` rows and the integer-negation row respectively rather than the
+  empty-role row the two supported kinds share.
 - **Root simplification** — Johnson's all-pairs shortest paths, then dropping
   redundant edges, fixing Booleans whose edge would close a negative cycle, and
   unifying variables on a zero-weight cycle. Note that dropping a redundant edge
   is a decision about which *propagators run*, not about what the model says: the
   OPB must always contain every posted constraint, so the removal has no proof
-  obligation at all.
+  obligation at all. Its Boolean-fixing step is `IncImp` restricted to the root,
+  and the measurement below argues it is where the paper's RCPSP/max
+  unsatisfiability headline actually comes from.
 - **Runtime propagator priorities.** The paper wants bound propagation at the
   lowest priority and Boolean propagation at the highest, as separate
   propagators. gcs has no runtime propagator priorities, only

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -395,6 +395,33 @@ branch and shrinks on backtrack — and nothing needs to be trailed for that,
 because nothing about the graph is stored between calls. This version recomputes
 from scratch every wake anyway.
 
+### Two things that cost 3× until they were measured
+
+Both were found by benchmarking `examples/difference_chain --variant=global` at
+`n = 640` against the table above, not by inspection, and both left the
+propagation and recursion counts *identical* — so nothing but wall clock would
+have caught either.
+
+- **The condition must not live in the edge struct.** An
+  `optional<IntegerVariableCondition>` is 64 bytes, which took the edge from 32
+  bytes to 96. The relaxation loop scans the whole edge array once per round, so
+  that is 3× the memory traffic in the innermost loop, and it cost exactly that:
+  0.32 s → 0.93 s. `DifferenceGraphEdge` therefore stays the convenient
+  *construction* type, with the condition attached to the edge it belongs to,
+  and `install_difference_propagator` repacks it once into a 32-byte arc array
+  plus a parallel condition array. The conditions are read when the active set is
+  snapshotted (once per call) and when a reason is built (only when something is
+  inferred) — never inside a round. A `static_assert` pins the arc size.
+- **An unconditional system must not go through the snapshot.** Iterating
+  `active_edges` rather than `0 .. m-1` is a level of indirection in the same
+  innermost loop, worth another 45% (0.32 s → 0.47 s). When nothing is
+  conditional the snapshot is not built at all and the arc array is scanned
+  straight through; the branch sits *outside* the per-edge loop, so the
+  conditional case pays nothing for the choice either.
+
+With both, `--variant=global` at `n = 640` is 0.332 s against the 0.323 s
+measured before half-reification existed, which is inside the noise.
+
 ### The completeness caveat, which is the paper's and not ours
 
 The paper's section 4.1 claims its propagator is a *domain* propagator only

--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -66,3 +66,17 @@ add_test(NAME rcpsp_presolved COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_a
 # refutation that sums the cycle's edge rows rather than crawling bounds.
 add_test(NAME rcpsp_global_infeasible COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_global_infeasible
     $<TARGET_FILE:rcpsp> --size 8 --seed 1 --infeasible --variant global)
+
+# --machine=difference, which is what puts *conditional* edges into the network,
+# in each of the three variants. All three must reach the same optimum as
+# --machine=disjunctive and --machine=pairwise --- they say the same thing --- but
+# unlike the unconditional network they do not search alike: the reified linears
+# infer their condition and DifferenceConstraints does not (IncImp is deliberately
+# absent), so global explores more nodes with fewer propagations. That divergence
+# is the point of having all three.
+add_test(NAME rcpsp_machine_difference COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_machine_difference
+    $<TARGET_FILE:rcpsp> --size 10 --seed 5 --machine-fraction 0.7 --machine difference)
+add_test(NAME rcpsp_machine_difference_global COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_machine_difference_global
+    $<TARGET_FILE:rcpsp> --size 10 --seed 5 --machine-fraction 0.7 --machine difference --variant global)
+add_test(NAME rcpsp_machine_difference_presolved COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_machine_difference_presolved
+    $<TARGET_FILE:rcpsp> --size 10 --seed 5 --machine-fraction 0.7 --machine difference --variant presolved)

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -202,6 +202,11 @@ namespace
         IntegerVariableID from;
         IntegerVariableID to;
         Integer d;
+
+        // Set only for the pairwise machine decomposition under
+        // --machine=difference, where each disjunct holds only under its
+        // ordering Boolean. The temporal network's edges are unconditional.
+        std::optional<IntegerVariableCondition> cond = nullopt;
     };
 
     // How the temporal network reaches the solver. All three say exactly the
@@ -309,10 +314,12 @@ auto main(int argc, char * argv[]) -> int
             ("deadline", "Solve the decision variant: is there a schedule finishing by this time?", //
                 cxxopts::value<long long>())                                                        //
             ("machine",
-                "How to post the unary machine resource: disjunctive (the Disjunctive global, the " //
-                "default), cumulative (a Cumulative of capacity one), or pairwise (reified "        //
-                "non-overlap clauses)",                                                             //
-                cxxopts::value<string>()->default_value("disjunctive"))                             //
+                "How to post the unary machine resource: disjunctive (the Disjunctive global, the "   //
+                "default), cumulative (a Cumulative of capacity one), pairwise (reified non-overlap " //
+                "clauses), or difference (the same pairwise decomposition written as conditional "    //
+                "difference constraints, which is what puts the machine into the difference "         //
+                "network that --variant handles)",                                                    //
+                cxxopts::value<string>()->default_value("disjunctive"))                               //
             ("branch",
                 "Branching variable order: in-order (default), dom-then-deg, or dom-wdeg[:VARIANT]" //
                 " (VARIANT = classic / ia / ca / id / cd / ca.cd / chs)",                           //
@@ -466,6 +473,38 @@ auto main(int argc, char * argv[]) -> int
     auto edges = model_edges(instance, starts, makespan);
     auto presolver_stats = std::make_shared<DifferenceLogicStats>();
 
+    // --machine=difference puts the machine into that same network, as the
+    // pairwise disjunctive decomposition written in conditional edges: one
+    // Boolean per pair, and the two disjuncts as edges holding under it and
+    // under its negation. It has to be built before the network is posted so
+    // that both end up in the *same* DifferenceConstraints under
+    // --variant=global --- a cycle that closes only through an ordering
+    // decision spans both halves, and two separate propagators would never see
+    // it. Nothing here runs in any other --machine mode, so no other path
+    // creates a variable or posts a row it did not create or post before.
+    vector<IntegerVariableID> machine_starts;
+    vector<Integer> machine_durations;
+    for (auto & i : instance.machine_tasks) {
+        machine_starts.push_back(starts[i]);
+        machine_durations.push_back(instance.durations[i]);
+    }
+
+    auto machine_variant = options_vars["machine"].as<string>();
+    if (machine_variant != "disjunctive" && machine_variant != "cumulative" && machine_variant != "pairwise" && machine_variant != "difference") {
+        println(cerr, "Error: unknown --machine value '{}'. Supported: disjunctive, cumulative, pairwise, difference.", machine_variant);
+        return EXIT_FAILURE;
+    }
+
+    vector<IntegerVariableID> machine_order_vars;
+    if (machine_variant == "difference" && machine_starts.size() >= 2)
+        for (std::size_t a = 0; a < machine_starts.size(); ++a)
+            for (auto b = a + 1; b < machine_starts.size(); ++b) {
+                auto first = problem.create_integer_variable(0_i, 1_i, "machine_before" + to_string(a) + "_" + to_string(b));
+                machine_order_vars.push_back(first);
+                edges.push_back(ModelEdge{machine_starts[a], machine_starts[b], machine_durations[a], first == 1_i});
+                edges.push_back(ModelEdge{machine_starts[b], machine_starts[a], machine_durations[b], first == 0_i});
+            }
+
     switch (*variant) {
         using enum Variant;
     case Presolved:
@@ -475,8 +514,13 @@ auto main(int argc, char * argv[]) -> int
         // every one of these has been posted in since this example landed.
         // Changing it would give the same constraint a different WeightedSum
         // term order, and so a different OPB row, for no reason.
-        for (const auto & e : edges)
-            problem.post(LinearGreaterThanEqual{WeightedSum{} + 1_i * e.to + -1_i * e.from, e.d});
+        for (const auto & e : edges) {
+            auto sum = WeightedSum{} + 1_i * e.to + -1_i * e.from;
+            if (e.cond)
+                problem.post(LinearGreaterThanEqualIf{sum, e.d, *e.cond});
+            else
+                problem.post(LinearGreaterThanEqual{sum, e.d});
+        }
         if (*variant == Presolved)
             problem.add_presolver(DifferenceLogic{presolver_stats});
         break;
@@ -488,7 +532,7 @@ auto main(int argc, char * argv[]) -> int
             vector<DifferenceEdge> difference_edges;
             difference_edges.reserve(edges.size());
             for (const auto & e : edges)
-                difference_edges.push_back(DifferenceEdge{e.from, e.to, -e.d});
+                difference_edges.push_back(DifferenceEdge{e.from, e.to, -e.d, e.cond});
             problem.post(DifferenceConstraints{difference_edges});
         }
         break;
@@ -534,22 +578,12 @@ auto main(int argc, char * argv[]) -> int
             problem.post(Cumulative{task_starts, task_durations, task_demands, instance.capacities[r]});
     }
 
-    vector<IntegerVariableID> machine_starts;
-    vector<Integer> machine_durations;
-    for (auto & i : instance.machine_tasks) {
-        machine_starts.push_back(starts[i]);
-        machine_durations.push_back(instance.durations[i]);
-    }
-
-    // The three ways of saying that the machine does one thing at a time. Every
+    // The four ways of saying that the machine does one thing at a time. Every
     // duration here is at least one, so the strict / non-strict distinction
     // does not arise, and the Cumulative form is exactly the Disjunctive one.
-    auto machine_variant = options_vars["machine"].as<string>();
-    if (machine_variant != "disjunctive" && machine_variant != "cumulative" && machine_variant != "pairwise") {
-        println(cerr, "Error: unknown --machine value '{}'. Supported: disjunctive, cumulative, pairwise.", machine_variant);
-        return EXIT_FAILURE;
-    }
-    if (machine_starts.size() >= 2) {
+    // The difference form was posted above, with the temporal network, because
+    // it has to share a propagator with it.
+    if (machine_variant != "difference" && machine_starts.size() >= 2) {
         if (machine_variant == "disjunctive")
             problem.post(Disjunctive{machine_starts, machine_durations});
         else if (machine_variant == "cumulative")
@@ -577,7 +611,17 @@ auto main(int argc, char * argv[]) -> int
     if (! all && ! deadline)
         problem.minimise(makespan);
 
-    auto branch_vars = starts;
+    // Under --machine=difference the ordering Booleans have to be branched on,
+    // and first. DifferenceConstraints makes no inference about an edge's
+    // condition at all --- that is the paper's IncImp, deliberately not
+    // implemented (see dev_docs/difference-logic.md) --- so an edge whose
+    // Boolean is unfixed simply does not constrain, and leaving them out of the
+    // branch list would let the solver report a schedule that runs two machine
+    // tasks at once. The reified linear forms do infer their condition, which is
+    // why --machine=pairwise is sound without them; relying on that here would
+    // be relying on the very thing this variant is meant to exercise.
+    auto branch_vars = machine_order_vars;
+    branch_vars.insert(branch_vars.end(), starts.begin(), starts.end());
     branch_vars.push_back(makespan);
 
     auto var_order = variable_order_from_string(options_vars["branch"].as<string>(), branch_vars);

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -306,7 +306,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
-    foreach(mode basic cycles views alias random)
+    foreach(mode basic cycles views alias reified random random_reified)
         add_test(NAME difference_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_test> ${mode})
     endforeach()

--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -4,12 +4,14 @@
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -20,6 +22,7 @@ using namespace gcs::innards;
 using std::make_unique;
 using std::map;
 using std::move;
+using std::optional;
 using std::size_t;
 using std::string;
 using std::to_string;
@@ -86,31 +89,40 @@ auto DifferenceConstraints::prepare(Propagators &, State &, ProofModel * const) 
         // edge's weight is expressed over bare variables and nothing else.
         auto d = e.d - left.offset + right.offset;
 
+        // A degenerate edge says 0 <= d. Unconditionally that is vacuous when
+        // d >= 0 and a root contradiction when d < 0. Half-reified it is
+        // vacuous when d >= 0 and says `!cond' when d < 0 --- which has to be
+        // *said*, since dropping it would let cond hold with the constraint
+        // violated. The propagator does that from the same row, so no
+        // initialiser is involved and a presolver could do the same.
+        auto degenerate = [&](Integer weight) {
+            if (weight >= 0_i)
+                return;
+            if (e.cond)
+                _graph.disallowed_conditions.push_back(DifferenceDisallowedCondition{*e.cond, i});
+            else if (! _root_contradiction_posted_index)
+                _root_contradiction_posted_index = i;
+        };
+
         if (left.variable && right.variable) {
             auto from = node_index(*left.variable);
             auto to = node_index(*right.variable);
-            if (from == to) {
-                // Aliasing: X - X <= d, i.e. 0 <= d. Vacuous when d >= 0, a
-                // root contradiction when d < 0 (the OPB row is directly
-                // false, so the contradiction RUPs from it).
-                if (d < 0_i && ! _root_contradiction_posted_index)
-                    _root_contradiction_posted_index = i;
-            }
+            if (from == to)
+                degenerate(d);
             else
-                _graph.edges.push_back(DifferenceGraphEdge{from, to, d, i});
+                _graph.edges.push_back(DifferenceGraphEdge{from, to, d, i, e.cond});
         }
         else if (left.variable) {
             // X - c2 <= d, i.e. X <= d (c2 already folded in above).
-            _graph.static_bounds.push_back(DifferenceStaticBound{node_index(*left.variable), d, false, i});
+            _graph.static_bounds.push_back(DifferenceStaticBound{node_index(*left.variable), d, false, i, e.cond});
         }
         else if (right.variable) {
             // c1 - Y <= d, i.e. Y >= -d.
-            _graph.static_bounds.push_back(DifferenceStaticBound{node_index(*right.variable), -d, true, i});
+            _graph.static_bounds.push_back(DifferenceStaticBound{node_index(*right.variable), -d, true, i, e.cond});
         }
         else {
             // Two constants: 0 <= d, exactly as for aliasing.
-            if (d < 0_i && ! _root_contradiction_posted_index)
-                _root_contradiction_posted_index = i;
+            degenerate(d);
         }
     }
 
@@ -158,7 +170,18 @@ auto DifferenceConstraints::define_proof_model(ProofModel & model, const State &
         // both render as a row whose left hand side is zero, which is exactly
         // what 0 <= d says, and which VeriPB reads as trivially true or
         // directly false according to d's sign.
-        _graph.edge_lines.push_back(model.add_labelled_constraint(constraint_id(), "e" + to_string(i), move(sum) <= d));
+        //
+        // A half-reified edge's row is emitted under HalfReifyOnConjunctionOf,
+        // so it says `cond -> X - Y <= d' and carries a big-M term on `~cond'.
+        // That term does not telescope, which is the point: it survives every
+        // sum as a residual and saturates into exactly the clause the propagator
+        // is entitled to learn. An unconditional edge passes nullopt and its row
+        // is byte-for-byte what it was before conditions existed.
+        optional<HalfReifyOnConjunctionOf> half_reif;
+        if (e.cond)
+            half_reif = HalfReifyOnConjunctionOf{*e.cond};
+
+        _graph.edge_lines.push_back(model.add_labelled_constraint(constraint_id(), "e" + to_string(i), move(sum) <= d, half_reif));
     }
 }
 
@@ -188,8 +211,14 @@ auto DifferenceConstraints::s_expr(const ProofModel * const model) const -> SExp
     auto & tracker = model->names_and_ids_tracker();
 
     vector<SExpr> edges;
-    for (const auto & e : _edges)
-        edges.push_back(SExpr::list({tracker.s_expr_term_of(e.x), tracker.s_expr_term_of(e.y), SExpr::atom(e.d.to_string())}));
+    for (const auto & e : _edges) {
+        vector<SExpr> edge{tracker.s_expr_term_of(e.x), tracker.s_expr_term_of(e.y), SExpr::atom(e.d.to_string())};
+        // A half-reified edge carries its condition as a fourth element, so
+        // that an unconditional system's s-expression is unchanged.
+        if (e.cond)
+            edge.push_back(tracker.s_expr_term_of(Literal{*e.cond}));
+        edges.push_back(SExpr::list(move(edge)));
+    }
 
     return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(move(edges))});
 }

--- a/gcs/constraints/difference/difference_constraints.hh
+++ b/gcs/constraints/difference/difference_constraints.hh
@@ -4,6 +4,7 @@
 #include <gcs/constraint.hh>
 #include <gcs/constraints/difference/difference_graph.hh>
 #include <gcs/integer.hh>
+#include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
 #include <cstddef>
@@ -15,11 +16,20 @@
 namespace gcs
 {
     /**
-     * \brief One edge of a DifferenceConstraints system: \f$x - y \le d\f$.
+     * \brief One edge of a DifferenceConstraints system: \f$x - y \le d\f$, or
+     * \f$cond \rightarrow x - y \le d\f$ when \c cond is given.
      *
      * Either operand may be a view or a constant. A negated view (`-X + c`) is
      * rejected: `V - W <= d` with `V = -X + c` is `-X - W <= d - c`, which is
      * not a difference constraint at all.
+     *
+     * A \c cond makes the edge *half-reified*: the constraint holds only when
+     * the condition does, and the edge takes part in the graph only while the
+     * condition currently holds. Nothing is inferred in the other direction ---
+     * the condition is never fixed from the graph. That is the paper's
+     * `IncImp`, which its own configuration study says to leave off, so it is
+     * deliberately absent; posting `b -> x - y <= d` on its own therefore leaves
+     * `b` for the search (or for some other constraint) to decide.
      *
      * \sa DifferenceConstraints
      * \ingroup Constraints
@@ -29,6 +39,7 @@ namespace gcs
         IntegerVariableID x;
         IntegerVariableID y;
         Integer d;
+        std::optional<IntegerVariableCondition> cond = std::nullopt;
     };
 
     /**
@@ -55,10 +66,21 @@ namespace gcs
      * an interior value, and gcs domains may have holes where the paper's
      * Theorem 2 assumes ranges.
      *
-     * This version handles unconditional edges only. Half-reified edges
-     * (`b -> x - y <= d`), which make the graph change during search, are not
-     * supported yet. Neither is incremental propagation: every wake recomputes
-     * from scratch.
+     * An edge may carry a reification condition, giving `b -> x - y <= d`; such
+     * an edge participates only while its condition currently holds, and every
+     * inference made using it cites that condition. Inference in the other
+     * direction (fixing a condition because its edge would close a negative
+     * cycle --- the paper's `IncImp`) is deliberately not implemented, since the
+     * paper's own configuration study says to leave it off. Note also the
+     * paper's caveat in its section 4.1: its "this is a domain propagator"
+     * claim assumes no Boolean appears in two difference constraints, which a
+     * disjunctive encoding (`b -> i before j`, `!b -> j before i`) violates by
+     * construction. That is a *completeness* caveat only; soundness is
+     * unaffected, and this propagator is bounds consistent rather than domain
+     * consistent in any case.
+     *
+     * Incremental propagation is not implemented: every wake recomputes from
+     * scratch.
      *
      * See `dev_docs/difference-logic.md` for the design, the proof shapes and
      * what is deferred.

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -75,11 +75,26 @@ namespace
         return Operand{nullopt, value};
     }
 
+    // A half-reification condition, written as `vars[var] == value` so that the
+    // condition variable is an ordinary member of the domain list and the
+    // oracle's enumeration covers both of its settings.
+    struct Cond
+    {
+        size_t var;
+        int value;
+    };
+
+    auto b(size_t i, int value = 1) -> optional<Cond>
+    {
+        return Cond{i, value};
+    }
+
     struct EdgeSpec
     {
         Operand x;
         Operand y;
         int d;
+        optional<Cond> cond = nullopt;
     };
 
     auto operand_value(const Operand & o, const vector<int> & vals) -> int
@@ -106,10 +121,25 @@ namespace
 
     auto satisfied(const vector<int> & vals, const vector<EdgeSpec> & edges) -> bool
     {
-        for (const auto & e : edges)
+        for (const auto & e : edges) {
+            // A half-reified edge constrains nothing when its condition is
+            // false. This is the whole semantics under test, and it is stated
+            // here independently of the solver, so an over-pruning propagator
+            // (one that let a false edge participate) loses solutions against
+            // this oracle.
+            if (e.cond && vals.at(e.cond->var) != e.cond->value)
+                continue;
             if (operand_value(e.x, vals) - operand_value(e.y, vals) > e.d)
                 return false;
+        }
         return true;
+    }
+
+    auto condition_id(const optional<Cond> & c, const vector<IntegerVariableID> & vars) -> optional<IntegerVariableCondition>
+    {
+        if (! c)
+            return nullopt;
+        return vars.at(c->var) == Integer(c->value);
     }
 
     // Post the same system as one DifferenceConstraints, and separately as one
@@ -133,7 +163,7 @@ namespace
             auto vars = make_vars(p, domains);
             vector<DifferenceEdge> posted;
             for (const auto & e : edges)
-                posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d)});
+                posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
             p.post(DifferenceConstraints{posted});
 
             auto proof_name = proofs ? make_optional("difference_test_" + mode + "_" + name) : nullopt;
@@ -147,8 +177,13 @@ namespace
         {
             Problem p;
             auto vars = make_vars(p, domains);
-            for (const auto & e : edges)
-                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars), Integer(e.d)});
+            for (const auto & e : edges) {
+                auto sum = WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars);
+                if (auto cond = condition_id(e.cond, vars))
+                    p.post(LinearLessThanEqualIf{sum, Integer(e.d), *cond});
+                else
+                    p.post(LinearLessThanEqual{sum, Integer(e.d)});
+            }
             solve_for_tests(p, nullopt, decomposed, tuple{vars});
         }
 
@@ -229,6 +264,84 @@ namespace
         if (z_lower != make_optional(8_i))
             throw UnexpectedException{"difference stopped at the first pass's lower bound for z instead of re-running from the snapped bound: "
                                       "the propagator must not claim idempotence"};
+    }
+
+    // The transitive push again, but across half-reified edges, plus the
+    // negative control that is the bug this feature most plausibly introduces:
+    // a propagator that ignored an edge's condition, or that tested it wrongly,
+    // would prune from an edge that is not in force. Solution counting alone
+    // would catch that only in the fixtures where the false edge actually
+    // excludes something, so assert the bounds directly.
+    //
+    //   b1 is fixed TRUE, and its edges must fire: x - y <= -3, y - z <= -4
+    //   give z >= 7 and x <= 3, exactly as in the unconditional case.
+    //   b2 is fixed FALSE, and its edge (w - z <= -20, impossible over these
+    //   domains) must not fire at all: w keeps its full 0..10 range.
+    //
+    // Confirmed by mutation: dropping the DefinitelyTrue test in the
+    // active-edge snapshot empties w's domain and this fails immediately.
+    auto run_reified_bounds_test() -> void
+    {
+        print(cerr, "difference reified push and negative control:");
+        cerr << flush;
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 10_i, "x");
+        auto y = p.create_integer_variable(0_i, 10_i, "y");
+        auto z = p.create_integer_variable(0_i, 10_i, "z");
+        auto w = p.create_integer_variable(0_i, 10_i, "w");
+        auto b1 = p.create_integer_variable(1_i, 1_i, "b1");
+        auto b2 = p.create_integer_variable(0_i, 0_i, "b2");
+        p.post(DifferenceConstraints{
+            {DifferenceEdge{x, y, -3_i, b1 == 1_i}, DifferenceEdge{y, z, -4_i, b1 == 1_i}, DifferenceEdge{w, z, -20_i, b2 == 1_i}}});
+
+        optional<Integer> z_lower, x_upper, w_lower, w_upper;
+        solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
+            z_lower = s.lower_bound(z);
+            x_upper = s.upper_bound(x);
+            w_lower = s.lower_bound(w);
+            w_upper = s.upper_bound(w);
+            return false;
+        }});
+
+        println(cerr, " z >= {}, x <= {}, w in {}..{}", z_lower ? z_lower->raw_value : -1, x_upper ? x_upper->raw_value : -1,
+            w_lower ? w_lower->raw_value : -1, w_upper ? w_upper->raw_value : -1);
+        if (z_lower != make_optional(7_i) || x_upper != make_optional(3_i))
+            throw UnexpectedException{"difference did not push transitively across half-reified edges whose condition is true"};
+        if (w_lower != make_optional(0_i) || w_upper != make_optional(10_i))
+            throw UnexpectedException{"difference propagated a half-reified edge whose condition is false: the edge must not participate in the "
+                                      "graph at all while its literal is not currently true"};
+    }
+
+    // A half-reified edge that canonicalises to `cond -> 0 <= d` with d < 0 is
+    // a fact about the condition, and one that has to be stated: quietly
+    // dropping it would let cond hold with the constraint violated, which is
+    // unsound rather than merely incomplete. Unconditionally the same edge is a
+    // root contradiction instead, which is why the two live in different places.
+    auto run_reified_degenerate_test() -> void
+    {
+        print(cerr, "difference reified degenerate edge:");
+        cerr << flush;
+
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 5_i, "x");
+        auto bad = p.create_integer_variable(0_i, 1_i, "bad");
+        auto fine = p.create_integer_variable(0_i, 1_i, "fine");
+        // bad -> x - x <= -1, i.e. !bad. fine -> x - x <= 0, i.e. nothing.
+        p.post(DifferenceConstraints{{DifferenceEdge{x, x, -1_i, bad == 1_i}, DifferenceEdge{x, x, 0_i, fine == 1_i}}});
+
+        optional<Integer> bad_upper, fine_upper;
+        solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
+            bad_upper = s.upper_bound(bad);
+            fine_upper = s.upper_bound(fine);
+            return false;
+        }});
+
+        println(cerr, " bad <= {}, fine <= {}", bad_upper ? bad_upper->raw_value : -1, fine_upper ? fine_upper->raw_value : -1);
+        if (bad_upper != make_optional(0_i))
+            throw UnexpectedException{"difference did not refute the condition of a half-reified edge saying cond -> 0 <= -1"};
+        if (fine_upper != make_optional(1_i))
+            throw UnexpectedException{"difference refuted the condition of a vacuous half-reified edge saying cond -> 0 <= 0"};
     }
 
     // A negated view operand is not a difference constraint at all, and
@@ -334,7 +447,76 @@ namespace
             // An empty system, and one with nothing but a vacuous edge.
             run_test(proofs, mode, "empty", {{0, 3}}, {});
         }
-        else if (mode == "random") {
+        else if (mode == "reified") {
+            // Throughout: the last one or two variables have domain 0..1 and
+            // are the reification conditions, so the oracle enumerates both
+            // settings of each and every fixture below checks the false branch
+            // as well as the true one.
+
+            // A negative cycle two of whose three edges are conditional. It
+            // closes only when both conditions hold, so exactly the (1, 1)
+            // quadrant is excluded -- and that is the case reified_hand.pbp
+            // verifies by hand: sum the three rows, saturate, and the residual
+            // is the clause ~b1 v ~b2.
+            run_test(proofs, mode, "negcycle_two_conds", {{0, 5}, {0, 5}, {0, 5}, {0, 1}, {0, 1}},
+                {{v(0), v(1), 0, b(3)}, {v(1), v(2), 0, b(4)}, {v(2), v(0), -1}});
+
+            // The same cycle with every edge conditional on the same Boolean.
+            // This is the paper's section 4.1 caveat made concrete (a Boolean
+            // appearing in more than one difference constraint, which its
+            // "domain propagator" claim excludes and which every disjunctive
+            // encoding does anyway): soundness must hold regardless, and the
+            // reason must not list the Boolean three times.
+            run_test(proofs, mode, "negcycle_shared_cond", {{0, 5}, {0, 5}, {0, 5}, {0, 1}},
+                {{v(0), v(1), 0, b(3)}, {v(1), v(2), 0, b(3)}, {v(2), v(0), -1, b(3)}});
+
+            // Mixed: an unconditional cycle would already be infeasible, so the
+            // conditional edge is the only thing standing between satisfiable
+            // and not.
+            run_test(proofs, mode, "negcycle_mixed", {{0, 4}, {0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(2), v(0), 1, b(3)}});
+
+            // Bound pushes across conditional edges, chained, so the reason of
+            // the second cites the first's inferred bound and its own condition.
+            run_test(proofs, mode, "chain_conds", {{0, 6}, {0, 6}, {0, 6}, {0, 1}, {0, 1}}, {{v(0), v(1), -2, b(3)}, {v(1), v(2), -2, b(4)}});
+
+            // A conditional edge that can never hold over these domains: the
+            // negative control, as a solution count. Every assignment with the
+            // condition false is a solution, and none with it true.
+            run_test(proofs, mode, "cond_impossible", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -10, b(2)}});
+
+            // Conditioning on the *false* value of a 0..1 variable, which is
+            // the other half of a disjunctive decomposition.
+            run_test(proofs, mode, "cond_on_zero", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -2, b(2, 0)}, {v(1), v(0), -2, b(2)}});
+
+            // A conditional edge whose condition is over a variable with a
+            // wider domain, so the condition is `x == 2' rather than a Boolean.
+            run_test(proofs, mode, "cond_not_boolean", {{0, 4}, {0, 4}, {0, 3}}, {{v(0), v(1), -3, b(2, 2)}});
+
+            // Conditional edges through offset views on both ends, which is
+            // where a proof only telescopes because the rows are emitted over
+            // the canonical bare variables.
+            run_test(proofs, mode, "cond_views", {{0, 5}, {0, 5}, {0, 5}, {0, 1}}, {{v(0, 2), v(1, -1), -1, b(3)}, {v(1, 3), v(2), 0, b(3)}});
+            run_test(proofs, mode, "cond_view_negcycle", {{0, 5}, {0, 5}, {0, 1}}, {{v(0, 2), v(1), 0, b(2)}, {v(1, 1), v(0, 4), 0}});
+
+            // Conditional static bounds (a constant operand) and conditional
+            // degenerate edges (aliasing), which are the two shapes that are not
+            // graph edges at all.
+            run_test(proofs, mode, "cond_constant", {{0, 8}, {0, 1}}, {{v(0), c(0), 3, b(1)}, {c(6), v(0), 0, b(1, 0)}});
+            run_test(proofs, mode, "cond_alias_bad", {{0, 3}, {0, 1}}, {{v(0), v(0), -1, b(1)}});
+            run_test(proofs, mode, "cond_alias_ok", {{0, 3}, {0, 1}}, {{v(0), v(0), 0, b(1)}});
+
+            // Two Booleans, four quadrants, each excluding a different part of
+            // the space: nothing may be pruned in the wrong quadrant.
+            run_test(
+                proofs, mode, "cond_quadrants", {{0, 4}, {0, 4}, {0, 1}, {0, 1}}, {{v(0), v(1), -2, b(2)}, {v(1), v(0), -2, b(3)}, {v(0), v(1), 1}});
+        }
+        else if (mode == "random" || mode == "random_reified") {
+            // In random_reified, two extra 0..1 variables sit at the end of the
+            // domain list and each edge is conditional on one of them (or on
+            // neither) with equal probability, so mixed conditional and
+            // unconditional systems, shared conditions and both polarities all
+            // turn up without being enumerated by hand.
+            auto reified = (mode == "random_reified");
             mt19937 rand(*get_seed());
             for (int iteration = 0; iteration < 12; ++iteration) {
                 uniform_int_distribution n_vars_dist{2, 4};
@@ -347,6 +529,10 @@ namespace
                     domains.emplace_back(lo, lo + width_dist(rand));
                 }
 
+                auto n_conds = reified ? 2 : 0;
+                for (int i = 0; i < n_conds; ++i)
+                    domains.emplace_back(0, 1);
+
                 uniform_int_distribution n_edges_dist{1, 6};
                 auto n_edges = n_edges_dist(rand);
                 vector<EdgeSpec> edges;
@@ -354,8 +540,15 @@ namespace
                     uniform_int_distribution var_dist{0, n_vars - 1};
                     uniform_int_distribution offset_dist{-2, 2};
                     uniform_int_distribution d_dist{-3, 3};
+                    optional<Cond> cond;
+                    if (reified) {
+                        uniform_int_distribution which_dist{0, 2 * n_conds};
+                        auto which = which_dist(rand);
+                        if (which > 0)
+                            cond = Cond{static_cast<size_t>(n_vars + (which - 1) / 2), (which - 1) % 2};
+                    }
                     edges.push_back(EdgeSpec{v(static_cast<size_t>(var_dist(rand)), offset_dist(rand)),
-                        v(static_cast<size_t>(var_dist(rand)), offset_dist(rand)), d_dist(rand)});
+                        v(static_cast<size_t>(var_dist(rand)), offset_dist(rand)), d_dist(rand), cond});
                 }
 
                 run_test(proofs, mode, "random" + to_string(iteration), domains, edges);
@@ -379,6 +572,10 @@ auto main(int argc, char * argv[]) -> int
     if (mode == "basic") {
         run_transitive_test();
         run_hole_snap_test();
+    }
+    if (mode == "reified") {
+        run_reified_bounds_test();
+        run_reified_degenerate_test();
     }
 
     for (bool proofs : {false, true}) {

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -158,6 +158,17 @@ namespace
         build_expected(expected, [&](const vector<int> & vals) { return satisfied(vals, edges); }, domains);
         println(cerr, " expecting {} solutions", expected.size());
 
+        // Whether either solve stopped early because a runtime cap fired (see
+        // GCS_TEST_CAP_DEFAULTS). check_results copes with that on its own --- it
+        // drops to checking soundness of what was produced --- but the
+        // cross-check below cannot: two truncated runs stop after the same
+        // *number* of solutions, not the same *set*, because the two models
+        // search in different orders. Comparing them then reports a disagreement
+        // where there is none, which is a defect of this harness rather than of
+        // the propagator, and it is what CI found on the reified random mode
+        // (whose extra condition variables multiply the solution count).
+        bool truncated = false;
+
         {
             Problem p;
             auto vars = make_vars(p, domains);
@@ -171,6 +182,7 @@ namespace
             // bounds, and gcs domains can have holes where the paper's Theorem
             // 2 assumes ranges.
             solve_for_tests(p, proof_name, actual, tuple{vars});
+            truncated = truncated || last_run_truncated();
             check_results(proof_name, expected, actual);
         }
 
@@ -185,9 +197,12 @@ namespace
                     p.post(LinearLessThanEqual{sum, Integer(e.d)});
             }
             solve_for_tests(p, nullopt, decomposed, tuple{vars});
+            truncated = truncated || last_run_truncated();
         }
 
-        if (actual != decomposed) {
+        if (truncated)
+            println(cerr, "difference {} {}: a cap fired, so the global/decomposed cross-check is skipped", mode, name);
+        else if (actual != decomposed) {
             println(cerr, "difference {} {}: global and decomposed models disagree", mode, name);
             println(cerr, "global has {} solutions, decomposed has {}", actual.size(), decomposed.size());
             throw UnexpectedException{"difference global and decomposed models disagree"};
@@ -477,7 +492,10 @@ namespace
 
             // Bound pushes across conditional edges, chained, so the reason of
             // the second cites the first's inferred bound and its own condition.
-            run_test(proofs, mode, "chain_conds", {{0, 6}, {0, 6}, {0, 6}, {0, 1}, {0, 1}}, {{v(0), v(1), -2, b(3)}, {v(1), v(2), -2, b(4)}});
+            // Domains kept narrow enough that the whole solution set fits inside
+            // the default runtime cap, so this keeps its cross-check against the
+            // decomposed model even in a capped run.
+            run_test(proofs, mode, "chain_conds", {{0, 4}, {0, 4}, {0, 4}, {0, 1}, {0, 1}}, {{v(0), v(1), -2, b(3)}, {v(1), v(2), -2, b(4)}});
 
             // A conditional edge that can never hold over these domains: the
             // negative control, as a solution count. Every assignment with the

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -10,6 +10,7 @@
 
 #include <util/overloaded.hh>
 
+#include <algorithm>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -22,6 +23,7 @@ using std::nullopt;
 using std::optional;
 using std::size_t;
 using std::vector;
+using std::ranges::find;
 
 auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> optional<DeviewedDifferenceOperand>
 {
@@ -39,17 +41,54 @@ auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> o
 
 auto gcs::innards::install_difference_propagator(Propagators & propagators, const ConstraintID & constraint_id, DifferenceGraph graph) -> void
 {
-    if (graph.edges.empty() && graph.static_bounds.empty())
+    if (graph.edges.empty() && graph.static_bounds.empty() && graph.disallowed_conditions.empty())
         return;
 
     Triggers triggers;
     for (const auto & v : graph.nodes)
         triggers.on_bounds.emplace_back(v);
 
+    // A half-reified edge joins the graph the moment its condition becomes
+    // true, so the propagator must wake on that as well as on the nodes'
+    // bounds. `on_change' on the condition's variable is the coarsest trigger
+    // gcs offers that is guaranteed to catch it: a condition can become true
+    // through an interior removal (`x != v' the instant v leaves the domain),
+    // which `on_bounds' does not see, and `on_instantiated' fires strictly less
+    // often still (`x >= v' can become true long before x is fixed). Nothing
+    // finer is needed, because there is no cheaper "becomes true" trigger and
+    // the refined per-literal watches would have to be armed one per condition
+    // anyway. Waking when a condition becomes *false* is not needed at all ---
+    // an inactive edge simply does not participate, and no inference is lost by
+    // finding that out later --- but `on_change' cannot distinguish the two
+    // directions, and paying for the extra wake is cheaper than the machinery
+    // to avoid it.
+    //
+    // Deliberately not deduplicated against the node list: a variable that is
+    // both a graph node and somebody's condition would then have to give up one
+    // of the two trigger kinds, and a duplicate wake is merely wasted work.
+    {
+        vector<IntegerVariableID> condition_vars;
+        auto note = [&](const IntegerVariableCondition & c) {
+            if (condition_vars.end() == find(condition_vars, c.var))
+                condition_vars.push_back(c.var);
+        };
+        for (const auto & e : graph.edges)
+            if (e.cond)
+                note(*e.cond);
+        for (const auto & sb : graph.static_bounds)
+            if (sb.cond)
+                note(*sb.cond);
+        for (const auto & dc : graph.disallowed_conditions)
+            note(dc.cond);
+        for (const auto & v : condition_vars)
+            triggers.on_change.emplace_back(v);
+    }
+
     propagators.install(
         constraint_id,
-        [nodes = move(graph.nodes), graph_edges = move(graph.edges), static_bounds = move(graph.static_bounds), edge_lines = move(graph.edge_lines)](
-            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        [nodes = move(graph.nodes), graph_edges = move(graph.edges), static_bounds = move(graph.static_bounds),
+            disallowed_conditions = move(graph.disallowed_conditions),
+            edge_lines = move(graph.edge_lines)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto n = nodes.size();
             auto m = graph_edges.size();
 
@@ -68,20 +107,63 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                 return pol;
             };
 
-            // Static bounds first: an edge with a constant operand is a plain
+            // A half-reified edge whose condition says `cond -> 0 <= d' with
+            // d < 0 says `!cond', and saying so is a soundness obligation, not a
+            // nicety: dropping the edge would licence solutions in which cond
+            // holds and the constraint is violated. The row is `M.~cond >= -d'
+            // with -d >= 1, which is the unit clause `~cond' after saturation,
+            // so plain RUP against it suffices and nothing in the state is
+            // involved. (Unconditionally this is a root contradiction instead;
+            // see DifferenceConstraints::install_propagators.)
+            for (const auto & dc : disallowed_conditions)
+                if (LiteralIs::DefinitelyFalse != state.test_literal(dc.cond))
+                    inference.infer(logger, ! dc.cond, JustifyUsingRUP{}, NoReason{});
+
+            // Static bounds next: an edge with a constant operand is a plain
             // bound on the other operand, and once applied it is just part of
-            // the state that Bellman-Ford seeds from. These never change, so
-            // after the first call every one of these is a no-op.
+            // the state that Bellman-Ford seeds from. An unconditional one never
+            // changes, so after the first call it is a no-op; a conditional one
+            // applies from the moment its condition holds, and cites it.
             for (const auto & sb : static_bounds) {
+                if (sb.cond && LiteralIs::DefinitelyTrue != state.test_literal(*sb.cond))
+                    continue;
+                Reason why = sb.cond ? Reason{ExplicitReason{ReasonLiterals{{*sb.cond}}}} : Reason{NoReason{}};
                 if (sb.is_lower) {
                     if (state.lower_bound(nodes[sb.node]) < sb.value)
-                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, NoReason{});
+                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, why);
                 }
                 else {
                     if (state.upper_bound(nodes[sb.node]) > sb.value)
-                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, NoReason{});
+                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, why);
                 }
             }
+
+            // Which edges are in the graph *for this call*. A half-reified edge
+            // participates exactly while its condition currently holds; the
+            // paper's E' set, restricted to the entailed half, since nothing
+            // here infers a condition from the graph.
+            //
+            // Snapshotting once, rather than re-testing as we go, is what keeps
+            // the round bound and the cycle-extraction argument in
+            // dev_docs/difference-logic.md applicable verbatim: both are
+            // statements about one Bellman-Ford run over one fixed edge set, and
+            // the edge set is now fixed for the duration of the call rather than
+            // for the lifetime of the constraint. Nothing else in those
+            // arguments mentions where the edges came from.
+            //
+            // The snapshot also stays *correct* as inferences land during the
+            // call, which is why it is safe to cite a snapshotted condition in a
+            // reason later on. A literal that is definitely true holds for every
+            // value in the current domain, so it holds for every value in any
+            // subset of it; all this propagator does is shrink domains, and a
+            // domain shrunk to empty is a contradiction, which stops the call.
+            // So a condition true at snapshot time is still true at every
+            // inference made from it.
+            vector<size_t> active_edges;
+            active_edges.reserve(m);
+            for (size_t e = 0; e < m; ++e)
+                if (! graph_edges[e].cond || LiteralIs::DefinitelyTrue == state.test_literal(*graph_edges[e].cond))
+                    active_edges.push_back(e);
 
             // Both passes walk a predecessor relation, one forwards along the
             // edges and one backwards, so each is parameterised by which end of
@@ -96,6 +178,29 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             // `0 >= -(cycle weight)' with the right hand side at least 1. No
             // domain state is involved, hence the empty reason.
             //
+            // A half-reified edge on the cycle contributes one extra term,
+            // `M.~cond', which does not telescope. Summing leaves
+            // `sum_i M_i.~cond_i >= -(cycle weight)', and one saturate turns it
+            // into the clause `~cond_1 v ... v ~cond_k' --- the learned clause,
+            // and exactly the shape hand-verified against real gcs OPB output in
+            // reified_hand.pbp before any of this was written. Every such
+            // condition therefore has to appear in the reason: the refutation is
+            // conditional on precisely them, and citing fewer would claim a
+            // contradiction the model does not entail. *That* part is
+            // load-bearing --- omitting a condition from the reason fails VeriPB
+            // on the reified fixtures, confirmed by mutation.
+            //
+            // The saturate itself is not: the closing RUP assumes every
+            // condition, which drives each `M.~cond' to zero and falsifies the
+            // unsaturated line just as well, and removing the saturate leaves
+            // every reified fixture verifying (also confirmed by mutation). It
+            // is emitted anyway because it makes the derived line *be* the
+            // clause rather than a big-M encoding of it, which is what a reader,
+            // an assertion hint or a longer-lived proof level would want. It is
+            // emitted only when there is a residual to saturate, so an
+            // unconditional cycle's proof line is byte-for-byte what it was
+            // before half-reified edges existed.
+            //
             // Before saying anything, verify the extracted cycle
             // arithmetically: that each edge meets the next, that it closes,
             // and that the total weight really is negative. That is O(cycle)
@@ -106,25 +211,39 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                 if (cycle.empty())
                     throw UnexpectedException{"difference logic extracted an empty negative cycle"};
                 Integer weight{0};
+                vector<IntegerVariableCondition> conditions;
                 for (size_t k = 0; k < cycle.size(); ++k) {
                     const auto & here = graph_edges[cycle[k]];
                     const auto & next = graph_edges[cycle[(k + 1) % cycle.size()]];
                     weight += here.d;
                     if (head_of(next) != tail_of(here))
                         throw UnexpectedException{"difference logic extracted a disconnected negative cycle"};
+                    // Deduplicated, because the same Boolean legitimately
+                    // appears on more than one edge (a disjunctive encoding
+                    // makes that the normal case) and a reason listing it twice
+                    // would render a proof line with a repeated literal.
+                    if (here.cond && conditions.end() == find(conditions, *here.cond))
+                        conditions.push_back(*here.cond);
                 }
                 if (weight >= 0_i)
                     throw UnexpectedException{"difference logic extracted a cycle of weight " + weight.to_string() + ", which is not negative"};
+
+                auto conditional = ! conditions.empty();
+                ReasonLiterals reason_literals;
+                for (const auto & c : conditions)
+                    reason_literals.push_back(c);
 
                 inference.contradiction(logger,
                     JustifyExplicitly{[&](const ReasonLiterals &) {
                                           auto pol = edge_line_pol();
                                           for (auto e : cycle)
                                               pol.add(edge_lines[graph_edges[e].posted_index]);
+                                          if (conditional)
+                                              pol.saturate();
                                           pol.emit(*logger, ProofLevel::Temporary);
                                       },
                         ThenRUP::Yes},
-                    NoReason{});
+                    conditional ? Reason{ExplicitReason{move(reason_literals)}} : Reason{NoReason{}});
             };
 
             // Walk predecessors back from `start' looking for a cycle, which is
@@ -199,7 +318,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
 
             for (size_t round = 0; round <= n; ++round) {
                 bool changed = false;
-                for (size_t e = 0; e < m; ++e) {
+                for (auto e : active_edges) {
                     const auto & edge = graph_edges[e];
                     auto candidate = lb[edge.from] - edge.d;
                     if (candidate > lb[edge.to]) {
@@ -233,6 +352,22 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                 // weakest antecedent for v >= L - d across this edge *is*
                 // source >= L, so the pol's degree comes out at exactly the
                 // pushed amount with no wasted slack.
+                //
+                // A half-reified edge adds `M.~cond' to that sum, and its
+                // condition to the reason. Only *this* edge's condition, because
+                // the inference is per edge: the predecessor's bound was either
+                // already there when the call started, or was itself inferred a
+                // moment ago carrying its own edge's condition in its own
+                // reason, so the conditions along a whole path are cited by the
+                // chain of inferences rather than by any one of them. Each link
+                // is a standalone entailment of one row, which is what makes its
+                // RUP check.
+                //
+                // No saturate here, unlike the cycle refutation: the residual is
+                // harmless under the closing RUP, which assumes cond and so
+                // drives that term to zero, leaving the line the unconditional
+                // case would have produced. Saturating would instead clamp
+                // BinEnc(v)'s own coefficients against the degree, for no gain.
                 inference.infer_greater_than_or_equal(logger, nodes[v], lb[v],
                     JustifyExplicitly{[&](const ReasonLiterals &) {
                                           auto pol = edge_line_pol();
@@ -241,7 +376,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                                           pol.emit(*logger, ProofLevel::Temporary);
                                       },
                         ThenRUP::Yes},
-                    ExplicitReason{ReasonLiterals{{source >= source_lb}}});
+                    ExplicitReason{edge.cond ? ReasonLiterals{{source >= source_lb}, {*edge.cond}} : ReasonLiterals{{source >= source_lb}}});
             });
 
             // Upper bounds flow backwards along the same edges. Edge
@@ -257,7 +392,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
 
             for (size_t round = 0; round <= n; ++round) {
                 bool changed = false;
-                for (size_t e = 0; e < m; ++e) {
+                for (auto e : active_edges) {
                     const auto & edge = graph_edges[e];
                     auto candidate = ub[edge.to] + edge.d;
                     if (candidate < ub[edge.from]) {
@@ -289,7 +424,8 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                                           pol.emit(*logger, ProofLevel::Temporary);
                                       },
                         ThenRUP::Yes},
-                    ExplicitReason{ReasonLiterals{{source < source_ub + 1_i}}});
+                    ExplicitReason{
+                        edge.cond ? ReasonLiterals{{source < source_ub + 1_i}, {*edge.cond}} : ReasonLiterals{{source < source_ub + 1_i}}});
             });
 
             // Deliberately not EnableButIdempotent, and not merely because the

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -24,6 +24,33 @@ using std::optional;
 using std::size_t;
 using std::vector;
 using std::ranges::find;
+using std::ranges::find_if;
+
+namespace
+{
+    // The propagator's hot data: one of these per edge, scanned end to end once
+    // per Bellman-Ford round, so its *size* is a measurable property rather than
+    // a detail. Carrying the edge's optional<IntegerVariableCondition> inline
+    // took DifferenceGraphEdge from 32 bytes to 96 and cost 2.9x on
+    // examples/difference_chain at n = 640 --- 0.32 s to 0.93 s with the
+    // propagation and recursion counts unchanged, i.e. pure memory traffic in
+    // the innermost loop.
+    //
+    // So DifferenceGraphEdge stays the convenient *construction* type, with the
+    // condition attached to the edge it belongs to, and install_difference_
+    // propagator repacks it once: arcs here, conditions in a parallel array read
+    // only when the active set is snapshotted (once per call) and when a reason
+    // is built (only when something is inferred). Never inside a round.
+    struct DifferenceArc
+    {
+        size_t from;
+        size_t to;
+        Integer d;
+        size_t posted_index;
+    };
+
+    static_assert(sizeof(DifferenceArc) <= 32, "the difference-logic relaxation loop scans this array once per round; keep it small");
+}
 
 auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> optional<DeviewedDifferenceOperand>
 {
@@ -84,13 +111,37 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             triggers.on_change.emplace_back(v);
     }
 
+    // Repack into the hot arc array plus a parallel condition array; see
+    // DifferenceArc. The condition array stays *empty* when nothing is
+    // conditional, which is both the check the propagator uses to take the
+    // straight-through path and a guarantee that an unconditional system pays
+    // nothing at all for this feature.
+    vector<DifferenceArc> arcs;
+    vector<optional<IntegerVariableCondition>> arc_conditions;
+    arcs.reserve(graph.edges.size());
+    for (const auto & e : graph.edges)
+        arcs.push_back(DifferenceArc{e.from, e.to, e.d, e.posted_index});
+    if (graph.edges.end() != find_if(graph.edges, [](const auto & e) { return e.cond.has_value(); })) {
+        arc_conditions.reserve(graph.edges.size());
+        for (const auto & e : graph.edges)
+            arc_conditions.push_back(e.cond);
+    }
+
     propagators.install(
         constraint_id,
-        [nodes = move(graph.nodes), graph_edges = move(graph.edges), static_bounds = move(graph.static_bounds),
+        [nodes = move(graph.nodes), arcs = move(arcs), arc_conditions = move(arc_conditions), static_bounds = move(graph.static_bounds),
             disallowed_conditions = move(graph.disallowed_conditions),
             edge_lines = move(graph.edge_lines)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             auto n = nodes.size();
-            auto m = graph_edges.size();
+            auto m = arcs.size();
+            // arc_conditions is either empty --- nothing in this system is
+            // conditional, and no per-edge storage exists at all --- or exactly
+            // as long as arcs. Only the cold paths go through here; see
+            // DifferenceArc for why the conditions are not in the arcs.
+            auto condition_of = [&](size_t e) -> const optional<IntegerVariableCondition> & {
+                static const optional<IntegerVariableCondition> none;
+                return arc_conditions.empty() ? none : arc_conditions[e];
+            };
 
             // Every pol below cites an edge row in deview mode. For rows this
             // constraint emitted itself that is a no-op: they are already over
@@ -159,11 +210,31 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             // domain shrunk to empty is a contradiction, which stops the call.
             // So a condition true at snapshot time is still true at every
             // inference made from it.
+            //
+            // An unconditional system is not snapshotted at all, and iterates
+            // the arc array straight through. That is not fastidiousness: the
+            // snapshot is a level of indirection inside the innermost loop, and
+            // going through it unconditionally cost 45% on
+            // examples/difference_chain at n = 640 (0.32 s to 0.47 s) with the
+            // propagation count unchanged. The branch is on the *outside* of the
+            // per-edge loop, so the conditional case pays nothing for it either.
             vector<size_t> active_edges;
-            active_edges.reserve(m);
-            for (size_t e = 0; e < m; ++e)
-                if (! graph_edges[e].cond || LiteralIs::DefinitelyTrue == state.test_literal(*graph_edges[e].cond))
-                    active_edges.push_back(e);
+            auto all_active = arc_conditions.empty();
+            if (! all_active) {
+                active_edges.reserve(m);
+                for (size_t e = 0; e < m; ++e)
+                    if (! arc_conditions[e] || LiteralIs::DefinitelyTrue == state.test_literal(*arc_conditions[e]))
+                        active_edges.push_back(e);
+            }
+
+            auto for_each_active_edge = [&](auto && relax) {
+                if (all_active)
+                    for (size_t e = 0; e < m; ++e)
+                        relax(e);
+                else
+                    for (auto e : active_edges)
+                        relax(e);
+            };
 
             // Both passes walk a predecessor relation, one forwards along the
             // edges and one backwards, so each is parameterised by which end of
@@ -213,8 +284,8 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                 Integer weight{0};
                 vector<IntegerVariableCondition> conditions;
                 for (size_t k = 0; k < cycle.size(); ++k) {
-                    const auto & here = graph_edges[cycle[k]];
-                    const auto & next = graph_edges[cycle[(k + 1) % cycle.size()]];
+                    const auto & here = arcs[cycle[k]];
+                    const auto & next = arcs[cycle[(k + 1) % cycle.size()]];
                     weight += here.d;
                     if (head_of(next) != tail_of(here))
                         throw UnexpectedException{"difference logic extracted a disconnected negative cycle"};
@@ -222,8 +293,9 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                     // appears on more than one edge (a disjunctive encoding
                     // makes that the normal case) and a reason listing it twice
                     // would render a proof line with a repeated literal.
-                    if (here.cond && conditions.end() == find(conditions, *here.cond))
-                        conditions.push_back(*here.cond);
+                    const auto & here_cond = condition_of(cycle[k]);
+                    if (here_cond && conditions.end() == find(conditions, *here_cond))
+                        conditions.push_back(*here_cond);
                 }
                 if (weight >= 0_i)
                     throw UnexpectedException{"difference logic extracted a cycle of weight " + weight.to_string() + ", which is not negative"};
@@ -237,7 +309,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                     JustifyExplicitly{[&](const ReasonLiterals &) {
                                           auto pol = edge_line_pol();
                                           for (auto e : cycle)
-                                              pol.add(edge_lines[graph_edges[e].posted_index]);
+                                              pol.add(edge_lines[arcs[e].posted_index]);
                                           if (conditional)
                                               pol.saturate();
                                           pol.emit(*logger, ProofLevel::Temporary);
@@ -262,14 +334,14 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                     seen[at] = true;
                     if (! pred[at])
                         throw UnexpectedException{"difference logic found no negative cycle where one must exist"};
-                    at = tail_of(graph_edges[*pred[at]]);
+                    at = tail_of(arcs[*pred[at]]);
                 }
 
                 vector<size_t> cycle;
                 auto here = at;
                 do {
                     cycle.push_back(*pred[here]);
-                    here = tail_of(graph_edges[*pred[here]]);
+                    here = tail_of(arcs[*pred[here]]);
                 } while (here != at);
                 return cycle;
             };
@@ -290,7 +362,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                     while (! done[at] && pred[at]) {
                         done[at] = true;
                         chain.push_back(at);
-                        at = tail_of(graph_edges[*pred[at]]);
+                        at = tail_of(arcs[*pred[at]]);
                     }
                     for (auto it = chain.rbegin(); it != chain.rend(); ++it)
                         infer_one(*it);
@@ -313,13 +385,13 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             // more than needed; round n relaxes nothing unless the system has a
             // negative cycle, so a success there is sound evidence of one and
             // the extraction above is guaranteed to find it.
-            auto lb_tail_of = [](const DifferenceGraphEdge & g) { return g.from; };
-            auto lb_head_of = [](const DifferenceGraphEdge & g) { return g.to; };
+            auto lb_tail_of = [](const DifferenceArc & g) { return g.from; };
+            auto lb_head_of = [](const DifferenceArc & g) { return g.to; };
 
             for (size_t round = 0; round <= n; ++round) {
                 bool changed = false;
-                for (auto e : active_edges) {
-                    const auto & edge = graph_edges[e];
+                for_each_active_edge([&](size_t e) {
+                    const auto & edge = arcs[e];
                     auto candidate = lb[edge.from] - edge.d;
                     if (candidate > lb[edge.to]) {
                         lb[edge.to] = candidate;
@@ -328,13 +400,14 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                         if (round == n)
                             contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
                     }
-                }
+                });
                 if (! changed)
                     break;
             }
 
             infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) {
-                const auto & edge = graph_edges[*lb_pred[v]];
+                const auto & edge = arcs[*lb_pred[v]];
+                const auto & edge_cond = condition_of(*lb_pred[v]);
                 auto source = nodes[edge.from];
                 auto source_lb = lb[edge.from];
                 if (source_lb - edge.d != lb[v])
@@ -376,7 +449,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                                           pol.emit(*logger, ProofLevel::Temporary);
                                       },
                         ThenRUP::Yes},
-                    ExplicitReason{edge.cond ? ReasonLiterals{{source >= source_lb}, {*edge.cond}} : ReasonLiterals{{source >= source_lb}}});
+                    ExplicitReason{edge_cond ? ReasonLiterals{{source >= source_lb}, {*edge_cond}} : ReasonLiterals{{source >= source_lb}}});
             });
 
             // Upper bounds flow backwards along the same edges. Edge
@@ -387,13 +460,13 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             for (size_t v = 0; v < n; ++v)
                 ub[v] = state.upper_bound(nodes[v]);
 
-            auto ub_tail_of = [](const DifferenceGraphEdge & g) { return g.to; };
-            auto ub_head_of = [](const DifferenceGraphEdge & g) { return g.from; };
+            auto ub_tail_of = [](const DifferenceArc & g) { return g.to; };
+            auto ub_head_of = [](const DifferenceArc & g) { return g.from; };
 
             for (size_t round = 0; round <= n; ++round) {
                 bool changed = false;
-                for (auto e : active_edges) {
-                    const auto & edge = graph_edges[e];
+                for_each_active_edge([&](size_t e) {
+                    const auto & edge = arcs[e];
                     auto candidate = ub[edge.to] + edge.d;
                     if (candidate < ub[edge.from]) {
                         ub[edge.from] = candidate;
@@ -402,13 +475,14 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                         if (round == n)
                             contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
                     }
-                }
+                });
                 if (! changed)
                     break;
             }
 
             infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) {
-                const auto & edge = graph_edges[*ub_pred[v]];
+                const auto & edge = arcs[*ub_pred[v]];
+                const auto & edge_cond = condition_of(*ub_pred[v]);
                 auto source = nodes[edge.to];
                 auto source_ub = ub[edge.to];
                 if (source_ub + edge.d != ub[v])
@@ -425,7 +499,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                                       },
                         ThenRUP::Yes},
                     ExplicitReason{
-                        edge.cond ? ReasonLiterals{{source < source_ub + 1_i}, {*edge.cond}} : ReasonLiterals{{source < source_ub + 1_i}}});
+                        edge_cond ? ReasonLiterals{{source < source_ub + 1_i}, {*edge_cond}} : ReasonLiterals{{source < source_ub + 1_i}}});
             });
 
             // Deliberately not EnableButIdempotent, and not merely because the

--- a/gcs/constraints/difference/difference_graph.hh
+++ b/gcs/constraints/difference/difference_graph.hh
@@ -5,6 +5,7 @@
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/integer.hh>
+#include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
 #include <cstddef>
@@ -18,6 +19,14 @@ namespace gcs::innards
      * nodes[to] <= d`, derived from the `posted_index`th constraint the caller
      * handed over.
      *
+     * When \c cond is engaged the edge is *half-reified*: the constraint states
+     * `cond -> nodes[from] - nodes[to] <= d`, and the edge takes part in the
+     * graph only while \c cond currently holds. Its OPB row is emitted under
+     * \c HalfReifyOnConjunctionOf, so it carries a big-M term on `~cond` which
+     * survives every telescoping sum as a residual --- which is exactly the
+     * clause the propagator wants to learn, and why \c cond must appear in the
+     * reason of anything derived using this edge.
+     *
      * \sa DifferenceGraph
      * \ingroup Innards
      */
@@ -27,12 +36,16 @@ namespace gcs::innards
         std::size_t to;
         Integer d;
         std::size_t posted_index;
+        std::optional<IntegerVariableCondition> cond = std::nullopt;
     };
 
     /**
      * \brief An edge with a constant operand, which is not a graph edge at all
      * but a plain bound on the other operand: `nodes[node] >= value` when
      * `is_lower`, `nodes[node] <= value` otherwise.
+     *
+     * A \c cond means the bound is only enforced while that condition holds, and
+     * is then cited as the reason for applying it.
      *
      * \sa DifferenceGraph
      * \ingroup Innards
@@ -42,6 +55,26 @@ namespace gcs::innards
         std::size_t node;
         Integer value;
         bool is_lower;
+        std::size_t posted_index;
+        std::optional<IntegerVariableCondition> cond = std::nullopt;
+    };
+
+    /**
+     * \brief A half-reified edge that canonicalises to `cond -> 0 <= d` with
+     * `d < 0`, i.e. to `!cond`.
+     *
+     * Unconditionally this would be a root contradiction; with a condition it is
+     * a fact about that condition instead, and one that *must* be stated --- an
+     * implementation that quietly dropped such an edge would allow solutions in
+     * which \c cond holds and the edge is violated. The row saturates to the
+     * unit clause `~cond`, so the inference is plain RUP against it.
+     *
+     * \sa DifferenceGraph
+     * \ingroup Innards
+     */
+    struct DifferenceDisallowedCondition
+    {
+        IntegerVariableCondition cond;
         std::size_t posted_index;
     };
 
@@ -98,6 +131,7 @@ namespace gcs::innards
         std::vector<SimpleIntegerVariableID> nodes;
         std::vector<DifferenceGraphEdge> edges;
         std::vector<DifferenceStaticBound> static_bounds;
+        std::vector<DifferenceDisallowedCondition> disallowed_conditions;
         std::vector<ProofLine> edge_lines;
     };
 
@@ -114,11 +148,18 @@ namespace gcs::innards
      * Problem: the algorithm cares only about the node list, the edge list and
      * the rows, never about where they came from.
      *
-     * A no-op if the system has neither edges nor static bounds. Detecting a
-     * root-level contradiction (an edge saying `0 <= d` with `d < 0`) is *not*
-     * this function's job --- see DifferenceConstraints::install_propagators,
-     * which handles it with an initialiser, a door that has closed by the time a
-     * presolver runs.
+     * Half-reified edges take part only while their condition currently holds.
+     * No inference runs the other way: the propagator never fixes a condition
+     * from the graph (the paper's `IncImp`), which its own configuration study
+     * says to leave off.
+     *
+     * A no-op if the system has no edges, static bounds or disallowed
+     * conditions. Detecting a root-level contradiction (an *unconditional* edge
+     * saying `0 <= d` with `d < 0`) is *not* this function's job --- see
+     * DifferenceConstraints::install_propagators, which handles it with an
+     * initialiser, a door that has closed by the time a presolver runs. The
+     * half-reified counterpart *is* handled here, as a
+     * DifferenceDisallowedCondition, precisely because it needs no initialiser.
      *
      * \ingroup Innards
      */

--- a/gcs/presolvers/difference_logic.cc
+++ b/gcs/presolvers/difference_logic.cc
@@ -156,8 +156,11 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &,
         // f rather than under the empty role. Counted rather than guessed at.
         auto liftable_kind = true;
         optional<IntegerVariableCondition> edge_condition;
-        overloaded{//
-            [&](const reif::MustHold &) {}, [&](const reif::If & cond) { edge_condition = cond.cond; }, [&](const auto &) { liftable_kind = false; }}
+        overloaded{
+            [&](const reif::MustHold &) {},                             //
+            [&](const reif::If & cond) { edge_condition = cond.cond; }, //
+            [&](const auto &) { liftable_kind = false; }                //
+        }
             .visit(c.reification_condition());
 
         if (! liftable_kind) {

--- a/gcs/presolvers/difference_logic.cc
+++ b/gcs/presolvers/difference_logic.cc
@@ -9,6 +9,8 @@
 #include <gcs/problem.hh>
 #include <gcs/reification.hh>
 
+#include <util/overloaded.hh>
+
 #include <concepts>
 #include <map>
 #include <memory>
@@ -26,6 +28,7 @@ using std::holds_alternative;
 using std::make_unique;
 using std::map;
 using std::move;
+using std::nullopt;
 using std::optional;
 using std::shared_ptr;
 using std::size_t;
@@ -132,19 +135,32 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &,
 
     // The donors whose edges were lifted, for the optional disable below. Kept
     // as ids rather than pointers because that is what Propagators indexes by.
+    // Half-reified donors are deliberately never added: see below.
     vector<ConstraintID> lifted_donors;
 
     size_t linears_seen = 0;
     for (const auto & c : problem.each_constraint_of_type<ReifiedLinearInequality>()) {
         ++linears_seen;
 
-        // Unconditional only. This is not a nicety: comparison.cc and
-        // linear_inequality.cc emit the `If` form's row *half-reified* under
-        // HalfReifyOnConjunctionOf, so treating it as an unconditional edge
-        // would licence inferences the model does not entail, and the pol
-        // citing it would carry an uncancelled gate term. Half-reified edges
-        // need the paper's E' machinery and a trailed edge journal; a later PR.
-        if (! holds_alternative<reif::MustHold>(c.reification_condition())) {
+        // MustHold gives a plain edge; If gives a half-reified one,
+        // `cond -> x - y <= d'. Both are citable and both are the shape the
+        // propagator's proofs assume: linear_inequality.cc labels the
+        // unconditional row and the `If' row identically, @c[<id>] with an empty
+        // role, and emits the latter under HalfReifyOnConjunctionOf on exactly
+        // the condition recorded here.
+        //
+        // The other three kinds are each expressible as difference edges too,
+        // and are skipped only because each needs a *different* row of the
+        // donor's output: MustNotHold and NotIf state the integer negation
+        // (`y - x <= -d-1'), and Iff emits its two halves under the roles r and
+        // f rather than under the empty role. Counted rather than guessed at.
+        auto liftable_kind = true;
+        optional<IntegerVariableCondition> edge_condition;
+        overloaded{//
+            [&](const reif::MustHold &) {}, [&](const reif::If & cond) { edge_condition = cond.cond; }, [&](const auto &) { liftable_kind = false; }}
+            .visit(c.reification_condition());
+
+        if (! liftable_kind) {
             ++stats.skipped_reified;
             continue;
         }
@@ -179,9 +195,10 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &,
 
         // A constant operand makes this a plain bound, which the donor's own
         // propagator applies once and which adds nothing to the graph; and
-        // aliasing says 0 <= d, which is vacuous or else a root contradiction
-        // that would need an initialiser --- and initialisers have already run
-        // by the time a presolver is called. Leave both to the donor, which
+        // aliasing says 0 <= d, which is vacuous, or else a root contradiction
+        // (unconditionally, needing an initialiser --- and initialisers have
+        // already run by the time a presolver is called) or a fact about the
+        // condition (half-reified). Leave all of them to the donor, which
         // handles them. Checked before node_index is called, so a skipped edge
         // never leaves an isolated node behind to be triggered on.
         if (! left->variable || ! right->variable || *left->variable == *right->variable) {
@@ -198,16 +215,26 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &,
         auto to = node_index(*right->variable);
 
         auto posted_index = graph.edges.size();
-        graph.edges.push_back(DifferenceGraphEdge{from, to, d, posted_index});
+        graph.edges.push_back(DifferenceGraphEdge{from, to, d, posted_index, edge_condition});
         if (logger) {
             // The donor's own row, which linear_inequality.cc labelled
-            // @c[<id>] with an empty role. Nothing new goes into the OPB ---
+            // @c[<id>] with an empty role, for the `If` form exactly as for the
+            // unconditional one. Nothing new goes into the OPB ---
             // Presolver::run has no ProofModel * precisely because that door has
             // closed --- and nothing needs to: every inference the propagator
             // makes is a cutting-planes consequence of these rows.
             graph.edge_lines.push_back(ProofLineLabel{"c[" + as_string(c.constraint_id()) + "]"});
         }
-        lifted_donors.push_back(c.constraint_id());
+
+        if (edge_condition)
+            ++stats.half_reified_edges_lifted;
+        else {
+            // Only unconditional donors are candidates for retirement. A
+            // half-reified donor also infers `!cond' from its own bounds, and
+            // the global propagator infers nothing about a condition at all, so
+            // retiring one would silently lose propagation.
+            lifted_donors.push_back(c.constraint_id());
+        }
     }
 
     // Comparisons are difference constraints too --- `x <= y + d` is a view, not

--- a/gcs/presolvers/difference_logic.hh
+++ b/gcs/presolvers/difference_logic.hh
@@ -27,6 +27,17 @@ namespace gcs
         /// Donors turned into graph edges: the number that matters.
         std::size_t edges_lifted = 0;
 
+        /**
+         * \brief How many of edges_lifted came from a half-reified (`reif::If`)
+         * donor, and so joined the graph as `cond -> x - y <= d`.
+         *
+         * Broken out rather than counted separately because these are the edges
+         * a disjunctive encoding contributes, which is where the paper's
+         * scheduling wins come from --- and because they are the ones whose
+         * donors must *not* be retired (see DifferenceLogic::disabling_lifted_donors).
+         */
+        std::size_t half_reified_edges_lifted = 0;
+
         /// Distinct variables those edges span.
         std::size_t nodes = 0;
 
@@ -51,9 +62,11 @@ namespace gcs
         /// A two-term linear whose coefficients are not exactly +1 and -1.
         std::size_t skipped_coefficients = 0;
 
-        /// A linear whose reification condition is not reif::MustHold. Lifting
-        /// one of these as though it were unconditional would be unsound: the
-        /// `If` form's row is emitted half-reified.
+        /// A linear whose reification condition is neither reif::MustHold nor
+        /// reif::If: MustNotHold, NotIf or Iff. Each of those *is* expressible
+        /// as one or two difference edges, but each needs a different row of the
+        /// donor's OPB output than the two forms handled here, so they are
+        /// counted rather than guessed at.
         std::size_t skipped_reified = 0;
 
         /// An operand that is a negated view (`-X + c`), which is not a
@@ -102,13 +115,18 @@ namespace gcs
      * \par What is lifted
      *
      * The paper's "level 1", restricted to what the propagator supports today: a
-     * two-term LinearLessThanEqual with coefficients exactly `+1` and `-1`, an
-     * unconditional (reif::MustHold) reification condition, and two distinct
-     * variable operands, each of which may carry a `+X + c` view offset (folded
-     * into the weight). Everything else is skipped and counted --- see
-     * DifferenceLogicStats, and note in particular that Comparison donors are
-     * skipped only because their unconditional OPB rows are emitted *unlabelled*
-     * and so cannot be cited, not because they are the wrong shape.
+     * two-term LinearLessThanEqual with coefficients exactly `+1` and `-1` and
+     * two distinct variable operands, each of which may carry a `+X + c` view
+     * offset (folded into the weight). The reification condition may be
+     * unconditional (reif::MustHold), giving a plain edge, or half-reified
+     * (reif::If), giving `cond -> x - y <= d`: `linear_inequality.cc` labels
+     * both forms `@c[<id>]` with no role suffix, so both are citable, and the
+     * `If` form's row is emitted under HalfReifyOnConjunctionOf, which is
+     * exactly the shape the propagator's proofs assume. Everything else is
+     * skipped and counted --- see DifferenceLogicStats, and note in particular
+     * that Comparison donors are skipped only because their unconditional OPB
+     * rows are emitted *unlabelled* and so cannot be cited, not because they are
+     * the wrong shape.
      *
      * Equalities (level 2) and disequalities (level 3) are not chased at all;
      * the paper measures both as losing to level 1.
@@ -132,16 +150,24 @@ namespace gcs
         explicit DifferenceLogic(std::shared_ptr<DifferenceLogicStats> stats = nullptr);
 
         /**
-         * \brief Also retire the propagators of every donor whose edge was
-         * lifted, so only the global propagator runs over them.
+         * \brief Also retire the propagators of every *unconditional* donor
+         * whose edge was lifted, so only the global propagator runs over them.
          *
          * Ships off, because the hybrid is what the paper measures as best; this
          * exists so the alternative can be measured rather than assumed. It is
          * also a soundness tripwire, and a strong one: the global propagator
-         * subsumes every donor's single-edge bound push, and disabling a
-         * propagator changes neither degrees nor adjacency, so the search tree
-         * must come out *identical* either way. It differing means the
-         * subsumption claim is wrong.
+         * subsumes every unconditional donor's single-edge bound push, and
+         * disabling a propagator changes neither degrees nor adjacency, so the
+         * search tree must come out *identical* either way. It differing means
+         * the subsumption claim is wrong.
+         *
+         * Half-reified donors are **never** retired, however many of their edges
+         * were lifted. Subsumption fails for them in one direction: a
+         * `LinearLessThanEqualIf` also infers `!cond` when its bounds make the
+         * inequality impossible, and the global propagator makes no inference
+         * about a condition at all (that is the paper's `IncImp`, deliberately
+         * not implemented). Retiring one would lose that inference, which is a
+         * completeness loss no proof could catch.
          */
         auto disabling_lifted_donors(bool = true) -> DifferenceLogic &;
 

--- a/gcs/presolvers/difference_logic_test.cc
+++ b/gcs/presolvers/difference_logic_test.cc
@@ -131,11 +131,26 @@ namespace
         return Operand{nullopt, value};
     }
 
+    // A half-reification condition, written as `vars[var] == value` so that the
+    // condition variable is an ordinary member of the domain list and the
+    // oracle enumerates both of its settings.
+    struct Cond
+    {
+        size_t var;
+        int value;
+    };
+
+    auto b(size_t i, int value = 1) -> optional<Cond>
+    {
+        return Cond{i, value};
+    }
+
     struct EdgeSpec
     {
         Operand x;
         Operand y;
         int d;
+        optional<Cond> cond = nullopt;
     };
 
     auto operand_value(const Operand & o, const vector<int> & vals) -> int
@@ -154,9 +169,12 @@ namespace
 
     auto satisfied(const vector<int> & vals, const vector<EdgeSpec> & edges) -> bool
     {
-        for (const auto & e : edges)
+        for (const auto & e : edges) {
+            if (e.cond && vals.at(e.cond->var) != e.cond->value)
+                continue;
             if (operand_value(e.x, vals) - operand_value(e.y, vals) > e.d)
                 return false;
+        }
         return true;
     }
 
@@ -191,8 +209,13 @@ namespace
         for (const auto & [lo, hi] : domains)
             vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
 
-        for (const auto & e : edges)
-            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars), Integer(e.d)});
+        for (const auto & e : edges) {
+            auto sum = WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars);
+            if (e.cond)
+                p.post(LinearLessThanEqualIf{sum, Integer(e.d), vars.at(e.cond->var) == Integer(e.cond->value)});
+            else
+                p.post(LinearLessThanEqual{sum, Integer(e.d)});
+        }
 
         switch (config) {
             using enum Config;
@@ -210,7 +233,7 @@ namespace
     // no proof would catch either, since a proof only certifies what was
     // derived.
     auto run_equivalence_test(bool proofs, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges,
-        size_t expected_edges_lifted) -> void
+        size_t expected_edges_lifted, size_t expected_half_reified) -> void
     {
         print(cerr, "difference presolver equivalence {} domains={} edges={}{}", name, domains, edges.size(), proofs ? " with proofs:" : ":");
         cerr << flush;
@@ -231,21 +254,34 @@ namespace
             solve_for_tests(p, proof_name, actual, tuple{vars});
             check_results(proof_name, expected, actual);
 
-            if (config != Config::NoPresolver)
+            if (config != Config::NoPresolver) {
                 check_count("edges lifted", expected_edges_lifted, stats->edges_lifted, name);
+                check_count("half-reified edges lifted", expected_half_reified, stats->half_reified_edges_lifted, name);
+            }
         }
     }
 
     // The tripwire. Disabling the donors' own propagators must not change the
-    // search tree at all: the global propagator subsumes every single-edge bound
-    // push, and disabling changes neither degrees nor adjacency, so the
-    // branching heuristic sees an unchanged problem. Solutions *and* recursions
-    // must match exactly. (Propagation counts of course do not, and are the
-    // point of the option.)
-    auto run_tripwire_test(const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges) -> void
+    // search tree at all: the global propagator subsumes every unconditional
+    // single-edge bound push, and disabling changes neither degrees nor
+    // adjacency, so the branching heuristic sees an unchanged problem.
+    // Solutions *and* recursions must match exactly. (Propagation counts of
+    // course do not, and are the point of the option.)
+    //
+    // It is also what guards the rule that a *half-reified* donor is never
+    // retired. Subsumption fails for those in one direction: a
+    // LinearLessThanEqualIf also infers `!cond' from its own bounds, and the
+    // global propagator makes no inference about a condition at all. Retire one
+    // and the search grows, which shows up here as a recursion mismatch.
+    auto run_tripwire_test(const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges, size_t expected_edges_lifted,
+        size_t expected_half_reified) -> void
     {
         print(cerr, "difference presolver tripwire {}:", name);
         cerr << flush;
+
+        // Only unconditional donors are candidates for retirement, so a fixture
+        // whose every lifted edge is conditional legitimately disables nothing.
+        auto expect_disabling = expected_edges_lifted > expected_half_reified;
 
         Stats results[2];
         for (auto [index, config] : {pair{0, Config::Hybrid}, pair{1, Config::DonorsDisabled}}) {
@@ -253,9 +289,14 @@ namespace
             Problem p;
             static_cast<void>(build(p, domains, edges, config, stats));
             results[index] = solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return true; }});
-            if (config == Config::DonorsDisabled && 0 == stats->donor_propagators_disabled)
+            if (config == Config::DonorsDisabled && expect_disabling && 0 == stats->donor_propagators_disabled)
                 throw UnexpectedException{"the difference-logic presolver disabled no donor propagators on fixture '" + name +
                     "', so the tripwire compared two identical configurations." + detection_is_broken};
+            if (config == Config::DonorsDisabled && ! expect_disabling && 0 != stats->donor_propagators_disabled)
+                throw UnexpectedException{"the difference-logic presolver disabled " + to_string(stats->donor_propagators_disabled) +
+                    " donor propagators on fixture '" + name +
+                    "', every one of whose lifted edges is half-reified. A half-reified donor must never be retired: it also infers !cond from its "
+                    "own bounds, and the global propagator infers nothing about a condition at all, so retiring one silently loses propagation."};
         }
 
         println(cerr, " hybrid {} solutions / {} recursions / {} propagations, donors off {} / {} / {}", results[0].solutions, results[0].recursions,
@@ -281,6 +322,7 @@ namespace
         vector<pair<int, int>> domains;
         vector<EdgeSpec> edges;
         size_t expected_edges_lifted;
+        size_t expected_half_reified = 0;
     };
 
     auto corpus() -> vector<Fixture>
@@ -312,19 +354,35 @@ namespace
             // A negated view is not a difference constraint at all, and must be
             // refused rather than lifted: -x - y <= d has both coefficients
             // negative. The other two edges still lift.
-            {"negated_view", {{-3, 3}, {-3, 3}, {-3, 3}}, {{neg(0), v(1), 1}, {v(0), v(2), -1}, {v(2), v(1), -1}}, 2}};
+            {"negated_view", {{-3, 3}, {-3, 3}, {-3, 3}}, {{neg(0), v(1), 1}, {v(0), v(2), -1}, {v(2), v(1), -1}}, 2},
+            // Half-reified donors. LinearLessThanEqualIf emits its row under
+            // HalfReifyOnConjunctionOf and labels it @c[<id>] with an empty
+            // role, exactly as the unconditional form does, so it is citable
+            // and lifts as a conditional edge. The last variable of each
+            // fixture is the condition, and the oracle enumerates both of its
+            // settings, so the false branch is checked as hard as the true one.
+            {"reified_chain", {{0, 5}, {0, 5}, {0, 5}, {0, 1}}, {{v(0), v(1), -1, b(3)}, {v(1), v(2), -1, b(3)}}, 2, 2},
+            {"reified_negcycle", {{0, 5}, {0, 5}, {0, 5}, {0, 1}, {0, 1}}, {{v(0), v(1), 0, b(3)}, {v(1), v(2), 0, b(4)}, {v(2), v(0), -1}}, 3, 2},
+            // Mixed, with views, so the pol has to telescope in deview mode
+            // *and* carry reification residuals.
+            {"reified_views", {{0, 5}, {0, 5}, {0, 5}, {0, 1}}, {{v(0, 2), v(1), -1, b(3)}, {v(1, -1), v(2), 0}, {v(2), v(0), 1, b(3)}}, 3, 2},
+            // The negative control: a conditional edge that is impossible over
+            // these domains. Every assignment with the condition false is a
+            // solution, so a presolver whose propagator ignored the condition
+            // would lose all of them.
+            {"reified_impossible", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -10, b(2)}, {v(1), v(0), 1}}, 2, 1}};
     }
 
     auto run_equivalence_tests(bool proofs) -> void
     {
         for (const auto & f : corpus())
-            run_equivalence_test(proofs, f.name, f.domains, f.edges, f.expected_edges_lifted);
+            run_equivalence_test(proofs, f.name, f.domains, f.edges, f.expected_edges_lifted, f.expected_half_reified);
     }
 
     auto run_tripwire_tests() -> void
     {
         for (const auto & f : corpus())
-            run_tripwire_test(f.name, f.domains, f.edges);
+            run_tripwire_test(f.name, f.domains, f.edges, f.expected_edges_lifted, f.expected_half_reified);
     }
 
     // Every donor shape, with the count it must land in. A donor migrating from
@@ -334,11 +392,12 @@ namespace
     {
         auto check = [](const string & fixture, const DifferenceLogicStats & stats, const DifferenceLogicStats & expected) {
             println(cerr,
-                "difference presolver detection {}: lifted {} over {} nodes, skipped {} not-two-terms, {} coefficients, {} reified, {} "
-                "negated-view, {} degenerate, {} unlabelled-comparison",
-                fixture, stats.edges_lifted, stats.nodes, stats.skipped_not_two_terms, stats.skipped_coefficients, stats.skipped_reified,
-                stats.skipped_negated_view, stats.skipped_degenerate, stats.skipped_unlabelled_comparison);
+                "difference presolver detection {}: lifted {} ({} half-reified) over {} nodes, skipped {} not-two-terms, {} coefficients, {} "
+                "reified, {} negated-view, {} degenerate, {} unlabelled-comparison",
+                fixture, stats.edges_lifted, stats.half_reified_edges_lifted, stats.nodes, stats.skipped_not_two_terms, stats.skipped_coefficients,
+                stats.skipped_reified, stats.skipped_negated_view, stats.skipped_degenerate, stats.skipped_unlabelled_comparison);
             check_count("edges lifted", expected.edges_lifted, stats.edges_lifted, fixture);
+            check_count("half-reified edges lifted", expected.half_reified_edges_lifted, stats.half_reified_edges_lifted, fixture);
             check_count("nodes", expected.nodes, stats.nodes, fixture);
             check_count("skipped: not two terms", expected.skipped_not_two_terms, stats.skipped_not_two_terms, fixture);
             check_count("skipped: coefficients", expected.skipped_coefficients, stats.skipped_coefficients, fixture);
@@ -384,11 +443,13 @@ namespace
             p.post(LinearLessThanEqual{WeightedSum{} + 2_i * x[0] + -1_i * x[1], 4_i});
             // Two terms, both positive.
             p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + 1_i * x[1], 9_i});
-            // Half-reified: the row is emitted under HalfReifyOnConjunctionOf, so
-            // lifting it as unconditional would be unsound.
-            p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -2_i, b == 1_i});
-            // Fully reified, likewise.
+            // Fully reified: the two halves are emitted under the roles r and f
+            // rather than under the empty role, so neither is the row this
+            // lifts, and both are counted rather than guessed at. (Half-reified
+            // `If` donors *are* lifted, and are exercised in the corpus above
+            // and in reified_donors below.)
             p.post(LinearLessThanEqualIff{WeightedSum{} + 1_i * x[1] + -1_i * x[2], -2_i, b == 1_i});
+            p.post(LinearGreaterThanEqualIff{WeightedSum{} + 1_i * x[2] + -1_i * x[3], 2_i, b == 1_i});
             // A negated view.
             p.post(LinearLessThanEqual{WeightedSum{} + 1_i * (-x[0]) + -1_i * x[1], 1_i});
             // Aliasing, and a constant operand.
@@ -418,6 +479,38 @@ namespace
                     .skipped_negated_view = 1,
                     .skipped_degenerate = 2,
                     .skipped_unlabelled_comparison = 2});
+        }
+
+        // Half-reified donors, in every shape the propagator distinguishes: two
+        // real conditional edges, one conditional edge that is degenerate (and
+        // so left to the donor, since its `!cond' is exactly what the donor
+        // already infers), one conditional edge with a constant operand, and one
+        // conditional negated view that must be refused just as the
+        // unconditional one is.
+        {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable_vector(4, 0_i, 6_i, "x");
+            auto b = p.create_integer_variable(0_i, 1_i, "b");
+
+            p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i, b == 1_i});
+            p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * x[1] + -1_i * x[2], -1_i, b == 0_i});
+            p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * x[0] + -1_i * x[0], -1_i, b == 1_i});
+            p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * x[2] + -1_i * constant_variable(4_i), 1_i, b == 1_i});
+            p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * (-x[0]) + -1_i * x[1], 1_i, b == 1_i});
+            // One unconditional edge as well, so the mixture is what is
+            // installed and the donor-disabling rule has something to bite on.
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[2] + -1_i * x[3], -1_i});
+
+            p.add_presolver(DifferenceLogic{stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
+            check("reified_donors", *stats,
+                DifferenceLogicStats{.edges_lifted = 3,
+                    .half_reified_edges_lifted = 2,
+                    .nodes = 4,
+                    .propagator_installed = true,
+                    .skipped_negated_view = 1,
+                    .skipped_degenerate = 2});
         }
 
         // A single edge is a degeneracy, not a threshold: over one edge the


### PR DESCRIPTION
Part 3 of #571: half-reified difference edges, `b -> x - y <= d`.

**Based on #587** (`difflogic-05-rcpsp`), which is this PR's base branch, so the
diff shown here is only this PR's six commits.

The stack used to fork at #588 and merge back in here, because work item 6
extended `examples/rcpsp_max`, which lived on the sibling #587. That example is
gone — folded into `examples/rcpsp` by the `rcpsp-unify` prep PR — and #587 has
shrunk to a flag addition, so the fork and its merge commit have been
linearised away: the chain is now #588 → #587 → this.

## Why this one

#587 found that the paper's RCPSP/max headline does not reproduce *in shape* in
gcs: on `--infeasible` instances both variants report `recursions: 1`, because
gcs runs root propagation to a fixpoint and so the decomposed model also refutes
at the root, just at Θ(horizon) cost. The stated reason was that the paper's
baseline searches because its disjunctive resources contribute *half-reified*
difference constraints, and we had none. This PR adds them, so the claim could be
tested. **It half-reproduces, and the other half turns out to say something
useful about the paper** — see the measurement section.

## Semantics: deliberately not `IncImp`

> An edge with a condition participates in the graph exactly while that
> condition currently holds. Nothing is ever inferred the other way.

Inferring a condition *from* the graph is the paper's `IncImp`, whose own
configuration study is its most strongly supported finding: on RCPSP/max every
configuration with it on scored below every configuration with it off.

Three shapes fall out of the existing canonicalisation:

| Canonical form | Unconditional | With condition `b` |
|---|---|---|
| two distinct variables | graph edge | graph edge, active while `b` holds |
| one constant operand | static bound | bound applied while `b` holds, citing `b` |
| `0 <= d`, `d < 0` | root contradiction | **`!b` is inferred** |

The last row is a soundness obligation, not a nicety: `b -> 0 <= -1` says `!b`,
and quietly dropping the edge would return solutions in which `b` holds and the
constraint is violated. It is handled in the propagator rather than by an
initialiser, because the row saturates directly to the unit clause `~b` so plain
RUP suffices — and because a presolver has no initialiser available.

## The reason, which is the whole soundness question

**A negative cycle** cites the conditions of every conditional edge on it, and
nothing else; the unconditional case keeps its empty reason. Deduplicated,
because the same Boolean legitimately appears on more than one edge (a
disjunctive encoding makes that the normal case) and a repeated literal would
render a malformed proof line.

**A bound push** cites the predecessor's bound and *this edge's* condition only.
That is not an omission. Inferences are made **per edge along the predecessor
forest, never per path**, so the predecessor's bound was either already there
when the call started or was itself inferred moments earlier carrying its own
edge's condition in its own reason. The conditions along a whole path are cited
by the *chain* of inferences, and each individual link is a standalone entailment
of exactly one OPB row — which is what makes each link's RUP check on its own.

## The proof: one `saturate`, and the honest note about it

A row emitted under `HalfReifyOnConjunctionOf` carries a big-M term on `~b` which
does not telescope. Everything else does, so summing a cycle leaves
`Σ M_i·~b_i >= -W` and one `s` turns it into the clause. Emitted:

```
pol @c[_1][e0] @c[_1][e2] + @c[_1][e1] + s ;
rup 1 ~i[_4][b0] 1 ~i[_5][b0] >= 1;
```

which is verbatim the shape hand-verified against real gcs OPB output in
`reified.opb` / `reified_hand.pbp` before any of this was written. With one
Boolean shared between all three edges it closes with `rup 1 ~i[_4][b0] >= 1;` —
the deduplication showing up in the proof.

Two mutation results, both recorded in the comments:

* **the reason is load-bearing** — omitting a condition fails VeriPB on the
  reified fixtures;
* **the `saturate` is not** — removing it leaves every reified fixture
  verifying, because the closing RUP assumes every condition and drives each
  residual to zero. It is emitted anyway so the derived line *is* the clause
  rather than a big-M encoding of it. The bound push deliberately does **not**
  saturate: same argument for why it is unnecessary, plus saturating would clamp
  `BinEnc(v)`'s own coefficients against the degree.

## Triggers

`on_change` on each distinct condition variable, which is the coarsest trigger
gcs offers that is guaranteed to catch a condition becoming true: `on_bounds`
misses `x != v` becoming true by an interior removal, and `on_instantiated` fires
strictly less often still (`x >= v` can become true long before `x` is fixed).
Waking on a condition becoming *false* is not needed — an inactive edge simply
does not participate — but `on_change` cannot distinguish the directions.

## The round bound survives, because the edge set is snapshotted

Both existing arguments (the `n - 1` round bound, and the totality of the
predecessor walk) are statements about **one Bellman-Ford run over one fixed edge
set**, and mention nothing about provenance. So the only new obligation is that
the edge set really is fixed for the duration of a call, and it is: the active
edges are snapshotted once at the top. The snapshot also stays *correct* as
inferences land, which is what licenses citing a snapshotted condition in a
reason later — a definitely-true literal holds for every value in the domain and
so for every value in any subset of it, and this propagator only shrinks domains.

## Presolver: the `If` rows really are citable

Checked, not assumed. `linear_inequality.cc` labels the unconditional and the
`If` forms **identically** — `add_labelled_constraint(id, "", …)`, i.e.
`@c[<id>]` — and differs only in passing `HalfReifyOnConjunctionOf`. So the `If`
row is citable and is exactly the shape the propagator's proofs assume, unlike
`Comparison`'s unconditional rows.

`MustNotHold`, `NotIf` and `Iff` are difference constraints too, and stay in
`skipped_reified` only because each needs a *different* row of the donor's output
(the integer negation, or the `r`/`f` halves).

**Half-reified donors are never retired.** `disabling_lifted_donors()` rests on
subsumption, and subsumption fails for them in one direction: a
`LinearLessThanEqualIf` also infers `!cond` from its own bounds, and the global
propagator makes no inference about a condition at all. The tripwire asserts both
halves — something must be disabled when an unconditional edge was lifted,
nothing may be when every lifted edge is conditional.

## The unconditional path is byte-identical

`.opb`, `.pbp`, `.scp` and `.varmap` all compare equal before and after, across
`difference_test views` (fixed seed), `difference_chain -n 6` in both modes and
all three variants, and `rcpsp` in both variants.

## Measurement: does the search shape move?

`--unary=difference` posts a capacity-1 resource as the pairwise disjunctive
decomposition in reified difference constraints, which is the paper's modelling.
`--variant=presolved` is the like-for-like comparison (donors kept, global
propagator added), so its search tree cannot move relative to `decomposed`.

First, correctness: `--unary=cumulative`, `disjunctive` and `difference` give the
identical optimal makespan on every generated instance tried.

**The search reproduces.** With `--max-lag-slack 0` the negative cycle runs
through conditional edges, so it closes only after orderings are decided. `n=10`,
one capacity-1 resource:

| seed | status | recursions (dec / presolved / global) |
|---:|---|---|
| 1 | unsat | 1 / 1 / 1 |
| 3 | unsat | 1 / 1 / 1 |
| 4 | unsat | 11 / 11 / 39 |
| 5 | unsat | 9 / 9 / 23 |
| 6 | unsat | 3 / 3 / 33 |
| 7 | unsat | 73 / 73 / 179 |

Seeds 4–7 are exactly the case the paper's baseline is in: infeasible, but only
conditionally, and gcs genuinely searches. (Seeds 1 and 3 still refute at the
root, which must be the temporal network alone doing it — at the root no
condition is fixed, so no conditional edge is in the graph.)

**The root refutation does not, and now we can say exactly why.** To detect that
*every* setting of the Booleans closes a cycle, the propagator would have to
reason over edges whose conditions are unfixed — which is `IncImp`, or in the
paper the **root simplification stage**, whose Johnson's-APSP pass does exactly
that Boolean fixing once at the root. Neither is implemented, deliberately.

So the honest reading is that **the paper's RCPSP/max unsatisfiability headline
belongs to its root simplification stage, not to `IncSat`/`IncLB`/`IncUB`** —
consistent with its own §6.3 numbers (320.95 vs 312.94 overall; ProdCons 637.50
vs 573.40).

**What half-reified edges do buy is the cost win extended to the disjunctive part
of the model, unbounded in the horizon.** Same instance (`n=10`, seed 5), horizon
forced:

| horizon | variant | recursions | propagations | `.pbp` lines | time (s) |
|---:|---|---:|---:|---:|---:|
| 200 | decomposed | 23 | 16,137 | 25,862 | 0.00723 |
| 200 | presolved | 23 | **185** | **610** | 0.00089 |
| 200 | global | 23 | **24** | **259** | 0.00069 |
| 800 | decomposed | 23 | 71,607 | 113,834 | 0.0300 |
| 800 | presolved | 23 | **185** | **610** | 0.00091 |
| 800 | global | 23 | **24** | **259** | 0.00064 |
| 3,200 | decomposed | 23 | 293,241 | 463,786 | 0.126 |
| 3,200 | presolved | 23 | **185** | **610** | 0.00095 |
| 3,200 | global | 23 | **24** | **259** | 0.00067 |

Linear in the horizon against flat, with `recursions` identical down every
column.

**One column does move at narrow horizons, and it is worth naming.**
`--variant=global` searches more than `decomposed` (39 vs 11, 179 vs 73). That is
not a defect in the global propagator, it is the missing half of
half-reification: `global` has no donors, and a `LinearLessThanEqualIf` donor
infers `!cond` from its own bounds. This is `IncImp`'s absence showing up as a
search-tree cost rather than as a lost root refutation — and it is the concrete
argument for reconsidering `IncImp` *for gcs specifically* even though the paper
measures it as a loss, since the paper's baseline always keeps the donor and
never pays this. It also disappears once the horizon is wide enough that the
donors' bound-driven inference stops firing early.

## Two performance defects this introduced, and how they were caught

Both were found by benchmarking `examples/difference_chain --variant=global` at
`n = 640` against the table already in `dev_docs/difference-logic.md`, not by
inspection — and **both left the propagation and recursion counts identical**, so
nothing except wall clock would have caught either.

* **`optional<IntegerVariableCondition>` is 64 bytes**, which took
  `DifferenceGraphEdge` from 32 to 96. The relaxation loop scans the whole edge
  array once per round, so that is 3× the memory traffic of the innermost loop,
  and it cost exactly that: **0.32 s → 0.93 s**. The struct stays the convenient
  *construction* type; `install_difference_propagator` now repacks it once into a
  32-byte arc array plus a parallel condition array read only on cold paths. A
  `static_assert` pins the arc size.
* **Going through the active-edge snapshot unconditionally** is a second level of
  indirection in the same loop, worth another **45%** (0.32 s → 0.47 s). An
  unconditional system now scans the arcs straight through, with the branch
  outside the per-edge loop so the conditional case pays nothing either.

`--variant=global` at `n = 640` is back to **0.332 s** against the 0.323 s
measured before half-reification existed, and `--variant=presolved` to 0.395 s
against 0.459 s.

## Testing

Release and Sanitize, caps off (`GCS_TEST_CAP_DEFAULTS=OFF`). `ctest --preset
release -j 12`: **560/560 pass**, no failures. New `difference_constraint_reified`
and `difference_constraint_random_reified` modes, four reified presolver
fixtures across all three configurations, and three `rcpsp-machine-difference`
proof-verification entries. VeriPB on everything.

The **negative control** is called out because it is the bug this change most
plausibly introduces: an edge whose condition is fixed false must leave its
operands' domains untouched, asserted on bounds rather than on solution counts,
and confirmed by mutation that dropping the condition test fails it immediately.

## One harness defect this exposed

CI runs with `GCS_TEST_CAP_DEFAULTS` **on**; a propagator developer's build has it
off (as `dev_docs/constraints.md` instructs). `run_test` posts each system twice
— once as `DifferenceConstraints`, once as one linear per edge — and requires the
two solution sets to be identical. `check_results` already copes with a capped
run on its own; the *cross-check* could not, because two truncated runs stop
after the same **number** of solutions, not the same **set**:

```
[truncated run: 300 of <= 563 solutions checked sound]
difference reified chain_conds: global and decomposed models disagree
global has 300 solutions, decomposed has 300
```

The hazard was already latent — the existing `random` mode could hit it — but
the reified modes made it certain, since two extra condition variables multiply
the solution count by four. The cross-check is now skipped (and says so) when
either solve was truncated, and `chain_conds` is narrowed to 186 solutions so the
deterministic reified mode keeps its cross-check even in a capped run. Verified
green with caps on *and* off.

## Also worth knowing

The paper's §4.1 "this is a domain propagator" claim assumes no Boolean appears
in two difference constraints, which every disjunctive encoding violates by
construction. That is a **completeness** caveat only — soundness is unaffected,
and this is a bounds-consistent propagator in any case — and it is stated in the
docs and in the class comment rather than silently inherited.
`difference_test reified negcycle_shared_cond` pins the sound-regardless part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lx8KBTVNSg44EEcVYcBoN

