### PR TITLE
Solve an optimisation .scp as one, and make maximisation chain-verifiable

### DIFF
--- a/dev_docs/workflow2_testing.md
+++ b/dev_docs/workflow2_testing.md
@@ -24,7 +24,12 @@ document is exactly four tagged sections, in order:
 
 `prob_type` is the bare atom `decide` or `enumerate`, or the list
 `(minimize var)` / `(maximize var)`. `innards::write_scp` emits this and
-`gcs::read_scp` consumes it; the reader rejects any version other than 1
+`gcs::read_scp` consumes it, returning an objective as
+`ScpModel::minimise_variable` (a `(maximize V)` comes back as the negated view,
+mirroring `Problem::optional_minimise_variable()`) without posting it, so that
+enumerating an optimisation document stays possible — `glasgow_scp_solver` is
+the caller that hands it to `Problem::minimise()`. The reader rejects any
+version other than 1
 outright rather than guessing at an unknown grammar, which is what makes a
 future format change a clean failure instead of a misread. Upstream's reference
 for the format lives outside this repo (cake's `SEXP_FORMAT.md`); the reader is

--- a/dev_docs/workflow2_testing.md
+++ b/dev_docs/workflow2_testing.md
@@ -28,8 +28,18 @@ document is exactly four tagged sections, in order:
 `ScpModel::minimise_variable` (a `(maximize V)` comes back as the negated view,
 mirroring `Problem::optional_minimise_variable()`) without posting it, so that
 enumerating an optimisation document stays possible — `glasgow_scp_solver` is
-the caller that hands it to `Problem::minimise()`. The reader rejects any
-version other than 1
+the caller that hands it to `Problem::minimise()`.
+
+For the chain to check a maximisation at all, the two ends have to agree on how
+the objective is *encoded*, not just what it is. cake re-derives `(maximize V)`
+as `min: -1 i[V][b0] -2 i[V][b1] ...` over V's own bits, so an offset-free
+negated objective — exactly what `Problem::maximise()` stores — is deviewed the
+same way rather than being hosted on its own proof-only bit vector
+(`ProofModel::write_preamble`). A hosted vector is invisible to cake, and the
+solver's proof would cite view-linking labels (`@c[neg_view_of_V][viewle]`)
+that cake's OPB has no counterpart for, failing the chain on an unknown label.
+
+The reader rejects any version other than 1
 outright rather than guessing at an unknown grammar, which is what makes a
 future format change a clean failure instead of a misread. Upstream's reference
 for the format lives outside this repo (cake's `SEXP_FORMAT.md`); the reader is

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -691,14 +691,27 @@ auto ProofModel::write_preamble() -> void
     // register it now (this appends BinEnc(V)'s set-up rows to the pending
     // text, where they land just after the variable rows). This also
     // guarantees find_view succeeds for the objective later, e.g. in the
-    // solution-logging soli path. The exception is a view whose bit vector
-    // cannot be represented at all -- negating a FlatZinc unbounded-int
-    // objective spans one more bit than an Integer holds -- which stays
-    // unregistered, and min: falls back to deviewing through the underlying.
+    // solution-logging soli path. There are two exceptions, both of which stay
+    // unregistered so that min: falls back to deviewing through the underlying:
+    //
+    //  - a view whose bit vector cannot be represented at all -- negating a
+    //    FlatZinc unbounded-int objective spans one more bit than an Integer
+    //    holds;
+    //
+    //  - a plain negation, which is what Problem::maximise() stores. Its bit
+    //    vector would be an extra proof-only variable that cake_pb_cp cannot
+    //    know about: cake re-derives a `(maximize V)` .scp as `min: -1 i[V][b0]
+    //    ...` straight over V's own bits, so an objective hosted on its own
+    //    vector leaves the solver's proof citing view-linking labels that
+    //    cake's OPB has no counterpart for, and the workflow-2 chain cannot
+    //    check a maximisation at all. Deviewing writes exactly cake's line.
+    //    Only the offset-free case is done this way: `then_add` shifts the
+    //    objective by a constant that the deviewed min: cannot carry, and the
+    //    .scp cannot express either (it renders as a bare `(maximize V)`).
     if (_imp->optional_minimise_variable)
         if (auto * view = std::get_if<ViewOfIntegerVariableID>(&*_imp->optional_minimise_variable)) {
             auto [v_lo, v_hi] = names_and_ids_tracker().view_bounds(*view);
-            if (bits_encoding_fits(v_lo, v_hi))
+            if (bits_encoding_fits(v_lo, v_hi) && ! (view->negate_first && view->then_add == 0_i))
                 static_cast<void>(names_and_ids_tracker().need_view(*view));
         }
 

--- a/gcs/scp_reader.cc
+++ b/gcs/scp_reader.cc
@@ -53,6 +53,8 @@
 
 using std::map;
 using std::move;
+using std::nullopt;
+using std::optional;
 using std::span;
 using std::string;
 using std::string_view;
@@ -68,14 +70,24 @@ ScpReadError::ScpReadError(const string & w) : MessageException("Error reading .
 
 namespace
 {
-    auto as_integer(const SExpr & e) -> Integer
+    // The atom's value if it is an integer, nullopt if it is some other atom.
+    // Callers that must have an integer use as_integer; the objective needs to
+    // tell "an integer constant" from "a name", without either being an error.
+    auto optional_integer(const SExpr & e) -> optional<Integer>
     {
         const auto & a = e.as_atom();
         long long value;
         auto [ptr, ec] = std::from_chars(a.data(), a.data() + a.size(), value);
         if (ec != std::errc{} || ptr != a.data() + a.size())
-            throw ScpReadError{"expected an integer, got '" + a + "'"};
+            return nullopt;
         return Integer{value};
+    }
+
+    auto as_integer(const SExpr & e) -> Integer
+    {
+        if (auto value = optional_integer(e))
+            return *value;
+        throw ScpReadError{"expected an integer, got '" + e.as_atom() + "'"};
     }
 
     // The children of a list term, or a clear error if `e` is an atom. `what`
@@ -652,14 +664,21 @@ namespace
         return {resolve_variable(variables, pair[0]), as_integer(pair[1])};
     }
 
+    // An objective from a (prob_type ...) section, before its operand has been
+    // resolved: the section is checked before any variable is created (so that
+    // a malformed document leaves `problem` untouched), but resolving needs the
+    // variables map, which does not exist until afterwards.
+    struct ObjectiveSpec
+    {
+        bool maximize;
+        SExpr variable;
+    };
+
     // (prob_type <spec>), where <spec> is the bare atom `decide` or `enumerate`,
-    // or the list (minimize var) / (maximize var). This reader enumerates
-    // whatever it is given, so the spec is checked but not acted on: honouring
-    // an objective would mean optimising instead of enumerating, which is the
-    // caller's decision to make. Checking it still matters -- the .scp is a
-    // contract with cake_pb_cp, and a spec quietly ignored here is one cake
-    // would reject downstream.
-    auto check_prob_type(const SExpr & section) -> void
+    // or the list (minimize var) / (maximize var). Checking this matters even
+    // for the bare atoms -- the .scp is a contract with cake_pb_cp, and a spec
+    // quietly ignored here is one cake would reject downstream.
+    auto check_prob_type(const SExpr & section) -> optional<ObjectiveSpec>
     {
         auto spec = section_items(section, "prob_type");
         if (spec.size() != 1)
@@ -669,17 +688,32 @@ namespace
             const auto & kind = spec[0].as_atom();
             if (kind != "decide" && kind != "enumerate")
                 throw ScpReadError{"unknown prob_type '" + kind + "'"};
-            return;
+            return nullopt;
         }
 
-        // An objective. The variable is left as an atom rather than resolved:
-        // the writer renders a constant objective as (minimize 3), so a name
-        // that isn't declared is legitimate here.
         const auto & parts = children_of(spec[0], "the prob_type specification");
         if (parts.size() != 2 || ! parts[0].is_atom() || (parts[0].as_atom() != "minimize" && parts[0].as_atom() != "maximize"))
             throw ScpReadError{"a prob_type objective is (minimize var) or (maximize var)"};
         if (! parts[1].is_atom())
             throw ScpReadError{"a prob_type objective's variable must be an atom"};
+        return ObjectiveSpec{parts[0].as_atom() == "maximize", parts[1]};
+    }
+
+    // The objective as a variable to minimise, mirroring what
+    // Problem::minimise() / Problem::maximise() would have stored -- so a
+    // caller can hand it straight back to Problem::minimise(), and so that
+    // reader and writer are inverses.
+    auto resolve_objective(const map<string, IntegerVariableID> & variables, const ObjectiveSpec & spec) -> IntegerVariableID
+    {
+        // The writer renders a constant objective as (minimize 3), so an
+        // undeclared atom is legitimate -- but only when it really is an
+        // integer. Anything else is a typo, and silently turning it into a
+        // constant would optimise something the document never mentioned.
+        if (! variables.contains(spec.variable.as_atom()) && ! optional_integer(spec.variable))
+            throw ScpReadError{"the prob_type objective names an unknown variable '" + spec.variable.as_atom() + "'"};
+
+        auto variable = resolve_variable(variables, spec.variable);
+        return spec.maximize ? -variable : variable;
     }
 
     auto read_element_2d(Problem & problem, const map<string, IntegerVariableID> & variables, const vector<SExpr> & terms, const string & label)
@@ -700,7 +734,7 @@ namespace
     }
 }
 
-auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVariableID>
+auto gcs::read_scp(Problem & problem, string_view text) -> ScpModel
 {
     auto top = parse_s_expr(text);
     const auto & sections = children_of(top, "the top-level (version variables constraints prob_type) form");
@@ -717,8 +751,9 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
         throw ScpReadError{"unsupported .scp format version " + number.to_string() + ": this reader only accepts version 1"};
 
     // Check the trailing section before anything is posted, so a malformed
-    // document leaves `problem` untouched rather than half-built.
-    check_prob_type(sections[3]);
+    // document leaves `problem` untouched rather than half-built. Its objective
+    // can only be resolved once the variables exist, below.
+    auto objective = check_prob_type(sections[3]);
 
     map<string, IntegerVariableID> variables;
 
@@ -1025,5 +1060,6 @@ auto gcs::read_scp(Problem & problem, string_view text) -> map<string, IntegerVa
             throw ScpReadError{"unsupported constraint operator '" + op + "'"};
     }
 
-    return variables;
+    auto minimise_variable = objective.transform([&](const ObjectiveSpec & spec) { return resolve_objective(variables, spec); });
+    return ScpModel{move(variables), minimise_variable};
 }

--- a/gcs/scp_reader.hh
+++ b/gcs/scp_reader.hh
@@ -6,6 +6,7 @@
 #include <gcs/variable_id.hh>
 
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -25,6 +26,34 @@ namespace gcs
     };
 
     /**
+     * \brief What read_scp recovered from a `.scp` beyond the Problem it built:
+     * the variables by name, and the objective if the document had one.
+     *
+     * \ingroup Core
+     */
+    struct ScpModel
+    {
+        /**
+         * \brief A map from each variable's `.scp` name to its IntegerVariableID,
+         * so a caller can report solution values by name.
+         */
+        std::map<std::string, IntegerVariableID> variables;
+
+        /**
+         * \brief The objective variable, to minimise, or nullopt for a `decide`
+         * or `enumerate` document.
+         *
+         * This mirrors Problem::optional_minimise_variable(), so that reader and
+         * writer are inverses: a `(maximize V)` spec gives back the negated view
+         * of V, exactly what Problem::maximise() would have stored, and feeding
+         * it to Problem::minimise() reinstates the original objective. A
+         * constant objective (the writer renders one as `(minimize 3)`) comes
+         * back as a constant variable.
+         */
+        std::optional<IntegerVariableID> minimise_variable;
+    };
+
+    /**
      * \brief Populate `problem` from the `.scp` (s-expression CP) description in
      * `text`: create its variables and post its constraints.
      *
@@ -36,9 +65,14 @@ namespace gcs
      * The document is the four-section version-1 form `( (version 1) (variables
      * ...) (constraints ...) (prob_type ...) )`. All four sections are required,
      * in that order, and the version must be exactly 1 — anything else is
-     * rejected rather than guessed at. The `prob_type` spec is validated but not
-     * acted on: this reader always enumerates, so honouring an objective is left
-     * to the caller.
+     * rejected rather than guessed at.
+     *
+     * An objective in the `prob_type` section is resolved and returned, but is
+     * deliberately *not* posted to `problem`: setting it would commit the caller
+     * to optimising, and there is no way to unset it afterwards, so a caller who
+     * wants to enumerate an optimisation instance (as the workflow-2 chain
+     * harness does) could not. Call Problem::minimise() with
+     * ScpModel::minimise_variable to honour it.
      *
      * Only a subset of constraints is supported so far (`abs`, `all_different`,
      * `in`, the comparisons, the linear forms, `equals`/`not_equals`, `element`
@@ -46,10 +80,9 @@ namespace gcs
      * being silently dropped. Throws ScpReadError (or SExprParseError) on
      * malformed input.
      *
-     * \returns A map from each variable's `.scp` name to its IntegerVariableID,
-     * so a caller can report solution values by name.
+     * \returns The variables by name, and the objective if there was one.
      */
