### PR TITLE
Difference logic: label Comparison's OPB rows, and lift Comparison donors

### DIFF
--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -595,32 +595,49 @@ constraints the model already contains.
 
 ### What is lifted, and what is not
 
-The paper's **level 1**, restricted to what the propagator supports today: a
-two-term linear with coefficients exactly `+1` and `-1` and two distinct variable
-operands, each of which may carry a `+X + c` view offset. The reification
-condition may be either of two kinds:
+The paper's **level 1**, restricted to what the propagator supports today, from
+two donor families:
+
+- a **two-term linear** with coefficients exactly `+1` and `-1` and two distinct
+  variable operands;
+- a **`Comparison`** — `LessThan`, `LessThanEqual`, `GreaterThan`,
+  `GreaterThanEqual` — over two distinct variable operands, which is the same
+  constraint written the way a model usually writes it: `x <= y + d` is a view on
+  one side, not a separate constraint kind.
+
+Either operand may carry a `+X + c` view offset, folded into the weight. The
+reification condition may be either of two kinds:
 
 - **`reif::MustHold`**, giving a plain edge;
 - **`reif::If`**, giving a half-reified one, `b -> x - y <= d`.
 
-**Both forms are citable, and this was checked rather than assumed.**
-`linear_inequality.cc` labels them identically — `add_labelled_constraint(id, "",
-…)`, i.e. `@c[<id>]` with an *empty* role — and differs only in passing
-`HalfReifyOnConjunctionOf{cond.cond}` for the `If` form. So the `If` row is
-exactly the shape the propagator's proofs assume, unlike `Comparison`'s
-unconditional rows, which go through the `void`-returning `add_constraint` and
-carry no label at all.
+**All four combinations are citable, and this was checked rather than assumed.**
+`linear_inequality.cc` and `comparison.cc` both label the unconditional and the
+`If` row identically — `add_labelled_constraint(id, "", …)`, i.e. `@c[<id>]` with
+an *empty* role — and differ only in passing
+`HalfReifyOnConjunctionOf{cond.cond}` for the `If` form. So all four are exactly
+the shape the propagator's proofs assume. For the comparison family the check was
+against the other end of the label as well as against our own code: `cake_pb_cp`
+re-derives `less_equal`, `less_than`, `greater_equal`, `greater_than` and their
+`_if` spellings as `@c[<id>]`, and the `_iff` spelling as `@c[<id>][r]` /
+`@c[<id>][f]` — see the section below.
 
-The other three reification kinds are *also* difference constraints, and are
-skipped only because each needs a **different row** of the donor's output than
-the two above:
+The other three reification kinds are *also* difference constraints:
 
-- `reif::MustNotHold` and `reif::NotIf` state the integer negation,
-  `y - x <= -d-1`;
 - `reif::Iff` emits its two halves under the roles `r` and `f` rather than under
-  the empty role — and both halves are edges, one on `cond` and one on `¬cond`.
+  the empty role — and both halves are edges, one on `cond` and one on `¬cond` —
+  so neither is the row a lifted edge cites. It **cannot** be lifted as things
+  stand.
+- `reif::MustNotHold` and `reif::NotIf` state the integer negation,
+  `y - x <= -d-1`. For a comparison, and for a linear `MustNotHold`, that row
+  goes out under the same empty role and so *is* citable; a linear `NotIf` uses
+  the role `ltn`. These are therefore a **deliberate gap, not an
+  impossibility** — nothing in gcs constructs a comparison with either (there is
+  no user-facing class, and `s_expr()` throws on both, so they have no `.scp`
+  spelling), and closing the gap is worth doing for both donor families at once
+  rather than for one of them.
 
-They are counted in `skipped_reified` rather than guessed at. Two exclusions
+All three are counted in `skipped_reified` rather than guessed at. Two exclusions
 remain soundness requirements rather than mere incompleteness:
 
 - **Negated views are refused**, for the reason given above.
@@ -646,13 +663,59 @@ also skipped, and left to the donor. This is not just tidiness: a `0 <= d` with
 time a presolver is called. Declining to lift such an edge leaves it with the
 donor, which handles it correctly.
 
-**`Comparison` donors are the shape we most want and cannot yet have.**
+### Labelling `Comparison`'s rows, and what it did to the cake chain
+
+`Comparison` donors were for one PR the shape we most wanted and could not have.
 `x <= y + d` over an offset view *is* a difference constraint, but
-`ReifiedCompareLessThanOrMaybeEqual::define_proof_model` emits its unconditional
-rows through the `void`-returning `add_constraint`, so they carry no `@label`
-and no proof step can cite them. They are detected, skipped, and **counted**, so
-what a later labelling PR would buy is measured rather than guessed at.
-Labelling them touches the `cake_pb_cp` chain surface, hence the deferral.
+`ReifiedCompareLessThanOrMaybeEqual::define_proof_model` used to emit every form
+except `Iff` through the `void`-returning `add_constraint`, so those rows carried
+no `@label` and no `pol` could cite them. They were detected, skipped and
+counted, which is how the size of the missed opportunity was known rather than
+guessed at.
+
+They are now emitted through `add_labelled_constraint` with an empty role, so
+they come out as `@c[<id>]`, exactly as `LinearLessThanEqual`'s do. The
+deferral was never about the shape; it was about the `cake_pb_cp` chain, which
+compares our `.opb` against a *verified* re-derivation of the same model, by
+label. The standing rule there is **chain-verify, not byte-match** — a label or
+flag *name* change is acceptable if the chain still verifies — so the question
+was empirical and was answered empirically:
+
+- **`cake_pb_cp` already labels these rows `@c[<id>]`.** Probed directly, before
+  changing anything: for `( … (constraints (_1 less_equal X Y)) … )` cake emits
+  `@c[_1] 1 i[Y][b0] 2 i[Y][b1] -1 i[X][b0] -2 i[X][b1] >= 0 ;` while the solver
+  emitted the same inequality with **no** label at all. Same for `less_than`,
+  `greater_equal`, `greater_than` and each one's `_if` spelling; the `_iff`
+  spelling comes back as `@c[_1][r]` and `@c[_1][f]`, which is what the solver
+  already emitted. So labelling did not invent a name — it *stopped omitting*
+  the name cake was already using, and the `.opb` moved towards cake rather than
+  away from it.
+- **All 157 `scp_chain_*` ctest cases pass the full verified chain**, before and
+  after, with `cake_pb_cp` on `PATH` (so `cake_pb_cp` re-derives the OPB, VeriPB
+  elaborates our proof against *that*, `cake_pb_cp` re-checks the elaborated
+  core, and `opbdiff --match-labels` compares). That includes the ten
+  comparison-carrying cases (`less_equal_*`, `less_than_*`, `greater_equal_*`,
+  `greater_than_unsat`, `greater_equal_neg_unsat`, `multi_comparison_unsat`,
+  `multi_mixed_unsat`) and the many others that use comparisons internally
+  (`increasing`, `decreasing`, `lex_*`, `all_equal`, `seq_precede_chain`, …).
+- The `.opb` byte-diff is exactly one token per comparison row, the added
+  `@c[<id>]`.
+
+`MustNotHold` and `NotIf` are labelled too, with the same empty role. Neither has
+a `.scp` spelling — `s_expr()` throws on both — so neither reaches cake, and the
+bare `@c[<id>]` is free for them; the row states the *negated* inequality, so
+anything citing the label has to read the reification condition to know which
+inequality it got. That is the reason the presolver's comparison loop branches on
+the condition rather than on the label.
+
+Because a lost label would only show up in a proof, in a model that both uses the
+affected form and makes the propagator derive something from it, the labelling
+has its own direct guard: `difference_logic_presolver_opb` posts one comparison
+of each of the five reification forms and counts the `@c[`-prefixed rows in the
+`.opb` (1, 1, 1, 1, 2). Mutation-tested — reverting `do_less` to the old
+`add_constraint` branch is caught by that check and by VeriPB, and by **nothing
+else**: the detection, equivalence and tripwire modes all still pass, because
+none of them looks at a proof.
 
 ### Deview mode is the one thing the shared propagator needed
 
@@ -733,6 +796,38 @@ to update the expectation. Mutation-tested: asking for `LinearLessThanEqual`
 instead of `ReifiedLinearInequality` — the exact regression being defended
 against — trips the cross-check, and with the cross-check also disabled all four
 test modes fail, each naming the presolver.
+
+The comparison family gets the same treatment, and needs it more, because it can
+regress *on its own*: a model built entirely out of `x <= y + d` whose comparison
+loop stopped detecting anything would still lift its linears, still look busy,
+and still pass every proof. So `comparison_edges_lifted` is broken out of
+`edges_lifted` and asserted separately, and the fixture corpus is run in **five
+donor spellings** — `1*x + -1*y <= d`, `x <= y + d`, `x < y + d + 1`,
+`y + d >= x`, and an alternating mixture — with the *same* expected lift and skip
+counts every time, since all five emit the same OPB row. The strict and
+swapped-operand spellings are there because `LessThan` and `GreaterThanEqual`
+reach `ReifiedCompareLessThanOrMaybeEqual` through constructors that move the
+operands around, which is where an edge could silently invert.
+
+What each mutation costs, measured rather than asserted (`✓` = caught):
+
+| mutation | detection | equivalence | tripwire | opb | proofs |
+|---|:-:|:-:|:-:|:-:|:-:|
+| comparison loop lifts nothing | ✓ | ✓ | ✓ | ✓ | ✓ |
+| comparison edge inverted (operands swapped) | ✓ | ✓ | ✓ | | ✓ |
+| strictness dropped (`<` treated as `<=`) | ✓ | ✓ | ✓ | | ✓ |
+| half-reified condition dropped from the edge | ✓ | ✓ | ✓ | | ✓ |
+| `Iff` lifted as though it were `If` | ✓ | | | | |
+| negated view approximated instead of refused | ✓ | ✓ | ✓ | | ✓ |
+| comparison rows emitted unlabelled again | | | | ✓ | ✓ |
+
+Two rows are worth reading carefully. Lifting an `Iff` as though it were an `If`
+is caught **only** by the detection counts: the `r` half really does say
+`cond -> x - y <= d`, so the solution set is unchanged, and the corpus has no
+`Iff` comparison donor for a proof to trip over — the `skipped_reified` count is
+the whole guard. And un-labelling the rows is caught **only** by the `.opb` label
+check and by VeriPB, which is why that check exists rather than being left
+implicit in "the proofs pass".
 
 The cross-check is on unconditionally, rather than being an opt-in strict mode,
 and it is deliberately *not* "throw if nothing was lifted". Lifting nothing is a
