### PR TITLE
Difference logic: root simplification (#571)

### DIFF
--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -7,8 +7,8 @@ negative-cycle extraction is total, the canonicalisation rule and why it exists,
 the two proof shapes with worked examples, half-reified edges
 (`b -> x - y <= d`) and what they cost in the reason and in the proof, the
 defects in the source paper's pseudocode, the presolver that lifts an
-already-posted model into the same propagator, and what is deliberately
-deferred.
+already-posted model into the same propagator, the root simplification stage,
+and what is deliberately deferred.
 
 The source is Kletzander, Dekker, Schutt and Stuckey, *Global Difference
 Constraint Propagation for Constraint Programming*, arXiv:2607.20022 — the
@@ -955,6 +955,317 @@ propagator:
   tables above a clean comparison. With conditional edges they do not, and a
   table that reports only propagations would hide the regression above.
 
+## Root simplification
+
+The paper's section 5.2 runs a one-off pass over the graph before search, and its
+section 6.3 measures that pass as most of the difference-logic win: 320.95 against
+312.94 on the MiniZinc challenge set, 637.50 against 573.40 on `ProdCons`, and on
+`RCPSP/max` an average unsatisfiability time *below 0.01 s* because "most of these
+instances are identified during simplification". The section above on half-reified
+resources argued, from measurement, that the RCPSP/max headline has to belong to
+this stage rather than to `IncSat`/`IncLB`/`IncUB`. This section is that stage,
+and the argument turns out to be right.
+
+It is on by default and can be turned off from either entry point:
+
+```cpp
+problem.post(DifferenceConstraints{edges}.simplifying_at_root(false));
+problem.add_presolver(DifferenceLogic{}.simplifying_at_root(false));
+```
+
+Both also take `reporting_simplification_to(shared_ptr<DifferenceSimplificationStats>)`,
+which is how the tests and the example binaries tell "worked" from "did nothing".
+
+### Where it runs, and why it is not an initialiser
+
+It runs **inside the propagator, on its first call**. That is not where one would
+first reach for. An initialiser would be the natural home for the posted
+constraint — but a presolver runs *after* `propagators.initialise()`, so an
+initialiser it installed would never fire, and `Presolver::run` is handed a
+`State &` and a `ProofLogger *` but no inference tracker, so it cannot infer
+anything itself either. Fixing a condition is an inference. So the only place
+that works for both entry points is the propagator, and putting it there means
+one implementation and one set of proof shapes rather than two.
+
+Two guards make that safe:
+
+- **it runs once**, latched by a flag in the propagator's own (mutable) state;
+- **only if that first call is at the root**, tested by `state.guesses()` being
+  empty.
+
+The second is not decoration. Everything the stage concludes is *permanent* —
+edges leave the internal graph and never come back, and no part of it is trailed
+— so doing it under a decision would keep conclusions that hold only under that
+decision. That would be a completeness bug in the general case and an
+**unsoundness** in the case of an edge dropped because a conditional path implied
+it, and no proof would ever complain, because losing propagation is invisible to
+a proof. In practice the first call is always at the root (search begins by
+propagating everything, before any decision), so the guard costs nothing and
+buys the argument.
+
+Not trailing is then justified, and by exactly the argument that puts the paper's
+own section 5.3/5.4 boundary where it is: every conclusion drawn here is a
+statement about the *graph*, and backtracking does not change the graph. The
+stage reads no domain. The one thing that looks like a domain read — testing
+whether a condition currently holds — is a read of a fact fixed at the root and
+never undone.
+
+### The four sub-steps, and which are here
+
+Johnson's all-pairs shortest paths first: Bellman-Ford from the paper's imaginary
+source `v0` (seeding every potential at zero *is* that source's edge set, exactly
+as in the propagator's own passes), then one Dijkstra per node on the
+reduced-cost graph. `O(n² log n + nm)`, paid once. The pass computes nothing that
+needs certifying; only its four conclusions do, and only one of them turns out to
+need anything at all.
+
+**1. Redundant-edge removal — implemented, and no proof obligation whatsoever.**
+An active edge `u --d--> v` goes when `d > D_uv`, i.e. when a strictly shorter
+path already implies it. An implied (conditional) edge goes on the weaker test
+`d >= D_uv`, since one that merely restates a distance the base graph already has
+can never add anything even once its condition holds. Among parallel edges that
+*attain* the distance exactly one is kept, because dropping them all would change
+the distance.
+
+The crucial point, and the one the issue framed as a model change: **the edge is
+not removed from the model.** gcs separates `define_proof_model()` from
+`install_propagators()`, and this is a decision about the second. The OPB keeps
+every posted row, so there is nothing to certify, nothing to delete, and no
+brush with VeriPB's checked-deletion rule (Hoen et al., CPAIOR 2024). It also
+keeps workflow-2 chain verification intact, since `cake_pb_cp` re-derives the
+`.opb` from the `.scp` and knows nothing about our internal pruning. Deleting
+from the OPB instead would be sound for proving UNSAT and *unsound* for SAT and
+for optimisation, for no benefit at all.
+
+**2. Fixing a condition false — implemented, and the one real inference.** If
+adding `u --d--(b)--> v` would close a negative cycle — `d + D_vu < 0` — then `b`
+cannot hold. This is the sub-step that carries the paper's RCPSP/max result, and
+it is the deliverable of this PR.
+
+**3. Zero-weight-cycle unification — not implemented, but detected and counted.**
+See below.
+
+**4. Node removal — implemented, internal.** A node with no incident edge left
+cannot send or receive a bound, so it is dropped from the relaxation loop and,
+more usefully, from the round bound. In practice these are nodes that only ever
+appeared in a static bound.
+
+### The proof for condition fixing
+
+Proof shape 1 with the candidate edge standing in for the missing link. Sum the
+candidate's row and the witness path's rows: every `BinEnc` term telescopes away,
+because consecutive edges meet at a node and every row is in the canonical
+representation. What survives is the big-M residual of each *conditional* row,
+and the candidate's is always one of them, so
+
+```
+pol @c[_1][e1] @c[_1][e0] + s ;
+rup 1 ~i[_3][b0] >= 1;
+```
+
+is the whole thing, copied verbatim from the `fix_one` fixture: `e1` is the
+candidate `b -> x - y <= -5`, `e0` is the unconditional `y - x <= 2` that is the
+witness path, and `~i[_3][b0]` is the Boolean. That is the `reified_hand.pbp` shape verified by hand against
+real gcs OPB output before any of this existed, with the roles of the conditions
+swapped round: there the conditions were the residuals that survived into a
+learned clause, here the surviving residual *is* the literal being inferred.
+
+The witness path is taken from the shortest-path tree, so it may itself contain
+conditional edges — an edge whose condition the model fixed, or one an earlier
+round of this stage fixed. Their conditions are cited in the `Reason`,
+deduplicated, exactly as a negative cycle's are.
+
+Two mutation results, both measured:
+
+* **the `saturate` is not load-bearing** — removing it leaves every fixture
+  verifying, because the closing RUP assumes every condition and drives each
+  residual to zero. It is emitted anyway so the derived line *is* the clause;
+* **neither, here, are the path's conditions in the reason.** That is specific to
+  running at the root: a path condition is definitely true only because it is a
+  *globally derived* fact, so unit propagation recovers it and the RUP passes
+  without being told. They are cited regardless, because the reason is also what
+  the state and the nogood machinery see, and there a missing antecedent is not
+  recoverable.
+
+Emitted inside a `JustifyExplicitly` at `ProofLevel::Temporary`, like every other
+justification here. Nothing is emitted at `ProofLevel::Top`, and nothing needed
+to be: the inference itself is recorded by the inference tracker, and the
+redundant-edge and node removals leave no trace anywhere. **No new OPB content
+from either entry point**, which is enforced by byte-diff tests on both.
+
+### The fixpoint, and how the refutation actually happens
+
+Fixing a condition false makes its complement definitely true, which can put an
+edge *into* the base graph, which can license further fixing. So the stage
+iterates — the paper's section 5.3 — until a round fixes nothing. It terminates
+because every round either fixes at least one condition (removing an edge) or
+stops, and there are finitely many edges.
+
+On RCPSP/max the refutation turns out to arrive more directly than that. Both
+polarities of an ordering Boolean are separately impossible, so both are found
+fixable in the *same* round: the first is inferred, the second contradicts it,
+and the model is refuted before search starts. The counters then read one
+condition fixed in one round, because the second fix is the contradiction and
+unwinds before it can be counted — which is why they are published by a
+destructor rather than at the end of the stage.
+
+If instead the newly-activated edges jointly close a cycle, the next round's
+Bellman-Ford sees it, the stage stops, and the propagator's own pass refutes it
+with the cycle extraction and the telescoping `pol` that already exist. The stage
+deliberately does not duplicate that machinery.
+
+### This is `IncImp`, restricted to the root
+
+Fixing a condition because its edge would close a negative cycle is exactly the
+paper's `IncImp`, which its own configuration study says to leave off — on
+RCPSP/max every configuration with it on scored below every configuration with it
+off. That is not a contradiction: what the study measures is running it on **every
+wake**, and what this is is running it **once**, at the root, where its cost is
+`O(n² log n + nm)` in total rather than per propagation. The section above on
+half-reified resources noted that `IncImp`'s absence shows up in gcs as a
+*search-tree* cost, since `--variant=global` has no donors to infer `!cond` from
+bounds; the root-only version removes most of that without paying the per-wake
+price. Whether the in-search version pays for itself in gcs remains open.
+
+### RCPSP/max: the headline reproduces
+
+`examples/rcpsp --size 9 --machine-fraction 0.9 --max-lag-density 0.4
+--max-lag-slack 0 --machine difference`, the shape the half-reified section
+measured: a machine posted as conditional edges, on a network whose maximum lags
+are already tight. Every seed below is infeasible, and infeasible only
+*conditionally* — at the root no Boolean is fixed, so no conditional edge is in
+the graph at all, which is why neither the decomposed model nor the global
+propagator could see it.
+
+| seed | decomposed | presolved, no simp. | presolved | global, no simp. | global |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 3 | 3 | **1** | 3 | **1** |
+| 2 | 5 | 5 | **1** | 5 | **1** |
+| 3 | 5 | 5 | **1** | 5 | **1** |
+| 4 | 77 | 77 | **1** | 121 | **1** |
+| 5 | 1 | 1 | **1** | 1 | **1** |
+| 6 | 1,525 | 1,525 | **1** | 4,149 | **1** |
+| 7 | 55 | 55 | **1** | 75 | **1** |
+| 8 | 5 | 5 | **1** | 5 | **1** |
+
+(recursions; seed 5 was already refuted at the root by the temporal network
+alone.) Two things to read off it. The no-simplification global column is
+*worse* than decomposed in every row where the search is non-trivial — 4,149
+against 1,525 on seed 6 — which is `IncImp`'s absence again. And the
+simplification column is 1 everywhere, whatever the row above it was.
+
+Proofs shrink accordingly, and all of them verify:
+
+| instance | variant | `.pbp` lines | `.pbp` bytes | VeriPB (s) |
+|---|---|---:|---:|---:|
+| seed 4 | decomposed | 4,662 | 210,129 | 0.058 |
+| seed 4 | global, no simplification | 897 | 60,715 | 0.026 |
+| seed 4 | global | **60** | **1,548** | **0.018** |
+| seed 4 | presolved | 131 | 6,575 | 0.020 |
+| seed 6 | decomposed | 69,050 | 3,218,361 | 0.798 |
+| seed 6 | global, no simplification | 39,451 | 3,323,224 | 0.474 |
+| seed 6 | global | **32** | **769** | **0.018** |
+| seed 6 | presolved | 51 | 2,052 | 0.022 |
+
+So: **the paper's RCPSP/max unsatisfiability headline reproduces in shape, and it
+reproduces here and nowhere else in this stack.** #587 established that the
+decomposed model refutes at the root too, just expensively; #590 added
+half-reified resources and established that the search reproduces but the root
+refutation does not; this PR closes it. That sequence is the evidence for the
+claim, made in the half-reified section, that the headline belongs to the
+simplification stage rather than to the incremental algorithms.
+
+### What it costs where it does not pay
+
+`examples/difference_chain`, the paper's Example 8, is the opposite case and is
+worth stating plainly. `--variant=global --order unlucky --mode fixpoint`:
+
+| n | recursions | propagations | wall, no simp. (s) | wall (s) | Johnson's (s) | edges dropped |
+|---:|---:|---:|---:|---:|---:|---:|
+| 80 | 163 | 167 | 0.00167 | 0.00233 | 0.00050 | 79 |
+| 160 | 323 | 327 | 0.00817 | 0.01135 | 0.00328 | 159 |
+| 320 | 643 | 647 | 0.0477 | 0.0729 | 0.0234 | 319 |
+| 640 | 1,283 | 1,287 | 0.312 | 0.474 | 0.164 | 639 |
+
+`recursions` and `propagations` are identical down every column — which is the
+point, since redundant-edge removal and node removal are propagation-neutral by
+construction — and the entire wall-time difference is the Johnson's pass. It
+drops `n - 1` edges out of `n(n+5)/2`, i.e. essentially nothing, and costs 30 to
+50 % of the solve. `--mode refute` is the same, with the Johnson's pass accounting
+for the whole of a 0.117 s → 0.239 s regression at `n = 640` and nothing at all
+dropped.
+
+The pure-temporal scaling curve says the same more precisely
+(`--resources 0 --max-lag-density 0 --variant=global`, satisfiable, so Johnson's
+runs to completion):
+
+| n | nodes | edges | Johnson's (s) | solve (s) | recursions (both) |
+|---:|---:|---:|---:|---:|---:|
+| 100 | 101 | 230 | 0.00025 | 0.0028 | 12,834 |
+| 200 | 201 | 478 | 0.00110 | 0.0145 | 47,093 |
+| 400 | 401 | 957 | 0.00532 | 0.0910 | 188,322 |
+| 800 | 801 | 1,930 | 0.0238 | 0.625 | 757,354 |
+| 1,600 | 1,601 | 3,844 | 0.0989 | 4.51 | 3,082,344 |
+
+Sparse and satisfiable, the pass is quadratic-ish in `n` and around 2 % of the
+solve — cheap. Dense, as in `difference_chain`, the `nm` term dominates and it is
+not. That is the honest shape of the trade-off, and it is why the option exists
+and defaults on rather than being unconditional: the paper reports simplification
+as a clear win on its benchmark families, and it is a clear win on ours too, but
+"clear win" is a statement about scheduling models with conditional edges, not
+about difference systems in general.
+
+### Zero-weight-cycle unification, and why it is deferred
+
+The fourth sub-step is not implemented. It *is* detected: reduced weights are
+non-negative and a cycle's reduced weight is its real weight, so a cycle weighs
+zero exactly when every edge on it has reduced weight zero, and the
+strongly-connected components of that subgraph are the sets of variables the
+system pins into fixed relative positions. Tarjan over it is `O(n + m)` on data
+Johnson's has already produced, so the counters cost nothing and answer the
+question the deferral raises.
+
+They answer it in the affirmative, which is worth recording: on the
+`--max-lag-slack 0` RCPSP/max instances above there is one zero-weight cycle
+spanning **10 of the 11 nodes**, because exactly-tight maximum time lags are
+precisely a zero-weight cycle. On `difference_chain` and on the slack RCPSP/max
+instances there are none. So unification would fire, and hard, on the family this
+stage is aimed at.
+
+It is deferred for two reasons, neither of them about the proof.
+
+The proof side is settled and easy, and this is the issue's open question
+answered: the two directions of `x - y = d` are **pure `pol` consequences with
+unit multipliers** — the edge itself gives `x - y <= d`, and summing the rest of
+the cycle (weight `-d`) gives `y - x <= -d`. Aggregation, not redundance. **No
+`red`, no `dom`.** Nor does anything need to be pre-derived at `ProofLevel::Top`:
+the cycle's rows are already in the OPB, so a derivation that crosses a merged
+node can just add them to its own `pol`, which is the "one extra addend" story of
+`dev_docs/view-proof-logging.md` paid at `Temporary`.
+
+What is not cheap is the model side. Survey section 5.2 item 2 is emphatic that a
+`ViewOfIntegerVariableID` must **not** be retro-fitted onto an already-encoded
+user variable: gcs views are a model-construction concept, and
+`NamesAndIDsTracker::need_view` creates a view's own bit-vector and its
+definitional link row, which cannot happen after the model is finalised — and by
+the time this stage runs it has been. So the merged variables keep independent
+domains, and that is where the cost lands:
+
+- seeding the merged node means taking the maximum over its members' bounds, and
+  recording *which* member achieved it, since that member's bound is what the
+  reason must cite;
+- every push on the merged node must be inferred on **every** member separately,
+  each with its own `pol` carrying the zero-cycle path from the pushing edge's
+  endpoint to that member.
+
+So the graph gets smaller — which is the algorithmic win — but the number of
+`infer()` calls does not, and the bound-push justification, which is currently
+one row plus one literal, becomes one row plus one literal plus a path. That is a
+substantial rework of the two `infer_along_forest` passes for a win that has not
+been measured, and it is the only sub-step whose proof shape changes at all. It
+is left for a separate PR, with the counters above as the evidence that the PR is
+worth writing.
+
 ## Deliberately deferred
 
 - **Incrementality.** The paper's `IncSat` / `IncLB` / `IncUB` maintain a valid
@@ -979,14 +1290,9 @@ propagator:
 - **Lifting `Iff`, `NotIf` and `MustNotHold` linear donors**, which need the `r`
   and `f` rows and the integer-negation row respectively rather than the
   empty-role row the two supported kinds share.
-- **Root simplification** — Johnson's all-pairs shortest paths, then dropping
-  redundant edges, fixing Booleans whose edge would close a negative cycle, and
-  unifying variables on a zero-weight cycle. Note that dropping a redundant edge
-  is a decision about which *propagators run*, not about what the model says: the
-  OPB must always contain every posted constraint, so the removal has no proof
-  obligation at all. Its Boolean-fixing step is `IncImp` restricted to the root,
-  and the measurement below argues it is where the paper's RCPSP/max
-  unsatisfiability headline actually comes from.
+- **Zero-weight-cycle unification**, the fourth of the root simplification
+  stage's sub-steps. The other three are implemented; see the section on it
+  above, which also reports how often a zero-weight cycle actually turns up.
 - **Runtime propagator priorities.** The paper wants bound propagation at the
   lowest priority and Boolean propagation at the highest, as separate
   propagators. gcs has no runtime propagator priorities, only

--- a/examples/difference_chain/CMakeLists.txt
+++ b/examples/difference_chain/CMakeLists.txt
@@ -17,3 +17,7 @@ add_test(NAME difference_chain-global-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_
 # a Problem built in-process, not through a posted model.
 add_test(NAME difference_chain-presolved-fixpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-presolved-fixpoint $<TARGET_FILE:difference_chain> --mode fixpoint --variant presolved)
 add_test(NAME difference_chain-presolved-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-presolved-refute $<TARGET_FILE:difference_chain> --mode refute --variant presolved)
+
+# And with the root simplification stage off, which is the configuration the
+# difference_chain measurements say to prefer on a dense system.
+add_test(NAME difference_chain-global-refute-nosimplify COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-global-refute-nosimplify $<TARGET_FILE:difference_chain> --mode refute --variant global --simplify off)

--- a/examples/difference_chain/difference_chain.cc
+++ b/examples/difference_chain/difference_chain.cc
@@ -194,7 +194,8 @@ namespace
     // once. Both variants produce the same OPB rows for the same edges (one
     // labelled inequality per edge), so the proofs are directly comparable.
     auto post_edges(Problem & problem, const vector<DifferenceEdge> & edges, Variant variant, bool disable_donors,
-        const shared_ptr<DifferenceLogicStats> & presolver_stats) -> void
+        const shared_ptr<DifferenceLogicStats> & presolver_stats, bool simplify, const shared_ptr<DifferenceSimplificationStats> & simplification)
+        -> void
     {
         switch (variant) {
             using enum Variant;
@@ -203,9 +204,12 @@ namespace
             for (const auto & e : edges)
                 problem.post(LinearLessThanEqual{WeightedSum{} + 1_i * e.x + -1_i * e.y, e.d});
             if (variant == Presolved)
-                problem.add_presolver(DifferenceLogic{presolver_stats}.disabling_lifted_donors(disable_donors));
+                problem.add_presolver(DifferenceLogic{presolver_stats}
+                        .disabling_lifted_donors(disable_donors)
+                        .simplifying_at_root(simplify)
+                        .reporting_simplification_to(simplification));
             break;
-        case Global: problem.post(DifferenceConstraints{edges}); break;
+        case Global: problem.post(DifferenceConstraints{edges}.simplifying_at_root(simplify).reporting_simplification_to(simplification)); break;
         }
     }
 
@@ -263,6 +267,10 @@ auto main(int argc, char * argv[]) -> int
                 "With --variant=presolved, also retire the lifted constraints' own propagators, so "     //
                 "only the global one runs over them")                                                    //
             ("all", "Find all solutions rather than stopping at the first")                              //
+            ("simplify",                                                                                 //
+                "Run the difference-logic root simplification stage. On by default; --simplify=off "     //
+                "turns it off. Ignored under --variant=decomposed, which has no difference propagator",  //
+                cxxopts::value<string>()->default_value("on"))                                           //
             ;
 
         options_vars = options.parse(argc, argv);
@@ -345,6 +353,13 @@ auto main(int argc, char * argv[]) -> int
     if (*mode == Mode::Refute)
         edges.push_back(DifferenceEdge{x[n], y[0], -1_i});
 
+    auto simplify_name = options_vars["simplify"].as<string>();
+    if (simplify_name != "on" && simplify_name != "off") {
+        println(cerr, "Error: --simplify must be on or off, not '{}'.", simplify_name);
+        return EXIT_FAILURE;
+    }
+    auto simplify = (simplify_name == "on");
+
     auto disable_donors = options_vars.contains("disable-donors");
     if (disable_donors && *variant != Variant::Presolved) {
         println(cerr, "Error: --disable-donors only means anything with --variant=presolved.");
@@ -352,7 +367,8 @@ auto main(int argc, char * argv[]) -> int
     }
 
     auto presolver_stats = make_shared<DifferenceLogicStats>();
-    post_edges(problem, edges, *variant, disable_donors, presolver_stats);
+    auto simplification = make_shared<DifferenceSimplificationStats>();
+    post_edges(problem, edges, *variant, disable_donors, presolver_stats, simplify, simplification);
 
     // The lower-bound bump that starts the chase. Posted last, so that the
     // difference constraints are all in the queue ahead of it and the bump wakes
@@ -392,6 +408,15 @@ auto main(int argc, char * argv[]) -> int
     println("order: {}", order_name);
     println("mode: {}", mode_name);
     println("variant: {}", variant_name_given);
+    if (*variant != Variant::Decomposed) {
+        println("simplify: {}", simplify_name);
+        println("simplify_ran: {}", simplification->ran ? "yes" : "no");
+        println("simplify_seconds: {:.6f}", simplification->seconds);
+        println("simplify_redundant_edges_removed: {}", simplification->redundant_edges_removed);
+        println("simplify_conditions_fixed: {}", simplification->conditions_fixed);
+        println("simplify_isolated_nodes_removed: {}", simplification->isolated_nodes_removed);
+        println("simplify_zero_weight_cycles: {}", simplification->zero_weight_cycles);
+    }
     if (*variant == Variant::Presolved) {
         println("disable_donors: {}", disable_donors ? "yes" : "no");
         println("presolver_edges_lifted: {}", presolver_stats->edges_lifted);

--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -80,3 +80,13 @@ add_test(NAME rcpsp_machine_difference_global COMMAND ${GCS_BASH} ${CMAKE_SOURCE
     $<TARGET_FILE:rcpsp> --size 10 --seed 5 --machine-fraction 0.7 --machine difference --variant global)
 add_test(NAME rcpsp_machine_difference_presolved COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_machine_difference_presolved
     $<TARGET_FILE:rcpsp> --size 10 --seed 5 --machine-fraction 0.7 --machine difference --variant presolved)
+
+# The same conditional-edge instance with the root simplification stage off, so
+# the fallback path keeps being proof-checked. With the stage on, 14 redundant
+# edges go and 9 conditions are fixed before search; with it off the solver has
+# to find all of that itself, and those are two different proofs of the same
+# optimum.
+add_test(NAME rcpsp_machine_difference_nosimplify COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_machine_difference_nosimplify
+    $<TARGET_FILE:rcpsp> --size 10 --seed 5 --machine-fraction 0.7 --machine difference --variant global --simplify off)
+add_test(NAME rcpsp_machine_difference_presolved_nosimplify COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_machine_difference_presolved_nosimplify
+    $<TARGET_FILE:rcpsp> --size 10 --seed 5 --machine-fraction 0.7 --machine difference --variant presolved --simplify off)

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -347,6 +347,12 @@ auto main(int argc, char * argv[]) -> int
                 "network as one DifferenceConstraints; presolved posts it decomposed and lets "    //
                 "the DifferenceLogic presolver lift it back",                                      //
                 cxxopts::value<string>()->default_value("decomposed"))                             //
+            ("simplify",
+                "Run the difference-logic root simplification stage (Johnson's all-pairs shortest " //
+                "paths, then redundant-edge removal, condition fixing and node removal). On by "    //
+                "default; --simplify=off turns it off. Ignored under --variant=decomposed, which "  //
+                "has no difference propagator to simplify for",                                     //
+                cxxopts::value<string>()->default_value("on"))                                      //
             ;
 
         options_vars = options.parse(argc, argv);
@@ -467,6 +473,14 @@ auto main(int argc, char * argv[]) -> int
         return EXIT_FAILURE;
     }
 
+    auto simplify_name = options_vars["simplify"].as<string>();
+    if (simplify_name != "on" && simplify_name != "off") {
+        println(cerr, "Error: --simplify must be on or off, not '{}'.", simplify_name);
+        return EXIT_FAILURE;
+    }
+    auto simplify = (simplify_name == "on");
+    auto simplification = std::make_shared<DifferenceSimplificationStats>();
+
     // The temporal network. --variant decides how it reaches the solver, over
     // the identical edge list in the identical order, so a comparison between
     // the three is between the handling and nothing else.
@@ -522,7 +536,7 @@ auto main(int argc, char * argv[]) -> int
                 problem.post(LinearGreaterThanEqual{sum, e.d});
         }
         if (*variant == Presolved)