-    auto read_scp(Problem & problem, std::string_view text) -> std::map<std::string, IntegerVariableID>;
+    auto read_scp(Problem & problem, std::string_view text) -> ScpModel;
 }
 
 #endif

--- a/gcs/scp_reader_test.cc
+++ b/gcs/scp_reader_test.cc
@@ -69,7 +69,7 @@ namespace
     auto enumerate(string_view scp) -> set<map<string, long long>>
     {
         Problem problem;
-        auto variables = read_scp(problem, scp);
+        auto variables = read_scp(problem, scp).variables;
 
         set<map<string, long long>> solutions;
         solve_with(problem, //
@@ -939,10 +939,11 @@ TEST_CASE("read_scp: a constant integer can stand in for a variable anywhere")
 TEST_CASE("read_scp: constraint labels and variable names round-trip via the map")
 {
     Problem problem;
-    auto variables = read_scp(problem, "( (version 1) (variables (X 0 1) (Y 0 1)) (constraints (_1 abs X Y)) (prob_type enumerate) )");
-    CHECK(variables.size() == 2);
-    CHECK(variables.contains("X"));
-    CHECK(variables.contains("Y"));
+    auto model = read_scp(problem, "( (version 1) (variables (X 0 1) (Y 0 1)) (constraints (_1 abs X Y)) (prob_type enumerate) )");
+    CHECK(model.variables.size() == 2);
+    CHECK(model.variables.contains("X"));
+    CHECK(model.variables.contains("Y"));
+    CHECK_FALSE(model.minimise_variable);
 }
 
 TEST_CASE("read_scp: a solver-written .scp survives write -> read -> write unchanged")
@@ -1030,12 +1031,13 @@ TEST_CASE("read_scp: all four sections are required, labelled and in order")
     CHECK_THROWS_AS(enumerate("( (version 1) (variables (X 0 1)) (constraint) (prob_type enumerate) )"), ScpReadError);
 }
 
-TEST_CASE("read_scp: the prob_type spec is checked, but this reader always enumerates")
+TEST_CASE("read_scp: the prob_type spec is checked, and a malformed one throws")
 {
-    // decide / enumerate are bare atoms and the objectives are lists. Every one
-    // of them enumerates here -- optimising instead is the caller's decision --
-    // but a spec cake_pb_cp would reject must not pass silently either.
+    // decide / enumerate are bare atoms and the objectives are lists. None of
+    // them is posted to the Problem, so all four still enumerate here -- but a
+    // spec cake_pb_cp would reject must not pass silently either.
     CHECK(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type decide) )").size() == 3);
+    CHECK(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type enumerate) )").size() == 3);
     CHECK(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type (minimize X)) )").size() == 3);
     CHECK(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type (maximize X)) )").size() == 3);
 
