### PR TITLE
Difference logic: incremental propagation (#571)

### DIFF
--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -1322,6 +1322,12 @@ Three things are true of `π` and all three are load-bearing:
   was fine when it was last active can need repair when it comes back. See
   "re-activation" below.
 
+Nothing bounds how far `π` drifts down over a long search, and the guard against
+that is free: `Integer`'s arithmetic is overflow-checked, so a drift that ever
+reached the edge of a `long long` is a loud exception at the operation that did
+it rather than silent wrap-around. Nothing has come close on anything measured
+here.
+
 **`IncSat`** (the paper's Algorithm 1, from Cotton and Maler) repairs `π` when
 one arc is added, or reports that the graph now has a negative cycle. It is a
 Dijkstra-shaped relaxation of the *violation* `γ`, touching only the nodes it

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -1471,6 +1471,19 @@ randomised or conflict-weighted heuristic; the default `dom_then_deg` and the
 harness's seeded random brancher are both fine, because both runs use the same
 one.)
 
+The `incremental` test mode then adds five deterministic scenarios --- the
+stale-`Do` sequence verbatim, a Boolean fixed with no node bound change
+anywhere, an arc activated and re-activated across four backtracks with a
+negative cycle that closes only when two conditions hold at once, the hole-snap
+topology, and a conditional static bound applied in a branch that fails --- each
+run both ways and each asserting its invariant at **every** search node rather
+than at the leaves, which is where a gate bug shows and a solution count does
+not. Last, a randomised stress of twenty systems under a Luby restart schedule
+with a tiny scale: a restart unwinds to the root at a moment nothing else
+chooses, which is the sharpest exercise of the undo trail there is, and the two
+routes have to agree on the optimum, the solution count *and* the recursion
+count.
+
 ### What actually went wrong, measured by mutation
 
 Every row was produced by breaking the shipping code in exactly that way,

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -8,7 +8,8 @@ the two proof shapes with worked examples, half-reified edges
 (`b -> x - y <= d`) and what they cost in the reason and in the proof, the
 defects in the source paper's pseudocode, the presolver that lifts an
 already-posted model into the same propagator, the root simplification stage,
-and what is deliberately deferred.
+the incremental algorithms and the invariants they rest on, and what is
+deliberately deferred.
 
 The source is Kletzander, Dekker, Schutt and Stuckey, *Global Difference
 Constraint Propagation for Constraint Programming*, arXiv:2607.20022 — the
@@ -495,8 +496,11 @@ belong to are not implemented yet:
 - The `Do` gate in Algorithm 3 is against the *previous run's* bounds, not the
   current ones, and the paper never says what happens to `Do` on backtracking.
   Loosening it is always sound, tightening it silently loses propagation — and
-  a lost propagation is invisible to proof logging. Relevant when incrementality
-  lands.
+  a lost propagation is invisible to proof logging. See "Incremental
+  propagation" below, which is where this bites and where the answer is.
+- **Section 5.4 describes half of what section 4.4 requires on edge addition.**
+  Transcribing the during-search section alone loses every push a reification
+  delivers. Also below.
 - Theorem 2 assumes **range** domains. gcs domains have holes. The propagator
   stays sound (it only reads and writes bounds), but the theorem's completeness
   half only holds for the bounds abstraction — so this is a bounds-consistent
@@ -535,11 +539,13 @@ Two honest caveats. First, `recursions` differs between the variants because the
 default `dom_then_deg` brancher sees different variable degrees — one global
 propagator gives every variable degree 1, where the decomposition gives `y_0`
 degree `n + 1` — so this is a search-shape change as well as a propagation
-change and the two columns have to be read together. Second, on the *lucky*
-order at large `n` the global propagator is slightly slower in wall time despite
-doing 640× fewer propagations, because this version is not incremental: every
-wake re-runs the whole `O(rounds × |E|)` pass from the current bounds. That is
-the deferred work below, not a property of the approach.
+change and the two columns have to be read together. Second, the table above was
+measured before incremental propagation existed, so its `global` column is the
+from-scratch route: on the *lucky* order at large `n` it is slightly slower in
+wall time despite doing 640× fewer propagations, because every wake re-ran the
+whole `O(rounds × |E|)` pass from the current bounds. That was a property of the
+implementation and not of the approach, and the section on incremental
+propagation below is where it goes away — 0.269 s → 0.057 s at `n = 640`.
 
 Proof size, `--mode=refute` (the same system plus one edge closing a
 negative cycle of weight `-1`), `n = 10`:
@@ -810,10 +816,16 @@ the extra sweeps but not the one-run-per-donor-per-round floor; only disabling
 the donors does that, and it takes the count to 647.
 
 **The redundant donors cost almost nothing in wall time here**, 0.459 s against
-0.452 s at `n = 640`, even though they are 1,275× of the propagation count.
-Time is dominated by the non-incremental Bellman-Ford, not by the donors' cheap
-two-term propagations. So on this family the hybrid is nearly free, which
-matches the paper preferring it.
+0.452 s at `n = 640`, even though they are 1,275× of the propagation count. So on
+this family the hybrid is nearly free, which matches the paper preferring it.
+That conclusion survives incremental propagation, which was the obvious thing to
+check: with it on the same pair is 0.239 s against 0.231 s, so the redundant
+sweeps go from 1.5 % to 3 % of the presolved route's wall time rather than
+becoming visible. What incrementality *does* change here is the gap between
+`presolved` and `global` — 0.410 s against 0.323 s before, 0.239 s against
+0.056 s after — and that residual is the presolver's own `O(constraints)`
+enumeration and the model carrying 205k posted constraints, not propagator
+ordering.
 
 **On the lucky order the presolver is a modest loss**, 0.257 s → 0.445 s at
 `n = 640`: nothing was wrong with the propagation order to begin with, and the
@@ -1266,15 +1278,374 @@ been measured, and it is the only sub-step whose proof shape changes at all. It
 is left for a separate PR, with the counters above as the evidence that the PR is
 worth writing.
 
+## Incremental propagation
+
+Every wake used to redo the whole `O(rounds × |E|)` Bellman-Ford pass from the
+current bounds. That is what the two honest caveats above were about: the
+propagation counts and the proof sizes were dramatically better than the
+decomposed model's, and the wall time was not. This section is the paper's
+`IncSat` / `IncLB` / `IncUB`, which fix that.
+
+It is on by default and can be turned off from either entry point, and from
+both example binaries:
+
+```cpp
+problem.post(DifferenceConstraints{edges}.incrementally(false));
+problem.add_presolver(DifferenceLogic{}.incrementally(false));
+```
+
+**The from-scratch version is not dead code and must not be deleted.** It is the
+reference the incremental one is checked against, in two ways that nothing else
+can supply — see "The two oracles" below.
+
+### The three moving parts
+
+**A potential function `π`**, maintained over the whole search, satisfying
+`π(u) + d − π(v) >= 0` for every arc `u --d--> v` **currently in the graph, and
+nothing else**. That makes every *reduced* cost `π(u) + d − π(v)` non-negative,
+which is what lets Dijkstra replace Bellman-Ford. It is computed once at the
+root by a single Bellman-Ford from an imaginary zero-weight source (seeding every
+potential at zero *is* that source's edge set, exactly as elsewhere in this
+file), and repaired by `IncSat` whenever an arc joins the graph.
+
+Three things are true of `π` and all three are load-bearing:
+
+- **it is never trailed**, because its invariant is a conjunction over the arcs
+  in the graph and backtracking only ever *removes* arcs. This is the paper's
+  section 4.1 remark, attributed to Wang et al.;
+- **bounds must not appear in it.** `π(v0)` is a per-call temporary, computed
+  over `Vl` only, and is never stored. (It turns out not to be able to break
+  anything if it were — see the mutation table below — but it is free to do the
+  right thing and the reason it is safe is a property of the priority queue
+  rather than of the algorithm);
+- **it decreases monotonically and is never reset**, which is why an arc that
+  was fine when it was last active can need repair when it comes back. See
+  "re-activation" below.
+
+**`IncSat`** (the paper's Algorithm 1, from Cotton and Maler) repairs `π` when
+one arc is added, or reports that the graph now has a negative cycle. It is a
+Dijkstra-shaped relaxation of the *violation* `γ`, touching only the nodes it
+has to, and it terminates either when nothing is violated any more or when the
+repair reaches back round to the new arc's own tail — which is exactly a negative
+cycle. It does not *extract* that cycle: on `false` the caller hands straight
+over to the from-scratch pass, which already carries the extraction and the
+telescoping `pol`, and re-verifies arithmetically that a cycle is really there.
+A negative cycle ends the search, so the `O(n·m)` is paid at most once per
+branch and buys a second implementation that does not have to be written or
+trusted. The same hand-off covers a negative cycle in the *initial* potential
+computation.
+
+**`IncLB`** (Algorithm 3) processes every bound change since the last run in one
+Dijkstra on the reduced-cost graph. `IncUB` is the same function applied to the
+reverse graph with the potential, the bounds and the gate all negated:
+`ub(x) <= ub(y) + d` is `−ub(x) >= −ub(y) − d`, which is the lower-bound relation
+along the arc read backwards, and `−π` is a valid potential for it. One
+implementation, two instantiations, and no second opportunity to mistranscribe
+Algorithm 3.
+
+### The `Do` array, which is where all the difficulty is
+
+`IncLB` is gated by `Do`, "the bounds of variables the last time the propagator
+was run". Two invariants have to hold at the entry to every call, and everything
+below is about keeping them:
+
+- **I1**: `Do(x) <= min D(x)` for every node;
+- **I2**: `Do(t) >= Do(s) − d` for every arc `(s, t, d)` currently in the graph.
+
+`Vl = { x | min D(x) > Do(x) }` seeds Dijkstra, and the *expansion* gate
+(Algorithm 3 line 12) declines to relax out of a settled node `s` whose new bound
+does not beat `Do(s)`. I2 is what makes that safe: if `−δ(s) <= Do(s)` then for
+every arc out of `s`, `−δ(s) − d <= Do(s) − d <= Do(t) <= min D(t)`, and the same
+argument chains along any path, so the whole sub-search is dead. Drop I2 and the
+gate silently throws away propagation.
+
+**At the end of a run, `Do` becomes the bounds the run propagated *from*, not the
+bounds the state ends up holding.** For every node Dijkstra settled, that is
+`max(Do(x), −δ(x))`; for every node it did not, `Do(x)` is unchanged. That
+assignment re-establishes I2 (the settled-and-expanded case is Dijkstra's own
+`δ(t) <= δ(s) + d`; the settled-but-not-expanded and unsettled cases fall back on
+the old I2) and preserves I1 (a pushed bound was inferred, so `min D` is at least
+it).
+
+**Recording the state's bounds instead is a real bug and it is gcs-specific.**
+gcs domains have holes, so `infer_greater_than_or_equal(x, 5)` on a domain with a
+hole at 5 lands the state's lower bound at 6 or higher. Recording 6 makes
+`min D(x) == Do(x)`, so on the mandatory self-re-wake `x ∉ Vl`, `Vl` comes out
+empty, and the consequences of the snapped bound are never propagated. The
+propagator returns `PropagatorState::Enable` precisely so that it is re-woken by
+its own inferences; recording the snapped value neuters that. Neither the paper
+(range domains) nor the survey mentions it, and `run_hole_snap_test` catches it
+immediately.
+
+### Backtracking: exact restoration, not a lazy clamp
+
+`Do` and the record of which arcs the invariants have been established for both
+have to be restored on backtracking, and **restored exactly**.
+
+The tempting cheap alternative — clamp `Do(x) := min(Do(x), min D(x))` at the
+next call rather than restoring it — is wrong. Guess `y >= 10`; the propagator
+runs and records `Do(y) = 10`; the branch fails; `y >= 5` is restored; the
+sibling guesses `y >= 7`. The clamp gives `Do(y) = min(10, 7) = 7`, which is
+`min D(y)`, so `y ∉ Vl`, the gate never expands, and the consequences of
+`y >= 7` — computed in a branch that has been thrown away — are simply gone.
+Successive guesses tightening the same variable is the commonest branching
+pattern there is, and no proof can see the loss. `difference_test incremental`
+runs that scenario verbatim.
+
+`State::on_backtrack` is not reachable from a propagator's `const State &`, so
+the restoration goes through the trailed constraint state. Putting `Do` itself
+there would make entering an epoch `O(n + m)`, since gcs copies the whole
+constraint-state vector at every `new_epoch`. So what is trailed is **one
+number**: the length of an undo trail that lives in the propagator's own
+(untrailed) memory. Entering an epoch is `O(1)`; the next call after a backtrack
+pops the trail down to the restored mark, which restores exact values. Doing that
+lazily is safe precisely *because* the values are exact and do not depend on the
+current domains — nothing reads `Do` between the backtrack and that call. The
+trail's length is bounded by the current root-to-leaf path, not by total work,
+because it shrinks again on every backtrack.
+
+### Arc activation: the paper's section 5.4 omits half of it
+
+`Do` says nothing whatsoever about an arc that has joined the graph since the
+last run, and a reification becoming true can deliver one **with no node bound
+changing anywhere**. `Vl` is then empty, `IncLB` does nothing, and the push the
+arc delivers is lost.
+
+The paper's section 4.4 gives the right recipe — on adding `(u, v, d)`, compute
+the possibly-new bounds `lb(v) := lb(u) − d` and `ub(u) := ub(v) + d` and feed
+them through `IncLB` / `IncUB` — but **its section 5.4, which is the
+during-search description one would naturally transcribe, mentions only `IncSat`
+and `IncImp`**. Transcribing section 5.4 alone builds a propagator that silently
+loses every reification-delivered push.
+
+Here that seeding is done by *forcing the arc's tail into `Vl` and forcing it to
+be expanded* (and its head, for the upper bound pass), rather than by touching
+`Do`: Dijkstra then carries that node's bound across the new arc and onwards to
+everything downstream, and the `Do` update at the end re-establishes I2 for the
+new arc as a side effect. Lowering `Do` instead would have needed a cascade, since
+lowering `Do(s)` can break I2 for arcs *into* `s`.
+
+**Re-activation after backtracking counts, every single time.** `π` is never
+reset and drifts downwards over the whole search, so an arc whose reduced cost
+was non-negative when it was last active can be negative when it comes back —
+`π`'s invariant is only maintained for arcs that are *in* the graph. Nothing may
+cache "this arc has been checked", which is why the activation record is trailed
+alongside `Do`. A negative reduced cost is not a slow path but a wrong one: it
+breaks Dijkstra's settle order.
+
+### The two oracles
+
+Both come from keeping the from-scratch pass compiled and runtime-selectable.
+They exist because of the asymmetry this whole file keeps running into: a proof
+certifies what *was* derived, so an inference that should have been made and was
+not is invisible to VeriPB. Every way the machinery above can go wrong loses
+propagation.
+
+**The differential fixpoint audit** re-runs the from-scratch pass after *every*
+incremental call, on the same starting bounds and the same active edge set, and
+requires the two to agree node for node — plus that it finds no negative cycle
+the incremental route missed. It is on for every fixture in
+`difference_constraints_test.cc`, and `GCS_DIFFERENCE_AUDIT=1` turns it on for
+every difference propagator in a process, so a whole corpus (or an example
+binary) can be run under it without touching a model. It catches a completeness
+failure **at the wake where it first occurs**, which is the only way to catch a
+stale `Do`, a stale `π`, a missed activation seed or a wrong `π(v0)`.
+
+**Search-shape equality.** Given I1 and I2 the incremental route reaches the
+*identical per-call fixpoint*, not merely the same eventual one: a bounds closure
+is the least fixpoint of monotone inflationary operators and is therefore unique.
+So the search tree must be bit-identical. Intra-call inference *order* does
+differ — Dijkstra settles in a different order from the predecessor forest — so
+`propagations`, other propagators' wake order and proof bytes may legitimately
+move; `recursions`, the solution sequence and every per-node domain may not.
+`run_test` therefore solves every fixture both ways and requires the solution set
+*and* the recursion count to match, with a failure message saying not to relax
+the check. Treat a `recursions` divergence as a bug with certainty. (Voided by a
+randomised or conflict-weighted heuristic; the default `dom_then_deg` and the
+harness's seeded random brancher are both fine, because both runs use the same
+one.)
+
+### What actually went wrong, measured by mutation
+
+Every row was produced by breaking the shipping code in exactly that way,
+rebuilding, and recording which test modes failed. The last two rows are the
+interesting ones.
+
+| mutation | caught by |
+|---|---|
+| record end-of-call state bounds in `Do` | `incremental`, `basic` (the hole snap), `reified`, `cycles`, `views` |
+| clamp `Do` lazily instead of restoring it | every mode, and the presolver |
+| never unwind the trail at all | every mode, and the presolver |
+| seed nothing on activation (section 5.4 only) | `incremental`, `reified`, `random_reified` |
+| cache "this arc has been checked" across backtracking | `incremental`, `reified`, `simplify`, `random_reified`, presolver |
+| `Vl` gate off by one | every mode |
+| expansion gate off by one | every mode |
+| Algorithm 3 lines 15–16 literally (`γ(s)` after the `+∞` reset) | every mode |
+| **`π(v0)` not the maximum over `Vl`** | **nothing — and it cannot be** |
+| **no expansion gate at all** | **nothing — and it should not be** |
+
+The last two are worth stating properly, because one of them contradicts a
+prediction and the other confirms the theory.
+
+**`π(v0)` cannot break anything here, whatever it is.** It enters only as
+`γ(v) = π(v0) − min D(v) − π(v)` and leaves as `−δ(v) = π(v0) − γ(v) − π(v)`, so
+any change to it is a *uniform shift* of every key in the priority queue and
+cancels exactly out of every bound the pass reports. A too-small `π(v0)` makes
+some seeds negative, which is harmless for a binary-heap Dijkstra: Dijkstra needs
+non-negative *edges*, and a multi-source search with differing (even negative)
+initial distances is fine. It is still computed per call over `Vl` — that is the
+cheapest correct thing and it costs nothing extra — but the predicted failure
+mode does not exist in this implementation. It *would* exist under a monotone
+bucket or radix priority queue, which assumes non-decreasing extraction, so this
+is a fact about the queue rather than about the algorithm.
+
+**Removing the expansion gate is sound and complete, just slower.** That is the
+correct answer, and it is a useful negative control on the mutation harness:
+over-expansion loses nothing, which is why every *tightening* of a gate above is
+caught and the loosening is not.
+
+### Measurements
+
+`examples/difference_chain`, the paper's Example 8, `--variant=global
+--simplify=off`, `k = 2`, release build, `taskset`-pinned, medians of 3, no
+`--prove`:
+
+| n | order | variant | recursions | propagations | time (s) |
+|---:|---|---|---:|---:|---:|
+| 40 | unlucky | decomposed | 43 | 37,102 | 0.00123 |
+| 40 | unlucky | global, from scratch | 83 | 87 | 0.00043 |
+| 40 | unlucky | global, incremental | 83 | 87 | **0.00028** |
+| 40 | lucky | decomposed | 43 | 3,601 | 0.00056 |
+| 40 | lucky | global, from scratch | 83 | 87 | 0.00042 |
+| 40 | lucky | global, incremental | 83 | 87 | **0.00028** |
+| 160 | unlucky | decomposed | 163 | 2,126,002 | 0.0455 |
+| 160 | unlucky | global, from scratch | 323 | 327 | 0.0081 |
+| 160 | unlucky | global, incremental | 323 | 327 | **0.0028** |
+| 160 | lucky | decomposed | 163 | 52,801 | 0.0081 |
+| 160 | lucky | global, from scratch | 323 | 327 | 0.0069 |
+| 160 | lucky | global, incremental | 323 | 327 | **0.0028** |
+| 640 | unlucky | decomposed | 643 | 132,305,602 | 3.654 |
+| 640 | unlucky | global, from scratch | 1,283 | 1,287 | 0.323 |
+| 640 | unlucky | global, incremental | 1,283 | 1,287 | **0.057** |
+| 640 | lucky | decomposed | 643 | 825,601 | 0.212 |
+| 640 | lucky | global, from scratch | 1,283 | 1,287 | 0.269 |
+| 640 | lucky | global, incremental | 1,283 | 1,287 | **0.057** |
+
+`recursions` and `propagations` are identical down every column, which is what
+says the wall-time column is measuring propagation cost and nothing else. The
+`n = 640` figures are the headline: `--variant=global` was the *slower* choice on
+the lucky order at that size (0.297 s against the decomposed model's 0.199 s in
+the table earlier in this file) and is now comfortably the faster one.
+
+`examples/rcpsp`, the real family, `--variant=global --simplify=off`, same
+protocol, maximum lags on:
+
+| instance | status | recursions | prop (dec) | prop (global) | dec (s) | global, scratch (s) | global, incr (s) |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `--size 20 --seed 5 --max-lag-density 0.3` | unsat | 1 | 1,155 | 1 | 0.000492 | 0.000153 | 0.000163 |
+| `--size 12 --seed 3 --max-lag-density 0.3` | optimal | 61 | 749 | 140 | 0.000502 | 0.000429 | 0.000430 |
+| `--size 18 --seed 11 --max-lag-density 0.3` | optimal | 102 | 2,669 | 227 | 0.001192 | 0.000770 | 0.000784 |
+| `--size 22 --seed 4 --max-lag-density 0.25` | optimal | 10,512 | 109,199 | 32,682 | 0.0775 | 0.0855 | **0.0701** |
+| `--size 15 --seed 0 --max-lag-density 0.3 --max-lag-slack 4` | unsat | 3,796,420 | 76,983,465 | 19,692,576 | 40.88 | 38.89 | **36.67** |
+
+`recursions` is identical across all three columns on every row, which is what
+says the time columns are measuring propagation cost and nothing else.
+
+**The `--size 22 --seed 4` row is the one this PR exists for.** The RCPSP/max
+section above measured it as the instance where the global propagator lost to
+the decomposed model in wall time — 3.3x fewer propagations and 8 % slower — and
+named non-incrementality as the cause. The from-scratch route is 10 % slower than
+the decomposed model there; the incremental route is 10 % *faster*. The largest
+row moves the same way, 38.89 s to 36.67 s against the decomposed model's 40.88 s.
+
+The small rows are flat, and honestly so: at this size the from-scratch pass
+early-exits after two or three relaxation rounds over a few dozen arcs, which is
+already cheap. The asymptotic win needs `|E| >> n` (which is what
+`difference_chain` is), long chains, or a search deep enough for the per-wake
+cost to dominate.
+
+Half-reified resources, `--machine=difference`, which is where the conditional
+edges live and therefore where `IncSat` and the activation seeding are exercised
+at all:
+
+| instance | variant | recursions | propagations | time (s) |
+|---|---|---:|---:|---:|
+| `--size 12 --seed 2 --machine-fraction 0.8` | decomposed | 277 | 13,638 | 0.00343 |
+| | global, from scratch | 2,091 | 3,640 | **0.01626** |
+| | global, incremental | 2,091 | 3,640 | 0.01717 |
+| `--size 11 --seed 4 --machine-fraction 0.9` | decomposed | 917 | 51,142 | 0.01102 |
+| | global, from scratch | 10,471 | 17,087 | **0.08168** |
+| | global, incremental | 10,471 | 17,087 | 0.08816 |
+| `--size 10 --seed 5 --machine-fraction 0.7` | decomposed | 3,172 | 178,964 | 0.03569 |
+| | global, from scratch | 28,138 | 44,369 | **0.21335** |
+| | global, incremental | 28,138 | 44,369 | 0.23048 |
+
+**This is the one family where incrementality loses, consistently, by 5 to
+8 %**, and the reason is worth stating because it is not a bug and not a missing
+optimisation.
+
+A pairwise disjunctive encoding contributes `n(n-1)` conditional arcs against `n`
+nodes, so `|E| ~ n^2` and every wake is dominated by the `O(|E|)` pass that tests
+which conditions currently hold --- which *both* routes pay, and which was 19 %
+of the profile in both. What the incremental route saves on top of that is the
+relaxation, which is cheap here because only the arcs whose Booleans have been
+fixed are active. What it adds is one `IncSat` per activation, and on this
+modelling those repairs are nearly always real: `pi` is seeded from the
+unconditional temporal network, and a disjunctive arc weighs `-p_i`, so its
+reduced cost starts out negative essentially every time. Each repair is a
+Dijkstra over a graph in which every node has `~2(n-1)` outgoing arcs.
+
+So the trade is: pay one potential repair per Boolean fixed, to save a
+relaxation that was not expensive. `--incremental=off` is there for exactly this,
+and the default stays on because the two families the paper and this stack care
+about most --- Example 8 and the unconditional temporal network --- both want it.
+Note that root simplification refutes most of these instances outright anyway
+(see above), which is where the real win on this family is.
+
+Root simplification interacts with this, because #592 measured Johnson's pass at
+30–50 % of the solve on dense `difference_chain`. Making the solve four times
+faster does not make the pass any cheaper, so its *share* rises:
+
+| n | incremental | simplify | recursions | Johnson's (s) | solve (s) | Johnson's share |
+|---:|---|---|---:|---:|---:|---:|
+| 160 | off | off | 323 | — | 0.0083 | — |
+| 160 | off | on | 323 | 0.0032 | 0.0112 | 29 % |
+| 160 | on | off | 323 | — | 0.0027 | — |
+| 160 | on | on | 323 | 0.0032 | 0.0060 | **54 %** |
+| 320 | off | off | 643 | — | 0.0514 | — |
+| 320 | off | on | 643 | 0.0220 | 0.0728 | 30 % |
+| 320 | on | off | 643 | — | 0.0123 | — |
+| 320 | on | on | 643 | 0.0228 | 0.0359 | **63 %** |
+| 640 | off | off | 1,283 | — | 0.352 | — |
+| 640 | off | on | 1,283 | 0.165 | 0.515 | 32 % |
+| 640 | on | off | 1,283 | — | 0.056 | — |
+| 640 | on | on | 1,283 | 0.164 | 0.220 | **75 %** |
+
+The pass itself has not changed and costs the same to the microsecond. What has
+changed is everything around it: on this family the root simplification stage is
+now **three quarters** of the solve, against the 30-50 % #592 measured. It still
+drops `n - 1` edges out of `n(n+5)/2` here and buys nothing, so this is the same
+trade-off as before, just with the losing side of it four times more visible.
+Nothing about that is an argument for changing the default, which is a statement
+about scheduling models with conditional edges and not about this one; it is an
+argument for `--simplify=off` being easy to reach, which it is.
+
+### What this does not fix
+
+The per-wake cost is now `O(n + |Vl| log n + reachable arcs)` rather than
+`O(rounds × |E|)`, but the `O(n)` term is unavoidable without advisors: `Vl` is
+built by scanning every node's bounds against `Do`. The refined-watch inbox could
+supply it directly, but `propagators.cc` drops undelivered payloads when a
+contradiction cuts a round short, so it could only ever be an optimisation on top
+of the scan and never the sole source of truth. On a small, sparse graph — 21
+nodes and a few dozen arcs, which is what `examples/rcpsp` is at the smaller
+`--size` values — that `O(n)` term
+plus a heap is not much cheaper than a Bellman-Ford pass that early-exits after
+two rounds, and the win is correspondingly modest. The win is large exactly where
+the asymptotics say it should be: `|E| >> n`, or long chains.
+
 ## Deliberately deferred
 
-- **Incrementality.** The paper's `IncSat` / `IncLB` / `IncUB` maintain a valid
-  potential function `π` and run Dijkstra on the reduced-cost graph, processing
-  all bound changes since the last run in one pass, in `O(n log n + m)`. `π`
-  stays valid when edges are removed — validity is a conjunction over edges — so
-  it needs no trailing, which suits backtracking well. None of that is here: this
-  version recomputes Bellman-Ford from scratch on every wake, which is
-  `O(n·m)` worst case. The wall-time caveat above is entirely this.
 - **`IncImp`** (implication checking, to disentail half-reified edges). It needs
   no new proof machinery — "shortest path `x ⇝ y` of weight `<= d'`" plus the
   candidate edge `y --(-d'-1)--(b)--> x` is a negative cycle, so it is proof

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -1482,13 +1482,19 @@ interesting ones.
 | record end-of-call state bounds in `Do` | `incremental`, `basic` (the hole snap), `reified`, `cycles`, `views` |
 | clamp `Do` lazily instead of restoring it | every mode, and the presolver |
 | never unwind the trail at all | every mode, and the presolver |
-| seed nothing on activation (section 5.4 only) | `incremental`, `reified`, `random_reified` |
+| seed nothing on activation (section 5.4 only) | `incremental`, `reified`, `simplify`, `random_reified` |
 | cache "this arc has been checked" across backtracking | `incremental`, `reified`, `simplify`, `random_reified`, presolver |
-| `Vl` gate off by one | every mode |
-| expansion gate off by one | every mode |
-| Algorithm 3 lines 15–16 literally (`γ(s)` after the `+∞` reset) | every mode |
+| `Vl` gate off by one | every mode, and the presolver |
+| expansion gate off by one | every mode, and the presolver |
+| Algorithm 3 lines 15–16 literally (`γ(s)` after the `+∞` reset) | every mode, and the presolver |
 | **`π(v0)` not the maximum over `Vl`** | **nothing — and it cannot be** |
 | **no expansion gate at all** | **nothing — and it should not be** |
+
+"Every mode" means every mode that fired on the run that produced this table;
+`random` and `random_reified` generate their systems from the announced test
+seed, so which of the two catches a given mutation moves about between seeds and
+neither is what any row is resting on. The deterministic modes were stable across
+the runs taken.
 
 The last two are worth stating properly, because one of them contradicts a
 prediction and the other confirms the theory.

--- a/examples/difference_chain/difference_chain.cc
+++ b/examples/difference_chain/difference_chain.cc
@@ -194,8 +194,8 @@ namespace
     // once. Both variants produce the same OPB rows for the same edges (one
     // labelled inequality per edge), so the proofs are directly comparable.
     auto post_edges(Problem & problem, const vector<DifferenceEdge> & edges, Variant variant, bool disable_donors,
-        const shared_ptr<DifferenceLogicStats> & presolver_stats, bool simplify, const shared_ptr<DifferenceSimplificationStats> & simplification)
-        -> void
+        const shared_ptr<DifferenceLogicStats> & presolver_stats, bool simplify, const shared_ptr<DifferenceSimplificationStats> & simplification,
+        bool incremental) -> void
     {
         switch (variant) {
             using enum Variant;
@@ -207,9 +207,13 @@ namespace
                 problem.add_presolver(DifferenceLogic{presolver_stats}
                         .disabling_lifted_donors(disable_donors)
                         .simplifying_at_root(simplify)
-                        .reporting_simplification_to(simplification));
+                        .reporting_simplification_to(simplification)
+                        .incrementally(incremental));
             break;
-        case Global: problem.post(DifferenceConstraints{edges}.simplifying_at_root(simplify).reporting_simplification_to(simplification)); break;
+        case Global:
+            problem.post(
+                DifferenceConstraints{edges}.simplifying_at_root(simplify).reporting_simplification_to(simplification).incrementally(incremental));
+            break;
         }
     }
 