-            problem.add_presolver(DifferenceLogic{presolver_stats});
+            problem.add_presolver(DifferenceLogic{presolver_stats}.simplifying_at_root(simplify).reporting_simplification_to(simplification));
         break;
 
     case Global:
@@ -533,7 +547,7 @@ auto main(int argc, char * argv[]) -> int
             difference_edges.reserve(edges.size());
             for (const auto & e : edges)
                 difference_edges.push_back(DifferenceEdge{e.from, e.to, -e.d, e.cond});
-            problem.post(DifferenceConstraints{difference_edges});
+            problem.post(DifferenceConstraints{difference_edges}.simplifying_at_root(simplify).reporting_simplification_to(simplification));
         }
         break;
     }
@@ -678,6 +692,13 @@ auto main(int argc, char * argv[]) -> int
     if (*variant == Variant::Presolved) {
         println("presolver_edges_lifted: {}", presolver_stats->edges_lifted);
         println("presolver_nodes: {}", presolver_stats->nodes);
+    }
+    if (*variant != Variant::Decomposed) {
+        println("simplify: {}", simplify_name);
+        println("simplify_ran: {}", simplification->ran ? "yes" : "no");
+        println("simplify_redundant_edges_removed: {}", simplification->redundant_edges_removed);
+        println("simplify_conditions_fixed: {}", simplification->conditions_fixed);
+        println("simplify_isolated_nodes_removed: {}", simplification->isolated_nodes_removed);
     }
     println("critical path: {}", critical_path);
     println("horizon: {}", horizon);

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(glasgow_constraint_solver
         constraints/cumulative/cumulative.cc
         constraints/difference/difference_constraints.cc
         constraints/difference/difference_graph.cc
+        constraints/difference/difference_simplify.cc
         constraints/disjunctive/disjunctive.cc
         constraints/disjunctive_2d/disjunctive_2d.cc
         constraints/divide_modulus/divide_modulus.cc
@@ -306,7 +307,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
-    foreach(mode basic cycles views alias reified random random_reified)
+    foreach(mode basic cycles views alias reified simplify random random_reified)
         add_test(NAME difference_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_test> ${mode})
     endforeach()

--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -23,6 +23,7 @@ using std::make_unique;
 using std::map;
 using std::move;
 using std::optional;
+using std::shared_ptr;
 using std::size_t;
 using std::string;
 using std::to_string;
@@ -62,9 +63,24 @@ DifferenceConstraints::DifferenceConstraints(vector<DifferenceEdge> edges) : _ed
     }
 }
 