@@ -833,6 +928,119 @@ extra global pass and the presolver's own O(number of constraints) enumeration
 (about 200 ns per constraint per pass, three passes, two of them the tripwire's)
 are pure overhead. That is the honest counterweight to the 9.7× on the unlucky
 order, and the reason this ships off by default.
+
+### Measurements: what the `Comparison` donors buy
+
+`difference_chain --donor=comparison` posts the identical system as
+`LessThanEqual{a, b + d}` instead of `LinearLessThanEqual{1*a + -1*b, d}`, so the
+two columns below differ in the *spelling* and in nothing else. Measured on
+fataepyc-10, release, `--order=unlucky`, `taskset -c 4`-pinned with boost
+disabled, medians of 3; `.pbp` sizes from a separate `--prove` run, never a timed
+one.
+
+| mode | n | k | donor | presolver | propagations | time (s) | `.pbp` |
+|---|---:|---:|---|---|---:|---:|---:|
+| fixpoint | 150 | 2 | linear | off | 1,756,127 | 0.1261 | 17.5 MB |
+| fixpoint | 150 | 2 | linear | on | 46,507 | 0.0411 | 350 kB |
+| fixpoint | 150 | 2 | **comparison** | off | 1,733,927 | 0.3576 | 28.2 MB |
+| fixpoint | 150 | 2 | **comparison** | on | **35,033** | **0.0360** | **723 kB** |
+| fixpoint | 300 | 2 | linear | off | 13,772,252 | 0.9056 | 76.1 MB |
+| fixpoint | 300 | 2 | linear | on | 183,007 | 0.1979 | 753 kB |
+| fixpoint | 300 | 2 | **comparison** | off | 13,682,852 | 2.7554 | 123.0 MB |
+| fixpoint | 300 | 2 | **comparison** | on | **137,558** | **0.1702** | **1.57 MB** |
+| refute | 100 | 4 | linear | off | 2,080,094 | 0.1440 | 40.6 MB |
+| refute | 100 | 4 | linear | on | 5,253 | 0.0167 | 3.7 kB |
+| refute | 100 | 4 | **comparison** | off | 2,148,034 | 0.4332 | 76.2 MB |
+| refute | 100 | 4 | **comparison** | on | **5,253** | **0.0135** | **11.8 kB** |
+| refute | 40 | 8 | **comparison** | off | 316,203 | 0.0641 | 25.6 MB |
+| refute | 40 | 8 | **comparison** | on | **903** | **0.00194** | **8.1 kB** |
+
+`recursions` is identical in every row of a given `(mode, n, k)` — 153, 303, 1, 1
+respectively — so none of this is search-shape noise; it is all propagation and
+proof.
+
+Three things to read out of it.
+
+**The win on a comparison-spelled model is larger than on a linear-spelled one,
+in every column.** At `n = 300` the presolver takes propagations down 99.5×
+(13.68M → 137.6k) against 75× for the linear spelling, wall time 16.2× (2.755 s →
+0.170 s) against 4.6×, and the proof 78× (123.0 MB → 1.57 MB) against 101×. On
+`--mode=refute` at `n = 100` it is 409× the propagations, 32× the time, and
+**6,448×** the proof (76.2 MB → 11.8 kB); at `n = 40, k = 8`, 3,171× the proof.
+
+**Most of that extra headroom is the comparison propagator being the more
+expensive one to leave running.** With the presolver off, the comparison spelling
+is 2.8–3.0× slower in wall time and 1.6–1.9× larger in proof than the linear
+spelling *at the same propagation count* — its per-wake work and per-inference
+proof output are simply bigger. So a model that used `<=` rather than a weighted
+sum was paying more, and had more to gain.
+
+**Once the donors are retired the two spellings converge exactly.** With
+`--disable-donors` at `n = 300` both give 307 propagations, 0.149 s (comparison)
+against 0.186 s (linear); at `refute n = 100` both give 2 propagations. That is
+the subsumption claim, measured: the global propagator computes the same thing
+from either donor family, and everything above it is what the surviving donors
+cost.
+
+The one row that does *not* improve is the presolved `.pbp` size, which is larger
+for the comparison spelling (1.57 MB against 753 kB at `n = 300`) because the
+surviving comparison donors log more per inference than the linear ones do. That
+is a hybrid cost, not a presolver cost: `--disable-donors` removes it.
+
+### The view-wrap sweep
+
+`GCS_ENABLE_VIEW_WRAP_SWEEP=ON` had never been run against this constraint. It is
+now registered for the seven data-driven modes (`basic`, `cycles`, `views`,
+`alias`, `reified`, `random`, `random_reified`) — the two hand-built modes
+(`incremental`, `simplify`) construct their models directly and take no wrap, so
+they self-skip — and `difference_test` threads a `ViewWrapConfig` through
+`run_test`, creating each fixture's variables behind the wrap its position was
+assigned with the underlying domain inverted, so the visible domain and hence the
+oracle are unchanged.
+
+**Ten of the nineteen canonical wraps negate, and the constraint refuses a
+negated operand by design.** Rather than skipping those, the test inverts its
+obligation: under a negating wrap it asserts that constructing
+`DifferenceConstraints` throws `InvalidProblemDefinitionException`. That turns
+what would have been ten-nineteenths of the sweep into a real check that the
+rejection is *total* — every fixture, every edge shape, every operand position —
+instead of a hole. Conditions are exempt: a condition is a literal, not a
+difference operand, and `b == 1` over a negated view is perfectly well-formed.
+
+**772 `difference_constraint*` ctest cases, all passing**, comprising 2,033
+rejection fixtures and 5,337 solve-and-verify fixtures — each run twice, with
+proofs off and on, so 14,740 runs. No defect found: the offset-only wraps,
+including the `±17` ones, telescope in the proof exactly as the hand-written
+`v(i, offset)` fixtures do, which is what the canonicalisation argument predicts
+and is worth having checked at magnitudes nobody would type by hand.
+
+Two of those counts move on their own, so treat them as an order of magnitude
+rather than a signature: the `random` and `random_reified` modes draw their
+corpus from the shared test-utils generator, so any change to it elsewhere in the
+tree reshuffles which instances get built and hence how many land on each side.
+The registration count and the hand-written modes do not move.
+
+### Extreme weights
+
+Bellman-Ford accumulates weights along a path, so a system whose edges are each
+representable can still have a path sum that is not. `Integer`'s arithmetic is
+overflow-checked and throws, so this cannot wrap silently — but nothing went
+anywhere near the limit until `run_overflow_test` did. It pins both halves:
+
+- a single vacuous edge of weight `LLONG_MAX / 4` over two `0..5` variables must
+  give the right answer (all 36 assignments), so "checked" does not mean "unusable
+  at large weights";
+- two chained edges of weight `-(LLONG_MAX / 2 + 1)`, each representable and
+  their sum not, must throw `IntegerOverflow`. The lower-bound relaxation
+  computes `lb[from] - d` before comparing, so the second edge asks for
+  `LLONG_MAX + 2` and `Integer` refuses.
+
+A wrapped sum would be the worst failure available: an enormous positive distance
+would come back negative, the propagator would refute a satisfiable system, and
+**proof logging could not catch it**, because nothing wrong would have been
+derived from the model's rows — only from the solver's own arithmetic. Mutation
+check: shrinking the second fixture's weights to `-(LLONG_MAX / 8)`, so the sum
+fits, makes the test fail.
 
 ## RCPSP/max: the benchmark this was built for
 
@@ -1681,11 +1889,14 @@ the asymptotics say it should be: `|E| >> n`, or long chains.
   RCPSP/max measurement below now costs something visible**: without it, a system
   whose infeasibility depends on edges nobody has fixed yet is invisible at the
   root.
-- **Lifting `Comparison` donors**, which needs their unconditional OPB rows
-  labelled; see the presolver section above.
-- **Lifting `Iff`, `NotIf` and `MustNotHold` linear donors**, which need the `r`
-  and `f` rows and the integer-negation row respectively rather than the
-  empty-role row the two supported kinds share.
+- **Lifting `Iff` donors** of either family, which needs the `r` and `f` rows
+  rather than the empty-role row the two supported kinds share. This one is a
+  real obstacle, not a choice.
+- **Lifting `MustNotHold` and `NotIf` donors** of either family. Their rows state
+  the integer negation and are citable (empty role, except a linear `NotIf`'s
+  `ltn`), so this is a gap rather than an obstacle — deferred so that it is
+  closed for both families at once, and because nothing in gcs currently
+  constructs a comparison with either.
 - **Zero-weight-cycle unification**, the fourth of the root simplification
   stage's sub-steps. The other three are implemented; see the section on it
   above, which also reports how often a zero-weight cycle actually turns up.

--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -1020,6 +1020,13 @@ corpus from the shared test-utils generator, so any change to it elsewhere in th
 tree reshuffles which instances get built and hence how many land on each side.
 The registration count and the hand-written modes do not move.
 
+The seven always-on `_view_mixed` cases are registered too, and for this
+constraint they land mostly on the rejection side: `mixed_view_cycle()` negates
+positions 1 and 3, which most fixtures use as operands, so 108 of their 134
+fixture runs are rejection checks. That is a fine thing for the always-on tier to
+be checking — it is the soundness half — but the offset-only coverage really does
+need `GCS_ENABLE_VIEW_WRAP_SWEEP=ON`, which is where the numbers above come from.
+
 ### Extreme weights
 
 Bellman-Ford accumulates weights along a path, so a system whose edges are each

--- a/examples/difference_chain/CMakeLists.txt
+++ b/examples/difference_chain/CMakeLists.txt
@@ -21,3 +21,10 @@ add_test(NAME difference_chain-presolved-refute COMMAND ${GCS_BASH} ${CMAKE_SOUR
 # And with the root simplification stage off, which is the configuration the
 # difference_chain measurements say to prefer on a dense system.
 add_test(NAME difference_chain-global-refute-nosimplify COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-global-refute-nosimplify $<TARGET_FILE:difference_chain> --mode refute --variant global --simplify off)
+
+# The presolved route over Comparison donors: `x <= y + d' lifted into the
+# global propagator, whose pols cite the comparison's own @c[<id>] row. That
+# citation is only valid because comparison.cc labels every row it emits, so
+# these two are what fail if it ever stops.
+add_test(NAME difference_chain-presolved-comparison-fixpoint COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-presolved-comparison-fixpoint $<TARGET_FILE:difference_chain> --mode fixpoint --variant presolved --donor comparison)
+add_test(NAME difference_chain-presolved-comparison-refute COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename difference_chain-presolved-comparison-refute $<TARGET_FILE:difference_chain> --mode refute --variant presolved --donor comparison)

--- a/examples/difference_chain/difference_chain.cc
+++ b/examples/difference_chain/difference_chain.cc
@@ -38,11 +38,14 @@
 // which is a single cutting-planes step whatever the domains are; this mode is
 // the baseline that claim will be measured against.
 //
-// --variant=decomposed posts every constraint as its own two-term
-// LinearLessThanEqual, i.e. 1*a + -1*b <= d, which is the shape the presolver
-// planned in issue #571 will detect. Deliberately not LessThanEqual/Comparison
-// over an offset view: those are emitted unlabelled in the OPB, so a global
-// propagator could not cite them in a proof.
+// --variant=decomposed posts every constraint as its own constraint, in the
+// spelling --donor selects. --donor=linear (the default) writes each edge as a
+// two-term LinearLessThanEqual, 1*a + -1*b <= d; --donor=comparison writes the
+// same edge as LessThanEqual{a, b + d}, i.e. a comparison over an offset view,
+// which is how a model that was not written with this presolver in mind
+// usually says it. The two produce the same OPB row under the same @c[<id>]
+// label, so the presolver lifts either and the proofs are directly comparable;
+// --donor is what measures whether the second route costs anything.
 //
 // --variant=global posts exactly the same edges, in exactly the same order, as
 // a single DifferenceConstraints. That runs one Bellman-Ford pass over the
@@ -62,6 +65,7 @@
 // anything measurable. --disable-donors additionally retires the lifted donors'
 // propagators, which is the same experiment with that cost removed.
 
+#include <gcs/constraints/comparison.hh>
 #include <gcs/constraints/difference.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/presolvers/difference_logic.hh>
@@ -132,6 +136,16 @@ namespace
         Global
     };
 
+    // How a decomposed edge is spelled. Both spellings emit the same labelled
+    // OPB row and are lifted by the same presolver; they differ in which of its
+    // two detection loops finds them, and in which propagator the hybrid leaves
+    // running alongside the global one.
+    enum struct Donor
+    {
+        Linear,
+        Comparison
+    };
+
     // Build Example 8's constraints over y and x. The two orders contain
     // exactly the same edges and differ only in the sequence they come out in,
     // which is what seeds the propagation queue for --variant=decomposed (and
@@ -193,7 +207,7 @@ namespace
     // Hand the same edges to the solver, either one propagator each or all at
     // once. Both variants produce the same OPB rows for the same edges (one
     // labelled inequality per edge), so the proofs are directly comparable.
-    auto post_edges(Problem & problem, const vector<DifferenceEdge> & edges, Variant variant, bool disable_donors,
+    auto post_edges(Problem & problem, const vector<DifferenceEdge> & edges, Variant variant, Donor donor, bool disable_donors,
         const shared_ptr<DifferenceLogicStats> & presolver_stats, bool simplify, const shared_ptr<DifferenceSimplificationStats> & simplification,
         bool incremental) -> void
     {
@@ -202,7 +216,10 @@ namespace
         case Presolved:
         case Decomposed:
             for (const auto & e : edges)
-                problem.post(LinearLessThanEqual{WeightedSum{} + 1_i * e.x + -1_i * e.y, e.d});
+                if (donor == Donor::Linear)
+                    problem.post(LinearLessThanEqual{WeightedSum{} + 1_i * e.x + -1_i * e.y, e.d});
+                else
+                    problem.post(LessThanEqual{e.x, e.y + e.d});
             if (variant == Presolved)
                 problem.add_presolver(DifferenceLogic{presolver_stats}
                         .disabling_lifted_donors(disable_donors)
@@ -267,6 +284,11 @@ auto main(int argc, char * argv[]) -> int
                 cxxopts::value<string>()->default_value("fixpoint"))                                     //
             ("variant", "Model variant to post. Supported: " + variant_names(),                          //
                 cxxopts::value<string>()->default_value("decomposed"))                                   //
+            ("donor",                                                                                    //
+                "How to spell each edge under --variant=decomposed or presolved: linear (a two-term "    //
+                "LinearLessThanEqual) or comparison (a LessThanEqual over an offset view). Both emit "   //
+                "the same labelled OPB row and both are lifted by the presolver",                        //
+                cxxopts::value<string>()->default_value("linear"))                                       //
             ("disable-donors",                                                                           //
                 "With --variant=presolved, also retire the lifted constraints' own propagators, so "     //
                 "only the global one runs over them")                                                    //
@@ -377,6 +399,21 @@ auto main(int argc, char * argv[]) -> int
     }
     auto incremental = (incremental_name == "on");
 
+    auto donor_name = options_vars["donor"].as<string>();
+    optional<Donor> donor;
+    if (donor_name == "linear")
+        donor = Donor::Linear;
+    else if (donor_name == "comparison")
+        donor = Donor::Comparison;
+    else {
+        println(cerr, "Error: unknown --donor '{}'. Supported: linear, comparison.", donor_name);
+        return EXIT_FAILURE;
+    }
+    if (donor == Donor::Comparison && *variant == Variant::Global) {
+        println(cerr, "Error: --donor only means anything with --variant=decomposed or --variant=presolved.");
+        return EXIT_FAILURE;
+    }
+
     auto disable_donors = options_vars.contains("disable-donors");
     if (disable_donors && *variant != Variant::Presolved) {
         println(cerr, "Error: --disable-donors only means anything with --variant=presolved.");
@@ -385,7 +422,7 @@ auto main(int argc, char * argv[]) -> int
 
     auto presolver_stats = make_shared<DifferenceLogicStats>();
     auto simplification = make_shared<DifferenceSimplificationStats>();
-    post_edges(problem, edges, *variant, disable_donors, presolver_stats, simplify, simplification, incremental);
+    post_edges(problem, edges, *variant, *donor, disable_donors, presolver_stats, simplify, simplification, incremental);
 
     // The lower-bound bump that starts the chase. Posted last, so that the
     // difference constraints are all in the queue ahead of it and the bump wakes
@@ -425,6 +462,8 @@ auto main(int argc, char * argv[]) -> int
     println("order: {}", order_name);
     println("mode: {}", mode_name);
     println("variant: {}", variant_name_given);
+    if (*variant != Variant::Global)
+        println("donor: {}", donor_name);
     if (*variant != Variant::Decomposed) {
         println("incremental: {}", incremental_name);
         println("simplify: {}", simplify_name);
@@ -438,6 +477,7 @@ auto main(int argc, char * argv[]) -> int
     if (*variant == Variant::Presolved) {
         println("disable_donors: {}", disable_donors ? "yes" : "no");
         println("presolver_edges_lifted: {}", presolver_stats->edges_lifted);
+        println("presolver_comparison_edges_lifted: {}", presolver_stats->comparison_edges_lifted);
         println("presolver_nodes: {}", presolver_stats->nodes);
         println("presolver_donors_disabled: {}", presolver_stats->donor_propagators_disabled);
     }

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -541,6 +541,12 @@ auto main(int argc, char * argv[]) -> int
         // every one of these has been posted in since this example landed.
         // Changing it would give the same constraint a different WeightedSum
         // term order, and so a different OPB row, for no reason.
+        //
+        // A LessThanEqual over an offset view would say the same thing, and the
+        // presolver lifts either --- both emit the same @c[<id>] row --- so the
+        // spelling here is a byte-identity choice and not a citability one.
+        // examples/difference_chain --donor is where the two are measured
+        // against each other.
         for (const auto & e : edges) {
             auto sum = WeightedSum{} + 1_i * e.to + -1_i * e.from;
             if (e.cond)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -386,6 +386,13 @@ if(GCS_BUILD_TESTS)
     foreach(mode ge ge_if ge_iff gt gt_if gt_iff le le_if le_iff lt lt_if lt_iff)
         add_view_tests(comparison_constraint_${mode} comparison_test 2 ${mode})
     endforeach()
+    # Ten of the nineteen wraps negate, and DifferenceConstraints rejects a
+    # negated operand by design; the test turns those into a rejection check
+    # rather than skipping them. The two hand-built modes (incremental,
+    # simplify) take no wrap and self-skip.
+    foreach(mode basic cycles views alias reified random random_reified)
+        add_view_tests(difference_constraint_${mode} difference_test 5 ${mode})
+    endforeach()
     add_view_tests(all_different_constraint all_different_test 6)
     add_view_tests(all_equal_constraint all_equal_test 4)
     add_view_tests(increasing_constraint increasing_test 5)

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -79,14 +79,23 @@ auto ReifiedCompareLessThanOrMaybeEqual::prepare(Propagators &, State & initial_
 
 auto ReifiedCompareLessThanOrMaybeEqual::define_proof_model(ProofModel & model, const State &) -> void
 {
-    // `role` is the cake_pb_cp @c label role, or "" for the lines cake leaves
-    // unlabelled (an unconditional comparison is a single bare inequality).
+    // `role` is the cake_pb_cp @c label role, empty for the forms cake labels
+    // with the bare @c[<id>] (a comparison is a single inequality, so there is
+    // no half to name). Every row is labelled: an unlabelled row cannot be
+    // cited, and the difference-logic presolver lifts these into a global
+    // propagator whose `pol`s cite exactly this row. Checked against
+    // cake_pb_cp: `less_equal`, `less_than`, `greater_equal`, `greater_than`
+    // and their `_if` spellings all come back as @c[<id>], and the `_iff`
+    // spelling as @c[<id>][r] and @c[<id>][f].
+    //
+    // MustNotHold and NotIf have no `.scp` spelling at all --- s_expr() throws
+    // on them --- so they never reach cake, and the bare @c[<id>] is free for
+    // them too. It states the *negated* inequality, which is still a single
+    // difference inequality with the operands the other way round; anything
+    // citing @c[<id>] must therefore look at the reification condition to know
+    // which inequality it got (see gcs/presolvers/difference_logic.cc).
     auto do_less = [&](IntegerVariableID v1, IntegerVariableID v2, optional<HalfReifyOnConjunctionOf> cond, bool or_equal, const string & role) {
-        auto ineq = WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i);
-        if (role.empty())
-            model.add_constraint(ineq, cond);
-        else
-            model.add_labelled_constraint(_constraint_id, role, ineq, cond);
+        model.add_labelled_constraint(_constraint_id, role, WPBSum{} + 1_i * v1 + -1_i * v2 <= (or_equal ? 0_i : -1_i), cond);
     };
 
     overloaded{

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -652,15 +652,26 @@ namespace
                 posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
             p.post(DifferenceConstraints{posted}.simplifying_at_root(simplify).reporting_simplification_to(simplify ? stats : nullptr));
 
-            // The same branching heuristic, from the same seed, in both runs, so
+            // A *deterministic* branching heuristic, identical in both runs, so
             // that a difference in the recursion count is a difference in
             // propagation and cannot be a difference in search order.
+            //
+            // This was a seeded random brancher, which is not good enough for
+            // the expect_fewer_recursions fixtures. Fixing a condition at the
+            // root only removes search if the search would otherwise have
+            // branched on that condition; whether it does depends on where the
+            // variable order happens to put it, so on some seeds the two runs
+            // came out equal and the assertion fired spuriously (seed 879451257
+            // on fix_cascade, one CI lane only). The equality-asserting
+            // fixtures were always safe -- propagation-neutral under any fixed
+            // order -- but the differential ones need the order pinned. Variety
+            // across search orders is the random and random_reified modes' job.
             auto result = solve_with(p,
                 SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
                                    into.emplace(extract_from_state(s, vars));
                                    return true;
                                },
-                    .branch = random_branch_with_optional_seed(p)},
+                    .branch = branch_with(variable_order::in_order(vars), value_order::smallest_first())},
                 proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
             return result.recursions;
         };

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -2,12 +2,14 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/integer_overflow.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <random>
@@ -26,6 +28,7 @@
 #include <fmt/ranges.h>
 #endif
 
+using gcs::innards::IntegerOverflow;
 using std::cerr;
 using std::flush;
 using std::function;
@@ -123,6 +126,32 @@ namespace
         return vars;
     }
 
+    // The view-wrap sweep's variant: each variable is created behind the wrap
+    // its position was assigned, with the underlying domain inverted so the
+    // *visible* domain -- and so the oracle, which speaks in visible values --
+    // is unchanged. Bare positions keep the plain creation above rather than
+    // going through the identity view, so a bare sweep really is the bare test.
+    auto make_vars(Problem & p, const vector<pair<int, int>> & domains, const vector<ViewWrap> & wraps) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> vars;
+        for (size_t i = 0; i < domains.size(); ++i)
+            vars.push_back(wraps.at(i).bare ? p.create_integer_variable(Integer(domains.at(i).first), Integer(domains.at(i).second))
+                                            : create_integer_variable_or_constant_with_view(p, domains.at(i), wraps.at(i)));
+        return vars;
+    }
+
+    // Whether any operand of any edge sits behind a negating wrap. Conditions
+    // do not count: a condition is a literal, not a difference operand, and a
+    // negated view is perfectly fine to write `v == k` about.
+    auto any_operand_negated(const vector<EdgeSpec> & edges, const vector<ViewWrap> & wraps) -> bool
+    {
+        for (const auto & e : edges)
+            for (const auto * o : {&e.x, &e.y})
+                if (o->var && wraps.at(*o->var).negate)
+                    return true;
+        return false;
+    }
+
     auto satisfied(const vector<int> & vals, const vector<EdgeSpec> & edges) -> bool
     {
         for (const auto & e : edges) {
@@ -165,11 +194,44 @@ namespace
     // This is the sharpest check there is on the incremental machinery, because
     // every way it can go wrong loses propagation, and lost propagation is
     // invisible to VeriPB.
-    auto run_test(bool proofs, const string & mode, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges)
-        -> void
+    auto run_test(bool proofs, const ViewWrapConfig & view_cfg, const string & mode, const string & name, const vector<pair<int, int>> & domains,
+        const vector<EdgeSpec> & edges) -> void
     {
-        print(cerr, "difference {} {} domains={} edges={}{}", mode, name, domains, edges.size(), proofs ? " with proofs:" : ":");
+        auto wraps = wraps_for_positions(view_cfg, static_cast<int>(domains.size()));
+
+        print(cerr, "difference {} [{}] {} domains={} edges={}{}", mode, view_wrap_config_label(view_cfg), name, domains, edges.size(),
+            proofs ? " with proofs:" : ":");
         cerr << flush;
+
+        // Ten of the nineteen canonical wraps negate, and DifferenceConstraints
+        // refuses a negated operand at construction rather than approximating
+        // it: `-X - Y <= d' has both coefficients negative, is not a difference
+        // constraint at all, and lifting it would be unsound rather than merely
+        // incomplete. So under a negating wrap the fixture's job changes from
+        // "solve this" to "refuse this" -- which is a real check run over every
+        // fixture, edge shape and operand position, not a skip.
+        if (any_operand_negated(edges, wraps)) {
+            Problem p;
+            auto vars = make_vars(p, domains, wraps);
+            vector<DifferenceEdge> posted;
+            for (const auto & e : edges)
+                posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
+
+            bool threw = false;
+            try {
+                DifferenceConstraints rejected{posted};
+                static_cast<void>(rejected);
+            }
+            catch (const InvalidProblemDefinitionException &) {
+                threw = true;
+            }
+            if (! threw)
+                throw UnexpectedException{"difference " + mode + " " + name + " under view wrap " + view_wrap_config_label(view_cfg) +
+                    " accepted a negated view operand. A negated view is not a difference constraint, and accepting one licences inferences the "
+                    "constraint does not entail; the rejection in deview_difference_operand must be total."};
+            println(cerr, " negated operand rejected as designed");
+            return;
+        }
 
         set<tuple<vector<int>>> expected, actual, decomposed, from_scratch;
         build_expected(expected, [&](const vector<int> & vals) { return satisfied(vals, edges); }, domains);
@@ -189,7 +251,7 @@ namespace
 
         {
             Problem p;
-            auto vars = make_vars(p, domains);
+            auto vars = make_vars(p, domains, wraps);
             vector<DifferenceEdge> posted;
             for (const auto & e : edges)
                 posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
@@ -201,7 +263,7 @@ namespace
             // solution a long way downstream, or not at all.
             p.post(DifferenceConstraints{posted}.auditing_incremental_propagation());
 
-            auto proof_name = proofs ? make_optional("difference_test_" + mode + "_" + name) : nullopt;
+            auto proof_name = proofs ? make_optional("difference_test_" + mode + "_" + name + "_" + view_wrap_config_label(view_cfg)) : nullopt;
             // Bounds consistent, not GAC: the propagator only reads and writes
             // bounds, and gcs domains can have holes where the paper's Theorem
             // 2 assumes ranges.
@@ -213,7 +275,7 @@ namespace
 
         {
             Problem p;
-            auto vars = make_vars(p, domains);
+            auto vars = make_vars(p, domains, wraps);
             vector<DifferenceEdge> posted;
             for (const auto & e : edges)
                 posted.push_back(DifferenceEdge{operand_id(e.x, vars), operand_id(e.y, vars), Integer(e.d), condition_id(e.cond, vars)});
@@ -226,7 +288,7 @@ namespace
 
         {
             Problem p;
-            auto vars = make_vars(p, domains);
+            auto vars = make_vars(p, domains, wraps);
             for (const auto & e : edges) {
                 auto sum = WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars);
                 if (auto cond = condition_id(e.cond, vars))
@@ -422,6 +484,73 @@ namespace
             throw UnexpectedException{"difference did not refute the condition of a half-reified edge saying cond -> 0 <= -1"};
         if (fine_upper != make_optional(1_i))
             throw UnexpectedException{"difference refuted the condition of a vacuous half-reified edge saying cond -> 0 <= 0"};
+    }
+
+    // Extreme edge weights.
+    //
+    // Bellman-Ford accumulates weights along a path, so a system whose edges
+    // are individually representable can still have a path sum that is not.
+    // Nothing else in this file goes anywhere near the limit, and a silently
+    // wrapped path sum is the worst failure available: it turns an enormous
+    // positive distance into a negative one, which is a negative cycle that
+    // does not exist, so the propagator would refute a satisfiable system --- a
+    // lost solution, which proof logging cannot catch because nothing wrong was
+    // ever *derived* from the model's rows, only from the solver's own
+    // arithmetic.
+    //
+    // Integer's arithmetic is overflow-checked and throws, so this cannot
+    // happen. The point of this test is to say so out loud: it demands the
+    // throw, and it demands the right answer at a weight one order of magnitude
+    // inside the boundary, so that "checked" and "usable up to the limit" are
+    // both pinned.
+    auto run_overflow_test() -> void
+    {
+        print(cerr, "difference extreme weights:");
+        cerr << flush;
+
+        constexpr auto limit = std::numeric_limits<long long>::max();
+
+        // Far below the boundary: `x - y <= limit / 4` is vacuous over these
+        // domains, and every relaxation the propagator performs (`ub[y] + d`,
+        // `lb[x] - d`) stays comfortably in range, so the answer must simply be
+        // right --- all 36 assignments.
+        {
+            Problem p;
+            auto x = p.create_integer_variable(0_i, 5_i, "x");
+            auto y = p.create_integer_variable(0_i, 5_i, "y");
+            p.post(DifferenceConstraints{{DifferenceEdge{x, y, Integer{limit / 4}}}}.auditing_incremental_propagation());
+            auto stats = solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }});
+            if (36 != stats.solutions)
+                throw UnexpectedException{"difference found " + to_string(stats.solutions) +
+                    " solutions for a single vacuous edge of weight limit/4 over two 0..5 variables, where all 36 assignments satisfy it. A large "
+                    "but perfectly representable weight must give the right answer, not a truncated one."};
+        }
+
+        // Over the boundary: two chained edges of weight -(limit/2 + 1). Each
+        // is representable; their sum is not. The lower-bound relaxation
+        // computes `lb[from] - d`, so the second edge asks for
+        // (limit/2 + 1) + (limit/2 + 1) = limit + 2 and Integer refuses.
+        {
+            Problem p;
+            auto x = p.create_integer_variable_vector(3, 0_i, 5_i, "x");
+            p.post(DifferenceConstraints{{DifferenceEdge{x[0], x[1], Integer{-(limit / 2 + 1)}}, //
+                DifferenceEdge{x[1], x[2], Integer{-(limit / 2 + 1)}}}});
+
+            bool threw = false;
+            try {
+                static_cast<void>(solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }}));
+            }
+            catch (const IntegerOverflow &) {
+                threw = true;
+            }
+            if (! threw)
+                throw UnexpectedException{"difference propagated a system whose path weight does not fit in an Integer without throwing "
+                                          "IntegerOverflow. Either the sum wrapped --- which would let the propagator refute a satisfiable system, "
+                                          "silently and invisibly to proof logging --- or the propagator has learnt to avoid forming the sum at all. "
+                                          "If it is genuinely the latter, this test needs a system that forces the sum, not deleting."};
+        }
+
+        println(cerr, " ok");
     }
 
     // A negated view operand is not a difference constraint at all, and
@@ -992,80 +1121,80 @@ namespace
         run_restart_stress();
     }
 
-    auto run_all_tests(bool proofs, const string & mode) -> void
+    auto run_all_tests(bool proofs, const ViewWrapConfig & view_cfg, const string & mode) -> void
     {
         if (mode == "basic") {
             // A single edge, both signs of d.
-            run_test(proofs, mode, "single_neg", {{0, 6}, {0, 6}}, {{v(0), v(1), -2}});
-            run_test(proofs, mode, "single_pos", {{0, 6}, {0, 6}}, {{v(0), v(1), 2}});
-            run_test(proofs, mode, "single_zero", {{0, 6}, {0, 6}}, {{v(0), v(1), 0}});
+            run_test(proofs, view_cfg, mode, "single_neg", {{0, 6}, {0, 6}}, {{v(0), v(1), -2}});
+            run_test(proofs, view_cfg, mode, "single_pos", {{0, 6}, {0, 6}}, {{v(0), v(1), 2}});
+            run_test(proofs, view_cfg, mode, "single_zero", {{0, 6}, {0, 6}}, {{v(0), v(1), 0}});
 
             // A chain: bounds have to travel the whole way in one pass.
-            run_test(proofs, mode, "chain", {{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(2), v(3), -1}});
+            run_test(proofs, view_cfg, mode, "chain", {{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(2), v(3), -1}});
 
             // A tree: one source, two branches, so the predecessor forest has
             // more than one leaf.
-            run_test(proofs, mode, "tree", {{0, 5}, {0, 5}, {0, 5}, {0, 5}, {0, 5}},
+            run_test(proofs, view_cfg, mode, "tree", {{0, 5}, {0, 5}, {0, 5}, {0, 5}, {0, 5}},
                 {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(1), v(3), -2}, {v(0), v(4), 1}});
 
             // Negative domains, and a mixture of edge weights.
-            run_test(proofs, mode, "negative_domain", {{-4, 2}, {-3, 3}, {-2, 4}}, {{v(0), v(1), -1}, {v(1), v(2), 2}, {v(2), v(0), 3}});
+            run_test(proofs, view_cfg, mode, "negative_domain", {{-4, 2}, {-3, 3}, {-2, 4}}, {{v(0), v(1), -1}, {v(1), v(2), 2}, {v(2), v(0), 3}});
 
             // Duplicate edges between the same pair, one strictly stronger.
-            run_test(proofs, mode, "duplicate_edges", {{0, 6}, {0, 6}}, {{v(0), v(1), 1}, {v(0), v(1), -2}, {v(0), v(1), 3}});
+            run_test(proofs, view_cfg, mode, "duplicate_edges", {{0, 6}, {0, 6}}, {{v(0), v(1), 1}, {v(0), v(1), -2}, {v(0), v(1), 3}});
         }
         else if (mode == "cycles") {
             // A negative cycle: unsatisfiable, and refuted by summing the cycle.
-            run_test(proofs, mode, "negcycle3", {{0, 6}, {0, 6}, {0, 6}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), -1}});
-            run_test(proofs, mode, "negcycle2", {{0, 8}, {0, 8}}, {{v(0), v(1), 0}, {v(1), v(0), -2}});
-            run_test(proofs, mode, "negcycle_weighted", {{0, 5}, {0, 5}, {0, 5}, {0, 5}},
+            run_test(proofs, view_cfg, mode, "negcycle3", {{0, 6}, {0, 6}, {0, 6}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), -1}});
+            run_test(proofs, view_cfg, mode, "negcycle2", {{0, 8}, {0, 8}}, {{v(0), v(1), 0}, {v(1), v(0), -2}});
+            run_test(proofs, view_cfg, mode, "negcycle_weighted", {{0, 5}, {0, 5}, {0, 5}, {0, 5}},
                 {{v(0), v(1), 2}, {v(1), v(2), -3}, {v(2), v(3), 1}, {v(3), v(0), -1}});
 
             // A zero-weight cycle: satisfiable, and it forces equalities all
             // the way round.