@@ -1044,4 +1046,79 @@ TEST_CASE("read_scp: the prob_type spec is checked, but this reader always enume
     CHECK_THROWS_AS(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type (minimize)) )"), ScpReadError);
     CHECK_THROWS_AS(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type (minimize X Y)) )"), ScpReadError);
     CHECK_THROWS_AS(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type) )"), ScpReadError);
+
+    // An objective naming something that is neither a declared variable nor an
+    // integer constant is a typo. Optimising a constant conjured out of the name
+    // would silently solve a different problem.
+    CHECK_THROWS_AS(enumerate("( (version 1) (variables (X 0 2)) (constraints) (prob_type (minimize Q)) )"), ScpReadError);
+}
+
+TEST_CASE("read_scp: the objective comes back as a variable to minimise")
+{
+    // The objective is resolved but not posted: the caller decides whether to
+    // optimise, so a Problem read from an optimisation .scp still enumerates
+    // until Problem::minimise() is called with what came back.
+    auto solve_objective = [](string_view scp) {
+        Problem problem;
+        auto model = read_scp(problem, scp);
+        REQUIRE(model.minimise_variable);
+        problem.minimise(*model.minimise_variable);
+
+        map<string, long long> best;
+        solve_with(problem, //
+            SolveCallbacks{ //
+                .solution = [&](const CurrentState & state) -> bool {
+                    best.clear();
+                    for (const auto & [name, id] : model.variables)
+                        best.emplace(name, state(id).raw_value);
+                    return true;
+                }});
+        return best;
+    };
+
+    // 2X + Y = 10 and P = X * Y: the product is largest at (2, 6) and (3, 4),
+    // and smallest at either end of the line.
+    auto scp = [](string_view sense) {
+        return "( (version 1) (variables (X 0 10) (Y 0 10) (P 0 100)) (constraints (_1 lin_equals (2 X 1 Y) 10) (_2 multiply X Y P)) (prob_type (" +
+            string{sense} + " P)) )";
+    };
+
+    CHECK(solve_objective(scp("maximize")).at("P") == 12);
+    CHECK(solve_objective(scp("minimize")).at("P") == 0);
+
+    // A constant objective -- what the writer renders for Problem::minimise() of
+    // a constant -- resolves to a constant variable rather than being rejected
+    // as an undeclared name.
+    Problem problem;
+    auto model = read_scp(problem, "( (version 1) (variables (X 0 2)) (constraints) (prob_type (minimize 3)) )");
+    REQUIRE(model.minimise_variable);
+    CHECK(*model.minimise_variable == constant_variable(3_i));
+}
+
+TEST_CASE("read_scp: an objective survives write -> read -> write unchanged")
+{
+    // The reader's objective mirrors Problem::optional_minimise_variable(), so
+    // handing it back to Problem::minimise() must reproduce the same .scp --
+    // including for maximise, which is stored as a negated view and so is the
+    // case that a sense flip would silently break.
+    for (bool maximise : {false, true}) {
+        Problem original;
+        auto x = original.create_integer_variable(0_i, 4_i, "X");
+        auto y = original.create_integer_variable(0_i, 4_i, "Y");
+        original.post(LessThan{x, y});
+        if (maximise)
+            original.maximise(x);
+        else
+            original.minimise(x);
+        auto scp_a = prove_to_scp(original, "scp_reader_obj_a");
+
+        Problem rebuilt;
+        auto model = read_scp(rebuilt, scp_a);
+        REQUIRE(model.minimise_variable);
+        rebuilt.minimise(*model.minimise_variable);
+        auto scp_b = prove_to_scp(rebuilt, "scp_reader_obj_b");
+
+        CHECK(scp_a == scp_b);
+        CHECK(scp_a.contains(maximise ? "(prob_type (maximize X))" : "(prob_type (minimize X))"));
+    }
 }