+auto DifferenceConstraints::simplifying_at_root(bool simplify) -> DifferenceConstraints &
+{
+    _simplify.enabled = simplify;
+    return *this;
+}
+
+auto DifferenceConstraints::reporting_simplification_to(shared_ptr<DifferenceSimplificationStats> stats) -> DifferenceConstraints &
+{
+    _simplify.stats = move(stats);
+    return *this;
+}
+
 auto DifferenceConstraints::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<DifferenceConstraints>(_edges);
+    auto result = make_unique<DifferenceConstraints>(_edges);
+    result->simplifying_at_root(_simplify.enabled);
+    result->reporting_simplification_to(_simplify.stats);
+    return result;
 }
 
 auto DifferenceConstraints::prepare(Propagators &, State &, ProofModel * const) -> bool
@@ -198,7 +214,7 @@ auto DifferenceConstraints::install_propagators(Propagators & propagators) -> vo
         return;
     }
 
-    install_difference_propagator(propagators, constraint_id(), move(_graph));
+    install_difference_propagator(propagators, constraint_id(), move(_graph), move(_simplify));
 }
 
 auto DifferenceConstraints::constraint_type() const -> string

--- a/gcs/constraints/difference/difference_constraints.hh
+++ b/gcs/constraints/difference/difference_constraints.hh
@@ -112,6 +112,11 @@ namespace gcs
         // first offending edge, for a future assertion hint to name.
         std::optional<std::size_t> _root_contradiction_posted_index;
 
+        // Whether to run the root simplification stage, and where to report what
+        // it did. On by default, unlike the presolver as a whole: the paper
+        // measures the simplification as most of the win.
+        innards::DifferenceSimplificationOptions _simplify;
+
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
@@ -119,6 +124,31 @@ namespace gcs
     public:
         explicit DifferenceConstraints(std::vector<DifferenceEdge> edges);
 
+        /**
+         * \brief Run (or do not run) the root simplification stage.
+         *
+         * On by default. Once, before search, Johnson's all-pairs shortest paths
+         * over the system says which edges a shorter path already implies (they
+         * stop being propagated, but stay in the model, so there is nothing to
+         * certify), which conditions would close a negative cycle if they held
+         * (they are fixed false, which is an inference and is proved), and which
+         * nodes are left with no edges. It is the paper's section 5.2, and its
+         * section 6.3 measures it as most of the difference-logic win --- but
+         * that is a claim about their solver, so it can be switched off here and
+         * checked rather than inherited.
+         */
+        auto simplifying_at_root(bool = true) -> DifferenceConstraints &;
+
+        /**
+         * \brief Share a stats block the simplification stage will fill in when
+         * it runs.
+         *
+         * Shared, not copied, so it survives Problem::post cloning the
+         * constraint, and it is filled in during the first propagation rather
+         * than at post time. A stage that silently did nothing would pass every
+         * other check there is, so these counters are what the tests assert on.
+         */
+        auto reporting_simplification_to(std::shared_ptr<DifferenceSimplificationStats>) -> DifferenceConstraints &;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -7,6 +7,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <optional>
 #include <random>
 #include <set>
@@ -27,6 +28,7 @@
 using std::cerr;
 using std::flush;
 using std::make_optional;
+using std::make_shared;
 using std::mt19937;
 using std::nullopt;
 using std::optional;
@@ -387,6 +389,276 @@ namespace
         println(cerr, " ok");
     }
 