@@ -270,6 +274,12 @@ auto main(int argc, char * argv[]) -> int
             ("simplify",                                                                                 //
                 "Run the difference-logic root simplification stage. On by default; --simplify=off "     //
                 "turns it off. Ignored under --variant=decomposed, which has no difference propagator",  //
+                cxxopts::value<string>()->default_value("on"))                                           //
+            ("incremental",                                                                              //
+                "Propagate the difference system incrementally (a maintained potential function and "    //
+                "Dijkstra on reduced costs) rather than re-running Bellman-Ford from scratch on every "  //
+                "wake. On by default; --incremental=off selects the from-scratch version, which must "   //
+                "reach the identical fixpoint and so must search identically",                           //
                 cxxopts::value<string>()->default_value("on"))                                           //
             ;
 
@@ -360,6 +370,13 @@ auto main(int argc, char * argv[]) -> int
     }
     auto simplify = (simplify_name == "on");
 
+    auto incremental_name = options_vars["incremental"].as<string>();
+    if (incremental_name != "on" && incremental_name != "off") {
+        println(cerr, "Error: --incremental must be on or off, not '{}'.", incremental_name);
+        return EXIT_FAILURE;
+    }
+    auto incremental = (incremental_name == "on");
+
     auto disable_donors = options_vars.contains("disable-donors");
     if (disable_donors && *variant != Variant::Presolved) {
         println(cerr, "Error: --disable-donors only means anything with --variant=presolved.");
@@ -368,7 +385,7 @@ auto main(int argc, char * argv[]) -> int
 
     auto presolver_stats = make_shared<DifferenceLogicStats>();
     auto simplification = make_shared<DifferenceSimplificationStats>();
-    post_edges(problem, edges, *variant, disable_donors, presolver_stats, simplify, simplification);
+    post_edges(problem, edges, *variant, disable_donors, presolver_stats, simplify, simplification, incremental);
 
     // The lower-bound bump that starts the chase. Posted last, so that the
     // difference constraints are all in the queue ahead of it and the bump wakes
@@ -409,6 +426,7 @@ auto main(int argc, char * argv[]) -> int
     println("mode: {}", mode_name);
     println("variant: {}", variant_name_given);
     if (*variant != Variant::Decomposed) {
+        println("incremental: {}", incremental_name);
         println("simplify: {}", simplify_name);
         println("simplify_ran: {}", simplification->ran ? "yes" : "no");
         println("simplify_seconds: {:.6f}", simplification->seconds);

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -353,6 +353,12 @@ auto main(int argc, char * argv[]) -> int
                 "default; --simplify=off turns it off. Ignored under --variant=decomposed, which "  //
                 "has no difference propagator to simplify for",                                     //
                 cxxopts::value<string>()->default_value("on"))                                      //
+            ("incremental",
+                "Propagate the difference system incrementally (a maintained potential function "  //
+                "and Dijkstra on reduced costs) rather than re-running Bellman-Ford from scratch " //
+                "on every wake. On by default; --incremental=off selects the from-scratch "        //
+                "version, which must reach the identical fixpoint and so must search identically", //
+                cxxopts::value<string>()->default_value("on"))                                     //
             ;
 
         options_vars = options.parse(argc, argv);
@@ -481,6 +487,13 @@ auto main(int argc, char * argv[]) -> int
     auto simplify = (simplify_name == "on");
     auto simplification = std::make_shared<DifferenceSimplificationStats>();
 
+    auto incremental_name = options_vars["incremental"].as<string>();
+    if (incremental_name != "on" && incremental_name != "off") {
+        println(cerr, "Error: --incremental must be on or off, not '{}'.", incremental_name);
+        return EXIT_FAILURE;
+    }
+    auto incremental = (incremental_name == "on");
+
     // The temporal network. --variant decides how it reaches the solver, over
     // the identical edge list in the identical order, so a comparison between
     // the three is between the handling and nothing else.
@@ -536,7 +549,10 @@ auto main(int argc, char * argv[]) -> int
                 problem.post(LinearGreaterThanEqual{sum, e.d});
         }
         if (*variant == Presolved)
-            problem.add_presolver(DifferenceLogic{presolver_stats}.simplifying_at_root(simplify).reporting_simplification_to(simplification));
+            problem.add_presolver(DifferenceLogic{presolver_stats}
+                    .simplifying_at_root(simplify)
+                    .reporting_simplification_to(simplification)
+                    .incrementally(incremental));
         break;
 
     case Global:
@@ -547,7 +563,10 @@ auto main(int argc, char * argv[]) -> int
             difference_edges.reserve(edges.size());
             for (const auto & e : edges)
                 difference_edges.push_back(DifferenceEdge{e.from, e.to, -e.d, e.cond});
-            problem.post(DifferenceConstraints{difference_edges}.simplifying_at_root(simplify).reporting_simplification_to(simplification));
+            problem.post(DifferenceConstraints{difference_edges}
+                    .simplifying_at_root(simplify)
+                    .reporting_simplification_to(simplification)
+                    .incrementally(incremental));
         }
         break;
     }
@@ -695,6 +714,7 @@ auto main(int argc, char * argv[]) -> int
     }
     if (*variant != Variant::Decomposed) {
         println("simplify: {}", simplify_name);
+        println("incremental: {}", incremental_name);
         println("simplify_ran: {}", simplification->ran ? "yes" : "no");
         println("simplify_redundant_edges_removed: {}", simplification->redundant_edges_removed);
         println("simplify_conditions_fixed: {}", simplification->conditions_fixed);

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(glasgow_constraint_solver
         constraints/cumulative/cumulative.cc
         constraints/difference/difference_constraints.cc
         constraints/difference/difference_graph.cc
+        constraints/difference/difference_incremental.cc
         constraints/difference/difference_simplify.cc
         constraints/disjunctive/disjunctive.cc
         constraints/disjunctive_2d/disjunctive_2d.cc

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -308,7 +308,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
-    foreach(mode basic cycles views alias reified simplify random random_reified)
+    foreach(mode basic cycles views alias reified simplify incremental random random_reified)
         add_test(NAME difference_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_test> ${mode})
     endforeach()

--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -75,16 +75,35 @@ auto DifferenceConstraints::reporting_simplification_to(shared_ptr<DifferenceSim
     return *this;
 }
 
+auto DifferenceConstraints::incrementally(bool incremental) -> DifferenceConstraints &
+{
+    _incremental.enabled = incremental;
+    return *this;
+}
+
+auto DifferenceConstraints::auditing_incremental_propagation(bool audit) -> DifferenceConstraints &
+{
+    _incremental.audit = audit;
+    return *this;
+}
+
 auto DifferenceConstraints::clone() const -> unique_ptr<Constraint>
 {
     auto result = make_unique<DifferenceConstraints>(_edges);
     result->simplifying_at_root(_simplify.enabled);
     result->reporting_simplification_to(_simplify.stats);
+    result->incrementally(_incremental.enabled);
+    result->auditing_incremental_propagation(_incremental.audit);
     return result;
 }
 
-auto DifferenceConstraints::prepare(Propagators &, State &, ProofModel * const) -> bool
+auto DifferenceConstraints::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
+    // The only phase handed a *mutable* State --- define_proof_model gets a
+    // const one --- and install_propagators() needs one to register the
+    // incremental machinery's trailed constraint state.
+    _initial_state = &initial_state;
+
     if (_edges.empty())
         return false;
 
@@ -214,7 +233,10 @@ auto DifferenceConstraints::install_propagators(Propagators & propagators) -> vo
         return;
     }
 
-    install_difference_propagator(propagators, constraint_id(), move(_graph), move(_simplify));
+    if (! _initial_state)
+        throw UnexpectedException{"DifferenceConstraints::install_propagators was called without prepare() having run first"};
+
+    install_difference_propagator(propagators, *_initial_state, constraint_id(), move(_graph), move(_simplify), move(_incremental));
 }
 
 auto DifferenceConstraints::constraint_type() const -> string

--- a/gcs/constraints/difference/difference_constraints.hh
+++ b/gcs/constraints/difference/difference_constraints.hh
@@ -79,8 +79,12 @@ namespace gcs
      * unaffected, and this propagator is bounds consistent rather than domain
      * consistent in any case.
      *
-     * Incremental propagation is not implemented: every wake recomputes from
-     * scratch.
+     * Propagation is incremental by default: a potential function is maintained
+     * across the whole search and never trailed, and each wake runs Dijkstra on
+     * the reduced-cost graph over just the bounds that have moved since the last
+     * one. \ref incrementally selects the from-scratch Bellman-Ford version
+     * instead, which reaches the identical per-call fixpoint and therefore must
+     * search identically.
      *
      * See `dev_docs/difference-logic.md` for the design, the proof shapes and
      * what is deferred.
@@ -117,6 +121,16 @@ namespace gcs
         // measures the simplification as most of the win.
         innards::DifferenceSimplificationOptions _simplify;
 
+        // Whether to propagate incrementally, and whether to audit that against
+        // the from-scratch pass. On and off respectively.
+        innards::DifferenceIncrementalOptions _incremental;
+
+        // Stashed by prepare(), which is the only place in the split install
+        // pattern that is handed a State, and needed by install_propagators()
+        // for the one piece of trailed constraint state the incremental
+        // machinery keeps.
+        innards::State * _initial_state = nullptr;
+
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
@@ -149,6 +163,36 @@ namespace gcs
          * other check there is, so these counters are what the tests assert on.
          */
         auto reporting_simplification_to(std::shared_ptr<DifferenceSimplificationStats>) -> DifferenceConstraints &;
+
+        /**
+         * \brief Propagate incrementally (the default), or from scratch on
+         * every wake.
+         *
+         * The incremental route maintains a potential function and runs
+         * Dijkstra on the reduced-cost graph over just the bounds that have
+         * moved, which is `O(n log n + m)` against the from-scratch route's
+         * `O(n.m)`. The two reach the identical per-call fixpoint, so
+         * `recursions` and the solution sequence must come out the same either
+         * way; that equality is the sharpest test there is of the incremental
+         * route, because a lost inference is invisible to proof logging.
+         */
+        auto incrementally(bool = true) -> DifferenceConstraints &;
+
+        /**
+         * \brief Re-run the from-scratch pass after every incremental call and
+         * require the two to agree, node for node.
+         *
+         * Off by default and intended for tests: it makes every wake cost what
+         * the non-incremental route costs, plus the incremental route on top.
+         * What it buys is catching a completeness failure --- a stale `Do`
+         * array, a stale potential function, a missed activation seed, a wrong
+         * `pi(v0)` --- at the wake where it first happens rather than as a
+         * missing solution a million nodes later, or not at all.
+         *
+         * Also forced on for every difference propagator in the process by the
+         * `GCS_DIFFERENCE_AUDIT` environment variable.
+         */
+        auto auditing_incremental_propagation(bool = true) -> DifferenceConstraints &;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -894,6 +894,87 @@ namespace
             66);
     }
 
+    // Randomised backtracking stress, with restarts. Restarts are the one thing
+    // in the engine that unwinds all the way to the root at a moment nothing
+    // else chooses, so they are the sharpest exercise of the undo trail there
+    // is: every restart pops it back to the root mark, and a Do array that
+    // survived a restart it should not have, or that was popped further than it
+    // should have been, shows up as a different optimum or a different search.
+    //
+    // Optimisation rather than enumeration, because a restart schedule without
+    // recorded nogoods re-finds solutions and gcs rejects combining it with
+    // all-solution enumeration. The Luby scale is deliberately tiny so that a
+    // few-hundred-node search restarts many times.
+    auto run_restart_stress() -> void
+    {
+        print(cerr, "difference incremental restart stress:");
+        cerr << flush;
+
+        mt19937 rand(*get_seed());
+        size_t agreed = 0;
+
+        for (int iteration = 0; iteration < 20; ++iteration) {
+            uniform_int_distribution n_vars_dist{3, 5};
+            auto n_vars = n_vars_dist(rand);
+            vector<pair<int, int>> domains;
+            for (int i = 0; i < n_vars; ++i) {
+                uniform_int_distribution lo_dist{-2, 2};
+                auto lo = lo_dist(rand);
+                uniform_int_distribution width_dist{2, 7};
+                domains.emplace_back(lo, lo + width_dist(rand));
+            }
+            domains.emplace_back(0, 1);
+            domains.emplace_back(0, 1);
+
+            uniform_int_distribution n_edges_dist{2, 7};
+            auto n_edges = n_edges_dist(rand);
+            vector<EdgeSpec> edges;
+            for (int e = 0; e < n_edges; ++e) {
+                uniform_int_distribution var_dist{0, n_vars - 1};
+                uniform_int_distribution d_dist{-3, 3};
+                uniform_int_distribution which_dist{0, 4};
+                auto which = which_dist(rand);
+                optional<Cond> cond;
+                if (which > 0)
+                    cond = Cond{static_cast<size_t>(n_vars + (which - 1) / 2), (which - 1) % 2};
+                edges.push_back(EdgeSpec{v(static_cast<size_t>(var_dist(rand))), v(static_cast<size_t>(var_dist(rand))), d_dist(rand), cond});
+            }
+
+            auto solve_one = [&](bool incremental) -> tuple<unsigned long long, unsigned long long, int> {
+                Problem p;
+                auto vars = make_vars(p, domains);
+                vector<DifferenceEdge> posted;
+                for (const auto & e : edges)
+                    posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
+                p.post(DifferenceConstraints{posted}.incrementally(incremental).auditing_incremental_propagation());
+                p.minimise(vars.front());
+
+                int best = 0;
+                auto result = solve_with(p,
+                    SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                                       best = s(vars.front()).raw_value;
+                                       return true;
+                                   },
+                        .branch = random_branch_with_optional_seed(p),
+                        .restarts = RestartSchedule::luby(3)});
+                return {result.recursions, result.solutions, best};
+            };
+
+            auto incremental = solve_one(true);
+            auto from_scratch = solve_one(false);
+            if (incremental != from_scratch)
+                throw UnexpectedException{"difference incremental restart stress iteration " + to_string(iteration) +
+                    ": with restarts, incremental propagation gave recursions/solutions/optimum " + to_string(std::get<0>(incremental)) + "/" +
+                    to_string(std::get<1>(incremental)) + "/" + to_string(std::get<2>(incremental)) + " against the from-scratch pass's " +
+                    to_string(std::get<0>(from_scratch)) + "/" + to_string(std::get<1>(from_scratch)) + "/" + to_string(std::get<2>(from_scratch)) +
+                    ". A restart unwinds to the root at a moment nothing else chooses, so this is the undo trail being popped too far or not far "
+                    "enough. Do NOT relax this check."};
+            ++agreed;
+        }
+
+        println(cerr, " {} random systems agreed on recursions, solutions and optimum", agreed);
+    }
+
     auto run_incremental_tests() -> void
     {
         for (bool incremental : {true, false}) {
@@ -907,6 +988,8 @@ namespace
             // the mandatory self-re-wake finds Vl empty and stops with z at 5.
             run_hole_snap_test(incremental);
         }
+
+        run_restart_stress();
     }
 
     auto run_all_tests(bool proofs, const string & mode) -> void

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -6,6 +6,7 @@
 #include <gcs/solve.hh>
 
 #include <cstdlib>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -27,6 +28,7 @@
 
 using std::cerr;
 using std::flush;
+using std::function;
 using std::make_optional;
 using std::make_shared;
 using std::mt19937;
@@ -150,13 +152,26 @@ namespace
     // the propagator shows up as a missing solution, over-pruning as an extra
     // one, and proof logging can catch neither of those (it only ever catches a
     // wrong inference). See the survey's section 5.2, item 11.
+    //
+    // The global model is then solved a second time with incrementality turned
+    // off, and *both* the solution set and the recursion count have to come out
+    // identical. That is not a smoke test: given the gate invariants the
+    // incremental route reaches the same per-call fixpoint as the from-scratch
+    // one, and a bounds fixpoint is the least fixpoint of monotone inflationary
+    // operators, so it is unique --- which makes the search tree bit-identical.
+    // `propagations` and the proof bytes may legitimately differ, because
+    // Dijkstra settles in a different order from the predecessor forest, but a
+    // `recursions` difference is a lost or gained inference and nothing else.
+    // This is the sharpest check there is on the incremental machinery, because
+    // every way it can go wrong loses propagation, and lost propagation is
+    // invisible to VeriPB.
     auto run_test(bool proofs, const string & mode, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges)
         -> void
     {
         print(cerr, "difference {} {} domains={} edges={}{}", mode, name, domains, edges.size(), proofs ? " with proofs:" : ":");
         cerr << flush;
 
-        set<tuple<vector<int>>> expected, actual, decomposed;
+        set<tuple<vector<int>>> expected, actual, decomposed, from_scratch;
         build_expected(expected, [&](const vector<int> & vals) { return satisfied(vals, edges); }, domains);
         println(cerr, " expecting {} solutions", expected.size());
 
@@ -170,6 +185,7 @@ namespace
         // the propagator, and it is what CI found on the reified random mode
         // (whose extra condition variables multiply the solution count).
         bool truncated = false;
+        unsigned long long incremental_recursions = 0, from_scratch_recursions = 0;
 
         {
             Problem p;
@@ -177,7 +193,13 @@ namespace
             vector<DifferenceEdge> posted;
             for (const auto & e : edges)
                 posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
-            p.post(DifferenceConstraints{posted});
+            // The differential fixpoint audit is on for every fixture in this
+            // file: after each incremental call the from-scratch pass is re-run
+            // on the same starting bounds and the same active edge set, and the
+            // two have to agree node for node. That catches a completeness
+            // failure at the wake where it happens rather than as a missing
+            // solution a long way downstream, or not at all.
+            p.post(DifferenceConstraints{posted}.auditing_incremental_propagation());
 
             auto proof_name = proofs ? make_optional("difference_test_" + mode + "_" + name) : nullopt;
             // Bounds consistent, not GAC: the propagator only reads and writes
@@ -185,7 +207,21 @@ namespace
             // 2 assumes ranges.
             solve_for_tests(p, proof_name, actual, tuple{vars});
             truncated = truncated || last_run_truncated();
+            incremental_recursions = last_run_recursions();
             check_results(proof_name, expected, actual);
+        }
+
+        {
+            Problem p;
+            auto vars = make_vars(p, domains);
+            vector<DifferenceEdge> posted;
+            for (const auto & e : edges)
+                posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
+            p.post(DifferenceConstraints{posted}.incrementally(false));
+
+            solve_for_tests(p, nullopt, from_scratch, tuple{vars});
+            truncated = truncated || last_run_truncated();
+            from_scratch_recursions = last_run_recursions();
         }
 
         {
@@ -202,13 +238,32 @@ namespace
             truncated = truncated || last_run_truncated();
         }
 
-        if (truncated)
+        if (truncated) {
             println(cerr, "difference {} {}: a cap fired, so the global/decomposed cross-check is skipped", mode, name);
-        else if (actual != decomposed) {
+            return;
+        }
+
+        if (actual != decomposed) {
             println(cerr, "difference {} {}: global and decomposed models disagree", mode, name);
             println(cerr, "global has {} solutions, decomposed has {}", actual.size(), decomposed.size());
             throw UnexpectedException{"difference global and decomposed models disagree"};
         }
+
+        if (actual != from_scratch) {
+            println(cerr, "difference {} {}: incremental and from-scratch propagation disagree", mode, name);
+            println(cerr, "incremental has {} solutions, from-scratch has {}", actual.size(), from_scratch.size());
+            throw UnexpectedException{"difference incremental and from-scratch propagation disagree"};
+        }
+
+        if (incremental_recursions != from_scratch_recursions)
+            throw UnexpectedException{"difference " + mode + " " + name + ": incremental propagation took " + to_string(incremental_recursions) +
+                " recursions against the from-scratch pass's " + to_string(from_scratch_recursions) +
+                ". The two reach the identical per-call fixpoint --- a bounds closure is the least fixpoint of monotone inflationary operators and "
+                "is "
+                "therefore unique --- so the search tree cannot legitimately differ. This is a lost or gained inference in the incremental route, "
+                "and "
+                "it is invisible to proof logging. Fix gcs/constraints/difference/difference_incremental.cc or the gate handling in "
+                "difference_graph.cc; do NOT relax this check."};
     }
 
     // The transitive push: two edges whose combined bound is strictly stronger
@@ -217,16 +272,18 @@ namespace
     // edge implies. Solve as far as the first complete propagation and read the
     // bounds off, so this asserts the propagator actually fires rather than
     // merely that the solution set is right.
-    auto run_transitive_test() -> void
+    auto run_transitive_test(bool incremental) -> void
     {
-        print(cerr, "difference transitive push:");
+        print(cerr, "difference transitive push (incremental={}):", incremental);
         cerr << flush;
 
         Problem p;
         auto x = p.create_integer_variable(0_i, 10_i, "x");
         auto y = p.create_integer_variable(0_i, 10_i, "y");
         auto z = p.create_integer_variable(0_i, 10_i, "z");
-        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -3_i}, DifferenceEdge{y, z, -4_i}}});
+        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -3_i}, DifferenceEdge{y, z, -4_i}}}
+                .incrementally(incremental)
+                .auditing_incremental_propagation());
 
         optional<Integer> z_lower, x_upper;
         solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
@@ -257,16 +314,18 @@ namespace
     // engine would not re-wake it from its own inferences and z would be left at
     // 5. Confirmed by mutation: switching the return to EnableButIdempotent makes
     // this fail (and also trips the harness's GCS_CHECK_IDEMPOTENT_CLAIMS re-run).
-    auto run_hole_snap_test() -> void
+    auto run_hole_snap_test(bool incremental) -> void
     {
-        print(cerr, "difference hole snap:");
+        print(cerr, "difference hole snap (incremental={}):", incremental);
         cerr << flush;
 
         Problem p;
         auto x = p.create_integer_variable(0_i, 10_i, "x");
         auto y = p.create_integer_variable(vector<Integer>{0_i, 1_i, 2_i, 6_i, 7_i, 8_i, 9_i, 10_i}, "y");
         auto z = p.create_integer_variable(0_i, 10_i, "z");
-        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -3_i}, DifferenceEdge{y, z, -2_i}}});
+        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -3_i}, DifferenceEdge{y, z, -2_i}}}
+                .incrementally(incremental)
+                .auditing_incremental_propagation());
 
         optional<Integer> y_lower, z_lower;
         solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
@@ -297,9 +356,9 @@ namespace
     //
     // Confirmed by mutation: dropping the DefinitelyTrue test in the
     // active-edge snapshot empties w's domain and this fails immediately.
-    auto run_reified_bounds_test() -> void
+    auto run_reified_bounds_test(bool incremental) -> void
     {
-        print(cerr, "difference reified push and negative control:");
+        print(cerr, "difference reified push and negative control (incremental={}):", incremental);
         cerr << flush;
 
         Problem p;
@@ -310,7 +369,9 @@ namespace
         auto b1 = p.create_integer_variable(1_i, 1_i, "b1");
         auto b2 = p.create_integer_variable(0_i, 0_i, "b2");
         p.post(DifferenceConstraints{
-            {DifferenceEdge{x, y, -3_i, b1 == 1_i}, DifferenceEdge{y, z, -4_i, b1 == 1_i}, DifferenceEdge{w, z, -20_i, b2 == 1_i}}});
+            {DifferenceEdge{x, y, -3_i, b1 == 1_i}, DifferenceEdge{y, z, -4_i, b1 == 1_i}, DifferenceEdge{w, z, -20_i, b2 == 1_i}}}
+                .incrementally(incremental)
+                .auditing_incremental_propagation());
 
         optional<Integer> z_lower, x_upper, w_lower, w_upper;
         solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
@@ -335,9 +396,9 @@ namespace
     // dropping it would let cond hold with the constraint violated, which is
     // unsound rather than merely incomplete. Unconditionally the same edge is a
     // root contradiction instead, which is why the two live in different places.
-    auto run_reified_degenerate_test() -> void
+    auto run_reified_degenerate_test(bool incremental) -> void
     {
-        print(cerr, "difference reified degenerate edge:");
+        print(cerr, "difference reified degenerate edge (incremental={}):", incremental);
         cerr << flush;
 
         Problem p;
@@ -345,7 +406,9 @@ namespace
         auto bad = p.create_integer_variable(0_i, 1_i, "bad");
         auto fine = p.create_integer_variable(0_i, 1_i, "fine");
         // bad -> x - x <= -1, i.e. !bad. fine -> x - x <= 0, i.e. nothing.
-        p.post(DifferenceConstraints{{DifferenceEdge{x, x, -1_i, bad == 1_i}, DifferenceEdge{x, x, 0_i, fine == 1_i}}});
+        p.post(DifferenceConstraints{{DifferenceEdge{x, x, -1_i, bad == 1_i}, DifferenceEdge{x, x, 0_i, fine == 1_i}}}
+                .incrementally(incremental)
+                .auditing_incremental_propagation());
 
         optional<Integer> bad_upper, fine_upper;
         solve_with(p, SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
@@ -659,6 +722,193 @@ namespace
                 to_string(off_recursions) + " recursions"};
     }
 