-            run_test(proofs, mode, "zerocycle", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), 0}});
-            run_test(proofs, mode, "zerocycle_offset", {{0, 6}, {0, 6}}, {{v(0), v(1), -2}, {v(1), v(0), 2}});
+            run_test(proofs, view_cfg, mode, "zerocycle", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(0), 0}});
+            run_test(proofs, view_cfg, mode, "zerocycle_offset", {{0, 6}, {0, 6}}, {{v(0), v(1), -2}, {v(1), v(0), 2}});
 
             // A negative cycle sitting inside a bigger graph, so the
             // predecessor walk has to skip the nodes hanging off it.
-            run_test(proofs, mode, "negcycle_with_tail", {{0, 4}, {0, 4}, {0, 4}, {0, 4}},
+            run_test(proofs, view_cfg, mode, "negcycle_with_tail", {{0, 4}, {0, 4}, {0, 4}, {0, 4}},
                 {{v(0), v(1), 0}, {v(1), v(2), 0}, {v(2), v(1), -1}, {v(2), v(3), 1}});
         }
         else if (mode == "views") {
             // Offset views on either or both ends. The offsets fold into the
             // weight, so the OPB row is over the bare variables and every
             // edge's row speaks the same representation.
-            run_test(proofs, mode, "view_left", {{0, 6}, {0, 6}}, {{v(0, 3), v(1), 0}});
-            run_test(proofs, mode, "view_right", {{0, 6}, {0, 6}}, {{v(0), v(1, -2), 1}});
-            run_test(proofs, mode, "view_both", {{0, 5}, {0, 5}, {0, 5}}, {{v(0, 4), v(1, -1), -1}, {v(1, 2), v(2, 2), 0}});
-            run_test(proofs, mode, "view_chain", {{0, 5}, {0, 5}, {0, 5}}, {{v(0, 1), v(1, 1), -1}, {v(1, -3), v(2, 3), 0}});
+            run_test(proofs, view_cfg, mode, "view_left", {{0, 6}, {0, 6}}, {{v(0, 3), v(1), 0}});
+            run_test(proofs, view_cfg, mode, "view_right", {{0, 6}, {0, 6}}, {{v(0), v(1, -2), 1}});
+            run_test(proofs, view_cfg, mode, "view_both", {{0, 5}, {0, 5}, {0, 5}}, {{v(0, 4), v(1, -1), -1}, {v(1, 2), v(2, 2), 0}});
+            run_test(proofs, view_cfg, mode, "view_chain", {{0, 5}, {0, 5}, {0, 5}}, {{v(0, 1), v(1, 1), -1}, {v(1, -3), v(2, 3), 0}});
 
             // The same variable reached through two different offset views in
             // two edges: the graph joins them at one node, which only cancels
             // because both rows are emitted over the bare variable.
-            run_test(proofs, mode, "view_shared_node", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1, 2), -1}, {v(1, -3), v(2), -1}});
+            run_test(proofs, view_cfg, mode, "view_shared_node", {{0, 5}, {0, 5}, {0, 5}}, {{v(0), v(1, 2), -1}, {v(1, -3), v(2), -1}});
 
             // A negative cycle whose edges are all expressed through views.
