### PR TITLE
Look a constraint's OPB row up, instead of rebuilding its label

### DIFF
--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -630,12 +630,21 @@ The other three reification kinds are *also* difference constraints:
   stand.
 - `reif::MustNotHold` and `reif::NotIf` state the integer negation,
   `y - x <= -d-1`. For a comparison, and for a linear `MustNotHold`, that row
-  goes out under the same empty role and so *is* citable; a linear `NotIf` uses
-  the role `ltn`. These are therefore a **deliberate gap, not an
-  impossibility** — nothing in gcs constructs a comparison with either (there is
-  no user-facing class, and `s_expr()` throws on both, so they have no `.scp`
-  spelling), and closing the gap is worth doing for both donor families at once
-  rather than for one of them.
+  goes out under the same empty role and so *is* citable. These are therefore a
+  **deliberate gap, not an impossibility** — nothing in gcs constructs either
+  form of either family (there is no user-facing class, and for a comparison
+  `s_expr()` throws on both, so they have no `.scp` spelling), and closing the
+  gap is worth doing for both donor families at once rather than for one of them.
+
+  A linear `NotIf` is a special case and not a citable one. Its row goes out
+  under the role `ltn`, but what that row *says* is `cond -> sum <= value` —
+  which is the thing the constraint states must **not** hold. Nothing constructs
+  a `ReifiedLinearInequality` with `NotIf` (the six derived classes cover
+  `MustHold`, `If` and `Iff`, and `scp_reader` builds only those), so the branch
+  is unreachable and the discrepancy has never been observable; it is recorded
+  here rather than fixed because fixing an unreachable proof path belongs with
+  whatever first makes it reachable. `ConstraintProofModelData` publishes nothing
+  for it, so the presolver cannot cite it by accident.
 
 All three are counted in `skipped_reified` rather than guessed at. Two exclusions
 remain soundness requirements rather than mere incompleteness:
@@ -716,6 +725,112 @@ of each of the five reification forms and counts the `@c[`-prefixed rows in the
 `add_constraint` branch is caught by that check and by VeriPB, and by **nothing
 else**: the detection, equivalence and tripwire modes all still pass, because
 none of them looks at a proof.
+
+### Citing the donor's row: published roles, not a constructed label
+
+The presolver builds `pol`s on rows it did not emit. That is an inherent
+dependency — you cannot cite somebody else's row without depending on how they
+defined their model — so the goal is not to remove the coupling but to make it
+typed, narrow and visible from both ends.
+
+For one PR it was none of those. The presolver built the label itself:
+
+```cpp
+graph.edge_lines.push_back(ProofLineLabel{"c[" + as_string(id) + "]"});
+```
+
+which hard-codes the assumption that the donor's interesting row is the one under
+the *empty* role. That happens to be true for the two kinds the presolver lifts,
+and it is silently wrong for two of the three it does not: a comparison's
+`MustNotHold` and `NotIf` rows go out under the empty role too, and they state
+the *negated* inequality with the operands the other way round. The loop is
+correct today only because it filters on the reification condition first. Nothing
+would have caught it if that filter had ever been widened, and nothing at all
+would have caught a donor renaming its roles.
+
+Two facts make the fix small. Citation is already by label: `ProofLine` is
+`variant<ProofLineNumber, ProofLineLabel>`, so nothing needs new plumbing. And a
+label is a pure function of `(ConstraintID, role)` — clone-independent,
+thread-independent, identical in every thread by construction — where a line
+*number* is a position in a file.
+
+So the constraint publishes the role, and the tracker answers whether a row went
+out under it:
+
+```cpp
+// in the constraint's own header, beside its posted-argument accessors
+template <>
+struct innards::ConstraintProofModelData<ReifiedCompareLessThanOrMaybeEqual>
+{
+    [[nodiscard]] static auto primary_row_role(const ReifiedCompareLessThanOrMaybeEqual &) -> std::optional<std::string>;
+};
+```
+
+```cpp
+// NamesAndIDsTracker
+[[nodiscard]] auto constraint_row_label(const ConstraintID &, const std::string & role) const
+    -> std::optional<ProofLineLabel>;
+```
+
+and `Problem::each_constraint_of_type_with_proof_data` hands a presolver the pair,
+so the dependency is visible at the point of use rather than buried in a lookup.
+
+Four things this buys, in rough order of how much they matter.
+
+**A constraint that publishes nothing cannot be asked.** The primary template is
+declared and deliberately left undefined, so `ConstraintProofModelData<Foo>` for
+an unpublished `Foo` is a compile error naming the type, not a `nullopt` to
+handle. Publishing a row is a deliberate act.
+
+**The role names the row a citer *means*, so the negated forms drop out by
+construction.** `primary_row_role` returns nullopt for `MustNotHold`, `NotIf` and
+`Iff`, and it does so in `comparison.cc`, where someone changing what those rows
+say is looking. The presolver's condition filter is now a second line of defence
+rather than the only one.
+
+**"Can I cite this?" is answered by the emission path itself.** The set the
+tracker consults is the one `claim_labels` claims into, which exists anyway for
+#613's duplicate-label check. There is no second container to keep in step, and a
+`yes` always names exactly one row — two rows under one label is a hard error at
+emission time, so the ambiguity a lookup would have to worry about cannot survive
+to be asked about. That set moved from `ProofModel::Imp` into the tracker for the
+one reason that made the move worth making: a presolver holds a `ProofLogger` and
+no `ProofModel`, and both are constructed with the same tracker.
+
+**Nothing is stored per solve.** Under the intended multi-threading model — one
+OPB file, N threads each with their own constraint clones —
+`define_proof_model` runs once before the fork and `install_propagators` runs per
+thread. `emitted_labels` is write-only during model definition and read-only
+afterwards, and a label is derived from `(id, role)`, so every thread computes
+the same answer without sharing anything. A publication slot on the `Constraint`
+base would also have worked and is the fallback if the payload ever outgrows a
+role name, but it is shared mutable state and would need a write-once assert to
+stay safe. Not worth it for two strings.
+
+The residual is that `primary_row_role` is a *second* visit over the same
+`ReificationCondition` that `define_proof_model` visits, so the two can drift
+apart. It is deliberately not a field `define_proof_model` sets, because
+`define_proof_model` does not run when proofs are off and the answer must not
+depend on that. `gcs/constraint_row_test.cc` is what keeps them together: it
+posts one constraint of every reification kind of both families, resolves the
+label through the real API from inside a presolver, and checks the answer against
+the `.opb` text — a resolved label must name a row the file contains, and a
+nullopt must mean no row under that name is in it. Mutation-tested, both
+directions: publishing `""` for a comparison's `NotIf` (the mistake the old
+constructed label made) fails it, and dropping the `contains` check from
+`constraint_row_label` so it returns a constructed label unconditionally fails it.
+
+The end-to-end check is the one the registry design was validated against, and
+the outcome is unchanged: revert #596 so `Comparison` emits through the
+void-returning `add_constraint` again, and the presolver declines to lift rather
+than citing a label the `.opb` lacks. On `difference_chain --mode refute -n 40
+-k 8 --variant presolved --donor comparison --prove` that is 901 comparison edges
+lifted before and **0** after, all of them counted in `skipped_uncitable_row`,
+and VeriPB still verifies the resulting proof. That last part is the point: the
+failure mode being defended against is an *invalid* proof, not a weaker one, so
+"declines and stays verifiable" is the outcome to want. (With proofs off the same
+model lifts all 901 either way, which is also right — there is nothing to cite,
+so there is nothing to be uncitable.)
 
 ### Deview mode is the one thing the shared propagator needed
 