+    // The incremental machinery's failure mode is always the same: an inference
+    // that should have been made is not, because a gate said there was nothing
+    // to do. Every one of those failures is invisible to proof logging, and most
+    // are invisible to a solution count too, because a lost bound push usually
+    // only makes the solver search harder. So these fixtures assert an
+    // *invariant at every search node*: the propagator's own consequence has to
+    // hold at every fully-propagated state the search visits, not merely at the
+    // leaves. That is a direct test of the gate, and it fails at the node where
+    // the gate first went wrong.
+    //
+    // The branching is fixed and deterministic in each, so the scenario really
+    // is the one described rather than whatever a random order happened to
+    // produce, and every one of them runs both incrementally and from scratch.
+    struct NodeInvariant
+    {
+        string what;
+        function<auto(const CurrentState &)->bool> holds;
+    };
+
+    auto run_node_invariant_test(const string & name, bool incremental, Problem & p, const vector<IntegerVariableID> & branch_vars,
+        const vector<NodeInvariant> & invariants, unsigned long long expected_solutions) -> void
+    {
+        print(cerr, "difference {} (incremental={}):", name, incremental);
+        cerr << flush;
+
+        optional<string> failure;
+        unsigned long long nodes = 0;
+        auto result = solve_with(p,
+            SolveCallbacks{.trace = [&](const CurrentState & s) -> bool {
+                               ++nodes;
+                               for (const auto & i : invariants)
+                                   if (! i.holds(s)) {
+                                       failure = i.what;
+                                       return false;
+                                   }
+                               return true;
+                           },
+                .branch = branch_with(variable_order::in_order(branch_vars), value_order::largest_first())});
+
+        println(cerr, " {} nodes, {} solutions", nodes, result.solutions);
+
+        if (failure)
+            throw UnexpectedException{"difference " + name + " (incremental=" + (incremental ? "yes" : "no") +
+                "): a consequence of the difference system does not hold at a search node the solver visited: " + *failure +
+                ". A bound the system entails was never pushed, which is a lost inference and is invisible to proof logging. Fix "
+                "gcs/constraints/difference/difference_incremental.cc or the gate handling in difference_graph.cc."};
+        if (result.solutions != expected_solutions)
+            throw UnexpectedException{"difference " + name + " (incremental=" + (incremental ? "yes" : "no") + "): found " +
+                to_string(result.solutions) + " solutions, expected " + to_string(expected_solutions)};
+    }
+
+    // (a) The stale-Do scenario, verbatim. `sel` is branched first and
+    // largest-value-first, so the search sets `y >= 10`, propagates (recording
+    // Do(y) = 10), fails against `z <= 12`, backtracks to `y >= 5`, and only
+    // then does the sibling set `y >= 7`.
+    //
+    // A `Do` array clamped lazily against the current bounds at the next call,
+    // rather than restored exactly, would compute Do(y) = min(10, 7) = 7, which
+    // is min D(y), leave `y` out of `Vl`, and never push `z >= 10`: the
+    // consequences of `y >= 7` were computed in a branch that no longer exists.
+    // Successive guesses tightening the same variable is the commonest
+    // branching pattern there is, so this is not an exotic case.
+    auto run_stale_do_test(bool incremental) -> void
+    {
+        Problem p;
+        auto sel = p.create_integer_variable(0_i, 1_i, "sel");
+        auto y = p.create_integer_variable(5_i, 20_i, "y");
+        auto z = p.create_integer_variable(0_i, 12_i, "z");
+        p.post(DifferenceConstraints{{DifferenceEdge{y, z, -3_i}}}.incrementally(incremental).auditing_incremental_propagation());
+        p.post(LinearGreaterThanEqualIf{WeightedSum{} + 1_i * y, 10_i, sel == 1_i});
+        p.post(LinearGreaterThanEqualIf{WeightedSum{} + 1_i * y, 7_i, sel == 0_i});
+
+        // y in 7..9 forced by z <= 12 and z >= y + 3, with sel = 0; sel = 1
+        // needs y >= 10 and so z >= 13, which is impossible.
+        run_node_invariant_test("incremental stale do", incremental, p, {sel, y, z},
+            {{"z >= y + 3", [=](const CurrentState & s) { return s.lower_bound(z) >= s.lower_bound(y) + 3_i; }},
+                {"y <= z - 3", [=](const CurrentState & s) { return s.upper_bound(y) <= s.upper_bound(z) - 3_i; }}},
+            6);
+    }
+
+    // (b) A Boolean fixed with no node bound change at all. At the root `b` is
+    // undecided, so its edge is not in the graph and nothing constrains y; the
+    // moment `b` is fixed true the edge joins the graph and `y >= x + 4` has to
+    // be pushed --- from x's *root* lower bound, which has not moved since the
+    // last run.
+    //
+    // So `Vl` is empty, and an implementation that transcribed only the paper's
+    // section 5.4 (repair the potential function on activation, and stop there)
+    // would do nothing at all here. Section 4.4 is the one that says to seed
+    // bound propagation across the new arc as well.
+    auto run_activation_seed_test(bool incremental) -> void
+    {
+        Problem p;
+        auto b = p.create_integer_variable(0_i, 1_i, "b");
+        auto x = p.create_integer_variable(0_i, 10_i, "x");
+        auto y = p.create_integer_variable(0_i, 10_i, "y");
+        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -4_i, b == 1_i}}}
+                .simplifying_at_root(false)
+                .incrementally(incremental)
+                .auditing_incremental_propagation());
+
+        auto b_holds = [=](const CurrentState & s) { return s.lower_bound(b) == 1_i; };
+        run_node_invariant_test("incremental activation seed", incremental, p, {b, x, y},
+            {{"y >= x + 4 once b is true", [=](const CurrentState & s) { return ! b_holds(s) || s.lower_bound(y) >= s.lower_bound(x) + 4_i; }},
+                {"x <= y - 4 once b is true", [=](const CurrentState & s) { return ! b_holds(s) || s.upper_bound(x) <= s.upper_bound(y) - 4_i; }}},
+            // b = 1: x in 0..6, y in x+4..10, so sum over x of (7 - x) = 28.
+            // b = 0: 121.
+            149);
+    }
+
+    // (c) Activate, backtrack, tighten elsewhere, re-activate, and close a
+    // negative cycle. `g` is branched first purely so that the (b, c) subtree is
+    // entered four times, each entry after a backtrack that deactivated both
+    // conditional edges; every activation after the first is a *re*-activation.
+    //
+    // The potential function is never trailed and drifts downwards over the
+    // whole search, so an edge that satisfied the potential invariant when it
+    // was last active can violate it when it comes back. Caching "this edge has
+    // been checked" would leave the reduced cost negative, which corrupts
+    // Dijkstra's settle order and can lose the refutation entirely.
+    auto run_reactivation_test(bool incremental) -> void
+    {
+        Problem p;
+        auto g = p.create_integer_variable(0_i, 3_i, "g");
+        auto b = p.create_integer_variable(0_i, 1_i, "b");
+        auto cc = p.create_integer_variable(0_i, 1_i, "c");
+        auto x = p.create_integer_variable(0_i, 10_i, "x");
+        auto y = p.create_integer_variable(0_i, 10_i, "y");
+        // b and c together close a cycle of weight -3; either alone is fine.
+        p.post(DifferenceConstraints{{DifferenceEdge{x, y, -5_i, b == 1_i}, DifferenceEdge{y, x, 2_i, cc == 1_i}}}
+                .simplifying_at_root(false)
+                .incrementally(incremental)
+                .auditing_incremental_propagation());
+
+        run_node_invariant_test("incremental reactivation", incremental, p, {g, b, cc, x, y},
+            {{"b and c are never both true", [=](const CurrentState & s) { return ! (s.lower_bound(b) == 1_i && s.lower_bound(cc) == 1_i); }},
+                {"y >= x + 5 once b is true",
+                    [=](const CurrentState & s) { return s.lower_bound(b) != 1_i || s.lower_bound(y) >= s.lower_bound(x) + 5_i; }}},
+            // Per g value: b=0,c=0 gives 121; b=0,c=1 gives |{x,y : x >= y - 2}|
+            // = 121 - |{y - x > 2}| = 121 - 36 = 85; b=1,c=0 gives
+            // |{y >= x + 5}| = 21; b=1,c=1 is refuted. 227 per g, four g values.
+            908);
+    }
+
+    // (e) A conditional static bound applied in a branch that then fails must
+    // leave nothing behind. Static bounds are re-derived from the state on every
+    // call and never enter Do or the arc records, so there is nothing to leak;
+    // this pins that, since a static bound is the one shape that is neither an
+    // arc nor a node bound change.
+    auto run_conditional_static_bound_test(bool incremental) -> void
+    {
+        Problem p;
+        auto b = p.create_integer_variable(0_i, 1_i, "b");
+        auto x = p.create_integer_variable(0_i, 10_i, "x");
+        auto y = p.create_integer_variable(0_i, 10_i, "y");
+        // b -> x <= 3 and b -> x >= 5, which cannot both hold, so every solution
+        // has b = 0 and x unconstrained. y hangs off x by an ordinary edge, so a
+        // bound left behind after the failed branch would show up as a missing
+        // solution rather than only as a tighter domain.
+        p.post(DifferenceConstraints{{DifferenceEdge{x, constant_variable(0_i), 3_i, b == 1_i},
+                                         DifferenceEdge{constant_variable(5_i), x, 0_i, b == 1_i}, DifferenceEdge{x, y, 0_i}}}
+                .simplifying_at_root(false)
+                .incrementally(incremental)
+                .auditing_incremental_propagation());
+
+        run_node_invariant_test("incremental conditional static bound", incremental, p, {b, x, y},
+            {{"y >= x", [=](const CurrentState & s) { return s.lower_bound(y) >= s.lower_bound(x); }},
+                {"b is never true", [=](const CurrentState & s) { return s.lower_bound(b) != 1_i; }}},
+            // b = 0, y >= x over 0..10: 66.
+            66);
+    }
+
+    auto run_incremental_tests() -> void
+    {
+        for (bool incremental : {true, false}) {
+            run_stale_do_test(incremental);
+            run_activation_seed_test(incremental);
+            run_reactivation_test(incremental);
+            run_conditional_static_bound_test(incremental);
+            // (d) The hole-snap topology, which is where recording the *state's*
+            // bounds in Do rather than the bounds the run propagated from goes
+            // wrong: the snap lands the state bound above the computed value, so
+            // the mandatory self-re-wake finds Vl empty and stops with z at 5.
+            run_hole_snap_test(incremental);
+        }
+    }
+
     auto run_all_tests(bool proofs, const string & mode) -> void
     {
         if (mode == "basic") {
@@ -859,13 +1109,19 @@ auto main(int argc, char * argv[]) -> int
     string mode{argv[1]};
 
     run_negated_view_test();
-    if (mode == "basic") {
-        run_transitive_test();
-        run_hole_snap_test();
-    }
-    if (mode == "reified") {
-        run_reified_bounds_test();
-        run_reified_degenerate_test();
+    if (mode == "basic")
+        for (bool incremental : {true, false}) {
+            run_transitive_test(incremental);
+            run_hole_snap_test(incremental);
+        }
+    if (mode == "reified")
+        for (bool incremental : {true, false}) {
+            run_reified_bounds_test(incremental);
+            run_reified_degenerate_test(incremental);
+        }
+    if (mode == "incremental") {
+        run_incremental_tests();
+        return EXIT_SUCCESS;
     }
     if (mode == "simplify") {
         run_root_refutation_test();

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -146,864 +147,684 @@ namespace
         DifferenceBoundsWorkspace bounds_work;
     };
 
-    // GCS_DIFFERENCE_AUDIT turns the differential fixpoint audit on for every
-    // difference propagator in the process, so a whole corpus can be run under
-    // it without touching a single model. Read once.
-    auto difference_audit_from_environment() -> bool
-    {
-        static const bool result = [] {
-            const char * e = std::getenv("GCS_DIFFERENCE_AUDIT");
-            return e && *e && string{e} != "0";
-        }();
-        return result;
-    }
-}
-
-auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> optional<DeviewedDifferenceOperand>
-{
-    return overloaded{
-        [&](const SimpleIntegerVariableID & v) { return optional<DeviewedDifferenceOperand>{{v, 0_i}}; },                   //
-        [&](const ConstantIntegerVariableID & v) { return optional<DeviewedDifferenceOperand>{{nullopt, v.const_value}}; }, //
-        [&](const ViewOfIntegerVariableID & v) {
-            if (v.negate_first)
-                return optional<DeviewedDifferenceOperand>{nullopt};
-            return optional<DeviewedDifferenceOperand>{{v.actual_variable, v.then_add}};
-        } //
-    }
-        .visit(var);
-}
-
-auto gcs::innards::install_difference_propagator(Propagators & propagators, State & initial_state, const ConstraintID & constraint_id,
-    DifferenceGraph graph, DifferenceSimplificationOptions simplify, DifferenceIncrementalOptions incremental) -> void
-{
-    if (graph.edges.empty() && graph.static_bounds.empty() && graph.disallowed_conditions.empty())
-        return;
-
-    incremental.audit = incremental.audit || difference_audit_from_environment();
-
-    Triggers triggers;
-    for (const auto & v : graph.nodes)
-        triggers.on_bounds.emplace_back(v);
-
-    // A half-reified edge joins the graph the moment its condition becomes
-    // true, so the propagator must wake on that as well as on the nodes'
-    // bounds. `on_change' on the condition's variable is the coarsest trigger
-    // gcs offers that is guaranteed to catch it: a condition can become true
-    // through an interior removal (`x != v' the instant v leaves the domain),
-    // which `on_bounds' does not see, and `on_instantiated' fires strictly less
-    // often still (`x >= v' can become true long before x is fixed). Nothing
-    // finer is needed, because there is no cheaper "becomes true" trigger and
-    // the refined per-literal watches would have to be armed one per condition
-    // anyway. Waking when a condition becomes *false* is not needed at all ---
-    // an inactive edge simply does not participate, and no inference is lost by
-    // finding that out later --- but `on_change' cannot distinguish the two
-    // directions, and paying for the extra wake is cheaper than the machinery
-    // to avoid it.
+    // The root simplification stage, which is the paper's Algorithm 4
+    // (its section 5.2) run to the fixpoint of its section 5.3. Once, on
+    // the first call, and only if that call is at the root --- which it
+    // always is, since search begins by propagating everything before
+    // any decision is made, but the guard is not decoration: everything
+    // below is *permanent*, so doing it below a decision would keep
+    // conclusions that only held under that decision, and no proof would
+    // ever complain because losing propagation is invisible to a proof.
     //
-    // Deliberately not deduplicated against the node list: a variable that is
-    // both a graph node and somebody's condition would then have to give up one
-    // of the two trigger kinds, and a duplicate wake is merely wasted work.
+    // Three of the paper's four sub-steps are here. Redundant-edge
+    // removal and node removal are decisions about what to propagate,
+    // not about what the model says --- the OPB keeps every posted row,
+    // so there is nothing to certify. Fixing a condition false is a real
+    // inference and carries the one proof obligation, discharged below.
+    // Zero-weight-cycle unification is not implemented; the cycles are
+    // counted so the question of whether it would pay is answerable from
+    // a measurement (see dev_docs/difference-logic.md).
+    //
+    // Lifted out of the propagator rather than left inline: MSVC's optimiser
+    // gives up with an internal compiler error on a function the size the
+    // propagator had reached, and a 230-line block inside a 700-line lambda was
+    // not doing a reader any favours either.
+    template <typename Inference_>
+    auto run_difference_root_simplification(const State & state, Inference_ & inference, ProofLogger * const logger, size_t number_of_nodes,
+        vector<DifferenceArc> & arcs, vector<optional<IntegerVariableCondition>> & arc_conditions, const vector<ProofLine> & edge_lines,
+        const DifferenceSimplificationOptions & simplify, size_t & round_bound, bool at_root) -> void
     {
-        vector<IntegerVariableID> condition_vars;
-        auto note = [&](const IntegerVariableCondition & c) {
-            if (condition_vars.end() == find(condition_vars, c.var))
-                condition_vars.push_back(c.var);
+        auto n = number_of_nodes;
+        auto m = arcs.size();
+
+        auto condition_of = [&](size_t e) -> const optional<IntegerVariableCondition> & {
+            static const optional<IntegerVariableCondition> none;
+            return arc_conditions.empty() ? none : arc_conditions[e];
         };
-        for (const auto & e : graph.edges)
-            if (e.cond)
-                note(*e.cond);
-        for (const auto & sb : graph.static_bounds)
-            if (sb.cond)
-                note(*sb.cond);
-        for (const auto & dc : graph.disallowed_conditions)
-            note(dc.cond);
-        for (const auto & v : condition_vars)
-            triggers.on_change.emplace_back(v);
-    }
 
-    // Repack into the hot arc array plus a parallel condition array; see
-    // DifferenceArc. The condition array stays *empty* when nothing is
-    // conditional, which is both the check the propagator uses to take the
-    // straight-through path and a guarantee that an unconditional system pays
-    // nothing at all for this feature.
-    vector<DifferenceArc> arcs;
-    vector<optional<IntegerVariableCondition>> arc_conditions;
-    arcs.reserve(graph.edges.size());
-    for (const auto & e : graph.edges)
-        arcs.push_back(DifferenceArc{e.from, e.to, e.d, e.posted_index});
-    if (graph.edges.end() != find_if(graph.edges, [](const auto & e) { return e.cond.has_value(); })) {
-        arc_conditions.reserve(graph.edges.size());
-        for (const auto & e : graph.edges)
-            arc_conditions.push_back(e.cond);
-    }
+        auto edge_line_pol = [&]() {
+            PolBuilder pol;
+            pol.enable_deview_mode(logger->names_and_ids_tracker());
+            return pol;
+        };
 
-    // Read before the capture list moves the node vector out from under it.
-    auto number_of_nodes = graph.nodes.size();
+        DifferenceSimplificationStats stats;
+        DifferenceSimplificationReporter reporter{stats, simplify.stats};
+        stats.nodes = n;
+        stats.edges = m;
+        for (size_t e = 0; e < m; ++e)
+            if (condition_of(e))
+                ++stats.conditional_edges;
 
-    // The only trailed state: how much of the undo trail belongs to the current
-    // epoch. State::on_backtrack is not reachable from a propagator's
-    // `const State &`, and copying the whole of Do into every epoch would make
-    // entering an epoch O(n + m); a single number in the trailed constraint
-    // state gives exact restoration at O(1) per epoch instead, unwound lazily at
-    // the next call. Lazily is safe precisely because the restored values are
-    // exact and do not depend on the current domains --- nothing reads Do
-    // between the backtrack and that call.
-    auto trail_mark_handle = initial_state.add_constraint_state(size_t{0});
+        if (simplify.enabled && at_root && ! arcs.empty()) {
+            stats.ran = true;
 
-    // The root simplification stage mutates `arcs`, `arc_conditions` and
-    // `round_bound` in place, once, on the first call --- hence the `mutable`
-    // below. It is safe without trailing for the same reason the paper's section
-    // 5.3 boundary is where it is: the stage runs only at the root, before any
-    // decision, and every conclusion it draws (this edge is implied by a path of
-    // unconditional or root-fixed edges; this node has no edges left) is a
-    // statement about the *graph*, which no amount of backtracking changes.
-    // Nothing there reads a domain. The incremental machinery below is `mutable`
-    // for a different reason, and one the paper is explicit about: the potential
-    // function survives backtracking by design.
-    propagators.install(
-        constraint_id,
-        [nodes = move(graph.nodes), arcs = move(arcs), arc_conditions = move(arc_conditions), static_bounds = move(graph.static_bounds),
-            disallowed_conditions = move(graph.disallowed_conditions), edge_lines = move(graph.edge_lines), simplify = move(simplify),
-            incremental = move(incremental), memory = DifferencePropagatorMemory{}, trail_mark_handle, simplification_pending = true,
-            round_bound = number_of_nodes](const State & state, auto & inference, ProofLogger * const logger) mutable -> PropagatorState {
-            auto n = nodes.size();
-            auto m = arcs.size();
-            // arc_conditions is either empty --- nothing in this system is
-            // conditional, and no per-edge storage exists at all --- or exactly
-            // as long as arcs. Only the cold paths go through here; see
-            // DifferenceArc for why the conditions are not in the arcs.
-            auto condition_of = [&](size_t e) -> const optional<IntegerVariableCondition> & {
-                static const optional<IntegerVariableCondition> none;
-                return arc_conditions.empty() ? none : arc_conditions[e];
-            };
+            vector<DifferenceSimplifyEdge> simplify_edges;
+            simplify_edges.reserve(m);
+            for (const auto & a : arcs)
+                simplify_edges.push_back(DifferenceSimplifyEdge{a.from, a.to, a.d});
 
-            // Every pol below cites an edge row in deview mode. For rows this
-            // constraint emitted itself that is a no-op: they are already over
-            // bare variables, so no deview-form is registered for them and
-            // deviewed_line_for hands the line straight back. It matters for a
-            // presolver-built graph, whose rows belong to somebody else's
-            // constraint and are therefore in the user's views' bits, while the
-            // arithmetic here (and the reason literals) is over the canonical
-            // bare variables. Same reasoning, and the same fix, as
-            // linear/justify.cc.
-            auto edge_line_pol = [&]() {
-                PolBuilder pol;
-                pol.enable_deview_mode(logger->names_and_ids_tracker());
-                return pol;
-            };
+            vector<bool> dropped(m, false);
+            vector<DifferenceSimplifyRole> roles(m, DifferenceSimplifyRole::Base);
 
-            // A half-reified edge whose condition says `cond -> 0 <= d' with
-            // d < 0 says `!cond', and saying so is a soundness obligation, not a
-            // nicety: dropping the edge would licence solutions in which cond
-            // holds and the constraint is violated. The row is `M.~cond >= -d'
-            // with -d >= 1, which is the unit clause `~cond' after saturation,
-            // so plain RUP against it suffices and nothing in the state is
-            // involved. (Unconditionally this is a root contradiction instead;
-            // see DifferenceConstraints::install_propagators.)
-            for (const auto & dc : disallowed_conditions)
-                if (LiteralIs::DefinitelyFalse != state.test_literal(dc.cond))
-                    inference.infer(logger, ! dc.cond, JustifyUsingRUP{}, NoReason{});
+            while (true) {
+                ++stats.rounds;
 
-            // Static bounds next: an edge with a constant operand is a plain
-            // bound on the other operand, and once applied it is just part of
-            // the state that the passes below seed from. An unconditional one
-            // never changes, so after the first call it is a no-op; a
-            // conditional one applies from the moment its condition holds, and
-            // cites it. Nothing about it needs trailing or gating: a bound it
-            // applies moves the state, and moving the state is exactly what puts
-            // the node into Vl on this very call.
-            for (const auto & sb : static_bounds) {
-                if (sb.cond && LiteralIs::DefinitelyTrue != state.test_literal(*sb.cond))
-                    continue;
-                Reason why = sb.cond ? Reason{ExplicitReason{ReasonLiterals{{*sb.cond}}}} : Reason{NoReason{}};
-                if (sb.is_lower) {
-                    if (state.lower_bound(nodes[sb.node]) < sb.value)
-                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, why);
+                for (size_t e = 0; e < m; ++e) {
+                    if (dropped[e])
+                        roles[e] = DifferenceSimplifyRole::Ignored;
+                    else if (const auto & cond = condition_of(e)) {
+                        switch (state.test_literal(*cond)) {
+                            using enum LiteralIs;
+                        case DefinitelyTrue: roles[e] = DifferenceSimplifyRole::Base; break;
+                        case DefinitelyFalse:
+                            roles[e] = DifferenceSimplifyRole::Ignored;
+                            dropped[e] = true;
+                            ++stats.dead_edges_removed;
+                            break;
+                        case Undecided: roles[e] = DifferenceSimplifyRole::Candidate; break;
+                        }
+                    }
+                    else
+                        roles[e] = DifferenceSimplifyRole::Base;
                 }
-                else {
-                    if (state.upper_bound(nodes[sb.node]) > sb.value)
-                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, why);
-                }
-            }
 
-            auto first_call = simplification_pending;
-            bool at_root = true;
-
-            // The root simplification stage, which is the paper's Algorithm 4
-            // (its section 5.2) run to the fixpoint of its section 5.3. Once, on
-            // the first call, and only if that call is at the root --- which it
-            // always is, since search begins by propagating everything before
-            // any decision is made, but the guard is not decoration: everything
-            // below is *permanent*, so doing it below a decision would keep
-            // conclusions that only held under that decision, and no proof would
-            // ever complain because losing propagation is invisible to a proof.
-            //
-            // Three of the paper's four sub-steps are here. Redundant-edge
-            // removal and node removal are decisions about what to propagate,
-            // not about what the model says --- the OPB keeps every posted row,
-            // so there is nothing to certify. Fixing a condition false is a real
-            // inference and carries the one proof obligation, discharged below.
-            // Zero-weight-cycle unification is not implemented; the cycles are
-            // counted so the question of whether it would pay is answerable from
-            // a measurement (see dev_docs/difference-logic.md).
-            if (first_call) {
-                simplification_pending = false;
-
-                for ([[maybe_unused]] const auto & guess : state.guesses()) {
-                    at_root = false;
+                auto outcome = simplify_difference_graph(n, simplify_edges, roles);
+                if (outcome.base_negative_cycle) {
+                    // The unconditional part of the system is already
+                    // infeasible. Stop and let the from-scratch pass
+                    // below refute it: that is where the cycle
+                    // extraction and the telescoping pol live, and
+                    // duplicating them here would buy nothing.
+                    stats.base_negative_cycle = true;
                     break;
                 }
 
-                DifferenceSimplificationStats stats;
-                DifferenceSimplificationReporter reporter{stats, simplify.stats};
-                stats.nodes = n;
-                stats.edges = m;
+                stats.zero_weight_cycles = outcome.zero_weight_cycles;
+                stats.nodes_on_zero_weight_cycles = outcome.nodes_on_zero_weight_cycles;
+
                 for (size_t e = 0; e < m; ++e)
-                    if (condition_of(e))
-                        ++stats.conditional_edges;
-
-                if (simplify.enabled && at_root && ! arcs.empty()) {
-                    stats.ran = true;
-
-                    vector<DifferenceSimplifyEdge> simplify_edges;
-                    simplify_edges.reserve(m);
-                    for (const auto & a : arcs)
-                        simplify_edges.push_back(DifferenceSimplifyEdge{a.from, a.to, a.d});
-
-                    vector<bool> dropped(m, false);
-                    vector<DifferenceSimplifyRole> roles(m, DifferenceSimplifyRole::Base);
-
-                    while (true) {
-                        ++stats.rounds;
-
-                        for (size_t e = 0; e < m; ++e) {
-                            if (dropped[e])
-                                roles[e] = DifferenceSimplifyRole::Ignored;
-                            else if (const auto & cond = condition_of(e)) {
-                                switch (state.test_literal(*cond)) {
-                                    using enum LiteralIs;
-                                case DefinitelyTrue: roles[e] = DifferenceSimplifyRole::Base; break;
-                                case DefinitelyFalse:
-                                    roles[e] = DifferenceSimplifyRole::Ignored;
-                                    dropped[e] = true;
-                                    ++stats.dead_edges_removed;
-                                    break;
-                                case Undecided: roles[e] = DifferenceSimplifyRole::Candidate; break;
-                                }
-                            }
-                            else
-                                roles[e] = DifferenceSimplifyRole::Base;
-                        }
-
-                        auto outcome = simplify_difference_graph(n, simplify_edges, roles);
-                        if (outcome.base_negative_cycle) {
-                            // The unconditional part of the system is already
-                            // infeasible. Stop and let the from-scratch pass
-                            // below refute it: that is where the cycle
-                            // extraction and the telescoping pol live, and
-                            // duplicating them here would buy nothing.
-                            stats.base_negative_cycle = true;
-                            break;
-                        }
-
-                        stats.zero_weight_cycles = outcome.zero_weight_cycles;
-                        stats.nodes_on_zero_weight_cycles = outcome.nodes_on_zero_weight_cycles;
-
-                        for (size_t e = 0; e < m; ++e)
-                            if (outcome.remove[e] && ! dropped[e]) {
-                                dropped[e] = true;
-                                ++stats.redundant_edges_removed;
-                                if (condition_of(e))
-                                    ++stats.redundant_conditional_edges_removed;
-                            }
-
-                        if (outcome.fix.empty())
-                            break;
-
-                        // Every round that gets here fixes at least one
-                        // condition and so drops at least one edge, which is
-                        // what bounds the loop --- an edge the pass wants to fix
-                        // is never also an edge it wants to remove, since
-                        // `d >= D_uv' and `d + D_vu < 0' cannot both hold when
-                        // the graph has no negative cycle. That is an argument
-                        // about the pass, though, and this is a loop inside a
-                        // propagator, so make the progress explicit rather than
-                        // inferred.
-                        bool progress = false;
-
-                        for (const auto & [candidate, path] : outcome.fix) {
-                            if (dropped[candidate])
-                                continue;
-
-                            // Check the witness arithmetically before saying
-                            // anything: that the candidate edge and the path
-                            // really do form a cycle, and that it really does
-                            // weigh less than zero. That is O(cycle), and it
-                            // turns a bug in the shortest-path pass into an
-                            // exception here rather than a VeriPB failure a
-                            // hundred lines later (survey section 2.9.4).
-                            auto weight = arcs[candidate].d;
-                            auto at = arcs[candidate].to;
-                            vector<IntegerVariableCondition> conditions;
-                            for (auto e : path) {
-                                if (arcs[e].from != at)
-                                    throw UnexpectedException{"difference logic simplification built a disconnected witness cycle"};
-                                weight += arcs[e].d;
-                                at = arcs[e].to;
-                                // A path edge may itself be conditional, on
-                                // something currently definitely true --- either
-                                // the model fixed it, or an earlier round of this
-                                // very loop did. Its row then carries a big-M
-                                // residual which does not telescope, so its
-                                // condition has to be in the reason for the same
-                                // reason a negative cycle's conditions are.
-                                // Deduplicated, since one Boolean may appear on
-                                // several edges.
-                                if (const auto & cond = condition_of(e))
-                                    if (conditions.end() == find(conditions, *cond))
-                                        conditions.push_back(*cond);
-                            }
-                            if (at != arcs[candidate].from)
-                                throw UnexpectedException{"difference logic simplification built a witness path that does not close"};
-                            if (weight >= 0_i)
-                                throw UnexpectedException{"difference logic simplification built a witness cycle of weight " + weight.to_string() +
-                                    ", which is not negative"};
-
-                            const auto & candidate_cond = condition_of(candidate);
-                            if (! candidate_cond)
-                                throw UnexpectedException{"difference logic simplification tried to fix the condition of an unconditional edge"};
-
-                            // The proof is proof shape 1 with the candidate edge
-                            // standing in for the missing link: sum the rows
-                            // around the cycle and every BinEnc term telescopes
-                            // away, leaving only the big-M residuals of the
-                            // conditional edges. The candidate's is always one of
-                            // them, so a saturate turns the sum into the clause
-                            // `~cand v ~c_1 v ... v ~c_k' over the path's
-                            // already-true conditions --- the reified_hand.pbp
-                            // shape with the roles of the conditions swapped
-                            // round. The closing RUP assumes the reason's
-                            // literals and reads off `~cand'.
-                            //
-                            // Two mutation results, both measured rather than
-                            // assumed, and both matching what the negative-cycle
-                            // refutation already found:
-                            //
-                            //  * the `saturate' is not load-bearing --- removing
-                            //    it leaves every fixture verifying, because the
-                            //    closing RUP assumes every condition and drives
-                            //    each residual to zero. Emitted anyway so the
-                            //    derived line *is* the clause;
-                            //  * neither, here, are the path's conditions in the
-                            //    reason. That is specific to running at the root:
-                            //    a path condition is definitely true only because
-                            //    it is a *globally derived* fact (the model fixed
-                            //    it, or an earlier round of this loop did), so
-                            //    unit propagation recovers it and the RUP passes
-                            //    without being told. They are cited regardless,
-                            //    because the reason is also what the state and
-                            //    the nogood machinery see, and there a missing
-                            //    antecedent is not recoverable.
-                            ReasonLiterals reason_literals;
-                            for (const auto & c : conditions)
-                                reason_literals.push_back(c);
-                            auto reason = conditions.empty() ? Reason{NoReason{}} : Reason{ExplicitReason{move(reason_literals)}};
-                            inference.infer(logger, ! *candidate_cond,
-                                JustifyExplicitly{[&](const ReasonLiterals &) {
-                                                      auto pol = edge_line_pol();
-                                                      pol.add(edge_lines[arcs[candidate].posted_index]);
-                                                      for (auto e : path)
-                                                          pol.add(edge_lines[arcs[e].posted_index]);
-                                                      pol.saturate();
-                                                      pol.emit(*logger, ProofLevel::Temporary);
-                                                  },
-                                    ThenRUP::Yes},
-                                reason);
-
-                            dropped[candidate] = true;
-                            progress = true;
-                            ++stats.conditions_fixed;
-                        }
-
-                        if (! progress)
-                            break;
+                    if (outcome.remove[e] && ! dropped[e]) {
+                        dropped[e] = true;
+                        ++stats.redundant_edges_removed;
+                        if (condition_of(e))
+                            ++stats.redundant_conditional_edges_removed;
                     }
 
-                    // Now actually shrink the graph. Everything above only
-                    // marked; this is where the propagator stops paying for what
-                    // it marked.
-                    if (dropped.end() != find(dropped, true)) {
-                        vector<DifferenceArc> kept_arcs;
-                        vector<optional<IntegerVariableCondition>> kept_conditions;
-                        for (size_t e = 0; e < m; ++e)
-                            if (! dropped[e]) {
-                                kept_arcs.push_back(arcs[e]);
-                                if (! arc_conditions.empty())
-                                    kept_conditions.push_back(arc_conditions[e]);
-                            }
-                        arcs = move(kept_arcs);
-                        // If nothing conditional survived, drop the parallel
-                        // array entirely: an empty one is what puts the
-                        // relaxation loop back on its straight-through path,
-                        // which is worth 45% on examples/difference_chain.
-                        if (kept_conditions.end() == find_if(kept_conditions, [](const auto & c) { return c.has_value(); }))
-                            kept_conditions.clear();
-                        arc_conditions = move(kept_conditions);
-                        m = arcs.size();
+                if (outcome.fix.empty())
+                    break;
+
+                // Every round that gets here fixes at least one
+                // condition and so drops at least one edge, which is
+                // what bounds the loop --- an edge the pass wants to fix
+                // is never also an edge it wants to remove, since
+                // `d >= D_uv' and `d + D_vu < 0' cannot both hold when
+                // the graph has no negative cycle. That is an argument
+                // about the pass, though, and this is a loop inside a
+                // propagator, so make the progress explicit rather than
+                // inferred.
+                bool progress = false;
+
+                for (const auto & [candidate, path] : outcome.fix) {
+                    if (dropped[candidate])
+                        continue;
+
+                    // Check the witness arithmetically before saying
+                    // anything: that the candidate edge and the path
+                    // really do form a cycle, and that it really does
+                    // weigh less than zero. That is O(cycle), and it
+                    // turns a bug in the shortest-path pass into an
+                    // exception here rather than a VeriPB failure a
+                    // hundred lines later (survey section 2.9.4).
+                    auto weight = arcs[candidate].d;
+                    auto at = arcs[candidate].to;
+                    vector<IntegerVariableCondition> conditions;
+                    for (auto e : path) {
+                        if (arcs[e].from != at)
+                            throw UnexpectedException{"difference logic simplification built a disconnected witness cycle"};
+                        weight += arcs[e].d;
+                        at = arcs[e].to;
+                        // A path edge may itself be conditional, on
+                        // something currently definitely true --- either
+                        // the model fixed it, or an earlier round of this
+                        // very loop did. Its row then carries a big-M
+                        // residual which does not telescope, so its
+                        // condition has to be in the reason for the same
+                        // reason a negative cycle's conditions are.
+                        // Deduplicated, since one Boolean may appear on
+                        // several edges.
+                        if (const auto & cond = condition_of(e))
+                            if (conditions.end() == find(conditions, *cond))
+                                conditions.push_back(*cond);
                     }
+                    if (at != arcs[candidate].from)
+                        throw UnexpectedException{"difference logic simplification built a witness path that does not close"};
+                    if (weight >= 0_i)
+                        throw UnexpectedException{
+                            "difference logic simplification built a witness cycle of weight " + weight.to_string() + ", which is not negative"};
 
-                    // Node removal, the paper's last sub-step, and internal in
-                    // exactly the same way: a node with no incident edge left
-                    // cannot send or receive a bound, so it neither needs seeding
-                    // nor counts towards the number of relaxation rounds a
-                    // simple path can need.
-                    vector<bool> live(n, false);
-                    for (const auto & a : arcs) {
-                        live[a.from] = true;
-                        live[a.to] = true;
-                    }
-                    auto live_count = static_cast<size_t>(count(live, true));
-                    stats.isolated_nodes_removed = n - live_count;
-                    round_bound = live_count;
-                }
-            }
+                    const auto & candidate_cond = condition_of(candidate);
+                    if (! candidate_cond)
+                        throw UnexpectedException{"difference logic simplification tried to fix the condition of an unconditional edge"};
 
-            // Which edges are in the graph *for this call*. A half-reified edge
-            // participates exactly while its condition currently holds; the
-            // paper's E' set, restricted to the entailed half, since nothing
-            // here infers a condition from the graph.
-            //
-            // Snapshotting once, rather than re-testing as we go, is what keeps
-            // the round bound and the cycle-extraction argument in
-            // dev_docs/difference-logic.md applicable verbatim: both are
-            // statements about one Bellman-Ford run over one fixed edge set, and
-            // the edge set is now fixed for the duration of the call rather than
-            // for the lifetime of the constraint. Nothing else in those
-            // arguments mentions where the edges came from.
-            //
-            // The snapshot also stays *correct* as inferences land during the
-            // call, which is why it is safe to cite a snapshotted condition in a
-            // reason later on. A literal that is definitely true holds for every
-            // value in the current domain, so it holds for every value in any
-            // subset of it; all this propagator does is shrink domains, and a
-            // domain shrunk to empty is a contradiction, which stops the call.
-            // So a condition true at snapshot time is still true at every
-            // inference made from it.
-            //
-            // An unconditional system is not snapshotted at all, and iterates
-            // the arc array straight through. That is not fastidiousness: the
-            // snapshot is a level of indirection inside the innermost loop, and
-            // going through it unconditionally cost 45% on
-            // examples/difference_chain at n = 640 (0.32 s to 0.47 s) with the
-            // propagation count unchanged. The branch is on the *outside* of the
-            // per-edge loop, so the conditional case pays nothing for it either.
-
-            // The undo trail is popped down to the mark *before* the snapshot,
-            // so that the snapshot loop can compare each arc's current activity
-            // against the restored record in the same pass. This restores exact
-            // values, which is what makes doing it here rather than at the
-            // moment of the backtrack sound *and* complete: nothing reads `Do`
-            // in between, and what is restored does not depend on the current
-            // domains. On the first call the trail is empty and the mark is
-            // zero, so this does nothing and the arrays below need not exist
-            // yet.
-            if (incremental.enabled) {
-                auto & mark = any_cast<size_t &>(state.get_constraint_state(trail_mark_handle));
-                while (memory.trail.size() > mark) {
-                    const auto & entry = memory.trail.back();
-                    switch (entry.kind) {
-                        using enum DifferenceTrailKind;
-                    case LowerGate: memory.do_lb[entry.index] = entry.value; break;
-                    case UpperGate: memory.do_ub_neg[entry.index] = entry.value; break;
-                    case Activation: memory.arc_was_active[entry.index] = (0_i == entry.value ? 0 : 1); break;
-                    }
-                    memory.trail.pop_back();
-                }
-            }
-
-            auto all_active = arc_conditions.empty();
-            memory.active_edges.clear();
-            memory.changed_arcs.clear();
-            if (! all_active) {
-                // One pass over the arcs, doing everything a conditional system
-                // needs: the flags the adjacency traversals filter on, the index
-                // list the from-scratch relaxation walks, and the list of arcs
-                // whose activity differs from what the incremental machinery has
-                // established its invariants for. Three separate passes here was
-                // 10-15% on the half-reified RCPSP/max instances, where the
-                // conditional edges make `m` an order of magnitude larger than
-                // `n` and these passes are the whole cost of a wake.
-                auto detect_changes = incremental.enabled && ! first_call;
-                memory.active_edges.reserve(m);
-                memory.active_flags.resize(m);
-                for (size_t e = 0; e < m; ++e) {
-                    char active = (! arc_conditions[e] || LiteralIs::DefinitelyTrue == state.test_literal(*arc_conditions[e])) ? 1 : 0;
-                    memory.active_flags[e] = active;
-                    if (active)
-                        memory.active_edges.push_back(e);
-                    if (detect_changes && active != memory.arc_was_active[e])
-                        memory.changed_arcs.push_back(e);
-                }
-            }
-            else
-                memory.active_flags.clear();
-
-            auto for_each_active_edge = [&](auto && relax) {
-                if (all_active)
-                    for (size_t e = 0; e < m; ++e)
-                        relax(e);
-                else
-                    for (auto e : memory.active_edges)
-                        relax(e);
-            };
-
-            // Both passes walk a predecessor relation, one forwards along the
-            // edges and one backwards, so each is parameterised by which end of
-            // an edge the predecessor sits at. `head_of' is the node whose
-            // bound the edge pushed (so pred[head_of(e)] == e), and `tail_of'
-            // is the node whose bound was cited.
-
-            // The refutation of a negative cycle is the sum of the cycle's edge
-            // rows and nothing else: each variable appears once with +1 (as
-            // some edge's head) and once with -1 (as the next edge's tail), so
-            // every BinEnc term telescopes away and what is left is
-            // `0 >= -(cycle weight)' with the right hand side at least 1. No
-            // domain state is involved, hence the empty reason.
-            //
-            // A half-reified edge on the cycle contributes one extra term,
-            // `M.~cond', which does not telescope. Summing leaves
-            // `sum_i M_i.~cond_i >= -(cycle weight)', and one saturate turns it
-            // into the clause `~cond_1 v ... v ~cond_k' --- the learned clause,
-            // and exactly the shape hand-verified against real gcs OPB output in
-            // reified_hand.pbp before any of this was written. Every such
-            // condition therefore has to appear in the reason: the refutation is
-            // conditional on precisely them, and citing fewer would claim a
-            // contradiction the model does not entail. *That* part is
-            // load-bearing --- omitting a condition from the reason fails VeriPB
-            // on the reified fixtures, confirmed by mutation.
-            //
-            // The saturate itself is not: the closing RUP assumes every
-            // condition, which drives each `M.~cond' to zero and falsifies the
-            // unsaturated line just as well, and removing the saturate leaves
-            // every reified fixture verifying (also confirmed by mutation). It
-            // is emitted anyway because it makes the derived line *be* the
-            // clause rather than a big-M encoding of it, which is what a reader,
-            // an assertion hint or a longer-lived proof level would want. It is
-            // emitted only when there is a residual to saturate, so an
-            // unconditional cycle's proof line is byte-for-byte what it was
-            // before half-reified edges existed.
-            //
-            // Before saying anything, verify the extracted cycle
-            // arithmetically: that each edge meets the next, that it closes,
-            // and that the total weight really is negative. That is O(cycle)
-            // and turns a predecessor-walk bug into an exception at the right
-            // place rather than a VeriPB failure hundreds of lines later
-            // (survey section 2.9.4).
-            auto contradict_on_cycle = [&](const vector<size_t> & cycle, auto && tail_of, auto && head_of) -> void {
-                if (cycle.empty())
-                    throw UnexpectedException{"difference logic extracted an empty negative cycle"};
-                Integer weight{0};
-                vector<IntegerVariableCondition> conditions;
-                for (size_t k = 0; k < cycle.size(); ++k) {
-                    const auto & here = arcs[cycle[k]];
-                    const auto & next = arcs[cycle[(k + 1) % cycle.size()]];
-                    weight += here.d;
-                    if (head_of(next) != tail_of(here))
-                        throw UnexpectedException{"difference logic extracted a disconnected negative cycle"};
-                    // Deduplicated, because the same Boolean legitimately
-                    // appears on more than one edge (a disjunctive encoding
-                    // makes that the normal case) and a reason listing it twice
-                    // would render a proof line with a repeated literal.
-                    const auto & here_cond = condition_of(cycle[k]);
-                    if (here_cond && conditions.end() == find(conditions, *here_cond))
-                        conditions.push_back(*here_cond);
-                }
-                if (weight >= 0_i)
-                    throw UnexpectedException{"difference logic extracted a cycle of weight " + weight.to_string() + ", which is not negative"};
-
-                auto conditional = ! conditions.empty();
-                ReasonLiterals reason_literals;
-                for (const auto & c : conditions)
-                    reason_literals.push_back(c);
-
-                inference.contradiction(logger,
-                    JustifyExplicitly{[&](const ReasonLiterals &) {
-                                          auto pol = edge_line_pol();
-                                          for (auto e : cycle)
-                                              pol.add(edge_lines[arcs[e].posted_index]);
-                                          if (conditional)
+                    // The proof is proof shape 1 with the candidate edge
+                    // standing in for the missing link: sum the rows
+                    // around the cycle and every BinEnc term telescopes
+                    // away, leaving only the big-M residuals of the
+                    // conditional edges. The candidate's is always one of
+                    // them, so a saturate turns the sum into the clause
+                    // `~cand v ~c_1 v ... v ~c_k' over the path's
+                    // already-true conditions --- the reified_hand.pbp
+                    // shape with the roles of the conditions swapped
+                    // round. The closing RUP assumes the reason's
+                    // literals and reads off `~cand'.
+                    //
+                    // Two mutation results, both measured rather than
+                    // assumed, and both matching what the negative-cycle
+                    // refutation already found:
+                    //
+                    //  * the `saturate' is not load-bearing --- removing
+                    //    it leaves every fixture verifying, because the
+                    //    closing RUP assumes every condition and drives
+                    //    each residual to zero. Emitted anyway so the
+                    //    derived line *is* the clause;
+                    //  * neither, here, are the path's conditions in the
+                    //    reason. That is specific to running at the root:
+                    //    a path condition is definitely true only because
+                    //    it is a *globally derived* fact (the model fixed
+                    //    it, or an earlier round of this loop did), so
+                    //    unit propagation recovers it and the RUP passes
+                    //    without being told. They are cited regardless,
+                    //    because the reason is also what the state and
+                    //    the nogood machinery see, and there a missing
+                    //    antecedent is not recoverable.
+                    ReasonLiterals reason_literals;
+                    for (const auto & c : conditions)
+                        reason_literals.push_back(c);
+                    auto reason = conditions.empty() ? Reason{NoReason{}} : Reason{ExplicitReason{move(reason_literals)}};
+                    inference.infer(logger, ! *candidate_cond,
+                        JustifyExplicitly{[&](const ReasonLiterals &) {
+                                              auto pol = edge_line_pol();
+                                              pol.add(edge_lines[arcs[candidate].posted_index]);
+                                              for (auto e : path)
+                                                  pol.add(edge_lines[arcs[e].posted_index]);
                                               pol.saturate();
-                                          pol.emit(*logger, ProofLevel::Temporary);
-                                      },
-                        ThenRUP::Yes},
-                    conditional ? Reason{ExplicitReason{move(reason_literals)}} : Reason{NoReason{}});
-            };
+                                              pol.emit(*logger, ProofLevel::Temporary);
+                                          },
+                            ThenRUP::Yes},
+                        reason);
 
-            // Walk predecessors back from `start' looking for a cycle, which is
-            // total: the walk cannot run off the end of the predecessor forest,
-            // and whatever cycle it does reach is a negative one. Both are
-            // proved in dev_docs/difference-logic.md ("Rounds, and why the
-            // extraction is total"); in outline, a walk that reached a
-            // predecessor-less node would exhibit a real path into `start'
-            // whose source has held its seeded distance since before round 0,
-            // and the round bound below says that path has already propagated,
-            // contradicting the strict improvement that just happened.
-            auto extract_cycle = [&](size_t start, const vector<optional<size_t>> & pred, auto && tail_of) -> vector<size_t> {
-                vector<bool> seen(n, false);
-                auto at = start;
-                while (! seen[at]) {
-                    seen[at] = true;
-                    if (! pred[at])
-                        throw UnexpectedException{"difference logic found no negative cycle where one must exist"};
+                    dropped[candidate] = true;
+                    progress = true;
+                    ++stats.conditions_fixed;
+                }
+
+                if (! progress)
+                    break;
+            }
+
+            // Now actually shrink the graph. Everything above only
+            // marked; this is where the propagator stops paying for what
+            // it marked.
+            if (dropped.end() != find(dropped, true)) {
+                vector<DifferenceArc> kept_arcs;
+                vector<optional<IntegerVariableCondition>> kept_conditions;
+                for (size_t e = 0; e < m; ++e)
+                    if (! dropped[e]) {
+                        kept_arcs.push_back(arcs[e]);
+                        if (! arc_conditions.empty())
+                            kept_conditions.push_back(arc_conditions[e]);
+                    }
+                arcs = move(kept_arcs);
+                // If nothing conditional survived, drop the parallel
+                // array entirely: an empty one is what puts the
+                // relaxation loop back on its straight-through path,
+                // which is worth 45% on examples/difference_chain.
+                if (kept_conditions.end() == find_if(kept_conditions, [](const auto & c) { return c.has_value(); }))
+                    kept_conditions.clear();
+                arc_conditions = move(kept_conditions);
+                m = arcs.size();
+            }
+
+            // Node removal, the paper's last sub-step, and internal in
+            // exactly the same way: a node with no incident edge left
+            // cannot send or receive a bound, so it neither needs seeding
+            // nor counts towards the number of relaxation rounds a
+            // simple path can need.
+            vector<bool> live(n, false);
+            for (const auto & a : arcs) {
+                live[a.from] = true;
+                live[a.to] = true;
+            }
+            auto live_count = static_cast<size_t>(count(live, true));
+            stats.isolated_nodes_removed = n - live_count;
+            round_bound = live_count;
+        }
+    }
+
+    // One call of the propagator, with the context every part of it needs.
+    //
+    // A struct rather than one very long lambda for a blunt reason: the lambda
+    // reached a size at which MSVC's front end gives up with an internal
+    // compiler error (`msc1.cpp`, line 1589), and it was well past readable
+    // before that. Splitting it changes nothing about what runs --- the members
+    // below are the same code with the same names, in the same order.
+    //
+    // The reference members are what the lambda's `[&]` capture was, so the
+    // bodies are unchanged; `const` on the members refers to the references and
+    // not to what they refer to, which is why a member that mutates `memory` or
+    // infers through `inference` is still const.
+    template <typename Inference_>
+    struct DifferenceCall
+    {
+        const State & state;
+        Inference_ & inference;
+        ProofLogger * const logger;
+        const vector<SimpleIntegerVariableID> & nodes;
+        const vector<DifferenceArc> & arcs;
+        const vector<optional<IntegerVariableCondition>> & arc_conditions;
+        const vector<ProofLine> & edge_lines;
+        const DifferenceIncrementalOptions & incremental;
+        DifferencePropagatorMemory & memory;
+        ConstraintStateHandle trail_mark_handle;
+        size_t n;
+        size_t m;
+        size_t round_bound;
+        bool all_active;
+
+        // arc_conditions is either empty --- nothing in this system is
+        // conditional, and no per-edge storage exists at all --- or exactly as
+        // long as arcs. Only the cold paths go through here; see DifferenceArc
+        // for why the conditions are not in the arcs.
+        auto condition_of(size_t e) const -> const optional<IntegerVariableCondition> &
+        {
+            static const optional<IntegerVariableCondition> none;
+            return arc_conditions.empty() ? none : arc_conditions[e];
+        }
+
+        // Every pol below cites an edge row in deview mode. For rows this
+        // constraint emitted itself that is a no-op: they are already over bare
+        // variables, so no deview-form is registered for them and
+        // deviewed_line_for hands the line straight back. It matters for a
+        // presolver-built graph, whose rows belong to somebody else's constraint
+        // and are therefore in the user's views' bits, while the arithmetic here
+        // (and the reason literals) is over the canonical bare variables. Same
+        // reasoning, and the same fix, as linear/justify.cc.
+        auto edge_line_pol() const -> PolBuilder
+        {
+            PolBuilder pol;
+            pol.enable_deview_mode(logger->names_and_ids_tracker());
+            return pol;
+        }
+
+        auto for_each_active_edge(auto && relax) const -> void
+        {
+            if (all_active)
+                for (size_t e = 0; e < m; ++e)
+                    relax(e);
+            else
+                for (auto e : memory.active_edges)
+                    relax(e);
+        }
+
+        // Both passes walk a predecessor relation, one forwards along the
+        // edges and one backwards, so each is parameterised by which end of
+        // an edge the predecessor sits at. `head_of' is the node whose
+        // bound the edge pushed (so pred[head_of(e)] == e), and `tail_of'
+        // is the node whose bound was cited.
+
+        // The refutation of a negative cycle is the sum of the cycle's edge
+        // rows and nothing else: each variable appears once with +1 (as
+        // some edge's head) and once with -1 (as the next edge's tail), so
+        // every BinEnc term telescopes away and what is left is
+        // `0 >= -(cycle weight)' with the right hand side at least 1. No
+        // domain state is involved, hence the empty reason.
+        //
+        // A half-reified edge on the cycle contributes one extra term,
+        // `M.~cond', which does not telescope. Summing leaves
+        // `sum_i M_i.~cond_i >= -(cycle weight)', and one saturate turns it
+        // into the clause `~cond_1 v ... v ~cond_k' --- the learned clause,
+        // and exactly the shape hand-verified against real gcs OPB output in
+        // reified_hand.pbp before any of this was written. Every such
+        // condition therefore has to appear in the reason: the refutation is
+        // conditional on precisely them, and citing fewer would claim a
+        // contradiction the model does not entail. *That* part is
+        // load-bearing --- omitting a condition from the reason fails VeriPB
+        // on the reified fixtures, confirmed by mutation.
+        //
+        // The saturate itself is not: the closing RUP assumes every
+        // condition, which drives each `M.~cond' to zero and falsifies the
+        // unsaturated line just as well, and removing the saturate leaves
+        // every reified fixture verifying (also confirmed by mutation). It
+        // is emitted anyway because it makes the derived line *be* the
+        // clause rather than a big-M encoding of it, which is what a reader,
+        // an assertion hint or a longer-lived proof level would want. It is
+        // emitted only when there is a residual to saturate, so an
+        // unconditional cycle's proof line is byte-for-byte what it was
+        // before half-reified edges existed.
+        //
+        // Before saying anything, verify the extracted cycle
+        // arithmetically: that each edge meets the next, that it closes,
+        // and that the total weight really is negative. That is O(cycle)
+        // and turns a predecessor-walk bug into an exception at the right
+        // place rather than a VeriPB failure hundreds of lines later
+        // (survey section 2.9.4).
+        auto contradict_on_cycle(const vector<size_t> & cycle, auto && tail_of, auto && head_of) const -> void
+        {
+            if (cycle.empty())
+                throw UnexpectedException{"difference logic extracted an empty negative cycle"};
+            Integer weight{0};
+            vector<IntegerVariableCondition> conditions;
+            for (size_t k = 0; k < cycle.size(); ++k) {
+                const auto & here = arcs[cycle[k]];
+                const auto & next = arcs[cycle[(k + 1) % cycle.size()]];
+                weight += here.d;
+                if (head_of(next) != tail_of(here))
+                    throw UnexpectedException{"difference logic extracted a disconnected negative cycle"};
+                // Deduplicated, because the same Boolean legitimately
+                // appears on more than one edge (a disjunctive encoding
+                // makes that the normal case) and a reason listing it twice
+                // would render a proof line with a repeated literal.
+                const auto & here_cond = condition_of(cycle[k]);
+                if (here_cond && conditions.end() == find(conditions, *here_cond))
+                    conditions.push_back(*here_cond);
+            }
+            if (weight >= 0_i)
+                throw UnexpectedException{"difference logic extracted a cycle of weight " + weight.to_string() + ", which is not negative"};
+
+            auto conditional = ! conditions.empty();
+            ReasonLiterals reason_literals;
+            for (const auto & c : conditions)
+                reason_literals.push_back(c);
+
+            inference.contradiction(logger,
+                JustifyExplicitly{[&](const ReasonLiterals &) {
+                                      auto pol = edge_line_pol();
+                                      for (auto e : cycle)
+                                          pol.add(edge_lines[arcs[e].posted_index]);
+                                      if (conditional)
+                                          pol.saturate();
+                                      pol.emit(*logger, ProofLevel::Temporary);
+                                  },
+                    ThenRUP::Yes},
+                conditional ? Reason{ExplicitReason{move(reason_literals)}} : Reason{NoReason{}});
+        }
+
+        // Walk predecessors back from `start' looking for a cycle, which is
+        // total: the walk cannot run off the end of the predecessor forest,
+        // and whatever cycle it does reach is a negative one. Both are
+        // proved in dev_docs/difference-logic.md ("Rounds, and why the
+        // extraction is total"); in outline, a walk that reached a
+        // predecessor-less node would exhibit a real path into `start'
+        // whose source has held its seeded distance since before round 0,
+        // and the round bound below says that path has already propagated,
+        // contradicting the strict improvement that just happened.
+        auto extract_cycle(size_t start, const vector<optional<size_t>> & pred, auto && tail_of) const -> vector<size_t>
+        {
+            vector<bool> seen(n, false);
+            auto at = start;
+            while (! seen[at]) {
+                seen[at] = true;
+                if (! pred[at])
+                    throw UnexpectedException{"difference logic found no negative cycle where one must exist"};
+                at = tail_of(arcs[*pred[at]]);
+            }
+
+            vector<size_t> cycle;
+            auto here = at;
+            do {
+                cycle.push_back(*pred[here]);
+                here = tail_of(arcs[*pred[here]]);
+            } while (here != at);
+            return cycle;
+        }
+
+        // Infer improved bounds in an order consistent with the predecessor
+        // forest, so that each node's push cites its predecessor's bound
+        // *after* that bound has been applied. Roots of the forest are the
+        // nodes whose bound did not improve, so every node with a
+        // predecessor gets exactly one inference.
+        auto infer_along_forest(const vector<optional<size_t>> & pred, auto && tail_of, auto && infer_one) const -> void
+        {
+            vector<bool> done(n, false);
+            vector<size_t> chain;
+            for (size_t v = 0; v < n; ++v) {
+                if (done[v] || ! pred[v])
+                    continue;
+                chain.clear();
+                auto at = v;
+                while (! done[at] && pred[at]) {
+                    done[at] = true;
+                    chain.push_back(at);
                     at = tail_of(arcs[*pred[at]]);
                 }
-
-                vector<size_t> cycle;
-                auto here = at;
-                do {
-                    cycle.push_back(*pred[here]);
-                    here = tail_of(arcs[*pred[here]]);
-                } while (here != at);
-                return cycle;
-            };
-
-            // Infer improved bounds in an order consistent with the predecessor
-            // forest, so that each node's push cites its predecessor's bound
-            // *after* that bound has been applied. Roots of the forest are the
-            // nodes whose bound did not improve, so every node with a
-            // predecessor gets exactly one inference.
-            auto infer_along_forest = [&](const vector<optional<size_t>> & pred, auto && tail_of, auto && infer_one) -> void {
-                vector<bool> done(n, false);
-                vector<size_t> chain;
-                for (size_t v = 0; v < n; ++v) {
-                    if (done[v] || ! pred[v])
-                        continue;
-                    chain.clear();
-                    auto at = v;
-                    while (! done[at] && pred[at]) {
-                        done[at] = true;
-                        chain.push_back(at);
-                        at = tail_of(arcs[*pred[at]]);
-                    }
-                    for (auto it = chain.rbegin(); it != chain.rend(); ++it)
-                        infer_one(*it);
-                }
-            };
-
-            // One edge, one pol: the edge row plus the definition row of the
-            // predecessor's bound literal cancels BinEnc(source) and leaves
-            // BinEnc(v) >= source_bound - d, which is exactly what the closing
-            // RUP needs. This is justify_linear_bounds for a two-term linear,
-            // and it is the shape verified by hand in boundpush_hand.pbp.
-            // Citing the predecessor's own bound is already the paper's
-            // "lifted" explanation: the weakest antecedent for v >= L - d
-            // across this edge *is* source >= L, so the pol's degree comes out
-            // at exactly the pushed amount with no wasted slack.
-            //
-            // A half-reified edge adds `M.~cond' to that sum, and its condition
-            // to the reason. Only *this* edge's condition, because the
-            // inference is per edge: the predecessor's bound was either already
-            // there when the call started, or was itself inferred a moment ago
-            // carrying its own edge's condition in its own reason, so the
-            // conditions along a whole path are cited by the chain of
-            // inferences rather than by any one of them. Each link is a
-            // standalone entailment of one row, which is what makes its RUP
-            // check.
-            //
-            // No saturate here, unlike the cycle refutation: the residual is
-            // harmless under the closing RUP, which assumes cond and so drives
-            // that term to zero, leaving the line the unconditional case would
-            // have produced. Saturating would instead clamp BinEnc(v)'s own
-            // coefficients against the degree, for no gain.
-            //
-            // Shared between the from-scratch and the incremental passes, so
-            // that the two cannot drift apart in what they emit. The self-checks
-            // are what turn a predecessor-walk or a settle-order bug into an
-            // exception here rather than a VeriPB failure much later.
-            auto infer_lower_bound = [&](size_t v, Integer new_bound, size_t arc_index, Integer source_bound) -> void {
-                const auto & edge = arcs[arc_index];
-                const auto & edge_cond = condition_of(arc_index);
-                if (edge.to != v)
-                    throw UnexpectedException{"difference logic lower bound was pushed along an edge that does not end at it"};
-                if (source_bound - edge.d != new_bound)
-                    throw UnexpectedException{"difference logic lower bound does not match its predecessor edge"};
-                if (state.lower_bound(nodes[v]) >= new_bound)
-                    return;
-
-                auto source = nodes[edge.from];
-                inference.infer_greater_than_or_equal(logger, nodes[v], new_bound,
-                    JustifyExplicitly{[&](const ReasonLiterals &) {
-                                          auto pol = edge_line_pol();
-                                          pol.add(edge_lines[edge.posted_index]);
-                                          pol.add_for_literal(logger->names_and_ids_tracker(), source >= source_bound);
-                                          pol.emit(*logger, ProofLevel::Temporary);
-                                      },
-                        ThenRUP::Yes},
-                    ExplicitReason{edge_cond ? ReasonLiterals{{source >= source_bound}, {*edge_cond}} : ReasonLiterals{{source >= source_bound}}});
-            };
-
-            auto infer_upper_bound = [&](size_t v, Integer new_bound, size_t arc_index, Integer source_bound) -> void {
-                const auto & edge = arcs[arc_index];
-                const auto & edge_cond = condition_of(arc_index);
-                if (edge.from != v)
-                    throw UnexpectedException{"difference logic upper bound was pushed along an edge that does not start at it"};
-                if (source_bound + edge.d != new_bound)
-                    throw UnexpectedException{"difference logic upper bound does not match its predecessor edge"};
-                if (state.upper_bound(nodes[v]) <= new_bound)
-                    return;
-
-                auto source = nodes[edge.to];
-                inference.infer_less_than(logger, nodes[v], new_bound + 1_i,
-                    JustifyExplicitly{[&](const ReasonLiterals &) {
-                                          auto pol = edge_line_pol();
-                                          pol.add(edge_lines[edge.posted_index]);
-                                          pol.add_for_literal(logger->names_and_ids_tracker(), source < source_bound + 1_i);
-                                          pol.emit(*logger, ProofLevel::Temporary);
-                                      },
-                        ThenRUP::Yes},
-                    ExplicitReason{
-                        edge_cond ? ReasonLiterals{{source < source_bound + 1_i}, {*edge_cond}} : ReasonLiterals{{source < source_bound + 1_i}}});
-            };
-
-            // Lower bounds flow forwards. Edge x --d--> y is x - y <= d, i.e.
-            // y >= x - d, so lb(y) >= lb(x) - d. Writing dist(v) = -lb(v) this
-            // is single-source shortest paths from the paper's dummy vertex v0,
-            // whose edge to v weighs -lb(v): that is exactly how the seeding
-            // below encodes the current bounds (Corollary 1). Upper bounds flow
-            // backwards along the same edges: x --d--> y is also x <= y + d, so
-            // ub(x) <= ub(y) + d, which is shortest paths in the reverse graph.
-            auto lb_tail_of = [](const DifferenceArc & g) { return g.from; };
-            auto lb_head_of = [](const DifferenceArc & g) { return g.to; };
-            auto ub_tail_of = [](const DifferenceArc & g) { return g.to; };
-            auto ub_head_of = [](const DifferenceArc & g) { return g.from; };
-
-            // The from-scratch Bellman-Ford relaxation, to the fixpoint of the
-            // bounds abstraction.
-            //
-            // A shortest path from v0 is simple, so after the seeding (which is
-            // the v0 edge set) it uses at most n - 1 real edges, and n - 1
-            // relaxation rounds suffice. Rounds 0 .. round_bound give one more
-            // than needed; a relaxation that still succeeds in the last round is
-            // sound evidence that the system has a negative cycle, and the
-            // extraction above is then guaranteed to find it.
-            //
-            // With `refute` set this refutes on the spot, at the exact edge that
-            // relaxed, which is what the shipping non-incremental path wants.
-            // Without it the cycle is only reported, which is what the audit
-            // wants: it needs to know whether the incremental pass missed one,
-            // not to duplicate the refutation.
-            auto relax_lower_bounds = [&](vector<Integer> & lb, vector<optional<size_t>> & lb_pred, bool refute) -> bool {
-                for (size_t round = 0; round <= round_bound; ++round) {
-                    bool changed = false, cycle = false;
-                    for_each_active_edge([&](size_t e) {
-                        if (cycle)
-                            return;
-                        const auto & edge = arcs[e];
-                        auto candidate = lb[edge.from] - edge.d;
-                        if (candidate > lb[edge.to]) {
-                            lb[edge.to] = candidate;
-                            lb_pred[edge.to] = e;
-                            changed = true;
-                            if (round == round_bound) {
-                                if (refute)
-                                    contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
-                                cycle = true;
-                            }
-                        }
-                    });
-                    if (cycle)
-                        return true;
-                    if (! changed)
-                        break;
-                }
-                return false;
-            };
-
-            auto relax_upper_bounds = [&](vector<Integer> & ub, vector<optional<size_t>> & ub_pred, bool refute) -> bool {
-                for (size_t round = 0; round <= round_bound; ++round) {
-                    bool changed = false, cycle = false;
-                    for_each_active_edge([&](size_t e) {
-                        if (cycle)
-                            return;
-                        const auto & edge = arcs[e];
-                        auto candidate = ub[edge.to] + edge.d;
-                        if (candidate < ub[edge.from]) {
-                            ub[edge.from] = candidate;
-                            ub_pred[edge.from] = e;
-                            changed = true;
-                            if (round == round_bound) {
-                                if (refute)
-                                    contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
-                                cycle = true;
-                            }
-                        }
-                    });
-                    if (cycle)
-                        return true;
-                    if (! changed)
-                        break;
-                }
-                return false;
-            };
-
-            // A negative cycle found by IncSat, or by the initial potential
-            // computation, is refuted by handing straight over to the
-            // from-scratch pass, which already carries the extraction and the
-            // telescoping pol. A negative cycle ends the search, so the O(n.m)
-            // is paid at most once per branch and buys a second implementation
-            // that does not have to be written or trusted.
-            auto refute_negative_cycle = [&](const char * who) -> void {
-                memory.pass_bound.assign(n, 0_i);
-                memory.pass_pred.assign(n, nullopt);
-                for (size_t v = 0; v < n; ++v)
-                    memory.pass_bound[v] = state.lower_bound(nodes[v]);
-                static_cast<void>(relax_lower_bounds(memory.pass_bound, memory.pass_pred, true));
-                throw UnexpectedException{string{"difference logic "} + who +
-                    " reported a negative cycle that the from-scratch pass could not find, so one of the two is wrong"};
-            };
-
-            if (! incremental.enabled) {
-                // The from-scratch route: one Bellman-Ford pass each way from
-                // the current bounds, every wake. Kept compiled and selectable
-                // because it is the reference the incremental route is checked
-                // against --- `recursions` and the solution sequence must come
-                // out identical, and a lost inference is invisible to VeriPB.
-                auto & lb = memory.pass_bound;
-                auto & lb_pred = memory.pass_pred;
-                lb.assign(n, 0_i);
-                lb_pred.assign(n, nullopt);
-                for (size_t v = 0; v < n; ++v)
-                    lb[v] = state.lower_bound(nodes[v]);
-                static_cast<void>(relax_lower_bounds(lb, lb_pred, true));
-                infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) { infer_lower_bound(v, lb[v], *lb_pred[v], lb[arcs[*lb_pred[v]].from]); });
-
-                auto & ub = memory.pass_bound;
-                auto & ub_pred = memory.pass_pred;
-                ub.assign(n, 0_i);
-                ub_pred.assign(n, nullopt);
-                for (size_t v = 0; v < n; ++v)
-                    ub[v] = state.upper_bound(nodes[v]);
-                static_cast<void>(relax_upper_bounds(ub, ub_pred, true));
-                infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) { infer_upper_bound(v, ub[v], *ub_pred[v], ub[arcs[*ub_pred[v]].to]); });
-
-                // Deliberately not EnableButIdempotent, and not merely because
-                // the scope aliases whenever one variable appears in several
-                // edges (which is the normal case here, and which
-                // Propagators::install detects and ignores the claim for
-                // anyway). The claim would be wrong on its own terms: the passes
-                // above reach the fixpoint of the bounds abstraction, but an
-                // inferred bound can snap past a hole in the domain and land
-                // strictly above the value computed here, which seeds the next
-                // call higher and lets it push further. So a second call
-                // genuinely can infer more, and the propagator has to be re-woken
-                // by its own inferences until the state settles.
-                // (run_hole_snap_test in difference_constraints_test.cc pins
-                // this, for both routes.)
-                return PropagatorState::Enable;
+                for (auto it = chain.rbegin(); it != chain.rend(); ++it)
+                    infer_one(*it);
             }
+        }
 
-            // ---- the incremental route ----
+        // One edge, one pol: the edge row plus the definition row of the
+        // predecessor's bound literal cancels BinEnc(source) and leaves
+        // BinEnc(v) >= source_bound - d, which is exactly what the closing
+        // RUP needs. This is justify_linear_bounds for a two-term linear,
+        // and it is the shape verified by hand in boundpush_hand.pbp.
+        // Citing the predecessor's own bound is already the paper's
+        // "lifted" explanation: the weakest antecedent for v >= L - d
+        // across this edge *is* source >= L, so the pol's degree comes out
+        // at exactly the pushed amount with no wasted slack.
+        //
+        // A half-reified edge adds `M.~cond' to that sum, and its condition
+        // to the reason. Only *this* edge's condition, because the
+        // inference is per edge: the predecessor's bound was either already
+        // there when the call started, or was itself inferred a moment ago
+        // carrying its own edge's condition in its own reason, so the
+        // conditions along a whole path are cited by the chain of
+        // inferences rather than by any one of them. Each link is a
+        // standalone entailment of one row, which is what makes its RUP
+        // check.
+        //
+        // No saturate here, unlike the cycle refutation: the residual is
+        // harmless under the closing RUP, which assumes cond and so drives
+        // that term to zero, leaving the line the unconditional case would
+        // have produced. Saturating would instead clamp BinEnc(v)'s own
+        // coefficients against the degree, for no gain.
+        //
+        // Shared between the from-scratch and the incremental passes, so
+        // that the two cannot drift apart in what they emit. The self-checks
+        // are what turn a predecessor-walk or a settle-order bug into an
+        // exception here rather than a VeriPB failure much later.
+        auto infer_lower_bound(size_t v, Integer new_bound, size_t arc_index, Integer source_bound) const -> void
+        {
+            const auto & edge = arcs[arc_index];
+            const auto & edge_cond = condition_of(arc_index);
+            if (edge.to != v)
+                throw UnexpectedException{"difference logic lower bound was pushed along an edge that does not end at it"};
+            if (source_bound - edge.d != new_bound)
+                throw UnexpectedException{"difference logic lower bound does not match its predecessor edge"};
+            if (state.lower_bound(nodes[v]) >= new_bound)
+                return;
 
+            auto source = nodes[edge.from];
+            inference.infer_greater_than_or_equal(logger, nodes[v], new_bound,
+                JustifyExplicitly{[&](const ReasonLiterals &) {
+                                      auto pol = edge_line_pol();
+                                      pol.add(edge_lines[edge.posted_index]);
+                                      pol.add_for_literal(logger->names_and_ids_tracker(), source >= source_bound);
+                                      pol.emit(*logger, ProofLevel::Temporary);
+                                  },
+                    ThenRUP::Yes},
+                ExplicitReason{edge_cond ? ReasonLiterals{{source >= source_bound}, {*edge_cond}} : ReasonLiterals{{source >= source_bound}}});
+        }
+
+        auto infer_upper_bound(size_t v, Integer new_bound, size_t arc_index, Integer source_bound) const -> void
+        {
+            const auto & edge = arcs[arc_index];
+            const auto & edge_cond = condition_of(arc_index);
+            if (edge.from != v)
+                throw UnexpectedException{"difference logic upper bound was pushed along an edge that does not start at it"};
+            if (source_bound + edge.d != new_bound)
+                throw UnexpectedException{"difference logic upper bound does not match its predecessor edge"};
+            if (state.upper_bound(nodes[v]) <= new_bound)
+                return;
+
+            auto source = nodes[edge.to];
+            inference.infer_less_than(logger, nodes[v], new_bound + 1_i,
+                JustifyExplicitly{[&](const ReasonLiterals &) {
+                                      auto pol = edge_line_pol();
+                                      pol.add(edge_lines[edge.posted_index]);
+                                      pol.add_for_literal(logger->names_and_ids_tracker(), source < source_bound + 1_i);
+                                      pol.emit(*logger, ProofLevel::Temporary);
+                                  },
+                    ThenRUP::Yes},
+                ExplicitReason{
+                    edge_cond ? ReasonLiterals{{source < source_bound + 1_i}, {*edge_cond}} : ReasonLiterals{{source < source_bound + 1_i}}});
+        }
+
+        // Lower bounds flow forwards. Edge x --d--> y is x - y <= d, i.e.
+        // y >= x - d, so lb(y) >= lb(x) - d. Writing dist(v) = -lb(v) this
+        // is single-source shortest paths from the paper's dummy vertex v0,
+        // whose edge to v weighs -lb(v): that is exactly how the seeding
+        // below encodes the current bounds (Corollary 1). Upper bounds flow
+        // backwards along the same edges: x --d--> y is also x <= y + d, so
+        // ub(x) <= ub(y) + d, which is shortest paths in the reverse graph.
+        static auto lb_tail_of(const DifferenceArc & g) -> size_t
+        {
+            return g.from;
+        }
+        static auto lb_head_of(const DifferenceArc & g) -> size_t
+        {
+            return g.to;
+        }
+        static auto ub_tail_of(const DifferenceArc & g) -> size_t
+        {
+            return g.to;
+        }
+        static auto ub_head_of(const DifferenceArc & g) -> size_t
+        {
+            return g.from;
+        }
+
+        // The from-scratch Bellman-Ford relaxation, to the fixpoint of the
+        // bounds abstraction.
+        //
+        // A shortest path from v0 is simple, so after the seeding (which is
+        // the v0 edge set) it uses at most n - 1 real edges, and n - 1
+        // relaxation rounds suffice. Rounds 0 .. round_bound give one more
+        // than needed; a relaxation that still succeeds in the last round is
+        // sound evidence that the system has a negative cycle, and the
+        // extraction above is then guaranteed to find it.
+        //
+        // With `refute` set this refutes on the spot, at the exact edge that
+        // relaxed, which is what the shipping non-incremental path wants.
+        // Without it the cycle is only reported, which is what the audit
+        // wants: it needs to know whether the incremental pass missed one,
+        // not to duplicate the refutation.
+        auto relax_lower_bounds(vector<Integer> & lb, vector<optional<size_t>> & lb_pred, bool refute) const -> bool
+        {
+            for (size_t round = 0; round <= round_bound; ++round) {
+                bool changed = false, cycle = false;
+                for_each_active_edge([&](size_t e) {
+                    if (cycle)
+                        return;
+                    const auto & edge = arcs[e];
+                    auto candidate = lb[edge.from] - edge.d;
+                    if (candidate > lb[edge.to]) {
+                        lb[edge.to] = candidate;
+                        lb_pred[edge.to] = e;
+                        changed = true;
+                        if (round == round_bound) {
+                            if (refute)
+                                contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
+                            cycle = true;
+                        }
+                    }
+                });
+                if (cycle)
+                    return true;
+                if (! changed)
+                    break;
+            }
+            return false;
+        }
+
+        auto relax_upper_bounds(vector<Integer> & ub, vector<optional<size_t>> & ub_pred, bool refute) const -> bool
+        {
+            for (size_t round = 0; round <= round_bound; ++round) {
+                bool changed = false, cycle = false;
+                for_each_active_edge([&](size_t e) {
+                    if (cycle)
+                        return;
+                    const auto & edge = arcs[e];
+                    auto candidate = ub[edge.to] + edge.d;
+                    if (candidate < ub[edge.from]) {
+                        ub[edge.from] = candidate;
+                        ub_pred[edge.from] = e;
+                        changed = true;
+                        if (round == round_bound) {
+                            if (refute)
+                                contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
+                            cycle = true;
+                        }
+                    }
+                });
+                if (cycle)
+                    return true;
+                if (! changed)
+                    break;
+            }
+            return false;
+        }
+
+        // A negative cycle found by IncSat, or by the initial potential
+        // computation, is refuted by handing straight over to the
+        // from-scratch pass, which already carries the extraction and the
+        // telescoping pol. A negative cycle ends the search, so the O(n.m)
+        // is paid at most once per branch and buys a second implementation
+        // that does not have to be written or trusted.
+        auto refute_negative_cycle(const char * who) const -> void
+        {
+            memory.pass_bound.assign(n, 0_i);
+            memory.pass_pred.assign(n, nullopt);
+            for (size_t v = 0; v < n; ++v)
+                memory.pass_bound[v] = state.lower_bound(nodes[v]);
+            static_cast<void>(relax_lower_bounds(memory.pass_bound, memory.pass_pred, true));
+            throw UnexpectedException{string{"difference logic "} + who +
+                " reported a negative cycle that the from-scratch pass could not find, so one of the two is wrong"};
+        }
+
+        // The from-scratch route: one Bellman-Ford pass each way from the
+        // current bounds, every wake. Kept compiled and selectable because it is
+        // the reference the incremental route is checked against --- `recursions`
+        // and the solution sequence must come out identical, and a lost
+        // inference is invisible to VeriPB.
+        auto run_from_scratch() const -> void
+        {
+            // The from-scratch route: one Bellman-Ford pass each way from
+            // the current bounds, every wake. Kept compiled and selectable
+            // because it is the reference the incremental route is checked
+            // against --- `recursions` and the solution sequence must come
+            // out identical, and a lost inference is invisible to VeriPB.
+            auto & lb = memory.pass_bound;
+            auto & lb_pred = memory.pass_pred;
+            lb.assign(n, 0_i);
+            lb_pred.assign(n, nullopt);
+            for (size_t v = 0; v < n; ++v)
+                lb[v] = state.lower_bound(nodes[v]);
+            static_cast<void>(relax_lower_bounds(lb, lb_pred, true));
+            infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) { infer_lower_bound(v, lb[v], *lb_pred[v], lb[arcs[*lb_pred[v]].from]); });
+
+            auto & ub = memory.pass_bound;
+            auto & ub_pred = memory.pass_pred;
+            ub.assign(n, 0_i);
+            ub_pred.assign(n, nullopt);
+            for (size_t v = 0; v < n; ++v)
+                ub[v] = state.upper_bound(nodes[v]);
+            static_cast<void>(relax_upper_bounds(ub, ub_pred, true));
+            infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) { infer_upper_bound(v, ub[v], *ub_pred[v], ub[arcs[*ub_pred[v]].to]); });
+        }
+
+        auto run_incremental(bool first_call, bool at_root) const -> void
+        {
             if (first_call) {
                 if (! at_root)
                     throw UnexpectedException{"difference logic incremental state was initialised below a decision, where nothing it concludes "
@@ -1218,7 +1039,281 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, Stat
             // those entries. Done last, so that a contradiction raised part way
             // through leaves the entries to be undone rather than committed.
             any_cast<size_t &>(state.get_constraint_state(trail_mark_handle)) = memory.trail.size();
+        }
+    };
 
+    // GCS_DIFFERENCE_AUDIT turns the differential fixpoint audit on for every
+    // difference propagator in the process, so a whole corpus can be run under
+    // it without touching a single model. Read once.
+    auto difference_audit_from_environment() -> bool
+    {
+        static const bool result = [] {
+            const char * e = std::getenv("GCS_DIFFERENCE_AUDIT");
+            return e && *e && string{e} != "0";
+        }();
+        return result;
+    }
+}
+
+auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> optional<DeviewedDifferenceOperand>
+{
+    return overloaded{
+        [&](const SimpleIntegerVariableID & v) { return optional<DeviewedDifferenceOperand>{{v, 0_i}}; },                   //
+        [&](const ConstantIntegerVariableID & v) { return optional<DeviewedDifferenceOperand>{{nullopt, v.const_value}}; }, //
+        [&](const ViewOfIntegerVariableID & v) {
+            if (v.negate_first)
+                return optional<DeviewedDifferenceOperand>{nullopt};
+            return optional<DeviewedDifferenceOperand>{{v.actual_variable, v.then_add}};
+        } //
+    }
+        .visit(var);
+}
+
+auto gcs::innards::install_difference_propagator(Propagators & propagators, State & initial_state, const ConstraintID & constraint_id,
+    DifferenceGraph graph, DifferenceSimplificationOptions simplify, DifferenceIncrementalOptions incremental) -> void
+{
+    if (graph.edges.empty() && graph.static_bounds.empty() && graph.disallowed_conditions.empty())
+        return;
+
+    incremental.audit = incremental.audit || difference_audit_from_environment();
+
+    Triggers triggers;
+    for (const auto & v : graph.nodes)
+        triggers.on_bounds.emplace_back(v);
+
+    // A half-reified edge joins the graph the moment its condition becomes
+    // true, so the propagator must wake on that as well as on the nodes'
+    // bounds. `on_change' on the condition's variable is the coarsest trigger
+    // gcs offers that is guaranteed to catch it: a condition can become true
+    // through an interior removal (`x != v' the instant v leaves the domain),
+    // which `on_bounds' does not see, and `on_instantiated' fires strictly less
+    // often still (`x >= v' can become true long before x is fixed). Nothing
+    // finer is needed, because there is no cheaper "becomes true" trigger and
+    // the refined per-literal watches would have to be armed one per condition
+    // anyway. Waking when a condition becomes *false* is not needed at all ---
+    // an inactive edge simply does not participate, and no inference is lost by
+    // finding that out later --- but `on_change' cannot distinguish the two
+    // directions, and paying for the extra wake is cheaper than the machinery
+    // to avoid it.
+    //
+    // Deliberately not deduplicated against the node list: a variable that is
+    // both a graph node and somebody's condition would then have to give up one
+    // of the two trigger kinds, and a duplicate wake is merely wasted work.
+    {
+        vector<IntegerVariableID> condition_vars;
+        auto note = [&](const IntegerVariableCondition & c) {
+            if (condition_vars.end() == find(condition_vars, c.var))
+                condition_vars.push_back(c.var);
+        };
+        for (const auto & e : graph.edges)
+            if (e.cond)
+                note(*e.cond);
+        for (const auto & sb : graph.static_bounds)
+            if (sb.cond)
+                note(*sb.cond);
+        for (const auto & dc : graph.disallowed_conditions)
+            note(dc.cond);
+        for (const auto & v : condition_vars)
+            triggers.on_change.emplace_back(v);
+    }
+
+    // Repack into the hot arc array plus a parallel condition array; see
+    // DifferenceArc. The condition array stays *empty* when nothing is
+    // conditional, which is both the check the propagator uses to take the
+    // straight-through path and a guarantee that an unconditional system pays
+    // nothing at all for this feature.
+    vector<DifferenceArc> arcs;
+    vector<optional<IntegerVariableCondition>> arc_conditions;
+    arcs.reserve(graph.edges.size());
+    for (const auto & e : graph.edges)
+        arcs.push_back(DifferenceArc{e.from, e.to, e.d, e.posted_index});
+    if (graph.edges.end() != find_if(graph.edges, [](const auto & e) { return e.cond.has_value(); })) {
+        arc_conditions.reserve(graph.edges.size());
+        for (const auto & e : graph.edges)
+            arc_conditions.push_back(e.cond);
+    }
+
+    // Read before the capture list moves the node vector out from under it.
+    auto number_of_nodes = graph.nodes.size();
+
+    // The only trailed state: how much of the undo trail belongs to the current
+    // epoch. State::on_backtrack is not reachable from a propagator's
+    // `const State &`, and copying the whole of Do into every epoch would make
+    // entering an epoch O(n + m); a single number in the trailed constraint
+    // state gives exact restoration at O(1) per epoch instead, unwound lazily at
+    // the next call. Lazily is safe precisely because the restored values are
+    // exact and do not depend on the current domains --- nothing reads Do
+    // between the backtrack and that call.
+    auto trail_mark_handle = initial_state.add_constraint_state(size_t{0});
+
+    // The root simplification stage mutates `arcs`, `arc_conditions` and
+    // `round_bound` in place, once, on the first call --- hence the `mutable`
+    // below. It is safe without trailing for the same reason the paper's section
+    // 5.3 boundary is where it is: the stage runs only at the root, before any
+    // decision, and every conclusion it draws (this edge is implied by a path of
+    // unconditional or root-fixed edges; this node has no edges left) is a
+    // statement about the *graph*, which no amount of backtracking changes.
+    // Nothing there reads a domain. The incremental machinery below is `mutable`
+    // for a different reason, and one the paper is explicit about: the potential
+    // function survives backtracking by design.
+    propagators.install(
+        constraint_id,
+        [nodes = move(graph.nodes), arcs = move(arcs), arc_conditions = move(arc_conditions), static_bounds = move(graph.static_bounds),
+            disallowed_conditions = move(graph.disallowed_conditions), edge_lines = move(graph.edge_lines), simplify = move(simplify),
+            incremental = move(incremental), memory = DifferencePropagatorMemory{}, trail_mark_handle, simplification_pending = true,
+            round_bound = number_of_nodes](const State & state, auto & inference, ProofLogger * const logger) mutable -> PropagatorState {
+            auto n = nodes.size();
+            auto m = arcs.size();
+
+            // A half-reified edge whose condition says `cond -> 0 <= d' with
+            // d < 0 says `!cond', and saying so is a soundness obligation, not a
+            // nicety: dropping the edge would licence solutions in which cond
+            // holds and the constraint is violated. The row is `M.~cond >= -d'
+            // with -d >= 1, which is the unit clause `~cond' after saturation,
+            // so plain RUP against it suffices and nothing in the state is
+            // involved. (Unconditionally this is a root contradiction instead;
+            // see DifferenceConstraints::install_propagators.)
+            for (const auto & dc : disallowed_conditions)
+                if (LiteralIs::DefinitelyFalse != state.test_literal(dc.cond))
+                    inference.infer(logger, ! dc.cond, JustifyUsingRUP{}, NoReason{});
+
+            // Static bounds next: an edge with a constant operand is a plain
+            // bound on the other operand, and once applied it is just part of
+            // the state that the passes below seed from. An unconditional one
+            // never changes, so after the first call it is a no-op; a
+            // conditional one applies from the moment its condition holds, and
+            // cites it. Nothing about it needs trailing or gating: a bound it
+            // applies moves the state, and moving the state is exactly what puts
+            // the node into Vl on this very call.
+            for (const auto & sb : static_bounds) {
+                if (sb.cond && LiteralIs::DefinitelyTrue != state.test_literal(*sb.cond))
+                    continue;
+                Reason why = sb.cond ? Reason{ExplicitReason{ReasonLiterals{{*sb.cond}}}} : Reason{NoReason{}};
+                if (sb.is_lower) {
+                    if (state.lower_bound(nodes[sb.node]) < sb.value)
+                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, why);
+                }
+                else {
+                    if (state.upper_bound(nodes[sb.node]) > sb.value)
+                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, why);
+                }
+            }
+
+            auto first_call = simplification_pending;
+            bool at_root = true;
+
+            if (first_call) {
+                simplification_pending = false;
+
+                for ([[maybe_unused]] const auto & guess : state.guesses()) {
+                    at_root = false;
+                    break;
+                }
+
+                run_difference_root_simplification(state, inference, logger, n, arcs, arc_conditions, edge_lines, simplify, round_bound, at_root);
+                m = arcs.size();
+            }
+
+            // Which edges are in the graph *for this call*. A half-reified edge
+            // participates exactly while its condition currently holds; the
+            // paper's E' set, restricted to the entailed half, since nothing
+            // here infers a condition from the graph.
+            //
+            // Snapshotting once, rather than re-testing as we go, is what keeps
+            // the round bound and the cycle-extraction argument in
+            // dev_docs/difference-logic.md applicable verbatim: both are
+            // statements about one Bellman-Ford run over one fixed edge set, and
+            // the edge set is now fixed for the duration of the call rather than
+            // for the lifetime of the constraint. Nothing else in those
+            // arguments mentions where the edges came from.
+            //
+            // The snapshot also stays *correct* as inferences land during the
+            // call, which is why it is safe to cite a snapshotted condition in a
+            // reason later on. A literal that is definitely true holds for every
+            // value in the current domain, so it holds for every value in any
+            // subset of it; all this propagator does is shrink domains, and a
+            // domain shrunk to empty is a contradiction, which stops the call.
+            // So a condition true at snapshot time is still true at every
+            // inference made from it.
+            //
+            // An unconditional system is not snapshotted at all, and iterates
+            // the arc array straight through. That is not fastidiousness: the
+            // snapshot is a level of indirection inside the innermost loop, and
+            // going through it unconditionally cost 45% on
+            // examples/difference_chain at n = 640 (0.32 s to 0.47 s) with the
+            // propagation count unchanged. The branch is on the *outside* of the
+            // per-edge loop, so the conditional case pays nothing for it either.
+
+            // The undo trail is popped down to the mark *before* the snapshot,
+            // so that the snapshot loop can compare each arc's current activity
+            // against the restored record in the same pass. This restores exact
+            // values, which is what makes doing it here rather than at the
+            // moment of the backtrack sound *and* complete: nothing reads `Do`
+            // in between, and what is restored does not depend on the current
+            // domains. On the first call the trail is empty and the mark is
+            // zero, so this does nothing and the arrays below need not exist
+            // yet.
+            if (incremental.enabled) {
+                auto & mark = any_cast<size_t &>(state.get_constraint_state(trail_mark_handle));
+                while (memory.trail.size() > mark) {
+                    const auto & entry = memory.trail.back();
+                    switch (entry.kind) {
+                        using enum DifferenceTrailKind;
+                    case LowerGate: memory.do_lb[entry.index] = entry.value; break;
+                    case UpperGate: memory.do_ub_neg[entry.index] = entry.value; break;
+                    case Activation: memory.arc_was_active[entry.index] = (0_i == entry.value ? 0 : 1); break;
+                    }
+                    memory.trail.pop_back();
+                }
+            }
+
+            auto all_active = arc_conditions.empty();
+            memory.active_edges.clear();
+            memory.changed_arcs.clear();
+            if (! all_active) {
+                // One pass over the arcs, doing everything a conditional system
+                // needs: the flags the adjacency traversals filter on, the index
+                // list the from-scratch relaxation walks, and the list of arcs
+                // whose activity differs from what the incremental machinery has
+                // established its invariants for. Three separate passes here was
+                // 10-15% on the half-reified RCPSP/max instances, where the
+                // conditional edges make `m` an order of magnitude larger than
+                // `n` and these passes are the whole cost of a wake.
+                auto detect_changes = incremental.enabled && ! first_call;
+                memory.active_edges.reserve(m);
+                memory.active_flags.resize(m);
+                for (size_t e = 0; e < m; ++e) {
+                    char active = (! arc_conditions[e] || LiteralIs::DefinitelyTrue == state.test_literal(*arc_conditions[e])) ? 1 : 0;
+                    memory.active_flags[e] = active;
+                    if (active)
+                        memory.active_edges.push_back(e);
+                    if (detect_changes && active != memory.arc_was_active[e])
+                        memory.changed_arcs.push_back(e);
+                }
+            }
+            else
+                memory.active_flags.clear();
+
+            DifferenceCall<std::remove_reference_t<decltype(inference)>> call{state, inference, logger, nodes, arcs, arc_conditions, edge_lines,
+                incremental, memory, trail_mark_handle, n, m, round_bound, all_active};
+
+            if (incremental.enabled)
+                call.run_incremental(first_call, at_root);
+            else
+                call.run_from_scratch();
+
+            // Deliberately not EnableButIdempotent, and not merely because the
+            // scope aliases whenever one variable appears in several edges
+            // (which is the normal case here, and which Propagators::install
+            // detects and ignores the claim for anyway). The claim would be
+            // wrong on its own terms: the passes above reach the fixpoint of the
+            // bounds abstraction, but an inferred bound can snap past a hole in
+            // the domain and land strictly above the value computed there, which
+            // seeds the next call higher and lets it push further. So a second
+            // call genuinely can infer more, and the propagator has to be
+            // re-woken by its own inferences until the state settles.
+            // (run_hole_snap_test in difference_constraints_test.cc pins this,
+            // for both routes.)
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -1048,13 +1048,12 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, Stat
                 }
             }
             else if (! memory.changed_arcs.empty()) {
-                // Arcs whose activity has changed since the last run. Each newly
-                // active one needs
-                // needs *both* halves of the paper's section 4.4 treatment, and
-                // its section 5.4's during-search description gives only the
-                // first: repair the potential function (or find that the arc
-                // closes a negative cycle), *and* seed bound propagation across
-                // it. Without the second, a condition becoming true with no node
+                // Arcs whose activity has changed since the last run. Each
+                // newly active one needs *both* halves of the paper's section
+                // 4.4 treatment, and its section 5.4's during-search description
+                // gives only the first: repair the potential function (or find
+                // that the arc closes a negative cycle), *and* seed bound
+                // propagation across it. Without the second, a condition becoming true with no node
                 // bound changing anywhere leaves Vl empty and the push the arc
                 // delivers is silently lost.
                 //

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -1,4 +1,5 @@
 #include <gcs/constraints/difference/difference_graph.hh>
+#include <gcs/constraints/difference/difference_incremental.hh>
 #include <gcs/constraints/difference/difference_simplify.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -12,18 +13,23 @@
 #include <util/overloaded.hh>
 
 #include <algorithm>
+#include <any>
 #include <chrono>
+#include <cstdlib>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
+using std::any_cast;
 using std::move;
 using std::nullopt;
 using std::optional;
 using std::size_t;
+using std::string;
 using std::vector;
 using std::chrono::duration;
 using std::chrono::steady_clock;
@@ -33,29 +39,6 @@ using std::ranges::find_if;
 
 namespace
 {
-    // The propagator's hot data: one of these per edge, scanned end to end once
-    // per Bellman-Ford round, so its *size* is a measurable property rather than
-    // a detail. Carrying the edge's optional<IntegerVariableCondition> inline
-    // took DifferenceGraphEdge from 32 bytes to 96 and cost 2.9x on
-    // examples/difference_chain at n = 640 --- 0.32 s to 0.93 s with the
-    // propagation and recursion counts unchanged, i.e. pure memory traffic in
-    // the innermost loop.
-    //
-    // So DifferenceGraphEdge stays the convenient *construction* type, with the
-    // condition attached to the edge it belongs to, and install_difference_
-    // propagator repacks it once: arcs here, conditions in a parallel array read
-    // only when the active set is snapshotted (once per call) and when a reason
-    // is built (only when something is inferred). Never inside a round.
-    struct DifferenceArc
-    {
-        size_t from;
-        size_t to;
-        Integer d;
-        size_t posted_index;
-    };
-
-    static_assert(sizeof(DifferenceArc) <= 32, "the difference-logic relaxation loop scans this array once per round; keep it small");
-
     // Publishes the simplification counters on the way out, whichever way out it
     // is.
     //
@@ -81,6 +64,99 @@ namespace
                 *report_to = stats;
         }
     };
+
+    // What one undo record restores. The potential function is deliberately not
+    // in here: it is never trailed, because its invariant is a conjunction over
+    // the edges currently in the graph and backtracking only ever removes edges.
+    enum class DifferenceTrailKind
+    {
+        LowerGate,
+        UpperGate,
+        Activation
+    };
+
+    // For a gate entry, `value` is the bound to restore; for an activation
+    // entry, it is the record's previous setting, which is not always zero ---
+    // the defensive path that drops a record for an arc that has gone inactive
+    // has to be undone the other way round.
+    struct DifferenceTrailEntry
+    {
+        DifferenceTrailKind kind;
+        size_t index;
+        Integer value;
+    };
+
+    // Everything the incremental propagator remembers between calls.
+    //
+    // None of it is copied by the engine: the one thing that *is* trailed is a
+    // single number, the length of `trail` that belongs to the current epoch, so
+    // an epoch costs O(1) to enter rather than O(n + m) to copy. Unwinding
+    // `trail` down to that mark restores `do_lb`, `do_ub` and `arc_was_active`
+    // to *exactly* the values they had at the restore point.
+    //
+    // Exactness is the whole point. The tempting cheap alternative --- clamp
+    // `Do` against the current bounds at the next call instead of restoring it
+    // --- is wrong, and silently so. Guess `y >= 10`; the propagator runs and
+    // records `Do(y) = 10`; the branch fails; `y >= 5` is restored; the sibling
+    // guesses `y >= 7`. The clamp gives `Do(y) = min(10, 7) = 7`, which is
+    // `min D(y)`, so `y` is not in `Vl`, the gate never expands, and the
+    // consequences of `y >= 7` --- which were computed in a branch that has been
+    // thrown away --- are lost. Successive guesses tightening the same variable
+    // is the single most common branching pattern there is, and no proof can see
+    // the loss.
+    struct DifferencePropagatorMemory
+    {
+        // Dijkstra needs adjacency where Bellman-Ford needed only a flat scan.
+        // Built once over every arc; the currently active ones are selected by
+        // `active_flags` during traversal.
+        DifferenceAdjacency by_tail, by_head;
+
+        // Valid for every currently active arc, monotonically decreasing over
+        // the whole search, never reset and never trailed. `neg_potential` is
+        // maintained alongside it rather than rebuilt per call, for the same
+        // reason as `do_ub_neg`: it is the upper bound pass's potential.
+        vector<Integer> potential, neg_potential;
+
+        // The paper's Do: the bounds the previous run propagated *from*. The
+        // upper half is stored negated, because that is the form the shared
+        // implementation of IncLB reads it in and negating it per call was
+        // measurable on `examples/rcpsp_max`.
+        vector<Integer> do_lb, do_ub_neg;
+
+        // Which arcs the incremental machinery has established its invariants
+        // for. Empty when the system is unconditional, in which case every arc
+        // is active for ever and there is nothing to track.
+        vector<char> arc_was_active;
+
+        vector<DifferenceTrailEntry> trail;
+
+        // Per-call scratch, hoisted so that a wake allocates nothing.
+        // `ub_start_neg` is the sign-flipped copy of the current upper bounds,
+        // which is what lets one implementation of IncLB serve both directions.
+        // `pass_bound` and `pass_pred` belong to the from-scratch route and to
+        // the audit's re-run of it.
+        vector<size_t> active_edges, changed_arcs;
+        vector<char> active_flags;
+        vector<char> forced_lb, forced_ub;
+        vector<Integer> lb_start, ub_start_neg;
+        vector<Integer> pass_bound, claim;
+        vector<optional<size_t>> pass_pred;
+
+        DifferencePotentialWorkspace potential_work;
+        DifferenceBoundsWorkspace bounds_work;
+    };
+
+    // GCS_DIFFERENCE_AUDIT turns the differential fixpoint audit on for every
+    // difference propagator in the process, so a whole corpus can be run under
+    // it without touching a single model. Read once.
+    auto difference_audit_from_environment() -> bool
+    {
+        static const bool result = [] {
+            const char * e = std::getenv("GCS_DIFFERENCE_AUDIT");
+            return e && *e && string{e} != "0";
+        }();
+        return result;
+    }
 }
 
 auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> optional<DeviewedDifferenceOperand>