+    // What a fixture expects the root simplification stage to have done. Only
+    // the fields that are set are checked, because a fixture usually pins one
+    // sub-step and would otherwise have to restate every other count.
+    //
+    // These assertions are the whole reason the counters exist. Redundant-edge
+    // removal, node removal and zero-cycle detection are all invisible from
+    // outside: they change no solution, no proof and no search tree. A stage
+    // that quietly did nothing at all would pass the solution-equivalence check,
+    // the recursion check, the OPB byte-diff and VeriPB. So "the counters say it
+    // fired" is the only thing standing between a working stage and a shipped
+    // no-op, and a failure here means the *stage* is broken, not that the
+    // expectation has gone stale.
+    struct SimplifyExpectation
+    {
+        optional<bool> ran = nullopt;
+        optional<size_t> rounds_at_least = nullopt;
+        optional<size_t> redundant_edges_removed = nullopt;
+        optional<size_t> conditions_fixed = nullopt;
+        optional<size_t> isolated_nodes_removed = nullopt;
+        optional<size_t> zero_weight_cycles = nullopt;
+        optional<size_t> nodes_on_zero_weight_cycles = nullopt;
+        optional<bool> base_negative_cycle = nullopt;
+        // Simplification is never allowed to make the search bigger. Set this
+        // when a fixture is one where fixing a condition should make it strictly
+        // smaller.
+        bool expect_fewer_recursions = false;
+    };
+
+    auto check_count(const string & name, const string & what, const optional<size_t> & expected, size_t actual) -> void
+    {
+        if (expected && *expected != actual)
+            throw UnexpectedException{"difference simplify " + name + ": the root simplification stage reported " + to_string(actual) + " " + what +
+                ", expected " + to_string(*expected) +
+                ". This is an assertion about the stage, not about the fixture: it fires when the stage stops doing its job, and a stage that "
+                "silently does nothing passes every other check in this file. Fix gcs/constraints/difference/difference_simplify.cc."};
+    }
+
+    // Solve the same system twice, once with the root simplification stage on
+    // and once with it off, and insist that the only thing that changed is how
+    // much searching it took.
+    //
+    // Redundant-edge removal, node removal and zero-cycle detection are
+    // propagation-neutral by construction, so on a fixture where no condition is
+    // fixed the recursion counts must be *equal*: a difference means an edge was
+    // dropped that was carrying propagation. Fixing a condition is strictly
+    // stronger, so on those fixtures the count may fall, and the fixture says so
+    // rather than the check quietly allowing it either way.
+    auto run_simplify_test(bool proofs, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges,
+        const SimplifyExpectation & expected) -> void
+    {
+        print(cerr, "difference simplify {} domains={} edges={}{}", name, domains, edges.size(), proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<tuple<vector<int>>> oracle, with, without;
+        build_expected(oracle, [&](const vector<int> & vals) { return satisfied(vals, edges); }, domains);
+
+        // Deliberately not solve_for_tests_with_callbacks: that wrapper applies
+        // the GCS_TEST_MAX_SOLUTIONS / GCS_TEST_MAX_RECURSIONS caps, and a run
+        // those truncate says nothing about completeness *and* reports a
+        // recursion count that is the cap rather than the search. Every fixture
+        // here is a handful of variables over a handful of values, so full
+        // enumeration is cheap and unconditional. \sa INCREMENTALITY-INVARIANTS
+        auto stats = make_shared<DifferenceSimplificationStats>();
+        auto solve_one = [&](bool simplify, set<tuple<vector<int>>> & into, const optional<string> & proof_name) -> unsigned long long {
+            Problem p;
+            auto vars = make_vars(p, domains);
+            vector<DifferenceEdge> posted;
+            for (const auto & e : edges)
+                posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
+            p.post(DifferenceConstraints{posted}.simplifying_at_root(simplify).reporting_simplification_to(simplify ? stats : nullptr));
+
+            // The same branching heuristic, from the same seed, in both runs, so
+            // that a difference in the recursion count is a difference in
+            // propagation and cannot be a difference in search order.
+            auto result = solve_with(p,
+                SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                                   into.emplace(extract_from_state(s, vars));
+                                   return true;
+                               },
+                    .branch = random_branch_with_optional_seed(p)},
+                proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+            return result.recursions;
+        };
+
+        auto with_recursions = solve_one(true, with, proofs ? make_optional("difference_simplify_" + name) : nullopt);
+        auto without_recursions = solve_one(false, without, nullopt);
+
+        println(cerr, " {} solutions, recursions {} -> {}, ran={} rounds={} redundant={} fixed={} isolated={} zerocycles={}/{} negcycle={} {:.6f}s",
+            oracle.size(), without_recursions, with_recursions, stats->ran, stats->rounds, stats->redundant_edges_removed, stats->conditions_fixed,
+            stats->isolated_nodes_removed, stats->zero_weight_cycles, stats->nodes_on_zero_weight_cycles, stats->base_negative_cycle, stats->seconds);
+
+        if (proofs)
+            verify_proof_and_clean_up("difference_simplify_" + name);
+
+        if (with != oracle)
+            throw UnexpectedException{"difference simplify " + name + ": simplification on disagrees with the oracle, " + to_string(with.size()) +
+                " solutions against " + to_string(oracle.size())};
+        if (without != oracle)
+            throw UnexpectedException{"difference simplify " + name + ": simplification off disagrees with the oracle, " + to_string(without.size()) +
+                " solutions against " + to_string(oracle.size())};
+
+        if (expected.ran && *expected.ran != stats->ran)
+            throw UnexpectedException{"difference simplify " + name + ": the root simplification stage " + (stats->ran ? "ran" : "did not run") +
+                ", and it was supposed to " + (*expected.ran ? "" : "not ") + "run"};
+        if (expected.rounds_at_least && stats->rounds < *expected.rounds_at_least)
+            throw UnexpectedException{"difference simplify " + name + ": the root simplification stage took " + to_string(stats->rounds) +
+                " rounds, expected at least " + to_string(*expected.rounds_at_least) +
+                ". Fewer rounds than that means it stopped before its fixpoint, so fixing a condition is no longer re-activating the edges that "
+                "fixing it makes definitely true."};
+        check_count(name, "redundant edges removed", expected.redundant_edges_removed, stats->redundant_edges_removed);
+        check_count(name, "conditions fixed", expected.conditions_fixed, stats->conditions_fixed);
+        check_count(name, "isolated nodes removed", expected.isolated_nodes_removed, stats->isolated_nodes_removed);
+        check_count(name, "zero weight cycles", expected.zero_weight_cycles, stats->zero_weight_cycles);
+        check_count(name, "nodes on zero weight cycles", expected.nodes_on_zero_weight_cycles, stats->nodes_on_zero_weight_cycles);
+        if (expected.base_negative_cycle && *expected.base_negative_cycle != stats->base_negative_cycle)
+            throw UnexpectedException{"difference simplify " + name + ": base_negative_cycle was " + to_string(stats->base_negative_cycle) +
+                ", expected " + to_string(*expected.base_negative_cycle)};
+
+        if (expected.expect_fewer_recursions) {
+            if (with_recursions >= without_recursions)
+                throw UnexpectedException{"difference simplify " + name + ": simplification took " + to_string(with_recursions) +
+                    " recursions against " + to_string(without_recursions) +
+                    " without it, but this fixture is one where fixing a condition at the root is supposed to remove search"};
+        }
+        else if (with_recursions != without_recursions)
+            throw UnexpectedException{"difference simplify " + name + ": simplification changed the search from " + to_string(without_recursions) +
+                " recursions to " + to_string(with_recursions) +
+                ". Redundant-edge removal, node removal and zero-cycle detection are propagation-neutral by construction, so a fixture that fixes "
+                "no condition must search identically. An edge that was carrying propagation has been dropped."};
+    }
+
+    auto run_simplify_tests(bool proofs) -> void
+    {
+        // Redundant edges. The direct edge is implied by the two-step path, so
+        // it stops being propagated; the model keeps it, and nothing else moves.
+        run_simplify_test(proofs, "redundant_direct", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(0), v(2), 0}},
+            SimplifyExpectation{.ran = true, .redundant_edges_removed = 1});
+
+        // Parallel edges: the weaker one is strictly implied, and of the two
+        // that attain the distance exactly one is kept --- dropping both would
+        // change the distance, which is why the tie is handled separately.
+        run_simplify_test(proofs, "redundant_parallel", {{0, 6}, {0, 6}}, {{v(0), v(1), 1}, {v(0), v(1), -2}, {v(0), v(1), -2}, {v(0), v(1), 3}},
+            SimplifyExpectation{.ran = true, .redundant_edges_removed = 3});
+
+        // A node that is only ever a static bound has no arcs at all, so it
+        // drops out of the relaxation loop and out of the round bound.
+        run_simplify_test(proofs, "isolated_node", {{0, 8}, {0, 8}, {0, 8}}, {{v(0), c(4), 3}, {v(1), v(2), -1}},
+            SimplifyExpectation{.ran = true, .isolated_nodes_removed = 1});
+
+        // A zero-weight cycle, which is what the unimplemented fourth sub-step
+        // would unify. Counted, so that "would it ever fire?" is a measurement.
+        run_simplify_test(proofs, "zero_cycle", {{0, 5}, {0, 5}}, {{v(0), v(1), -2}, {v(1), v(0), 2}},
+            SimplifyExpectation{.ran = true, .zero_weight_cycles = 1, .nodes_on_zero_weight_cycles = 2});
+        run_simplify_test(proofs, "zero_cycle_three", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), 0}},
+            SimplifyExpectation{.ran = true, .zero_weight_cycles = 1, .nodes_on_zero_weight_cycles = 3});
+        run_simplify_test(proofs, "no_zero_cycle", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), -1}, {v(1), v(2), -1}},
+            SimplifyExpectation{.ran = true, .zero_weight_cycles = 0, .nodes_on_zero_weight_cycles = 0});
+
+        // The deliverable. `b -> x - y <= -5` together with the unconditional
+        // `y - x <= 2` closes a cycle of weight -3, so b cannot hold, and saying
+        // so at the root removes the branch that would have discovered it.
+        run_simplify_test(proofs, "fix_one", {{0, 10}, {0, 10}, {0, 1}}, {{v(1), v(0), 2}, {v(0), v(1), -5, b(2)}},
+            SimplifyExpectation{.ran = true, .conditions_fixed = 1, .expect_fewer_recursions = true});
+
+        // The same, through a two-edge witness path, so the pol has three
+        // addends and the path is recovered from the shortest-path tree rather
+        // than being a single edge.
+        run_simplify_test(proofs, "fix_via_path", {{0, 10}, {0, 10}, {0, 10}, {0, 1}}, {{v(1), v(2), 1}, {v(2), v(0), 1}, {v(0), v(1), -5, b(3)}},
+            SimplifyExpectation{.ran = true, .conditions_fixed = 1, .expect_fewer_recursions = true});
+
+        // A conditional edge that does *not* close a cycle must be left alone.
+        // The negative control: a stage that fixed conditions too eagerly would
+        // lose solutions, and the oracle comparison above is what catches it.
+        run_simplify_test(proofs, "fix_none", {{0, 10}, {0, 10}, {0, 1}}, {{v(1), v(0), 5}, {v(0), v(1), -2, b(2)}},
+            SimplifyExpectation{.ran = true, .conditions_fixed = 0});
+
+        // The boundary: the cycle weighs exactly zero, so the condition is
+        // perfectly satisfiable and must not be touched. Changing the test from
+        // `< 0` to `<= 0` fixes b here and loses every solution with b true,
+        // which the oracle comparison catches immediately (confirmed by
+        // mutation).
+        run_simplify_test(proofs, "fix_boundary_zero", {{0, 10}, {0, 10}, {0, 1}}, {{v(1), v(0), 5}, {v(0), v(1), -5, b(2)}},
+            SimplifyExpectation{.ran = true, .conditions_fixed = 0});
+
+        // Both polarities of one Boolean, which is what a disjunctive resource
+        // contributes. Only the one that closes a cycle is fixed.
+        run_simplify_test(proofs, "fix_one_polarity", {{0, 10}, {0, 10}, {0, 1}},
+            {{v(1), v(0), 2}, {v(0), v(1), -5, b(2)}, {v(1), v(0), -1, b(2, 0)}},
+            SimplifyExpectation{.ran = true, .conditions_fixed = 1, .expect_fewer_recursions = true});
+
+        // Two independent Booleans, both fixable, in one round.
+        run_simplify_test(proofs, "fix_two", {{0, 10}, {0, 10}, {0, 10}, {0, 1}, {0, 1}},
+            {{v(1), v(0), 2}, {v(0), v(1), -5, b(3)}, {v(2), v(0), 1}, {v(0), v(2), -4, b(4)}},
+            SimplifyExpectation{.ran = true, .conditions_fixed = 2, .expect_fewer_recursions = true});
+
+        // The cascade, which is why the stage iterates rather than running once.
+        // b1's true edge closes a cycle against `y - x <= 1`, so b1 is false ---
+        // which makes b1's *false* edge `y - z <= -3` definitely active, and only
+        // then is there any path from x to z at all, which is what makes b2's
+        // edge close a cycle in its turn. Round one cannot see the second fix,
+        // because in round one z has no incoming edge.
+        //
+        // Confirmed by mutation: replacing the fixpoint loop with a single round
+        // leaves b2 unfixed and this fails on the count.
+        run_simplify_test(proofs, "fix_cascade", {{0, 10}, {0, 10}, {0, 10}, {0, 1}, {0, 1}},
+            {{v(1), v(0), 1}, {v(0), v(1), 2}, {v(0), v(1), -5, b(3)}, {v(1), v(2), -3, b(3, 0)}, {v(2), v(0), -1, b(4)}},
+            SimplifyExpectation{.ran = true, .rounds_at_least = 3, .conditions_fixed = 2, .expect_fewer_recursions = true});
+    }
+
+    // The paper's RCPSP/max headline, in miniature: two unit-capacity tasks
+    // whose maximum time lags are tight enough that neither can precede the
+    // other. Every setting of the ordering Boolean closes a negative cycle, so
+    // the model is infeasible --- but at the root no Boolean is fixed and so no
+    // conditional edge is in the graph, which is exactly why #590 measured that
+    // the propagator alone cannot see it and #587 before it.
+    //
+    // The simplification stage can, and the way it does is worth stating because
+    // it is simpler than expected. Both polarities of the ordering Boolean are
+    // separately impossible, so both are found fixable in the *same* round: the
+    // first is inferred, the second contradicts it, and the model is refuted
+    // before search starts. So the counters read one condition fixed in one
+    // round --- the second fix is the contradiction, and never gets counted,
+    // which is also why the counters are published by a destructor rather than
+    // at the end of the stage.
+    auto run_root_refutation_test() -> void
+    {
+        print(cerr, "difference root refutation:");
+        cerr << flush;
+
+        auto solve_one = [&](bool simplify, DifferenceSimplificationStats & into) -> pair<unsigned long long, unsigned long long> {
+            Problem p;
+            auto s_i = p.create_integer_variable(0_i, 20_i, "s_i");
+            auto s_j = p.create_integer_variable(0_i, 20_i, "s_j");
+            auto before = p.create_integer_variable(0_i, 1_i, "before");
+            auto stats = make_shared<DifferenceSimplificationStats>();
+            p.post(DifferenceConstraints{{// maximum time lags, in both directions: the two starts are within 2 of each other
+                                             DifferenceEdge{s_j, s_i, 2_i}, DifferenceEdge{s_i, s_j, 2_i},
+                                             // the unary resource, as a disjunction over durations of 4
+                                             DifferenceEdge{s_i, s_j, -4_i, before == 1_i}, DifferenceEdge{s_j, s_i, -4_i, before == 0_i}}}
+                    .simplifying_at_root(simplify)
+                    .reporting_simplification_to(stats));
+
+            auto result = solve_with(p, SolveCallbacks{.branch = random_branch_with_optional_seed(p)});
+            into = *stats;
+            return {result.recursions, result.solutions};
+        };
+
+        DifferenceSimplificationStats on, off;
+        auto [on_recursions, on_solutions] = solve_one(true, on);
+        auto [off_recursions, off_solutions] = solve_one(false, off);
+
+        println(cerr, " recursions {} -> {}, solutions {}/{}, fixed={} rounds={} negcycle={}", off_recursions, on_recursions, off_solutions,
+            on_solutions, on.conditions_fixed, on.rounds, on.base_negative_cycle);
+
+        if (0 != on_solutions || 0 != off_solutions)
+            throw UnexpectedException{"difference root refutation: the fixture is supposed to be unsatisfiable"};
+        if (! on.ran)
+            throw UnexpectedException{"difference root refutation: the simplification stage did not run at all"};
+        if (1 != on.conditions_fixed)
+            throw UnexpectedException{"difference root refutation: the simplification stage recorded " + to_string(on.conditions_fixed) +
+                " conditions fixed, expected exactly 1: both polarities of the ordering Boolean close a cycle against the maximum time lag, the "
+                "first is inferred and the second is the contradiction, which unwinds before it can be counted"};
+        if (1 != on_recursions)
+            throw UnexpectedException{"difference root refutation: with simplification the model must be refuted at the root, in " +
+                to_string(on_recursions) + " recursions rather than 1"};
+        if (off_recursions <= on_recursions)
+            throw UnexpectedException{"difference root refutation: without simplification the solver is supposed to have to search, and it took " +
+                to_string(off_recursions) + " recursions"};
+    }
+
     auto run_all_tests(bool proofs, const string & mode) -> void
     {
         if (mode == "basic") {
@@ -594,6 +866,15 @@ auto main(int argc, char * argv[]) -> int
     if (mode == "reified") {
         run_reified_bounds_test();
         run_reified_degenerate_test();
+    }
+    if (mode == "simplify") {
+        run_root_refutation_test();
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            run_simplify_tests(proofs);
+        }
+        return EXIT_SUCCESS;
     }
 
     for (bool proofs : {false, true}) {

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/difference/difference_graph.hh>
+#include <gcs/constraints/difference/difference_simplify.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
@@ -11,6 +12,7 @@
 #include <util/overloaded.hh>
 
 #include <algorithm>
+#include <chrono>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -23,6 +25,9 @@ using std::nullopt;
 using std::optional;
 using std::size_t;
 using std::vector;
+using std::chrono::duration;
+using std::chrono::steady_clock;
+using std::ranges::count;
 using std::ranges::find;
 using std::ranges::find_if;
 
@@ -50,6 +55,32 @@ namespace
     };
 
     static_assert(sizeof(DifferenceArc) <= 32, "the difference-logic relaxation loop scans this array once per round; keep it small");
+
+    // Publishes the simplification counters on the way out, whichever way out it
+    // is.
+    //
+    // The stage can raise a contradiction in the middle of its own work, and
+    // that is not an edge case: it is the *best* outcome it has. Fixing one
+    // polarity of an ordering Boolean and then finding that the other polarity
+    // is equally impossible is a root refutation, and the inference tracker
+    // signals it by unwinding out of the propagator. Counters assigned at the
+    // end of the block would be lost exactly on the runs that most need
+    // explaining, so a destructor publishes them instead --- and times the stage
+    // while it is there, since the paper is explicit that its one-off cubic cost
+    // should be reported separately rather than folded into the solve.
+    struct DifferenceSimplificationReporter
+    {
+        DifferenceSimplificationStats & stats;
+        const std::shared_ptr<DifferenceSimplificationStats> & report_to;
+        steady_clock::time_point started = steady_clock::now();
+
+        ~DifferenceSimplificationReporter()
+        {
+            stats.seconds = duration<double>(steady_clock::now() - started).count();
+            if (report_to)
+                *report_to = stats;
+        }
+    };
 }
 
 auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> optional<DeviewedDifferenceOperand>