@@ -1919,11 +2034,14 @@ the asymptotics say it should be: `|E| >> n`, or long chains.
 - **Lifting `Iff` donors** of either family, which needs the `r` and `f` rows
   rather than the empty-role row the two supported kinds share. This one is a
   real obstacle, not a choice.
-- **Lifting `MustNotHold` and `NotIf` donors** of either family. Their rows state
-  the integer negation and are citable (empty role, except a linear `NotIf`'s
-  `ltn`), so this is a gap rather than an obstacle — deferred so that it is
-  closed for both families at once, and because nothing in gcs currently
-  constructs a comparison with either.
+- **Lifting `MustNotHold` and `NotIf` donors** of either family. A comparison's
+  rows, and a linear `MustNotHold`'s, state the integer negation under the empty
+  role and are citable, so this is a gap rather than an obstacle — deferred so
+  that it is closed for both families at once, and because nothing in gcs
+  currently constructs either form. A linear `NotIf` needs its row looked at
+  first: see the presolver section above for why the `ltn` row does not say what
+  a citer would want it to. Doing any of this means publishing the extra roles
+  through `ConstraintProofModelData`, which is where the decision now belongs.
 - **Zero-weight-cycle unification**, the fourth of the root simplification
   stage's sub-steps. The other three are implemented; see the section on it
   above, which also reports how often a zero-weight cycle actually turns up.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(glasgow_constraint_solver
         innards/literal.cc
         innards/power.cc
         innards/proofs/bits_encoding.cc
+        innards/proofs/constraint_proof_model_data.cc
         innards/proofs/emit_inequality_to.cc
         innards/proofs/names_and_ids_tracker.cc
         innards/proofs/pol_builder.cc

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -196,6 +196,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(constraint_enumeration_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME constraint_enumeration_test COMMAND $<TARGET_FILE:constraint_enumeration_test>)
 
+    add_executable(constraint_row_test constraint_row_test.cc)
+    target_link_libraries(constraint_row_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
+    add_test(NAME constraint_row_test COMMAND $<TARGET_FILE:constraint_row_test>)
+
     add_executable(array_param_test array_param_test.cc)
     target_link_libraries(array_param_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)
     add_test(NAME array_param_test COMMAND $<TARGET_FILE:array_param_test>)

--- a/gcs/constraint_row_test.cc
+++ b/gcs/constraint_row_test.cc
@@ -1,0 +1,315 @@
+/* Published constraint rows: does a role a constraint publishes actually name a
+ * row the .opb contains, and can a proof step cite it?
+ *
+ * This is the contract behind Problem::each_constraint_of_type_with_proof_data.
+ * It has two halves, and each is only worth having because the other exists:
+ *
+ *   - ConstraintProofModelData<C>::primary_row_role says which row of C's OPB
+ *     output a citer means. It is a second visit over the same reification
+ *     condition define_proof_model visits, so the two can drift apart --- and if
+ *     they do, a presolver builds a pol on a row that says something else, or on
+ *     a row that is not there.
+ *
+ *   - NamesAndIDsTracker::constraint_row_label says whether a row was emitted
+ *     under that (id, role). It reads the set ProofModel::claim_labels claims
+ *     into, so it is exactly as truthful as the emission path.
+ *
+ * The tests below post one constraint of each reification kind of both
+ * published families, resolve the label through the real API, and then check the
+ * answer against the .opb text: a resolved label must appear in the file, and a
+ * nullopt must mean no row under that name is in it. Nothing here trusts the
+ * roles to be right by inspection; the file is the oracle.
+ */
+
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/presolver.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_tostring.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace std::string_literals;
+
+using gcs::innards::ConstraintProofModelData;
+using gcs::innards::ProofLineLabel;
+
+using std::ifstream;
+using std::istreambuf_iterator;
+using std::make_optional;
+using std::make_unique;
+using std::nullopt;
+using std::optional;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+namespace
+{
+    // What one enumerated constraint looked like to a citer: the role it
+    // published, and the label that role resolved to.
+    struct Resolved final
+    {
+        string id;
+        optional<string> role;
+        optional<string> label;
+    };
+
+    // A presolver exists purely so that this test runs at the point a real
+    // presolver runs: after define_proof_model has emitted every row and
+    // claimed every label, with a ProofLogger and no ProofModel. Resolving a
+    // label anywhere else would be testing a different question.
+    template <typename Constraint_>
+    struct CapturingPresolver final : Presolver
+    {
+        vector<Resolved> * out;
+
+        explicit CapturingPresolver(vector<Resolved> * o) : out(o)
+        {
+        }
+
+        auto run(Problem & problem, innards::Propagators &, innards::State &, innards::ProofLogger * const logger) -> bool override
+        {
+            for (const auto & [c, label] : problem.each_constraint_of_type_with_proof_data<Constraint_>(logger))
+                out->push_back(Resolved{as_string(c.constraint_id()), ConstraintProofModelData<Constraint_>::primary_row_role(c),
+                    label.transform([](const ProofLineLabel & l) { return l.label; })});
+            return true;
+        }
+
+        [[nodiscard]] auto clone() const -> unique_ptr<Presolver> override
+        {
+            return make_unique<CapturingPresolver>(out);
+        }
+    };
+
+    [[nodiscard]] auto read_file(const string & name) -> string
+    {
+        ifstream f{name, std::ios::binary};
+        REQUIRE(f);
+        return string{istreambuf_iterator<char>{f}, istreambuf_iterator<char>{}};
+    }
+
+    // Does the .opb contain a row emitted under this label? A label is written
+    // as the first token of its row, so anchoring on "@<label> " avoids
+    // "@c[_1]" matching a row actually labelled "@c[_1][r]".
+    [[nodiscard]] auto opb_has_row_labelled(const string & opb, const string & label) -> bool
+    {
+        auto needle = "@" + label + " ";
+        for (size_t pos = 0; pos != string::npos;) {
+            if (opb.compare(pos, needle.size(), needle) == 0)
+                return true;
+            auto line_end = opb.find('\n', pos);
+            pos = line_end == string::npos ? string::npos : line_end + 1;
+        }
+        return false;
+    }
+
+    // Solve with proofs on, running a CapturingPresolver over Constraint_, and
+    // return what it saw together with the .opb it saw it against.
+    template <typename Constraint_>
+    struct Run final
+    {
+        vector<Resolved> resolved;
+        string opb;
+    };
+
+    template <typename Constraint_, typename Post_>
+    [[nodiscard]] auto run_with_proof(const string & basename, Post_ && post) -> Run<Constraint_>
+    {
+        Run<Constraint_> result;
+        Problem p;
+        post(p);
+        p.add_presolver(CapturingPresolver<Constraint_>{&result.resolved});
+        // No .scp: s_expr() throws on the MustNotHold and NotIf comparison
+        // forms, which have no cake_pb_cp spelling --- and those are exactly the
+        // forms this has to cover, since they are the ones whose row is under
+        // the label a naive citer would build. The .opb is written either way,
+        // and the .opb is the oracle here.
+        ProofFileNames names{basename};
+        names.s_expr_file = nullopt;
+        static_cast<void>(
+            solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }}, make_optional<ProofOptions>(names)));
+        result.opb = read_file(basename + ".opb");
+        for (const auto & suffix : {".opb"s, ".pbp"s, ".scp"s, ".varmap"s})
+            std::remove((basename + suffix).c_str());
+        return result;
+    }
+
+    // The check both families share: a published role that resolved must name a
+    // row the file contains, and a role that resolved to nothing must not.
+    template <typename Constraint_>
+    auto check_labels_against_opb(const Run<Constraint_> & run) -> void
+    {
+        for (const auto & r : run.resolved) {
+            CAPTURE(r.id);
+            CAPTURE(r.role.value_or("<none published>"));
+            CAPTURE(r.label.value_or("<unresolved>"));
+
+            if (r.label) {
+                // Resolving is a claim about the file, so check the file.
+                CHECK(opb_has_row_labelled(run.opb, *r.label));
+                // And a label only ever comes from a published role.
+                CHECK(r.role.has_value());
+            }
+            else if (r.role) {
+                // A role published but nothing emitted under it: then the file
+                // must really not contain that row, or the tracker is lying.
+                auto expected = "c[" + r.id + "]" + (r.role->empty() ? "" : "[" + *r.role + "]");
+                CHECK_FALSE(opb_has_row_labelled(run.opb, expected));
+            }
+        }
+    }
+}
+
+TEST_CASE("a linear's published role resolves to a row the .opb contains")
+{
+    auto run = run_with_proof<ReifiedLinearInequality>("constraint_row_test_linear", [](Problem & p) {
+        auto x = p.create_integer_variable(0_i, 10_i, "x"s);
+        auto y = p.create_integer_variable(0_i, 10_i, "y"s);
+        auto b = p.create_integer_variable(0_i, 1_i, "b"s);
+        p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x + -1_i * y, 3_i});
+        p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * y + -1_i * x, 4_i, b == 1_i});
+        p.post(LinearLessThanEqualIff{WeightedSum{} + 1_i * x + 1_i * y, 12_i, b == 0_i});
+    });
+
+    // Three posted, three enumerated: the enumeration is the same one the
+    // presolver uses, so a shortfall here would be a different bug.
+    REQUIRE(run.resolved.size() == 3);
+    check_labels_against_opb(run);
+
+    // MustHold and If publish the empty role and resolve; Iff publishes nothing,
+    // because its r and f halves say the two directions of the equivalence
+    // rather than `sum <= value`.
+    CHECK(run.resolved[0].role == make_optional(""s));
+    CHECK(run.resolved[0].label.has_value());
+    CHECK(run.resolved[1].role == make_optional(""s));
+    CHECK(run.resolved[1].label.has_value());
+    CHECK_FALSE(run.resolved[2].role.has_value());
+    CHECK_FALSE(run.resolved[2].label.has_value());
+
+    // The Iff donor really did emit rows --- it published no role, which is not
+    // the same as having emitted nothing. Without this the previous check would
+    // pass just as well against a constraint that emitted no model at all.
+    CHECK(opb_has_row_labelled(run.opb, "c[" + run.resolved[2].id + "][r]"));
+    CHECK(opb_has_row_labelled(run.opb, "c[" + run.resolved[2].id + "][f]"));
+}
+
+TEST_CASE("a comparison's published role resolves to a row the .opb contains")
+{
+    auto run = run_with_proof<ReifiedCompareLessThanOrMaybeEqual>("constraint_row_test_comparison", [](Problem & p) {
+        auto x = p.create_integer_variable(0_i, 10_i, "x"s);
+        auto y = p.create_integer_variable(0_i, 10_i, "y"s);
+        auto z = p.create_integer_variable(0_i, 10_i, "z"s);
+        auto b = p.create_integer_variable(0_i, 1_i, "b"s);
+        p.post(LessThanEqual{x, y});
+        p.post(LessThan{y, z});
+        p.post(LessThanEqualIf{z, x + 6_i, b == 1_i});
+        p.post(ReifiedCompareLessThanOrMaybeEqual{x, z, reif::Iff{b == 0_i}, true});
+        p.post(ReifiedCompareLessThanOrMaybeEqual{y, x, reif::NotIf{b == 1_i}, true});
+    });
+
+    REQUIRE(run.resolved.size() == 5);
+    check_labels_against_opb(run);
+
+    // MustHold (twice) and If publish the empty role.
+    for (auto i : {0u, 1u, 2u}) {
+        CAPTURE(i);
+        CHECK(run.resolved[i].role == make_optional(""s));
+        CHECK(run.resolved[i].label.has_value());
+    }
+
+    // Iff publishes nothing (r and f halves), and NotIf publishes nothing even
+    // though its row *is* under the empty role: that row states the negated
+    // inequality with the operands the other way round, so it is not the row a
+    // citer asking for `left <= right` means. This is the case a
+    // build-the-label-yourself citer gets wrong, and it is the reason the role
+    // is published rather than constructed.
+    CHECK_FALSE(run.resolved[3].role.has_value());
+    CHECK_FALSE(run.resolved[3].label.has_value());
+    CHECK_FALSE(run.resolved[4].role.has_value());
+    CHECK_FALSE(run.resolved[4].label.has_value());
+
+    // The NotIf donor did emit a row, under exactly the label a naive citer
+    // would have built. Publishing is what keeps it out of a pol.
+    CHECK(opb_has_row_labelled(run.opb, "c[" + run.resolved[4].id + "]"));
+}
+
+TEST_CASE("no label resolves when proofs are off")
+{
+    // The same posting, with no ProofOptions. Nothing is emitted, so nothing is
+    // citable, and a caller must see that rather than a label it could not have
+    // cited. This is what stops a presolver behaving differently under --prove.
+    vector<Resolved> resolved;
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 10_i, "x"s);
+    auto y = p.create_integer_variable(0_i, 10_i, "y"s);
+    p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x + -1_i * y, 3_i});
+    p.add_presolver(CapturingPresolver<ReifiedLinearInequality>{&resolved});
+    static_cast<void>(solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }}));
+
+    REQUIRE(resolved.size() == 1);
+    // The role is still published --- it is a property of the constraint, not of
+    // whether a proof is being written --- but there is no row to resolve to.
+    CHECK(resolved[0].role == make_optional(""s));
+    CHECK_FALSE(resolved[0].label.has_value());
+}
+
+TEST_CASE("a role that names no emitted row does not resolve")
+{
+    // The tracker's half, on its own: ask for a role nothing was emitted under
+    // and get nullopt rather than a constructed label. Uses a role no
+    // constraint uses, on a constraint id that does exist, so the only thing
+    // wrong with it is that no row carries it.
+    vector<Resolved> resolved;
+    Problem p;
+    auto x = p.create_integer_variable(0_i, 10_i, "x"s);
+    auto y = p.create_integer_variable(0_i, 10_i, "y"s);
+    p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x + -1_i * y, 3_i});
+
+    struct AskingPresolver final : Presolver
+    {
+        optional<ProofLineLabel> * real;
+        optional<ProofLineLabel> * invented;
+
+        AskingPresolver(optional<ProofLineLabel> * r, optional<ProofLineLabel> * i) : real(r), invented(i)
+        {
+        }
+
+        auto run(Problem & problem, innards::Propagators &, innards::State &, innards::ProofLogger * const logger) -> bool override
+        {
+            for (const auto & c : problem.each_constraint_of_type<ReifiedLinearInequality>()) {
+                *real = innards::constraint_row_label_from(*logger, c.constraint_id(), ""s);
+                *invented = innards::constraint_row_label_from(*logger, c.constraint_id(), "no_such_role"s);
+            }
+            return true;
+        }
+
+        [[nodiscard]] auto clone() const -> unique_ptr<Presolver> override
+        {
+            return make_unique<AskingPresolver>(real, invented);
+        }
+    };
+
+    optional<ProofLineLabel> real, invented;
+    p.add_presolver(AskingPresolver{&real, &invented});
+    static_cast<void>(solve_with(p, SolveCallbacks{.solution = [](const CurrentState &) -> bool { return true; }},
+        make_optional<ProofOptions>(ProofFileNames{"constraint_row_test_missing_role"})));
+    for (const auto & suffix : {".opb"s, ".pbp"s, ".scp"s, ".varmap"s})
+        std::remove(("constraint_row_test_missing_role"s + suffix).c_str());
+
+    CHECK(real.has_value());
+    CHECK_FALSE(invented.has_value());
+}

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -113,6 +113,25 @@ auto ReifiedCompareLessThanOrMaybeEqual::define_proof_model(ProofModel & model, 
         .visit(_reif_cond);
 }
 