@@ -97,11 +173,13 @@ auto gcs::innards::deview_difference_operand(const IntegerVariableID & var) -> o
         .visit(var);
 }
 
-auto gcs::innards::install_difference_propagator(
-    Propagators & propagators, const ConstraintID & constraint_id, DifferenceGraph graph, DifferenceSimplificationOptions simplify) -> void
+auto gcs::innards::install_difference_propagator(Propagators & propagators, State & initial_state, const ConstraintID & constraint_id,
+    DifferenceGraph graph, DifferenceSimplificationOptions simplify, DifferenceIncrementalOptions incremental) -> void
 {
     if (graph.edges.empty() && graph.static_bounds.empty() && graph.disallowed_conditions.empty())
         return;
+
+    incremental.audit = incremental.audit || difference_audit_from_environment();
 
     Triggers triggers;
     for (const auto & v : graph.nodes)
@@ -162,20 +240,31 @@ auto gcs::innards::install_difference_propagator(
     // Read before the capture list moves the node vector out from under it.
     auto number_of_nodes = graph.nodes.size();
 
+    // The only trailed state: how much of the undo trail belongs to the current
+    // epoch. State::on_backtrack is not reachable from a propagator's
+    // `const State &`, and copying the whole of Do into every epoch would make
+    // entering an epoch O(n + m); a single number in the trailed constraint
+    // state gives exact restoration at O(1) per epoch instead, unwound lazily at
+    // the next call. Lazily is safe precisely because the restored values are
+    // exact and do not depend on the current domains --- nothing reads Do
+    // between the backtrack and that call.
+    auto trail_mark_handle = initial_state.add_constraint_state(size_t{0});
+
     // The root simplification stage mutates `arcs`, `arc_conditions` and
     // `round_bound` in place, once, on the first call --- hence the `mutable`
-    // below, which is the only mutable propagator state in this file. It is safe
-    // without trailing for the same reason the paper's section 5.3 boundary is
-    // where it is: the stage runs only at the root, before any decision, and
-    // every conclusion it draws (this edge is implied by a path of unconditional
-    // or root-fixed edges; this node has no edges left) is a statement about the
-    // *graph*, which no amount of backtracking changes. Nothing here reads a
-    // domain.
+    // below. It is safe without trailing for the same reason the paper's section
+    // 5.3 boundary is where it is: the stage runs only at the root, before any
+    // decision, and every conclusion it draws (this edge is implied by a path of
+    // unconditional or root-fixed edges; this node has no edges left) is a
+    // statement about the *graph*, which no amount of backtracking changes.
+    // Nothing there reads a domain. The incremental machinery below is `mutable`
+    // for a different reason, and one the paper is explicit about: the potential
+    // function survives backtracking by design.
     propagators.install(
         constraint_id,
         [nodes = move(graph.nodes), arcs = move(arcs), arc_conditions = move(arc_conditions), static_bounds = move(graph.static_bounds),
             disallowed_conditions = move(graph.disallowed_conditions), edge_lines = move(graph.edge_lines), simplify = move(simplify),
-            simplification_pending = true,
+            incremental = move(incremental), memory = DifferencePropagatorMemory{}, trail_mark_handle, simplification_pending = true,
             round_bound = number_of_nodes](const State & state, auto & inference, ProofLogger * const logger) mutable -> PropagatorState {
             auto n = nodes.size();
             auto m = arcs.size();
@@ -217,9 +306,12 @@ auto gcs::innards::install_difference_propagator(
 
             // Static bounds next: an edge with a constant operand is a plain
             // bound on the other operand, and once applied it is just part of
-            // the state that Bellman-Ford seeds from. An unconditional one never
-            // changes, so after the first call it is a no-op; a conditional one
-            // applies from the moment its condition holds, and cites it.
+            // the state that the passes below seed from. An unconditional one
+            // never changes, so after the first call it is a no-op; a
+            // conditional one applies from the moment its condition holds, and
+            // cites it. Nothing about it needs trailing or gating: a bound it
+            // applies moves the state, and moving the state is exactly what puts
+            // the node into Vl on this very call.
             for (const auto & sb : static_bounds) {
                 if (sb.cond && LiteralIs::DefinitelyTrue != state.test_literal(*sb.cond))
                     continue;
@@ -233,6 +325,9 @@ auto gcs::innards::install_difference_propagator(
                         inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, why);
                 }
             }
+
+            auto first_call = simplification_pending;
+            bool at_root = true;
 
             // The root simplification stage, which is the paper's Algorithm 4
             // (its section 5.2) run to the fixpoint of its section 5.3. Once, on
@@ -251,10 +346,9 @@ auto gcs::innards::install_difference_propagator(
             // Zero-weight-cycle unification is not implemented; the cycles are
             // counted so the question of whether it would pay is answerable from
             // a measurement (see dev_docs/difference-logic.md).
-            if (simplification_pending) {
+            if (first_call) {
                 simplification_pending = false;
 
-                bool at_root = true;
                 for ([[maybe_unused]] const auto & guess : state.guesses()) {
                     at_root = false;
                     break;
@@ -304,7 +398,7 @@ auto gcs::innards::install_difference_propagator(
                         auto outcome = simplify_difference_graph(n, simplify_edges, roles);
                         if (outcome.base_negative_cycle) {
                             // The unconditional part of the system is already
-                            // infeasible. Stop and let the Bellman-Ford pass
+                            // infeasible. Stop and let the from-scratch pass
                             // below refute it: that is where the cycle
                             // extraction and the telescoping pol live, and
                             // duplicating them here would buy nothing.
@@ -503,21 +597,63 @@ auto gcs::innards::install_difference_propagator(
             // examples/difference_chain at n = 640 (0.32 s to 0.47 s) with the
             // propagation count unchanged. The branch is on the *outside* of the
             // per-edge loop, so the conditional case pays nothing for it either.
-            vector<size_t> active_edges;
-            auto all_active = arc_conditions.empty();
-            if (! all_active) {
-                active_edges.reserve(m);
-                for (size_t e = 0; e < m; ++e)
-                    if (! arc_conditions[e] || LiteralIs::DefinitelyTrue == state.test_literal(*arc_conditions[e]))
-                        active_edges.push_back(e);
+
+            // The undo trail is popped down to the mark *before* the snapshot,
+            // so that the snapshot loop can compare each arc's current activity
+            // against the restored record in the same pass. This restores exact
+            // values, which is what makes doing it here rather than at the
+            // moment of the backtrack sound *and* complete: nothing reads `Do`
+            // in between, and what is restored does not depend on the current
+            // domains. On the first call the trail is empty and the mark is
+            // zero, so this does nothing and the arrays below need not exist
+            // yet.
+            if (incremental.enabled) {
+                auto & mark = any_cast<size_t &>(state.get_constraint_state(trail_mark_handle));
+                while (memory.trail.size() > mark) {
+                    const auto & entry = memory.trail.back();
+                    switch (entry.kind) {
+                        using enum DifferenceTrailKind;
+                    case LowerGate: memory.do_lb[entry.index] = entry.value; break;
+                    case UpperGate: memory.do_ub_neg[entry.index] = entry.value; break;
+                    case Activation: memory.arc_was_active[entry.index] = (0_i == entry.value ? 0 : 1); break;
+                    }
+                    memory.trail.pop_back();
+                }
             }
+
+            auto all_active = arc_conditions.empty();
+            memory.active_edges.clear();
+            memory.changed_arcs.clear();
+            if (! all_active) {
+                // One pass over the arcs, doing everything a conditional system
+                // needs: the flags the adjacency traversals filter on, the index
+                // list the from-scratch relaxation walks, and the list of arcs
+                // whose activity differs from what the incremental machinery has
+                // established its invariants for. Three separate passes here was
+                // 10-15% on the half-reified RCPSP/max instances, where the
+                // conditional edges make `m` an order of magnitude larger than
+                // `n` and these passes are the whole cost of a wake.
+                auto detect_changes = incremental.enabled && ! first_call;
+                memory.active_edges.reserve(m);
+                memory.active_flags.resize(m);
+                for (size_t e = 0; e < m; ++e) {
+                    char active = (! arc_conditions[e] || LiteralIs::DefinitelyTrue == state.test_literal(*arc_conditions[e])) ? 1 : 0;
+                    memory.active_flags[e] = active;
+                    if (active)
+                        memory.active_edges.push_back(e);
+                    if (detect_changes && active != memory.arc_was_active[e])
+                        memory.changed_arcs.push_back(e);
+                }
+            }
+            else
+                memory.active_flags.clear();
 
             auto for_each_active_edge = [&](auto && relax) {
                 if (all_active)
                     for (size_t e = 0; e < m; ++e)
                         relax(e);
                 else
-                    for (auto e : active_edges)
+                    for (auto e : memory.active_edges)
                         relax(e);
             };
 
@@ -654,150 +790,436 @@ auto gcs::innards::install_difference_propagator(
                 }
             };
 
-            // Lower bounds flow forwards. Edge x --d--> y is x - y <= d, i.e.
-            // y >= x - d, so lb(y) >= lb(x) - d. Writing dist(v) = -lb(v) this
-            // is single-source shortest paths from the paper's dummy vertex v0,
-            // whose edge to v weighs -lb(v): that is exactly how the seeding
-            // below encodes the current bounds (Corollary 1).
-            vector<Integer> lb(n, 0_i);
-            vector<optional<size_t>> lb_pred(n, nullopt);
-            for (size_t v = 0; v < n; ++v)
-                lb[v] = state.lower_bound(nodes[v]);
-
-            // A shortest path from v0 is simple, so after the seeding (which is
-            // the v0 edge set) it uses at most n - 1 real edges, and n - 1
-            // relaxation rounds suffice. Rounds 0 .. n - 1 give n of them, one
-            // more than needed; round n relaxes nothing unless the system has a
-            // negative cycle, so a success there is sound evidence of one and
-            // the extraction above is guaranteed to find it.
-            auto lb_tail_of = [](const DifferenceArc & g) { return g.from; };
-            auto lb_head_of = [](const DifferenceArc & g) { return g.to; };
-
-            for (size_t round = 0; round <= round_bound; ++round) {
-                bool changed = false;
-                for_each_active_edge([&](size_t e) {
-                    const auto & edge = arcs[e];
-                    auto candidate = lb[edge.from] - edge.d;
-                    if (candidate > lb[edge.to]) {
-                        lb[edge.to] = candidate;
-                        lb_pred[edge.to] = e;
-                        changed = true;
-                        if (round == round_bound)
-                            contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
-                    }
-                });
-                if (! changed)
-                    break;
-            }
-
-            infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) {
-                const auto & edge = arcs[*lb_pred[v]];
-                const auto & edge_cond = condition_of(*lb_pred[v]);
-                auto source = nodes[edge.from];
-                auto source_lb = lb[edge.from];
-                if (source_lb - edge.d != lb[v])
+            // One edge, one pol: the edge row plus the definition row of the
+            // predecessor's bound literal cancels BinEnc(source) and leaves
+            // BinEnc(v) >= source_bound - d, which is exactly what the closing
+            // RUP needs. This is justify_linear_bounds for a two-term linear,
+            // and it is the shape verified by hand in boundpush_hand.pbp.
+            // Citing the predecessor's own bound is already the paper's
+            // "lifted" explanation: the weakest antecedent for v >= L - d
+            // across this edge *is* source >= L, so the pol's degree comes out
+            // at exactly the pushed amount with no wasted slack.
+            //
+            // A half-reified edge adds `M.~cond' to that sum, and its condition
+            // to the reason. Only *this* edge's condition, because the
+            // inference is per edge: the predecessor's bound was either already
+            // there when the call started, or was itself inferred a moment ago
+            // carrying its own edge's condition in its own reason, so the
+            // conditions along a whole path are cited by the chain of
+            // inferences rather than by any one of them. Each link is a
+            // standalone entailment of one row, which is what makes its RUP
+            // check.
+            //
+            // No saturate here, unlike the cycle refutation: the residual is
+            // harmless under the closing RUP, which assumes cond and so drives
+            // that term to zero, leaving the line the unconditional case would
+            // have produced. Saturating would instead clamp BinEnc(v)'s own
+            // coefficients against the degree, for no gain.
+            //
+            // Shared between the from-scratch and the incremental passes, so
+            // that the two cannot drift apart in what they emit. The self-checks
+            // are what turn a predecessor-walk or a settle-order bug into an
+            // exception here rather than a VeriPB failure much later.
+            auto infer_lower_bound = [&](size_t v, Integer new_bound, size_t arc_index, Integer source_bound) -> void {
+                const auto & edge = arcs[arc_index];
+                const auto & edge_cond = condition_of(arc_index);
+                if (edge.to != v)
+                    throw UnexpectedException{"difference logic lower bound was pushed along an edge that does not end at it"};
+                if (source_bound - edge.d != new_bound)
                     throw UnexpectedException{"difference logic lower bound does not match its predecessor edge"};
-                if (state.lower_bound(nodes[v]) >= lb[v])
+                if (state.lower_bound(nodes[v]) >= new_bound)
                     return;
 
-                // One edge, one pol: the edge row plus the definition row
-                // of the predecessor's bound literal cancels BinEnc(source)
-                // and leaves BinEnc(v) >= source_lb - d, which is exactly
-                // what the closing RUP needs. This is justify_linear_bounds
-                // for a two-term linear, and it is the shape verified by
-                // hand in boundpush_hand.pbp. Citing the predecessor's own
-                // bound is already the paper's "lifted" explanation: the
-                // weakest antecedent for v >= L - d across this edge *is*
-                // source >= L, so the pol's degree comes out at exactly the
-                // pushed amount with no wasted slack.
-                //
-                // A half-reified edge adds `M.~cond' to that sum, and its
-                // condition to the reason. Only *this* edge's condition, because
-                // the inference is per edge: the predecessor's bound was either
-                // already there when the call started, or was itself inferred a
-                // moment ago carrying its own edge's condition in its own
-                // reason, so the conditions along a whole path are cited by the
-                // chain of inferences rather than by any one of them. Each link
-                // is a standalone entailment of one row, which is what makes its
-                // RUP check.
-                //
-                // No saturate here, unlike the cycle refutation: the residual is
-                // harmless under the closing RUP, which assumes cond and so
-                // drives that term to zero, leaving the line the unconditional
-                // case would have produced. Saturating would instead clamp
-                // BinEnc(v)'s own coefficients against the degree, for no gain.
-                inference.infer_greater_than_or_equal(logger, nodes[v], lb[v],
+                auto source = nodes[edge.from];
+                inference.infer_greater_than_or_equal(logger, nodes[v], new_bound,
                     JustifyExplicitly{[&](const ReasonLiterals &) {
                                           auto pol = edge_line_pol();
                                           pol.add(edge_lines[edge.posted_index]);
-                                          pol.add_for_literal(logger->names_and_ids_tracker(), source >= source_lb);
+                                          pol.add_for_literal(logger->names_and_ids_tracker(), source >= source_bound);
                                           pol.emit(*logger, ProofLevel::Temporary);
                                       },
                         ThenRUP::Yes},
-                    ExplicitReason{edge_cond ? ReasonLiterals{{source >= source_lb}, {*edge_cond}} : ReasonLiterals{{source >= source_lb}}});
-            });
+                    ExplicitReason{edge_cond ? ReasonLiterals{{source >= source_bound}, {*edge_cond}} : ReasonLiterals{{source >= source_bound}}});
+            };
 
-            // Upper bounds flow backwards along the same edges. Edge
-            // x --d--> y is also x <= y + d, so ub(x) <= ub(y) + d: shortest
-            // paths in the reverse graph, seeded from the current upper bounds.
-            vector<Integer> ub(n, 0_i);
-            vector<optional<size_t>> ub_pred(n, nullopt);
-            for (size_t v = 0; v < n; ++v)
-                ub[v] = state.upper_bound(nodes[v]);
-
-            auto ub_tail_of = [](const DifferenceArc & g) { return g.to; };
-            auto ub_head_of = [](const DifferenceArc & g) { return g.from; };
-
-            for (size_t round = 0; round <= round_bound; ++round) {
-                bool changed = false;
-                for_each_active_edge([&](size_t e) {
-                    const auto & edge = arcs[e];
-                    auto candidate = ub[edge.to] + edge.d;
-                    if (candidate < ub[edge.from]) {
-                        ub[edge.from] = candidate;
-                        ub_pred[edge.from] = e;
-                        changed = true;
-                        if (round == round_bound)
-                            contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
-                    }
-                });
-                if (! changed)
-                    break;
-            }
-
-            infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) {
-                const auto & edge = arcs[*ub_pred[v]];
-                const auto & edge_cond = condition_of(*ub_pred[v]);
-                auto source = nodes[edge.to];
-                auto source_ub = ub[edge.to];
-                if (source_ub + edge.d != ub[v])
+            auto infer_upper_bound = [&](size_t v, Integer new_bound, size_t arc_index, Integer source_bound) -> void {
+                const auto & edge = arcs[arc_index];
+                const auto & edge_cond = condition_of(arc_index);
+                if (edge.from != v)
+                    throw UnexpectedException{"difference logic upper bound was pushed along an edge that does not start at it"};
+                if (source_bound + edge.d != new_bound)
                     throw UnexpectedException{"difference logic upper bound does not match its predecessor edge"};
-                if (state.upper_bound(nodes[v]) <= ub[v])
+                if (state.upper_bound(nodes[v]) <= new_bound)
                     return;
 
-                inference.infer_less_than(logger, nodes[v], ub[v] + 1_i,
+                auto source = nodes[edge.to];
+                inference.infer_less_than(logger, nodes[v], new_bound + 1_i,
                     JustifyExplicitly{[&](const ReasonLiterals &) {
                                           auto pol = edge_line_pol();
                                           pol.add(edge_lines[edge.posted_index]);
-                                          pol.add_for_literal(logger->names_and_ids_tracker(), source < source_ub + 1_i);
+                                          pol.add_for_literal(logger->names_and_ids_tracker(), source < source_bound + 1_i);
                                           pol.emit(*logger, ProofLevel::Temporary);
                                       },
                         ThenRUP::Yes},
                     ExplicitReason{
-                        edge_cond ? ReasonLiterals{{source < source_ub + 1_i}, {*edge_cond}} : ReasonLiterals{{source < source_ub + 1_i}}});
-            });
+                        edge_cond ? ReasonLiterals{{source < source_bound + 1_i}, {*edge_cond}} : ReasonLiterals{{source < source_bound + 1_i}}});
+            };
 
-            // Deliberately not EnableButIdempotent, and not merely because the
-            // scope aliases whenever one variable appears in several edges
-            // (which is the normal case here, and which Propagators::install
-            // detects and ignores the claim for anyway). The claim would be
-            // wrong on its own terms: the passes above reach the fixpoint of
-            // the bounds abstraction, but an inferred bound can snap past a
-            // hole in the domain and land strictly above the value computed
-            // here, which seeds the next call higher and lets it push further.
-            // So a second call genuinely can infer more, and the propagator has
-            // to be re-woken by its own inferences until the state settles.
-            // (run_hole_snap_test in difference_constraints_test.cc pins this.)
+            // Lower bounds flow forwards. Edge x --d--> y is x - y <= d, i.e.
+            // y >= x - d, so lb(y) >= lb(x) - d. Writing dist(v) = -lb(v) this
+            // is single-source shortest paths from the paper's dummy vertex v0,
+            // whose edge to v weighs -lb(v): that is exactly how the seeding
+            // below encodes the current bounds (Corollary 1). Upper bounds flow
+            // backwards along the same edges: x --d--> y is also x <= y + d, so
+            // ub(x) <= ub(y) + d, which is shortest paths in the reverse graph.
+            auto lb_tail_of = [](const DifferenceArc & g) { return g.from; };
+            auto lb_head_of = [](const DifferenceArc & g) { return g.to; };
+            auto ub_tail_of = [](const DifferenceArc & g) { return g.to; };
+            auto ub_head_of = [](const DifferenceArc & g) { return g.from; };
+
+            // The from-scratch Bellman-Ford relaxation, to the fixpoint of the
+            // bounds abstraction.
+            //
+            // A shortest path from v0 is simple, so after the seeding (which is
+            // the v0 edge set) it uses at most n - 1 real edges, and n - 1
+            // relaxation rounds suffice. Rounds 0 .. round_bound give one more
+            // than needed; a relaxation that still succeeds in the last round is
+            // sound evidence that the system has a negative cycle, and the
+            // extraction above is then guaranteed to find it.
+            //
+            // With `refute` set this refutes on the spot, at the exact edge that
+            // relaxed, which is what the shipping non-incremental path wants.
+            // Without it the cycle is only reported, which is what the audit
+            // wants: it needs to know whether the incremental pass missed one,
+            // not to duplicate the refutation.
+            auto relax_lower_bounds = [&](vector<Integer> & lb, vector<optional<size_t>> & lb_pred, bool refute) -> bool {
+                for (size_t round = 0; round <= round_bound; ++round) {
+                    bool changed = false, cycle = false;
+                    for_each_active_edge([&](size_t e) {
+                        if (cycle)
+                            return;
+                        const auto & edge = arcs[e];
+                        auto candidate = lb[edge.from] - edge.d;
+                        if (candidate > lb[edge.to]) {
+                            lb[edge.to] = candidate;
+                            lb_pred[edge.to] = e;
+                            changed = true;
+                            if (round == round_bound) {
+                                if (refute)
+                                    contradict_on_cycle(extract_cycle(edge.to, lb_pred, lb_tail_of), lb_tail_of, lb_head_of);
+                                cycle = true;
+                            }
+                        }
+                    });
+                    if (cycle)
+                        return true;
+                    if (! changed)
+                        break;
+                }
+                return false;
+            };
+
+            auto relax_upper_bounds = [&](vector<Integer> & ub, vector<optional<size_t>> & ub_pred, bool refute) -> bool {
+                for (size_t round = 0; round <= round_bound; ++round) {
+                    bool changed = false, cycle = false;
+                    for_each_active_edge([&](size_t e) {
+                        if (cycle)
+                            return;
+                        const auto & edge = arcs[e];
+                        auto candidate = ub[edge.to] + edge.d;
+                        if (candidate < ub[edge.from]) {
+                            ub[edge.from] = candidate;
+                            ub_pred[edge.from] = e;
+                            changed = true;
+                            if (round == round_bound) {
+                                if (refute)
+                                    contradict_on_cycle(extract_cycle(edge.from, ub_pred, ub_tail_of), ub_tail_of, ub_head_of);
+                                cycle = true;
+                            }
+                        }
+                    });
+                    if (cycle)
+                        return true;
+                    if (! changed)
+                        break;
+                }
+                return false;
+            };
+
+            // A negative cycle found by IncSat, or by the initial potential
+            // computation, is refuted by handing straight over to the
+            // from-scratch pass, which already carries the extraction and the
+            // telescoping pol. A negative cycle ends the search, so the O(n.m)
+            // is paid at most once per branch and buys a second implementation
+            // that does not have to be written or trusted.
+            auto refute_negative_cycle = [&](const char * who) -> void {
+                memory.pass_bound.assign(n, 0_i);
+                memory.pass_pred.assign(n, nullopt);
+                for (size_t v = 0; v < n; ++v)
+                    memory.pass_bound[v] = state.lower_bound(nodes[v]);
+                static_cast<void>(relax_lower_bounds(memory.pass_bound, memory.pass_pred, true));
+                throw UnexpectedException{string{"difference logic "} + who +
+                    " reported a negative cycle that the from-scratch pass could not find, so one of the two is wrong"};
+            };
+
+            if (! incremental.enabled) {
+                // The from-scratch route: one Bellman-Ford pass each way from
+                // the current bounds, every wake. Kept compiled and selectable
+                // because it is the reference the incremental route is checked
+                // against --- `recursions` and the solution sequence must come
+                // out identical, and a lost inference is invisible to VeriPB.
+                auto & lb = memory.pass_bound;
+                auto & lb_pred = memory.pass_pred;
+                lb.assign(n, 0_i);
+                lb_pred.assign(n, nullopt);
+                for (size_t v = 0; v < n; ++v)
+                    lb[v] = state.lower_bound(nodes[v]);
+                static_cast<void>(relax_lower_bounds(lb, lb_pred, true));
+                infer_along_forest(lb_pred, lb_tail_of, [&](size_t v) { infer_lower_bound(v, lb[v], *lb_pred[v], lb[arcs[*lb_pred[v]].from]); });
+
+                auto & ub = memory.pass_bound;
+                auto & ub_pred = memory.pass_pred;
+                ub.assign(n, 0_i);
+                ub_pred.assign(n, nullopt);
+                for (size_t v = 0; v < n; ++v)
+                    ub[v] = state.upper_bound(nodes[v]);
+                static_cast<void>(relax_upper_bounds(ub, ub_pred, true));
+                infer_along_forest(ub_pred, ub_tail_of, [&](size_t v) { infer_upper_bound(v, ub[v], *ub_pred[v], ub[arcs[*ub_pred[v]].to]); });
+
+                // Deliberately not EnableButIdempotent, and not merely because
+                // the scope aliases whenever one variable appears in several
+                // edges (which is the normal case here, and which
+                // Propagators::install detects and ignores the claim for
+                // anyway). The claim would be wrong on its own terms: the passes
+                // above reach the fixpoint of the bounds abstraction, but an
+                // inferred bound can snap past a hole in the domain and land
+                // strictly above the value computed here, which seeds the next
+                // call higher and lets it push further. So a second call
+                // genuinely can infer more, and the propagator has to be re-woken
+                // by its own inferences until the state settles.
+                // (run_hole_snap_test in difference_constraints_test.cc pins
+                // this, for both routes.)
+                return PropagatorState::Enable;
+            }
+
+            // ---- the incremental route ----
+
+            if (first_call) {
+                if (! at_root)
+                    throw UnexpectedException{"difference logic incremental state was initialised below a decision, where nothing it concludes "
+                                              "would survive backtracking"};
+
+                memory.by_tail = build_difference_adjacency(n, arcs, true);
+                memory.by_head = build_difference_adjacency(n, arcs, false);
+                memory.do_lb.assign(n, 0_i);
+                memory.do_ub_neg.assign(n, 0_i);
+                memory.forced_lb.assign(n, 0);
+                memory.forced_ub.assign(n, 0);
+                memory.lb_start.assign(n, 0_i);
+                memory.ub_start_neg.assign(n, 0_i);
+                if (! all_active)
+                    memory.arc_was_active = memory.active_flags;
+
+                // One Bellman-Ford, once, for the potential function. Every
+                // later change to the active arc set goes through IncSat
+                // instead, which is what makes a wake O(n log n + m) rather
+                // than O(n.m). No trail entries: this is the root, and the
+                // trail mark stays where it is.
+                auto initial_potential = difference_initial_potential(n, arcs, memory.active_flags);
+                if (! initial_potential)
+                    refute_negative_cycle("the initial potential computation");
+                memory.potential = move(*initial_potential);
+                memory.neg_potential.assign(n, 0_i);
+                for (size_t v = 0; v < n; ++v)
+                    memory.neg_potential[v] = -memory.potential[v];
+            }
+
+            memory.forced_lb.assign(n, 0);
+            memory.forced_ub.assign(n, 0);
+
+            if (first_call) {
+                // Nothing has been propagated from anything yet, so every node
+                // has to be seeded and expanded once. Setting Do to the current
+                // bounds and forcing every node is exactly that, and it leaves
+                // both gate invariants established when the pass finishes.
+                for (size_t v = 0; v < n; ++v) {
+                    memory.forced_lb[v] = 1;
+                    memory.forced_ub[v] = 1;
+                }
+            }
+            else if (! memory.changed_arcs.empty()) {
+                // Arcs whose activity has changed since the last run. Each newly
+                // active one needs
+                // needs *both* halves of the paper's section 4.4 treatment, and
+                // its section 5.4's during-search description gives only the
+                // first: repair the potential function (or find that the arc
+                // closes a negative cycle), *and* seed bound propagation across
+                // it. Without the second, a condition becoming true with no node
+                // bound changing anywhere leaves Vl empty and the push the arc
+                // delivers is silently lost.
+                //
+                // Seeding is done by forcing the arc's tail into Vl for the
+                // lower bound pass and its head for the upper bound pass, rather
+                // than by touching Do: Dijkstra then carries that node's bound
+                // across the new arc and on downstream, and the Do update at the
+                // end re-establishes I2 for the arc as a side effect.
+                //
+                // Re-activation after backtracking counts, every time. The
+                // potential function is never reset and drifts downwards over
+                // the whole search, so an arc that was valid when it was last
+                // active may need repair now; nothing may cache "this arc has
+                // been checked".
+                bool potential_moved = false;
+                for (auto e : memory.changed_arcs) {
+                    if (0 != memory.active_flags[e]) {
+                        memory.trail.push_back(DifferenceTrailEntry{DifferenceTrailKind::Activation, e, 0_i});
+                        memory.arc_was_active[e] = 1;
+
+                        // IncSat over `arc_was_active`, not over the current
+                        // active set: the potential is valid for exactly the
+                        // arcs recorded there, and the loop adds this one to it
+                        // just before repairing, so each new arc is handled
+                        // against a graph the potential is already valid for.
+                        if (! difference_repair_potential(n, arcs, memory.by_tail, memory.arc_was_active, memory.potential, e, memory.potential_work))
+                            refute_negative_cycle("IncSat");
+                        potential_moved = true;
+                        memory.forced_lb[arcs[e].from] = 1;
+                        memory.forced_ub[arcs[e].to] = 1;
+                    }
+                    else {
+                        // An arc that was active at the restore point but is not
+                        // now. Going down a branch this cannot happen --- a
+                        // definitely-true literal stays definitely true as
+                        // domains shrink --- so this is defensive. Dropping the
+                        // record is always safe: an inactive arc has no
+                        // invariant to maintain, and it will be treated as new
+                        // if it ever comes back.
+                        memory.trail.push_back(DifferenceTrailEntry{DifferenceTrailKind::Activation, e, 1_i});
+                        memory.arc_was_active[e] = 0;
+                    }
+                }
+
+                if (potential_moved)
+                    for (size_t v = 0; v < n; ++v)
+                        memory.neg_potential[v] = -memory.potential[v];
+            }
+
+            if (incremental.audit)
+                if (auto bad = difference_invalid_potential_arc(arcs, memory.active_flags, memory.potential))
+                    throw UnexpectedException{"difference logic entered a call with an invalid potential function, at arc " + std::to_string(*bad)};
+
+            // Both bounds of every node, in one pass. Reading the upper bounds
+            // now rather than after the lower bound pass is not a shortcut: a
+            // lower bound inference removes values *below* a bound and so cannot
+            // move an upper bound at all (a domain it emptied would have raised
+            // a contradiction and ended the call), so the values are the same
+            // either way. It matters because the two accessors were the single
+            // largest line in the profile of a wake.
+            for (size_t v = 0; v < n; ++v) {
+                auto [l, u] = state.bounds(nodes[v]);
+                memory.lb_start[v] = l;
+                memory.ub_start_neg[v] = -u;
+            }
+
+            // IncLB. `Vl`, `pi(v0)` and the seeds are all computed inside; the
+            // settle order that comes back is the order the pushes have to be
+            // made in, so that each cites the one before it.
+            if (first_call) {
+                memory.do_lb = memory.lb_start;
+                memory.do_ub_neg = memory.ub_start_neg;
+            }
+
+            difference_incremental_bounds(n, arcs, memory.by_tail, true, memory.active_flags, memory.potential, memory.lb_start, memory.do_lb,
+                memory.forced_lb, memory.bounds_work);
+
+            for (auto v : memory.bounds_work.settle_order)
+                if (memory.bounds_work.has_predecessor[v] && memory.bounds_work.settled_bound[v] > memory.lb_start[v]) {
+                    auto e = memory.bounds_work.predecessor[v];
+                    infer_lower_bound(v, memory.bounds_work.settled_bound[v], e, memory.bounds_work.settled_bound[arcs[e].from]);
+                }
+
+            // Do becomes the bounds this run propagated *from*, which is what
+            // the pass computed and emphatically not what the state ends up
+            // holding. gcs domains have holes, so an inferred bound can snap
+            // above the value computed here; recording the snapped value would
+            // leave the mandatory self-re-wake with `Vl` empty, and the
+            // consequences of the snap would be lost with nothing to show for
+            // it. Recording the computed value instead is what puts the snapped
+            // node back into `Vl` next time. (`run_hole_snap_test` pins it.)
+            for (auto v : memory.bounds_work.settle_order)
+                if (memory.bounds_work.settled_bound[v] > memory.do_lb[v]) {
+                    memory.trail.push_back(DifferenceTrailEntry{DifferenceTrailKind::LowerGate, v, memory.do_lb[v]});
+                    memory.do_lb[v] = memory.bounds_work.settled_bound[v];
+                }
+
+            if (incremental.audit) {
+                memory.claim = memory.lb_start;
+                for (auto v : memory.bounds_work.settle_order)
+                    if (memory.bounds_work.settled_bound[v] > memory.claim[v])
+                        memory.claim[v] = memory.bounds_work.settled_bound[v];
+
+                memory.pass_bound = memory.lb_start;
+                memory.pass_pred.assign(n, nullopt);
+                if (relax_lower_bounds(memory.pass_bound, memory.pass_pred, false))
+                    throw UnexpectedException{"difference logic incremental propagation missed a negative cycle that the from-scratch pass found"};
+                for (size_t v = 0; v < n; ++v)
+                    if (memory.claim[v] != memory.pass_bound[v])
+                        throw UnexpectedException{"difference logic incremental propagation reached a different lower bound fixpoint from the "
+                                                  "from-scratch pass at node " +
+                            std::to_string(v) + ": " + memory.claim[v].to_string() + " against " + memory.pass_bound[v].to_string() +
+                            ". The incremental pass has lost propagation, which no proof can see."};
+            }
+
+            // IncUB is IncLB on the reverse graph with the potential, the bounds
+            // and the gate all negated: `ub(x) <= ub(y) + d` is
+            // `-ub(x) >= -ub(y) - d`, which is the lower bound relation along
+            // the arc read backwards, and `-pi` is a valid potential for it.
+            // One implementation, two instantiations, and no second chance to
+            // mistranscribe Algorithm 3. All three negated arrays are stored
+            // that way rather than rebuilt per call.
+            difference_incremental_bounds(n, arcs, memory.by_head, false, memory.active_flags, memory.neg_potential, memory.ub_start_neg,
+                memory.do_ub_neg, memory.forced_ub, memory.bounds_work);
+
+            for (auto v : memory.bounds_work.settle_order)
+                if (memory.bounds_work.has_predecessor[v] && memory.bounds_work.settled_bound[v] > memory.ub_start_neg[v]) {
+                    auto e = memory.bounds_work.predecessor[v];
+                    infer_upper_bound(v, -memory.bounds_work.settled_bound[v], e, -memory.bounds_work.settled_bound[arcs[e].to]);
+                }
+
+            for (auto v : memory.bounds_work.settle_order)
+                if (memory.bounds_work.settled_bound[v] > memory.do_ub_neg[v]) {
+                    memory.trail.push_back(DifferenceTrailEntry{DifferenceTrailKind::UpperGate, v, memory.do_ub_neg[v]});
+                    memory.do_ub_neg[v] = memory.bounds_work.settled_bound[v];
+                }
+
+            if (incremental.audit) {
+                memory.claim = memory.ub_start_neg;
+                for (auto v : memory.bounds_work.settle_order)
+                    if (memory.bounds_work.settled_bound[v] > memory.claim[v])
+                        memory.claim[v] = memory.bounds_work.settled_bound[v];
+                for (size_t v = 0; v < n; ++v)
+                    memory.claim[v] = -memory.claim[v];
+
+                memory.pass_bound.assign(n, 0_i);
+                for (size_t v = 0; v < n; ++v)
+                    memory.pass_bound[v] = -memory.ub_start_neg[v];
+                memory.pass_pred.assign(n, nullopt);
+                if (relax_upper_bounds(memory.pass_bound, memory.pass_pred, false))
+                    throw UnexpectedException{"difference logic incremental propagation missed a negative cycle that the from-scratch pass found"};
+                for (size_t v = 0; v < n; ++v)
+                    if (memory.claim[v] != memory.pass_bound[v])
+                        throw UnexpectedException{"difference logic incremental propagation reached a different upper bound fixpoint from the "
+                                                  "from-scratch pass at node " +
+                            std::to_string(v) + ": " + memory.claim[v].to_string() + " against " + memory.pass_bound[v].to_string() +
+                            ". The incremental pass has lost propagation, which no proof can see."};
+            }
+
+            // Publish the trail: everything pushed above belongs to this epoch,
+            // and a backtrack past it will restore this number and undo exactly
+            // those entries. Done last, so that a contradiction raised part way
+            // through leaves the entries to be undone rather than committed.
+            any_cast<size_t &>(state.get_constraint_state(trail_mark_handle)) = memory.trail.size();
+
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/difference/difference_graph.hh
+++ b/gcs/constraints/difference/difference_graph.hh
@@ -2,9 +2,11 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_GRAPH_HH
 
 #include <gcs/constraint_id.hh>
+#include <gcs/constraints/difference/difference_incremental.hh>
 #include <gcs/constraints/difference/difference_simplify.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/state-fwd.hh>
 #include <gcs/integer.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
@@ -186,9 +188,18 @@ namespace gcs::innards
      * first call, guarded on that call being at the root --- which is where every
      * propagator's first call is, since search starts by propagating everything.
      *
+     * The \c State is needed at install time for one thing only: a trailed
+     * constraint state holding the length of the incremental machinery's undo
+     * trail. `State::on_backtrack` is not reachable from a propagator's
+     * `const State &`, so that number is how the `Do` array and the active arc
+     * record are restored exactly on backtracking --- which they must be, since
+     * clamping them lazily against the current bounds loses propagation
+     * silently. \sa DifferenceIncrementalOptions
+     *
      * \ingroup Innards
      */
-    auto install_difference_propagator(Propagators &, const ConstraintID &, DifferenceGraph, DifferenceSimplificationOptions = {}) -> void;
+    auto install_difference_propagator(Propagators &, State &, const ConstraintID &, DifferenceGraph, DifferenceSimplificationOptions = {},
+        DifferenceIncrementalOptions = {}) -> void;
 }
 
 #endif

--- a/gcs/constraints/difference/difference_incremental.cc
+++ b/gcs/constraints/difference/difference_incremental.cc
@@ -1,0 +1,284 @@
+#include <gcs/constraints/difference/difference_incremental.hh>
+#include <gcs/exception.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::greater;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::size_t;
+using std::vector;
+using std::ranges::make_heap;
+using std::ranges::pop_heap;
+using std::ranges::push_heap;
+
+auto gcs::innards::build_difference_adjacency(size_t number_of_nodes, const vector<DifferenceArc> & arcs, bool by_tail) -> DifferenceAdjacency
+{
+    DifferenceAdjacency result;
+    result.start.assign(number_of_nodes + 1, 0);
+    result.arcs.resize(arcs.size());
+
+    auto end_of = [&](const DifferenceArc & a) { return by_tail ? a.from : a.to; };
+
+    for (const auto & a : arcs)
+        ++result.start[end_of(a) + 1];
+    for (size_t v = 0; v < number_of_nodes; ++v)
+        result.start[v + 1] += result.start[v];
+
+    auto next = result.start;
+    for (size_t e = 0; e < arcs.size(); ++e)
+        result.arcs[next[end_of(arcs[e])]++] = e;
+
+    return result;
+}
+
+auto gcs::innards::difference_initial_potential(size_t number_of_nodes, const vector<DifferenceArc> & arcs, const vector<char> & active)
+    -> optional<vector<Integer>>
+{
+    // Bellman-Ford from an imaginary source with a zero-weight edge to every
+    // node: seeding every potential at zero *is* that source's edge set, exactly
+    // as the propagator's own passes encode the bounds. What comes out is
+    // pi(v) = wSP(source, v), so pi(v) <= pi(u) + d for every arc u --d--> v,
+    // which is the potential invariant.
+    //
+    // A shortest path out of the source is simple, so after the seeding it uses
+    // at most n - 1 real arcs and n - 1 rounds suffice; one more that still
+    // relaxes something is sound evidence of a negative cycle.
+    vector<Integer> potential(number_of_nodes, 0_i);
+
+    for (size_t round = 0; round <= number_of_nodes; ++round) {
+        bool changed = false;
+        for (size_t e = 0; e < arcs.size(); ++e) {
+            if (! difference_arc_is_active(active, e))
+                continue;
+            auto candidate = potential[arcs[e].from] + arcs[e].d;
+            if (candidate < potential[arcs[e].to]) {
+                potential[arcs[e].to] = candidate;
+                changed = true;
+            }
+        }
+        if (! changed)
+            return potential;
+    }
+
+    return nullopt;
+}
+
+auto gcs::innards::difference_invalid_potential_arc(
+    const vector<DifferenceArc> & arcs, const vector<char> & active, const vector<Integer> & potential) -> optional<size_t>
+{
+    for (size_t e = 0; e < arcs.size(); ++e)
+        if (difference_arc_is_active(active, e) && potential[arcs[e].from] + arcs[e].d - potential[arcs[e].to] < 0_i)
+            return e;
+    return nullopt;
+}
+
+auto gcs::innards::difference_repair_potential(size_t number_of_nodes, const vector<DifferenceArc> & arcs, const DifferenceAdjacency & by_tail,
+    const vector<char> & active, vector<Integer> & potential, size_t added_arc, DifferencePotentialWorkspace & work) -> bool
+{
+    // The paper's Algorithm 1 (Cotton and Maler's IncSat). gamma is zero
+    // everywhere except at the nodes this call touches, and is restored to that
+    // on the way out, so a wake that adds no arc pays nothing and a wake that
+    // does pays only for what it reached.
+    if (work.gamma.size() != number_of_nodes) {
+        work.gamma.assign(number_of_nodes, 0_i);
+        work.updated.assign(number_of_nodes, 0_i);
+        work.is_updated.assign(number_of_nodes, 0);
+    }
+    work.touched.clear();
+    work.heap.clear();
+
+    auto source = arcs[added_arc].from, target = arcs[added_arc].to;
+    auto result = true;
+
+    // gamma(target) := pi(source) + d - pi(target), the reduced cost of the new
+    // arc. Non-negative means the potential is already valid for it and there is
+    // nothing at all to do, which is the common case.
+    auto initial = potential[source] + arcs[added_arc].d - potential[target];
+    if (initial < 0_i) {
+        work.gamma[target] = initial;
+        work.touched.push_back(target);
+        work.heap.emplace_back(initial, target);
+        make_heap(work.heap, greater{});
+
+        while (! work.heap.empty()) {
+            // The loop's other termination condition: once the repair has
+            // reached back round to the new arc's own tail, the arc lies on a
+            // negative cycle and no potential function exists.
+            if (work.gamma[source] < 0_i) {
+                result = false;
+                break;
+            }
+
+            pop_heap(work.heap, greater{});
+            auto [gamma_here, here] = work.heap.back();
+            work.heap.pop_back();
+            if (gamma_here != work.gamma[here])
+                continue;
+
+            work.updated[here] = potential[here] + gamma_here;
+            work.is_updated[here] = 1;
+            work.gamma[here] = 0_i;
+
+            for (auto i = by_tail.start[here]; i != by_tail.start[here + 1]; ++i) {
+                auto e = by_tail.arcs[i];
+                if (! difference_arc_is_active(active, e))
+                    continue;
+                auto next = arcs[e].to;
+                // The paper's line 9, `if pi'(t) = pi(t)': a node whose
+                // potential has already been lowered is never revisited, which
+                // is what bounds the loop at one update per node.
+                if (work.is_updated[next])
+                    continue;
+                auto candidate = work.updated[here] + arcs[e].d - potential[next];
+                if (candidate < work.gamma[next]) {
+                    if (0_i == work.gamma[next])
+                        work.touched.push_back(next);
+                    work.gamma[next] = candidate;
+                    work.heap.emplace_back(candidate, next);
+                    push_heap(work.heap, greater{});
+                }
+            }
+        }
+
+        if (result && work.gamma[source] < 0_i)
+            result = false;
+
+        // Commit only on success: an unsatisfiable addition must leave the
+        // potential exactly as it was, because the caller may go on to refute
+        // using the from-scratch pass and the arc may be back tomorrow.
+        if (result)
+            for (auto v : work.touched)
+                if (work.is_updated[v])
+                    potential[v] = work.updated[v];
+    }
+
+    for (auto v : work.touched) {
+        work.gamma[v] = 0_i;
+        work.is_updated[v] = 0;
+    }
+
+    return result;
+}
+
+auto gcs::innards::difference_incremental_bounds(size_t number_of_nodes, const vector<DifferenceArc> & arcs, const DifferenceAdjacency & adjacency,
+    bool by_tail, const vector<char> & active, const vector<Integer> & potential, const vector<Integer> & bound, const vector<Integer> & gate,
+    const vector<char> & forced, DifferenceBoundsWorkspace & work) -> void
+{
+    work.settle_order.clear();
+    if (work.gamma.size() != number_of_nodes) {
+        work.gamma.assign(number_of_nodes, 0_i);
+        work.queued.assign(number_of_nodes, 0);
+        work.settled.assign(number_of_nodes, 0);
+        work.has_predecessor.assign(number_of_nodes, 0);
+        work.predecessor.assign(number_of_nodes, 0);
+        work.settled_bound.assign(number_of_nodes, 0_i);
+    }
+    work.heap.clear();
+
+    // Vl: the nodes whose bound has moved since the last run, plus the nodes an
+    // arc activation has forced in. The paper's Algorithm 3 line 1 and the
+    // section 4.4 recipe its section 5.4 leaves out, in one place.
+    auto in_start_set = [&](size_t v) { return bound[v] > gate[v] || 0 != forced[v]; };
+
+    // pi(v0) is a **per-call temporary**, computed over Vl and nothing else. It
+    // is what makes every seed non-negative, so caching it across calls (where
+    // Vl is different) or computing it over all of V would let a negative seed
+    // into the queue and corrupt Dijkstra's settle order --- which loses
+    // propagation silently, since no proof can see it. It is deliberately not
+    // stored anywhere.
+    bool any = false;
+    Integer pi_v0{0};
+    for (size_t v = 0; v < number_of_nodes; ++v)
+        if (in_start_set(v)) {
+            auto here = bound[v] + potential[v];
+            if (! any || here > pi_v0)
+                pi_v0 = here;
+            any = true;
+        }
+
+    if (! any)
+        return;
+
+    for (size_t v = 0; v < number_of_nodes; ++v)
+        if (in_start_set(v)) {
+            // The reduced cost of the imaginary edge v0 --(-bound(v))--> v,
+            // which is >= 0 exactly because pi_v0 is the maximum above.
+            work.gamma[v] = pi_v0 - bound[v] - potential[v];
+            work.queued[v] = 1;
+            work.has_predecessor[v] = 0;
+            work.heap.emplace_back(work.gamma[v], v);
+        }
+    make_heap(work.heap, greater{});
+
+    while (! work.heap.empty()) {
+        pop_heap(work.heap, greater{});
+        auto [gamma_here, here] = work.heap.back();
+        work.heap.pop_back();
+        if (work.settled[here] || gamma_here != work.gamma[here])
+            continue;
+
+        work.settled[here] = 1;
+        work.settle_order.push_back(here);
+
+        // wSP(v0, here) is gamma_here in reduced costs, so the real weight is
+        // gamma_here + pi(here) - pi(v0) and the bound it licenses is its
+        // negation. (The paper's line 11, read as "distance *from* v0" --- its
+        // delta arrow notation is not self-consistent with its section 3.1.)
+        work.settled_bound[here] = pi_v0 - gamma_here - potential[here];
+
+        // Algorithm 3 line 12, the expansion gate, and the whole point of the
+        // Do array. If this node's new bound does not beat the bound the last
+        // run propagated from, then invariant I2 says every node downstream of
+        // it already knows everything this route could tell it, so the entire
+        // sub-search is dead. A forced node is expanded regardless: its arc was
+        // not in the graph last time, so I2 says nothing about it.
+        if (! (work.settled_bound[here] > gate[here] || 0 != forced[here]))
+            continue;
+
+        for (auto i = adjacency.start[here]; i != adjacency.start[here + 1]; ++i) {
+            auto e = adjacency.arcs[i];
+            if (! difference_arc_is_active(active, e))
+                continue;
+            auto next = by_tail ? arcs[e].to : arcs[e].from;
+            // Algorithm 3 line 14: a settled node has its final distance, and
+            // in the reduced-cost graph no later relaxation can improve it.
+            if (work.settled[next])
+                continue;
+
+            // Note gamma_here, not gamma[here]: the pseudocode's lines 15-16
+            // read gamma(s) after line 10 has set it to +infinity, which makes
+            // the test always false and the algorithm never propagate anything.
+            // The value intended is wSP(v0, s), saved before the reset.
+            auto reduced = potential[here] + arcs[e].d - potential[next];
+            if (reduced < 0_i)
+                throw UnexpectedException{"difference logic found a negative reduced cost, so its potential function is invalid"};
+            auto candidate = gamma_here + reduced;
+
+            if (! work.queued[next] || candidate < work.gamma[next]) {
+                work.gamma[next] = candidate;
+                work.queued[next] = 1;
+                work.has_predecessor[next] = 1;
+                work.predecessor[next] = e;
+                work.heap.emplace_back(candidate, next);
+                push_heap(work.heap, greater{});
+            }
+        }
+    }
+
+    // Every queued node ends up settled, because the loop drains the heap, so
+    // the settle order is enough to reset the flags for the next call.
+    for (auto v : work.settle_order) {
+        work.queued[v] = 0;
+        work.settled[v] = 0;
+    }
+}

--- a/gcs/constraints/difference/difference_incremental.cc
+++ b/gcs/constraints/difference/difference_incremental.cc
@@ -190,12 +190,21 @@ auto gcs::innards::difference_incremental_bounds(size_t number_of_nodes, const v
     // section 4.4 recipe its section 5.4 leaves out, in one place.
     auto in_start_set = [&](size_t v) { return bound[v] > gate[v] || 0 != forced[v]; };
 
-    // pi(v0) is a **per-call temporary**, computed over Vl and nothing else. It
-    // is what makes every seed non-negative, so caching it across calls (where
-    // Vl is different) or computing it over all of V would let a negative seed
-    // into the queue and corrupt Dijkstra's settle order --- which loses
-    // propagation silently, since no proof can see it. It is deliberately not
-    // stored anywhere.
+    // pi(v0), the paper's line 2: the maximum over Vl, which is what makes every
+    // seed below non-negative. It is a per-call temporary and is deliberately
+    // not stored anywhere.
+    //
+    // Worth knowing, because it is easy to over-fear: with a binary heap this
+    // value cannot actually affect the answer. It enters as
+    // `gamma(v) = pi_v0 - bound(v) - pi(v)' and leaves as
+    // `-delta(v) = pi_v0 - gamma(v) - pi(v)', so any change to it is a uniform
+    // shift of every key in the queue and cancels exactly out of every bound
+    // reported --- and Dijkstra needs non-negative *edges*, not non-negative
+    // starting distances. It is computed properly anyway because that costs
+    // nothing on a loop that has to run regardless, and because the invariant
+    // stops being free under a monotone bucket or radix queue, which assumes
+    // non-decreasing extraction. Confirmed by mutation: a deliberately
+    // non-maximal pi_v0 changes no test's behaviour at all.
     bool any = false;
     Integer pi_v0{0};
     for (size_t v = 0; v < number_of_nodes; ++v)
@@ -255,13 +264,16 @@ auto gcs::innards::difference_incremental_bounds(size_t number_of_nodes, const v
             if (work.settled[next])
                 continue;
 
-            // Note gamma_here, not gamma[here]: the pseudocode's lines 15-16
-            // read gamma(s) after line 10 has set it to +infinity, which makes
-            // the test always false and the algorithm never propagate anything.
-            // The value intended is wSP(v0, s), saved before the reset.
             auto reduced = potential[here] + arcs[e].d - potential[next];
             if (reduced < 0_i)
                 throw UnexpectedException{"difference logic found a negative reduced cost, so its potential function is invalid"};
+
+            // `gamma_here', not `work.gamma[here]'. The pseudocode's lines 15-16
+            // read gamma(s) after its line 10 has set it to +infinity, which
+            // makes the relaxation test always false and the algorithm never
+            // propagate anything at all. The value intended is wSP(v0, s), which
+            // line 9 saved and which is kept in a local here so there is nothing
+            // to reset and nothing to read back wrongly.
             auto candidate = gamma_here + reduced;
 
             if (! work.queued[next] || candidate < work.gamma[next]) {

--- a/gcs/constraints/difference/difference_incremental.hh
+++ b/gcs/constraints/difference/difference_incremental.hh
@@ -1,0 +1,252 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_INCREMENTAL_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIFFERENCE_DIFFERENCE_INCREMENTAL_HH
+
+#include <gcs/integer.hh>
+
+#include <cstddef>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief One edge of a difference system as the propagator's hot loops see
+     * it: `arcs[from] - arcs[to] <= d`, derived from the \c posted_index th
+     * constraint the caller handed over.
+     *
+     * The *size* of this is a measurable property rather than a detail: the
+     * from-scratch Bellman-Ford pass scans the whole array once per round.
+     * Carrying an `optional<IntegerVariableCondition>` inline took it from 32
+     * bytes to 96 and cost 2.9x on `examples/difference_chain` at `n = 640`,
+     * with the propagation and recursion counts unchanged --- i.e. pure memory
+     * traffic in the innermost loop. So DifferenceGraphEdge stays the convenient
+     * *construction* type, with the condition attached to the edge it belongs
+     * to, and install_difference_propagator repacks it once into this plus a
+     * parallel condition array read only on the cold paths.
+     *
+     * \ingroup Innards
+     */
+    struct DifferenceArc
+    {
+        std::size_t from;
+        std::size_t to;
+        Integer d;
+        std::size_t posted_index;
+    };
+
+    static_assert(sizeof(DifferenceArc) <= 32, "the difference-logic relaxation loop scans this array once per round; keep it small");
+
+    /**
+     * \brief Whether the shared propagator runs the incremental algorithms, and
+     * whether it audits them against the from-scratch pass.
+     *
+     * The from-scratch Bellman-Ford version stays compiled and selectable for
+     * two reasons, and both are about the fact that **every incrementality bug
+     * is invisible to proof logging**: a proof certifies what was derived, so a
+     * *lost* inference passes VeriPB silently.
+     *
+     * - \c enabled off gives a trusted reference implementation, against which
+     *   `recursions` and the solution sequence must come out **identical** ---
+     *   given the gate invariants the incremental version reaches the same
+     *   per-call fixpoint, and a bounds fixpoint is unique, so the search tree
+     *   cannot legitimately move. (`propagations`, other propagators' wake order
+     *   and proof bytes may differ: Dijkstra settles in a different order from
+     *   the predecessor forest.)
+     * - \c audit re-runs the from-scratch pass after *every* incremental call,
+     *   on the same starting bounds and the same active edge set, and requires
+     *   the two to agree node for node. That catches a completeness failure at
+     *   the wake where it first occurs, which is the only way to catch a stale
+     *   `Do` array, a stale potential function, a missed activation seed or a
+     *   wrong `pi(v0)`.
+     *
+     * \c audit is also forced on by the `GCS_DIFFERENCE_AUDIT` environment
+     * variable, so a whole corpus can be run under it without touching any
+     * model.
+     *
+     * \sa install_difference_propagator
+     * \ingroup Innards
+     */
+    struct DifferenceIncrementalOptions
+    {
+        bool enabled = true;
+        bool audit = false;
+    };
+
+    /**
+     * \brief Compressed adjacency over a fixed arc array: `arcs[start[v]]` up to
+     * `arcs[start[v + 1]]` are the indices of the arcs incident to \c v at the
+     * chosen end.
+     *
+     * Dijkstra needs adjacency where Bellman-Ford needed only a flat scan, and
+     * the adjacency is over *all* arcs, with the currently active ones selected
+     * by a flag array as they are traversed. That keeps it a build-once
+     * structure even though the active set changes on every wake.
+     *
+     * \ingroup Innards
+     */
+    struct DifferenceAdjacency
+    {
+        std::vector<std::size_t> start;
+        std::vector<std::size_t> arcs;
+    };
+
+    /**
+     * \brief Build adjacency grouped by each arc's tail (\c by_tail) or head.
+     *
+     * Lower bounds flow forwards along the arcs, so IncLB and IncSat want the
+     * by-tail adjacency; upper bounds flow backwards, so IncUB wants the
+     * by-head one.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto build_difference_adjacency(std::size_t number_of_nodes, const std::vector<DifferenceArc> & arcs, bool by_tail)
+        -> DifferenceAdjacency;
+
+    /**
+     * \brief Whether \c active selects arc \c e. An empty \c active means every
+     * arc is active, which is the shape an unconditional system takes.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] inline auto difference_arc_is_active(const std::vector<char> & active, std::size_t e) -> bool
+    {
+        return active.empty() || 0 != active[e];
+    }
+
+    /**
+     * \brief A valid potential function for the active sub-graph, or nullopt if
+     * that sub-graph has a negative cycle.
+     *
+     * Bellman-Ford from the paper's imaginary source `v0` with a zero-weight
+     * edge to every node --- seeding every potential at zero *is* that source's
+     * edge set --- so the result satisfies `pi(u) + d - pi(v) >= 0` for every
+     * active arc `u --d--> v`, which is what makes the reduced-cost graph
+     * non-negative and Dijkstra applicable.
+     *
+     * Paid once, at the propagator's first call. Every later change to the
+     * active set goes through difference_repair_potential.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto difference_initial_potential(std::size_t number_of_nodes, const std::vector<DifferenceArc> & arcs,
+        const std::vector<char> & active) -> std::optional<std::vector<Integer>>;
+
+    /**
+     * \brief Check the potential invariant over the active arcs. O(m), for the
+     * audit and for assertions; nothing on a shipping path calls it.
+     *
+     * Returns the offending arc index, or nullopt if the potential is valid.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto difference_invalid_potential_arc(const std::vector<DifferenceArc> & arcs, const std::vector<char> & active,
+        const std::vector<Integer> & potential) -> std::optional<std::size_t>;
+
+    /**
+     * \brief Scratch for difference_repair_potential, hoisted out so that a wake
+     * allocates nothing.
+     *
+     * \ingroup Innards
+     */
+    struct DifferencePotentialWorkspace
+    {
+        std::vector<Integer> gamma;
+        std::vector<Integer> updated;
+        std::vector<char> is_updated;
+        std::vector<std::size_t> touched;
+        std::vector<std::pair<Integer, std::size_t>> heap;
+    };
+
+    /**
+     * \brief IncSat: repair a valid potential function after one arc joins the
+     * active set, or report that the active sub-graph now has a negative cycle.
+     *
+     * The paper's Algorithm 1, from Cotton and Maler. \c potential must be valid
+     * for the active arcs *excluding* \c added_arc, and \c active must already
+     * include \c added_arc. On \c true the potential is valid for the whole
+     * active set; on \c false the caller must refute --- this function does not
+     * extract the cycle, because the from-scratch pass already carries the
+     * extraction and the telescoping `pol` that goes with it, and a negative
+     * cycle ends the search anyway.
+     *
+     * Must be run on **every** activation, including re-activation after
+     * backtracking. The potential is never trailed and drifts downwards over the
+     * whole search, so an arc that was valid when it was last active may need
+     * repair when it comes back: nothing may cache "this arc has been checked".
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto difference_repair_potential(std::size_t number_of_nodes, const std::vector<DifferenceArc> & arcs,
+        const DifferenceAdjacency & by_tail, const std::vector<char> & active, std::vector<Integer> & potential, std::size_t added_arc,
+        DifferencePotentialWorkspace & work) -> bool;
+
+    /**
+     * \brief Scratch and results for difference_incremental_bounds, hoisted out
+     * so that a wake allocates nothing.
+     *
+     * \c settle_order is the output that matters: the nodes Dijkstra settled, in
+     * the order it settled them. Each node's predecessor is settled before it,
+     * so walking this order is exactly the order in which the bound pushes have
+     * to be inferred for each to be able to cite the one before it.
+     *
+     * \ingroup Innards
+     */
+    struct DifferenceBoundsWorkspace
+    {
+        std::vector<Integer> gamma;
+        std::vector<char> queued;
+        std::vector<char> settled;
+        std::vector<char> has_predecessor;
+        std::vector<std::size_t> predecessor;
+        std::vector<Integer> settled_bound;
+        std::vector<std::size_t> settle_order;
+        std::vector<std::pair<Integer, std::size_t>> heap;
+    };
+
+    /**
+     * \brief IncLB: process every bound change since the last run in one
+     * Dijkstra on the reduced-cost graph.
+     *
+     * The paper's Algorithm 3, transcribed from its Example 7's arithmetic
+     * rather than from the pseudocode, whose lines 15-16 read `gamma(s)` after
+     * line 10 has set it to `+infinity` and therefore never propagate anything.
+     *
+     * Everything is in *lower bound* orientation: arc `(s, t, d)` reads
+     * `bound(t) >= bound(s) - d`, \c by_tail selects the by-tail adjacency, and
+     * \c potential must satisfy `potential(s) + d - potential(t) >= 0`. IncUB is
+     * the same function with the by-head adjacency and with the potential, the
+     * bounds and the gate all negated by the caller, which is why there is only
+     * one copy of this.
+     *
+     * \c gate is the paper's `Do`, the bounds the *previous* run propagated
+     * from, and the two invariants on it are what make the pass complete:
+     *
+     * - I1, `gate(x) <= bound(x)` for every node;
+     * - I2, `gate(t) >= gate(s) - d` for every currently active arc.
+     *
+     * \c forced marks nodes that must be seeded and expanded whatever the gate
+     * says. That is how a newly activated arc gets its bound propagation: mark
+     * its tail, and Dijkstra carries the tail's bound across the new arc and
+     * onwards. The paper's section 4.4 says to do this and its section 5.4's
+     * during-search description omits it; transcribing the latter alone loses
+     * every push a reification delivers.
+     *
+     * On return \c work.settle_order holds the settled nodes in settle order,
+     * \c work.settled_bound their new bounds, and \c work.predecessor the arc
+     * each one's bound came across. The caller infers along \c settle_order and
+     * then sets `gate(v) := settled_bound(v)` for every settled `v` --- which is
+     * the bounds this run propagated *from*, and emphatically not the bounds the
+     * state ends the call with: gcs domains have holes, an inferred bound can
+     * snap above the value this pass computed, and recording the snapped value
+     * would leave the mandatory self-re-wake with nothing in `Vl` and the
+     * consequences of the snap silently lost.
+     *
+     * \ingroup Innards
+     */
+    auto difference_incremental_bounds(std::size_t number_of_nodes, const std::vector<DifferenceArc> & arcs, const DifferenceAdjacency & adjacency,
+        bool by_tail, const std::vector<char> & active, const std::vector<Integer> & potential, const std::vector<Integer> & bound,
+        const std::vector<Integer> & gate, const std::vector<char> & forced, DifferenceBoundsWorkspace & work) -> void;
+}
+
+#endif

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -246,6 +246,23 @@ namespace gcs::test_innards
         static bool truncated = false;
         return truncated;
     }
+
+    /// How many search nodes the most recent solve_for_tests*() call took. Set
+    /// by solve_for_tests_with_callbacks(); single-threaded, one solve per
+    /// check by construction, exactly like last_run_truncated().
+    ///
+    /// This is what lets a test compare two ways of propagating the same model
+    /// and require the *search* to be identical rather than merely the answers.
+    /// A propagator that reaches the same fixpoint by a different route must
+    /// leave the search tree alone, and a divergence is then a bug with
+    /// certainty rather than an ambiguous search-shape effect --- as long as the
+    /// heuristic is not randomised or conflict-weighted, and as long as no cap
+    /// fired (a truncated run reports the cap, not the search).
+    inline auto last_run_recursions() -> unsigned long long &
+    {
+        static unsigned long long recursions = 0;
+        return recursions;
+    }
     /// @}
 
     template <typename ResultsSet_, typename IsSatisfying_, typename... Accumulated_>
@@ -567,13 +584,14 @@ namespace gcs::test_innards
             return t(s);
         };
 
-        solve_with(p,
+        auto stats = solve_with(p,
             SolveCallbacks{
                 .solution = capped_solution,                  //
                 .trace = capped_trace,                        //
                 .branch = random_branch_with_optional_seed(p) //
             },
             proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}) : std::nullopt);
+        last_run_recursions() = stats.recursions;
     }
 
     /**

--- a/gcs/presolvers/difference_logic.cc
+++ b/gcs/presolvers/difference_logic.cc
@@ -88,7 +88,8 @@ namespace
     }
 }
 
-DifferenceLogic::DifferenceLogic(shared_ptr<DifferenceLogicStats> stats) : _stats(move(stats)), _disable_lifted_donors(false), _simplify(true)
+DifferenceLogic::DifferenceLogic(shared_ptr<DifferenceLogicStats> stats) :
+    _stats(move(stats)), _disable_lifted_donors(false), _simplify(true), _incremental()
 {
 }
 
@@ -110,16 +111,30 @@ auto DifferenceLogic::reporting_simplification_to(shared_ptr<DifferenceSimplific
     return *this;
 }
 
+auto DifferenceLogic::incrementally(bool incremental) -> DifferenceLogic &
+{
+    _incremental.enabled = incremental;
+    return *this;
+}
+
+auto DifferenceLogic::auditing_incremental_propagation(bool audit) -> DifferenceLogic &
+{
+    _incremental.audit = audit;
+    return *this;
+}
+
 auto DifferenceLogic::clone() const -> unique_ptr<Presolver>
 {
     auto result = make_unique<DifferenceLogic>(_stats);
     result->disabling_lifted_donors(_disable_lifted_donors);
     result->simplifying_at_root(_simplify);
     result->reporting_simplification_to(_simplification_stats);
+    result->incrementally(_incremental.enabled);
+    result->auditing_incremental_propagation(_incremental.audit);
     return result;
 }
 
-auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &, ProofLogger * const logger) -> bool
+auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & initial_state, ProofLogger * const logger) -> bool
 {
     // Compile-time pins on the contract the enumeration below relies upon. The
     // helper matches the type Problem *stores*, which is what clone() returns,
@@ -284,8 +299,8 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State &,
     if (graph.edges.size() >= 2) {
         // A presolver-derived propagator has no posted-constraint identity of
         // its own, exactly as for AutoTable.
-        install_difference_propagator(
-            propagators, CurrentlyUnnamedConstraint{}, move(graph), DifferenceSimplificationOptions{_simplify, _simplification_stats});
+        install_difference_propagator(propagators, initial_state, CurrentlyUnnamedConstraint{}, move(graph),
+            DifferenceSimplificationOptions{_simplify, _simplification_stats}, _incremental);
         stats.propagator_installed = true;
 
         if (_disable_lifted_donors)

--- a/gcs/presolvers/difference_logic.hh
+++ b/gcs/presolvers/difference_logic.hh
@@ -1,6 +1,7 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_DIFFERENCE_LOGIC_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_DIFFERENCE_LOGIC_HH
 
+#include <gcs/constraints/difference/difference_incremental.hh>
 #include <gcs/constraints/difference/difference_simplify.hh>
 #include <gcs/presolver.hh>
 
@@ -141,6 +142,7 @@ namespace gcs
         std::shared_ptr<DifferenceSimplificationStats> _simplification_stats;
         bool _disable_lifted_donors;
         bool _simplify;
+        innards::DifferenceIncrementalOptions _incremental;
 
     public:
         /**
@@ -196,6 +198,22 @@ namespace gcs
          * once the propagator has first fired.
          */
         auto reporting_simplification_to(std::shared_ptr<DifferenceSimplificationStats>) -> DifferenceLogic &;
+
+        /**
+         * \brief Propagate the lifted system incrementally (the default), or
+         * from scratch on every wake.
+         *
+         * \sa DifferenceConstraints::incrementally
+         */
+        auto incrementally(bool = true) -> DifferenceLogic &;
+
+        /**
+         * \brief Re-run the from-scratch pass after every incremental call and
+         * require the two to agree. For tests.
+         *
+         * \sa DifferenceConstraints::auditing_incremental_propagation
+         */
+        auto auditing_incremental_propagation(bool = true) -> DifferenceLogic &;
 
         [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;


### PR DESCRIPTION
Makes `DifferenceConstraints` incremental: a potential function maintained across
the whole search, `IncLB` / `IncUB` as one Dijkstra on the reduced-cost graph over
just the bounds that have moved, `IncSat` to repair the potential when a
half-reified arc joins the graph, and exact restoration of the gate on
backtracking. This is the paper's section 4.2 and 4.4, and it is what the
wall-time caveats in #583, #587 and #590 were all about.

**Based on #592** (`difflogic-07-simplify`), which is this PR's base branch, so
the diff shown here is only this PR's ten commits. Refs #571.

## The headline

`examples/difference_chain`, the paper's Example 8, `--variant=global
--simplify=off`, medians of 3, `taskset`-pinned:

| n | order | variant | recursions | propagations | time (s) |
|---:|---|---|---:|---:|---:|
| 640 | unlucky | decomposed | 643 | 132,305,602 | 3.654 |
| 640 | unlucky | global, from scratch | 1,283 | 1,287 | 0.323 |
| 640 | unlucky | global, incremental | 1,283 | 1,287 | **0.057** |
| 640 | lucky | decomposed | 643 | 825,601 | 0.212 |
| 640 | lucky | global, from scratch | 1,283 | 1,287 | 0.269 |
| 640 | lucky | global, incremental | 1,283 | 1,287 | **0.057** |

5.7×, and the global route stops being the *slower* choice on the lucky order.

`examples/rcpsp`, the real family, `--variant=global --simplify=off`, maximum
lags on, the same instances #587 measures. (`examples/rcpsp_max` no longer
exists — it was folded into `examples/rcpsp` by the `rcpsp-unify` prep PR — so
these are re-measured, not carried over.)

| instance | recursions | dec (s) | global, scratch (s) | global, incr (s) |
|---|---:|---:|---:|---:|
| n=15 seed=3 | 6,916 | 0.0243 | 0.0192 | 0.0168 |
| n=25 seed=4 | 24,995 | 0.130 | 0.128 | 0.112 |
| n=30 seed=3 | 70,363 | 0.325 | 0.302 | 0.270 |
| n=30 seed=4 | 239,511 | 2.923 | 1.970 | 1.764 |
| n=30 seed=2 | 1,856,113 | 5.944 | 5.171 | 4.510 |
| n=20 seed=1 | 9,286,595 | 25.85 | 31.39 | **26.51** |

**`n=20 seed=1` is the row this PR exists for**: #587 found it 14 % slower with
the global propagator despite 4.4× fewer propagations, and named
non-incrementality. It is 21 % slower from scratch and 2.5 % slower incrementally
— close to fixed, not fixed. The residual is structural: 21 nodes and 69 arcs
means the from-scratch pass early-exits after two rounds of a flat scan, and at
`|E| ~ 3n` a heap-based Dijkstra is the same order with worse constants. Full
tables, including the two losses below, are in `dev_docs/difference-logic.md`.

## Two honest losses

**Half-reified `--unary=difference` instances are ~12 % slower.** A pairwise
disjunctive encoding gives `|E| ~ n²` against `n` nodes, so every wake is
dominated by the `O(|E|)` condition-testing pass that *both* routes pay; what
incrementality saves there is small, and what it adds is one potential repair per
Boolean fixed — repairs that are nearly always real, because `π` is seeded from
the unconditional network and a disjunctive arc's reduced cost starts negative.
`--incremental=off` exists for this. The default stays on because Example 8 and
the unconditional temporal network both want it, and because root simplification
refutes most of those instances outright anyway.

**Root simplification's share goes from 30–50 % to 75 %** on dense
`difference_chain` (#592's finding). Johnson's pass costs the same to the
microsecond; everything around it is four times faster.

## What is checked, and how

`π`, the reduced costs and every gate here are **invisible to the proof**: VeriPB
catches every unsound bug and no incomplete one. So the from-scratch pass stays
compiled and runtime-selectable, and supplies two oracles:

- a **differential fixpoint audit** — after every incremental call, re-run the
  from-scratch pass on the same starting bounds and the same active edge set and
  require agreement node for node. On for every fixture in the test file;
  `GCS_DIFFERENCE_AUDIT=1` turns it on process-wide;
- **search-shape equality** — the two routes reach the identical *per-call*
  fixpoint (a bounds closure is a unique least fixpoint), so `recursions` and the
  solution sequence must be identical. `run_test` solves every fixture both ways
  and asserts both. `recursions` came out identical on every instance measured,
  in the tests and in both example binaries.

Plus a new `incremental` test mode: five deterministic scenarios, each run both
ways and each asserting an invariant at *every* search node rather than at the
leaves (the stale-`Do` sequence verbatim; a Boolean fixed with no node bound
change anywhere; an arc activated and re-activated across four backtracks with a
cycle that closes only when two conditions hold at once; the hole-snap topology;
a conditional static bound applied in a branch that fails), and a randomised
stress of twenty systems under a Luby restart schedule — a restart unwinds to the
root at a moment nothing else chooses, which is the sharpest exercise of the undo
trail there is.

Everything above was mutation-tested rather than believed:

| mutation | caught by |
|---|---|
| record end-of-call state bounds in `Do` | `incremental`, `basic` (hole snap), `reified`, `cycles`, `views` |
| clamp `Do` lazily instead of restoring it | every mode, and the presolver |
| never unwind the trail | every mode, and the presolver |
| seed nothing on activation (paper §5.4 only) | `incremental`, `reified`, `simplify`, `random_reified` |
| cache "this arc has been checked" | `incremental`, `reified`, `simplify`, `random_reified`, presolver |
| Algorithm 3 lines 15–16 literally | every mode, and the presolver |
| `Vl` / expansion gate off by one | every mode, and the presolver |
| `π(v0)` not the maximum over `Vl` | nothing — and it cannot be |
| no expansion gate at all | nothing — and it should not be |

The last two are findings rather than gaps. `π(v0)` enters as a uniform shift of
every priority-queue key and cancels exactly out of every bound reported, so it
cannot break anything *given a binary heap* — it would matter under a monotone
bucket queue. And removing the expansion gate is sound and complete, just slower,
which is the correct answer and a useful negative control on the harness.

## Notes for review

- `install_difference_propagator` now takes a `State &`, for one trailed
  constraint state holding a single number: the length of the propagator's own
  undo trail. `State::on_backtrack` is not reachable from a propagator's
  `const State &`, and trailing `Do` itself would make entering an epoch
  `O(n + m)` because gcs copies the whole constraint-state vector at every
  `new_epoch`.
- The from-scratch route's proof output looks unchanged, to the extent that was
  checked: `difference_chain --mode=refute` emits exactly the 12 lines recorded
  in dev_docs, and every proof-verifying test in the suite passes. Incrementally
  a proof may differ from the from-scratch one in settle order, which is
  legitimate and verifies just as happily. (This bullet used to quote line counts
  for `rcpsp_max n=20 seed=0`; that example no longer exists, so the figures went
  with it rather than being rescaled onto a different instance.)
- **`propagations` is not an invariant** between the incremental and
  from-scratch routes, only `recursions`, `solutions`, `makespan` and `status`
  are. On `examples/rcpsp --size 22 --seed 4 --max-lag-density 0.25 --variant global` the two give 31,973 against 32,682
  for an identical search and optimum. Anything asserting on propagations across
  the two would be asserting on a coincidence.
- Full `ctest` green at this tip; sanitize build clean. Neither tree had a
  pre-existing failure to distinguish from a new one.
- `dev_docs/difference-logic.md` gains a section covering the invariants, the two
  defects in the paper this had to work around, the measurements and the mutation
  table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lx8KBTVNSg44EEcVYcBoN