-            run_test(proofs, mode, "view_negcycle", {{0, 5}, {0, 5}}, {{v(0, 2), v(1), 0}, {v(1, 1), v(0, 4), 0}});
+            run_test(proofs, view_cfg, mode, "view_negcycle", {{0, 5}, {0, 5}}, {{v(0, 2), v(1), 0}, {v(1, 1), v(0, 4), 0}});
 
             // Constant operands, which are static bounds on the other end.
-            run_test(proofs, mode, "constant_upper", {{0, 8}}, {{v(0), c(2), 3}});
-            run_test(proofs, mode, "constant_lower", {{0, 8}}, {{c(7), v(0), 2}});
-            run_test(proofs, mode, "constant_both_true", {{0, 3}}, {{c(1), c(4), 0}, {v(0), c(0), 2}});
-            run_test(proofs, mode, "constant_both_false", {{0, 3}}, {{c(4), c(1), 0}});
-            run_test(proofs, mode, "constant_and_edge", {{0, 8}, {0, 8}}, {{c(4), v(0), 0}, {v(0), v(1), -2}});
+            run_test(proofs, view_cfg, mode, "constant_upper", {{0, 8}}, {{v(0), c(2), 3}});
+            run_test(proofs, view_cfg, mode, "constant_lower", {{0, 8}}, {{c(7), v(0), 2}});
+            run_test(proofs, view_cfg, mode, "constant_both_true", {{0, 3}}, {{c(1), c(4), 0}, {v(0), c(0), 2}});
+            run_test(proofs, view_cfg, mode, "constant_both_false", {{0, 3}}, {{c(4), c(1), 0}});
+            run_test(proofs, view_cfg, mode, "constant_and_edge", {{0, 8}, {0, 8}}, {{c(4), v(0), 0}, {v(0), v(1), -2}});
         }
         else if (mode == "alias") {
             // The same variable in both slots, once vacuous and once a root
             // contradiction. Handled, not thrown: x - x <= d is 0 <= d.
-            run_test(proofs, mode, "alias_ok", {{0, 5}, {0, 5}}, {{v(0), v(0), 0}, {v(0), v(1), -1}});
-            run_test(proofs, mode, "alias_ok_pos", {{0, 5}}, {{v(0), v(0), 3}});
-            run_test(proofs, mode, "alias_bad", {{0, 5}, {0, 5}}, {{v(0), v(0), -1}, {v(0), v(1), 0}});
+            run_test(proofs, view_cfg, mode, "alias_ok", {{0, 5}, {0, 5}}, {{v(0), v(0), 0}, {v(0), v(1), -1}});
+            run_test(proofs, view_cfg, mode, "alias_ok_pos", {{0, 5}}, {{v(0), v(0), 3}});
+            run_test(proofs, view_cfg, mode, "alias_bad", {{0, 5}, {0, 5}}, {{v(0), v(0), -1}, {v(0), v(1), 0}});
             // Aliasing through views, where the offsets decide the sign.
-            run_test(proofs, mode, "alias_view_ok", {{0, 5}}, {{v(0, 2), v(0), 3}});
-            run_test(proofs, mode, "alias_view_bad", {{0, 5}}, {{v(0, 2), v(0), 1}});
+            run_test(proofs, view_cfg, mode, "alias_view_ok", {{0, 5}}, {{v(0, 2), v(0), 3}});
+            run_test(proofs, view_cfg, mode, "alias_view_bad", {{0, 5}}, {{v(0, 2), v(0), 1}});
             // An empty system, and one with nothing but a vacuous edge.
-            run_test(proofs, mode, "empty", {{0, 3}}, {});
+            run_test(proofs, view_cfg, mode, "empty", {{0, 3}}, {});
         }
         else if (mode == "reified") {
             // Throughout: the last one or two variables have domain 0..1 and
@@ -1078,7 +1207,7 @@ namespace
             // quadrant is excluded -- and that is the case reified_hand.pbp
             // verifies by hand: sum the three rows, saturate, and the residual
             // is the clause ~b1 v ~b2.
-            run_test(proofs, mode, "negcycle_two_conds", {{0, 5}, {0, 5}, {0, 5}, {0, 1}, {0, 1}},
+            run_test(proofs, view_cfg, mode, "negcycle_two_conds", {{0, 5}, {0, 5}, {0, 5}, {0, 1}, {0, 1}},
                 {{v(0), v(1), 0, b(3)}, {v(1), v(2), 0, b(4)}, {v(2), v(0), -1}});
 
             // The same cycle with every edge conditional on the same Boolean.
@@ -1087,51 +1216,54 @@ namespace
             // "domain propagator" claim excludes and which every disjunctive
             // encoding does anyway): soundness must hold regardless, and the
             // reason must not list the Boolean three times.
-            run_test(proofs, mode, "negcycle_shared_cond", {{0, 5}, {0, 5}, {0, 5}, {0, 1}},
+            run_test(proofs, view_cfg, mode, "negcycle_shared_cond", {{0, 5}, {0, 5}, {0, 5}, {0, 1}},
                 {{v(0), v(1), 0, b(3)}, {v(1), v(2), 0, b(3)}, {v(2), v(0), -1, b(3)}});
 
             // Mixed: an unconditional cycle would already be infeasible, so the
             // conditional edge is the only thing standing between satisfiable
             // and not.
-            run_test(proofs, mode, "negcycle_mixed", {{0, 4}, {0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(2), v(0), 1, b(3)}});
+            run_test(proofs, view_cfg, mode, "negcycle_mixed", {{0, 4}, {0, 4}, {0, 4}, {0, 1}},
+                {{v(0), v(1), -1}, {v(1), v(2), -1}, {v(2), v(0), 1, b(3)}});
 
             // Bound pushes across conditional edges, chained, so the reason of
             // the second cites the first's inferred bound and its own condition.
             // Domains kept narrow enough that the whole solution set fits inside
             // the default runtime cap, so this keeps its cross-check against the
             // decomposed model even in a capped run.
-            run_test(proofs, mode, "chain_conds", {{0, 4}, {0, 4}, {0, 4}, {0, 1}, {0, 1}}, {{v(0), v(1), -2, b(3)}, {v(1), v(2), -2, b(4)}});
+            run_test(
+                proofs, view_cfg, mode, "chain_conds", {{0, 4}, {0, 4}, {0, 4}, {0, 1}, {0, 1}}, {{v(0), v(1), -2, b(3)}, {v(1), v(2), -2, b(4)}});
 
             // A conditional edge that can never hold over these domains: the
             // negative control, as a solution count. Every assignment with the
             // condition false is a solution, and none with it true.
-            run_test(proofs, mode, "cond_impossible", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -10, b(2)}});
+            run_test(proofs, view_cfg, mode, "cond_impossible", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -10, b(2)}});
 
             // Conditioning on the *false* value of a 0..1 variable, which is
             // the other half of a disjunctive decomposition.
-            run_test(proofs, mode, "cond_on_zero", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -2, b(2, 0)}, {v(1), v(0), -2, b(2)}});
+            run_test(proofs, view_cfg, mode, "cond_on_zero", {{0, 4}, {0, 4}, {0, 1}}, {{v(0), v(1), -2, b(2, 0)}, {v(1), v(0), -2, b(2)}});
 
             // A conditional edge whose condition is over a variable with a
             // wider domain, so the condition is `x == 2' rather than a Boolean.
-            run_test(proofs, mode, "cond_not_boolean", {{0, 4}, {0, 4}, {0, 3}}, {{v(0), v(1), -3, b(2, 2)}});
+            run_test(proofs, view_cfg, mode, "cond_not_boolean", {{0, 4}, {0, 4}, {0, 3}}, {{v(0), v(1), -3, b(2, 2)}});
 
             // Conditional edges through offset views on both ends, which is
             // where a proof only telescopes because the rows are emitted over
             // the canonical bare variables.
-            run_test(proofs, mode, "cond_views", {{0, 5}, {0, 5}, {0, 5}, {0, 1}}, {{v(0, 2), v(1, -1), -1, b(3)}, {v(1, 3), v(2), 0, b(3)}});
-            run_test(proofs, mode, "cond_view_negcycle", {{0, 5}, {0, 5}, {0, 1}}, {{v(0, 2), v(1), 0, b(2)}, {v(1, 1), v(0, 4), 0}});
+            run_test(
+                proofs, view_cfg, mode, "cond_views", {{0, 5}, {0, 5}, {0, 5}, {0, 1}}, {{v(0, 2), v(1, -1), -1, b(3)}, {v(1, 3), v(2), 0, b(3)}});
+            run_test(proofs, view_cfg, mode, "cond_view_negcycle", {{0, 5}, {0, 5}, {0, 1}}, {{v(0, 2), v(1), 0, b(2)}, {v(1, 1), v(0, 4), 0}});
 
             // Conditional static bounds (a constant operand) and conditional
             // degenerate edges (aliasing), which are the two shapes that are not
             // graph edges at all.
-            run_test(proofs, mode, "cond_constant", {{0, 8}, {0, 1}}, {{v(0), c(0), 3, b(1)}, {c(6), v(0), 0, b(1, 0)}});
-            run_test(proofs, mode, "cond_alias_bad", {{0, 3}, {0, 1}}, {{v(0), v(0), -1, b(1)}});
-            run_test(proofs, mode, "cond_alias_ok", {{0, 3}, {0, 1}}, {{v(0), v(0), 0, b(1)}});
+            run_test(proofs, view_cfg, mode, "cond_constant", {{0, 8}, {0, 1}}, {{v(0), c(0), 3, b(1)}, {c(6), v(0), 0, b(1, 0)}});
+            run_test(proofs, view_cfg, mode, "cond_alias_bad", {{0, 3}, {0, 1}}, {{v(0), v(0), -1, b(1)}});
+            run_test(proofs, view_cfg, mode, "cond_alias_ok", {{0, 3}, {0, 1}}, {{v(0), v(0), 0, b(1)}});
 
             // Two Booleans, four quadrants, each excluding a different part of
             // the space: nothing may be pruned in the wrong quadrant.
-            run_test(
-                proofs, mode, "cond_quadrants", {{0, 4}, {0, 4}, {0, 1}, {0, 1}}, {{v(0), v(1), -2, b(2)}, {v(1), v(0), -2, b(3)}, {v(0), v(1), 1}});
+            run_test(proofs, view_cfg, mode, "cond_quadrants", {{0, 4}, {0, 4}, {0, 1}, {0, 1}},
+                {{v(0), v(1), -2, b(2)}, {v(1), v(0), -2, b(3)}, {v(0), v(1), 1}});
         }
         else if (mode == "random" || mode == "random_reified") {
             // In random_reified, two extra 0..1 variables sit at the end of the
@@ -1174,7 +1306,7 @@ namespace
                         v(static_cast<size_t>(var_dist(rand)), offset_dist(rand)), d_dist(rand), cond});
                 }
 
-                run_test(proofs, mode, "random" + to_string(iteration), domains, edges);
+                run_test(proofs, view_cfg, mode, "random" + to_string(iteration), domains, edges);
             }
         }
         else
@@ -1191,35 +1323,61 @@ auto main(int argc, char * argv[]) -> int
 
     string mode{argv[1]};
 