@@ -66,7 +97,8 @@ auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> o
         .visit(var);
 }
 
-auto gcs::innards::install_difference_propagator(Propagators & propagators, const ConstraintID & constraint_id, DifferenceGraph graph) -> void
+auto gcs::innards::install_difference_propagator(
+    Propagators & propagators, const ConstraintID & constraint_id, DifferenceGraph graph, DifferenceSimplificationOptions simplify) -> void
 {
     if (graph.edges.empty() && graph.static_bounds.empty() && graph.disallowed_conditions.empty())
         return;
@@ -127,11 +159,24 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             arc_conditions.push_back(e.cond);
     }
 
+    // Read before the capture list moves the node vector out from under it.
+    auto number_of_nodes = graph.nodes.size();
+
+    // The root simplification stage mutates `arcs`, `arc_conditions` and
+    // `round_bound` in place, once, on the first call --- hence the `mutable`
+    // below, which is the only mutable propagator state in this file. It is safe
+    // without trailing for the same reason the paper's section 5.3 boundary is
+    // where it is: the stage runs only at the root, before any decision, and
+    // every conclusion it draws (this edge is implied by a path of unconditional
+    // or root-fixed edges; this node has no edges left) is a statement about the
+    // *graph*, which no amount of backtracking changes. Nothing here reads a
+    // domain.
     propagators.install(
         constraint_id,
         [nodes = move(graph.nodes), arcs = move(arcs), arc_conditions = move(arc_conditions), static_bounds = move(graph.static_bounds),
-            disallowed_conditions = move(graph.disallowed_conditions),
-            edge_lines = move(graph.edge_lines)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            disallowed_conditions = move(graph.disallowed_conditions), edge_lines = move(graph.edge_lines), simplify = move(simplify),
+            simplification_pending = true,
+            round_bound = number_of_nodes](const State & state, auto & inference, ProofLogger * const logger) mutable -> PropagatorState {
             auto n = nodes.size();
             auto m = arcs.size();
             // arc_conditions is either empty --- nothing in this system is
@@ -186,6 +231,231 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                 else {
                     if (state.upper_bound(nodes[sb.node]) > sb.value)
                         inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, why);
+                }
+            }
+
+            // The root simplification stage, which is the paper's Algorithm 4
+            // (its section 5.2) run to the fixpoint of its section 5.3. Once, on
+            // the first call, and only if that call is at the root --- which it
+            // always is, since search begins by propagating everything before
+            // any decision is made, but the guard is not decoration: everything
+            // below is *permanent*, so doing it below a decision would keep
+            // conclusions that only held under that decision, and no proof would
+            // ever complain because losing propagation is invisible to a proof.
+            //
+            // Three of the paper's four sub-steps are here. Redundant-edge
+            // removal and node removal are decisions about what to propagate,
+            // not about what the model says --- the OPB keeps every posted row,
+            // so there is nothing to certify. Fixing a condition false is a real
+            // inference and carries the one proof obligation, discharged below.
+            // Zero-weight-cycle unification is not implemented; the cycles are
+            // counted so the question of whether it would pay is answerable from
+            // a measurement (see dev_docs/difference-logic.md).
+            if (simplification_pending) {
+                simplification_pending = false;
+
+                bool at_root = true;
+                for ([[maybe_unused]] const auto & guess : state.guesses()) {
+                    at_root = false;
+                    break;
+                }
+
+                DifferenceSimplificationStats stats;
+                DifferenceSimplificationReporter reporter{stats, simplify.stats};
+                stats.nodes = n;
+                stats.edges = m;
+                for (size_t e = 0; e < m; ++e)
+                    if (condition_of(e))
+                        ++stats.conditional_edges;
+
+                if (simplify.enabled && at_root && ! arcs.empty()) {
+                    stats.ran = true;
+
+                    vector<DifferenceSimplifyEdge> simplify_edges;
+                    simplify_edges.reserve(m);
+                    for (const auto & a : arcs)
+                        simplify_edges.push_back(DifferenceSimplifyEdge{a.from, a.to, a.d});
+
+                    vector<bool> dropped(m, false);
+                    vector<DifferenceSimplifyRole> roles(m, DifferenceSimplifyRole::Base);
+
+                    while (true) {
+                        ++stats.rounds;
+
+                        for (size_t e = 0; e < m; ++e) {
+                            if (dropped[e])
+                                roles[e] = DifferenceSimplifyRole::Ignored;
+                            else if (const auto & cond = condition_of(e)) {
+                                switch (state.test_literal(*cond)) {
+                                    using enum LiteralIs;
+                                case DefinitelyTrue: roles[e] = DifferenceSimplifyRole::Base; break;
+                                case DefinitelyFalse:
+                                    roles[e] = DifferenceSimplifyRole::Ignored;
+                                    dropped[e] = true;
+                                    ++stats.dead_edges_removed;
+                                    break;
+                                case Undecided: roles[e] = DifferenceSimplifyRole::Candidate; break;
+                                }
+                            }
+                            else
+                                roles[e] = DifferenceSimplifyRole::Base;
+                        }
+
+                        auto outcome = simplify_difference_graph(n, simplify_edges, roles);
+                        if (outcome.base_negative_cycle) {
+                            // The unconditional part of the system is already
+                            // infeasible. Stop and let the Bellman-Ford pass
+                            // below refute it: that is where the cycle
+                            // extraction and the telescoping pol live, and
+                            // duplicating them here would buy nothing.
+                            stats.base_negative_cycle = true;
+                            break;
+                        }
+
+                        stats.zero_weight_cycles = outcome.zero_weight_cycles;
+                        stats.nodes_on_zero_weight_cycles = outcome.nodes_on_zero_weight_cycles;
+
+                        for (size_t e = 0; e < m; ++e)
+                            if (outcome.remove[e] && ! dropped[e]) {
+                                dropped[e] = true;
+                                ++stats.redundant_edges_removed;
+                                if (condition_of(e))
+                                    ++stats.redundant_conditional_edges_removed;
+                            }
+
+                        if (outcome.fix.empty())
+                            break;
+
+                        for (const auto & [candidate, path] : outcome.fix) {
+                            if (dropped[candidate])
+                                continue;
+
+                            // Check the witness arithmetically before saying
+                            // anything: that the candidate edge and the path
+                            // really do form a cycle, and that it really does
+                            // weigh less than zero. That is O(cycle), and it
+                            // turns a bug in the shortest-path pass into an
+                            // exception here rather than a VeriPB failure a
+                            // hundred lines later (survey section 2.9.4).
+                            auto weight = arcs[candidate].d;
+                            auto at = arcs[candidate].to;
+                            vector<IntegerVariableCondition> conditions;
+                            for (auto e : path) {
+                                if (arcs[e].from != at)
+                                    throw UnexpectedException{"difference logic simplification built a disconnected witness cycle"};
+                                weight += arcs[e].d;
+                                at = arcs[e].to;
+                                // A path edge may itself be conditional, on
+                                // something currently definitely true --- either
+                                // the model fixed it, or an earlier round of this
+                                // very loop did. Its row then carries a big-M
+                                // residual which does not telescope, so its
+                                // condition has to be in the reason for the same
+                                // reason a negative cycle's conditions are.
+                                // Deduplicated, since one Boolean may appear on
+                                // several edges.
+                                if (const auto & cond = condition_of(e))
+                                    if (conditions.end() == find(conditions, *cond))
+                                        conditions.push_back(*cond);
+                            }
+                            if (at != arcs[candidate].from)
+                                throw UnexpectedException{"difference logic simplification built a witness path that does not close"};
+                            if (weight >= 0_i)
+                                throw UnexpectedException{"difference logic simplification built a witness cycle of weight " + weight.to_string() +
+                                    ", which is not negative"};
+
+                            const auto & candidate_cond = condition_of(candidate);
+                            if (! candidate_cond)
+                                throw UnexpectedException{"difference logic simplification tried to fix the condition of an unconditional edge"};
+
+                            // The proof is proof shape 1 with the candidate edge
+                            // standing in for the missing link: sum the rows
+                            // around the cycle and every BinEnc term telescopes
+                            // away, leaving only the big-M residuals of the
+                            // conditional edges. The candidate's is always one of
+                            // them, so a saturate turns the sum into the clause
+                            // `~cand v ~c_1 v ... v ~c_k' over the path's
+                            // already-true conditions --- the reified_hand.pbp
+                            // shape with the roles of the conditions swapped
+                            // round. The closing RUP assumes the reason's
+                            // literals and reads off `~cand'.
+                            //
+                            // Two mutation results, both measured rather than
+                            // assumed, and both matching what the negative-cycle
+                            // refutation already found:
+                            //
+                            //  * the `saturate' is not load-bearing --- removing
+                            //    it leaves every fixture verifying, because the
+                            //    closing RUP assumes every condition and drives
+                            //    each residual to zero. Emitted anyway so the
+                            //    derived line *is* the clause;
+                            //  * neither, here, are the path's conditions in the
+                            //    reason. That is specific to running at the root:
+                            //    a path condition is definitely true only because
+                            //    it is a *globally derived* fact (the model fixed
+                            //    it, or an earlier round of this loop did), so
+                            //    unit propagation recovers it and the RUP passes
+                            //    without being told. They are cited regardless,
+                            //    because the reason is also what the state and
+                            //    the nogood machinery see, and there a missing
+                            //    antecedent is not recoverable.
+                            ReasonLiterals reason_literals;
+                            for (const auto & c : conditions)
+                                reason_literals.push_back(c);
+                            auto reason = conditions.empty() ? Reason{NoReason{}} : Reason{ExplicitReason{move(reason_literals)}};
+                            inference.infer(logger, ! *candidate_cond,
+                                JustifyExplicitly{[&](const ReasonLiterals &) {
+                                                      auto pol = edge_line_pol();
+                                                      pol.add(edge_lines[arcs[candidate].posted_index]);
+                                                      for (auto e : path)
+                                                          pol.add(edge_lines[arcs[e].posted_index]);
+                                                      pol.saturate();
+                                                      pol.emit(*logger, ProofLevel::Temporary);
+                                                  },
+                                    ThenRUP::Yes},
+                                reason);
+
+                            dropped[candidate] = true;
+                            ++stats.conditions_fixed;
+                        }
+                    }
+
+                    // Now actually shrink the graph. Everything above only
+                    // marked; this is where the propagator stops paying for what
+                    // it marked.
+                    if (dropped.end() != find(dropped, true)) {
+                        vector<DifferenceArc> kept_arcs;
+                        vector<optional<IntegerVariableCondition>> kept_conditions;
+                        for (size_t e = 0; e < m; ++e)
+                            if (! dropped[e]) {
+                                kept_arcs.push_back(arcs[e]);
+                                if (! arc_conditions.empty())
+                                    kept_conditions.push_back(arc_conditions[e]);
+                            }
+                        arcs = move(kept_arcs);
+                        // If nothing conditional survived, drop the parallel
+                        // array entirely: an empty one is what puts the
+                        // relaxation loop back on its straight-through path,
+                        // which is worth 45% on examples/difference_chain.
+                        if (kept_conditions.end() == find_if(kept_conditions, [](const auto & c) { return c.has_value(); }))
+                            kept_conditions.clear();
+                        arc_conditions = move(kept_conditions);
+                        m = arcs.size();
+                    }
+
+                    // Node removal, the paper's last sub-step, and internal in
+                    // exactly the same way: a node with no incident edge left
+                    // cannot send or receive a bound, so it neither needs seeding
+                    // nor counts towards the number of relaxation rounds a
+                    // simple path can need.
+                    vector<bool> live(n, false);
+                    for (const auto & a : arcs) {
+                        live[a.from] = true;
+                        live[a.to] = true;
+                    }
+                    auto live_count = static_cast<size_t>(count(live, true));
+                    stats.isolated_nodes_removed = n - live_count;
+                    round_bound = live_count;
                 }
             }
 
@@ -388,7 +658,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             auto lb_tail_of = [](const DifferenceArc & g) { return g.from; };
             auto lb_head_of = [](const DifferenceArc & g) { return g.to; };
 