--- a/scp/glasgow_scp_solver.cc
+++ b/scp/glasgow_scp_solver.cc
@@ -8,7 +8,6 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
-#include <map>
 #include <string>
 
 #include <cxxopts.hpp>
@@ -29,7 +28,6 @@ using std::cout;
 using std::ifstream;
 using std::istreambuf_iterator;
 using std::make_optional;
-using std::map;
 using std::nullopt;
 using std::string;
 
@@ -45,6 +43,10 @@ using fmt::println;
 // .scp is the *input* (e.g. produced by another solver's --prove, or by a
 // higher-level translator), and with --prove the run emits a proof that, via
 // cake_pb_cp, is verified against that same .scp. See gcs/scp_reader.hh.
+//
+// A `(prob_type (minimize V))` / `(maximize V)` document is solved as the
+// optimisation problem it says it is, so `--prove` on one yields an
+// optimisation proof rather than an enumeration of every feasible solution.
 auto main(int argc, char * argv[]) -> int
 {
     cxxopts::Options options("glasgow_scp_solver", "Solve a .scp (s-expression CP) problem");
@@ -56,7 +58,7 @@ auto main(int argc, char * argv[]) -> int
             ("prove", "Create a proof")                                      //
             ("proof-files-basename", "Basename for the .opb and .pbp files", //
                 cxxopts::value<string>()->default_value("scp"))              //
-            ("all", "Find all solutions rather than just the first")         //
+            ("all", "Find all solutions (implied by an objective)")          //
             ("stats", "Print solve statistics")                              //
             ("file", "The .scp file to solve", cxxopts::value<string>())     //
             ;
@@ -85,20 +87,30 @@ auto main(int argc, char * argv[]) -> int
     string text{istreambuf_iterator<char>{infile}, istreambuf_iterator<char>{}};
 
     Problem problem;
-    map<string, IntegerVariableID> variables;
+    ScpModel model;
     try {
-        variables = read_scp(problem, text);
+        model = read_scp(problem, text);
     }
     catch (const std::exception & e) {
         println(cerr, "Error: {}", e.what());
         return EXIT_FAILURE;
     }
 
-    bool find_all = options_vars.contains("all");
+    // read_scp resolves an objective but leaves posting it to us, so that a
+    // caller who wants to enumerate an optimisation instance still can. Here we
+    // honour it: the .scp says what problem it is, and solving something else
+    // would be answering a different question.
+    if (model.minimise_variable)
+        problem.minimise(*model.minimise_variable);
+
+    // With an objective, every solution is just the next bound on the way to
+    // the optimum, so the search must run to completion however --all is set;
+    // the last solution printed is the optimal one.
+    bool find_all = options_vars.contains("all") || model.minimise_variable.has_value();
     auto stats = solve_with(problem, //
         SolveCallbacks{              //
             .solution = [&](const CurrentState & state) -> bool {
-                for (const auto & [name, id] : variables)
+                for (const auto & [name, id] : model.variables)
                     print("{}={} ", name, state(id));
                 println("");
                 return find_all;

--- a/verified_encodings/run_scp_chain.bash
+++ b/verified_encodings/run_scp_chain.bash
@@ -43,6 +43,19 @@ CAKE_PB_CP=${CAKE_PB_CP:-cake_pb_cp}
 have() { command -v "$1" >/dev/null 2>&1; }
 verified() { grep -qE '^s VERIFIED' <<< "$1"; }
 
+# A case whose .scp carries an objective must come back as an *optimality*
+# proof. A bare "s VERIFIED" would mean the objective went missing somewhere --
+# the solver not posting it, or the re-emitted .scp losing it -- and the run
+# enumerated instead, which every check below would happily accept.
+optimisation_case() { grep -qE '\(prob_type +\((minimize|maximize)' "$scp"; }
+check_bounds() {
+    if optimisation_case && ! grep -qE '^s VERIFIED BOUNDS' <<< "$1"; then
+        echo "FAIL: $(basename "$scp") has an objective, but the proof is not an optimality proof"
+        echo "$1"
+        exit 1
+    fi
+}
+
 [[ -x "$solver" ]] || { echo "SKIP: glasgow_scp_solver not built at '$solver'"; exit 77; }
 have veripb || { echo "SKIP: veripb not on PATH"; exit 77; }
 
@@ -59,6 +72,7 @@ if ! have "$CAKE_PB_CP"; then
     echo "[fallback] cake_pb_cp not on PATH (set CAKE_PB_CP to override); workflow-1 self-verify only"
     out=$(veripb "${base}.opb" "${base}.pbp" 2>&1)
     if ! verified "$out"; then echo "FAIL: self-verify"; tail -5 <<< "$out"; exit 1; fi
+    check_bounds "$out"
     grep -E '^s VERIFIED' <<< "$out"
     dispose_proof "${base}"
     echo "OK: workflow-1 self-verify passed for $(basename "$scp") (cake_pb_cp absent)"
@@ -76,6 +90,7 @@ if ! verified "$out"; then echo "FAIL: veripb did not verify"; tail -5 <<< "$out
 echo "[4] cake_pb_cp: re-check the elaborated core (the verified step)"
 core_out=$("$CAKE_PB_CP" "${base}.scp" "${base}.corepb")
 if ! verified "$core_out"; then echo "FAIL: cake_pb_cp rejected the core"; tail -5 <<< "$core_out"; exit 1; fi
+check_bounds "$core_out"
 echo "$core_out"
 
 echo "[5] opbdiff oracle (mode: $opbdiff_mode)"

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -43,6 +43,18 @@ add_scp_chain_test(lin_greater_equal_unsat  strict)
 add_scp_chain_test(multi_comparison_unsat   strict)  # two interacting comparisons
 add_scp_chain_test(multi_mixed_unsat        strict)  # comparison + linear together
 
+# strict: the third proof shape, optimisation. Every other case here is a
+# refutation or a complete enumeration; this one carries a `(prob_type (minimize
+# X))`, which glasgow_scp_solver posts as the objective, so the chain checks an
+# `s VERIFIED BOUNDS` optimality proof rather than a `preserved:` enumeration.
+# There is deliberately no `maximize` twin: Problem::maximise() stores a negated
+# view, so the solver's OPB materialises a `p[0_neg_view_of_p]` variable and its
+# proof cites the view-linking labels, while cake re-derives the objective as
+# `min: -1 i[X][b0] ...` straight over X's own bits and has no such constraint to
+# cite -- step 3 fails on the unknown label. Conforming the solver's objective
+# encoding to cake's would fix it; until then maximisation is workflow-1 only.
+add_scp_chain_test(lin_equals_minimize_opt  strict)
+
 # strict: not_equals' single selector is now named b[id][ne] with cake's
 # polarity (selector TRUE = gt half, FALSE = lt half), via the
 # create_proof_flag(ConstraintID, annotation) overload -- the first consumer of

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -44,16 +44,18 @@ add_scp_chain_test(multi_comparison_unsat   strict)  # two interacting compariso
 add_scp_chain_test(multi_mixed_unsat        strict)  # comparison + linear together
 
 # strict: the third proof shape, optimisation. Every other case here is a
-# refutation or a complete enumeration; this one carries a `(prob_type (minimize
-# X))`, which glasgow_scp_solver posts as the objective, so the chain checks an
-# `s VERIFIED BOUNDS` optimality proof rather than a `preserved:` enumeration.
-# There is deliberately no `maximize` twin: Problem::maximise() stores a negated
-# view, so the solver's OPB materialises a `p[0_neg_view_of_p]` variable and its
-# proof cites the view-linking labels, while cake re-derives the objective as
-# `min: -1 i[X][b0] ...` straight over X's own bits and has no such constraint to
-# cite -- step 3 fails on the unknown label. Conforming the solver's objective
-# encoding to cake's would fix it; until then maximisation is workflow-1 only.
-add_scp_chain_test(lin_equals_minimize_opt  strict)
+# refutation or a complete enumeration; these carry a `(prob_type (minimize X))`
+# / `(maximize X)`, which glasgow_scp_solver posts as the objective, so the
+# chain checks an `s VERIFIED BOUNDS` optimality proof rather than a
+# `preserved:` enumeration. The maximise case is the one that pins the objective
+# encoding down: Problem::maximise() stores a negated view, and hosting that on
+# its own proof-only bit vector would leave the proof citing view-linking labels
+# cake's OPB has no counterpart for, so an offset-free negated objective is
+# deviewed into cake's `min: -1 i[X][b0] ...` form instead (ProofModel::
+# write_preamble). Without that these two would not even share a min: line.
+add_scp_chain_test(lin_equals_minimize_opt      strict)
+add_scp_chain_test(lin_equals_maximize_opt      strict)
+add_scp_chain_test(lin_equals_maximize_neg_opt  strict)  # sign bit inside the objective
 
 # strict: not_equals' single selector is now named b[id][ne] with cake's
 # polarity (selector TRUE = gt half, FALSE = lt half), via the

--- a/verified_encodings/scp_cases/lin_equals_maximize_neg_opt.scp
+++ b/verified_encodings/scp_cases/lin_equals_maximize_neg_opt.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (X -3 3) (Y -3 3)) (constraints (_1 lin_equals (1 X 1 Y) 0)) (prob_type (maximize X)) )

--- a/verified_encodings/scp_cases/lin_equals_maximize_opt.scp
+++ b/verified_encodings/scp_cases/lin_equals_maximize_opt.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (X 0 3) (Y 0 3)) (constraints (_1 lin_equals (1 X 1 Y) 3)) (prob_type (maximize X)) )