-    run_negated_view_test();
-    if (mode == "basic")
-        for (bool incremental : {true, false}) {
-            run_transitive_test(incremental);
-            run_hole_snap_test(incremental);
-        }
-    if (mode == "reified")
-        for (bool incremental : {true, false}) {
-            run_reified_bounds_test(incremental);
-            run_reified_degenerate_test(incremental);
-        }
-    if (mode == "incremental") {
-        run_incremental_tests();
+    auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
+
+    // The sweep names positions 0..n_positions-1; fixtures here have between
+    // one and six variables, so a position past a fixture's end simply leaves
+    // that fixture bare, which wraps_for_positions already does. Only a
+    // position past *every* fixture is worth declining outright.
+    constexpr int n_positions = 5;
+    if (view_cfg.single_position && (*view_cfg.single_position < 0 || *view_cfg.single_position >= n_positions)) {
+        println(cerr, "difference view sweep: position {} out of range for n_positions = {}; skipping", *view_cfg.single_position, n_positions);
         return EXIT_SUCCESS;
     }
-    if (mode == "simplify") {
-        run_root_refutation_test();
-        for (bool proofs : {false, true}) {
-            if (proofs && ! can_run_veripb())
-                continue;
-            run_simplify_tests(proofs);
+
+    run_negated_view_test();
+    run_overflow_test();
+
+    // The bespoke tests below build their own models by hand rather than going
+    // through run_test's fixture machinery, so they take no wrap; running them
+    // again under every wrap would only repeat the bare run. The sweep is over
+    // the data-driven fixtures, which is where the operand shapes live.
+    auto bare = view_wrap_config_is_effectively_bare(view_cfg, n_positions);
+
+    if (bare) {
+        if (mode == "basic")
+            for (bool incremental : {true, false}) {
+                run_transitive_test(incremental);
+                run_hole_snap_test(incremental);
+            }
+        if (mode == "reified")
+            for (bool incremental : {true, false}) {
+                run_reified_bounds_test(incremental);
+                run_reified_degenerate_test(incremental);
+            }
+        if (mode == "incremental") {
+            run_incremental_tests();
+            return EXIT_SUCCESS;
         }
+        if (mode == "simplify") {
+            run_root_refutation_test();
+            for (bool proofs : {false, true}) {
+                if (proofs && ! can_run_veripb())
+                    continue;
+                run_simplify_tests(proofs);
+            }
+            return EXIT_SUCCESS;
+        }
+    }
+    else if (mode == "incremental" || mode == "simplify") {
+        println(cerr, "difference view sweep: mode {} builds its models by hand and takes no wrap; skipping", mode);
         return EXIT_SUCCESS;
     }
 
     for (bool proofs : {false, true}) {
         if (proofs && ! can_run_veripb())
             continue;
-        run_all_tests(proofs, mode);
+        run_all_tests(proofs, view_cfg, mode);
     }
 
     return EXIT_SUCCESS;

--- a/gcs/presolvers/difference_logic.cc
+++ b/gcs/presolvers/difference_logic.cc
@@ -24,7 +24,6 @@
 using namespace gcs;
 using namespace gcs::innards;
 
-using std::holds_alternative;
 using std::make_unique;
 using std::map;
 using std::move;
@@ -86,6 +85,22 @@ namespace
             complain(
                 "less_than / less_equal / greater_than / greater_equal", "ReifiedCompareLessThanOrMaybeEqual", comparisons_by_type, comparisons_seen);
     }
+
+    // One OPB row of the only shape this presolver can lift: `1 * positive +
+    // -1 * negative <= value`, emitted under the bare @c[<id>] label and, when
+    // `cond` is engaged, under HalfReifyOnConjunctionOf on that condition.
+    //
+    // Both donor families reduce to this, which is why the deview, degeneracy
+    // and weight arithmetic below is written once. Note that the row, not the
+    // constraint, is what is described: for a comparison stated negatively the
+    // row's operands are the other way round from the ones the user posted.
+    struct DifferenceRow
+    {
+        IntegerVariableID positive;
+        IntegerVariableID negative;
+        Integer value;
+        optional<IntegerVariableCondition> cond;
+    };
 }
 
 DifferenceLogic::DifferenceLogic(shared_ptr<DifferenceLogicStats> stats) :
@@ -149,7 +164,10 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
     static_assert(std::derived_from<LinearGreaterThanEqual, ReifiedLinearInequality>);
     static_assert(std::derived_from<LessThan, ReifiedCompareLessThanOrMaybeEqual>);
     static_assert(std::derived_from<LessThanEqual, ReifiedCompareLessThanOrMaybeEqual>);
+    static_assert(std::derived_from<LessThanEqualIf, ReifiedCompareLessThanOrMaybeEqual>);
+    static_assert(std::derived_from<GreaterThan, ReifiedCompareLessThanOrMaybeEqual>);
     static_assert(std::derived_from<GreaterThanEqual, ReifiedCompareLessThanOrMaybeEqual>);
+    static_assert(std::derived_from<GreaterThanEqualIf, ReifiedCompareLessThanOrMaybeEqual>);
 
     DifferenceLogicStats stats;
 
@@ -167,6 +185,68 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
     // Half-reified donors are deliberately never added: see below.
     vector<ConstraintID> lifted_donors;
 
+    // Turn one donor row into a graph edge, or account for why it cannot be.
+    // Returns whether an edge was added, so a caller can also count the row in
+    // whatever family bucket it belongs to. The graph does not care which
+    // constraint class emitted the row --- only that the row exists, carries a
+    // citable @c[<id>] label, and says `positive - negative <= value`.
+    auto lift_row = [&](const DifferenceRow & row, const ConstraintID & id) -> bool {
+        auto left = deview_difference_operand(row.positive);
+        auto right = deview_difference_operand(row.negative);
+        if (! left || ! right) {
+            // A negated view: `-X - Y <= d` has both coefficients negative and
+            // is not a difference constraint at all. Unsound to lift, not
+            // merely unhelpful.
+            ++stats.skipped_negated_view;
+            return false;
+        }
+
+        // A constant operand makes this a plain bound, which the donor's own
+        // propagator applies once and which adds nothing to the graph; and
+        // aliasing says 0 <= d, which is vacuous, or else a root contradiction
+        // (unconditionally, needing an initialiser --- and initialisers have
+        // already run by the time a presolver is called) or a fact about the
+        // condition (half-reified). Leave all of them to the donor, which
+        // handles them. Checked before node_index is called, so a skipped edge
+        // never leaves an isolated node behind to be triggered on.
+        if (! left->variable || ! right->variable || *left->variable == *right->variable) {
+            ++stats.skipped_degenerate;
+            return false;
+        }
+
+        // (X + c1) - (Y + c2) <= d becomes X - Y <= d - c1 + c2, matching
+        // DifferenceConstraints exactly. The donor's OPB row is still in the
+        // user's views' bits; the propagator cites it in deview mode, which is
+        // what puts it in the same representation as this arithmetic.
+        auto d = row.value - left->offset + right->offset;
+        auto from = node_index(*left->variable);
+        auto to = node_index(*right->variable);
+
+        auto posted_index = graph.edges.size();
+        graph.edges.push_back(DifferenceGraphEdge{from, to, d, posted_index, row.cond});
+        if (logger) {
+            // The donor's own row, which both families label @c[<id>] with an
+            // empty role, for the conditional forms exactly as for the
+            // unconditional ones. Nothing new goes into the OPB ---
+            // Presolver::run has no ProofModel * precisely because that door
+            // has closed --- and nothing needs to: every inference the
+            // propagator makes is a cutting-planes consequence of these rows.
+            graph.edge_lines.push_back(ProofLineLabel{"c[" + as_string(id) + "]"});
+        }
+
+        if (row.cond)
+            ++stats.half_reified_edges_lifted;
+        else {
+            // Only unconditional donors are candidates for retirement. A
+            // half-reified donor also infers `!cond' from its own bounds, and
+            // the global propagator infers nothing about a condition at all, so
+            // retiring one would silently lose propagation.
+            lifted_donors.push_back(id);
+        }
+
+        return true;
+    };
+
     size_t linears_seen = 0;
     for (const auto & c : problem.each_constraint_of_type<ReifiedLinearInequality>()) {
         ++linears_seen;
@@ -178,11 +258,15 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
         // role, and emits the latter under HalfReifyOnConjunctionOf on exactly
         // the condition recorded here.
         //
-        // The other three kinds are each expressible as difference edges too,
-        // and are skipped only because each needs a *different* row of the
-        // donor's output: MustNotHold and NotIf state the integer negation
-        // (`y - x <= -d-1'), and Iff emits its two halves under the roles r and
-        // f rather than under the empty role. Counted rather than guessed at.
+        // The other three kinds are each expressible as difference edges too.
+        // Iff needs a *different* row of the donor's output: its two halves go
+        // out under the roles r and f rather than under the empty role.
+        // MustNotHold and NotIf state the integer negation, `y - x <= -d-1',
+        // which is still a difference row --- MustNotHold's even under the
+        // same empty role, NotIf's under `ltn' --- so those two are a
+        // deliberate gap rather than an impossibility, and one to close for
+        // the comparison family at the same time. Counted rather than guessed
+        // at.
         auto liftable_kind = true;
         optional<IntegerVariableCondition> edge_condition;
         overloaded{
@@ -215,75 +299,51 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
             continue;
         }
 
-        auto left = deview_difference_operand(*positive);
-        auto right = deview_difference_operand(*negative);
-        if (! left || ! right) {
-            // A negated view: `-X - Y <= d` has both coefficients negative and
-            // is not a difference constraint at all. Unsound to lift, not
-            // merely unhelpful.
-            ++stats.skipped_negated_view;
-            continue;
-        }
-
-        // A constant operand makes this a plain bound, which the donor's own
-        // propagator applies once and which adds nothing to the graph; and
-        // aliasing says 0 <= d, which is vacuous, or else a root contradiction
-        // (unconditionally, needing an initialiser --- and initialisers have
-        // already run by the time a presolver is called) or a fact about the
-        // condition (half-reified). Leave all of them to the donor, which
-        // handles them. Checked before node_index is called, so a skipped edge
-        // never leaves an isolated node behind to be triggered on.
-        if (! left->variable || ! right->variable || *left->variable == *right->variable) {
-            ++stats.skipped_degenerate;
-            continue;
-        }
-
-        // (X + c1) - (Y + c2) <= d becomes X - Y <= d - c1 + c2, matching
-        // DifferenceConstraints exactly. The donor's OPB row is still in the
-        // user's views' bits; the propagator cites it in deview mode, which is
-        // what puts it in the same representation as this arithmetic.
-        auto d = c.value() - left->offset + right->offset;
-        auto from = node_index(*left->variable);
-        auto to = node_index(*right->variable);
-
-        auto posted_index = graph.edges.size();
-        graph.edges.push_back(DifferenceGraphEdge{from, to, d, posted_index, edge_condition});
-        if (logger) {
-            // The donor's own row, which linear_inequality.cc labelled
-            // @c[<id>] with an empty role, for the `If` form exactly as for the
-            // unconditional one. Nothing new goes into the OPB ---
-            // Presolver::run has no ProofModel * precisely because that door has
-            // closed --- and nothing needs to: every inference the propagator
-            // makes is a cutting-planes consequence of these rows.
-            graph.edge_lines.push_back(ProofLineLabel{"c[" + as_string(c.constraint_id()) + "]"});
-        }
-
-        if (edge_condition)
-            ++stats.half_reified_edges_lifted;
-        else {
-            // Only unconditional donors are candidates for retirement. A
-            // half-reified donor also infers `!cond' from its own bounds, and
-            // the global propagator infers nothing about a condition at all, so
-            // retiring one would silently lose propagation.
-            lifted_donors.push_back(c.constraint_id());
-        }
+        static_cast<void>(lift_row(DifferenceRow{*positive, *negative, c.value(), edge_condition}, c.constraint_id()));
     }
 
     // Comparisons are difference constraints too --- `x <= y + d` is a view, not
-    // a separate constraint kind --- but ReifiedCompareLessThanOrMaybeEqual
-    // emits its unconditional rows through the void-returning add_constraint, so
-    // they carry no @label and no proof step can cite them. Count what that
-    // costs us rather than silently ignoring it; labelling those rows touches
-    // the cake_pb_cp chain surface and is deliberately a later PR.
+    // a separate constraint kind --- and every row
+    // ReifiedCompareLessThanOrMaybeEqual emits now carries an @label, so every
+    // row is citable.
     size_t comparisons_seen = 0;
     for (const auto & c : problem.each_constraint_of_type<ReifiedCompareLessThanOrMaybeEqual>()) {
         ++comparisons_seen;
-        if (! holds_alternative<reif::MustHold>(c.reification_condition()))
+
+        // `x <= y` states `x - y <= 0` and `x < y` states `x - y <= -1`, both
+        // under the bare @c[<id>] label; the `If' form states the same row
+        // under HalfReifyOnConjunctionOf on the recorded condition, and under
+        // the same label. Verified against cake_pb_cp, which is the other end
+        // of that label: `less_equal', `less_than', `greater_equal',
+        // `greater_than' and their `_if' spellings all come back as @c[<id>].
+        //
+        // The remaining three kinds are skipped, exactly as for the linear
+        // family and for the same reasons, one of which no longer applies and
+        // one of which still does. Iff's two halves are labelled @c[<id>][r]
+        // and @c[<id>][f], neither of which is the row cited here. MustNotHold
+        // and NotIf *are* now citable --- they state the integer negation,
+        // `y - x <= -1' or `y - x <= 0', and they too go out under the bare
+        // @c[<id>] --- but nothing in gcs constructs a
+        // comparison with either (there is no user-facing class for them, and
+        // s_expr() throws on both, so they have no .scp spelling either), and
+        // the linear family leaves its own equally-citable MustNotHold row on
+        // the floor as well. Lifting the negated forms is therefore a single
+        // follow-up that should be done for both families at once, not an
+        // asymmetry introduced here. Counted rather than guessed at.
+        optional<DifferenceRow> row;
+        overloaded{//
+            [&](const reif::MustHold &) { row = DifferenceRow{c.left_variable(), c.right_variable(), c.or_equal() ? 0_i : -1_i, nullopt}; },
+            [&](const reif::If & cond) { row = DifferenceRow{c.left_variable(), c.right_variable(), c.or_equal() ? 0_i : -1_i, cond.cond}; },
+            [&](const auto &) {}}
+            .visit(c.reification_condition());
+
+        if (! row) {
+            ++stats.skipped_reified;
             continue;
-        auto left = deview_difference_operand(c.left_variable());
-        auto right = deview_difference_operand(c.right_variable());
-        if (left && right && left->variable && right->variable && *left->variable != *right->variable)
-            ++stats.skipped_unlabelled_comparison;
+        }
+
+        if (lift_row(*row, c.constraint_id()))
+            ++stats.comparison_edges_lifted;
     }
 
     check_enumeration_is_working(problem, linears_seen, comparisons_seen);

--- a/gcs/presolvers/difference_logic.hh
+++ b/gcs/presolvers/difference_logic.hh
@@ -30,6 +30,20 @@ namespace gcs
         std::size_t edges_lifted = 0;
 
         /**
+         * \brief How many of edges_lifted came from a Comparison donor
+         * (`LessThan`, `LessThanEqual`, `GreaterThan`, `GreaterThanEqual` and
+         * their `If` forms) rather than from a two-term linear.
+         *
+         * Broken out because it is a separate detection path over a separate
+         * class hierarchy, reading the constraint back through
+         * ReifiedCompareLessThanOrMaybeEqual's accessors rather than through a
+         * WeightedSum, and because it is the one that can regress silently on
+         * its own: a model built entirely out of `x <= y + d` would still lift
+         * its linears and still look busy.
+         */
+        std::size_t comparison_edges_lifted = 0;
+
+        /**
          * \brief How many of edges_lifted came from a half-reified (`reif::If`)
          * donor, and so joined the graph as `cond -> x - y <= d`.
          *
@@ -52,9 +66,12 @@ namespace gcs
         /**
          * \name Why a candidate was not lifted.
          *
-         * Every posted linear inequality the presolver looked at falls into
-         * exactly one of edges_lifted or one of the first five buckets, so those
-         * six numbers account for every ReifiedLinearInequality in the model.
+         * Every donor the presolver looked at, of either family, falls into
+         * exactly one of edges_lifted or one of these five buckets, so the six
+         * numbers together account for every ReifiedLinearInequality *and*
+         * every ReifiedCompareLessThanOrMaybeEqual in the model. (The first two
+         * only ever fire on a linear: a comparison is two terms with
+         * coefficients +1 and -1 by construction.)
          * @{
          */
 
@@ -64,11 +81,14 @@ namespace gcs
         /// A two-term linear whose coefficients are not exactly +1 and -1.
         std::size_t skipped_coefficients = 0;
 
-        /// A linear whose reification condition is neither reif::MustHold nor
+        /// A donor whose reification condition is neither reif::MustHold nor
         /// reif::If: MustNotHold, NotIf or Iff. Each of those *is* expressible
-        /// as one or two difference edges, but each needs a different row of the
-        /// donor's OPB output than the two forms handled here, so they are
-        /// counted rather than guessed at.
+        /// as one or two difference edges. Iff cannot be lifted as things
+        /// stand, because its halves are labelled with the roles r and f rather
+        /// than with the empty role the propagator cites; MustNotHold and NotIf
+        /// could be, and are a deliberate gap, to be closed for both donor
+        /// families at once rather than for one of them. Counted rather than
+        /// guessed at.
         std::size_t skipped_reified = 0;
 
         /// An operand that is a negated view (`-X + c`), which is not a
@@ -82,12 +102,6 @@ namespace gcs
         /// the time a presolver runs, so they are left to their own propagator.
         std::size_t skipped_degenerate = 0;
 
-        /// A Comparison (`x < y`, `x <= y + d`, ...) that *is* difference
-        /// shaped but whose OPB row is emitted unlabelled, so no proof step can
-        /// cite it. This is the measure of what a later PR that labels those
-        /// rows would gain. \sa DifferenceLogic
-        std::size_t skipped_unlabelled_comparison = 0;
-
         ///@}
     };
 