-            for (size_t round = 0; round <= n; ++round) {
+            for (size_t round = 0; round <= round_bound; ++round) {
                 bool changed = false;
                 for_each_active_edge([&](size_t e) {
                     const auto & edge = arcs[e];
@@ -397,7 +667,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                         lb[edge.to] = candidate;
                         lb_pred[edge.to] = e;
                         changed = true;
-                        if (round == n)
+                        if (round == round_bound)
                             contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
                     }
                 });
@@ -463,7 +733,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
             auto ub_tail_of = [](const DifferenceArc & g) { return g.to; };
             auto ub_head_of = [](const DifferenceArc & g) { return g.from; };
 
-            for (size_t round = 0; round <= n; ++round) {
+            for (size_t round = 0; round <= round_bound; ++round) {
                 bool changed = false;
                 for_each_active_edge([&](size_t e) {
                     const auto & edge = arcs[e];
@@ -472,7 +742,7 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, cons
                         ub[edge.from] = candidate;
                         ub_pred[edge.from] = e;
                         changed = true;
-                        if (round == n)
+                        if (round == round_bound)
                             contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
                     }
                 });

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -326,6 +326,17 @@ auto gcs::innards::install_difference_propagator(
                         if (outcome.fix.empty())
                             break;
 
+                        // Every round that gets here fixes at least one
+                        // condition and so drops at least one edge, which is
+                        // what bounds the loop --- an edge the pass wants to fix
+                        // is never also an edge it wants to remove, since
+                        // `d >= D_uv' and `d + D_vu < 0' cannot both hold when
+                        // the graph has no negative cycle. That is an argument
+                        // about the pass, though, and this is a loop inside a
+                        // propagator, so make the progress explicit rather than
+                        // inferred.
+                        bool progress = false;
+
                         for (const auto & [candidate, path] : outcome.fix) {
                             if (dropped[candidate])
                                 continue;
@@ -416,8 +427,12 @@ auto gcs::innards::install_difference_propagator(
                                 reason);
 
                             dropped[candidate] = true;
+                            progress = true;
                             ++stats.conditions_fixed;
                         }
+
+                        if (! progress)
+                            break;
                     }
 
                     // Now actually shrink the graph. Everything above only

--- a/gcs/constraints/difference/difference_graph.hh
+++ b/gcs/constraints/difference/difference_graph.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_GRAPH_HH
 
 #include <gcs/constraint_id.hh>
+#include <gcs/constraints/difference/difference_simplify.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/integer.hh>
@@ -9,6 +10,7 @@
 #include <gcs/variable_id.hh>
 
 #include <cstddef>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -136,6 +138,24 @@ namespace gcs::innards
     };
 
     /**
+     * \brief Whether the shared propagator should run the root simplification
+     * stage, and where to report what it did.
+     *
+     * On by default: the paper's section 6.3 measures the simplification stage
+     * as most of the difference-logic win (320.95 against 312.94 overall), while
+     * the propagator on its own is near-noise. It can be turned off from either
+     * entry point so that claim can be checked rather than inherited.
+     *
+     * \sa install_difference_propagator
+     * \ingroup Innards
+     */
+    struct DifferenceSimplificationOptions
+    {
+        bool enabled = true;
+        std::shared_ptr<DifferenceSimplificationStats> stats = nullptr;
+    };
+
+    /**
      * \brief Install the global difference-logic propagator over a canonicalised
      * system, attributed to the given constraint.
      *
@@ -161,9 +181,14 @@ namespace gcs::innards
      * half-reified counterpart *is* handled here, as a
      * DifferenceDisallowedCondition, precisely because it needs no initialiser.
      *
+     * The root simplification stage lives here too, for the same reason: it must
+     * infer, and a presolver has no way to. It runs inside the propagator, on its
+     * first call, guarded on that call being at the root --- which is where every
+     * propagator's first call is, since search starts by propagating everything.
+     *
      * \ingroup Innards
      */
-    auto install_difference_propagator(Propagators &, const ConstraintID &, DifferenceGraph) -> void;
+    auto install_difference_propagator(Propagators &, const ConstraintID &, DifferenceGraph, DifferenceSimplificationOptions = {}) -> void;
 }
 
 #endif

--- a/gcs/constraints/difference/difference_simplify.cc
+++ b/gcs/constraints/difference/difference_simplify.cc
@@ -1,0 +1,268 @@
+#include <gcs/constraints/difference/difference_simplify.hh>
+#include <gcs/exception.hh>
+
+#include <algorithm>
+#include <optional>
+#include <queue>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::greater;
+using std::min;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::priority_queue;
+using std::size_t;
+using std::vector;
+using std::ranges::reverse;
+
+namespace
+{
+    // Strongly connected components of the zero-reduced-weight subgraph, which
+    // is exactly the set of edges lying on a zero-weight cycle: reduced weights
+    // are non-negative and a cycle's reduced weight equals its real weight, so a
+    // cycle weighs zero iff every edge on it has reduced weight zero. Any SCC of
+    // more than one node is therefore a set of variables the system forces into
+    // fixed relative positions.
+    //
+    // Iterative Tarjan, because a scheduling network can be deep enough that a
+    // recursive one would not be safe.
+    auto count_zero_weight_cycles(size_t n, const vector<vector<size_t>> & zero_out, size_t & cycles, size_t & nodes_on_cycles) -> void
+    {
+        vector<size_t> index(n, 0), low(n, 0);
+        vector<bool> on_stack(n, false);
+        vector<size_t> component_stack;
+        vector<pair<size_t, size_t>> work;
+        size_t next_index = 1;
+
+        for (size_t root = 0; root < n; ++root) {
+            if (index[root])
+                continue;
+            work.emplace_back(root, 0);
+            while (! work.empty()) {
+                auto v = work.back().first;
+                if (0 == work.back().second && 0 == index[v]) {
+                    index[v] = low[v] = next_index++;
+                    component_stack.push_back(v);
+                    on_stack[v] = true;
+                }
+
+                if (work.back().second < zero_out[v].size()) {
+                    auto w = zero_out[v][work.back().second++];
+                    if (0 == index[w])
+                        work.emplace_back(w, 0);
+                    else if (on_stack[w])
+                        low[v] = min(low[v], index[w]);
+                }
+                else {
+                    if (low[v] == index[v]) {
+                        size_t size = 0;
+                        while (true) {
+                            auto w = component_stack.back();
+                            component_stack.pop_back();
+                            on_stack[w] = false;
+                            ++size;
+                            if (w == v)
+                                break;
+                        }
+                        if (size > 1) {
+                            ++cycles;
+                            nodes_on_cycles += size;
+                        }
+                    }
+
+                    auto low_v = low[v];
+                    work.pop_back();
+                    if (! work.empty())
+                        low[work.back().first] = min(low[work.back().first], low_v);
+                }
+            }
+        }
+    }
+}
+
+auto gcs::innards::simplify_difference_graph(size_t n, const vector<DifferenceSimplifyEdge> & edges, const vector<DifferenceSimplifyRole> & roles)
+    -> DifferenceSimplifyOutcome
+{
+    using enum DifferenceSimplifyRole;
+
+    if (roles.size() != edges.size())
+        throw UnexpectedException{"difference logic simplification was handed a role list of the wrong length"};
+
+    DifferenceSimplifyOutcome outcome;
+    outcome.remove.resize(edges.size(), false);
+    if (0 == n || edges.empty())
+        return outcome;
+
+    vector<size_t> base;
+    for (size_t e = 0; e < edges.size(); ++e)
+        if (Base == roles[e])
+            base.push_back(e);
+
+    // The paper's step 1: Bellman-Ford from an imaginary source v0 with a
+    // zero-weight edge to every node. Seeding every potential at zero *is* that
+    // source's edge set, exactly as the propagator's own passes seed from the
+    // current bounds. It both detects root infeasibility and leaves
+    // h(v) = wSP(v0, v), which is a valid potential function.
+    vector<Integer> h(n, 0_i);
+    for (size_t round = 0; round <= n; ++round) {
+        bool changed = false;
+        for (auto e : base) {
+            auto candidate = h[edges[e].from] + edges[e].d;
+            if (candidate < h[edges[e].to]) {
+                h[edges[e].to] = candidate;
+                changed = true;
+            }
+        }
+        if (! changed)
+            break;
+        if (round == n) {
+            // A shortest path from v0 is simple and so uses at most n - 1 real
+            // edges, so rounds 0 .. n - 1 suffice; a relaxation in round n is
+            // sound evidence of a negative cycle. Stop: the caller's own pass
+            // finds and refutes it, with the cycle extraction and the
+            // telescoping pol this function deliberately does not carry.
+            outcome.base_negative_cycle = true;
+            return outcome;
+        }
+    }
+
+    // Reduced weights are non-negative for every base edge, which is what lets
+    // Dijkstra run below, and a cycle's reduced weight is its real weight, since
+    // every potential appears once positively and once negatively.
+    vector<vector<size_t>> out(n), edges_from(n), candidates_to(n);
+    vector<Integer> reduced(edges.size(), 0_i);
+    for (auto e : base) {
+        reduced[e] = edges[e].d + h[edges[e].from] - h[edges[e].to];
+        if (reduced[e] < 0_i)
+            throw UnexpectedException{"difference logic simplification computed a negative reduced weight, so its potential function is invalid"};
+        out[edges[e].from].push_back(e);
+    }
+
+    vector<bool> need_source(n, false);
+    for (size_t e = 0; e < edges.size(); ++e) {
+        if (Ignored == roles[e])
+            continue;
+        // The tail, to decide whether this edge is redundant (is there a
+        // strictly shorter path from `from` to `to`?).
+        edges_from[edges[e].from].push_back(e);
+        need_source[edges[e].from] = true;
+        if (Candidate == roles[e]) {
+            // And the head, to decide whether activating it would close a
+            // negative cycle (how short is the path back from `to` to `from`?).
+            candidates_to[edges[e].to].push_back(e);
+            need_source[edges[e].to] = true;
+        }
+    }
+
+    {
+        vector<vector<size_t>> zero_out(n);
+        for (auto e : base)
+            if (0_i == reduced[e])
+                zero_out[edges[e].from].push_back(edges[e].to);
+        count_zero_weight_cycles(n, zero_out, outcome.zero_weight_cycles, outcome.nodes_on_zero_weight_cycles);
+    }
+
+    vector<optional<Integer>> dist(n, nullopt);
+    vector<optional<size_t>> parent(n, nullopt);
+    vector<size_t> touched;
+    priority_queue<pair<Integer, size_t>, vector<pair<Integer, size_t>>, greater<pair<Integer, size_t>>> queue;
+
+    // Whether some edge from u to v with weight exactly D_uv has already been
+    // kept. Cleared per source, and only ever read for the source's own edges.
+    vector<bool> tight_kept(n, false);
+
+    for (size_t s = 0; s < n; ++s) {
+        if (! need_source[s])
+            continue;
+
+        for (auto v : touched) {
+            dist[v] = nullopt;
+            parent[v] = nullopt;
+            tight_kept[v] = false;
+        }
+        touched.clear();
+
+        dist[s] = 0_i;
+        touched.push_back(s);
+        queue.emplace(0_i, s);
+        while (! queue.empty()) {
+            auto [reduced_distance, v] = queue.top();
+            queue.pop();
+            if (dist[v] != reduced_distance)
+                continue;
+            for (auto e : out[v]) {
+                auto w = edges[e].to;
+                auto candidate = reduced_distance + reduced[e];
+                if (! dist[w] || candidate < *dist[w]) {
+                    if (! dist[w])
+                        touched.push_back(w);
+                    dist[w] = candidate;
+                    parent[w] = e;
+                    queue.emplace(candidate, w);
+                }
+            }
+        }
+
+        // Undo Johnson's reweighting: a path from s to v has reduced weight
+        // dist(v) = weight + h(s) - h(v).
+        auto real_distance = [&](size_t v) { return *dist[v] - h[s] + h[v]; };
+
+        // Redundant edges, both kinds. An active edge goes when a strictly
+        // shorter path already implies it; among edges that *attain* the
+        // distance, exactly one is kept, since dropping them all would change
+        // the distance. An implied edge goes on the weaker test, because one
+        // that merely restates a distance the base graph already has can never
+        // add anything even when its condition becomes true.
+        for (auto e : edges_from[s]) {
+            auto v = edges[e].to;
+            if (! dist[v])
+                continue;
+            auto distance = real_distance(v);
+            if (Candidate == roles[e]) {
+                if (edges[e].d >= distance)
+                    outcome.remove[e] = true;
+            }
+            else if (edges[e].d > distance)
+                outcome.remove[e] = true;
+            else if (edges[e].d == distance) {
+                if (tight_kept[v])
+                    outcome.remove[e] = true;
+                else
+                    tight_kept[v] = true;
+            }
+        }
+
+        // Conditions that must be false: the candidate edge u --d--> v plus the
+        // shortest path v ~> u is a cycle, and if it weighs less than zero then
+        // the condition holding would make the system infeasible. This is the
+        // paper's step 3, and it is the only conclusion here that needs a proof.
+        for (auto e : candidates_to[s]) {
+            if (outcome.remove[e])
+                continue;
+            auto u = edges[e].from;
+            if (! dist[u])
+                continue;
+            if (edges[e].d + real_distance(u) >= 0_i)
+                continue;
+
+            vector<size_t> path;
+            auto at = u;
+            while (at != s) {
+                if (! parent[at])
+                    throw UnexpectedException{"difference logic simplification lost the witness path for a condition it wants to fix"};
+                path.push_back(*parent[at]);
+                at = edges[*parent[at]].from;
+            }
+            reverse(path);
+            outcome.fix.emplace_back(e, move(path));
+        }
+    }
+
+    return outcome;
+}