+auto innards::ConstraintProofModelData<ReifiedCompareLessThanOrMaybeEqual>::primary_row_role(const ReifiedCompareLessThanOrMaybeEqual & c)
+    -> optional<string>
+{
+    // Deliberately a second visit over the same ReificationCondition that
+    // define_proof_model visits, rather than a field it sets: define_proof_model
+    // does not run when proofs are off, and a presolver that asks this must get
+    // the same answer either way. The two are kept honest by
+    // constraint_row_test.cc, which posts each kind and checks that a published
+    // role resolves to a label the .opb actually contains.
+    return overloaded{
+        [&](const reif::MustHold &) -> optional<string> { return ""; },         //
+        [&](const reif::If &) -> optional<string> { return ""; },               //
+        [&](const reif::MustNotHold &) -> optional<string> { return nullopt; }, //
+        [&](const reif::NotIf &) -> optional<string> { return nullopt; },       //
+        [&](const reif::Iff &) -> optional<string> { return nullopt; }          //
+    }
+        .visit(c.reification_condition());
+}
+
 auto ReifiedCompareLessThanOrMaybeEqual::install_propagators(Propagators & propagators) -> void
 {
     if (_v1_is_constant && _v2_is_constant) {

--- a/gcs/constraints/comparison/comparison.hh
+++ b/gcs/constraints/comparison/comparison.hh
@@ -4,12 +4,14 @@
 #include <gcs/constraint.hh>
 #include <gcs/constraints/innards/reified_state.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
 #include <gcs/integer.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
 #include <gcs/variable_id.hh>
 
 #include <optional>
+#include <string>
 
 namespace gcs
 {
@@ -109,6 +111,34 @@ namespace gcs
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+
+    /**
+     * \brief The rows ReifiedCompareLessThanOrMaybeEqual commits to keeping
+     * citable.
+     *
+     * \ingroup Innards
+     */
+    template <>
+    struct innards::ConstraintProofModelData<ReifiedCompareLessThanOrMaybeEqual>
+    {
+        /**
+         * \brief The role of the row stating `left <= right` (or `<`, per
+         * or_equal()), under the reification condition if there is one.
+         *
+         * Public API: the difference-logic presolver builds `pol`s on this row.
+         * Changing which row this names is a breaking change. Note that
+         * cake_pb_cp is the other end of these labels and re-derives the same
+         * ones, so a rename is a cross-tool break, not merely an internal one.
+         *
+         * MustHold and If both use the empty role, giving `@c[<id>]`.
+         * MustNotHold and NotIf share that role but state the *negated*
+         * inequality, with the operands the other way round, and Iff's halves
+         * are `r` and `f`; none of the three is the row a citer asking for
+         * `left <= right` means, so this returns nullopt for them rather than
+         * naming a row that says something else.
+         */
+        [[nodiscard]] static auto primary_row_role(const ReifiedCompareLessThanOrMaybeEqual &) -> std::optional<std::string>;
     };
 
     /**

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -180,6 +180,21 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model, const State
         .visit(_reif_cond);
 }
 
+auto innards::ConstraintProofModelData<ReifiedLinearInequality>::primary_row_role(const ReifiedLinearInequality & c) -> optional<string>
+{
+    // As for the comparison family, this re-visits the ReificationCondition
+    // rather than reading anything define_proof_model left behind: a presolver
+    // asking must get the same answer whether or not proofs are being logged.
+    return overloaded{
+        [&](const reif::MustHold &) -> optional<string> { return ""; },         //
+        [&](const reif::If &) -> optional<string> { return ""; },               //
+        [&](const reif::MustNotHold &) -> optional<string> { return nullopt; }, //
+        [&](const reif::NotIf &) -> optional<string> { return nullopt; },       //
+        [&](const reif::Iff &) -> optional<string> { return nullopt; }          //
+    }
+        .visit(c.reification_condition());
+}
+
 auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> void
 {
     auto proof_lines = _proof_lines;

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -6,6 +6,7 @@
 #include <gcs/constraints/linear/utils.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/literal.hh>
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/propagators-fwd.hh>
 #include <gcs/innards/state.hh>
@@ -118,6 +119,42 @@ namespace gcs
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+
+    /**
+     * \brief The rows ReifiedLinearInequality commits to keeping citable.
+     *
+     * \ingroup Innards
+     */
+    template <>
+    struct innards::ConstraintProofModelData<ReifiedLinearInequality>
+    {
+        /**
+         * \brief The role of the row stating `sum <= value`, under the
+         * reification condition if there is one.
+         *
+         * Public API: the difference-logic presolver builds `pol`s on this row.
+         * Changing which row this names is a breaking change.
+         *
+         * MustHold and If both use the empty role, so both come out as
+         * `@c[<id>]`. The other three publish nothing. MustNotHold's empty-role
+         * row states the integer negation and Iff's `r` / `f` halves state the
+         * two directions of the equivalence, so neither is the row a citer
+         * asking for `sum <= value` means. NotIf is excluded for a different and
+         * less comfortable reason: its `ltn` row is emitted as
+         * `cond -> sum <= value`, which is what the constraint says must *not*
+         * hold, so the row as written looks wrong rather than merely unwanted.
+         * Nothing in gcs constructs a ReifiedLinearInequality with either
+         * negated kind --- the six derived classes cover MustHold, If and Iff,
+         * and scp_reader builds only those --- so this publishes nothing rather
+         * than committing to a row that has never been exercised.
+         *
+         * A nullopt here means "no such row exists", which is different from a
+         * nullopt out of NamesAndIDsTracker::constraint_row_label, where the row
+         * exists in principle but was not emitted (no proof was being logged,
+         * say).
+         */
+        [[nodiscard]] static auto primary_row_role(const ReifiedLinearInequality &) -> std::optional<std::string>;
     };
 }
 

--- a/gcs/innards/proofs/constraint_proof_model_data.cc
+++ b/gcs/innards/proofs/constraint_proof_model_data.cc
@@ -1,0 +1,17 @@
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+
+#include <optional>
+#include <string>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::optional;
+using std::string;
+
+auto gcs::innards::constraint_row_label_from(const ProofLogger & logger, const ConstraintID & id, const string & role) -> optional<ProofLineLabel>
+{
+    return logger.names_and_ids_tracker().constraint_row_label(id, role);
+}

--- a/gcs/innards/proofs/constraint_proof_model_data.hh
+++ b/gcs/innards/proofs/constraint_proof_model_data.hh
@@ -1,0 +1,64 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_CONSTRAINT_PROOF_MODEL_DATA_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_CONSTRAINT_PROOF_MODEL_DATA_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+
+#include <optional>
+#include <string>
+
+namespace gcs::innards
+{
+    /**
+     * \brief How a constraint publishes the parts of its OPB output that other
+     * code is allowed to build proof steps on.
+     *
+     * Every labelled row a define_proof_model emits is, today, implicitly public
+     * API: anything can construct the label `c[id][role]` and cite it. That is
+     * how the difference-logic presolver started out, and it is a bad contract
+     * in both directions --- the citer is guessing at another constraint's
+     * naming scheme, and the constraint's author has no way of knowing that
+     * renaming a role breaks somebody.
+     *
+     * Specialising this turns that into a declaration. The specialisation lives
+     * in the constraint's own header, beside its posted-argument accessors,
+     * which is the place where the dependency is visible to the person most
+     * likely to break it. What it publishes is the *role name*, not a line
+     * number or a label: a role is stable across solves, clones and threads,
+     * whereas a line number is a position in one particular file.
+     *
+     * The primary template is deliberately left undefined, so asking a
+     * constraint that publishes nothing is a compile error naming the type,
+     * rather than a nullopt to be handled at runtime. A constraint that has no
+     * stable rows should stay unspecialised.
+     *
+     * A published role answers "which row do you mean", not "does that row
+     * exist": a role whose reification kind was never emitted has no row.
+     * NamesAndIDsTracker::constraint_row_label is the other half, and returns
+     * nullopt in exactly that case.
+     *
+     * \ingroup Innards
+     * \sa NamesAndIDsTracker::constraint_row_label
+     * \sa Problem::each_constraint_of_type_with_proof_data
+     */
+    template <typename Constraint_>
+    struct ConstraintProofModelData;
+
+    /**
+     * \brief NamesAndIDsTracker::constraint_row_label, reached through a
+     * ProofLogger.
+     *
+     * Exists so that Problem::each_constraint_of_type_with_proof_data, which is
+     * a template in the public gcs/problem.hh, can resolve a label without
+     * problem.hh having to include the whole of proof_logger.hh and
+     * names_and_ids_tracker.hh. The logger and the model share one tracker, so
+     * this reaches the same set the model claimed into.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto constraint_row_label_from(const ProofLogger &, const ConstraintID &, const std::string & role)
+        -> std::optional<ProofLineLabel>;
+}
+
+#endif

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -56,6 +56,7 @@ using std::min;
 using std::nullopt;
 using std::optional;
 using std::pair;
+using std::set;
 using std::shared_ptr;
 using std::string;
 using std::stringstream;
@@ -139,6 +140,14 @@ struct NamesAndIDsTracker::Imp
 {
     ProofModel * model = nullptr;
     ProofLogger * logger = nullptr;
+
+    // Every c[id][role] label emitted so far. A label is how a proof step cites
+    // a row, so two constraint rows must never share one; see
+    // claim_constraint_row_labels, and note the variable-encoding namespaces are
+    // deliberately not tracked here. Write-only while the model is being
+    // defined, read-only afterwards, and derived entirely from (id, role) --- so
+    // it needs no synchronisation under the intended one-OPB, N-thread model.
+    set<string> emitted_constraint_row_labels;
 
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     // Indexed by variable index (variables are allocated with sequential
@@ -1562,6 +1571,46 @@ auto NamesAndIDsTracker::note_bounds_not_trivially_derivable(const SimpleOrProof
 auto NamesAndIDsTracker::note_recover_atom_labels_in_proof(const SimpleOrProofOnlyIntegerVariableID & id) -> void
 {
     _imp->vars_recover_labels.insert(id);
+}
+
+auto NamesAndIDsTracker::claim_constraint_row_labels(const vector<string> & labels) -> void
+{
+    // A label exists so that a proof step can cite this row, so no two rows in
+    // the c[id][role] namespace may carry the same one: with both spelled
+    // @c[id][role], a reference to either is ambiguous, and opbdiff
+    // --match-labels pairs the two encoders' rows by label. A duplicate is
+    // always a bug in the emitting define_proof_model -- a role that does not
+    // name everything the surrounding loops vary over (#604: ValuePrecede keyed
+    // its ub/ex roles by position but not by chain value, inside a loop over
+    // values) -- so it is a hard error rather than a first-wins or last-wins
+    // pick.
+    //
+    // Only the ConstraintID-taking overloads claim, which is what confines this
+    // to c[id][role]. The variable-encoding namespaces -- @i[name][...] for a
+    // real variable, @po[index] for a proof-only one -- are deliberately left
+    // out: a variable's encoding rows can be deleted and re-emitted to keep the
+    // proof database small, so a repeat there is by design rather than a naming
+    // bug. Their uniqueness is the namer's business, not this check's.
+    //
+    // The whole pack is claimed before any of it is emitted, so that the
+    // equality overload's two halves are all-or-nothing: a rejected pair must
+    // not leave its LE row behind in the OPB. Claiming them together is also
+    // what catches a caller passing the same role for both halves.
+    for (const auto & label : labels)
+        if (! _imp->emitted_constraint_row_labels.insert(label).second)
+            throw ProofError{"two OPB rows emitted under the same label '@" + label +
+                "': a role must name everything that varies, so that each row can be cited unambiguously"};
+}
+
+auto NamesAndIDsTracker::constraint_row_label(const ConstraintID & id, const string & role) const -> optional<ProofLineLabel>
+{
+    // Built the same way ProofModel::emit_constraint_label builds it, because it
+    // has to be the same string: that is what makes this a pure function of
+    // (id, role) rather than a lookup into per-solve state.
+    auto label = "c[" + as_string(id) + "]" + (role.empty() ? "" : "[" + role + "]");
+    if (! _imp->emitted_constraint_row_labels.contains(label))
+        return nullopt;
+    return ProofLineLabel{label};
 }
 
 auto NamesAndIDsTracker::create_proof_flag(const string & name) -> ProofFlag

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/constraint_id.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
+#include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
 #include <gcs/innards/proofs/proof_only_variables-fwd.hh>
@@ -497,6 +498,42 @@ namespace gcs::innards
          * are forced model-time under @i labels.
          */
         auto note_recover_atom_labels_in_proof(const SimpleOrProofOnlyIntegerVariableID & id) -> void;
+
+        /**
+         * \brief Claim each of these `c[id][role]` labels for rows about to be
+         * emitted, throwing ProofError if any is already taken or if the pack
+         * repeats one.
+         *
+         * Called only by ProofModel::add_labelled_constraint's ConstraintID
+         * overloads, which is what confines the set to the `c[id][role]`
+         * namespace; the variable-encoding namespaces are deliberately out of
+         * scope, because those rows may be deleted and re-emitted. It lives here
+         * rather than in ProofModel because \ref constraint_row_label reads it,
+         * and its reader is a presolver, which holds a ProofLogger and no
+         * ProofModel --- and both are constructed with this same tracker.
+         */
+        auto claim_constraint_row_labels(const std::vector<std::string> & labels) -> void;
+
+        /**
+         * \brief The label of the row this constraint emitted under this role,
+         * or nullopt if it emitted none.
+         *
+         * Answers "can I cite this?", not "what does it say". A label is a pure
+         * function of `(id, role)`, so this needs no per-solve state beyond the
+         * claimed set, and every clone of a constraint in every thread computes
+         * the same answer.
+         *
+         * A `yes` always names exactly one row:
+         * \ref claim_constraint_row_labels rejects two rows under one label at
+         * emission time (#613), so the ambiguity a "look it up" answer would
+         * otherwise have to worry about cannot exist by the time this is asked.
+         *
+         * Pair it with innards::ConstraintProofModelData, which is how a
+         * constraint publishes *which* role names the row a citer wants;
+         * constructing a role string here instead would be guessing at another
+         * constraint's naming scheme.
+         */
+        [[nodiscard]] auto constraint_row_label(const ConstraintID & id, const std::string & role) const -> std::optional<ProofLineLabel>;
 
         /**
          * Create a proof flag with a new identifier, named `f[index][stem]`.

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -719,6 +719,11 @@ auto ProofLogger::names_and_ids_tracker() -> NamesAndIDsTracker &
     return _imp->tracker;
 }
 
+auto ProofLogger::names_and_ids_tracker() const -> const NamesAndIDsTracker &
+{
+    return _imp->tracker;
+}
+
 auto ProofLogger::emit_subproofs(const map<ProofGoal, Subproof> & subproofs)
 {
     _imp->proof << " : subproof\n";

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -352,6 +352,13 @@ namespace gcs::innards
         [[nodiscard]] auto names_and_ids_tracker() -> NamesAndIDsTracker &;
 
         /**
+         * As above, for a caller that only reads. Exists so that resolving a
+         * constraint row's label --- which is a const query on the tracker ---
+         * does not have to launder away constness to ask.
+         */
+        [[nodiscard]] auto names_and_ids_tracker() const -> const NamesAndIDsTracker &;
+
+        /**
          * Delete a specified range of ids.
          * NB: This uses half-open range semantics, so "from" is included but "up_to" is excluded.
          */

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -77,11 +77,6 @@ struct ProofModel::Imp
 
     map<Integer, ProofModel::CakeConstantAtoms> cake_constant_atoms;
 
-    // Every c[id][role] label emitted so far. A label is how a proof step cites
-    // a row, so two constraint rows must never share one; see claim_labels, and
-    // note the variable-encoding namespaces are deliberately not tracked here.
-    set<string> emitted_labels;
-
     string opb_file;
     // Text not yet written out. Until write_preamble() runs this holds
     // everything emitted so far (the variable set-up rows); afterwards each
@@ -119,31 +114,15 @@ auto ProofModel::advance_constraint_counter() -> ProofLineNumber
 
 auto ProofModel::claim_labels(const vector<string> & labels) -> void
 {
-    // A label exists so that a proof step can cite this row, so no two rows in
-    // the c[id][role] namespace may carry the same one: with both spelled
-    // @c[id][role], a reference to either is ambiguous, and opbdiff
-    // --match-labels pairs the two encoders' rows by label. A duplicate is
-    // always a bug in the emitting define_proof_model -- a role that does not
-    // name everything the surrounding loops vary over (#604: ValuePrecede keyed
-    // its ub/ex roles by position but not by chain value, inside a loop over
-    // values) -- so it is a hard error rather than a first-wins or last-wins
-    // pick.
-    //
-    // Only the ConstraintID-taking overloads claim, which is what confines this
-    // to c[id][role]. The variable-encoding namespaces -- @i[name][...] for a
-    // real variable, @po[index] for a proof-only one -- are deliberately left
-    // out: a variable's encoding rows can be deleted and re-emitted to keep the
-    // proof database small, so a repeat there is by design rather than a naming
-    // bug. Their uniqueness is the namer's business, not this check's.
-    //
-    // The whole pack is claimed before any of it is emitted, so that the
-    // equality overload's two halves are all-or-nothing: a rejected pair must
-    // not leave its LE row behind in the OPB. Claiming them together is also
-    // what catches a caller passing the same role for both halves.
-    for (const auto & label : labels)
-        if (! _imp->emitted_labels.insert(label).second)
-            throw ProofError{"two OPB rows emitted under the same label '@" + label +
-                "': a role must name everything that varies, so that each row can be cited unambiguously"};
+    // The set itself lives in the tracker, not here, because it has a second
+    // reader: NamesAndIDsTracker::constraint_row_label answers "was a row
+    // emitted under this (id, role), so may I cite it?", and its caller is a
+    // presolver, which holds a ProofLogger and no ProofModel. Both objects are
+    // constructed with the same tracker, so moving the set there is what puts it
+    // in reach of both without handing anyone a ProofModel after the model is
+    // closed. The claiming rule, and the reasons for it, are documented on
+    // NamesAndIDsTracker::claim_constraint_row_labels.
+    _imp->tracker.claim_constraint_row_labels(labels);
 }
 
 auto ProofModel::emit_constraint_label(const string & constraint_id, const string & role) -> ProofLineLabel

--- a/gcs/presolvers/difference_logic/difference_logic.cc
+++ b/gcs/presolvers/difference_logic/difference_logic.cc
@@ -144,9 +144,21 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
     // Turn one donor row into a graph edge, or account for why it cannot be.
     // Returns whether an edge was added, so a caller can also count the row in
     // whatever family bucket it belongs to. The graph does not care which
-    // constraint class emitted the row --- only that the row exists, carries a
-    // citable @c[<id>] label, and says `positive - negative <= value`.
-    auto lift_row = [&](const DifferenceRow & row, const ConstraintID & id) -> bool {
+    // constraint class emitted the row --- only that the row says
+    // `positive - negative <= value` and, when proofs are on, that `label` names
+    // it. The label is resolved by the caller, through the donor's published
+    // role: see Problem::each_constraint_of_type_with_proof_data.
+    auto lift_row = [&](const DifferenceRow & row, const ConstraintID & id, const optional<ProofLineLabel> & label) -> bool {
+        if (logger && ! label) {
+            // The donor is the right shape but there is no row to build a pol
+            // on. Either it published no primary row for the kind it was posted
+            // with, or it published one and nothing was emitted under it. Lifting
+            // anyway would produce a propagator whose justifications cite a label
+            // the .opb does not contain, so decline and count it.
+            ++stats.skipped_uncitable_row;
+            return false;
+        }
+
         auto left = deview_difference_operand(row.positive);
         auto right = deview_difference_operand(row.negative);
         if (! left || ! right) {
@@ -181,13 +193,12 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
         auto posted_index = graph.edges.size();
         graph.edges.push_back(DifferenceGraphEdge{from, to, d, posted_index, row.cond});
         if (logger) {
-            // The donor's own row, which both families label @c[<id>] with an
-            // empty role, for the conditional forms exactly as for the
-            // unconditional ones. Nothing new goes into the OPB ---
-            // Presolver::run has no ProofModel * precisely because that door
+            // The donor's own row, named by the donor rather than by a label
+            // this presolver builds for itself. Nothing new goes into the OPB
+            // --- Presolver::run has no ProofModel * precisely because that door
             // has closed --- and nothing needs to: every inference the
             // propagator makes is a cutting-planes consequence of these rows.
-            graph.edge_lines.push_back(ProofLineLabel{"c[" + as_string(id) + "]"});
+            graph.edge_lines.push_back(*label);
         }
 
         if (row.cond)
@@ -203,7 +214,7 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
         return true;
     };
 
-    for (const auto & c : problem.each_constraint_of_type<ReifiedLinearInequality>()) {
+    for (const auto & [c, label] : problem.each_constraint_of_type_with_proof_data<ReifiedLinearInequality>(logger)) {
         // MustHold gives a plain edge; If gives a half-reified one,
         // `cond -> x - y <= d'. Both are citable and both are the shape the
         // propagator's proofs assume: linear_inequality.cc labels the
@@ -252,14 +263,14 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
             continue;
         }
 
-        static_cast<void>(lift_row(DifferenceRow{*positive, *negative, c.value(), edge_condition}, c.constraint_id()));
+        static_cast<void>(lift_row(DifferenceRow{*positive, *negative, c.value(), edge_condition}, c.constraint_id(), label));
     }
 
     // Comparisons are difference constraints too --- `x <= y + d` is a view, not
     // a separate constraint kind --- and every row
     // ReifiedCompareLessThanOrMaybeEqual emits now carries an @label, so every
     // row is citable.
-    for (const auto & c : problem.each_constraint_of_type<ReifiedCompareLessThanOrMaybeEqual>()) {
+    for (const auto & [c, label] : problem.each_constraint_of_type_with_proof_data<ReifiedCompareLessThanOrMaybeEqual>(logger)) {
         // `x <= y` states `x - y <= 0` and `x < y` states `x - y <= -1`, both
         // under the bare @c[<id>] label; the `If' form states the same row
         // under HalfReifyOnConjunctionOf on the recorded condition, and under
@@ -292,7 +303,7 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
             continue;
         }
 
-        if (lift_row(*row, c.constraint_id()))
+        if (lift_row(*row, c.constraint_id(), label))
             ++stats.comparison_edges_lifted;
     }
 

--- a/gcs/presolvers/difference_logic/difference_logic.hh
+++ b/gcs/presolvers/difference_logic/difference_logic.hh
@@ -69,7 +69,7 @@ namespace gcs
          * \name Why a candidate was not lifted.
          *
          * Every donor the presolver looked at, of either family, falls into
-         * exactly one of edges_lifted or one of these five buckets, so the six
+         * exactly one of edges_lifted or one of these six buckets, so the seven
          * numbers together account for every ReifiedLinearInequality *and*
          * every ReifiedCompareLessThanOrMaybeEqual in the model. (The first two
          * only ever fire on a linear: a comparison is two terms with
@@ -103,6 +103,16 @@ namespace gcs
         /// `d < 0` case would need an initialiser, a door that has closed by
         /// the time a presolver runs, so they are left to their own propagator.
         std::size_t skipped_degenerate = 0;
+
+        /// A donor of the right shape whose primary OPB row cannot be cited: it
+        /// published no role for the reification kind it was posted with, or it
+        /// published one and no row was emitted under it. The propagator's
+        /// justifications are `pol`s over the donors' rows, so a row that is not
+        /// there is not a weaker proof but an invalid one, and the edge is left
+        /// with its own propagator instead. Only ever non-zero when proofs are
+        /// being logged: with no logger there is nothing to cite and nothing to
+        /// check.
+        std::size_t skipped_uncitable_row = 0;
 
         ///@}
     };

--- a/gcs/problem.hh
+++ b/gcs/problem.hh
@@ -4,6 +4,7 @@
 #include <gcs/constraint.hh>
 #include <gcs/exception.hh>
 #include <gcs/expression.hh>
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
 #include <gcs/innards/proofs/proof_model-fwd.hh>
 #include <gcs/innards/state-fwd.hh>
@@ -277,6 +278,47 @@ namespace gcs
             for (const auto & c : each_constraint())
                 if (auto typed = dynamic_cast<const Constraint_ *>(&c))
                     co_yield *typed;
+        }
+
+        /**
+         * \brief As each_constraint_of_type, but pairing each constraint with
+         * the label of the OPB row it publishes, for a caller that means to
+         * build proof steps on that row.
+         *
+         * The label comes from asking the constraint which role names its
+         * primary row (innards::ConstraintProofModelData, specialised in the
+         * constraint's own header) and then asking the tracker whether a row was
+         * emitted under that `(id, role)`. Neither half guesses: a caller that
+         * built the label itself would be hard-coding another constraint's
+         * naming scheme, which is what this exists to stop.
+         *
+         * The label is nullopt when the constraint publishes no primary row for
+         * the reification kind it was posted with, when no row was emitted under
+         * the published role, or when `logger` is null because proofs are off.
+         * All three mean the same thing to a caller --- there is nothing to cite,
+         * so do not do the thing that would need citing.
+         *
+         * Asking for a `Constraint_` that has no ConstraintProofModelData
+         * specialisation is a compile error naming the type, which is the point:
+         * a constraint publishes its stable rows deliberately or not at all.
+         *
+         * \warning The same warnings as each_constraint_of_type apply: ask for
+         * the type Problem *stores*, and the yielded references alias objects
+         * owned by this Problem.
+         */
+        template <std::derived_from<Constraint> Constraint_>
+        [[nodiscard]] auto each_constraint_of_type_with_proof_data(const innards::ProofLogger * const logger) const
+            -> std::generator<std::pair<const Constraint_ &, std::optional<innards::ProofLineLabel>>>
+        {
+            for (const auto & c : each_constraint_of_type<Constraint_>()) {
+                std::optional<innards::ProofLineLabel> label;
+                if (logger) {
+                    auto role = innards::ConstraintProofModelData<Constraint_>::primary_row_role(c);
+                    if (role)
+                        label = innards::constraint_row_label_from(*logger, c.constraint_id(), *role);
+                }
+                co_yield {c, label};
+            }
         }
 
         /**


### PR DESCRIPTION
**Based on #602** (`difflogic-12-enumeration-check`), which is this PR's base
branch, so the diff shown here is only this PR's four commits.

Follow-up to the review point on #588/#596: the presolver was reconstructing
another constraint's `@label` as a string rather than being handed it.

> [!NOTE]
> **This PR has been redesigned, not rebased.** The previous version added a
> `ProofModel` registry — `track_constraint_row` / `constraint_row`, an
> `unordered_map<pair<ConstraintID, string>, ProofLine>` with its own hasher, and
> duplicate-poisoning logic for when two rows claimed one label. Main has since
> landed #613, which makes two rows under one label a hard `ProofError` at
> emission time, so the poisoning path is now unreachable; and main
> independently fixed #604, which the old version had only filed. What is left
> is smaller and says more, so the registry is gone rather than rebased. None of
> its commits are cherry-picked.

## The problem

`difference_logic.cc` cited a donor's row as:

```cpp
graph.edge_lines.push_back(ProofLineLabel{"c[" + as_string(id) + "]"});
```

That hard-codes the assumption that the row the presolver wants is the donor's
*empty-role* one. It happens to be true for the two reification kinds the
presolver lifts. It is silently false for two it does not: a comparison's
`MustNotHold` and `NotIf` rows go out under the empty role too, and they state
the **negated** inequality with the operands the other way round. The loop is
correct today only because it filters on the reification condition several lines
earlier. Nothing would have caught it if that filter were ever widened, and
nothing at all would have caught a donor renaming a role.

That format is also owned by `ProofModel::emit_constraint_label`, which is
private, and this was the only place in the tree outside `proof_model.cc` that
spelled it out.

## The design

Citing another constraint's row is an inherent dependency — you cannot build a
`pol` on somebody else's row without depending on how they defined their model.
The goal is not to remove the coupling but to make it **typed, narrow and
visible from both ends**.

Two facts make that cheap. Citation is already by label (`ProofLine` is
`variant<ProofLineNumber, ProofLineLabel>`), so nothing needs new plumbing. And
a label is a pure function of `(ConstraintID, role)` — clone-independent,
thread-independent — where a line *number* is a position in a file.

**The constraint publishes the role.** `ConstraintProofModelData<C>` is declared
and deliberately left **undefined**, so asking a constraint that publishes
nothing is a compile error naming the type rather than a `nullopt` to handle. A
specialisation lives in the constraint's own header, beside its posted-argument
accessors — where it is visible to whoever is most likely to break it. What is
published is the role *name*, not a line number.

**The tracker says whether a row went out under it.**
`NamesAndIDsTracker::constraint_row_label(id, role)` answers "may I cite this?",
not "what does it say". `emitted_labels` moves out of `ProofModel::Imp` into the
tracker for one reason: it needs a second reader, and that reader is a
presolver, which holds a `ProofLogger` and no `ProofModel`. Both are constructed
with the same tracker. `claim_labels` keeps its signature and both call sites.

**The enumeration hands over the pair.**
`Problem::each_constraint_of_type_with_proof_data` yields
`(constraint, optional<ProofLineLabel>)`, so the dependency is visible at the
point of use rather than buried in a lookup.

Two properties fall out. A `yes` always names exactly one row — #613 makes two
rows under one label a hard error at emission time, so the ambiguity a lookup
would have to worry about cannot survive to be asked about. And nothing is
stored per solve: under the intended one-OPB, N-thread model,
`define_proof_model` runs once before the fork, `emitted_labels` is write-only
during it and read-only afterwards, and every thread derives the same label from
`(id, role)` without sharing anything.

## What the published roles say

`primary_row_role` returns the empty role for `MustHold` and `If` — the row
stating `sum <= value` under the reification condition if there is one — and
`nullopt` for the other three. The `nullopt`s are the part worth having: they are
exactly the rows the constructed label would have got wrong.

A linear `NotIf` publishes nothing for a different reason, and this PR does not
fix it. Its `ltn` row is emitted as `cond -> sum <= value`, which is what the
constraint says must **not** hold. Nothing constructs a `ReifiedLinearInequality`
with `NotIf` or `MustNotHold` — the six derived classes cover `MustHold`, `If`
and `Iff`, and `scp_reader` builds only those — so the branch is unreachable and
this has never been observable. It is recorded in the header and in `dev_docs`
rather than fixed, because fixing an unreachable proof path belongs with whatever
first makes it reachable.

## `skipped_uncitable_row`

`lift_row` declines when there is nothing to cite, and the new bucket counts it,
keeping the accounting invariant that every donor examined lands in exactly one
of `edges_lifted` or a skip. It is only ever non-zero with a logger: with proofs
off there is nothing to cite and so nothing to be uncitable, and the presolver
must not lift differently under `--prove`.

## Checking

`gcs/constraint_row_test.cc` treats the `.opb` as the oracle rather than trusting
the roles by inspection. It posts one constraint of every reification kind of
both published families, resolves each label through the real API **from inside a
presolver** — the point in the solve where a real one asks — and requires that a
resolved label names a row the file contains, and that a `nullopt` means it does
not. It also pins that the `Iff` and `NotIf` donors really did emit rows, so
"publishes nothing" is not confused with "emitted nothing".

Mutation-tested, both directions:

| mutation | caught by |
|---|---|
| comparison publishes `""` for `NotIf` (the constructed label's mistake) | `constraint_row_test` |
| `constraint_row_label` returns its constructed label without checking the emitted set | `constraint_row_test` |

End-to-end, the check the registry design was validated against, unchanged in
outcome: revert #596 so `Comparison` emits through the void-returning
`add_constraint` again, and on
`difference_chain --mode refute -n 40 -k 8 --variant presolved --donor comparison --prove`
the presolver goes from **901 comparison edges lifted to 0**, all 901 counted in
`skipped_uncitable_row`, and **VeriPB still verifies the proof**. Declining and
staying verifiable is the outcome to want: what is being defended against is an
*invalid* proof, not a weaker one. With proofs off the same model lifts all 901
either way.

## No output change

`.opb` and `.scp` byte-identical across all 91 example snapshots
(`tools/opb_snapshot.bash`) against #602. Full suite **590/590**.

Refs #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb9fgE3SAiASdwREZVrU3p