@@ -98,8 +112,9 @@ namespace gcs
      *
      * A model does not have to be rewritten against DifferenceConstraints to get
      * the global propagation: post `1*x + -1*y <= d` as an ordinary
-     * LinearLessThanEqual, add this presolver, and the edges are lifted into one
-     * Bellman-Ford pass over the whole graph. This is the hybrid of section 4.4
+     * LinearLessThanEqual, or `x <= y + d` as an ordinary LessThanEqual, add
+     * this presolver, and the edges are lifted into one Bellman-Ford pass over
+     * the whole graph. This is the hybrid of section 4.4
      * of Kletzander, Dekker, Schutt and Stuckey, "Global Difference Constraint
      * Propagation for Constraint Programming" (arXiv:2607.20022) --- and it is
      * what the timing forces in any case, since presolvers run after
@@ -116,19 +131,24 @@ namespace gcs
      *
      * \par What is lifted
      *
-     * The paper's "level 1", restricted to what the propagator supports today: a
-     * two-term LinearLessThanEqual with coefficients exactly `+1` and `-1` and
-     * two distinct variable operands, each of which may carry a `+X + c` view
-     * offset (folded into the weight). The reification condition may be
-     * unconditional (reif::MustHold), giving a plain edge, or half-reified
-     * (reif::If), giving `cond -> x - y <= d`: `linear_inequality.cc` labels
-     * both forms `@c[<id>]` with no role suffix, so both are citable, and the
-     * `If` form's row is emitted under HalfReifyOnConjunctionOf, which is
-     * exactly the shape the propagator's proofs assume. Everything else is
-     * skipped and counted --- see DifferenceLogicStats, and note in particular
-     * that Comparison donors are skipped only because their unconditional OPB
-     * rows are emitted *unlabelled* and so cannot be cited, not because they are
-     * the wrong shape.
+     * The paper's "level 1", restricted to what the propagator supports today,
+     * from two donor families:
+     *
+     *  - a two-term LinearLessThanEqual with coefficients exactly `+1` and `-1`
+     *    and two distinct variable operands;
+     *  - a Comparison --- LessThan, LessThanEqual, GreaterThan,
+     *    GreaterThanEqual --- over two distinct variable operands, which is the
+     *    same thing written the way a model usually writes it: `x <= y + d` is
+     *    a view on one side, not a separate constraint kind.
+     *
+     * Either operand may carry a `+X + c` view offset, folded into the weight.
+     * The reification condition may be unconditional (reif::MustHold), giving a
+     * plain edge, or half-reified (reif::If), giving `cond -> x - y <= d`: both
+     * families label both forms `@c[<id>]` with no role suffix, so all four are
+     * citable, and the `If` form's row is emitted under
+     * HalfReifyOnConjunctionOf, which is exactly the shape the propagator's
+     * proofs assume. Everything else is skipped and counted --- see
+     * DifferenceLogicStats.
      *
      * Equalities (level 2) and disequalities (level 3) are not chased at all;
      * the paper measures both as losing to level 1.

--- a/gcs/presolvers/difference_logic_test.cc
+++ b/gcs/presolvers/difference_logic_test.cc
@@ -85,10 +85,11 @@ namespace
     // enough on its own: the whole hazard is that "just update the number" looks
     // like a reasonable response to one of these.
     const string detection_is_broken = "\n\nThis means the presolver's DETECTION is broken, not that this expectation is stale.\n"
-                                       "The most likely cause is a change to Constraint::clone() or to the Linear class\n"
-                                       "hierarchy, such that Problem::each_constraint_of_type<ReifiedLinearInequality>()\n"
-                                       "no longer yields posted LinearLessThanEqual constraints (clone() currently returns\n"
-                                       "the family base -- see PR #585).\n\n"
+                                       "The most likely cause is a change to Constraint::clone() or to the Linear or\n"
+                                       "Comparison class hierarchy, such that\n"
+                                       "Problem::each_constraint_of_type<ReifiedLinearInequality>() (or\n"
+                                       "<ReifiedCompareLessThanOrMaybeEqual>()) no longer yields the posted derived\n"
+                                       "constraints (clone() currently returns the family base -- see PR #585).\n\n"
                                        "Fix gcs/presolvers/difference_logic.cc. Do NOT update the expected count here: a\n"
                                        "presolver that lifts nothing still passes every solution-equivalence, OPB byte-diff\n"
                                        "and VeriPB check, so this assertion is the only thing standing between a silent\n"
@@ -200,22 +201,100 @@ namespace
         throw UnimplementedException{};
     }
 
-    // Post the system as one two-term LinearLessThanEqual per edge -- the shape
-    // the presolver detects -- and attach the presolver as asked.
+    // Which constraint an edge is written as. Every one of these spellings ends
+    // up emitting the *same* OPB row -- `x - y <= d` under the bare @c[<id>]
+    // label -- which is the whole reason the presolver can lift them all, and
+    // which is what makes sweeping a fixture across the lot a real check rather
+    // than five unrelated test sets: the lift and skip counts must come out
+    // identical every time.
+    enum class Donor
+    {
+        Linear,
+        Le,
+        Lt,
+        Ge,
+        Mixed
+    };
+
+    auto donor_name(Donor donor) -> string
+    {
+        switch (donor) {
+            using enum Donor;
+        case Linear: return "linear";
+        case Le: return "less-equal";
+        case Lt: return "less-than";
+        case Ge: return "greater-equal";
+        case Mixed: return "mixed";
+        }
+        throw UnimplementedException{};
+    }
+
+    auto all_donors() -> vector<Donor>
+    {
+        return {Donor::Linear, Donor::Le, Donor::Lt, Donor::Ge, Donor::Mixed};
+    }
+
+    // Post one edge in one donor's spelling. The comparison spellings put the
+    // weight in a view on the larger side, which is exactly how a real model
+    // writes `x <= y + d`, and (for the strict form) rely on `x - y <= d` being
+    // `x < y + d + 1` over the integers.
+    auto post_edge(Problem & p, const EdgeSpec & e, const vector<IntegerVariableID> & vars, Donor donor) -> void
+    {
+        auto x = operand_id(e.x, vars), y = operand_id(e.y, vars);
+        optional<IntegerVariableCondition> cond;
+        if (e.cond)
+            cond = vars.at(e.cond->var) == Integer(e.cond->value);
+
+        switch (donor) {
+            using enum Donor;
+        case Linear: {
+            auto sum = WeightedSum{} + 1_i * x + -1_i * y;
+            if (cond)
+                p.post(LinearLessThanEqualIf{sum, Integer(e.d), *cond});
+            else
+                p.post(LinearLessThanEqual{sum, Integer(e.d)});
+            return;
+        }
+        case Le:
+            if (cond)
+                p.post(LessThanEqualIf{x, y + Integer(e.d), *cond});
+            else
+                p.post(LessThanEqual{x, y + Integer(e.d)});
+            return;
+        case Lt:
+            if (cond)
+                p.post(LessThanIf{x, y + Integer(e.d + 1), *cond});
+            else
+                p.post(LessThan{x, y + Integer(e.d + 1)});
+            return;
+        case Ge:
+            // GreaterThanEqual(a, b) normalises to left = b, right = a, so this
+            // reads back as the same `x <= y + d` the Le case posts -- through
+            // the swapped-operand constructor, which is the part that could
+            // silently invert an edge.
+            if (cond)
+                p.post(GreaterThanEqualIf{y + Integer(e.d), x, *cond});
+            else
+                p.post(GreaterThanEqual{y + Integer(e.d), x});
+            return;
+        case Mixed: throw UnimplementedException{};
+        }
+        throw UnimplementedException{};
+    }
+
+    // Post the system one constraint per edge, in the requested spelling, and
+    // attach the presolver as asked. Donor::Mixed alternates linear and
+    // comparison donors so that both detection loops contribute to one graph,
+    // which is where an edge-index or ordering mistake between them would show.
     auto build(Problem & p, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges, Config config,
-        const shared_ptr<DifferenceLogicStats> & stats) -> vector<IntegerVariableID>
+        const shared_ptr<DifferenceLogicStats> & stats, Donor donor) -> vector<IntegerVariableID>
     {
         vector<IntegerVariableID> vars;
         for (const auto & [lo, hi] : domains)
             vars.push_back(p.create_integer_variable(Integer(lo), Integer(hi)));
 
-        for (const auto & e : edges) {
-            auto sum = WeightedSum{} + 1_i * operand_id(e.x, vars) + -1_i * operand_id(e.y, vars);
-            if (e.cond)
-                p.post(LinearLessThanEqualIf{sum, Integer(e.d), vars.at(e.cond->var) == Integer(e.cond->value)});
-            else
-                p.post(LinearLessThanEqual{sum, Integer(e.d)});
-        }
+        for (size_t i = 0; i < edges.size(); ++i)
+            post_edge(p, edges.at(i), vars, donor == Donor::Mixed ? (i % 2 == 0 ? Donor::Linear : Donor::Le) : donor);
 
         switch (config) {
             using enum Config;
@@ -232,10 +311,11 @@ namespace
     // over-pruning presolver loses a solution and an unsound one gains one, and
     // no proof would catch either, since a proof only certifies what was
     // derived.
-    auto run_equivalence_test(bool proofs, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges,
+    auto run_equivalence_test(bool proofs, Donor donor, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges,
         size_t expected_edges_lifted, size_t expected_half_reified) -> void
     {
-        print(cerr, "difference presolver equivalence {} domains={} edges={}{}", name, domains, edges.size(), proofs ? " with proofs:" : ":");
+        print(cerr, "difference presolver equivalence {} {} domains={} edges={}{}", donor_name(donor), name, domains, edges.size(),
+            proofs ? " with proofs:" : ":");
         cerr << flush;
 
         set<tuple<vector<int>>> expected;
@@ -245,18 +325,28 @@ namespace
         for (auto config : {Config::NoPresolver, Config::Hybrid, Config::DonorsDisabled}) {
             auto stats = make_shared<DifferenceLogicStats>();
             Problem p;
-            auto vars = build(p, domains, edges, config, stats);
+            auto vars = build(p, domains, edges, config, stats, donor);
 
             set<tuple<vector<int>>> actual;
             // The presolver only reads and writes bounds, so bounds consistent,
             // not GAC.
-            auto proof_name = proofs ? make_optional("difference_presolver_" + name + "_" + config_name(config)) : nullopt;
+            auto proof_name = proofs ? make_optional("difference_presolver_" + donor_name(donor) + "_" + name + "_" + config_name(config)) : nullopt;
             solve_for_tests(p, proof_name, actual, tuple{vars});
             check_results(proof_name, expected, actual);
 
             if (config != Config::NoPresolver) {
                 check_count("edges lifted", expected_edges_lifted, stats->edges_lifted, name);
                 check_count("half-reified edges lifted", expected_half_reified, stats->half_reified_edges_lifted, name);
+                // Whichever spelling the fixture used, the same edges come out
+                // of it -- so a comparison-donor sweep is only checking
+                // anything at all if the *comparison* detection loop is what
+                // produced them, and this is what says so. (Donor::Mixed's
+                // split depends on which of the alternating edges happen to
+                // skip, so it is pinned by an exact detection fixture instead
+                // of restated here.)
+                if (donor != Donor::Mixed)
+                    check_count("edges lifted from comparison donors", donor == Donor::Linear ? 0 : expected_edges_lifted,
+                        stats->comparison_edges_lifted, name);
             }
         }
     }
@@ -273,10 +363,10 @@ namespace
     // LinearLessThanEqualIf also infers `!cond' from its own bounds, and the
     // global propagator makes no inference about a condition at all. Retire one
     // and the search grows, which shows up here as a recursion mismatch.
-    auto run_tripwire_test(const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges, size_t expected_edges_lifted,
-        size_t expected_half_reified) -> void
+    auto run_tripwire_test(Donor donor, const string & name, const vector<pair<int, int>> & domains, const vector<EdgeSpec> & edges,
+        size_t expected_edges_lifted, size_t expected_half_reified) -> void
     {
-        print(cerr, "difference presolver tripwire {}:", name);
+        print(cerr, "difference presolver tripwire {} {}:", donor_name(donor), name);
         cerr << flush;
 
         // Only unconditional donors are candidates for retirement, so a fixture
@@ -287,7 +377,7 @@ namespace
         for (auto [index, config] : {pair{0, Config::Hybrid}, pair{1, Config::DonorsDisabled}}) {
             auto stats = make_shared<DifferenceLogicStats>();
             Problem p;
-            static_cast<void>(build(p, domains, edges, config, stats));
+            static_cast<void>(build(p, domains, edges, config, stats, donor));
             results[index] = solve_with(p, SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return true; }});
             if (config == Config::DonorsDisabled && expect_disabling && 0 == stats->donor_propagators_disabled)
                 throw UnexpectedException{"the difference-logic presolver disabled no donor propagators on fixture '" + name +
@@ -355,10 +445,12 @@ namespace
             // refused rather than lifted: -x - y <= d has both coefficients
             // negative. The other two edges still lift.
             {"negated_view", {{-3, 3}, {-3, 3}, {-3, 3}}, {{neg(0), v(1), 1}, {v(0), v(2), -1}, {v(2), v(1), -1}}, 2},
-            // Half-reified donors. LinearLessThanEqualIf emits its row under
-            // HalfReifyOnConjunctionOf and labels it @c[<id>] with an empty
-            // role, exactly as the unconditional form does, so it is citable
-            // and lifts as a conditional edge. The last variable of each
+            // Half-reified donors. LinearLessThanEqualIf and LessThanEqualIf
+            // both emit their row under HalfReifyOnConjunctionOf and label it
+            // @c[<id>] with an empty role, exactly as the unconditional forms
+            // do, so both are citable and both lift as a conditional edge (the
+            // donor sweep runs each of these fixtures as each spelling in
+            // turn). The last variable of each
             // fixture is the condition, and the oracle enumerates both of its
             // settings, so the false branch is checked as hard as the true one.
             {"reified_chain", {{0, 5}, {0, 5}, {0, 5}, {0, 1}}, {{v(0), v(1), -1, b(3)}, {v(1), v(2), -1, b(3)}}, 2, 2},
@@ -387,16 +479,23 @@ namespace
             {"reified_root_fix_views", {{0, 10}, {0, 10}, {0, 1}}, {{v(1, 1), v(0), 2}, {v(0, 2), v(1, -1), -5, b(2)}}, 2, 1}};
     }
 
+    // Each fixture is run in every donor spelling. The lift counts are stated
+    // once, in the corpus, because they must not depend on the spelling: an
+    // `x <= y + d` and a `1*x + -1*y <= d` are the same difference constraint
+    // and the same OPB row, and if a sweep ever produced different numbers,
+    // that would be the bug.
     auto run_equivalence_tests(bool proofs) -> void
     {
-        for (const auto & f : corpus())
-            run_equivalence_test(proofs, f.name, f.domains, f.edges, f.expected_edges_lifted, f.expected_half_reified);
+        for (auto donor : all_donors())
+            for (const auto & f : corpus())
+                run_equivalence_test(proofs, donor, f.name, f.domains, f.edges, f.expected_edges_lifted, f.expected_half_reified);
     }
 
     auto run_tripwire_tests() -> void
     {
-        for (const auto & f : corpus())
-            run_tripwire_test(f.name, f.domains, f.edges, f.expected_edges_lifted, f.expected_half_reified);
+        for (auto donor : all_donors())
+            for (const auto & f : corpus())
+                run_tripwire_test(donor, f.name, f.domains, f.edges, f.expected_edges_lifted, f.expected_half_reified);
     }
 
     // Every donor shape, with the count it must land in. A donor migrating from
@@ -406,11 +505,12 @@ namespace
     {
         auto check = [](const string & fixture, const DifferenceLogicStats & stats, const DifferenceLogicStats & expected) {
             println(cerr,
-                "difference presolver detection {}: lifted {} ({} half-reified) over {} nodes, skipped {} not-two-terms, {} coefficients, {} "
-                "reified, {} negated-view, {} degenerate, {} unlabelled-comparison",
-                fixture, stats.edges_lifted, stats.half_reified_edges_lifted, stats.nodes, stats.skipped_not_two_terms, stats.skipped_coefficients,
-                stats.skipped_reified, stats.skipped_negated_view, stats.skipped_degenerate, stats.skipped_unlabelled_comparison);
+                "difference presolver detection {}: lifted {} ({} from comparisons, {} half-reified) over {} nodes, skipped {} not-two-terms, {} "
+                "coefficients, {} reified, {} negated-view, {} degenerate",
+                fixture, stats.edges_lifted, stats.comparison_edges_lifted, stats.half_reified_edges_lifted, stats.nodes, stats.skipped_not_two_terms,
+                stats.skipped_coefficients, stats.skipped_reified, stats.skipped_negated_view, stats.skipped_degenerate);
             check_count("edges lifted", expected.edges_lifted, stats.edges_lifted, fixture);
+            check_count("edges lifted from comparison donors", expected.comparison_edges_lifted, stats.comparison_edges_lifted, fixture);
             check_count("half-reified edges lifted", expected.half_reified_edges_lifted, stats.half_reified_edges_lifted, fixture);
             check_count("nodes", expected.nodes, stats.nodes, fixture);
             check_count("skipped: not two terms", expected.skipped_not_two_terms, stats.skipped_not_two_terms, fixture);
@@ -418,7 +518,6 @@ namespace
             check_count("skipped: reified", expected.skipped_reified, stats.skipped_reified, fixture);
             check_count("skipped: negated view", expected.skipped_negated_view, stats.skipped_negated_view, fixture);
             check_count("skipped: degenerate", expected.skipped_degenerate, stats.skipped_degenerate, fixture);
-            check_count("skipped: unlabelled comparison", expected.skipped_unlabelled_comparison, stats.skipped_unlabelled_comparison, fixture);
             if (expected.propagator_installed != stats.propagator_installed)
                 throw UnexpectedException{"the difference-logic presolver " + string{stats.propagator_installed ? "did" : "did not"} +
                     " install a propagator on fixture '" + fixture + "', but it should " + (expected.propagator_installed ? "have" : "not have") +
@@ -469,12 +568,12 @@ namespace
             // Aliasing, and a constant operand.
             p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[0], 0_i});
             p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * constant_variable(4_i), 1_i});