--- a/gcs/constraints/difference/difference_simplify.hh
+++ b/gcs/constraints/difference/difference_simplify.hh
@@ -1,0 +1,186 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_SIMPLIFY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_SIMPLIFY_HH
+
+#include <gcs/integer.hh>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace gcs
+{
+    /**
+     * \brief What the difference-logic root simplification stage did, filled in
+     * the first time the propagator runs.
+     *
+     * A simplification stage that silently does nothing preserves the solution
+     * set, adds no OPB content, leaves every proof verifying and leaves every
+     * search tree unchanged --- so it passes every check there is. These counters
+     * are how a test tells "working" from "no-op", and every one of them is
+     * asserted on somewhere in `difference_constraints_test.cc` or
+     * `difference_logic_test.cc`. Do not turn them into decoration.
+     *
+     * \sa DifferenceConstraints::simplifying_at_root
+     * \ingroup Constraints
+     */
+    struct DifferenceSimplificationStats
+    {
+        /// True if the stage actually ran. It runs once, on the propagator's
+        /// first call, and only if that call is at the root (see
+        /// `dev_docs/difference-logic.md`).
+        bool ran = false;
+
+        /// How many times the Johnson's pass was repeated. Fixing a condition
+        /// false can make its complement definitely true, which adds an edge to
+        /// the base graph and can license further fixing, so the stage iterates
+        /// to a fixpoint exactly as the paper's section 5.3 does. One round means
+        /// nothing was fixed.
+        std::size_t rounds = 0;
+
+        /// Nodes and edges the stage was handed.
+        ///@{
+        std::size_t nodes = 0;
+        std::size_t edges = 0;
+        std::size_t conditional_edges = 0;
+        ///@}
+
+        /// Edges dropped from the propagator's *internal* graph because a
+        /// strictly shorter path already implies them (or because they duplicate
+        /// another edge attaining the same distance). The model keeps them: this
+        /// is a decision about what to propagate, not about what the model says,
+        /// and so it has no proof obligation at all.
+        std::size_t redundant_edges_removed = 0;
+
+        /// Of those, how many carried a condition. A conditional edge is dropped
+        /// on the weaker test `d >= D_uv`, since an implied edge that merely
+        /// restates a distance the base graph already has cannot ever add
+        /// anything.
+        std::size_t redundant_conditional_edges_removed = 0;
+
+        /// Conditional edges dropped because their condition is already
+        /// definitely false, so the edge can never participate again.
+        std::size_t dead_edges_removed = 0;
+
+        /// Conditions fixed false because activating their edge would close a
+        /// negative cycle. This is the sub-step that carries a proof obligation,
+        /// and the one the paper's RCPSP/max unsatisfiability headline belongs
+        /// to.
+        std::size_t conditions_fixed = 0;
+
+        /// Nodes left with no incident edge once the above was done, and so
+        /// dropped from the relaxation loop and from the round bound.
+        std::size_t isolated_nodes_removed = 0;
+
+        /// Zero-weight cycles found, and how many nodes lie on one. Unifying
+        /// those nodes is the paper's fourth sub-step, which is *not*
+        /// implemented; these are reported so that the question of whether it
+        /// would ever fire on a real model is answered with a measurement rather
+        /// than a guess. \sa dev_docs/difference-logic.md
+        ///@{
+        std::size_t zero_weight_cycles = 0;
+        std::size_t nodes_on_zero_weight_cycles = 0;
+        ///@}
+
+        /// True if the base graph was found to contain a negative cycle while
+        /// simplifying. The stage then stops and leaves the refutation to the
+        /// propagator's own Bellman-Ford pass, which has the cycle extraction and
+        /// the proof shape for it.
+        bool base_negative_cycle = false;
+
+        /// Wall-clock seconds the stage cost, summed over its rounds. Reported
+        /// separately from the solve time because it is a one-off cubic-ish price
+        /// paid at the root, and the paper is explicit that it should be judged
+        /// on its own.
+        double seconds = 0.0;
+    };
+}
+
+namespace gcs::innards
+{
+    /**
+     * \brief What part an edge plays in one round of the simplification.
+     *
+     * \sa simplify_difference_graph
+     * \ingroup Innards
+     */
+    enum class DifferenceSimplifyRole
+    {
+        /// In the base graph: unconditional, or conditional on something that is
+        /// currently definitely true. Distances are computed over exactly these.
+        Base,
+
+        /// Conditional on something undecided. Not in the base graph, but a
+        /// candidate for having its condition fixed false.
+        Candidate,
+
+        /// Conditional on something definitely false. Not in the graph and never
+        /// will be.
+        Ignored
+    };
+
+    /**
+     * \brief One edge as the simplification pass sees it: `from - to <= d` over
+     * node indices, with no notion of what constraint it came from.
+     *
+     * \sa simplify_difference_graph
+     * \ingroup Innards
+     */
+    struct DifferenceSimplifyEdge
+    {
+        std::size_t from;
+        std::size_t to;
+        Integer d;
+    };
+
+    /**
+     * \brief What one round of simplification concluded.
+     *
+     * \sa simplify_difference_graph
+     * \ingroup Innards
+     */
+    struct DifferenceSimplifyOutcome
+    {
+        /// The base graph has a negative cycle, so it is already infeasible and
+        /// nothing else here is filled in. The caller refutes; this pass does not
+        /// carry the cycle-extraction machinery.
+        bool base_negative_cycle = false;
+
+        /// Parallel to the edge list: this edge may be dropped from the internal
+        /// graph without weakening propagation.
+        std::vector<bool> remove;
+
+        /// Candidate edges whose condition must be false, each with the witness
+        /// path: a list of edge indices forming a path from the candidate's `to`
+        /// back to its `from`, so that the candidate edge followed by the path is
+        /// a cycle of strictly negative weight.
+        std::vector<std::pair<std::size_t, std::vector<std::size_t>>> fix;
+
+        /// Zero-weight cycles found in the base graph, and how many nodes lie on
+        /// one.
+        ///@{
+        std::size_t zero_weight_cycles = 0;
+        std::size_t nodes_on_zero_weight_cycles = 0;
+        ///@}
+    };
+
+    /**
+     * \brief One round of the paper's root simplification: Johnson's all-pairs
+     * shortest paths over the base graph, then redundant-edge detection,
+     * condition fixing, and zero-weight-cycle detection.
+     *
+     * This is a pure function of the graph. It reads no state, makes no
+     * inference, emits no proof line and allocates nothing that outlives it,
+     * which is what makes it the same code for a posted DifferenceConstraints and
+     * for a presolver-built system, and what makes it directly unit-testable.
+     *
+     * Bellman-Ford from the paper's imaginary source `v0` (a zero-weight edge to
+     * every node) gives the potentials, `n` Dijkstras on the reduced-cost graph
+     * give the distances. That is `O(n^2 log n + nm)`, paid once.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto simplify_difference_graph(std::size_t number_of_nodes, const std::vector<DifferenceSimplifyEdge> & edges,
+        const std::vector<DifferenceSimplifyRole> & roles) -> DifferenceSimplifyOutcome;
+}
+
+#endif

--- a/gcs/presolvers/difference_logic.cc
+++ b/gcs/presolvers/difference_logic.cc
@@ -88,7 +88,7 @@ namespace
     }
 }
 
-DifferenceLogic::DifferenceLogic(shared_ptr<DifferenceLogicStats> stats) : _stats(move(stats)), _disable_lifted_donors(false)
+DifferenceLogic::DifferenceLogic(shared_ptr<DifferenceLogicStats> stats) : _stats(move(stats)), _disable_lifted_donors(false), _simplify(true)
 {
 }
 
@@ -98,10 +98,24 @@ auto DifferenceLogic::disabling_lifted_donors(bool disable) -> DifferenceLogic &
     return *this;
 }
 
+auto DifferenceLogic::simplifying_at_root(bool simplify) -> DifferenceLogic &
+{
+    _simplify = simplify;
+    return *this;
+}
+
+auto DifferenceLogic::reporting_simplification_to(shared_ptr<DifferenceSimplificationStats> stats) -> DifferenceLogic &
+{
+    _simplification_stats = move(stats);
+    return *this;
+}
+
 auto DifferenceLogic::clone() const -> unique_ptr<Presolver>
 {
     auto result = make_unique<DifferenceLogic>(_stats);
     result->disabling_lifted_donors(_disable_lifted_donors);
+    result->simplifying_at_root(_simplify);
+    result->reporting_simplification_to(_simplification_stats);
     return result;
 }
 
@@ -270,7 +284,8 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &,
     if (graph.edges.size() >= 2) {
         // A presolver-derived propagator has no posted-constraint identity of
         // its own, exactly as for AutoTable.
-        install_difference_propagator(propagators, CurrentlyUnnamedConstraint{}, move(graph));
+        install_difference_propagator(
+            propagators, CurrentlyUnnamedConstraint{}, move(graph), DifferenceSimplificationOptions{_simplify, _simplification_stats});
         stats.propagator_installed = true;
 
         if (_disable_lifted_donors)

--- a/gcs/presolvers/difference_logic.hh
+++ b/gcs/presolvers/difference_logic.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_DIFFERENCE_LOGIC_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_DIFFERENCE_LOGIC_HH
 
+#include <gcs/constraints/difference/difference_simplify.hh>
 #include <gcs/presolver.hh>
 
 #include <cstddef>
@@ -137,7 +138,9 @@ namespace gcs
     {
     private:
         std::shared_ptr<DifferenceLogicStats> _stats;
+        std::shared_ptr<DifferenceSimplificationStats> _simplification_stats;
         bool _disable_lifted_donors;
+        bool _simplify;
 
     public:
         /**
@@ -170,6 +173,29 @@ namespace gcs
          * completeness loss no proof could catch.
          */
         auto disabling_lifted_donors(bool = true) -> DifferenceLogic &;
+
+        /**
+         * \brief Run (or do not run) the root simplification stage over the
+         * lifted graph.
+         *
+         * On by default, matching DifferenceConstraints, and for the same
+         * reason: the paper's section 6.3 measures the simplification stage as
+         * most of the difference-logic win. It is exactly the same code and the
+         * same proof shapes from either entry point --- it runs inside the shared
+         * propagator, on its first call, precisely because a presolver runs after
+         * propagators.initialise() and so has no initialiser available and no way
+         * to infer anything itself.
+         */
+        auto simplifying_at_root(bool = true) -> DifferenceLogic &;
+
+        /**
+         * \brief Share a stats block the simplification stage will fill in.
+         *
+         * Separate from DifferenceLogicStats because the presolver's own counts
+         * are known when it runs, whereas the simplification's are only known
+         * once the propagator has first fired.
+         */
+        auto reporting_simplification_to(std::shared_ptr<DifferenceSimplificationStats>) -> DifferenceLogic &;
 
         [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;

--- a/gcs/presolvers/difference_logic_test.cc
+++ b/gcs/presolvers/difference_logic_test.cc
@@ -370,7 +370,21 @@ namespace
             // these domains. Every assignment with the condition false is a
             // solution, so a presolver whose propagator ignored the condition
             // would lose all of them.
-            {"reified_impossible", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -10, b(2)}, {v(1), v(0), 1}}, 2, 1}};
+            {"reified_impossible", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -10, b(2)}, {v(1), v(0), 1}}, 2, 1},
+            // The root simplification stage's one proof obligation, through the
+            // presolver path: the conditional edge closes a cycle of weight -3
+            // against the unconditional one, so the stage fixes the condition
+            // false before search. The weight is chosen so the *donor* cannot
+            // refute the condition from its own bounds --- over 0..10 an
+            // x0 - x1 of -5 is perfectly possible --- so if the stage stops
+            // working the condition is simply left to the search, which is a
+            // completeness loss no proof would notice.
+            {"reified_root_fix", {{0, 10}, {0, 10}, {0, 1}}, {{v(1), v(0), 2}, {v(0), v(1), -5, b(2)}}, 2, 1},
+            // The same, with both ends of both edges behind offset views, so the
+            // fixing pol only telescopes because it cites the donors' rows in
+            // deview mode --- the same property view_negcycle_wide pins for the
+            // refutation pol.
+            {"reified_root_fix_views", {{0, 10}, {0, 10}, {0, 1}}, {{v(1, 1), v(0), 2}, {v(0, 2), v(1, -1), -5, b(2)}}, 2, 1}};
     }
 
     auto run_equivalence_tests(bool proofs) -> void
@@ -611,6 +625,62 @@ namespace
             if (off_opb != on_opb || off_pbp != on_pbp)
                 throw UnexpectedException{"the difference-logic presolver changed the proof of a model containing nothing difference shaped"};
             println(cerr, "difference presolver opb: control .opb and .pbp both identical ({} and {} bytes)", off_opb.size(), off_pbp.size());