--- a/verified_encodings/scp_cases/lin_equals_minimize_opt.scp
+++ b/verified_encodings/scp_cases/lin_equals_minimize_opt.scp
@@ -1,0 +1,1 @@
+( (version 1) (variables (X 0 3) (Y 0 3)) (constraints (_1 lin_equals (1 X 1 Y) 3)) (prob_type (minimize X)) )


### PR DESCRIPTION
`read_scp` validated a `(prob_type (minimize V))` / `(maximize V)` spec and then discarded it, and returned only the name → `IntegerVariableID` map — so a caller could not learn the objective even in principle. `glasgow_scp_solver` therefore enumerated every feasible solution of an optimisation instance, silently.

The practical consequence: an optimisation proof was unreachable from a `.scp` input. Workflow 2 could only ever be driven over refutations and enumerations, and getting an optimisation proof out of the solver meant rebuilding the model against the C++ API instead.

## 1. Surfacing the objective

`read_scp` returns an `ScpModel`: the same variables map, plus the objective as `minimise_variable`. That mirrors `Problem::optional_minimise_variable()`, so reader and writer are inverses — a `(maximize V)` comes back as the negated view `Problem::maximise()` would have stored, and feeding it to `Problem::minimise()` reinstates the original objective, `.scp` and all.

The reader deliberately does **not** post the objective. Setting it commits the caller to optimising, with no way to unset it, so the chain harness — which enumerates whatever it is handed — could no longer do its job. `glasgow_scp_solver` is the caller that honours it, and with an objective it runs to the optimum however `--all` is set, since every solution before the last is just a bound on the way there.

