### PR TITLE
Difference presolver: drop the runtime enumeration self-audit

### DIFF
--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -771,13 +771,13 @@ not, the subsumption claim would be wrong.
 ### Why the tests assert on counts
 
 The presolver is invisible from the outside. A version that silently lifted
-nothing — because, say, `clone()` stopped flattening a posted
-`LinearLessThanEqual` to `ReifiedLinearInequality`, so
-`each_constraint_of_type<ReifiedLinearInequality>()` no longer matched it —
-would pass **every** validation we would otherwise write: solution-set
-equivalence (a no-op presolver preserves solutions), the OPB byte-diff
-(byte-identical is the *expected* result), and VeriPB (there would be nothing
-new to check).
+nothing — because, say, `clone()` started returning a type from outside the
+`ReifiedLinearInequality` family, so
+`each_constraint_of_type<ReifiedLinearInequality>()` no longer matched a posted
+`LinearLessThanEqual` — would pass **every** validation we would otherwise
+write: solution-set equivalence (a no-op presolver preserves solutions), the OPB
+byte-diff (byte-identical is the *expected* result), and VeriPB (there would be
+nothing new to check).
 
 So the presolver reports what it did in `DifferenceLogicStats`, and three
 things guard it:
@@ -785,17 +785,37 @@ things guard it:
 - `static_assert`s in `run()` pinning the class relationships the enumeration
   relies on, so a hierarchy change is a compiler error at the site that needs
   fixing;
-- a **runtime cross-check** of the typed enumeration against
-  `Constraint::constraint_type()`, which does not depend on the hierarchy at all:
-  if more constraints report `lin_less_equal` than the typed enumeration
-  yielded, the presolver throws;
-- assertions on the counts, and the propagation-count differential below.
+- `gcs/constraint_enumeration_test.cc`, which posts one of every member of both
+  families and requires the base enumeration to recover each with the arguments
+  posted. That is the contract this presolver rests on, stated where anyone
+  else's presolver can rely on it too;
+- assertions on the counts here, and the propagation-count differential below.
 
 Every one of those failure messages names the invariant and says explicitly not
-to update the expectation. Mutation-tested: asking for `LinearLessThanEqual`
-instead of `ReifiedLinearInequality` — the exact regression being defended
-against — trips the cross-check, and with the cross-check also disabled all four
-test modes fail, each naming the presolver.
+to update the expectation. Mutation-tested: asking the enumeration for
+`LinearLessThanEqual` instead of `ReifiedLinearInequality` — a stand-in for the
+regression being defended against, since it makes the enumeration yield nothing
+in exactly the same way — fails all five presolver test modes, each naming the
+presolver. (That mutation is local to the presolver, so it does not disturb
+`constraint_enumeration_test`; the real regression, which is in `clone()`, would
+fail that one first.)
+
+There is deliberately **no runtime self-audit**. An earlier version cross-checked
+the typed enumeration against `Constraint::constraint_type()` on every run, and
+threw if more constraints reported `lin_less_equal` than the enumeration yielded.
+It went, for four reasons. Whether the enumeration works is a property of gcs's
+own types, fixed when gcs is compiled, so nothing about a user's model can change
+the answer — checking it per solve, on the user's data, is the wrong place, which
+is exactly the distinction the `static_assert`s get right. The scenario it named
+could not happen: `each_constraint_of_type` is a `dynamic_cast`, so asking for the
+base matches whatever a family member clones to, flattened or not. It could decay
+into a no-op in precisely the way it existed to prevent, since the by-type count
+turns to zero if the `constraint_type()` string is ever renamed, and `0 > seen` is
+false — and in production you cannot fix that by requiring a non-zero count,
+because a model legitimately may contain no linears, while in a test with a known
+corpus you can. And the failure it guarded is a performance regression, not an
+unsound one: lifting nothing leaves every answer correct, which does not warrant
+throwing out of a user's solve.
 
 The comparison family gets the same treatment, and needs it more, because it can
 regress *on its own*: a model built entirely out of `x <= y + d` whose comparison