-            // A Comparison, which *is* difference shaped but whose OPB row is
-            // emitted unlabelled, so no proof step could cite it.
+            // Comparisons, which are difference shaped and, since their OPB
+            // rows carry an @c[<id>] label, citable: these two lift.
             p.post(LessThanEqual{x[2], x[3] + 2_i});
             p.post(GreaterThan{x[3], x[2]});
-            // ... and one that is not, so it is not counted as a missed
-            // opportunity either.
+            // ... and one whose right-hand operand is a constant, which is a
+            // plain bound rather than an edge.
             p.post(LessThan{x[2], constant_variable(5_i)});
 
             // The two real edges.
@@ -484,15 +583,76 @@ namespace
             p.add_presolver(DifferenceLogic{stats});
             solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
             check("every_skip", *stats,
-                DifferenceLogicStats{.edges_lifted = 2,
-                    .nodes = 3,
+                DifferenceLogicStats{.edges_lifted = 4,
+                    .comparison_edges_lifted = 2,
+                    .nodes = 4,
                     .propagator_installed = true,
                     .skipped_not_two_terms = 1,
                     .skipped_coefficients = 2,
                     .skipped_reified = 2,
                     .skipped_negated_view = 1,
-                    .skipped_degenerate = 2,
-                    .skipped_unlabelled_comparison = 2});
+                    .skipped_degenerate = 3});
+        }
+
+        // Every comparison spelling the presolver lifts, and every reason it
+        // declines one. This is the fixture that fails if the comparison
+        // detection loop stops working: the linear loop would still lift its
+        // edges and the presolver would still look busy.
+        {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable_vector(5, 0_i, 9_i, "x");
+            auto b = p.create_integer_variable(0_i, 1_i, "b");
+
+            // The four unconditional spellings, including both swapped-operand
+            // constructors, and a view offset on either side.
+            p.post(LessThanEqual{x[0], x[1] + 2_i});
+            p.post(LessThan{x[1] + 1_i, x[2]});
+            p.post(GreaterThanEqual{x[3], x[2]});
+            p.post(GreaterThan{x[4], x[3] - 1_i});
+            // Half-reified, which joins the graph as a conditional edge and
+            // whose donor must therefore never be retired.
+            p.post(LessThanEqualIf{x[0], x[4], b == 1_i});
+            // Fully reified: the halves are labelled @c[<id>][r] and
+            // @c[<id>][f], neither of which is the row cited, so counted.
+            p.post(LessThanEqualIff{x[0], x[2], b == 1_i});
+            // Stated negatively. Also a difference row, also citable, and also
+            // deliberately not lifted --- see the comment in the presolver.
+            p.post(ReifiedCompareLessThanOrMaybeEqual{x[0], x[1], reif::MustNotHold{}, true});
+            // A negated view, which is not a difference constraint at all.
+            p.post(LessThanEqual{-x[0], x[1]});
+            // Aliasing (`0 <= 3`, vacuous) and a constant operand (a bound).
+            p.post(LessThanEqual{x[0], x[0] + 3_i});
+            p.post(LessThan{x[0], constant_variable(9_i)});
+
+            p.add_presolver(DifferenceLogic{stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
+            check("comparison_donors", *stats,
+                DifferenceLogicStats{.edges_lifted = 5,
+                    .comparison_edges_lifted = 5,
+                    .half_reified_edges_lifted = 1,
+                    .nodes = 5,
+                    .propagator_installed = true,
+                    .skipped_reified = 2,
+                    .skipped_negated_view = 1,
+                    .skipped_degenerate = 2});
+        }
+
+        // Both detection loops feeding one graph. The comparison loop runs
+        // second, so its edges land at higher posted indices than the linears';
+        // the proof-line vector is indexed by that same number, and a mismatch
+        // between the two would make the propagator cite the wrong donor's row.
+        {
+            auto stats = make_shared<DifferenceLogicStats>();
+            Problem p;
+            auto x = p.create_integer_variable_vector(4, 0_i, 9_i, "x");
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
+            p.post(LessThanEqual{x[1] + 1_i, x[2]});
+            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[2] + -1_i * x[3], -1_i});
+            p.add_presolver(DifferenceLogic{stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }});
+            check("mixed_donors", *stats,
+                DifferenceLogicStats{.edges_lifted = 3, .comparison_edges_lifted = 1, .nodes = 4, .propagator_installed = true});
         }
 
         // Half-reified donors, in every shape the propagator distinguishes: two
@@ -563,12 +723,90 @@ namespace
         return string{istreambuf_iterator<char>{f}, istreambuf_iterator<char>{}};
     }
 
+    // How many rows of an OPB carry a constraint @label. Variable encodings are
+    // @i[...] and proof flags @b[...] / @x[...], so this counts constraint rows
+    // and nothing else.
+    auto count_labelled_constraint_rows(const string & opb) -> size_t
+    {
+        size_t count = 0;
+        for (size_t pos = 0; pos != string::npos;) {
+            auto line_end = opb.find('\n', pos);
+            if (opb.compare(pos, 3, "@c[") == 0)
+                ++count;
+            pos = line_end == string::npos ? string::npos : line_end + 1;
+        }
+        return count;
+    }
+
+    // Every row ReifiedCompareLessThanOrMaybeEqual emits must carry an @label.
+    // The presolver's whole licence for lifting a comparison is that it can
+    // cite the donor's row by name, and an unlabelled row cannot be cited at
+    // all -- a `pol` would name something the OPB never defines.
+    //
+    // Checked here on the .opb text rather than left to the presolver's own
+    // proofs, for two reasons. A form the presolver does not lift today
+    // (MustNotHold, NotIf) would lose its label with nothing noticing, and a
+    // regression that dropped the label from a form the presolver *does* lift
+    // would only show up in a proof, in a model that both uses that form and
+    // makes the propagator derive something from it.
+    auto run_comparison_label_tests() -> void
+    {
+        auto rows_for = [](const string & basename, auto && post) -> size_t {
+            Problem p;
+            auto x = p.create_integer_variable_vector(2, 0_i, 5_i, "x");
+            auto b = p.create_integer_variable(0_i, 1_i, "b");
+            post(p, x, b);
+            // No .scp: the MustNotHold and NotIf forms have no cake spelling
+            // and s_expr() throws on them, which is precisely why their @label
+            // is free to be the bare @c[<id>] --- and why the OPB is the only
+            // place their labelling can be checked.
+            ProofFileNames names{basename};
+            names.s_expr_file = nullopt;
+            static_cast<void>(
+                solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, make_optional<ProofOptions>(names)));
+            auto opb = read_file(basename + ".opb");
+            for (auto ext : proof_file_extensions)
+                std::remove((basename + ext).c_str());
+            return count_labelled_constraint_rows(opb);
+        };
+
+        // One row per form, except the iff, whose two halves are @c[id][r] and
+        // @c[id][f].
+        auto check = [&](const string & form, size_t expected, size_t actual) {
+            println(cerr, "difference presolver comparison labels: {} emits {} labelled row(s)", form, actual);
+            if (expected != actual)
+                throw UnexpectedException{"a " + form + " comparison emitted " + to_string(actual) + " @label'd OPB rows, expected " +
+                    to_string(expected) +
+                    ". Every row ReifiedCompareLessThanOrMaybeEqual emits must go out through "
+                    "ProofModel::add_labelled_constraint, never the void-returning add_constraint: an unlabelled row cannot be cited, and the "
+                    "difference-logic presolver lifts these constraints into a propagator whose pols cite exactly them by name. Fix "
+                    "gcs/constraints/comparison/comparison.cc."};
+        };
+
+        check("must-hold", 1,
+            rows_for("difference_presolver_label_hold", [](Problem & p, const auto & x, const auto &) { p.post(LessThanEqual{x[0], x[1]}); }));
+        check("if", 1, rows_for("difference_presolver_label_if", [](Problem & p, const auto & x, const auto & b) {
+            p.post(LessThanEqualIf{x[0], x[1], b == 1_i});
+        }));
+        check("must-not-hold", 1, rows_for("difference_presolver_label_not_hold", [](Problem & p, const auto & x, const auto &) {
+            p.post(ReifiedCompareLessThanOrMaybeEqual{x[0], x[1], reif::MustNotHold{}, true});
+        }));
+        check("not-if", 1, rows_for("difference_presolver_label_not_if", [](Problem & p, const auto & x, const auto & b) {
+            p.post(ReifiedCompareLessThanOrMaybeEqual{x[0], x[1], reif::NotIf{b == 1_i}, true});
+        }));
+        check("iff", 2, rows_for("difference_presolver_label_iff", [](Problem & p, const auto & x, const auto & b) {
+            p.post(LessThanEqualIff{x[0], x[1], b == 1_i});
+        }));
+    }
+
     // The defining property: a presolver adds no OPB content. Presolver::run has
     // no ProofModel * at all, so this should be true by construction; check it
     // anyway, since it is the entire licence for lifting other people's
     // constraints after the model has been finalised.
     auto run_opb_tests() -> void
     {
+        run_comparison_label_tests();
+
         auto solve_and_read = [](const string & basename, Config config, auto && post) -> pair<string, string> {
             auto stats = make_shared<DifferenceLogicStats>();
             Problem p;
@@ -590,25 +828,36 @@ namespace
             return {opb, pbp};
         };
 
-        // Positive case: a system the presolver does lift.
-        {
-            auto post = [](Problem & p) {
-                auto x = p.create_integer_variable_vector(4, 0_i, 5_i, "x");
-                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
-                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[1] + -1_i * (x[2] + 1_i), -1_i});
-                p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[2] + -1_i * x[3], -1_i});
-            };
-            auto [off_opb, off_pbp] = solve_and_read("difference_presolver_opb_off", Config::NoPresolver, post);
-            auto [on_opb, on_pbp] = solve_and_read("difference_presolver_opb_on", Config::Hybrid, post);
+        // Positive case: a system the presolver does lift, once written as
+        // linears and once as comparisons. The second is the one that says the
+        // comparison donors add no OPB content of their own either --- they
+        // must not, for exactly the same reason, and it is worth stating
+        // separately because it is a different detection path.
+        for (auto [what, post] : vector<pair<string, void (*)(Problem &)>>{//
+                 {"linear",
+                     [](Problem & p) {
+                         auto x = p.create_integer_variable_vector(4, 0_i, 5_i, "x");
+                         p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[0] + -1_i * x[1], -1_i});
+                         p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[1] + -1_i * (x[2] + 1_i), -1_i});
+                         p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x[2] + -1_i * x[3], -1_i});
+                     }},
+                 {"comparison", [](Problem & p) {
+                      auto x = p.create_integer_variable_vector(4, 0_i, 5_i, "x");
+                      p.post(LessThan{x[0], x[1]});
+                      p.post(LessThan{x[1], x[2] + 1_i});
+                      p.post(LessThan{x[2], x[3]});
+                  }}}) {
+            auto [off_opb, off_pbp] = solve_and_read("difference_presolver_opb_" + what + "_off", Config::NoPresolver, post);
+            auto [on_opb, on_pbp] = solve_and_read("difference_presolver_opb_" + what + "_on", Config::Hybrid, post);
             if (off_opb != on_opb)
-                throw UnexpectedException{"the difference-logic presolver changed the .opb. It must not: Presolver::run is handed no ProofModel, "
-                                          "and the whole design rests on the global propagator citing rows the donors already emitted"};
+                throw UnexpectedException{"the difference-logic presolver changed the .opb on the " + what +
+                    " fixture. It must not: Presolver::run is handed no ProofModel, "
+                    "and the whole design rests on the global propagator citing rows the donors already emitted"};
             if (off_pbp == on_pbp)
-                throw UnexpectedException{"the difference-logic presolver left the .pbp byte-identical on a fixture it is supposed to lift three "
-                                          "edges from, so it evidently propagated nothing." +
-                    detection_is_broken};
-            println(cerr, "difference presolver opb: lifted fixture .opb identical ({} bytes), .pbp differs ({} vs {} bytes)", off_opb.size(),
-                off_pbp.size(), on_pbp.size());
+                throw UnexpectedException{"the difference-logic presolver left the .pbp byte-identical on the " + what +
+                    " fixture, which it is supposed to lift three edges from, so it evidently propagated nothing." + detection_is_broken};
+            println(cerr, "difference presolver opb: lifted {} fixture .opb identical ({} bytes), .pbp differs ({} vs {} bytes)", what,
+                off_opb.size(), off_pbp.size(), on_pbp.size());
         }
 
         // Negative control: nothing is difference shaped, so the presolver posts
