### PR TITLE
Make the Sanitize build type actually sanitize, and cover the frontends

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -94,15 +94,26 @@ jobs:
     - name: Install VeriPB using cargo
       run: cargo install --path ./VeriPB
 
+    - name: Install MiniZinc bundle (Linux)
+      # Same bundle as the build lanes above. Without it every minizinc-* test
+      # skips (exit 66), so the frontend would be built under the sanitizers but
+      # never actually run under them.
+      run: |
+        sudo apt-get update && sudo apt-get install -y libegl1 libgl1
+        mkdir -p "$HOME/minizinc"
+        curl -fsSL https://github.com/MiniZinc/MiniZincIDE/releases/download/2.9.7/MiniZincIDE-2.9.7-bundle-linux-x86_64.tgz \
+          | tar xz -C "$HOME/minizinc" --strip-components=1
+        mzn="$(find "$HOME/minizinc" -name minizinc -type f | head -1)"
+        dirname "$mzn" >> "$GITHUB_PATH"
+        "$mzn" --version
+
     - name: Configure CMake (Sanitize)
       run: cmake --preset sanitize -B ${{github.workspace}}/build-sanitize
 
     - name: Build (Sanitize)
       run: cmake --build ${{github.workspace}}/build-sanitize --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 
+    # Run through the test preset rather than repeating its environment here, so a
+    # local `ctest --preset sanitize` and this lane run with the same options.
     - name: Test (Sanitize)