--- a/gcs/presolvers/difference_logic/difference_logic.cc
+++ b/gcs/presolvers/difference_logic/difference_logic.cc
@@ -3,7 +3,6 @@
 #include <gcs/constraints/linear/linear_greater_than_equal.hh>
 #include <gcs/constraints/linear/linear_inequality.hh>
 #include <gcs/constraints/linear/linear_less_than_equal.hh>
-#include <gcs/exception.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/presolvers/difference_logic/difference_logic.hh>
 #include <gcs/problem.hh>
@@ -31,61 +30,11 @@ using std::nullopt;
 using std::optional;
 using std::shared_ptr;
 using std::size_t;
-using std::string;
-using std::to_string;
 using std::unique_ptr;
 using std::vector;
 
 namespace
 {
-    // The type strings the two donor families report. Constraint::constraint_type()
-    // is total and independent of the C++ class hierarchy, which is exactly what
-    // makes it usable as a cross-check on the hierarchy: see check_enumeration_is_working.
-    const string linear_inequality_type = "lin_less_equal";
-
-    auto is_comparison_type(const string & t) -> bool
-    {
-        return t == "less_than" || t == "less_equal" || t == "greater_than" || t == "greater_equal";
-    }
-
-    // The failure this exists to catch is a silent one, so it says so at length.
-    // Problem stores what Constraint::clone() returns, and every member of these
-    // families currently clones to its family base, which is why asking for the
-    // base is what finds a posted LinearLessThanEqual. If that ever stops being
-    // true, each_constraint_of_type<ReifiedLinearInequality>() yields nothing, the
-    // presolver lifts nothing, and *every* validation still passes: a presolver
-    // that does nothing preserves the solution set, adds no OPB content and leaves
-    // every proof verifying. So cross-check the typed enumeration against
-    // constraint_type(), which does not depend on the hierarchy at all, and fail
-    // loudly rather than quietly doing nothing.
-    auto check_enumeration_is_working(const Problem & problem, size_t linears_seen, size_t comparisons_seen) -> void
-    {
-        size_t linears_by_type = 0, comparisons_by_type = 0;
-        for (const auto & c : problem.each_constraint()) {
-            auto type = c.constraint_type();
-            if (type == linear_inequality_type)
-                ++linears_by_type;
-            else if (is_comparison_type(type))
-                ++comparisons_by_type;
-        }
-
-        auto complain = [&](const string & family, const string & base, size_t by_type, size_t seen) {
-            throw UnexpectedException{"the difference-logic presolver's constraint enumeration is broken: " + to_string(by_type) +
-                " posted constraints report a " + family + " constraint_type(), but Problem::each_constraint_of_type<" + base + ">() yielded only " +
-                to_string(seen) +
-                " of them. DETECTION is what needs fixing here, not this check. The likely cause is a change to Constraint::clone() or to the class "
-                "hierarchy, so that a posted constraint is no longer stored as its family base (see PR #585). Do NOT relax this check: a presolver "
-                "that lifts nothing still passes every solution-equivalence, OPB byte-diff and VeriPB check, so this is the only thing standing "
-                "between a silent regression and shipping. Fix gcs/presolvers/difference_logic/difference_logic.cc."};
-        };
-
-        if (linears_by_type > linears_seen)
-            complain(linear_inequality_type, "ReifiedLinearInequality", linears_by_type, linears_seen);
-        if (comparisons_by_type > comparisons_seen)
-            complain(
-                "less_than / less_equal / greater_than / greater_equal", "ReifiedCompareLessThanOrMaybeEqual", comparisons_by_type, comparisons_seen);
-    }
-
     // One OPB row of the only shape this presolver can lift: `1 * positive +
     // -1 * negative <= value`, emitted under the bare @c[<id>] label and, when
     // `cond` is engaged, under HalfReifyOnConjunctionOf on that condition.
@@ -156,9 +105,16 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
     // and for both of these families that is the base; asking for the derived
     // user-facing type is not a compile error, it simply matches nothing. If a
     // future refactor breaks these relationships, this is the place that needs
-    // to change, so fail here rather than at runtime. (The base being a base is
-    // necessary but not sufficient --- clone() must also still return it --- so
-    // check_enumeration_is_working covers the rest.)
+    // to change, so fail here rather than at runtime.
+    //
+    // These are necessary but not sufficient: each_constraint_of_type is a
+    // dynamic_cast, so asking for the base keeps working however clone()
+    // flattens within a family, but it would find nothing at all if clone()
+    // started returning a type from outside one. That residual is pinned by
+    // gcs/constraint_enumeration_test.cc, which posts one of each of these and
+    // requires the base enumeration to recover them; a change that broke it
+    // would fail there, and again on the exact counts in
+    // difference_logic_test.cc, before anything reached a user.
     static_assert(std::derived_from<LinearLessThanEqual, ReifiedLinearInequality>);
     static_assert(std::derived_from<LinearLessThanEqualIf, ReifiedLinearInequality>);
     static_assert(std::derived_from<LinearGreaterThanEqual, ReifiedLinearInequality>);
@@ -247,10 +203,7 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
         return true;
     };
 