@@ -690,9 +939,13 @@ namespace
     // per-constraint propagation can only find it by crawling both bounds two
     // units at a time -- Theta(domain size) propagations. The global propagator
     // sums the two edges round the cycle and refutes at once.
-    auto run_differential_test() -> void
+    //
+    // Run for each donor spelling: `x <= y` and `y <= x - 2` is the same
+    // pathology written the way a scheduling model would write it, and it is
+    // the shape the measurement in dev_docs/difference-logic.md uses.
+    auto run_differential_test(Donor donor) -> void
     {
-        print(cerr, "difference presolver differential:");
+        print(cerr, "difference presolver differential {}:", donor_name(donor));
         cerr << flush;
 
         const int n = 500;
@@ -701,8 +954,9 @@ namespace
             Problem p;
             auto x = p.create_integer_variable(0_i, Integer(n), "x");
             auto y = p.create_integer_variable(0_i, Integer(n), "y");
-            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x + -1_i * y, 0_i});
-            p.post(LinearLessThanEqual{WeightedSum{} + 1_i * y + -1_i * x, -2_i});
+            vector<IntegerVariableID> vars{x, y};
+            post_edge(p, EdgeSpec{v(0), v(1), 0}, vars, donor == Donor::Mixed ? Donor::Linear : donor);
+            post_edge(p, EdgeSpec{v(1), v(0), -2}, vars, donor == Donor::Mixed ? Donor::Le : donor);
             switch (config) {
                 using enum Config;
             case NoPresolver: break;
@@ -724,6 +978,8 @@ namespace
 
         check_count("edges lifted", 2, with_stats.edges_lifted, "differential");
         check_count("edges lifted", 2, disabled_stats.edges_lifted, "differential");
+        if (donor != Donor::Linear && donor != Donor::Mixed)
+            check_count("edges lifted from comparison donors", 2, with_stats.comparison_edges_lifted, "differential");
 
         // A factor of ten is far inside the margin: the measured numbers are
         // around 500 against 3. Equality is what a no-op presolver would give.
@@ -749,7 +1005,8 @@ auto main(int argc, char * argv[]) -> int
 
     if (mode == "detection") {
         run_detection_tests();
-        run_differential_test();
+        for (auto donor : all_donors())
+            run_differential_test(donor);
     }
     else if (mode == "equivalence")
         run_equivalence_tests(false);


### PR DESCRIPTION
Part of #571. **Based on #593** (`difflogic-08-incremental`), which is this PR's
base branch, so the diff shown here is only this PR's eight commits.

> [!IMPORTANT]
> **Sibling conflict with #595, at merge time.** This PR deletes
> `DifferenceLogicStats::skipped_unlabelled_comparison` — once comparison rows
> carry an `@label`, nothing can be skipped for want of one — and #595 reads it
> in three places. Two of them are **compile errors**, not test failures, so
> whichever of the two lands second does not just go red in CI, it fails to
> build:
>
> | site | what breaks |
> |---|---|
> | `minizinc/fzn_glasgow.cc` (`differenceLogicSkippedUnlabelledComparison` stat) | compile error |
> | `xcsp/xcsp_glasgow_constraint_solver.cc` (`d DIFFERENCE LOGIC SKIPPED UNLABELLED COMPARISON`) | compile error |
> | `xcsp/CMakeLists.txt` (the `^d DIFFERENCE LOGIC SKIPPED UNLABELLED COMPARISON 0$` assertion) | test failure |
>
> The `[^cmp]` footnote in `dev_docs/frontend-support-matrix.md` also goes stale:
> it says a `Comparison`'s unconditional row is emitted unlabelled, which stops
> being true. All four were correct when #595 was cut.
>
> This is not new to the rebase — #595 and #596 are siblings off #593 upstream
> too, and the same three sites conflicted there. Flagged here rather than
> resolved because the fix belongs to whichever merges second, and depends on
> which counter it should print instead (`comparison_edges_lifted` is the
> natural replacement).


`LessThan` / `LessThanEqual` / `GreaterThan` / `GreaterThanEqual` were, in
PR #588's words, "the donor shape we most want and cannot have": `x <= y + d`
over an offset view *is* a difference constraint, but
`ReifiedCompareLessThanOrMaybeEqual::define_proof_model` emitted every form
except `Iff` through the `void`-returning `add_constraint`, so those rows
carried no `@label` and no `pol` could cite them. The presolver detected them,
skipped them, and counted the skips. This PR labels them and lifts them.

## The cake chain survived, and the evidence says it was always going to

The risk was workflow 2 — `cake_pb_cp` re-derives the `.opb` from the `.scp` and
`opbdiff --match-labels` compares. Probed before changing anything, with
`cake_pb_cp` on `PATH`:

```
$ cake_pb_cp less_equal_sat.scp
@c[_1] 1 i[Y][b0] 2 i[Y][b1] -1 i[X][b0] -2 i[X][b1] >= 0 ;
$ glasgow_scp_solver --all --prove less_equal_sat.scp   # before
       -1 i[X][b0] -2 i[X][b1] 1 i[Y][b0] 2 i[Y][b1] >= 0;
```

**Cake was already using the label we were omitting.** Same for `less_than`,
`greater_equal`, `greater_than` and each one's `_if` spelling; the `_iff`
spelling comes back as `@c[_1][r]` / `@c[_1][f]`, which the solver already
emitted. So labelling moved our `.opb` *towards* cake's.

All **157 `scp_chain_*` ctest cases pass the full verified chain** (cake
re-derives, VeriPB elaborates our proof against that, cake re-checks the
elaborated core, `opbdiff` compares by label), before and after — including the
ten comparison-carrying cases and the many that use comparisons internally
(`increasing`, `lex_*`, `all_equal`, `seq_precede_chain`, …). The `.opb` byte
diff is one added token per comparison row.

### The exact blast radius, measured

`tools/opb_snapshot.bash` over **all 91 example snapshots**, against #593:
**510 rows change across 8 files, and every one of them is a `@c[...]` label
prepended to a previously-unlabelled row.** No row's terms, no row's
right-hand side and no row's order changes; nothing else in the tree differs.
(Two files are new — the `--donor=comparison` registrations this PR adds.)

That includes `examples/rcpsp`, which is in the proof benchmark set (#632,
#633), so it is worth stating explicitly rather than leaving to the aggregate:
**`rcpsp_deadline.opb` gains exactly one token**, on the row for the single
`LessThanEqual{makespan, deadline}` that `--deadline` posts. `rcpsp.opb` and
`rcpsp_split.opb` are untouched, because neither posts a `Comparison`. The
benchmark contract is about search, and that is unaffected: all ten of #638's
published rows reproduce their `horizon`, `status`, `makespan`, `recursions`
and `propagations` exactly at this tip.

## What the new donors buy

`difference_chain --donor=comparison` posts the identical system as
`LessThanEqual{a, b + d}`. Release, `--order=unlucky`, `taskset`-pinned, medians
of 3; `.pbp` sizes from a separate `--prove` run. `recursions` is identical
within each `(mode, n, k)`, so none of this is search-shape noise.

| mode | n | k | donor | presolver | propagations | time (s) | `.pbp` |
|---|---:|---:|---|---|---:|---:|---:|
| fixpoint | 300 | 2 | linear | off | 13,772,252 | 0.2811 | 76.1 MB |
| fixpoint | 300 | 2 | linear | on | 183,007 | 0.0604 | 753 kB |
| fixpoint | 300 | 2 | **comparison** | off | 13,682,852 | 0.8558 | 123.0 MB |
| fixpoint | 300 | 2 | **comparison** | on | **137,558** | **0.0522** | **1.57 MB** |
| refute | 100 | 4 | **comparison** | off | 2,148,034 | 0.1350 | 76.2 MB |
| refute | 100 | 4 | **comparison** | on | **5,253** | **0.0039** | **11.8 kB** |
| refute | 40 | 8 | **comparison** | off | 316,203 | 0.0205 | 25.6 MB |
| refute | 40 | 8 | **comparison** | on | **903** | **0.00059** | **8.1 kB** |

99.5× the propagations, 16.4× the wall time, 78× the proof at `n = 300`;
**6,448×** the proof on `--mode=refute`. Larger than the linear spelling in every
column, because with the presolver off the comparison spelling is 2.2–3.3×
slower and 1.6–1.9× larger in proof *at the same propagation count* — its
propagator is simply the more expensive one to leave running. With
`--disable-donors` the two spellings converge exactly (307 propagations either
way at `n = 300`), which is the subsumption claim measured.

## What is still skipped, and why

`Iff` cannot be lifted: its halves carry the roles `r` and `f`, neither of which
is the row cited. `MustNotHold` and `NotIf` **could** be — their rows state the
integer negation and go out under the same empty role — so they are a deliberate
gap, counted in `skipped_reified`: nothing in gcs constructs a comparison with
either (no user-facing class, and `s_expr()` throws on both), and the linear
family leaves its own equally-citable `MustNotHold` row on the floor too, so
closing it is one follow-up for both families rather than an asymmetry
introduced here.

## Testing, and what each guard actually catches

A presolver that lifts nothing passes solution-equivalence, the OPB byte-diff
and VeriPB, so the "it fired" assertions are the only checks with power — and
the comparison family can regress on its own, since a comparison-only model
would still lift no linears and still look busy. So `comparison_edges_lifted` is
broken out and asserted, and the whole fixture corpus is run in **five donor
spellings** (`1*x + -1*y <= d`, `x <= y + d`, `x < y + d + 1`, `y + d >= x`, and
an alternating mixture) with the same expected counts each time.

Mutation-tested (`✓` = caught):

| mutation | detection | equivalence | tripwire | opb | proofs |
|---|:-:|:-:|:-:|:-:|:-:|
| comparison loop lifts nothing | ✓ | ✓ | ✓ | ✓ | ✓ |
| comparison edge inverted | ✓ | ✓ | ✓ | | ✓ |
| strictness dropped | ✓ | ✓ | ✓ | | ✓ |
| half-reified condition dropped | ✓ | ✓ | ✓ | | ✓ |
| `Iff` lifted as though it were `If` | ✓ | | | | |
| negated view approximated, not refused | ✓ | ✓ | ✓ | | ✓ |
| rows emitted unlabelled again | | | | ✓ | ✓ |

Two rows matter. Lifting an `Iff` as an `If` changes no solution and trips no
proof — the `skipped_reified` count is the whole guard. And un-labelling is
caught only by the new `.opb` label check (which posts one comparison of each
reification form and counts `@c[`-prefixed rows) and by VeriPB, which is why
that check exists rather than being left implicit in "the proofs pass".

## Two leftovers from PR #584's review

**The view-wrap sweep, run for the first time on this constraint.**
`difference_test` now threads a `ViewWrapConfig`, registered for the seven
data-driven modes. Ten of the nineteen wraps negate and the constraint refuses a
negated operand by design; rather than skipping those, the test inverts its
obligation and asserts the throw, turning ten-nineteenths of the sweep from a
hole into a check that the rejection is *total*. **763 cases, all passing**:
3,880 rejection checks and 5,296 solve-and-verify fixture instances. No defect
found.

**Extreme weights.** A wrapped path sum would turn an enormous positive distance
negative — a negative cycle that does not exist, so a satisfiable system refuted,
and proof logging could not catch it, because nothing wrong would have been
derived from the model's rows. `Integer` is overflow-checked, so the new test
demands the throw: two chained edges of `-(LLONG_MAX/2 + 1)` must raise
`IntegerOverflow`, and a single vacuous edge of `LLONG_MAX/4` must give the right
answer. Mutation check: shrinking the weights so the sum fits makes it fail.

## Checks

`ctest --preset release -j 8`: **574/574 pass**. Sanitize: affected targets
built and their 212 tests pass, including 270 VeriPB verifications in the
presolver's proofs mode. clang-format 21. `dev_docs/frontend-support-matrix.md`
needed no change (it does not mention difference logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lx8KBTVNSg44EEcVYcBoN