-      working-directory: ${{github.workspace}}/build-sanitize
-      run: ctest -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu) --output-on-failure --rerun-failed
-      env:
-        ASAN_OPTIONS: detect_leaks=1:halt_on_error=1
-        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+      run: ctest --preset sanitize -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu) --rerun-failed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,15 @@ cmake -S . -B build
 cmake --build build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 ```
 
+The per-configuration flags at the top of `CMakeLists.txt` are plain `set()` calls,
+not `set(... CACHE ...)`, and must stay that way: a cached `set()` there is a silent
+no-op, because `project()` has already created those cache entries. That is how the
+Sanitize build spent months containing no sanitizers (issue #597). Do not "tidy" them
+back into cache variables — `sanitizers_enabled_test` and a configure-time check will
+both object, and `-DCMAKE_CXX_FLAGS_SANITIZE=...` on the command line has no effect
+either way. `grep`ping `CMakeCache.txt` for these tells you nothing; check
+`build-sanitize/gcs/CMakeFiles/*.dir/flags.make` instead.
+
 Use `--parallel N` for parallel builds. The expression `$(nproc 2>/dev/null || sysctl -n
 hw.logicalcpu)` gives the CPU count on both Linux and macOS. Omitting the count causes
 `make` to spawn unlimited jobs, which exhausts memory. If the build fails and the error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,24 +29,69 @@ endif()
 # on top of the always-on flags set below.  They are GCC/Clang syntax, so on MSVC we
 # leave CMake's own sane per-config defaults (/O2 for Release, /Od /Zi for Debug) in
 # place instead.  The Sanitize configuration is GCC/Clang-only.
+#
+# These are plain set() calls, deliberately, and the reason is worth spelling out
+# because the obvious-looking alternative is silently broken (issue #597).
+#
+# CMake has two kinds of variable.  A *cache* variable is written into
+# CMakeCache.txt, persists across configures, and is what -D on the command line
+# sets.  A *normal* variable lives only for this configure run, and takes
+# precedence over a cache entry of the same name for the rest of the run.
+#
+# `set(FOO "value" CACHE STRING "help")` means "put this in the cache **if it is
+# not there already**" -- it is a defaulting operation, not an assignment, and it
+# does nothing at all, without a word of warning, when the entry already exists.
+# By the time this file runs, project() has already run the compiler-setup modules,
+# and those create a CMAKE_CXX_FLAGS_<CONFIG> cache entry for every configuration:
+# the standard ones get CMake's defaults (Release "-O3 -DNDEBUG", Debug "-g"), and
+# since CMake 4.2 our custom Sanitize configuration gets an *empty* one.  So every
+# cached set() below was a no-op.  For Release and Debug that went unnoticed, because
+# CMake's defaults are close enough to what we wanted; for Sanitize it meant compiling
+# with no flags whatsoever -- no -fsanitize=..., no sanitizers in the binaries, and a
+# CI lane that had been reporting "sanitize clean" for months without ever running a
+# sanitizer.
+#
+# A plain set() has no such conditional behaviour: it always assigns, and shadows
+# whatever CMake put in the cache.  The trade-off is that -DCMAKE_CXX_FLAGS_DEBUG=...
+# on the command line no longer reaches the compiler -- but it never did, so nothing
+# is lost.  To add flags to a build, use CMAKE_CXX_FLAGS, which is applied to every
+# configuration ahead of these and is unaffected; to change what a build type *means*,
+# edit it here.  The guard further down, and sanitizers_enabled_test, exist so that
+# if this ever silently stops working again the build says so instead of pretending.
+#
+# One consequence to know about when checking a build: CMakeCache.txt keeps CMake's
+# own (for Sanitize, empty) entries, because nothing writes to the cache any more, so
+# grepping the cache tells you nothing about the flags in use.  The build files are
+# the truth -- `grep CXX_FLAGS build-sanitize/gcs/CMakeFiles/*.dir/flags.make`, or
+# just run sanitizers_enabled_test, which asks the compiler itself.
 if(NOT MSVC)
     # Release: full optimisation, no sanitizers.  -march=native is added later after the
-    #   compiler capability check.  We omit -DNDEBUG deliberately because the codebase does
-    #   not use assert(), so it buys nothing while making behaviour harder to reason about.
-    set(CMAKE_CXX_FLAGS_RELEASE         "-O3"
-        CACHE STRING "Flags for release builds")
+    #   compiler capability check.  -DNDEBUG is here because gch::small_vector -- which
+    #   backs IntervalSet, and so is on the hottest path in the solver -- asserts on
+    #   erase(), pop_back() and friends.  Our own code has no runtime assert() at all, so
+    #   this comment used to say NDEBUG bought nothing and was deliberately omitted; the
+    #   omission never actually took effect (see above), and it would not have been free.
+    set(CMAKE_CXX_FLAGS_RELEASE         "-O3 -DNDEBUG")
     # Debug: disable optimisation so the debugger can follow every step.
-    set(CMAKE_CXX_FLAGS_DEBUG           "-O0"
-        CACHE STRING "Flags for debug builds")
+    set(CMAKE_CXX_FLAGS_DEBUG           "-O0")
     # Sanitize: light optimisation keeps stack traces readable; -O0 is too slow and hides
     #   inlining bugs.  ASan + UBSan together catch memory errors and undefined behaviour.
-    set(CMAKE_CXX_FLAGS_SANITIZE
-        "-O1 -fsanitize=address,undefined -fno-omit-frame-pointer"
-        CACHE STRING "Flags for sanitizer builds (ASan + UBSan)")
-    set(CMAKE_EXE_LINKER_FLAGS_SANITIZE    "-fsanitize=address,undefined"
-        CACHE STRING "Linker flags for sanitizer builds")
-    set(CMAKE_SHARED_LINKER_FLAGS_SANITIZE "-fsanitize=address,undefined"
-        CACHE STRING "Linker flags for sanitizer builds")
+    set(CMAKE_CXX_FLAGS_SANITIZE           "-O1 -fsanitize=address,undefined -fno-omit-frame-pointer")
+    set(CMAKE_EXE_LINKER_FLAGS_SANITIZE    "-fsanitize=address,undefined")
+    set(CMAKE_SHARED_LINKER_FLAGS_SANITIZE "-fsanitize=address,undefined")
+
+    # A sanitizer build that quietly stops sanitizing is worse than not having one,
+    # so fail the configure rather than hand back a build that only looks instrumented.
+    # This catches the flags going missing however it happens: the shadowing above
+    # breaking again, someone reintroducing a cached set(), or a future CMake changing
+    # the rules once more.  sanitizers_enabled_test then checks the other end, that the
+    # flags actually reached the compiler and are present in the binaries.
+    if(CMAKE_BUILD_TYPE STREQUAL "Sanitize" AND NOT CMAKE_CXX_FLAGS_SANITIZE MATCHES "fsanitize")
+        message(FATAL_ERROR
+            "Sanitize build type selected but CMAKE_CXX_FLAGS_SANITIZE (\"${CMAKE_CXX_FLAGS_SANITIZE}\") "
+            "carries no -fsanitize flag, so this build would contain no sanitizers. "
+            "Fix the flag handling in CMakeLists.txt; see issue #597.")
+    endif()
 endif()
 
 option(GCS_ENABLE_DOXYGEN "Add a doxygen target to generate the documentation" OFF)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,9 +22,7 @@
             "displayName": "Sanitize (ASan + UBSan)",
             "binaryDir": "${sourceDir}/build-sanitize",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Sanitize",
-                "GCS_ENABLE_XCSP": "OFF",
-                "GCS_ENABLE_MINIZINC": "OFF"
+                "CMAKE_BUILD_TYPE": "Sanitize"
             }
         }
     ],

--- a/README.md
+++ b/README.md
@@ -110,14 +110,19 @@ ctest --preset release          # using presets
 { cd build ; ctest ; }          # without presets
 ```
 
-For a sanitizer test run, set the following environment variables so that the first error
-halts the process with a useful backtrace rather than continuing:
+For a sanitizer test run, use the preset:
 
 ```shell
-ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
-UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
 ctest --preset sanitize
 ```
+
+It sets `ASAN_OPTIONS` and `UBSAN_OPTIONS` so that the first error halts the process with a
+useful backtrace rather than continuing.
+
+The `xcsp_*` tests additionally run with `lsan_suppressions.txt`, which exists for one
+thing: the XCSP3 parser we fetch from upstream never frees the variables it allocates, so
+without it those tests report a leak in code we do not own and cannot fix. Leak detection
+stays on for everything else, including the rest of those same test runs.
 
 ### Optional features
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ cmake --build build --parallel $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 The sanitize build runs the code under [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
 and [UndefinedBehaviourSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html),
 which catch memory errors and undefined behaviour at runtime. It is roughly 2× slower than
-release and is run automatically on every check-in.
+release and is run automatically on every check-in. `sanitizers_enabled_test` fails if a
+Sanitize build was somehow compiled without them, because a sanitizer build that quietly
+stops sanitizing is worse than not having one.
 
 ### Running the tests
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -160,6 +160,19 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(stacktrace_logging_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME stacktrace_logging_test COMMAND $<TARGET_FILE:stacktrace_logging_test>)
 
+    # The Sanitize counterpart of stacktrace_logging_test: it fails if a Sanitize
+    # build was compiled without the sanitizers it is named after (issue #597).
+    # This test unit is compiled with the same configuration-wide flags as the
+    # library, so what it sees is what the library got. GCS_CONFIG_IS_SANITIZE is
+    # what tells it to expect them; in any other configuration, and on MSVC where
+    # the Sanitize build type is not supported at all, the test trivially passes.
+    add_executable(sanitizers_enabled_test sanitizers_enabled_test.cc)
+    target_link_libraries(sanitizers_enabled_test PRIVATE Catch2::Catch2WithMain)
+    if(NOT MSVC)
+        target_compile_definitions(sanitizers_enabled_test PRIVATE $<$<CONFIG:Sanitize>:GCS_CONFIG_IS_SANITIZE>)
+    endif()
+    add_test(NAME sanitizers_enabled_test COMMAND $<TARGET_FILE:sanitizers_enabled_test>)
+
     add_executable(problem_test problem_test.cc)
     target_link_libraries(problem_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME problem_test COMMAND $<TARGET_FILE:problem_test>)

--- a/gcs/presolvers/auto_table.cc
+++ b/gcs/presolvers/auto_table.cc
@@ -39,7 +39,12 @@ namespace
         if (this_branch_guess)
             guesses.push_back(*this_branch_guess);
         if (propagators.propagate(guesses, state, logger)) {
-            auto brancher = branch_callback(state.current(), propagators);
+            // As in solve_with_state: the brancher is a coroutine, so it only stores
+            // this reference now and reads it when begin() resumes it. State::current()
+            // returns by value, so the CurrentState has to be a named local that
+            // outlives the generator rather than a temporary that dies on this line.
+            auto current_state = state.current();
+            auto brancher = branch_callback(current_state, propagators);
             auto branch_iter = brancher.begin();
             if (branch_iter == brancher.end()) {
                 vector<Integer> tuple;

--- a/gcs/sanitizers_enabled_test.cc
+++ b/gcs/sanitizers_enabled_test.cc
@@ -1,0 +1,57 @@
+#include <catch2/catch_test_macros.hpp>
+
+// Guards the Sanitize build type against silently containing no sanitizers.
+//
+// This is not a hypothetical. Under CMake 4.2 the cached set() that supplied
+// -fsanitize=address,undefined was a no-op, so `cmake --preset sanitize` built
+// an ordinary -O1 tree and the CI lane reported "sanitize clean" for months
+// without a sanitizer ever running (issue #597). Nothing warned: the flags were
+// simply absent. The top-level CMakeLists.txt now fails the configure if
+// CMAKE_CXX_FLAGS_SANITIZE has lost its -fsanitize flag; this test checks the
+// far end of the same chain, that the flag actually reached the compiler.
+//
+// GCS_CONFIG_IS_SANITIZE is defined by gcs/CMakeLists.txt only for the Sanitize
+// configuration on non-MSVC compilers, so in every other build this file compiles
+// to a test that trivially passes.
+//
+// The compiler tells us what it was asked to instrument in two different ways:
+// clang, and GCC from 14 onwards, answer __has_feature(); older GCC only defines
+// __SANITIZE_ADDRESS__. Accept either. UBSan has no __SANITIZE_UNDEFINED__
+// equivalent, so it can only be checked where __has_feature() exists -- but both
+// sanitizers come from the same -fsanitize=address,undefined flag, so ASan being
+// present already establishes that the flag arrived intact.
+
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define GCS_ASAN_PRESENT
+#endif
+#if __has_feature(undefined_behavior_sanitizer)
+#define GCS_UBSAN_PRESENT
+#endif
+#define GCS_UBSAN_DETECTABLE
+#endif
+
+#if defined(__SANITIZE_ADDRESS__) && ! defined(GCS_ASAN_PRESENT)
+#define GCS_ASAN_PRESENT
+#endif
+
+TEST_CASE("A Sanitize build really is built with sanitizers")
+{
+#if ! defined(GCS_CONFIG_IS_SANITIZE)
+    SUCCEED("not a Sanitize build, nothing to check");
+#else
+#if ! defined(GCS_ASAN_PRESENT)
+    FAIL("This is a Sanitize build, but AddressSanitizer is not compiled in: the "
+         "-fsanitize=address,undefined flag never reached the compiler. Everything "
+         "this build type exists to catch is going undetected, and every result from "
+         "it is meaningless. Fix the flag handling in CMakeLists.txt -- do not relax "
+         "this test. See issue #597 for how it happened last time.");
+#elif defined(GCS_UBSAN_DETECTABLE) && ! defined(GCS_UBSAN_PRESENT)
+    FAIL("This is a Sanitize build with AddressSanitizer but without "
+         "UndefinedBehaviorSanitizer, so undefined behaviour is going undetected. "
+         "Restore ,undefined in CMAKE_CXX_FLAGS_SANITIZE in CMakeLists.txt.");
+#else
+    SUCCEED("sanitizers are compiled in");
+#endif
+#endif
+}

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -115,7 +115,14 @@ namespace
                 if (optional_abort_flag && optional_abort_flag->load())
                     return SearchResult::Stop;
 
-                auto branch_generator = branch_callback(state.current(), propagators);
+                // The branchers in search_heuristics.cc are coroutines, so calling
+                // branch_callback only builds the frame: the CurrentState reference is
+                // stored, and nothing reads it until begin() resumes the coroutine on
+                // the next line. State::current() returns by value, so a temporary here
+                // would be dead by then -- it works only for as long as nothing reuses
+                // that stack slot. Bind it to a local that outlives the generator.
+                auto current_state = state.current();
+                auto branch_generator = branch_callback(current_state, propagators);
                 auto branch_iter = branch_generator.begin();
 
                 if (branch_iter == branch_generator.end()) {

--- a/lsan_suppressions.txt
+++ b/lsan_suppressions.txt
@@ -1,0 +1,18 @@
+# LeakSanitizer suppressions for the sanitize build.
+#
+# Point LeakSanitizer at this file with LSAN_OPTIONS=suppressions=<path to this
+# file>; the sanitize test preset and the CI lane both do. A frame matches if the
+# pattern appears anywhere in its demangled function name, source file or module,
+# and one matching frame suppresses the whole leak report.
+#
+# Keep this list to leaks in code we do not own and cannot fix. Anything we can fix
+# should be fixed, not listed here -- every entry below is coverage given up.
+
+# The XCSP3 parser (fetched from xcsp3team/XCSP3-CPP-Parser) allocates an XVariable
+# per variable in XMLParser::VarTagAction::beginTag/endTag -- XMLParserTags.cc:126
+# and :151 -- and never frees them, so every xcsp_* test reports a few hundred bytes
+# leaked before it has run any of our code. It is a FetchContent dependency pinned to
+# an upstream commit, so there is nothing to fix on our side. Suppressing just this
+# leaves leak detection on for everything else in those same test runs, which is the
+# part we actually care about.
+leak:XCSP3Core::XMLParser

--- a/xcsp/CMakeLists.txt
+++ b/xcsp/CMakeLists.txt
@@ -19,6 +19,13 @@ target_link_libraries(xcsp_glasgow_constraint_solver PRIVATE
 # instance and diffs the streamed solutions against a cached expected
 # output committed under tests/expected/<name>.sols. If the cache is
 # missing, the test skips (ctest exit code 66) rather than failing.
+#
+# Under the sanitize build these tests would also report a leak that is not ours:
+# the parser allocates an XVariable per variable and never frees them, so point
+# LeakSanitizer at the suppressions file that ignores exactly that (and nothing
+# else) and leave leak detection on for the rest of the run. Setting it here rather
+# than in the sanitize test preset means it applies however ctest is invoked, and
+# only to the tests that need it. LSAN_OPTIONS is inert in a non-sanitizer build.
 function(add_xcsp_test name)
     add_test(NAME xcsp_${name}
         COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/xcsp/run_xcsp_test.bash
@@ -26,7 +33,8 @@ function(add_xcsp_test name)
             ${CMAKE_SOURCE_DIR}/xcsp/tests/
             ${name})
     set_tests_properties(xcsp_${name} PROPERTIES
-        SKIP_RETURN_CODE 66)
+        SKIP_RETURN_CODE 66
+        ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/lsan_suppressions.txt:print_suppressions=0")
 endfunction()
 
 add_xcsp_test(all_different_matrix)


### PR DESCRIPTION
Fixes #597. Also fixes #599, which has to be in the same PR: the moment the
sanitizers become real, every solve trips over a dangling reference, so the lane
cannot go green without it.

## What was wrong, in one paragraph of CMake

CMake has two kinds of variable. A **cache** variable is the persistent kind that
lives in `CMakeCache.txt` and that `-D` on the command line sets. A **normal**
variable exists only for the current configure run, and hides any cache entry of
the same name for the rest of that run.

`set(FOO "value" CACHE STRING "help")` does not mean "set FOO". It means "put FOO
in the cache **if it is not there already**" — a defaulting operation. If the entry
already exists, the call does nothing whatsoever, and says nothing about it.

By the time our `CMakeLists.txt` runs, `project()` has already run CMake's
compiler-setup modules, and those create a `CMAKE_CXX_FLAGS_<CONFIG>` cache entry
for every configuration — including, since CMake 4.2, an empty one for our custom
`Sanitize`. So the three cached `set()` calls that supplied
`-fsanitize=address,undefined` were no-ops, and `cmake --preset sanitize` has been
producing an ordinary `-O1` build with no sanitizers in it.

The fix is to drop `CACHE STRING` and use a plain `set()`, which always assigns and
shadows the cache entry. The cost is that `-DCMAKE_CXX_FLAGS_SANITIZE=...` on the
command line is ignored — but it was already being ignored, so nothing is lost. The
comment in the file now explains all of the above at length, because the broken
spelling is the one that looks right, and the next person to tidy it up needs to
know why not to.

One gotcha that survives the fix: `CMakeCache.txt` still shows the empty entry,
because nothing writes to the cache any more. The reproduction recipe in the issue
will keep "reproducing". The build files are the truth
(`grep CXX_FLAGS build-sanitize/gcs/CMakeFiles/*.dir/flags.make`), or just run the
new test.

### Release and Debug were being dropped the same way

Unnoticed, because CMake's own defaults are close to ours. Debug is unaffected in
practice (`-O0` is the default anyway, and `-g3` is added separately). Release was
compiling with CMake's `-O3 -DNDEBUG` rather than the `-O3` the comment above it
described — **and I have kept `-DNDEBUG` rather than "restoring" the documented
intent.** That comment's reasoning was that we have no runtime `assert()` of our
own, which is true, but `gch::small_vector` has 22 of them, including in `erase()`
and `pop_back()`, and it backs `IntervalSet`. Dropping NDEBUG would put those on
the solver's hottest path. So Release compiles with exactly the flags it has been
getting all along; only the comment changes. Shout if you'd rather have it the
other way — it is one word.

## Guarding it, because the failure mode is silence

Two checks, at opposite ends of the chain:

- the **configure fails outright** if a `Sanitize` build has no `-fsanitize` flag,
  however that happens — the shadowing breaking again, someone reintroducing a
  cached `set()`, a future CMake changing the rules once more;
- **`sanitizers_enabled_test`** asks the compiler itself, via `__has_feature()` /
  `__SANITIZE_ADDRESS__`, whether ASan and UBSan actually got compiled in. I
  checked that it fails when it should, not merely that it passes today: built
  with the config define but without the flags, it fails with the message telling
  you to fix the flags rather than the test.

## The frontends

The preset also had `GCS_ENABLE_XCSP=OFF` and `GCS_ENABLE_MINIZINC=OFF`, so
`xcsp/` and `minizinc/` had never been sanitized by any route. They are on now.

You were right that "roughly doubles the build" was a big overestimate. On a
32-core machine:

- **10 extra translation units**, 358 → 368.
- **+103 s of CPU** (98.2 user + 4.9 sys) to enable both on an already-built tree,
  against roughly 4100 s for the build as a whole — about 2.5%. Clean builds
  either way put it at about +4%; run-to-run wall-clock noise on a loaded machine
  is larger than the difference, so the incremental figure is the trustworthy one.

Two things did get in the way, and both are handled here rather than left as
tripwires:

**The upstream parser leaks**, as you found. `XMLParser::VarTagAction::endTag`
allocates an `XVariable` per variable and never frees it — 12 allocations, 432
bytes, on `all_equal.xml` — before any of our code runs. It is a FetchContent
dependency pinned to an upstream commit, so there is nothing for us to fix.
`lsan_suppressions.txt` ignores exactly those frames, in preference to
`detect_leaks=0`, which would give up leak detection for our own code in those same
runs. It is attached to the `xcsp_*` tests rather than to the test preset, so it
applies however `ctest` is invoked and only where it is needed. Verified both ways:
the leak reports without it, and LSan confirms the suppression firing with it.

**MiniZinc tests skip when `minizinc` is not on PATH**, so the lane gets the same
bundle install the build lanes have — otherwise the frontend would be built under
the sanitizers but never actually run under them, which would have been an
expensive way to achieve nothing. While there, the lane now runs
`ctest --preset sanitize` rather than repeating the sanitizer environment inline.

XCSP needs libxml2, but the existing `ubuntu-26.04` lane already builds the XCSP
frontend with no install step, so the runner image supplies it.

## Testing

Everything below on Ubuntu, GCC 15.2, 32 cores, on this branch.

**The whole suite, under sanitizers that are actually there: 536/536 pass, none
skipped, 115 s wall at `-j 32`.** As far as I can tell that is the first time the
test suite has ever run under ASan + UBSan.

**The frontend tests are indeed fast.** 110 of them, 260 s of the suite's 2364 s
of aggregate test time (11%), averaging 2.4 s each; the slowest is well under the
100 s that several `linear_constraint_*` tests take. The CI lane will get slower,
but from the sanitizers becoming real, not from the frontends.

Checks that the new guards actually fire, rather than passing vacuously:

- `sanitizers_enabled_test` compiled with the config define but without the
  sanitizer flags: fails, with the message pointing at `CMakeLists.txt` rather
  than at itself.
- the configure guard with an empty `CMAKE_CXX_FLAGS_SANITIZE`: `FATAL_ERROR`;
  with real flags, or in Release: quiet.
- the leak suppression: `xcsp_glasgow_constraint_solver all_equal.xml` reports
  `Direct leak of 240 byte(s)` in `VarTagAction::endTag` without it, and exits 0
  with it, LSan reporting `12 allocations, 432 bytes` suppressed under
  `print_suppressions=1`.
- #599 reverted in an otherwise identical tree: `solve_test` dies immediately on
  `stack-use-after-scope` at `solve.cc:119`, read by `CurrentState::each_value`
  through the resumed coroutine. Which is also a decent demonstration that the
  repaired lane is doing something.

## Reading it

Three commits, in dependency order: the dangling reference first, so the tree is
sanitizer-clean before the sanitizers become real; then the flags; then the
frontends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lx8KBTVNSg44EEcVYcBoN