-    size_t linears_seen = 0;
     for (const auto & c : problem.each_constraint_of_type<ReifiedLinearInequality>()) {
-        ++linears_seen;
-
         // MustHold gives a plain edge; If gives a half-reified one,
         // `cond -> x - y <= d'. Both are citable and both are the shape the
         // propagator's proofs assume: linear_inequality.cc labels the
@@ -306,10 +259,7 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
     // a separate constraint kind --- and every row
     // ReifiedCompareLessThanOrMaybeEqual emits now carries an @label, so every
     // row is citable.
-    size_t comparisons_seen = 0;
     for (const auto & c : problem.each_constraint_of_type<ReifiedCompareLessThanOrMaybeEqual>()) {
-        ++comparisons_seen;
-
         // `x <= y` states `x - y <= 0` and `x < y` states `x - y <= -1`, both
         // under the bare @c[<id>] label; the `If' form states the same row
         // under HalfReifyOnConjunctionOf on the recorded condition, and under
@@ -345,8 +295,6 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
         if (lift_row(*row, c.constraint_id()))
             ++stats.comparison_edges_lifted;
     }
-
-    check_enumeration_is_working(problem, linears_seen, comparisons_seen);
 
     stats.edges_lifted = graph.edges.size();
     stats.nodes = graph.nodes.size();

--- a/gcs/presolvers/difference_logic/difference_logic.hh
+++ b/gcs/presolvers/difference_logic/difference_logic.hh
@@ -16,8 +16,10 @@ namespace gcs
      * The presolver's whole job is invisible from the outside: it adds no OPB
      * content, changes no solution, and leaves proofs verifying whether it fired
      * or not. A presolver that silently lifted nothing --- because, say,
-     * Constraint::clone() stopped flattening a posted LinearLessThanEqual to
-     * ReifiedLinearInequality --- would pass every solution-equivalence, OPB
+     * Constraint::clone() started returning a type from outside the
+     * ReifiedLinearInequality family, so that
+     * Problem::each_constraint_of_type() no longer found a posted
+     * LinearLessThanEqual --- would pass every solution-equivalence, OPB
      * byte-diff and VeriPB check there is. So the counts are not decoration:
      * they are how the tests, and the measurements, tell "working" from
      * "no-op". \sa DifferenceLogic

--- a/gcs/presolvers/difference_logic/difference_logic_test.cc
+++ b/gcs/presolvers/difference_logic/difference_logic_test.cc
@@ -5,10 +5,9 @@
 // This presolver is invisible from the outside by design. It adds no OPB
 // content, changes no solution, and leaves every proof verifying. That means a
 // presolver which silently lifted *nothing* -- because, say, Constraint::clone()
-// stopped flattening a posted LinearLessThanEqual down to
-// ReifiedLinearInequality, so that
-// Problem::each_constraint_of_type<ReifiedLinearInequality>() no longer matched
-// it -- would pass:
+// started returning a type from outside the ReifiedLinearInequality family, so
+// that Problem::each_constraint_of_type<ReifiedLinearInequality>() no longer
+// matched a posted LinearLessThanEqual -- would pass:
 //
 //   * every solution-set equivalence check (a no-op presolver preserves them);
 //   * the OPB byte-identical check (byte-identical is the *expected* result);
@@ -88,8 +87,11 @@ namespace
                                        "The most likely cause is a change to Constraint::clone() or to the Linear or\n"
                                        "Comparison class hierarchy, such that\n"
                                        "Problem::each_constraint_of_type<ReifiedLinearInequality>() (or\n"
-                                       "<ReifiedCompareLessThanOrMaybeEqual>()) no longer yields the posted derived\n"
-                                       "constraints (clone() currently returns the family base -- see PR #585).\n\n"
+                                       "<ReifiedCompareLessThanOrMaybeEqual>()) no longer yields the posted\n"
+                                       "constraints. Enumeration is a dynamic_cast, so asking for the base survives\n"
+                                       "clone() flattening within a family, but not clone() returning a type from\n"
+                                       "outside one (see PR #585). If gcs/constraint_enumeration_test.cc is failing\n"
+                                       "too, start there: it pins that contract directly.\n\n"
                                        "Fix gcs/presolvers/difference_logic/difference_logic.cc. Do NOT update the\n"
                                        "expected count here: a presolver that lifts nothing still passes every\n"
                                        "solution-equivalence, OPB byte-diff and VeriPB check, so this assertion is the\n"


### PR DESCRIPTION
**Based on #600** (`difflogic-11-presolver-dirs`), which is this PR's base branch, so the diff shown here is only this PR's one commit. Cleanup only: no behavioural change to what the presolver lifts.

`check_enumeration_is_working` scanned every posted constraint on every run, counted those whose `constraint_type()` reported `lin_less_equal` or a comparison, and threw if that exceeded what the typed enumeration had yielded. This removes it, keeps the `static_assert`s, and corrects the comments that stated its rationale.

## Why

**It is checking a property of gcs's own types on the user's data.** Whether the enumeration works is fixed when gcs is compiled; no model can change the answer. That is what the `static_assert`s above it are for, and they get the placement right.

**The scenario it named could not arise.** `each_constraint_of_type` is a `dynamic_cast`, so asking for the base matches whatever a family member clones to, flattened or not — "`clone()` stopped flattening a posted `LinearLessThanEqual` to `ReifiedLinearInequality`" would have left the enumeration working perfectly. What *would* break it is `clone()` returning a type from outside the family, and the check catches that only if `constraint_type()` still reports the old string. Every comment repeating the old scenario (the stats doc, the test header, the dev doc) is corrected.

**It could decay into the no-op it existed to prevent.** `linear_inequality_type` is a hand-maintained magic string; rename `constraint_type()`'s output and the by-type count goes to zero, `0 > seen` is false, and the check passes silently forever. In production that hole cannot be closed by demanding a non-zero count, because a model legitimately may contain no linears. In a test with a known corpus it can — which is the argument for where this belongs.

**The failure it guarded is a performance regression, not a soundness one.** Lifting nothing leaves every answer correct. Throwing out of a user's solve over that is disproportionate — unlike the skips in `lift_row` (half-reified donors, negated views), which are soundness guards on the user's actual data and stay where they are.

## What still covers this

The concern behind the check is real: this presolver is invisible from the outside, so a version that lifted nothing passes solution-equivalence, the OPB byte-diff and VeriPB. Two things already cover it, both better:

- `gcs/constraint_enumeration_test.cc` (#585) posts one of every member of both families and requires the base enumeration to recover each with the arguments posted. That is the contract itself, with no `constraint_type()` string to fall out of date, and it serves every other presolver that relies on it.
- `difference_logic_test.cc` pins the exact lift and skip counts per fixture, plus the propagation-count differential and the "`.pbp` must differ" check.

## Verification

- Mutated the enumeration to ask for `LinearLessThanEqual`, which makes it yield nothing in exactly the way the real regression would: with the runtime check gone, **all five presolver test modes fail**, each naming the presolver and saying not to update the number. Reverted, all pass.
- Full suite 574/574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