An objective naming something that is neither a declared variable nor an integer constant is now an error. The constant form is legitimate (the writer renders `Problem::minimise()` of a constant as `(minimize 3)`), but a bare unknown name is a typo, and optimising a constant conjured from it would solve a different problem.

## 2. Making maximisation chain-verifiable

Surfacing the objective exposed a second gap. `Problem::maximise()` stores a negated view, and `ProofModel::write_preamble` hosted that view on its own proof-only bit vector: `min:` ran over `p[0_neg_view_of_p][sign|b0..]`, linked to `i[p]` by `@c[neg_view_of_p][viewle]`/`[viewge]`, and the objective-improving steps cited those labels. cake has no view variables — it re-derives a `(maximize V)` `.scp` as `min: -1 i[V][b0] -2 i[V][b1] ...` over V's own bits — so it had nothing to match: veripb stopped at `The label @po[0][ge1][r] is not assigned to a constraint ID`.

An offset-free negated objective is now left unregistered, so `min:` takes the deviewing path that already existed for a view too wide to host a bit vector (a FlatZinc unbounded-int objective), which writes exactly cake's line. Nothing else needed a special case: `emit_inequality_to` and the `soli` witness already fall back to the underlying's bits for an unregistered view. An *offset* view keeps its own vector — `then_add` shifts the objective by a constant a deviewed `min:` cannot carry, and the `.scp` cannot express it either.