+        }
+
+        // The root simplification stage, from the presolver entry point, adds no
+        // OPB content either --- and it is the sub-step that most looks as though
+        // it would want to. Fixing a Boolean at the root is a real inference, so
+        // the .pbp gains a pol and a rup; dropping a redundant edge is a decision
+        // about which propagator runs and leaves no trace anywhere. Neither may
+        // touch the .opb: the model must always contain every posted constraint,
+        // which is also what keeps workflow-2 chain verification intact, since
+        // cake_pb_cp re-derives the .opb from the .scp and knows nothing about
+        // our internal pruning.
+        {
+            auto simplification = make_shared<DifferenceSimplificationStats>();
+            auto solve_with_simplification = [&](const string & basename, bool simplify) -> pair<string, string> {
+                Problem p;
+                auto x = p.create_integer_variable_vector(3, 0_i, 6_i, "x");
+                auto b = p.create_integer_variable(0_i, 1_i, "b");
+                // x0 - x1 <= 2 and x1 - x2 <= 2 unconditionally, so x0 - x2 <= 4,
+                // which makes the posted x0 - x2 <= 5 redundant. Then
+                // b -> x2 - x0 <= -5 closes a cycle of weight -1. The weight is
+                // chosen so the donor's *own* propagator cannot refute b from
+                // bounds --- over 0..6 an x0 - x2 of 5 is perfectly possible ---
+                // because if it could, b would already be false by the time the
+                // simplification stage looked and the fixture would be testing
+                // nothing.
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], 2_i});
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[1] + -1_i * x[2], 2_i});
+                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[2], 5_i});
+                p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * x[2] + -1_i * x[0], -5_i, b == 1_i});
+                p.add_presolver(DifferenceLogic{}.simplifying_at_root(simplify).reporting_simplification_to(simplify ? simplification : nullptr));
+                static_cast<void>(solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }},
+                    make_optional<ProofOptions>(ProofFileNames{basename})));
+                auto opb = read_file(basename + ".opb"), pbp = read_file(basename + ".pbp");
+                for (auto ext : proof_file_extensions)
+                    std::remove((basename + ext).c_str());
+                return {opb, pbp};
+            };
+
+            auto [off_opb, off_pbp] = solve_with_simplification("difference_presolver_simplify_off", false);
+            auto [on_opb, on_pbp] = solve_with_simplification("difference_presolver_simplify_on", true);
+            if (off_opb != on_opb)
+                throw UnexpectedException{"the difference-logic root simplification stage changed the .opb. It must not: every one of its "
+                                          "conclusions is either internal to the propagator or a cutting-planes consequence of rows the model "
+                                          "already contains, and Presolver::run is handed no ProofModel to add anything with"};
+            if (! simplification->ran)
+                throw UnexpectedException{"the root simplification stage did not run from the presolver entry point, so this fixture checked "
+                                          "nothing at all"};
+            if (0 == simplification->conditions_fixed || 0 == simplification->redundant_edges_removed)
+                throw UnexpectedException{"the root simplification stage ran from the presolver entry point but fixed " +
+                    to_string(simplification->conditions_fixed) + " conditions and removed " + to_string(simplification->redundant_edges_removed) +
+                    " redundant edges, where this fixture is built so that both are nonzero. An OPB byte-diff that a no-op passes is not a test."};
+            if (off_pbp == on_pbp)
+                throw UnexpectedException{"the root simplification stage left the .pbp byte-identical on a fixture where it fixes a Boolean at the "
+                                          "root, which it cannot do without emitting a pol and a rup"};
+            println(cerr, "difference presolver opb: simplification .opb identical ({} bytes), .pbp differs ({} vs {} bytes), fixed {}, dropped {}",
+                off_opb.size(), off_pbp.size(), on_pbp.size(), simplification->conditions_fixed, simplification->redundant_edges_removed);
         }
     }
 


### PR DESCRIPTION
Part 4 of #571: the paper's **root simplification stage** (its §5.2–5.3).

**Based on #590** (`difflogic-06-halfreified`), which is this PR's base branch,
so the diff shown here is only this PR's seven commits. The stack is now
strictly linear — #590 no longer merges in a sibling.

## Why this one, and what it settles

#587 found that the paper's RCPSP/max unsatisfiability headline does not
reproduce *in shape*: gcs runs root propagation to a fixpoint, so the decomposed
model also refutes at the root, just at Θ(horizon) cost. #590 added half-reified
difference edges so a disjunctive resource could contribute to the network, and
found that the *search* reproduces and the *root refutation* still does not — for
the reason that at the root no condition is fixed, so no conditional edge is in
the graph at all, and the propagator sees only the unconditional sub-system. It
argued from that that the headline has to belong to the **simplification stage**,
not to `IncSat`/`IncLB`/`IncUB`, and pointed at the paper's own §6.3 (320.95 with
simplification against 312.94 without; ProdCons 637.50 against 573.40).

**This PR closes it. The headline reproduces.** Same instances as #590
(`--generate 10 --resources 1 --capacity 1 --max-lag-slack 0 --unary=difference`),
recursions:

| seed | decomposed | presolved, no simp. | presolved | global, no simp. | global |
|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 1 | **1** | 1 | **1** |
| 3 | 1 | 1 | **1** | 1 | **1** |
| 4 | 11 | 11 | **1** | 39 | **1** |
| 5 | 9 | 9 | **1** | 23 | **1** |
| 6 | 3 | 3 | **1** | 33 | **1** |
| 7 | 73 | 73 | **1** | 179 | **1** |

Seeds 1 and 3 were already refuted by the temporal network alone. The stage costs
**24–63 µs** on these, against solve times of 75–320 µs, and it fires from *both*
entry points. Proofs shrink with it — seed 7 goes 4,485 lines / 168 KB
(decomposed) → 1,603 / 115 KB (global, no simplification) → **132 / 3.6 KB** —
and every one verifies.

That completes an argument built over three PRs, and each step of it was a
measurement rather than a reading of the paper.

## Which sub-steps

**1. Redundant-edge removal** (`d > D_uv` active, `d >= D_uv` implied, one kept
among ties). Done in the propagator's *internal* graph. **The OPB keeps every
posted row**, so this is a decision about which propagators run, not about what
the model says, and there is **no proof obligation whatsoever** — no `delc`, no
brush with checked deletion, and workflow-2 chain verification stays intact since
`cake_pb_cp` re-derives the `.opb` from the `.scp`.

**2. Fixing a condition false** when activating its edge would close a negative
cycle. The deliverable, and the one real inference. Proof shape 1 with the
candidate edge standing in for the missing link:

```
pol @c[_1][e1] @c[_1][e0] + s ;
rup 1 ~i[_3][b0] >= 1;
```

verbatim from the `fix_one` fixture. Everything telescopes except the big-M
residuals of the conditional rows, the candidate's is always one of them, and one
`saturate` leaves the clause. That is `reified_hand.pbp` with the roles of the
conditions swapped round: there they were the residuals that survived into a
learned clause, here the surviving residual *is* the literal being inferred.

**3. Zero-weight-cycle unification: deferred**, but *detected and counted* — see
below.

**4. Node removal** (a node with no incident edge left drops out of the
relaxation loop and out of the round bound). Internal, no obligation.

## Where it runs, and the guard that is not decoration

Inside the propagator, on its first call. An initialiser would be the natural home
for the posted constraint, but a presolver runs *after* `propagators.initialise()`
and `Presolver::run` has no inference tracker, so it could neither install one nor
infer anything itself. The propagator is the only place that works for both — and
putting it there means one implementation and one set of proof shapes.

Two guards: **it runs once**, and **only if that first call is at the root**
(`state.guesses()` empty). The second matters. Everything the stage concludes is
permanent and untrailed, so doing it under a decision would keep conclusions that
hold only under that decision, and *no proof would complain*, because losing
propagation is invisible to a proof. Not trailing is then justified by exactly the
argument that puts the paper's own §5.3/5.4 boundary where it is: every conclusion
is a statement about the **graph**, and backtracking does not change the graph.

## No `red`, no `dom`, no new OPB content

Everything is derived. `pol` inside `JustifyExplicitly` at
`ProofLevel::Temporary`; nothing needed `ProofLevel::Top` at all, because the
inference itself is recorded by the tracker and the two internal removals leave no
trace anywhere. Enforced by OPB byte-diff tests on both entry points, as #588 did.

## How the refutation actually arrives

The stage iterates to a fixpoint, because fixing a condition makes its complement
definitely true, which can put an edge *into* the base graph. On RCPSP/max the
refutation arrives more directly: both polarities of an ordering Boolean are
separately impossible, so both are found fixable in the *same* round — the first
is inferred, the second contradicts it. The counters then read one condition fixed
in one round, because the second fix unwinds before it can be counted, which is
why they are published by a destructor rather than at the end of the stage.

## This is `IncImp`, restricted to the root

Fixing a condition because its edge would close a negative cycle *is* `IncImp`,
which the paper's configuration study says to leave off. Not a contradiction: the
study measures it on **every wake**; this runs it **once**. #590 noted that
`IncImp`'s absence shows up in gcs as a search-tree cost (`--variant=global` has
no donors to infer `!cond` from bounds), and the root-only version removes most of
that without the per-wake price.

## The honest other half

On `examples/difference_chain` (the paper's Example 8) the stage **hurts**.
`--variant=global --order unlucky --mode fixpoint`:

| n | recursions | propagations | wall, no simp. (s) | wall (s) | Johnson's (s) | edges dropped |
|---:|---:|---:|---:|---:|---:|---:|
| 80 | 163 | 167 | 0.00167 | 0.00233 | 0.00050 | 79 |
| 160 | 323 | 327 | 0.00817 | 0.01135 | 0.00328 | 159 |
| 320 | 643 | 647 | 0.0477 | 0.0729 | 0.0234 | 319 |
| 640 | 1,283 | 1,287 | 0.312 | 0.474 | 0.164 | 639 |

`recursions` and `propagations` identical down every column — which is the point —
and the whole difference is the Johnson's pass. It drops `n - 1` edges out of
`n(n+5)/2` and costs 30–50 % of the solve, because the `nm` term dominates on a
dense system. Sparse and satisfiable it is fine: on a pure temporal network at
`n = 1600` (3,844 edges) it is 0.099 s of a 4.51 s solve, ~2 %, with identical
recursions. That is why the option exists and why it defaults on rather than being
unconditional.

## Unification: deferred, with the data that says it is worth doing

Detected for free — reduced weights are non-negative and a cycle's reduced weight
is its real weight, so a zero cycle is exactly a strongly connected component of
the zero-reduced-weight subgraph, and Tarjan over it is `O(n + m)` on data
Johnson's already produced. The counters say it would fire **hard** on the family
this stage is aimed at: one cycle spanning **10 of the 11 nodes** on the
`--max-lag-slack 0` instances, because exactly-tight maximum time lags *are* a
zero-weight cycle. None on `difference_chain` or on slack instances.

The issue's open proof question is answered and it is easy: both directions of
`x - y = d` are **pure `pol` consequences with unit multipliers** — the edge gives
one, summing the rest of the cycle gives the other. Aggregation, not redundance.
No `red`, no `dom`, and nothing even needs pre-deriving at `Top`, since a
derivation crossing a merged node can add the cycle's rows to its own `pol` at
`Temporary`.

What is not cheap is the model side. Per survey §5.2 item 2 a
`ViewOfIntegerVariableID` must not be retro-fitted onto an already-encoded user
variable, so merged variables keep independent domains: seeding takes the maximum
over members (and must record which member achieved it, for the reason), and every
push must be inferred on *every* member with its own `pol` carrying the zero-cycle
path. That is a substantial rework of both `infer_along_forest` passes for an
unmeasured win, and it is the only sub-step whose proof shape changes. Left for a
separate PR, with these counters as the argument for writing it.

## Testing

New `simplify` mode on `difference_test`: each fixture solved twice, on and off,
asserting identical solution sets against an independent oracle, and asserting
`recursions` **equal** where no condition is fixed (redundant-edge and node
removal are propagation-neutral by construction) and **strictly smaller** where
one is. Deliberately not `solve_for_tests_with_callbacks`: a run the runtime caps
truncate says nothing about completeness and reports the cap rather than the
search (per the caps warning in `INCREMENTALITY-INVARIANTS.md`). Whole difference
and presolver suites re-run under `GCS_TEST_CAP_DEFAULTS=OFF`.

Per the "a no-op passes every check" rule #588 established, every fixture asserts
on counters, and the failure messages say the *stage* is broken rather than the
expectation stale. Mutation-tested:

| mutation | caught by |
|---|---|
| fix on a zero-weight cycle (`>= 0` → `> 0`) | the witness self-check, immediately |
| remove tight edges as redundant (`d > D` → `d >= D`) | the oracle, in two suites |
| one round instead of a fixpoint | the cascade fixture's round count |
| drop the fixing entirely | the counters and `expect_fewer_recursions` |
| **the `saturate`** | **nothing** — recorded in the comments, kept anyway |
| **path conditions in the reason** | **nothing** — see below, kept anyway |

The last is worth stating: at the root a path condition is definitely true only
because it is a *globally derived* fact, so unit propagation recovers it and the
RUP passes without being told. It is cited regardless, because the reason is also
what the state and nogood machinery see, and there a missing antecedent is not
recoverable.

Full release suite 561/561. ASan+UBSan clean on the difference and presolver
suites and on `rcpsp`.

Closes nothing; #571 stays open for incrementality, `IncImp` proper, unification
and `Comparison` donors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lx8KBTVNSg44EEcVYcBoN