Smaller proofs fall out of it: one fewer bit vector and its link rows. On the AM-GM instance (`2x + y = 10`, `p = xy`, maximise `p`), OPB 82 → 76 lines and proof 771 → 719.

## Effect

```
$ glasgow_scp_solver --prove ex.scp        # (prob_type (maximize p))
p=0 x=0 y=10
p=8 x=1 y=8
p=12 x=2 y=6
$ veripb ex.opb ex.pbp
s VERIFIED BOUNDS -12 <= obj <= -12
```

and the full chain, over both senses, neither of which was expressible before:

```
cake_pb_cp ex.scp > verifiedopb
veripb verifiedopb ex.pbp --elaborate corepb   ->  s VERIFIED BOUNDS -12 <= obj <= -12
cake_pb_cp ex.scp corepb                       ->  s VERIFIED BOUNDS 12 <= OBJ <= 12
```

## Testing

- `read_scp` returns the objective and optimises correctly once posted, for both senses; a constant objective resolves to a constant variable; an objective survives write → read → write unchanged (the maximise case is the one a sense flip would silently break).
- Three new chain cases, all `strict`, so the optimisation OPBs byte-match cake's rather than merely chain-verifying: `lin_equals_minimize_opt`, `lin_equals_maximize_opt`, and `lin_equals_maximize_neg_opt` (a sign bit inside the objective — the case two's complement could break). These are the first chain cases that are neither a refutation nor an enumeration.
- `run_scp_chain.bash` now requires an objective case to produce an *optimality* proof. Without that check a dropped objective sails through every step of the chain as a complete enumeration — confirmed by probing with a solver patched to skip `Problem::minimise()`, which the check turns into a loud failure (`s VERIFIED COMPLETE ENUMERATION OF 4 SOLUTIONS` → FAIL).
- Full suite 534/534 with `cake_pb_cp` on `PATH`, so the chain lanes run for real. The in-tree maximisers (knapsack, cake, p_dispersion, random_polynomial, and the `minizinc-cake` / `minizinc-knapsack` lanes) all still self-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)