### PR TITLE
Brancher stages A and B: decision types, split-family bound advances, structural atom retirement

### DIFF
--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1,0 +1,1010 @@
+# Step 2 — the Brancher-API refactor: concrete, decided design
+
+**Status: DESIGN, decided, not implemented.** Against worktree
+`gcs-links-worktree`, branch `delete-order-links-on-backtrack`, HEAD `c2f12525`.
+This note is the single committed record of the step-2 design: it turns the
+user-approved conceptual sketch in
+[order-encoding-deletion.md](order-encoding-deletion.md) ("Design overview"
+through "Implementation staging") into concrete C++ against the real code, folds
+in the two objective follow-ups the owner attached (the improvement-constraint
+`delc` + Top-eviction, and the objective-variable deletion exemption from the 2b
+findings), and integrates the eq-atom sliding window that turns ascending and
+descending eq branching into a win. Where a call needed the owner it has been
+made; the five decisions are recorded up front. Where a claim needed a checker it
+was validated against `veripb 3.0.2`, and the raw drivers are cited in
+Provenance. The three remaining unknowns are implementation gates, not owner
+calls, and are flagged as such.
+
+Step 2 changes no model, no propagator, no search order. It is a proof-only
+change and must be verified as one: search identical mode-off vs mode-on at every
+stage, byte-identity where the byte-identity section promises it.
+
+The supervisor reviews this before any code is written.
+
+## Decisions (owner)
+
+1. **Per-node object: a generator, not a virtual class.** Keep the coroutine
+   `std::generator` the solver already uses and only widen its yield type; do not
+   build the virtual `Brancher` class the sketch drew. Revisit "at least until it
+   starts showing up in benchmarks as being the hotspot" — stage E watches
+   brancher overhead explicitly.
+
+2. **Accept the public yield-type source break.** Pre-0.1, there is no
+   API-stability obligation; the implicit `IntegerVariableCondition →
+   BranchDecision` conversion is the compatibility bridge and a permanent dual API
+   is not worth its maintenance. No shim.
+
+3. **Objective handling: Option A, both mechanisms composed, unconditionally.**
+   The exemption owns the objective's `ge` residency (its delete/reintroduce churn
+   goes away); the incumbent `delc` keeps exactly **one** improvement constraint
+   resident and checked-deletes every superseded one. Do the `delc` unconditionally
+   — "even if it rarely matters, because occasionally it will matter a lot."
+
+4. **The value-order mapping (final).** `split_*` win by the bound *jump*;
+   `smallest_first` / `largest_first` / `smallest_in` / `largest_in` win by being
+   O(1)-resident via the eq window; `median` / `random` / `random_out` /
+   `reject_random_interval` stay `Exclude`; `smallest_out` / `largest_out` stay
+   `Exclude` but are recorded as likely foldable future work (see below). This
+   supersedes the eq rows of the earlier sketch, which had the eq orders wrong.
+
+5. **The eq window ships default-off for eq orders**, wired but gated, until the
+   stage-E eq-heavy measurement settles the transient-for-permanent trade — the
+   same measure-first discipline as the chain gate's default. The split family is
+   likewise flag-gated.
+
+Two of these (4, 5) supersede the "map the eq orders to `Exclude`, only split
+wins" stance that an earlier iteration of this design held; the eq-atom window
+(below) is what changed the calculus, and it is validated (8/8 in VeriPB 3.0.2).
+
+## What is already committed, and what step 2 restructures
+
+Done and committed on this branch (do **not** re-do):
+
+- The **hoist primitive** — `ProofLogger::hoist_literal_to_{level,top}` over
+  `NamesAndIDsTracker::hoist_order_literal_to_{level,top}` (definition move via
+  `move_proof_lines_to_level` + re-stitch via `stitch_hoisted_order_literal`).
+- The **Literals mode** (`OrderEncodingDeletion::Literals`): deletable interior
+  `ge` defs at `Current`, forget-driven delete-and-stitch
+  (`forget_order_literals_at_level`), reintroduction (`reintroduce_order_literal`),
+  and the four hoist call sites (`backtrack`, `emit_learned_nogood`, `solution`,
+  and the eq/invar `hoist_ges_named_by_top_atom`).
+- The **chain-length gate** (`order_encoding_deletion_min_chain`, default 16;
+  0 = off = the aggressive-testing mode).
+- The **residency-cause diagnostic** (`OrderEncodingResidencyCause`,
+  `GCS_ORDER_ENCODING_STATS`), currently stats-gated.
+
+Today deletion is a **side-effect** of the existing branch/backtrack flow: a
+guess literal happens to be emitted at `Current`, a backtrack `forget` happens to
+delete it, and `backtrack()` / `emit_learned_nogood()` hoist the survivors. There
+is **no explicit advance** — the verified guess-reasoned bound jump
+(`order_jump_check`, the "verified foundation") is proven sound in isolation but
+is not wired in.
+
+Step 2 makes the advance a first-class, brancher-declared emission
+(**consolidate → hoist → delete**), so the frontier is explicitly monotone and
+deletion follows from the advance rather than from an incidental forget. It also
+gives the branch layer the two things the flat machinery cannot express: a
+**per-variable deletion-policy hook** (so the always-bound-tightened objective can
+be exempted from churn) and an **objective-improvement lifecycle** (`delc`
+superseded improvement constraints, evict their stale threshold from Top).
+
+## Concrete types and signatures
+
+### The decision and its backtrack advance
+
+The sketch drew `BranchDecision { guess; on_refuted; }` with
+`BacktrackAdvance = variant<LowerBound, UpperBound, Exclude, Custom>`. Grounded in
+the real code (`gcs/variable_condition.hh`, `gcs/search_heuristics.hh`):
+
+```cpp
+namespace gcs
+{
+    namespace backtrack_advance
+    {
+        // The node's backtrack constraint tightens to a lower bound on `var`:
+        // refuting this decision's subtree entails `var >= (next live threshold)`.
+        // Emitted by the guess-reasoned bound-jump RUP; names ONE order literal.
+        struct LowerBound final { IntegerVariableID var; };
+
+        // Symmetric: refuting entails `var <= (next live threshold)` i.e. `var < t`.
+        struct UpperBound final { IntegerVariableID var; };
+
+        // The generic fallback: accumulate `! guess` into the node's excluded set.
+        // Exactly today's `~(all guesses)` backtrack clause. Names a growing set,
+        // so nothing is deletable for that variable. The default.
+        struct Exclude final { };
+
+        // Escape hatch: the brancher hands back the backtrack constraint it has
+        // proven plus a callback that writes the advance. For exotic branchers only;
+        // the callback still never writes raw guess/hoist/delete bookkeeping — it
+        // hands the framework a WPBSum and a reason, and the framework emits.
+        struct Custom final
+        {
+            std::function<auto(const CurrentState &)->WPBSumLE> constraint;
+            // Reserved; not fleshed out until a use case appears.
+        };
+    }
+
+    using BacktrackAdvance = std::variant<
+        backtrack_advance::LowerBound,
+        backtrack_advance::UpperBound,
+        backtrack_advance::Exclude,
+        backtrack_advance::Custom>;
+
+    struct BranchDecision final
+    {
+        IntegerVariableCondition guess;   // what to branch on (unchanged type)
+        BacktrackAdvance on_refuted = backtrack_advance::Exclude{};
+
+        // Implicit bridge from a bare condition: an existing branch generator that
+        // yields IntegerVariableConditions keeps compiling and, defaulting to
+        // Exclude, keeps its proof byte-identical. This is the whole compat story
+        // for hand-written branchers.
+        BranchDecision(IntegerVariableCondition c) : guess(c) {}
+        BranchDecision(IntegerVariableCondition c, BacktrackAdvance a) : guess(c), on_refuted(a) {}
+    };
+}
+```
+
+`BacktrackConstraint` — the node's *standing* fact, as opposed to a single
+decision's advance — is the framework's internal fold of the advances seen so far,
+and does **not** need to be a public type:
+
+```cpp
+namespace gcs::innards
+{
+    // The weakest constraint proven to hold at this node given every sibling tried
+    // so far is refuted, under the current guesses. Folded from BranchDecision
+    // advances as the framework refutes siblings. Lives at Current; a restart's
+    // forget wipes it.
+    struct BacktrackConstraint final
+    {
+        // Kind inferred from the advances: all-Exclude => ExcludedSet (today's
+        // ~guesses); a Lower/UpperBound advance switches it to a monotone Bound on
+        // that variable, carrying the current frontier threshold.
+        std::variant<
+            std::monostate,                                  // ExcludedSet (default / empty)
+            std::pair<SimpleIntegerVariableID, Integer>>     // Bound: (var, frontier threshold)
+            state = std::monostate{};
+        bool is_lower = true;                                // meaningful only in the Bound arm
+    };
+}
+```
+
+### The per-node object: a generator, not a virtual class
+
+The sketch drew `Brancher` as a virtual class with `next()` +
+`initial_backtrack_constraint()`. The real per-node object today is a coroutine
+`std::generator<IntegerVariableCondition>` (`search_heuristics.hh:63`,
+`solve.hh:65`). Per Decision 1, keep the coroutine model and only widen its yield
+type:
+
+```cpp
+namespace gcs
+{
+    // The per-node object. Yields the node's decisions, each carrying how the
+    // node's backtrack constraint tightens if that decision's subtree is refuted.
+    // A coroutine, exactly as today — no per-node vtable, no virtual dispatch in
+    // the hot loop; a stateful brancher's state lives in the coroutine frame just
+    // as it does now.
+    using BranchCallback = std::function<std::generator<BranchDecision>(const CurrentState &, const innards::Propagators &)>;
+
+    using BranchValueGenerator =
+        std::function<std::generator<BranchDecision>(const CurrentState &, const innards::Propagators &, const IntegerVariableID &)>;
+}
+```
+
+`initial_backtrack_constraint()` is not a separate method: the node's constraint
+is *derived* by the framework from the advances it folds, so a generator that
+yields only `Exclude` decisions reproduces today's ExcludedSet node byte-for-byte
+with no extra protocol. This is strictly less machinery than a two-method virtual
+class whose second method's answer is a function of the first, and it keeps
+`Custom` expressible.
+
+The one cost against the virtual-class alternative: the generator cannot be
+*asked* its standing constraint out of band — it only tells the framework via the
+decisions it yields. That is fine for Lower/Upper/Exclude (folded mechanically);
+it only bites a hypothetical brancher that wants a node-level constraint
+independent of any decision, which is exactly the `Custom` escape hatch. If such a
+consumer ever lands, a virtual `Brancher` alias can be added alongside — the two
+are not mutually exclusive. Ship the generator form now (Decision 1).
+
+`branch_with`, `branch_sequence`, and every `variable_order::` / `value_order::`
+factory keep their **exact signatures** — only the yield type inside
+`BranchValueGenerator` / `BranchCallback` changes.
+
+### Helpers
+
+The sketch's `frontier_ascending()` / `bisect()` / `excluded_set()` are thin tags
+applied inside the existing value_order coroutines. They are not new public entry
+points; they are how each `value_order::` factory declares its advance:
+
+```cpp
+namespace gcs::value_order::detail
+{
+    // Tag a d-way / two-way ascending value branch: each refutation advances the
+    // lower-bound frontier over the variable (jumping any holes) via the verified
+    // guess-reasoned RUP. `var` is the branch variable.
+    [[nodiscard]] auto frontier_ascending(IntegerVariableID var) -> BacktrackAdvance;   // = LowerBound{var}
+    [[nodiscard]] auto frontier_descending(IntegerVariableID var) -> BacktrackAdvance;  // = UpperBound{var}
+
+    // Bisection (split_*): the single order-atom split is a LowerBound (lower half
+    // first) or UpperBound (upper half first) advance; identical to the above but
+    // named for the split call sites.
+    [[nodiscard]] auto bisect_lower(IntegerVariableID var) -> BacktrackAdvance;         // = LowerBound{var}
+    [[nodiscard]] auto bisect_upper(IntegerVariableID var) -> BacktrackAdvance;         // = UpperBound{var}
+
+    // The default: accumulate ~guess. Nothing new emitted.
+    [[nodiscard]] auto excluded_set() -> BacktrackAdvance;                              // = Exclude{}
+}
+```
+
+A new brancher is then: yield `IntegerVariableCondition`s as today, and where it
+is a monotone bound, yield `BranchDecision{cond, bisect_lower(var)}` instead of
+the bare `cond`. Everything else (consolidate, hoist, delete) is the framework's.
+
+## Mapping the existing value orders
+
+Which atom a value order branches on — the **eq atom** or the **order atom** —
+decides how its advance deletes. There are two wins, and they are different
+mechanisms: the split family wins by a bound *jump* over holes; the contiguous eq
+family wins by being *O(1)-resident* via the eq window. Read against the real
+`value_order` coroutines (`search_heuristics.cc`), the final mapping is:
+
+| value_order (real code) | branches on | monotone frontier? | advance | deletable? |
+|---|---|---|---|---|
+| `split_smallest_first` (`var <= v` / `var > v`) | **order atom** `ge(v+1)` | yes (lower) | `LowerBound` — jump | **yes — one ge pin** |
+| `split_largest_first` (`var > v` / `var <= v`) | order atom `ge(v+1)` | yes (upper) | `UpperBound` — jump | **yes** |
+| `split_random` | order atom `ge(v+1)` | yes | `LowerBound` — jump [1] | yes |
+| `smallest_first` (`==v`, ascending) | **eq atom** `eq(v)` | yes (lower) | `LowerBound` **+ windowed eq** | **yes — O(1) resident, via the window** |
+| `largest_first` (`==v`, descending) | eq atom | yes (upper) | `UpperBound` **+ windowed eq** | **yes** |
+| `smallest_in` (`==lb` then `!=lb`) | eq atom | yes (lower) | `LowerBound` **+ windowed eq** | **yes** |
+| `largest_in` (`==ub` then `!=ub`) | eq atom | yes (upper) | `UpperBound` **+ windowed eq** | **yes** |
+| `smallest_out` (`!=lb` then `==lb`) | eq atom | — (reject-first) | `Exclude` [2] | no |
+| `largest_out` (`!=ub` then `==ub`) | eq atom | — (reject-first) | `Exclude` [2] | no |
+| `median` (`==m` / `!=m`) | eq atom | no | `Exclude` | no |
+| `random`, `random_out` | eq atom | no | `Exclude` | no |
+| `reject_random_interval` (`not_in_range` / `in_range`) | **invar atom** | no (disjunctive) | `Exclude` [3] | no |
+
+Why the eq family splits the way it does:
+
+- **`LowerBound`/`UpperBound` + windowed eq** — `smallest_first`, `largest_first`,
+  `smallest_in`, `largest_in`. Each refutes `x == frontier` and advances the
+  frontier by one; the window applies exactly. There is *no gap to jump* in
+  contiguous ascending eq (refuting `x == lb` moves the frontier from `lb` to
+  `lb+1`, with only the two ges the eq atom already pins in between), and an eq
+  atom's permanent Top definition pins **both** `ge(v)` and `ge(v+1)`
+  (`hoist_ges_named_by_top_atom` → `EqHoist`; the measured 44.2% `eq_hoist` on
+  seat-moving). The window does **not** try to jump gaps — it deletes *behind* a
+  one-step frontier, evicting each `eq(v)`/`ge(v)` once the frontier has stepped
+  past it, bounding the permanent proof objects per branched variable from
+  O(domain-width) to O(1). That is the win, and it is driver-backed (see "The
+  eq-atom window").
+
+- **Stay `Exclude`** — `median` / `random` / `random_out` refute a *non-boundary*
+  value, so the frontier does not move and there is no "behind" to delete;
+  `smallest_out` / `largest_out` are reject-first and never establish the sibling
+  refutation the advance needs; `reject_random_interval` mints an **invar** atom
+  (partition machinery, `InvarHoist`) and is genuinely disjunctive.
+
+Net: `LowerBound`/`UpperBound` are wired for `split_*` (jump) and for the four
+contiguous eq orders (windowed); everything else is `Exclude`. This is the honest,
+search-preserving mapping. The framework must **never** silently swap an eq guess
+for an order guess to manufacture a win — that changes propagation strength and
+therefore search.
+
+Footnotes:
+
+1. **Pre-existing oddity, leave alone.** `split_random_value_generator`
+   (`search_heuristics.cc:442`) has *identical* then/else arms — both yield
+   `var > v` then `var <= v` regardless of the coin flip, so it is effectively
+   `split_largest_first`. The mapping is unaffected; do not "fix" it as part of
+   step 2 (it changes search and is out of scope).
+
+2. `smallest_out` / `largest_out` are **likely foldable**, but as their own small
+   design, not this one: refuting the reject-first sibling (`x != lb` first)
+   COMMITS `x == lb` rather than *advancing a frontier*, so the eq window's
+   advance-and-evict does not apply directly. There is no known application, so
+   this is recorded as deferred future work rather than built.
+
+3. `reject_random_interval` is the natural first consumer of a future first-class
+   `ExcludedInterval` / disjunctive advance kind (see Deferred / future work). Map
+   it to `Exclude` for now.
+
+## The eq-atom window
+
+The mechanism that makes the four contiguous eq orders win. Audited (window closes
+cleanly at assertion Off; one scoping caveat, eq⨯interval) and driver-validated
+(8/8 in VeriPB 3.0.2, including the load-bearing eq-def-traversal control). The
+advance is emitted by **the framework** (`solve.cc` + `ProofLogger`), never the
+brancher — the same framework/brancher split the split family uses; branchers only
+declare `LowerBound`/`UpperBound`, and the mode gate makes it inert under `None`.
+
+Grounding facts the window rests on:
+
+- For a Bits variable with **only** eq atoms, the sole Top-resident thing naming
+  `eq(v)` is its two `red` def lines; the containment/partition pins are inert
+  (they need a `containment_tree` / `interval_partition`, created only by
+  `need_invar`). So the window closes cleanly for pure eq branching.
+- The advance `rup <guesses> ge(v+1)` is RUP through `eq(v)`'s **reverse
+  reification** and is genuinely load-bearing — driver control D2c rejects when
+  that reverse def is deleted before the advance.
+- VeriPB polices a stranded ge only at a **point of use** (D4c rejects, D4c-silent
+  is tolerated), so ge-under-eq residency is a solver-side invariant, not a
+  checker-enforced one.
+
+### Mint-time lifetime tagging (the narrow API)
+
+Today `need_direct_encoding_for` hardcodes the eq def at `ProofLevel::Top`
+(`names_and_ids_tracker.cc:672`), unlike `need_gevar`, which already chooses
+`Current` vs `Top` from `def_at_current`. The window gives the eq path the same
+choice, **gated so ordinary `need_proof_name` callers are oblivious** — a scoped
+RAII guard set by the branch layer around the guess mint only:
+
+```cpp
+// NamesAndIDsTracker — RAII, set by the branch layer around the guess mint only.
+struct WindowedEqScope {                       // ctor sets _imp->minting_windowed_eq = true
+    explicit WindowedEqScope(NamesAndIDsTracker &); ~WindowedEqScope();
+};
+```
+
+`need_direct_encoding_for` reads `minting_windowed_eq` exactly where `need_gevar`
+reads its residency inputs: when set (and Literals mode / `AssertionLevel::Off` —
+the same pairing every existing Literals-machinery guard uses / real Bits var /
+not a bound / not eq⨯interval — see the guard below) it emits the two eq def lines at
+`ProofLevel::Current` and records the atom in a new live-eq index, instead of Top.
+**Every other caller** — propagator reasons, reified constraints,
+`need_pol_item_defining_literal` — runs with the flag clear and gets today's
+byte-identical Top behaviour. This meets the owner's bar: only the guess/mint path
+knows about lifetimes. (A tagged
+`need_direct_encoding_for(id, v, Lifetime::Windowed)` overload is equivalent but
+threads the tag through more call sites; the scoped guard keeps the surface to one
+RAII object set in `solve.cc`'s branch loop, where the guess is made.)
+
+### The per-iteration tidy sequence
+
+For an ascending window step refuting `x == v` (standing bound `x >= v`), landing
+at the sibling's backtrack level `L`; this order **verifies as `d1_main.pbp`** and
+the marked orderings are load-bearing:
+
+1. Mint frontier `ge(v+1)` (Current) + chain link to the current live lower
+   neighbour (`make_pol_chain`).
+2. Mint `eq(v)` (Current, windowed): **reverse reification first, then forward** —
+   the reverse must exist when the forward's `red` witness is checked (fresh-atom
+   order). **[ordering constraint 1]**
+3. Emit the sibling refutation `~guesses | ~eq(v)` (the generalised
+   `ProofLogger::backtrack`; in the solver this is RUP from the still-live child).
+4. **Advance** `rup <guesses> ge(v+1)` — RUP through {standing `~g | ge(v)`,
+   sibling `~g | ~eq(v)`, `eq(v)` reverse-reif}. Must come **after** steps 2/3 and
+   **before** any deletion of `eq(v)`'s reverse reif. **[ordering constraint 2 —
+   this is exactly what driver control D2c violates and VeriPB rejects.]**
+5. **Hoist** the new frontier `ge(v+1)` to `L` (existing
+   `hoist_live_order_literals_toward_level`), so the standing advance never names a
+   to-be-deleted literal.
+6. **Tidy** (all `del id`, derived/unchecked): the superseded previous advance
+   `~g | ge(v)`; `eq(v)`'s two def lines; **the sibling `~g | ~eq(v)` — it named
+   `eq(v)`, so it must go for the atom to be fully unreferenced** (this is *not* in
+   the naive "delete eq def + ge def" list, and is required for full eviction; see
+   the tidy note below); the stepped-over `ge(v)` def + its dangling chain link.
+   Then **re-stitch** `ge(v+1)` to its surviving lower neighbour.
+
+**[ordering constraint 3 — stitch vs delete]** re-stitch *after* deleting the
+dangling links, at the surviving neighbour's level, exactly as
+`forget_order_literals_at_level` already does for the ge case. In pure ascending
+branching the surviving lower neighbour is always the true boundary `ge0`, so this
+stitch is trivial (`rup 1 ge0 1 ~ge(v+1) >= 1`); a non-trivial `make_pol_chain`
+stitch arises only around a *hoisted-out* interior ge (below).
+
+Tidy note (**the sibling-clause deletion**): the tidy must delete the sibling
+`~g | ~eq(v)` for full eviction, because it names `eq(v)`. The naive "delete eq
+def + ge def" list omits it; it is confirmed necessary and safe in `d1_main.pbp`,
+and is called out here so it is not forgotten in the implementation.
+
+Steady state after each tidy is the design's target: **one boundary `ge0` + one
+frontier `ge` + one standing advance clause live** (plus, mid-iteration, one eq
+def). Descending (`largest_first` / `largest_in`) is the `UpperBound` mirror
+(`x == ub`, advance `x < ub` i.e. `~ge(ub)`), mechanically symmetric; the driver
+validated the ascending direction only (see Implementation gates).
+
+### The hoist-out rule for permanent references
+
+Unchanged from the design's deletion rule ("delete only when unreferenced; hoist
+otherwise"), applied to eq atoms: if `eq(v)` acquires a **permanent (Top)
+reference** — a solx blocking clause, a learned-nogood decision literal, or a
+reified-constraint use that names `id == v` — then at tidy time `eq(v)` is **not
+evicted**; instead it and the two ges it names are hoisted to Top, exactly as
+`hoist_ges_named_by_top_atom` already does for the ges, plus a new
+`hoist_eq_to_top`. The window then evicts `eq(v)`'s **neighbours** normally and
+stitches the chain **around** the retained interior ges (the genuine
+`make_pol_chain` case — driver D4, `ge3 -> ge2`). Detecting "has a permanent
+reference" reuses the residency-cause bookkeeping the design already mandates for
+the ge/soli case. VeriPB will not catch a wrongly-evicted referenced ge except at
+a point of use (D4c vs D4c-silent), so this is a solver invariant, not something
+the checker enforces.
+
+### Bookkeeping mirrors
+
+An eq eviction must update, mirroring the ge eviction's
+`gevars_that_exist` / `live_order_literals` / `order_literals_by_level` triple:
+
+- `eqvars_that_exist[id].erase(v)` — so a later `need_direct_encoding_for(id, v)`
+  re-mints; readers to keep consistent: `need_pol_item_defining_literal`
+  (386-387 / 407-408), containment/partition seeders (1917 / 1986), view eq-links
+  (2131).
+- `variable_conditions_to_x.erase(id == v)` **and** `.erase(id != v)` — so the
+  guard at 595 (`contains(id == v)`) stops short-circuiting and re-mint proceeds
+  (the eq analogue of `need_gevar`'s fast-path at 792, and of the ge-eviction
+  path). This is the piece with **no current analogue**, because eq defs are
+  unconditionally Top today and so are never erased.
+- **New `live_eq_literals` + `eq_literals_by_level`** (mirroring
+  `live_order_literals` / `order_literals_by_level`): a per-level index of windowed
+  eq defs, so a backtrack `forget` deletes the right eq def lines and an eviction
+  can find and retag an atom. `forget_order_literals_at_level` gains an eq sweep
+  (or a sibling `forget_eq_literals_at_level`), called from the same
+  `forget_proof_level` funnel.
+
+### WindowedFrontier vs FrontierExempt, and the chain gate
+
+The chain gate (`order_encoding_deletion_min_chain`) keeps *short-chain
+non-frontier* variables resident to avoid stitch churn with no win. A windowed eq
+variable is a **frontier** variable by construction, so it must not be held
+resident by the gate — or the window degenerates to the baseline (every eq stays
+Top, O(width) again). The windowed-eq lifetime tag therefore takes **priority over
+the gate** in `need_gevar`'s residency ladder: insert a new lowest-structural
+reason `WindowedFrontier`, checked *above* the gate (so a windowed var's interior
+ges are deletable regardless of chain length) but *below* the structural pins
+(boundary / aux / view) and below a genuine permanent reference (hoist-out). The
+gate keeps its job for the **non-frontier short-chain tail**
+(crystal_maze / talent eq atoms that are *not* branched on), which the window
+never touches.
+
+This composes with payload 3's `FrontierExempt` (below) as its exact opposite:
+`FrontierExempt` says "resident *despite* being frontier" (the churn-regime
+objective); `WindowedFrontier` says "deletable *because* frontier" (the win-regime
+eq branch). They are the two opposite frontier policies and only the frontier
+owner (branch layer / objective owner) can pick which applies. They never apply to
+the same variable, so they sit as sibling slots just above the gate.
+
+### The one hidden pin — eq⨯interval (bidirectional guard)
+
+A windowed eq variable that *also* receives an `in`/`not_in` interval literal has
+its live eq atoms retro-pinned as `Top` partition singleton cells
+(`init_interval_partition` / `define_plain_invar` walk `eqvars_that_exist`),
+holding the window open. Ascending eq branching alone never does this, but a
+constraint on the same variable might. The guard must be **bidirectional**
+(supervisor correction):
+
+- **(i-static)** `WindowedEqScope` refuses to window a variable that already has an
+  `interval_partition` — conservative: eq stays Top, correct, no win.
+- **(i-dynamic)** if an interval literal is requested mid-search on a
+  currently-windowed variable, `init_interval_partition` would build Top singleton
+  cells naming eq defs that live at Current — a Top-discipline violation that
+  rejects at the next backtrack — so the partition path must first **collapse the
+  window** (hoist-out every live windowed eq def + its ges to Top, the existing
+  hoist-out mechanism run wholesale) and only then build the partition; the
+  variable is thereafter unwindowed.
+
+Both are recommended for step 2, flagged as a future extension. The alternative —
+the window managing partition coverings on evict — stays out of step-2 scope. This
+is the single scoping caveat the audit surfaced.
+
+## Ownership and lifecycle
+
+- **`BranchHeuristic` (per-search setup)** — unchanged. `solve_with` calls it once
+  after propagators are final (`solve.cc:351-353`) and reuses the returned
+  `BranchCallback` at every node. `dom_wdeg`'s conflict-observer attachment, the
+  RNG `shared_ptr` sharing, all unchanged.
+- **The per-node generator (the "Brancher")** — created per node by
+  `branch_callback(state.current(), propagators)` (`solve.cc:118`), lives for that
+  node's branch loop, destroyed when the loop ends. Same lifetime as today's
+  generator; its coroutine frame holds any per-node state (RNG draws, the split
+  point). **No per-search or per-solve Brancher object** — the standing
+  `BacktrackConstraint` is a stack local in `solve_with_state`, born and folded
+  within one frame.
+- **State across restarts** — nothing to carry. The `BacktrackConstraint` and the
+  advance RUPs live at `Current`, so the restart `forget` wipes them and the next
+  pass re-runs the generator and re-derives them. The only cross-restart coupling
+  is learned nogoods (below).
+- **The `guesses` vectors.** Two distinct vectors; step 2 must not conflate them:
+  - `solve.cc`'s local `Literals guesses` (`solve.cc:97-111`) is the **propagation
+    seed** only (this_branch_guess + the B&B objective bound). The brancher never
+    touches it. Under the objective exemption the B&B bound still seeds propagation
+    exactly as today.
+  - `state.guesses()` — the full decision stack — feeds `backtrack()`
+    (`solve.cc:263-265`) and nogood learning (`solve.cc:236-240`). Under `Exclude`
+    this is unchanged. Under a `Bound` node, the frame's terminal lemma is the
+    standing bound rather than `~(state.guesses())`.
+  - The **reduced nld-nogood prefix** (`solve.cc:180-195`) and its negative-flip
+    detection (`guess == ! *first_sibling`) operate on `BranchDecision.guess`
+    (still an `IntegerVariableCondition`), so they are untouched: a split node's two
+    siblings `var <= v` and `var > v` are still exact negations (`operator!`,
+    `variable_condition.hh:245`), the flip is still detected, and the prefix still
+    drops the second sibling.
+- **The existing hoist call sites — which move, which stay:**
+  - `ProofLogger::backtrack` (`GuessHoist`) — **stays**, generalised: under a
+    `Bound` node the framework emits the advance-derived bound instead of the
+    `~guesses` clause. Under `Exclude` it is verbatim today's code.
+  - `ProofLogger::emit_learned_nogood` (`NogoodHoist`) — **stays verbatim**.
+    Nogoods still hoist their decision literals to Top so they survive the restart
+    forget.
+  - `ProofLogger::solution` (`SoliHoist`) — **stays, and gains the payload-2
+    lifecycle**: it still hoists the incumbent threshold to Top, and now also records
+    the improvement-constraint id and, on the *next* incumbent, delcs the superseded
+    one and evicts the stale threshold.
+  - `hoist_ges_named_by_top_atom` (eq/invar, `EqHoist`/`InvarHoist`) — **stays
+    verbatim**. Independent of branching. (`hoist_eq_to_top`, above, is its eq-atom
+    sibling for the window's hoist-out.)
+  - The **new** advance-RUP + frontier-hoist + delete-behind is the one genuinely
+    new call site, driven from `solve_with_state`'s branch loop.
+
+## The framework's proof duties
+
+Per node, in `solve_with_state`'s branch loop (`solve.cc:182-207`). "The framework"
+= `solve.cc` + `ProofLogger`; branchers never write raw VeriPB.
+
+**Mode gating (load-bearing).** The advances are *declared* always but *acted on*
+(proof-wise) only under `OrderEncodingDeletion::Literals`. Under `None` (the
+default) a `Bound` advance is treated exactly like `Exclude`: no advance RUP, no
+hoist, no delete — the frame emits `backtrack(state.guesses())` as today. This is
+what keeps flag-off byte-identity true even after the bound advances are wired.
+
+Per node, for each `BranchDecision d` the generator yields:
+
+1. Guess `d.guess`, recurse (unchanged: `new_epoch` / `state.guess` / recurse /
+   `state.backtrack`).
+2. If the child subtree completed (was refuted), **fold the advance** into the
+   node's `BacktrackConstraint`, and — under Literals, for a `Lower/UpperBound`
+   advance only — perform **consolidate → hoist → delete**:
+   - **Advance RUP.** Emit the guess-reasoned bound jump
+     `rup <state.guesses()> (var >= H) >= 1` (resp. `var < L`), where `H` is the new
+     frontier = the next live threshold above the refuted region. This is the
+     verified foundation (`order_jump_check`); VeriPB re-derives the holes from the
+     guesses and climbs the chain. One `.pbp` line. (For the windowed eq case the
+     one-hole analogue climbs through `eq(v)`'s reverse reif, per the tidy sequence.)
+   - **Hoist** the new frontier literal `ge(H)` to the advance's level (so the
+     backtrack constraint never names a to-be-deleted literal), via
+     `hoist_live_order_literals_toward_level`.
+   - **Delete** behind the frontier: the ges the advance stepped over that no
+     surviving constraint names. This is *already* what the child's
+     `forget_proof_level(depth+1)` + `forget_order_literals_at_level` do; the new
+     advance RUP is what lets those deletions keep exactly one hoisted frontier ge
+     instead of relying on the incidental guess-hoist. The deletion rule is
+     unchanged: delete only when unreferenced, hoist otherwise; the backtrack
+     constraint's named literal is the one surviving reference.
+3. When the generator is exhausted (`next() == nullopt`), the standing
+   `BacktrackConstraint` is the node's refutation lemma:
+   - **ExcludedSet** → emit today's `backtrack(state.guesses())` verbatim.
+   - **Bound** reaching past the domain (`H > ub` / `L < lb`) → the bound is a
+     contradiction under the variable's bound axioms, which is the refutation; it
+     subsumes the `~guesses` clause (the frontier reaching `ub+1` IS the
+     at-least-one closure). Emit the terminal advance RUP at the frame's backtrack
+     level in place of `backtrack(state.guesses())`.
+
+**The exact proof level of the advance RUP and the frontier hoist is the one
+delicate mechanic.** The child frame has already emitted its own backtrack clause
+at `depth+1` and forgotten `depth+2` before control returns; the advance must land
+where it both (a) reasons from the still-live guesses and (b) survives to drive the
+next sibling / close the node. The anchor is `order_jump_check` (verified at wide
+gaps). The design does not pin the level here beyond "reasoned from
+`state.guesses()`, landed at the sibling's backtrack level" — stage B validates it
+empirically against VeriPB with `MIN_CHAIN=0` (see Implementation gates).
+
+**The chain gate survives, with a narrowed role.** The gate was a *blanket*
+no-harm floor: keep short chains resident so propagation-strong models pay no
+churn. Post-refactor:
+
+- The advance model makes a bound-branched variable's frontier explicitly monotone
+  within the node, so there is no reintroduction churn along the advancing frontier
+  itself.
+- The 2b churn the flat gate could not kill — concentrated on the
+  always-bound-tightened objective/cost — is removed precisely by the payload-3
+  exemption (which the gate cannot express: it is length-based, and the objective's
+  chain is only ~98 long, well inside any win-preserving gate).
+- But the gate still guards the **long tail of short-chain non-frontier variables**
+  on eq/small-domain models (crystal_maze, talent), where deletion emits stitch
+  churn with no win and which no advance or exemption covers (they are not frontier
+  variables). There the gate is the only thing that makes the feature
+  strictly-no-harm (measured: gate 16 → crystal_maze byte-identical to `None`).
+
+So the gate stays; its job narrows from "cover all churn" to "cover the non-frontier
+short-chain tail," with the exemption taking the objective/cost churn it never
+handled well. Gate, `FrontierExempt`, and `WindowedFrontier` compose as residency
+reasons in `need_gevar` (the exemption and the windowed tag are both checked *above*
+the gate).
+
+## Objective handling
+
+Two independent mechanisms, both under the Literals flag, both new in step 2, both
+adopted per Decision 3.
+
+### Where incumbent state lives
+
+Today the objective is a `min:` line in the OPB (`proof_model.cc:626`); there is
+**no** model-time improvement constraint. Each improving solution emits, in
+`ProofLogger::solution` (`proof_logger.cc:227-237`), a permanent `Top` RUP
+`~ge(incumbent) >= 1` (the improvement constraint) after the `soli`, and hoists
+`ge(incumbent)` to Top (`SoliHoist`, `proof_logger.cc:211-217`). Over an
+optimisation descent this accumulates **O(#incumbents)** resident unit clauses plus
+O(#incumbents) Top-pinned thresholds. Payloads 2 and 3 convert this to O(1)
+resident.
+
+`solution()` gains a small **incumbent record** (in `ProofLogger::Imp`, or threaded
+from the tracker):
+
+```cpp
+struct IncumbentRecord {
+    Integer value;             // the incumbent objective value
+    ProofLine improvement_line; // the Top RUP `~ge(value) >= 1` just emitted
+};
+std::optional<IncumbentRecord> last_incumbent;   // per objective, per solve
+```
+
+Today `emit_rup_proof_line(... id < value ...)`'s return is discarded
+(`proof_logger.cc:235`); the `soli` improvement constraint lands in **core** at the
+next sequential ID (`IDmax+1`), which is exactly the ID to capture here.
+
+### Payload 2 — delc the superseded improvement constraint + evict its threshold
+
+When solution `k+1` lands (value `v' < v`, minimisation), `solution()`:
+
+1. Emit the new `soli`, hoist `ge(v')` to Top, emit the new improvement constraint
+   `~ge(v') >= 1` (as today), and set `last_incumbent = {v', line'}`.
+2. **Delc the old improvement constraint** `~ge(v) >= 1`. It is implied by the new
+   one plus the resident order chain: `v' < v` gives the chain link
+   `ge(v) → ge(v')`, so `~ge(v')` (the new unit) RUP-derives `~ge(v)` (the old
+   unit).
+3. **Evict `ge(v)` from Top** — the new evict-from-Top primitive (below), *iff* the
+   residency bookkeeping says the `soli` pin was `ge(v)`'s **only** Top cause. If
+   `ge(v)` is also pinned by an eq atom, an invar atom, a nogood, or the objective
+   exemption, it stays resident and only the improvement constraint is delc'd.
+
+**Ordering is load-bearing:** delc the old constraint (step 2) *before* evicting
+`ge(v)` (step 3), because the delc's subproof needs `ge(v)` and its chain link still
+resident. This delc-before-evict discipline is a **solver-side invariant** — see the
+validated mechanics below.
+
+`-n 1` / find-first optimisation: only one incumbent is ever produced, so
+`last_incumbent` is set once and payload 2 never fires — a clean no-op. Full
+optimisation: fires on every improvement after the first. No objective (`solx`
+enumeration, `--all`): `solution()` takes the `solx` path,
+`optional_minimise_variable_and_value` is `nullopt`, and the whole of payload 2 is
+skipped — the `blocking_sum` / `SolxBlock` path is untouched.
+
+Interaction with `solution()`'s existing hoist: unchanged for the *current*
+incumbent (still `SoliHoist` to Top so the fresh improvement constraint does not
+name a to-be-deleted literal); payload 2 only adds the *retirement* of the *previous*
+incumbent's hoist. Measured benefit is TBD and stated honestly: this converts
+O(#incumbents) resident constraints to O(1), matching the "shrink the resident DB"
+thesis, but its verify-time payoff is unproven until the stage-E optimisation sweep.
+
+#### Validated delc mechanics (veripb 3.0.2)
+
+The `delc` syntax and its obligations are validated against `veripb 3.0.2` (9/9
+driver checks, independently re-run by the supervisor; see Provenance):
+
+- **Autoproof form (the one to emit): `delc <id> ;`** — succeeds via veripb's RUP
+  shortcut for the weaker-from-tighter implication (the empty witness fires the
+  shortcut).
+- **Explicit-subproof form (on record if ever needed):**
+  `delc <id> : <witness> : subproof <goals> qed ;` with an empty witness; the negated
+  deleted constraint is goal premise `-1`, discharged by a one-line
+  `pol <new_bound_id> -1 +`.
+- The `soli` improvement constraint lands in **core** at the next sequential ID
+  (delc-able); `delc` on a *derived* constraint is rejected outright, so it cannot be
+  misapplied to ge defs by accident.
+
+Two load-bearing caveats:
+
+1. **A failed `delc` autoproof without `-c` downgrades rather than rejects — but the
+   downgrade is enforced at exactly the right conclusions** (owner-corrected,
+   source-read, and empirically confirmed). The downgrade clears veripb's
+   `strong_solution_guarantees`; thereafter solutions do not update the valid-witness
+   bookkeeping, so a `conclusion BOUNDS` whose upper bound cites a post-downgrade
+   solution **rejects** (confirmed: "claimed upper bound of 8 mismatches the best
+   recorded upper bound of 12", no `-c`), an `ENUMERATION_COMPLETE N` with
+   post-downgrade exclusions **rejects** on count mismatch (confirmed), and strong
+   `output` guarantees (EQUIOPTIMAL/EQUISATISFIABLE/EQUIENUMERABLE) reject outright.
+   Only UNSAT / no-solution conclusions — where deletion-weakened refutations remain
+   sound — tolerate the downgrade, and those tolerated cases are in fact sound.
+   **Consequence: veripb's defaults are sound-by-construction; `-c` is NOT a soundness
+   requirement.** Still run `-c` (`--force-checked-deletion`) in suites and gates from
+   stage D on, for a different reason: it fails fast AT the delc site (precise line)
+   and catches a broken implication in GCS's emission logic even on proofs whose
+   conclusions happen to remain checkable without it.
+2. **veripb does not police eviction ordering.** Deleting the ge defs while the old
+   improvement constraint still names the atom also verifies (defs are derived and
+   redundant over the bits; rejection happens only at a later point of use). The
+   delc-before-evict ordering is therefore a **solver-side invariant** — VeriPB
+   acceptance is not evidence the discipline held.
+
+These are two instances of the same fact — **VeriPB polices order-encoding soundness
+only at a point of use, not at deletion** — and the two solver-side invariants it
+will not police are:
+
+- **Eviction ordering** (delc the improvement constraint before evicting its ge).
+- **ge-under-eq residency** (do not evict a ge a live Top eq atom names; the eq
+  window's hoist-out rule).
+
+Both are exactly why the always-on residency-cause bookkeeping (below) is mandatory,
+not optional.
+
+### The evict-from-Top primitive — mirror of hoist
+
+Hoist moves a def *to* Top and stitches it *in*. Evict moves a def *off* Top and
+stitches the chain *over* it:
+
+```cpp
+// NamesAndIDsTracker
+// Evict a real variable's Top-resident ge threshold v: emit `del` for its two
+// reification def lines and its two Top chain links, stitch the surviving Top
+// neighbours lo,hi with a skip link ge(hi) -> ge(lo) (the run-stitch of
+// forget_order_literals_at_level, run for a single Top literal on demand), and drop
+// v from live_order_literals / gevars_that_exist so a later need_gevar reintroduces
+// it as a deletable interior literal. Precondition (asserted): v's only Top
+// residency cause is the one the caller names (e.g. SoliHoist).
+auto evict_order_literal_from_top(const SimpleIntegerVariableID & id, Integer v,
+    OrderEncodingResidencyCause expected_sole_cause) -> void;
+```
+
+This **requires the residency-cause bookkeeping to be always-on under Literals**,
+not stats-gated. Today `stats_ge_top_cause` is populated only when
+`collect_order_encoding_stats` (Literals *and* the env var). Payload 2's safety
+assertion needs a per-Top-ge cause record — a minimal cause set or a Top-pin
+refcount — populated whenever the mode is Literals, with the existing stats map
+layered on top; without it, eviction cannot safely fire and must conservatively skip
+(leaving the ge resident — correct, no win). This promotion is now stage B'
+(shared with the eq window), not a stage-D prerequisite.
+
+The evict primitive has **two consumers**: payload 2 (evict a superseded soli
+threshold) and the eq window's per-iteration tidy (evict a Current-level eq/ge def +
+re-stitch). Its hoist-out path needs the same always-on residency bookkeeping. So the
+primitive and the bookkeeping promotion are a shared stage B' (below), rather than
+payload 2 owning them.
+
+### Payload 3 — objective / frontier deletion exemption
+
+The 2b finding: seat-moving's residual ~20.8k delete/reintroduce churn at gate 16 is
+concentrated on the **always-bound-tightened objective (chain 98) and cost (76)**
+variables, which any win-preserving flat gate leaves deletable, and which churn
+*verify-neutrally* (OFF 305.9 s ≈ L16 298.3 s) for **zero** shrinkage. The fix is a
+per-variable **deletion-exempt** policy hook, consulted in `need_gevar`'s residency
+decision:
+
+```cpp
+// NamesAndIDsTracker — model/solve-time note, like note_order_encoding_stays_resident.
+// A variable exempted from Literals-mode deletion: every ge def stays resident at
+// Top (tagged level 0), never churned. Populated by the frontier owner.
+auto note_deletion_exempt(const SimpleOrProofOnlyIntegerVariableID & id) -> void;
+```
+
+In `need_gevar` (`names_and_ids_tracker.cc:841-896`) the residency priority becomes
+**boundary > aux > view > exempt > gate**, with the eq window's `WindowedFrontier`
+as `exempt`'s opposite-signed sibling (both just above the gate). The exempt check
+sits just above the gate (a new `OrderEncodingResidencyCause::FrontierExempt`),
+because an exempt variable is resident regardless of chain length but below the
+structural pins that already force residency for their own reasons.
+
+Who populates it:
+
+- The **framework** exempts the **objective** — `solve_with` (or `model->minimise`)
+  calls `note_deletion_exempt(objective_var)`, because `solve.cc` owns the B&B
+  bound-tightening step (`solve.cc:100-111`) that makes the objective a
+  perpetually-re-tightened, backtrack-relaxed frontier. This is the primary, measured
+  case.
+- Optionally, a **brancher** may designate a frontier variable it does not want
+  churned (a bound brancher whose variable is re-touched by another mechanism). The
+  `BacktrackConstraint`'s Bound arm names the variable, so the framework can offer
+  `note_deletion_exempt` for it — but **not by default**: exempting a bound-branched
+  variable defeats the split win (the win *is* deleting its stepped-over chain). The
+  exemption is opt-in, for the churn-regime where a variable is bound-frontier *and*
+  re-touched such that deletion churns without winning — the objective being the
+  canonical instance.
+
+This is why it belongs in the branch layer and not the flat chain gate: the gate is
+length-based and cannot tell a **win-regime long chain** (a weak-prop split variable
+— delete it) from a **churn-regime long chain** (the always-tightened objective —
+keep it resident). Only the frontier owner knows which is which.
+
+**Composition with payload 2.** If the objective is exempt, its ges are resident by
+`FrontierExempt`, so payload 2's *ge*-eviction never fires for them (soli is not the
+only cause) — but payload 2's *improvement-constraint* delc still fires and still
+matters (those O(#incumbents) unit clauses exist regardless of ge residency). So the
+two compose cleanly: **payload 3 owns the objective's ge residency; payload 2 owns
+the improvement constraints.** The measured objective chain (median a dozen, max 98)
+is short, so keeping it resident is cheap and the ge-eviction half of payload 2 buys
+little on the objective — its value is for a future long-objective-chain regime or a
+non-exempt configuration. Per Decision 3, ship both.
+
+## Byte-identity: exactly what must not move
+
+- **`None` mode, forever:** a `Bound` advance is inert (treated as `Exclude`); the
+  proof is byte-identical to pre-step-2. Enforced by the mode gate in the branch
+  loop.
+- **`Literals` mode, stage A only:** every value order maps to `Exclude`, so the
+  proof is byte-identical to the *current* Literals proof (forget-driven deletion +
+  guess/eq/nogood/soli hoists, no advance RUP). The Brancher types and the yield-type
+  widening are pure plumbing at stage A.
+- Stages B onward deliberately change the Literals-mode proof (advance RUPs, windowed
+  eq, delc, eviction, exemption) and are gated on **VeriPB-verifies +
+  search-identical**, not byte-identity — except stage B', whose primitives are
+  unused and which is itself byte-identical.
+
+## Public-API compatibility
+
+**Keeps compiling unchanged** (all real user code): `branch_with`,
+`branch_sequence`, every `variable_order::` and `value_order::` factory,
+`SolveCallbacks::branch`, and every in-tree consumer — the 18 examples,
+`minizinc/fzn_glasgow.cc` (`indomain*` → value_order at 990-1007), `xcsp`, and the
+two `BranchValueGenerator` *variables* (`order_deletion_bench:304`, `fzn:989`, which
+merely hold a factory result). They all go through the factories, which keep their
+signatures, and run byte-identically at stage A.
+
+**Changes shape but not source for factory users:** the yield type inside
+`BranchValueGenerator` / `BranchCallback` becomes `std::generator<BranchDecision>`
+instead of `std::generator<IntegerVariableCondition>`.
+
+**Needs a mechanical one-line migration (internal only):**
+
+- The scripted-branching tests `range_witness_w{1,2,3}_test.cc` construct a
+  `BranchCallback` by hand returning `std::generator<IntegerVariableCondition>`.
+  Change the two return-type annotations to `std::generator<BranchDecision>`; the
+  bodies (`co_yield var != 0_i;`) are **unchanged** thanks to the implicit
+  conversion. Behaviour byte-identical (Exclude default).
+- `gcs/presolvers/auto_table.cc` consumes `*branch_iter` and does
+  `state.guess(branch)`; change to `state.guess(branch.guess)` (one line). It
+  maintains no `BacktrackConstraint`, so it takes the `Exclude` path and its
+  `logger->backtrack(guesses)` call is verbatim today.
+
+Per Decision 2, this small, well-contained source break is accepted: a user who
+hand-wrote a `std::function<generator<IntegerVariableCondition>(...)>` (none exist
+in-tree, but the type is public) must change their coroutine's declared return type
+to `generator<BranchDecision>`; their `co_yield cond;` bodies keep working via the
+implicit conversion. This is a source break, not a behaviour break, and is better
+than a permanent dual API (two branch protocols and two deletion-driving code paths
+to maintain). The rejected fallback — keep `generator<IntegerVariableCondition>` as
+the public yield type and carry the advance in a parallel side-channel — reintroduces
+the "keep value order and consolidation strategy mutually consistent" hazard the
+Brancher is meant to abolish.
+
+## Migration staging
+
+Every stage that exercises deletion runs with **`MIN_CHAIN=0`** (the aggressive
+mode; tiny test domains never cross a nonzero gate), caps-off. "search-identical" =
+recursions / propagations / solutions unchanged mode-off vs mode-on.
+
+- **Stage A — Brancher types + plumbing (byte-identical; independently committable).**
+  Add `BranchDecision`, `BacktrackAdvance`, the implicit conversion, the
+  `BacktrackConstraint` fold (folding only `Exclude` so far); widen
+  `BranchValueGenerator`/`BranchCallback` yield to `BranchDecision`; port every
+  value_order to `Exclude`; migrate the three scripted tests + `auto_table`.
+  **Oracle:** `.opb`/`.pbp` **byte-identical** to pre-change across the whole caps-off
+  suite, in each of {`None`, `Literals` gate 0, `Literals` gate 16}. No VeriPB
+  behaviour may move.
+
+- **Stage B — split-family bound advances + advance-RUP-driven deletion (flag-gated;
+  committable after A).**
+  Tag `split_smallest_first` / `split_largest_first` / `split_random` with
+  `Lower/UpperBound`; wire the framework's consolidate→hoist→delete + the
+  terminal-bound backtrack lemma, Literals-only. **Oracle:** VeriPB verifies +
+  search-identical at `MIN_CHAIN=0` across the suite; flag-off byte-identity preserved;
+  re-run the synthetic split/UNSAT sweep (`order_deletion_bench --problem pairwise
+  --domain D --window D --tightness 90 --unsat`, D ∈ {250,1000,2000}) and confirm the
+  win is preserved vs the current forget-driven numbers. **This is the stage that
+  validates the advance-RUP proof level against VeriPB.**
+
+- **Stage B' (shared prerequisite) — residency-cause bookkeeping + evict/hoist
+  primitives, always-on under Literals.**
+  Promote `stats_ge_top_cause` to a minimal always-on per-ge cause set/refcount; add
+  `evict_order_literal_from_top`, `hoist_eq_to_top`, and the eq analogues of the
+  live/level indices (`live_eq_literals` / `eq_literals_by_level`). **No behaviour
+  change yet** — the primitives are unused; **Oracle:** byte-identity + unit coverage
+  of the bookkeeping. This is the shared foundation for both the window (B'') and
+  payload 2 (D).
+
+- **Stage B'' — the eq-atom window.**
+  The `WindowedEqScope` tag, `need_direct_encoding_for` Current-emission, the
+  per-iteration tidy, the hoist-out rule, the `WindowedFrontier` residency slot, and
+  the bidirectional eq⨯interval guard. Tag `smallest_first` / `largest_first` /
+  `smallest_in` / `largest_in` with `Lower/UpperBound`. **Oracle:** VeriPB verifies +
+  search-identical at `MIN_CHAIN=0`; flag-off byte-identity preserved; resident eq/ge
+  count per branched var is **O(1) not O(width)**; the driver-analogue behaviours
+  (D1–D4) hold on a real enumerated-domain instance. Ships **default-off for eq orders**
+  (Decision 5). **This stage re-confirms the real-solver eq advance level** (see
+  Implementation gates).
+
+- **Stage C — objective / frontier exemption (payload 3; flag-gated; committable).**
+  Add `note_deletion_exempt` + the `FrontierExempt` residency cause + the `need_gevar`
+  priority slot (now reusing B''s residency ladder; `FrontierExempt` and
+  `WindowedFrontier` are sibling slots); `solve_with` exempts the objective.
+  **Oracle:** VeriPB verifies + search-identical; on seat-moving 2018 the
+  objective/cost churn (~20.8k delete/reintroduce at gate 16) drops toward 0 at no win
+  cost on the synthetic sweep (the exemption must not touch non-objective wins).
+
+- **Stage D — objective-improvement delc + Top-eviction (payload 2; flag-gated;
+  committable). Reuses B''s evict primitive** rather than introducing it.
+  Add the incumbent record + the delc + the evict call. **Oracle:** VeriPB verifies,
+  with **`-c` (`--force-checked-deletion`) in suites and gates from this stage on** —
+  not for soundness (veripb's guarantee machinery already rejects deletion-endangered
+  sat/enumeration conclusions) but as a **fail-fast discipline**: `-c` errors at the
+  delc site, catching a broken implication in our emission even when the conclusion
+  would still check. Plus search-identical on an optimisation instance with many
+  incumbents (colour, knapsack, seat-moving); resident improvement-constraint count at
+  proof end **O(1) not O(#incumbents)**; `-n 1` and no-objective paths proven inert.
+
+- **Stage E — benchmark + cleanup.**
+  Re-run the eq-free large-domain sweep and the optimisation sweep for the step-2
+  numbers; **measure the eq window on the eq-heavy instances (crystal_maze, talent)
+  and the ascending-eq large-domain case to decide whether it becomes the default for
+  `smallest_first`** (Decision 5's transient-for-permanent trade). Remove the dormant
+  `OrderEncodingDeletion::Links` mode; rename `forget_order_links_at_level` /
+  `live_order_links` and the `_links_`-named machinery the tracker header flags as
+  "left unchanged until the planned Brancher refactor renames it."
+
+Stages A, B, B', B'', C have no external dependency and can land in sequence. Stage D
+is the only one gated on work outside this task (the delc mechanics, now validated),
+and can be prepared ahead (it reuses B''s primitives) and finished once wired.
+
+## Implementation gates (not owner calls)
+
+Three unknowns remain; all are validated empirically against VeriPB, not decided by
+the owner:
+
+1. **Advance-RUP proof level (stage B).** The exact level at which the split-family
+   advance RUP and frontier hoist land, given the child has already
+   emitted-and-forgotten its own levels. *Resolution:* validate empirically in stage B
+   against VeriPB with the `order_jump_check` foundation as the anchor and
+   `MIN_CHAIN=0`; do not trust the level until a wide-gap split instance verifies.
+
+2. **Real-solver eq advance re-confirmation (stage B'').** The eq analogue of gate 1.
+   The driver commits the sibling `~g | ~eq(v)` via an order-hole `red` witness because
+   it has no child subtree; the *solver* emits it as `ProofLogger::backtrack`'s RUP
+   clause from the still-live child. The two produce the identical clause, but the real
+   path's RUP must be re-confirmed once wired — specifically that hoisting the frontier
+   `ge(v+1)` to `L` before the child `forget` leaves the advance RUP at `L`. Validate
+   against VeriPB at `MIN_CHAIN=0`, with `order_jump_check` + `d1_main.pbp` as anchors.
+   (The descending direction — `largest_first` / `largest_in`, the `UpperBound` mirror
+   — is expected to verify by symmetry but was not driver-tested; confirm before
+   shipping the descending orders.)
+
+3. **Residency-bookkeeping promotion (stage B').** Eviction's "sole Top cause"
+   assertion needs always-on per-ge cause tracking under Literals. *Resolution:* ship a
+   minimal refcount/cause-set in stage B'; the stats map layers on top.
+
+## Deferred / future work
+
+- **`smallest_out` / `largest_out` folding.** Likely foldable, but as their own small
+  design (the reject-first sibling COMMITS `x == lb` rather than advancing a frontier).
+  No known application; deferred.
+- **`reject_random_interval` and a first-class disjunctive advance.** It mints an invar
+  atom and is genuinely disjunctive — the natural first consumer of a future
+  `ExcludedInterval` advance kind. `Exclude` for now.
+- **eq⨯interval option (ii)** — the window managing partition coverings on evict —
+  stays out of step-2 scope; step 2 uses the bidirectional (i-static)+(i-dynamic)
+  guard instead.
+- **Virtual `Brancher` alias** — build only if a `Custom` consumer appears
+  (Decision 1).
+- **`split_random` duplicated arms** — pre-existing; note, do not fix in step 2.
+
+## Provenance
+
+The design drivers, raw findings, and validated `.pbp` scenarios live under
+`/cluster/ciaran/claude/order-encoding-deletion-artifacts/`:
+
+- **`brancher-design/`** — `design.md`, the working design record this note
+  consolidates (concrete C++ against the real code; the five owner decisions folded in).
+- **`eq-window/`** — the eq-atom window: `audit.md` (code audit — the window closes
+  cleanly at assertion Off, plus the eq⨯interval scoping caveat), `findings.md` (the
+  8/8 VeriPB 3.0.2 driver, D1–D4 + the load-bearing D2c control), the `.pbp` scenarios
+  (`d1_main.pbp` … `d4c_silent.pbp`), and `design-revision-draft.md` (the revision this
+  note merges inline).
+- **`objective-delc/`** — the `delc` / eviction mechanics: `findings.md` (9/9 driver
+  checks, both `delc` forms, the `-c`/downgrade correction, and the "veripb polices only
+  at point of use" result), the `q*.pbp` scenarios, and `run.sh`.
+
+Upstream, the two verified foundations `order_jump_check` (guess-reasoned bound jump +
+its two must-fail controls) and `order_hoist_check` are preserved uncommitted under the
+artifacts dir; the phase-2 real-instance campaign that motivated the objective exemption
+and the chain gate is under `real-instance-bench/`. Background: McIlree PhD thesis,
+Chapter 3 (integer-literal propagation properties); [variable-encodings.md](variable-encodings.md);
+[reasons-improvement.md](reasons-improvement.md); the feature's standing dev-doc
+[order-encoding-deletion.md](order-encoding-deletion.md).

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -295,11 +295,14 @@ therefore search.
 
 Footnotes:
 
-1. **Pre-existing oddity, leave alone.** `split_random_value_generator`
-   (`search_heuristics.cc:442`) has *identical* then/else arms — both yield
-   `var > v` then `var <= v` regardless of the coin flip, so it is effectively
-   `split_largest_first`. The mapping is unaffected; do not "fix" it as part of
-   step 2 (it changes search and is out of scope).
+1. **Fixed upstream; the note is kept for history.** `split_random_value_generator`
+   used to have *identical* then/else arms — both yielding `var > v` then
+   `var <= v` regardless of the coin flip, making it effectively
+   `split_largest_first`. That was filed as issue #568 and fixed upstream in
+   `e8befc17` ("make split_random actually pick a random half"), which this branch
+   picked up when it rebased onto `3800424f`. The mapping was unaffected either way:
+   the advance is derived from the *yielded condition*, so both arms tag correctly
+   whether or not they differ.
 
 2. `smallest_out` / `largest_out` are **likely foldable**, but as their own small
    design, not this one: refuting the reject-first sibling (`x != lb` first)
@@ -424,18 +427,35 @@ the checker enforces.
 
 ### Bookkeeping mirrors
 
-An eq eviction must update, mirroring the ge eviction's
-`gevars_that_exist` / `live_order_literals` / `order_literals_by_level` triple:
+**The storage moved.** Since the rebase onto `3800424f`, `variable_conditions_to_x`,
+`gevars_that_exist` and `eqvars_that_exist` are gone: conditions resolve through
+per-variable `VariableAtoms` tables holding the atom literals (`eq` / `ge` / `in`,
+**positive polarity only** — the negative op is the flip, resolved in `find_condition`)
+alongside their defining lines (`eq_defs` / `ge_defs`), keyed by raw value. The one
+remaining ordered structure is `Imp::gevar_values`, the per-variable set of ge thresholds
+the chain walk iterates — distinct from `live_order_literals`, which is the *currently
+resident* subset. An eq eviction mirrors the ge eviction's
+`ge_defs` / `live_order_literals` / `order_literals_by_level` triple:
 
-- `eqvars_that_exist[id].erase(v)` — so a later `need_direct_encoding_for(id, v)`
-  re-mints; readers to keep consistent: `need_pol_item_defining_literal`
-  (386-387 / 407-408), containment/partition seeders (1917 / 1986), view eq-links
-  (2131).
-- `variable_conditions_to_x.erase(id == v)` **and** `.erase(id != v)` — so the
-  guard at 595 (`contains(id == v)`) stops short-circuiting and re-mint proceeds
-  (the eq analogue of `need_gevar`'s fast-path at 792, and of the ge-eviction
-  path). This is the piece with **no current analogue**, because eq defs are
-  unconditionally Top today and so are never erased.
+- `atoms_for(id).eq_defs.erase(v.raw_value)` — drop the **definition lines only**.
+- **Keep `atoms_for(id).eq[v]`: the atom stays permanent** (owner decision, 2026-07-29).
+  This mirrors the ge side exactly — `need_gevar` keeps the atom and re-emits only the
+  definition (`reintroduce_order_literal`), so `need_direct_encoding_for` gains the same
+  liveness fast-path plus a `reintroduce_eq_literal`. The earlier draft of this section
+  said to erase the atom and let the guard re-mint; that is wrong. Re-minting goes through
+  `allocate_xliteral_meaning`, which allocates a **fresh** xliteral and a fresh varmap
+  entry — under verbose names rendering to the *same* PB variable name as the dead atom,
+  and without them a genuinely distinct variable — while stale copies of the old `XLiteral`
+  can outlive the erase in `containment_trees`, the partition coverings, the view eq-link
+  pair and the `at_least_one` clause. Atom identity permanent, definition residency
+  transient, on both sides.
+- A DirectOnly `{0,1}` variable's eq entries hold `XLiteral`s, not `ProofLine`s
+  (`track_eqvar`, from `proof_model.cc`), so eviction must skip them — exactly as the ge
+  hoist filters on `get_if<ProofLine>` and `order_literal_aliased_to_bit` skips aliased
+  re-introduction.
+- Whatever the eviction does, it must not break the naming invariant recorded in
+  [order-encoding-deletion.md](order-encoding-deletion.md) (Implementation status): every
+  path that names a literal in an emitted line has to go through the re-introduction hook.
 - **New `live_eq_literals` + `eq_literals_by_level`** (mirroring
   `live_order_literals` / `order_literals_by_level`): a per-level index of windowed
   eq defs, so a backtrack `forget` deletes the right eq def lines and an eviction
@@ -469,7 +489,7 @@ the same variable, so they sit as sibling slots just above the gate.
 
 A windowed eq variable that *also* receives an `in`/`not_in` interval literal has
 its live eq atoms retro-pinned as `Top` partition singleton cells
-(`init_interval_partition` / `define_plain_invar` walk `eqvars_that_exist`),
+(`init_interval_partition` / `define_plain_invar` walk the variable's `eq_defs` table),
 holding the window open. Ascending eq branching alone never does this, but a
 constraint on the same variable might. The guard must be **bidirectional**
 (supervisor correction):
@@ -739,7 +759,7 @@ stitches the chain *over* it:
 // reification def lines and its two Top chain links, stitch the surviving Top
 // neighbours lo,hi with a skip link ge(hi) -> ge(lo) (the run-stitch of
 // forget_order_literals_at_level, run for a single Top literal on demand), and drop
-// v from live_order_literals / gevars_that_exist so a later need_gevar reintroduces
+// v from live_order_literals (leaving the atom and its ge_defs slot) so a later need_gevar reintroduces
 // it as a deletable interior literal. Precondition (asserted): v's only Top
 // residency cause is the one the caller names (e.g. SoliHoist).
 auto evict_order_literal_from_top(const SimpleIntegerVariableID & id, Integer v,
@@ -983,7 +1003,8 @@ the owner:
   guard instead.
 - **Virtual `Brancher` alias** — build only if a `Custom` consumer appears
   (Decision 1).
-- **`split_random` duplicated arms** — pre-existing; note, do not fix in step 2.
+- ~~**`split_random` duplicated arms**~~ — was issue #568; fixed upstream in `e8befc17`
+  and picked up by the rebase onto `3800424f`. Nothing left to do.
 
 ## Provenance
 

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -438,39 +438,31 @@ resident* subset. An eq eviction mirrors the ge eviction's
 `ge_defs` / `live_order_literals` / `order_literals_by_level` triple:
 
 - `atoms_for(id).eq_defs.erase(v.raw_value)` — drop the **definition lines only**.
-- **Keep `atoms_for(id).eq[v]`: the atom stays permanent** (owner decision, 2026-07-29) —
-  mirroring the ge side, where `need_gevar` keeps the atom and re-emits only the definition
-  (`reintroduce_order_literal`), so `need_direct_encoding_for` gains the same liveness
-  fast-path plus a `reintroduce_eq_literal`.
+- **Retire `atoms_for(id).eq[v]` into a `retired_eq` table, mirroring what the ge side now
+  does** (owner decision, 2026-07-29, revised the same day once the ge side proved it out).
+  Do *not* leave the atom in place and track liveness separately, and do *not* erase it
+  outright and let it re-mint.
 
-  **This decision is worth revisiting, because deleting the atom would make the naming
-  invariant self-enforcing** rather than a discipline: an absent atom makes
-  `find_condition` return `nullopt`, which is exactly the trigger `xliteral_for_ensuring`
-  already acts on, so the mode-gated `else` branch disappears — and the const
-  `xliteral_for` throws instead of silently rendering a stale literal, turning a future
-  bypass into a loud failure at emission rather than a VeriPB rejection far downstream.
-  Two objections that were raised against it do **not** hold up on inspection: nothing
-  outside the atom tables keeps a long-lived `XLiteral` for a ge or eq atom
-  (`containment_trees` holds an `IntervalTree` of values, `interval_partitions` a
-  `set<Integer>`, `variable_at_least_one_constraints` a `ProofLine`; the coverings, view
-  eq-links and at-least-one clause all resolve conditions to literals at emit time), and
-  the extra Top-emitting work in the cold mint path cannot coincide with a deletable ge
-  (`vars_recover_labels` recovery is on the model path only, `fix_bound` and the
-  view-bridge `pol`s fire only for boundary and viewed variables, whose encodings are
-  resident).
+  Retiring is what makes the naming rule self-enforcing: an atom absent from the lookup
+  table makes `find_condition` return `nullopt`, which is exactly the trigger
+  `xliteral_for_ensuring` already acts on, so no mode-specific special case is needed and
+  the const `xliteral_for` throws rather than rendering a stale name. Keeping the retired
+  `XLiteral` and taking it back on re-introduction is what keeps identity stable: a fresh
+  `allocate_xliteral_meaning` would render as the same verbose name but as a different
+  `x<n>` with `set_verbose_names(false)`, making proof semantics depend on a rendering flag.
 
-  Two things genuinely block it and must be settled first. (i) **Identity would become
-  rendering-dependent**: `allocate_xliteral_meaning` mints a fresh xliteral, which under
-  `verbose_names` (the default) re-registers the *same* PB name — so VeriPB sees the same
-  variable and today's witness-vs-pin analysis carries over — but under
-  `set_verbose_names(false)` becomes `x<new id>`, a genuinely different variable. The two
-  settings would then have different proof semantics and the default gate would never
-  exercise the other; the clean fix is to derive the non-verbose name from
-  (variable, op, value) instead of the xliteral id, after which atom deletion is
-  identity-stable either way. (ii) **The chain gate's monotone basis moves**: it counts
-  `ge_defs.size()`, which would shrink on deletion and let a variable fall back below the
-  gate and flip residency mid-search; `gevar_values` is the right basis — never erased,
-  and inserted *after* the gate check, so the counted semantics match exactly.
+  Follow the two traps the ge side hit (see
+  [order-encoding-deletion.md](order-encoding-deletion.md), Implementation status):
+  `eq_defs` keeps its entry and the re-introduction must `insert_or_assign` its refreshed
+  line numbers, because `need_pol_item_defining_literal` resolves pol operands through
+  them; and there is no aliased-atom exception to carve out, since #554's fix removed the
+  aliasing that motivated one. A DirectOnly `{0,1}` variable's `eq_defs` entries do still
+  hold `XLiteral`s rather than `ProofLine`s (`track_eqvar`), so an eq eviction must skip
+  those, as the ge hoist does via `get_if<ProofLine>`.
+
+  `reintroduce_eq_literal` is therefore **not** needed: `need_direct_encoding_for`'s
+  existing guard becomes the re-introduction path for free, exactly as `need_gevar`'s did
+  once `reintroduce_order_literal` was deleted.
 - A DirectOnly `{0,1}` variable's eq entries hold `XLiteral`s, not `ProofLine`s
   (`track_eqvar`, from `proof_model.cc`), so eviction must skip them — exactly as the ge
   hoist filters on `get_if<ProofLine>` and `order_literal_aliased_to_bit` skips aliased

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -438,17 +438,39 @@ resident* subset. An eq eviction mirrors the ge eviction's
 `ge_defs` / `live_order_literals` / `order_literals_by_level` triple:
 
 - `atoms_for(id).eq_defs.erase(v.raw_value)` — drop the **definition lines only**.
-- **Keep `atoms_for(id).eq[v]`: the atom stays permanent** (owner decision, 2026-07-29).
-  This mirrors the ge side exactly — `need_gevar` keeps the atom and re-emits only the
-  definition (`reintroduce_order_literal`), so `need_direct_encoding_for` gains the same
-  liveness fast-path plus a `reintroduce_eq_literal`. The earlier draft of this section
-  said to erase the atom and let the guard re-mint; that is wrong. Re-minting goes through
-  `allocate_xliteral_meaning`, which allocates a **fresh** xliteral and a fresh varmap
-  entry — under verbose names rendering to the *same* PB variable name as the dead atom,
-  and without them a genuinely distinct variable — while stale copies of the old `XLiteral`
-  can outlive the erase in `containment_trees`, the partition coverings, the view eq-link
-  pair and the `at_least_one` clause. Atom identity permanent, definition residency
-  transient, on both sides.
+- **Keep `atoms_for(id).eq[v]`: the atom stays permanent** (owner decision, 2026-07-29) —
+  mirroring the ge side, where `need_gevar` keeps the atom and re-emits only the definition
+  (`reintroduce_order_literal`), so `need_direct_encoding_for` gains the same liveness
+  fast-path plus a `reintroduce_eq_literal`.
+
+  **This decision is worth revisiting, because deleting the atom would make the naming
+  invariant self-enforcing** rather than a discipline: an absent atom makes
+  `find_condition` return `nullopt`, which is exactly the trigger `xliteral_for_ensuring`
+  already acts on, so the mode-gated `else` branch disappears — and the const
+  `xliteral_for` throws instead of silently rendering a stale literal, turning a future
+  bypass into a loud failure at emission rather than a VeriPB rejection far downstream.
+  Two objections that were raised against it do **not** hold up on inspection: nothing
+  outside the atom tables keeps a long-lived `XLiteral` for a ge or eq atom
+  (`containment_trees` holds an `IntervalTree` of values, `interval_partitions` a
+  `set<Integer>`, `variable_at_least_one_constraints` a `ProofLine`; the coverings, view
+  eq-links and at-least-one clause all resolve conditions to literals at emit time), and
+  the extra Top-emitting work in the cold mint path cannot coincide with a deletable ge
+  (`vars_recover_labels` recovery is on the model path only, `fix_bound` and the
+  view-bridge `pol`s fire only for boundary and viewed variables, whose encodings are
+  resident).
+
+  Two things genuinely block it and must be settled first. (i) **Identity would become
+  rendering-dependent**: `allocate_xliteral_meaning` mints a fresh xliteral, which under
+  `verbose_names` (the default) re-registers the *same* PB name — so VeriPB sees the same
+  variable and today's witness-vs-pin analysis carries over — but under
+  `set_verbose_names(false)` becomes `x<new id>`, a genuinely different variable. The two
+  settings would then have different proof semantics and the default gate would never
+  exercise the other; the clean fix is to derive the non-verbose name from
+  (variable, op, value) instead of the xliteral id, after which atom deletion is
+  identity-stable either way. (ii) **The chain gate's monotone basis moves**: it counts
+  `ge_defs.size()`, which would shrink on deletion and let a variable fall back below the
+  gate and flip residency mid-search; `gevar_values` is the right basis — never erased,
+  and inserted *after* the gate check, so the counted semantics match exactly.
 - A DirectOnly `{0,1}` variable's eq entries hold `XLiteral`s, not `ProofLine`s
   (`track_eqvar`, from `proof_model.cc`), so eviction must skip them — exactly as the ge
   hoist filters on `get_if<ProofLine>` and `order_literal_aliased_to_bit` skips aliased

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -163,32 +163,42 @@ owns the MiniZinc frontend proofs.
   flag-induced VeriPB rejections; mode-off byte-identical; flag-off 536/536). The
   hoist primitive, guess/eq/partition-atom hoisting, and the aux/view dispositions
   below are all in `gcs/innards/proofs/{names_and_ids_tracker,proof_logger,proof_model}.*`.
-- **LOAD-BEARING INVARIANT — every path that *names* a literal in an emitted line must
-  go through `need_gevar`.** Deletion makes atom identity permanent but the atom's
-  *definition* transient, so "the atom exists" no longer implies "the line can name it":
-  `need_gevar`'s fast path is what re-introduces a deleted definition before the naming
-  line is written. Any short-cut that resolves a known condition straight to its
-  `XLiteral` silently bypasses re-introduction, and the resulting line names a literal
-  with no definition — a VeriPB rejection far from the cause.
+- **A line must never name a literal whose definition has been deleted — and that is now
+  structural, not a discipline.** Deletion makes a `ge` atom's *definition* transient, so
+  "the atom exists" does not imply "a line may name it". Rather than requiring every
+  naming path to remember to consult a liveness check, deletion **retires the atom**: the
+  sweep in `forget_order_literals_at_level` moves the `XLiteral` out of `VariableAtoms::ge`
+  into `VariableAtoms::retired_ge`, so `find_condition` stops answering for it. The only
+  route back to the literal is `need_gevar`, which re-introduces the definition and takes
+  the retired `XLiteral` back — so the atom keeps its identity and its PB name across
+  delete/re-introduce cycles. Anything that tries to render it without going through
+  `need_gevar` now hits the const `xliteral_for`, which **throws** rather than silently
+  emitting a stale name: a bypass fails loudly at emission instead of becoming a VeriPB
+  rejection hundreds of lines downstream.
 
-  This is not hypothetical. The `proof-writing-perf` stack fused name introduction into
-  line rendering (`834b7029`), and its `xliteral_for_ensuring` calls `need_proof_name`
-  **only when the atom is missing** — correct for every other mode, fatal here. Rebasing
-  onto that stack turned 0 flag-induced rejections into 37 across the caps-off suite, all
-  of the same shape: a `rup` naming a `ge` whose definition had been deleted, with the
-  re-introduction appearing a few lines *later* in the proof, triggered by whatever next
-  needed the atom. The fix is the mode-gated `else` branch in `xliteral_for_ensuring`,
-  which restores the unconditional `need_proof_name` for the deletion modes only, leaving
-  the single-lookup fast path intact when deletion is off. `reintroduce_order_literal`
-  then needs the `building_order_link` guard around its `red`, because the re-emitted
-  reification names the very atom being re-introduced and would otherwise recurse.
+  Why it is written this way. The `proof-writing-perf` stack fused name introduction into
+  line rendering (`834b7029`), and its `xliteral_for_ensuring` introduces a name **only
+  when the atom is missing** — correct for every other mode. When the atom stayed put and
+  only its definition was deleted, that check passed and re-introduction never fired:
+  rebasing onto the stack turned 0 flag-induced rejections into **37** across the caps-off
+  suite, every one a line naming a `ge` whose definition had gone, with the re-introduction
+  appearing a few lines *later*, triggered by whatever next needed the atom. Retiring the
+  atom makes "missing" true exactly when it should be, so the renderer's own check is the
+  enforcement and no mode-specific special case is needed.
 
-  Two consequences worth carrying forward: (i) the invariant is currently enforced by
-  nothing — a cheap always-on-under-Literals check that every named `ge` is live would
-  have caught this at the first emission rather than at VeriPB; (ii) the extra
-  `need_proof_name` per literal restores the pre-`834b7029` cost profile under Literals,
-  which is the right trade for now but is a candidate for narrowing (a per-variable
-  "has a non-live threshold" flag) if rendering shows up as a hotspot in stage E.
+  Two traps worth carrying forward:
+
+  - `ge_defs` keeps its entry when a threshold is retired, and the re-introduction must
+    **`insert_or_assign`, not `try_emplace`**. The stale entry holds the deleted
+    definition's line numbers, and every chain `pol` resolves its operands through them
+    (`need_pol_item_defining_literal`), so `try_emplace` leaves the links pointing at
+    deleted lines. That entry is deliberately never erased: it keeps `ge_defs` monotone,
+    which is what makes it a sound basis for the chain gate's "thresholds ever named"
+    count.
+  - There is no longer an aliased-`ge` exception. Issue #554's fix deliberately stopped
+    aliasing a DirectOnly `{0,1}` variable's `>= 1` atom to its bit, so every `ge` owns its
+    own reification and `order_literal_aliased_to_bit` — which existed only to keep such a
+    literal out of the re-introduction path — became dead and has been removed.
 - **Gate — randomized-test seed sweeps are part of the flag-ON gate.** A single caps-off
   suite run exercises only *one* random seed per data-driven test, and the fixed corpus
   missed a ~10 %-of-seeds VeriPB-rejection hole in divide/modulus (seed 3072268882 was one

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -160,9 +160,35 @@ owns the MiniZinc frontend proofs.
 ## Implementation status
 
 - **Done, suite-safe:** the full caps-off test suite passes with the flag on (0
-  flag-induced VeriPB rejections; mode-off byte-identical; flag-off 525/525). The
+  flag-induced VeriPB rejections; mode-off byte-identical; flag-off 536/536). The
   hoist primitive, guess/eq/partition-atom hoisting, and the aux/view dispositions
   below are all in `gcs/innards/proofs/{names_and_ids_tracker,proof_logger,proof_model}.*`.
+- **LOAD-BEARING INVARIANT — every path that *names* a literal in an emitted line must
+  go through `need_gevar`.** Deletion makes atom identity permanent but the atom's
+  *definition* transient, so "the atom exists" no longer implies "the line can name it":
+  `need_gevar`'s fast path is what re-introduces a deleted definition before the naming
+  line is written. Any short-cut that resolves a known condition straight to its
+  `XLiteral` silently bypasses re-introduction, and the resulting line names a literal
+  with no definition — a VeriPB rejection far from the cause.
+
+  This is not hypothetical. The `proof-writing-perf` stack fused name introduction into
+  line rendering (`834b7029`), and its `xliteral_for_ensuring` calls `need_proof_name`
+  **only when the atom is missing** — correct for every other mode, fatal here. Rebasing
+  onto that stack turned 0 flag-induced rejections into 37 across the caps-off suite, all
+  of the same shape: a `rup` naming a `ge` whose definition had been deleted, with the
+  re-introduction appearing a few lines *later* in the proof, triggered by whatever next
+  needed the atom. The fix is the mode-gated `else` branch in `xliteral_for_ensuring`,
+  which restores the unconditional `need_proof_name` for the deletion modes only, leaving
+  the single-lookup fast path intact when deletion is off. `reintroduce_order_literal`
+  then needs the `building_order_link` guard around its `red`, because the re-emitted
+  reification names the very atom being re-introduced and would otherwise recurse.
+
+  Two consequences worth carrying forward: (i) the invariant is currently enforced by
+  nothing — a cheap always-on-under-Literals check that every named `ge` is live would
+  have caught this at the first emission rather than at VeriPB; (ii) the extra
+  `need_proof_name` per literal restores the pre-`834b7029` cost profile under Literals,
+  which is the right trade for now but is a candidate for narrowing (a per-variable
+  "has a non-live threshold" flag) if rendering shows up as a hotspot in stage E.
 - **Gate — randomized-test seed sweeps are part of the flag-ON gate.** A single caps-off
   suite run exercises only *one* random seed per data-driven test, and the fixed corpus
   missed a ~10 %-of-seeds VeriPB-rejection hole in divide/modulus (seed 3072268882 was one
@@ -261,7 +287,8 @@ by the bound *jump*, but ascending/descending eq now wins too, by the window.
 Under `OrderEncodingDeletion::Literals`, a real variable's interior (non-boundary)
 `ge` definition is only emitted deletable-at-`Current` once the variable has crossed
 a chain-length gate: when the number of `ge` thresholds ever named for it (its
-`gevars_that_exist[id]` count at decision time in `need_gevar` — model-time atoms
+`ge_defs` count for it at decision time in `need_gevar`, taken before this threshold is
+inserted — model-time atoms
 included) exceeds `min_chain`. At or below the gate the def stays resident at `Top`,
 exactly like the boundary / view-pin / aux-pin paths. The gate is monotone (the
 count only grows; once crossed, stays crossed; below-gate residents are never

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -163,14 +163,41 @@ owns the MiniZinc frontend proofs.
   flag-induced VeriPB rejections; mode-off byte-identical; flag-off 525/525). The
   hoist primitive, guess/eq/partition-atom hoisting, and the aux/view dispositions
   below are all in `gcs/innards/proofs/{names_and_ids_tracker,proof_logger,proof_model}.*`.
+- **Gate — randomized-test seed sweeps are part of the flag-ON gate.** A single caps-off
+  suite run exercises only *one* random seed per data-driven test, and the fixed corpus
+  missed a ~10 %-of-seeds VeriPB-rejection hole in divide/modulus (seed 3072268882 was one
+  such seed). So any change to the deletion machinery, and any new resident/hoist
+  disposition, must additionally clear a **seed sweep** of the affected randomized tests:
+  ~200 fixed seeds, flag-ON at `GCS_DELETE_ORDER_ENCODING_MIN_CHAIN=0` (the gate-off,
+  aggressive-testing mode — a nonzero gate hides short-chain shapes), each run isolated in
+  its own working directory, **zero** rejections required. Report the before/after failure
+  counts. (Sweep harness + results live under
+  `.../order-encoding-deletion-artifacts/divide-modulus-seed-bug/`.)
 - **Kept resident (not deletable), per the "delete only when unreferenced" rule,
   because their `ge`s are named by *permanent* Top constraints:**
   - divide/modulus in-proof-bit **aux-magnitude** variables (`register_state_variable_bits_in_proof`)
     — pinned by the product-justification caches;
+  - the **real operands** of the magnitude-product constraints — divide/modulus `x, y, out`
+    and multiply/power `x, y, z` (marked in `install_divide_modulus` and in
+    `signed_multiply::make_data`, which multiply and power both route through) — pinned by
+    the permanent identity / remainder / magnitude-channel / **sign-clause** rows
+    (`product_encoding.cc`) and the `pol`/`rup` product reasons derived over them, all of
+    which name these operands' order/eq literals (e.g. an `emit_sign_clauses` row naming
+    `v >= 0` / `v < 1`, or a `mult_bc` reason naming `31 i[out][ge1]`). Without this an
+    interior operand `ge` is born deletable, a backtrack deletes it while a pinning row
+    stays live, a later reference **re-introduces** it, and the re-introduction's
+    falsify-witness `ge := 0` collides with the pin — VeriPB rejects the proofgoal. (This
+    was the divide/modulus seed-3072268882 bug: a ~10 %-of-random-seeds hole the fixed test
+    corpus missed. Multiply/power share the identical pin mechanism; the fix is applied to
+    them as a latent-bug closure — see the seed-sweep note under Gates.);
   - **viewed** variables (underlying of a registered view) — pinned by the
     always-at-Top view-bridge `pol`s in `need_gevar`.
-  These get no deletion win, but are correct. Making them deletable needs the
-  bridge-lifetime redesign (Future work).
+  These get no deletion win, but are correct. **This narrows the win scope: any variable
+  appearing as an operand of a divide/modulus/multiply/power constraint is now wholly
+  resident, so it contributes no chain-shrinkage win** (its long chains, if any, are
+  recoverable only by the parked bridge-lifetime redesign — Future work). In the win regime
+  (weak-propagation, large-domain, bound-split) such variables are typically not the
+  split-branched ones anyway.
 - **`soli` objective atom** is hoisted to Top when the objective-improvement
   constraint is emitted (latent optimisation-mode bug fixed defensively).
 - **Not yet done:** the clean Brancher abstraction (below) — the current wiring

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -4,9 +4,12 @@
 measured on synthetic AND real instances; suite-safe; committed on this branch;
 not default.** This note records the design for shrinking the integer
 order-encoding that VeriPB carries, plus the measured outcome and what is and
-isn't yet done. The full Brancher-API refactor (below) is still a proposal; the
-current implementation wires deletion into the existing branch/backtrack flow via
-hoisting.
+isn't yet done. The full Brancher-API refactor (step 2, below) is now a
+**decided design, recorded in [brancher-design.md](brancher-design.md)** but not
+yet implemented; the current implementation wires deletion into the existing
+branch/backtrack flow via hoisting, and the sketch of the refactor further down
+this note is superseded by that decided design (see the note at "Design
+overview").
 
 ## Results (measured)
 
@@ -206,10 +209,25 @@ builds long chains (seat-moving: median chain 12, max 98, despite maxdom 901), a
 the deletion machinery churns (22 857 deletes / 22 829 reintroductions, net 28) for
 nothing there.
 
-**2. Brancher-API refactor** (the abstraction below) to generalise
-consolidate-then-delete and tidy the current direct wiring. Its value was always
-design quality, not measured performance; that stands. It is also the natural home
-for the chain-length-gated deletion policy below.
+**2. Brancher-API refactor — DESIGN DECIDED (see
+[brancher-design.md](brancher-design.md)); not yet implemented.** The concrete,
+decided step-2 design lives in that note; it generalises consolidate-then-delete,
+tidies the current direct wiring, and is the natural home for the chain-gated
+deletion policy, the objective-variable exemption (from 2b, below), and the
+objective-improvement `delc` lifecycle. Five owner decisions are settled there:
+the per-node object stays a `std::generator` (not a virtual class) until it shows
+as a benchmark hotspot; the pre-0.1 public yield-type source break is accepted
+(the implicit `IntegerVariableCondition → BranchDecision` conversion is the
+bridge); the objective is handled by exemption for its ges *and* an unconditional
+delete-all-but-the-most-recent improvement constraint; the value-order mapping is
+final; and the eq-atom window ships default-off pending a stage-E measurement.
+
+Crucially, the design adds an **eq-atom sliding window** (validated 8/8 in VeriPB
+3.0.2) that moves the four contiguous in-order/eq value orders —
+`smallest_first`, `largest_first`, `smallest_in`, `largest_in` — into the win
+regime as *O(1)-resident* (evict each eq/ge once the frontier steps past it),
+**superseding this note's earlier claim that only split wins**: split still wins
+by the bound *jump*, but ascending/descending eq now wins too, by the window.
 
 **2b. Chain-length-gated deletion — DONE (implemented + measured; default gate 16).**
 
@@ -355,6 +373,19 @@ Two consequences that shape the design:
    *resident* database is smaller, so every *other* RUP's closure shrinks.
 
 ## Design overview: consolidate -> hoist -> delete
+
+> **Historical sketch — superseded by [brancher-design.md](brancher-design.md).**
+> The sections from here through "Implementation staging" are the original
+> user-approved *conceptual* sketch; the concrete, decided step-2 design (grounded
+> in the real code, with the five owner decisions and the eq-atom window folded in)
+> is [brancher-design.md](brancher-design.md). In particular the "Mapping the
+> existing heuristics" table below is **wrong** and superseded: its in-order/eq rows
+> claimed `smallest_first`/`smallest_in`/`largest_first`/`largest_in` win by an
+> "O(1) pin" bound-jump, but eq branching has no gap to jump and an eq atom pins
+> both ges — those orders instead win via the **eq-atom window** (evict behind a
+> one-step frontier), while the bound-*jump* win is the `split_*` family only. The
+> foundation above this note ("The verified foundation: guess-reasoned bound jumps")
+> stands. The prose below is kept for provenance; do not treat it as current.
 
 A brancher maintains a compact **backtrack constraint** — the "what we'll use to
 backtrack" fact, i.e. the weakest constraint it has proven must hold given every

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -1083,6 +1083,23 @@ namespace
     auto define_proof_model_divide_modulus(InstallState & st, const ConstraintID & owner, bool expose_quotient, const IntegerVariableID & x,
         const IntegerVariableID & y, const IntegerVariableID & out, ProofModel & model) -> void
     {
+        // Under OrderEncodingDeletion::Literals, keep the WHOLE order encoding of the three
+        // real operands resident (defs at Top, never deleted), exactly as the in-proof aux
+        // magnitudes are (register_state_variable_bits_in_proof). The magnitude-product
+        // justification pins these operands' order literals in permanent product/identity/
+        // remainder/sign rows and the pol/rup reasons derived over them (e.g. a mult_bc row
+        // naming `31 i[out][ge1]`). Were an interior ge of x/y/out born deletable, a backtrack
+        // could delete it while such a pinning constraint stays live; a later reference then
+        // re-introduces the ge, and the re-introduction's falsify-witness (ge := 0) collides
+        // with the pin -- VeriPB cannot autoprove the resulting proofgoal. (The VIEW form of an
+        // operand is already held resident by the view-bridge path; this closes the same hole
+        // for the BARE form.) Constants have no order encoding, so skip them. Marked at the head
+        // of the model-building phase, before any row below names an operand threshold and
+        // before any search-time need_gevar, so every ge of these operands is born at Top.
+        for (const auto & a : {affine_of(x), affine_of(y), affine_of(out)})
+            if (a.var)
+                model.names_and_ids_tracker().note_order_encoding_stays_resident(*a.var);
+
         if (st.zero_divisor) {
             // Morally what an empty divisor domain encodes.
             model.add_constraint(WPBSum{} >= 1_i);

--- a/gcs/constraints/multiply/signed_multiply.cc
+++ b/gcs/constraints/multiply/signed_multiply.cc
@@ -1,3 +1,4 @@
+#include <gcs/constraints/innards/arithmetic_utils.hh>
 #include <gcs/constraints/innards/product_bounds.hh>
 #include <gcs/constraints/innards/product_justify.hh>
 #include <gcs/constraints/multiply/hints.hh>
@@ -42,6 +43,26 @@ auto gcs::innards::signed_multiply::make_data(
 auto gcs::innards::signed_multiply::emit_encoding(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id, Data & data)
     -> void
 {
+    // Under OrderEncodingDeletion::Literals, keep the WHOLE order encoding of the three
+    // real operands resident (defs at Top, never deleted), exactly as the in-proof
+    // magnitude channels are (product_enc emits them via
+    // register_state_variable_bits_in_proof). The magnitude channels, result channel and
+    // sign clauses below are permanent (Top) rows that name these operands' order/eq
+    // literals (e.g. `v >= 0`, `v < 1` in emit_sign_clauses/emit_magnitude_channel), and
+    // the pol/rup product reasons derived over them name further operand ge thresholds.
+    // Were an interior ge of x/y/z born deletable, a backtrack could delete it while such a
+    // pinning row stays live; a later reference then re-introduces the ge, and the
+    // re-introduction's falsify-witness (ge := 0) collides with the pin -- VeriPB cannot
+    // autoprove the resulting proofgoal. (The VIEW form of an operand is already held
+    // resident by the view-bridge path; this closes the same hole for the BARE form. This
+    // mirrors the divide/modulus operand-residency fix; both share this product machinery.)
+    // Constants have no order encoding, so skip them. Marked at the head of the
+    // model-building phase, before the rows below name an operand threshold and before any
+    // search-time need_gevar, so every ge of these operands is born at Top.
+    for (const auto & a : {affine_of(data.x), affine_of(data.y), affine_of(data.z)})
+        if (a.var)
+            model.names_and_ids_tracker().note_order_encoding_stays_resident(*a.var);
+
     // cake_pb_cp's multiplication encoding: a magnitude channel per
     // operand slot (axis 0 -> "X", 1 -> "Y", a fresh proof-only magnitude
     // each, even for a repeated operand), the bit-product grid, the

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -116,6 +116,24 @@ namespace
         // variable's values). Value-keyed like the literal tables.
         std::unordered_map<long long, AtomDefs> eq_defs;
         std::unordered_map<long long, AtomDefs> ge_defs;
+        // OrderEncodingDeletion::Literals only: the XLiterals of ge atoms whose
+        // definitions have been deleted on backtrack. Deletion moves the atom out of
+        // `ge` and into here, so find_condition stops answering for it: a line can
+        // then only name the literal by going through need_gevar, which re-introduces
+        // the definition first. That makes the "never name a literal whose definition
+        // is gone" rule structural rather than a discipline every naming path has to
+        // remember -- and the const xliteral_for throws rather than silently rendering
+        // a stale name, so a bypass fails at emission instead of at VeriPB.
+        //
+        // The XLiteral is *retired, not discarded*: need_gevar takes it back on
+        // re-introduction, so the atom keeps its identity (and its PB name) across
+        // delete/re-introduce cycles, exactly as it did when the atom stayed put. That
+        // matters because a fresh allocation would render as the same verbose name but a
+        // different `x<n>` with verbose names off -- proof semantics that depended on a
+        // rendering flag. `ge_defs` deliberately keeps its (stale, overwritten on
+        // re-introduction) entry, so it stays monotone and remains the chain gate's
+        // "thresholds ever named" count.
+        std::unordered_map<long long, XLiteral> retired_ge;
     };
 
     struct HashView
@@ -384,7 +402,7 @@ struct NamesAndIDsTracker::Imp
     // Event counters.
     long long stats_deletes = 0;                                    // literals dropped by forget_order_literals_at_level.
     long long stats_stitches = 0;                                   // forget-path skip-link emissions (emit_order_stitch).
-    long long stats_reintroductions = 0;                            // reintroduce_order_literal calls.
+    long long stats_reintroductions = 0;                            // ge definitions re-introduced after deletion.
     long long stats_dup_top_stitches = 0;                           // Top-level stitch clauses re-emitted for an already-linked pair.
     map<OrderEncodingResidencyCause, long long> stats_hoist_events; // actual hoist events, by cause.
     // Top-level (level-0) stitch pairs already emitted per variable, for cheap
@@ -942,31 +960,37 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // carry deletable chain links. building_order_link suppresses this while a
         // chain-link pol is being built (those need_gevar calls only want the resident
         // definitions).
+        //
+        // Under Literals there is deliberately nothing to do here: a ge whose definition
+        // was deleted has had its atom retired out of the lookup table, so it does not
+        // reach this branch at all -- it falls through to the introduction path below,
+        // which re-introduces the definition and takes the retired XLiteral back.
         if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Links && _imp->logger && ! _imp->building_order_link) {
             if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id))
                 ensure_order_chain_connected(*sid_ptr);
         }
-        else if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals && _imp->logger && _imp->assertion_level == AssertionLevel::Off &&
-            ! _imp->building_order_link) {
-            // Literals mode: the atom is permanent, but its definition may have been
-            // deleted by an earlier backtrack. If this threshold is no longer live,
-            // re-introduce it (re-emit its def at Current and re-link it to its current
-            // live neighbours). Boundary / model-time literals are tagged level 0 and
-            // never leave the live set, so this only fires for interior literals. A
-            // ge aliased to a preserved bit (DirectOnly {0,1}) is skipped: it has no
-            // proof-time reification to delete or re-introduce, and re-emitting one would
-            // put the preserved bit in a red witness -- rejected at a derived level.
-            if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
-                auto live_it = _imp->live_order_literals.find(*sid_ptr);
-                if ((live_it == _imp->live_order_literals.end() || ! live_it->second.contains(v)) && ! order_literal_aliased_to_bit(id, v))
-                    reintroduce_order_literal(*sid_ptr, v);
-            }
-        }
         return;
     }
 
-    auto gevar = allocate_xliteral_meaning(id, EqualsOrGreaterEqual::GreaterEqual, v);
+    // Take back a retired XLiteral if this threshold is being re-introduced after a
+    // backtrack deleted its definition, so the atom keeps its identity and its PB name;
+    // otherwise mint a fresh one. Only Literals mode ever retires anything.
+    bool reintroducing = false;
+    auto gevar = [&]() {
+        if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals) {
+            auto & atoms = _imp->atoms_for(id);
+            if (auto retired = atoms.retired_ge.find(v.raw_value); retired != atoms.retired_ge.end()) {
+                auto reused = retired->second;
+                atoms.retired_ge.erase(retired);
+                reintroducing = true;
+                return reused;
+            }
+        }
+        return allocate_xliteral_meaning(id, EqualsOrGreaterEqual::GreaterEqual, v);
+    }();
     _imp->store_condition(id >= v, gevar);
+    if (reintroducing && _imp->collect_order_encoding_stats)
+        ++_imp->stats_reintroductions;
 
     // Literals order-encoding-deletion mode: a real variable's non-boundary ge
     // definition is emitted at ProofLevel::Current, so a backtrack deletes it and a
@@ -1042,15 +1066,20 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     }
     auto ge_def_level = def_at_current ? ProofLevel::Current : ProofLevel::Top;
 
-    // gevar -> bits
+    // gevar -> bits. insert_or_assign, not try_emplace: on a re-introduction the
+    // ge_defs entry is still present but holds the line numbers of the definition the
+    // backtrack deleted, and every chain pol resolves its operands through those numbers
+    // (need_pol_item_defining_literal). try_emplace would keep the stale pair and the
+    // links would reference deleted lines. The entry is deliberately never erased, so
+    // ge_defs stays monotone and remains the chain gate's "thresholds ever named" count.
     if (_imp->logger && _imp->assertion_level > AssertionLevel::Definitions) {
-        _imp->atoms_for(id).ge_defs.try_emplace(
+        _imp->atoms_for(id).ge_defs.insert_or_assign(
             v.raw_value, make_pair(ProofLine{}, ProofLine{})); // Don't output geqvar definitions if using assertions
     }
     else if (_imp->logger) {
         auto def_lines = visit(
             [&](const auto & id) { return _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ge_def_level); }, id);
-        _imp->atoms_for(id).ge_defs.try_emplace(v.raw_value, def_lines);
+        _imp->atoms_for(id).ge_defs.insert_or_assign(v.raw_value, def_lines);
     }
     else {
         // Label the two halves @<base>[ge<v>][r]/[f]: the base is @i[name] for a
@@ -1059,7 +1088,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // ~ge..) is cake's [r]; the second is [f]. v may be negative -- veripb
         // 3.0.2 allows `-` in @labels.
         string ge_label = definitional_label_base(id) + "[ge" + to_string(v.raw_value) + "]";
-        _imp->atoms_for(id).ge_defs.try_emplace(v.raw_value,
+        _imp->atoms_for(id).ge_defs.insert_or_assign(v.raw_value,
             visit(
                 [&](const auto & vid) -> pair<ProofLine, ProofLine> {
                     return pair{_imp->model->add_labelled_constraint(ge_label + "[r]", WPBSum{} + (1_i * vid) >= v, {{vid >= v}}),
@@ -1478,41 +1507,6 @@ auto NamesAndIDsTracker::link_order_literal_to_live_neighbours(const SimpleInteg
     _imp->building_order_link = saved;
 }
 
-auto NamesAndIDsTracker::reintroduce_order_literal(const SimpleIntegerVariableID & id, Integer v) -> void
-{
-    // The atom already exists but its Current-level definition was deleted on an
-    // earlier backtrack, and the search has genuinely re-touched it. Re-emit the
-    // reification def at Current, overwrite the stale def lines, re-record as live at
-    // Current, then re-link to live neighbours. Only interior literals reach here
-    // (level-0 literals never leave the live set), and in practice only *unpinned*
-    // ones: a ge pinned by a surviving Top constraint -- in particular a ge named by an
-    // eq atom's permanent (Top) definition -- is hoisted to Top when that atom is
-    // created and is thereafter never deleted, so it never reaches reintroduction. That
-    // is why the fresh `red` VeriPB accepts here never collides with a pin against its
-    // falsify-witness: pinned literals are hoisted, not reintroduced. Only genuinely
-    // re-touched unpinned interior literals reintroduce, and they verify.
-    SimpleOrProofOnlyIntegerVariableID key{id};
-    // The re-emitted `red` reifies against `id >= v` itself, so rendering it resolves
-    // that very condition through xliteral_for_ensuring -- which, under this mode, calls
-    // back into need_gevar to re-introduce a non-live literal. v is not live again until
-    // record_live_order_literal below, so without this guard the call recurses forever.
-    // building_order_link is the existing "we are emitting order-encoding machinery, do
-    // not recursively re-introduce" flag, used the same way by emit_order_stitch.
-    auto saved_building = _imp->building_order_link;
-    _imp->building_order_link = true;
-    auto def_lines = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * id) >= v, id >= v, ProofLevel::Current);
-    _imp->building_order_link = saved_building;
-    auto & entry = _imp->atoms_for(key).ge_defs.at(v.raw_value);
-    entry.first = def_lines.first;
-    entry.second = def_lines.second;
-
-    if (_imp->collect_order_encoding_stats)
-        ++_imp->stats_reintroductions;
-
-    record_live_order_literal(id, v, /*top=*/false);
-    link_order_literal_to_live_neighbours(id, v);
-}
-
 auto NamesAndIDsTracker::emit_order_stitch(const SimpleIntegerVariableID & id, Integer lo, Integer hi, int at_level, int restore_level) -> void
 {
     // Derive the skip link ge(hi) -> ge(lo) (clause ge(lo) OR ~ge(hi)) from the two
@@ -1586,12 +1580,29 @@ auto NamesAndIDsTracker::forget_order_literals_at_level(int level) -> void
         }
 
         // The deleted literals' def+link lines were del'd by forget_proof_level's own
-        // loop; drop the thresholds from the live set so a later need_gevar
-        // re-introduces them.
+        // loop; drop the thresholds from the live set and RETIRE their atoms out of the
+        // lookup table, so a later reference cannot name a literal whose definition is
+        // gone -- find_condition stops answering, and the only way back to the literal is
+        // through need_gevar, which re-introduces the definition and takes the retired
+        // XLiteral back. `ge_defs` deliberately keeps its now-stale entry: it is
+        // overwritten on re-introduction and is the chain gate's monotone
+        // "thresholds ever named" count.
+        //
+        // There is no longer an aliased-ge case to exclude here: issue #554's fix
+        // (set_up_direct_only_variable_encoding) deliberately stopped aliasing a
+        // DirectOnly {0,1} variable's `>= 1` atom to its bit, precisely so the atom gets a
+        // genuine reified pair, and need_gevar now mints it lazily like any other. So
+        // every ge that reaches this sweep owns its own reification and can be retired.
         if (_imp->collect_order_encoding_stats)
             _imp->stats_deletes += static_cast<long long>(dvals.size());
-        for (auto v : dvals)
+        auto & atoms = _imp->atoms_for(SimpleOrProofOnlyIntegerVariableID{id});
+        for (auto v : dvals) {
             live.erase(v);
+            if (auto atom = atoms.ge.find(v.raw_value); atom != atoms.ge.end()) {
+                atoms.retired_ge.insert_or_assign(v.raw_value, atom->second);
+                atoms.ge.erase(atom);
+            }
+        }
         if (live.empty())
             _imp->live_order_literals.erase(live_it);
     }
@@ -1745,19 +1756,6 @@ auto NamesAndIDsTracker::hoist_order_literal_to_top_if_live(
     // v and its nearest Top neighbour must stay chained -- link to the immediate live
     // neighbours, not only the Top ones.
     hoist_order_literal_to_level(id, v, 0, /*immediate_neighbours=*/true, stats_cause);
-}
-
-auto NamesAndIDsTracker::order_literal_aliased_to_bit(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> bool
-{
-    // Aliasing (proof_model.cc set_up_direct_only_variable_encoding) only ever happens
-    // for a single-bit DirectOnly {0,1} variable, so a >1-bit variable is excluded up
-    // front (cheap). For a one-bit variable, the ge is aliased iff id >= v's xliteral
-    // *is* that bit's xliteral (a Bits-encoded {0,1} variable instead mints a distinct
-    // ge1 atom, whose xliteral differs, so it returns false and stays reintroducible).
-    if (! has_bit_representation(id) || num_bits(id) != 1_i)
-        return false;
-    auto cond = _imp->find_condition(id >= v);
-    return cond && *cond == get_bit(id, 0_i).second;
 }
 
 auto NamesAndIDsTracker::hoist_ges_named_by_top_atom(
@@ -2610,20 +2608,6 @@ auto NamesAndIDsTracker::xliteral_for_ensuring(const VariableConditionFrom<Simpl
         f = _imp->find_condition(cond);
         if (! f)
             throw ProofError{"still can't find literals for cond after introducing it"};
-    }
-    else if (_imp->order_link_deletion_mode != OrderEncodingDeletion::None && _imp->logger && ! _imp->building_order_link) {
-        // Under order-encoding deletion an existing atom is NOT enough: atom identity is
-        // permanent, but the atom's *definition* may have been deleted by a backtrack, and
-        // a line naming a literal whose definition is gone does not verify. So go through
-        // need_proof_name anyway -- need_gevar's fast path re-introduces a deleted
-        // definition (and reconnects the chain) before this line names the literal. This
-        // is what the old need_all_proof_names_in pre-pass did unconditionally; the fused
-        // renderer skips it for known atoms, which is right for every other mode.
-        // Deletion off (the default) keeps the single-lookup path untouched.
-        // The XLiteral itself never changes -- re-introduction re-emits definition lines
-        // and rewrites their line numbers, it never re-mints the atom -- so the value
-        // found above stays correct.
-        need_proof_name(cond);
     }
     return *f;
 }

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -153,17 +153,6 @@ namespace gcs::innards
         // exist and lb <= p <= ub+1.
         auto ensure_partition_cut(SimpleOrProofOnlyIntegerVariableID id, Integer p) -> void;
 
-        // True iff the order literal `id >= v` is aliased directly to one of `id`'s
-        // preserved encoding bits -- the DirectOnly {0,1} case, where
-        // set_up_direct_only_variable_encoding registers `id >= 1` as the lone bit b0
-        // rather than a distinct `ge` atom. Such a ge has no proof-time reification of
-        // its own (its meaning is the model-time OPB bit), so under the Literals mode it
-        // must never be treated as a deletable/reintroducible order literal: re-emitting
-        // a reification would place the preserved bit in a `red` witness, which VeriPB
-        // rejects at a derived proof level. A distinct-atom ge (e.g. a Bits-encoded
-        // variable's `ge1`) is not aliased and returns false, staying reintroducible.
-        [[nodiscard]] auto order_literal_aliased_to_bit(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> bool;
-
         // First interval request for `id`: set up the always-covered partition, with a
         // singleton cell for every pre-existing eq atom (earlier per-value conclusions
         // must be reachable from later coverings), define a literal for every cell, and
@@ -206,11 +195,6 @@ namespace gcs::innards
         // for a re-introduced one; linking to live (not gevars) neighbours keeps the
         // chain valid across deleted thresholds.
         auto link_order_literal_to_live_neighbours(const SimpleIntegerVariableID & id, Integer v) -> void;
-
-        // Fast-path helper for need_gevar when a real variable's ge atom already exists
-        // but its Current-level def was deleted on backtrack: re-emit the def at
-        // Current, re-link to live neighbours, and re-record as live.
-        auto reintroduce_order_literal(const SimpleIntegerVariableID & id, Integer v) -> void;
 
         // Emit the stitch link ge(hi) -> ge(lo) skipping a deleted run of thresholds,
         // recorded at at_level (= max(level(lo), level(hi))), restoring the logger's

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -187,6 +187,7 @@ struct ProofLogger::Imp
     vector<char> proof_stream_buffer;
     int current_indent = 0;
     AssertionLevel assertion_level;
+    OrderEncodingDeletion order_encoding_deletion = OrderEncodingDeletion::None;
 
     // Scratch buffers for assembling proof lines before they are written out,
     // reused across emissions to avoid a stringstream per logged inference.
@@ -220,6 +221,7 @@ ProofLogger::ProofLogger(const ProofOptions & proof_options, NamesAndIDsTracker 
     _imp->proof_file = proof_options.proof_file_names.proof_file;
     _imp->proof_lines_by_level.resize(2);
     _imp->assertion_level = proof_options.assertion_level;
+    _imp->order_encoding_deletion = proof_options.order_encoding_deletion;
 }
 
 ProofLogger::~ProofLogger() = default;
@@ -366,6 +368,42 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
     emit_under_reason(
         assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Current, guesses_as_reason, AssertionAnnotation{.hint_name = hints::Backtrack::hint_name});
+}
+
+auto ProofLogger::bound_advances_active() const -> bool
+{
+    // Bound advances act on the proof only under the Literals order-encoding-deletion
+    // mode with assertions off --- the same pairing every Literals-machinery guard uses.
+    // Under None a Bound advance is treated exactly like Exclude (no advance emitted),
+    // which is what keeps flag-off proofs byte-identical after the split family is tagged.
+    return _imp->order_encoding_deletion == OrderEncodingDeletion::Literals && _imp->assertion_level == AssertionLevel::Off;
+}
+
+auto ProofLogger::emit_split_bound_advance(const vector<Literal> & guesses, const Literal & refuted_guess) -> void
+{
+    if (! bound_advances_active())
+        return;
+
+    // The frontier order literal is the refuted guess's own negation. For a split
+    // sibling this is a single `ge` threshold: refuting `var <= v` (`var < v+1`) gives
+    // `var >= v+1`; refuting `var > v` (`var >= v+1`) gives `var < v+1`. No hole-jumping
+    // is needed in stage B --- the split refutes the half directly, so the advance clause
+    // coincides with the refuted child's still-live backtrack clause and RUP is immediate.
+    auto frontier = ! refuted_guess;
+
+    // Hoist the frontier to this level (the sibling's backtrack level == the active
+    // level) so the advance never names a to-be-deleted literal and the child's forget
+    // keeps exactly the frontier resident behind the monotone bound. Usually a no-op:
+    // the child's backtrack GuessHoist already placed the frontier here (it is named by
+    // the refuted guess); re-run so the frontier is anchored even were that to change.
+    names_and_ids_tracker().hoist_live_order_literals_toward_level(vector<Literal>{frontier}, proof_level(), OrderEncodingResidencyCause::GuessHoist);
+
+    _imp->proof << "% bound advance\n";
+    WPBSum advance;
+    for (const auto & guess : guesses)
+        advance += 1_i * ! guess;
+    advance += 1_i * frontier;
+    emit_rup_proof_line(move(advance) >= 1_i, ProofLevel::Current);
 }
 
 auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions) -> ProofLine

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -95,6 +95,33 @@ namespace gcs::innards
         auto backtrack(const std::vector<Literal> & guesses) -> void;
 
         /**
+         * \brief True iff brancher bound advances are proof-active: the mode is
+         * OrderEncodingDeletion::Literals and assertions are off.
+         *
+         * The search loop consults this before building the advance's guess list, so
+         * that under mode None (or with assertions on) a Bound advance is fully inert
+         * --- no advance line, no guess-list materialisation --- which is what keeps
+         * flag-off proofs byte-identical and flag-off search free of extra work.
+         */
+        [[nodiscard]] auto bound_advances_active() const -> bool;
+
+        /**
+         * \brief Emit the guess-reasoned bound advance for a refuted split sibling.
+         *
+         * The refuted guess's own negation is the frontier order literal (refuting
+         * `var <= v`, i.e. `var < v+1`, proves `var >= v+1`; refuting `var > v` proves
+         * `var < v+1`), so no hole-jumping is needed: the split refutes the half
+         * directly. One RUP line `~guesses OR ~refuted_guess` is emitted at
+         * ProofLevel::Current (the sibling's backtrack level), which VeriPB re-derives
+         * from the refuted child's still-live backtrack clause; the frontier literal is
+         * first hoisted to that level so the child's forget deletes behind it while
+         * keeping exactly the frontier resident. \p guesses is the decision stack below
+         * this node (the just-refuted sibling already popped). A no-op unless
+         * bound_advances_active() --- under None a Bound advance is inert.
+         */
+        auto emit_split_bound_advance(const std::vector<Literal> & guesses, const Literal & refuted_guess) -> void;
+
+        /**
          * Derive a learned nogood --- the clause forbidding the given conjunction
          * of decisions --- as a persistent (ProofLevel::Top) RUP line, returning
          * its proof line. Used when restart learning records a nogood as the stack

--- a/gcs/innards/proofs/range_witness_w1_test.cc
+++ b/gcs/innards/proofs/range_witness_w1_test.cc
@@ -25,8 +25,8 @@ namespace
     auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchHeuristic
     {
         return [var](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
-            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
-                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
+            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<BranchDecision> {
+                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<BranchDecision> {
                     if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
                         co_yield var != 0_i;
                         co_yield var == 0_i;

--- a/gcs/innards/proofs/range_witness_w2_test.cc
+++ b/gcs/innards/proofs/range_witness_w2_test.cc
@@ -22,8 +22,8 @@ namespace
     auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchHeuristic
     {
         return [var](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
-            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
-                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
+            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<BranchDecision> {
+                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<BranchDecision> {
                     if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
                         co_yield var != 0_i;
                         co_yield var == 0_i;

--- a/gcs/innards/proofs/range_witness_w3_test.cc
+++ b/gcs/innards/proofs/range_witness_w3_test.cc
@@ -20,8 +20,8 @@ namespace
     auto scripted_neq_then_eq_zero(IntegerVariableID var) -> BranchHeuristic
     {
         return [var](const Problem &, innards::State &, innards::Propagators &) -> BranchCallback {
-            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<IntegerVariableCondition> {
-                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<IntegerVariableCondition> {
+            return [var](const CurrentState & state, const innards::Propagators &) -> std::generator<BranchDecision> {
+                return [](const CurrentState & state, IntegerVariableID var) -> std::generator<BranchDecision> {
                     if (state.domain_size(var) >= 2_i && state.in_domain(var, 0_i)) {
                         co_yield var != 0_i;
                         co_yield var == 0_i;

--- a/gcs/presolvers/auto_table/auto_table.cc
+++ b/gcs/presolvers/auto_table/auto_table.cc
@@ -78,8 +78,11 @@ namespace
                 for (; branch_iter != brancher.end(); ++branch_iter) {
                     auto timestamp = state.new_epoch();
                     auto branch = *branch_iter;
-                    state.guess(branch);
-                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch, branch_callback, logger, selector_var_id);
+                    // AutoTable maintains no BacktrackConstraint: it takes the Exclude
+                    // path, so it only needs the decision's guess (its logger->backtrack
+                    // below is verbatim today's ~guesses).
+                    state.guess(branch.guess);
+                    solve_subproblem(depth + 1, tuples, vars, propagators, state, branch.guess, branch_callback, logger, selector_var_id);
                     state.backtrack(timestamp);
                 }
             }

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -47,15 +47,14 @@ auto gcs::branch_with(BranchVariableHeuristic var, BranchValueGenerator val) -> 
         // Run the variable heuristic's per-search setup once, then reuse the
         // resulting selector at every node.
         auto select_var = var(problem, state, propagators);
-        return [select_var = move(select_var), val = val](
-                   const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
+        return [select_var = move(select_var), val = val](const CurrentState & s, const innards::Propagators & p) -> generator<BranchDecision> {
             return [](const CurrentState & s, const innards::Propagators & p, BranchVariableSelector select_var,
-                       BranchValueGenerator make_val_gen) -> generator<IntegerVariableCondition> {
+                       BranchValueGenerator make_val_gen) -> generator<BranchDecision> {
                 auto branch_var = select_var(s, p);
                 if (branch_var)
                     return make_val_gen(s, p, *branch_var);
                 else
-                    return []() -> generator<IntegerVariableCondition> { co_return; }();
+                    return []() -> generator<BranchDecision> { co_return; }();
             }(s, p, select_var, val);
         };
     };
@@ -67,9 +66,8 @@ auto gcs::branch_sequence(BranchHeuristic a, BranchHeuristic b) -> BranchHeurist
         auto callback_a = a(problem, state, propagators);
         auto callback_b = b(problem, state, propagators);
         return [callback_a = move(callback_a), callback_b = move(callback_b)](
-                   const CurrentState & s, const innards::Propagators & p) -> generator<IntegerVariableCondition> {
-            return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a,
-                       BranchCallback b) -> generator<IntegerVariableCondition> {
+                   const CurrentState & s, const innards::Propagators & p) -> generator<BranchDecision> {
+            return [](const CurrentState & s, const innards::Propagators & p, BranchCallback a, BranchCallback b) -> generator<BranchDecision> {
                 auto gen_a = a(s, p);
                 auto iter_a = gen_a.begin();
                 if (iter_a != gen_a.end()) {
@@ -288,9 +286,8 @@ namespace
 {
     auto random_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
-        return [rand = move(rand)](
-                   const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
                 vector<Integer> values;
                 for (auto v : s.each_value(var))
                     values.push_back(v);
@@ -303,9 +300,8 @@ namespace
 
     auto random_out_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
-        return [rand = move(rand)](
-                   const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
                 vector<Integer> values;
                 for (auto v : s.each_value(var))
                     values.push_back(v);
@@ -319,9 +315,8 @@ namespace
 
     auto reject_random_interval_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
-        return [rand = move(rand)](
-                   const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
                 vector<Integer> values;
                 for (auto v : s.each_value(var))
                     values.push_back(v);
@@ -383,8 +378,8 @@ auto gcs::value_order::reject_random_interval(uint_fast32_t seed) -> BranchValue
 
 auto gcs::value_order::smallest_in() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto value = s.lower_bound(var);
             co_yield var == value;
             co_yield var != value;
@@ -394,8 +389,8 @@ auto gcs::value_order::smallest_in() -> BranchValueGenerator
 
 auto gcs::value_order::smallest_out() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto value = s.lower_bound(var);
             co_yield var != value;
             co_yield var == value;
@@ -405,8 +400,8 @@ auto gcs::value_order::smallest_out() -> BranchValueGenerator
 
 auto gcs::value_order::smallest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             for (auto v : s.each_value(var))
                 co_yield var == v;
         }(s, var);
@@ -415,8 +410,8 @@ auto gcs::value_order::smallest_first() -> BranchValueGenerator
 
 auto gcs::value_order::split_smallest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto mid = s.domain_size(var) / 2_i;
             auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
             co_yield var <= v;
@@ -427,8 +422,8 @@ auto gcs::value_order::split_smallest_first() -> BranchValueGenerator
 
 auto gcs::value_order::split_largest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto mid = s.domain_size(var) / 2_i;
             auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
             co_yield var > v;
@@ -441,9 +436,8 @@ namespace
 {
     auto split_random_value_generator(shared_ptr<mt19937> rand) -> BranchValueGenerator
     {
-        return [rand = move(rand)](
-                   const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+        return [rand = move(rand)](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+            return [](shared_ptr<mt19937> rand, const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
                 auto mid = s.domain_size(var) / 2_i;
                 auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
                 if (uniform_int_distribution(0, 1)(*rand) == 0) {
@@ -471,8 +465,8 @@ auto gcs::value_order::split_random(uint_fast32_t seed) -> BranchValueGenerator
 
 auto gcs::value_order::largest_in() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto value = s.upper_bound(var);
             co_yield var == value;
             co_yield var != value;
@@ -482,8 +476,8 @@ auto gcs::value_order::largest_in() -> BranchValueGenerator
 
 auto gcs::value_order::largest_out() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto value = s.upper_bound(var);
             co_yield var != value;
             co_yield var == value;
@@ -493,8 +487,8 @@ auto gcs::value_order::largest_out() -> BranchValueGenerator
 
 auto gcs::value_order::largest_first() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             for (auto v : s.each_value_reversed(var))
                 co_yield var == v;
         }(s, var);
@@ -503,8 +497,8 @@ auto gcs::value_order::largest_first() -> BranchValueGenerator
 
 auto gcs::value_order::median() -> BranchValueGenerator
 {
-    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<IntegerVariableCondition> {
-        return [](const CurrentState & s, IntegerVariableID var) -> generator<IntegerVariableCondition> {
+    return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
+        return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             vector<Integer> values;
             for (auto v : s.each_value(var))
                 values.push_back(v);

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -408,14 +408,39 @@ auto gcs::value_order::smallest_first() -> BranchValueGenerator
     };
 }
 
+namespace
+{
+    // Tag a split sibling with the Bound advance its refutation entails, derived from
+    // the condition it ACTUALLY yields (never from which arm produced it). A split
+    // yields order-atom conditions only: `var <= v` lowers to `var < v+1` (Less), whose
+    // refutation proves `var >= v+1` --- a LowerBound advance on var; `var > v` lowers to
+    // `var >= v+1` (GreaterEqual), whose refutation proves `var < v+1` --- an UpperBound.
+    // Deriving from the yielded condition keeps split_random's tags honest whatever its
+    // (duplicated-arm) coin flip does. Any other operator would leave the sibling
+    // Exclude-tagged (byte-identical), but a split never yields one.
+    [[nodiscard]] auto split_decision(const IntegerVariableCondition & cond) -> BranchDecision
+    {
+        switch (cond.op) {
+            using enum VariableConditionOperator;
+        case Less: return BranchDecision{cond, backtrack_advance::LowerBound{cond.var}};
+        case GreaterEqual: return BranchDecision{cond, backtrack_advance::UpperBound{cond.var}};
+        case Equal:
+        case NotEqual:
+        case InRange:
+        case NotInRange: return BranchDecision{cond};
+        }
+        return BranchDecision{cond};
+    }
+}
+
 auto gcs::value_order::split_smallest_first() -> BranchValueGenerator
 {
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto mid = s.domain_size(var) / 2_i;
             auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
-            co_yield var <= v;
-            co_yield var > v;
+            co_yield split_decision(var <= v);
+            co_yield split_decision(var > v);
         }(s, var);
     };
 }
@@ -426,8 +451,8 @@ auto gcs::value_order::split_largest_first() -> BranchValueGenerator
         return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto mid = s.domain_size(var) / 2_i;
             auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
-            co_yield var > v;
-            co_yield var <= v;
+            co_yield split_decision(var > v);
+            co_yield split_decision(var <= v);
         }(s, var);
     };
 }
@@ -441,12 +466,12 @@ namespace
                 auto mid = s.domain_size(var) / 2_i;
                 auto v = *(s.each_value(var) | std::ranges::views::drop((mid - 1_i).as_index())).begin();
                 if (uniform_int_distribution(0, 1)(*rand) == 0) {
-                    co_yield var <= v;
-                    co_yield var > v;
+                    co_yield split_decision(var <= v);
+                    co_yield split_decision(var > v);
                 }
                 else {
-                    co_yield var > v;
-                    co_yield var <= v;
+                    co_yield split_decision(var > v);
+                    co_yield split_decision(var <= v);
                 }
             }(rand, s, var);
         };

--- a/gcs/search_heuristics.hh
+++ b/gcs/search_heuristics.hh
@@ -61,7 +61,7 @@ namespace gcs
      * \ingroup SearchHeuristics
      */
     using BranchValueGenerator =
-        std::function<std::generator<IntegerVariableCondition>(const CurrentState &, const innards::Propagators &, const IntegerVariableID &)>;
+        std::function<std::generator<BranchDecision>(const CurrentState &, const innards::Propagators &, const IntegerVariableID &)>;
 
     /**
      * Combine a BranchVariableHeuristic from gcs::variable_order:: with a BranchValueGenerator

--- a/gcs/search_heuristics_test.cc
+++ b/gcs/search_heuristics_test.cc
@@ -146,8 +146,8 @@ TEST_CASE("split_random takes each half first sometimes")
     bool saw_lower_first = false, saw_upper_first = false;
     for (int draw = 0; draw < 100; ++draw) {
         vector<IntegerVariableCondition> yielded;
-        for (auto && cond : generate(state.current(), propagators, x))
-            yielded.push_back(cond);
+        for (auto && decision : generate(state.current(), propagators, x))
+            yielded.push_back(decision.guess);
 
         REQUIRE(yielded.size() == 2);
         if (yielded[0] == lower_half) {

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -13,6 +13,7 @@
 #include <gcs/solve.hh>
 
 #include <util/enumerate.hh>
+#include <util/overloaded.hh>
 
 #include <cstdlib>
 #include <limits>
@@ -64,6 +65,42 @@ namespace
         unsigned long long conflicts_since_restart;
         unsigned long long cutoff;
         bool enabled;
+    };
+
+    /**
+     * The node's standing backtrack constraint: the framework's internal fold of
+     * the BranchDecision advances refuted so far at this node (design 1.1). It is
+     * derived, not a public type, and lives as a stack local for one frame.
+     *
+     * Stage A folds only backtrack_advance::Exclude, so the constraint never
+     * leaves the ExcludedSet (monostate) arm: the node's refutation lemma stays
+     * today's ~state.guesses(), emitted verbatim at node close. The Bound arm and
+     * its terminal-bound lemma are wired in stage B; they are structurally present
+     * here but behaviourally inert.
+     */
+    struct BacktrackConstraint final
+    {
+        std::variant<std::monostate, std::pair<SimpleIntegerVariableID, Integer>> state = std::monostate{};
+        bool is_lower = true; // meaningful only in the Bound arm
+
+        auto fold(const BacktrackAdvance & advance) -> void
+        {
+            overloaded{//
+                [&](const backtrack_advance::Exclude &) {
+                    // Accumulate ~guess into the excluded set: nothing to record here,
+                    // the ExcludedSet lemma is state.guesses() emitted at node close.
+                },
+                [&](const backtrack_advance::LowerBound &) {
+                    // Stage B: switch to / advance a monotone lower-bound frontier.
+                },
+                [&](const backtrack_advance::UpperBound &) {
+                    // Stage B: switch to / advance a monotone upper-bound frontier.
+                },
+                [&](const backtrack_advance::Custom &) {
+                    // Escape hatch; no consumer in stage A.
+                }}
+                .visit(advance);
+        }
     };
 
     auto solve_with_state(unsigned long long depth, Stats & stats, Problem & problem, Propagators & propagators, State & state,
@@ -184,10 +221,18 @@ namespace
                     // re-derives it on the next pass. Every other descended sibling
                     // (a first sibling, or any d-way value) is a free positive
                     // decision and extends the prefix.
+                    // The framework's fold of this node's backtrack advances. Stage A
+                    // only ever folds Exclude, so it stays an ExcludedSet and the node
+                    // close below is verbatim today's ~state.guesses().
+                    BacktrackConstraint backtrack_constraint;
                     optional<IntegerVariableCondition> first_sibling;
                     unsigned long long sibling_index = 0;
                     for (; branch_iter != branch_generator.end(); ++branch_iter) {
-                        auto guess = *branch_iter;
+                        auto decision = *branch_iter;
+                        // The nld-nogood prefix and negative-flip detection operate on
+                        // the decision's guess (still an IntegerVariableCondition), not
+                        // on its backtrack advance (design 3).
+                        const auto & guess = decision.guess;
                         // Only maintain the reduced prefix when we are actually
                         // learning nogoods: otherwise reduced_prefix stays empty and
                         // the copy is free, so ordinary search pays nothing.
@@ -209,7 +254,10 @@ namespace
                             break;
                         }
                         // Complete: this sibling's subtree was refuted under the
-                        // current path, so record it for restart-nogood learning.
+                        // current path. Fold its backtrack advance into the node's
+                        // standing constraint (stage A: Exclude, so inert), and record
+                        // it for restart-nogood learning.
+                        backtrack_constraint.fold(decision.on_refuted);
                         refuted_siblings.push_back(guess);
                     }
                 }

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -83,25 +83,42 @@ namespace
         std::variant<std::monostate, std::pair<SimpleIntegerVariableID, Integer>> state = std::monostate{};
         bool is_lower = true; // meaningful only in the Bound arm
 
-        auto fold(const BacktrackAdvance & advance) -> void
+        // Switch the node's standing constraint to a monotone bound on the branched
+        // variable at the new frontier threshold (the refuted split guess's own value:
+        // `var <= v` == `var < v+1` and `var > v` == `var >= v+1` both carry threshold
+        // v+1). Recorded only for a real (Simple) variable; other kinds leave the
+        // ExcludedSet arm. See fold() for why stage B does not yet consume this.
+        auto note_bound(const IntegerVariableID & var, Integer threshold, bool lower) -> void
+        {
+            if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&var)) {
+                state = std::pair{*sid, threshold};
+                is_lower = lower;
+            }
+        }
+
+        auto fold(const BranchDecision & decision) -> void
         {
             overloaded{//
                 [&](const backtrack_advance::Exclude &) {
                     // Accumulate ~guess into the excluded set: nothing to record here,
                     // the ExcludedSet lemma is state.guesses() emitted at node close.
                 },
-                [&](const backtrack_advance::LowerBound &) {
-                    // Stage B: switch to / advance a monotone lower-bound frontier.
-                },
-                [&](const backtrack_advance::UpperBound &) {
-                    // Stage B: switch to / advance a monotone upper-bound frontier.
-                },
+                [&](const backtrack_advance::LowerBound & lb) { note_bound(lb.var, decision.guess.value, /*lower=*/true); },
+                [&](const backtrack_advance::UpperBound & ub) { note_bound(ub.var, decision.guess.value, /*lower=*/false); },
                 [&](const backtrack_advance::Custom &) {
-                    // Escape hatch; no consumer in stage A.
+                    // Escape hatch; no consumer in stage B.
                 }}
-                .visit(advance);
+                .visit(decision.on_refuted);
         }
     };
+
+    // A refuted split sibling carries a Bound (Lower/Upper) advance; every other value
+    // order stays Exclude. The framework emits a guess-reasoned frontier advance only
+    // for the Bound siblings.
+    [[nodiscard]] auto is_bound_advance(const BacktrackAdvance & advance) -> bool
+    {
+        return std::holds_alternative<backtrack_advance::LowerBound>(advance) || std::holds_alternative<backtrack_advance::UpperBound>(advance);
+    }
 
     auto solve_with_state(unsigned long long depth, Stats & stats, Problem & problem, Propagators & propagators, State & state,
         const optional<Literal> & this_branch_guess, SolveCallbacks & callbacks, const BranchCallback & branch_callback, ProofLogger * const logger,
@@ -221,13 +238,16 @@ namespace
                     // re-derives it on the next pass. Every other descended sibling
                     // (a first sibling, or any d-way value) is a free positive
                     // decision and extends the prefix.
-                    // The framework's fold of this node's backtrack advances. Stage A
-                    // only ever folds Exclude, so it stays an ExcludedSet and the node
-                    // close below is verbatim today's ~state.guesses().
+                    // The framework's fold of this node's backtrack advances. A split
+                    // family folds Lower/UpperBound (recorded in the Bound arm); every
+                    // other value order folds Exclude. The node-close lemma below stays
+                    // today's ~state.guesses() either way (a two-way split is closed by
+                    // complementarity), so the fold's Bound state is not yet consumed at
+                    // close; the per-sibling advances are emitted inside the loop.
                     BacktrackConstraint backtrack_constraint;
                     optional<IntegerVariableCondition> first_sibling;
                     unsigned long long sibling_index = 0;
-                    for (; branch_iter != branch_generator.end(); ++branch_iter) {
+                    while (branch_iter != branch_generator.end()) {
                         auto decision = *branch_iter;
                         // The nld-nogood prefix and negative-flip detection operate on
                         // the decision's guess (still an IntegerVariableCondition), not
@@ -253,12 +273,31 @@ namespace
                             result = SearchResult::RestartCutoffHit;
                             break;
                         }
-                        // Complete: this sibling's subtree was refuted under the
-                        // current path. Fold its backtrack advance into the node's
-                        // standing constraint (stage A: Exclude, so inert), and record
-                        // it for restart-nogood learning.
-                        backtrack_constraint.fold(decision.on_refuted);
+                        // Complete: this sibling's subtree was refuted under the current
+                        // path. Fold its backtrack advance into the node's standing
+                        // constraint, and record it for restart-nogood learning.
+                        backtrack_constraint.fold(decision);
                         refuted_siblings.push_back(guess);
+
+                        // Advance the brancher, then --- under Literals, for a refuted
+                        // sibling carrying a Bound advance that is NOT the node's last ---
+                        // emit the guess-reasoned frontier advance. It lands at the
+                        // sibling's backtrack level (the active level here), reasoning from
+                        // the decision stack below this node (state.guesses(); the sibling
+                        // itself already backtracked), while the child's backtrack clause is
+                        // still live below the parent forget. The last refuted sibling emits
+                        // none: its refutation closes the node via complementarity, and the
+                        // node-close backtrack clause subsumes it (see the tail). Under None
+                        // / Exclude the whole block is skipped, so flag-off search does no
+                        // extra work and its proof is byte-identical.
+                        ++branch_iter;
+                        if (logger && logger->bound_advances_active() && is_bound_advance(decision.on_refuted) &&
+                            branch_iter != branch_generator.end()) {
+                            vector<Literal> guesses;
+                            for (const auto & g : state.guesses())
+                                guesses.push_back(g);
+                            logger->emit_split_bound_advance(guesses, guess);
+                        }
                     }
                 }
             }
@@ -313,7 +352,15 @@ namespace
             else {
                 // A normal backtrack: the subtree under these guesses was refuted,
                 // so we may assert the negation of the guess set (RUP from the
-                // refutation that the forget below then discards).
+                // refutation that the forget below then discards). This is also the
+                // node-close lemma for a Bound (split-family) node: a two-way split's
+                // second sibling is the first's complement, so the two children's
+                // still-live backtrack clauses make ~guesses RUP exactly as today ---
+                // byte-identical to what the parent level expects. The split family
+                // never advances a single monotone frontier past the domain, so the
+                // design's "terminal advance in place of ~guesses" close is not produced
+                // here (it is the d-way / eq-window shape, deferred); the folded Bound
+                // state is maintained but not consumed at close in stage B.
                 vector<Literal> guesses;
                 for (const auto & g : state.guesses())
                     guesses.push_back(g);

--- a/gcs/solve.hh
+++ b/gcs/solve.hh
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <functional>
+#include <variant>
 #include <version>
 
 #ifdef __cpp_lib_generator
@@ -50,11 +51,108 @@ namespace gcs
     using TraceCallback = std::function<auto(const CurrentState &)->bool>;
 
     /**
+     * \defgroup BranchDecisions Branch decisions and their backtrack advances
+     *
+     * A branching generator yields BranchDecision instances. Each pairs the
+     * IntegerVariableCondition to branch on (the \c guess) with a declaration of
+     * how the node's backtrack constraint tightens once that decision's subtree
+     * is refuted (the \c on_refuted BacktrackAdvance). The framework folds those
+     * advances; branchers never write raw proof bookkeeping.
+     *
+     * \ingroup SolveCallbacks
+     */
+
+    /**
+     * \brief The backtrack-advance kinds a BranchDecision can declare.
+     *
+     * \ingroup BranchDecisions
+     */
+    namespace backtrack_advance
+    {
+        /**
+         * \brief Refuting this decision's subtree entails a new lower bound on
+         * \c var: the node's backtrack constraint tightens to \c var >= (next
+         * live threshold), naming ONE order literal.
+         */
+        struct LowerBound final
+        {
+            IntegerVariableID var;
+        };
+
+        /**
+         * \brief Symmetric to LowerBound: refuting entails \c var <= (next live
+         * threshold), i.e. \c var < t.
+         */
+        struct UpperBound final
+        {
+            IntegerVariableID var;
+        };
+
+        /**
+         * \brief The generic fallback: accumulate \c !guess into the node's
+         * excluded set. This is exactly today's \c ~(all guesses) backtrack
+         * clause; it names a growing set, so nothing is deletable for that
+         * variable. The default advance.
+         */
+        struct Exclude final
+        {
+        };
+
+        /**
+         * \brief Escape hatch for exotic branchers that prove their own backtrack
+         * constraint.
+         *
+         * Placeholder for now: the design's sketched WPBSum callback is "not
+         * fleshed out until a use case appears" (dev-doc "Extensibility"), and
+         * spelling it would drag the proof-innards WPBSumLE type into this public
+         * header. Stage A ships an empty struct so BacktrackAdvance's variant is
+         * exhaustive and compiles; nothing constructs it yet.
+         */
+        struct Custom final
+        {
+        };
+    }
+
+    /**
+     * \brief How a BranchDecision's backtrack constraint tightens when its
+     * subtree is refuted.
+     *
+     * \ingroup BranchDecisions
+     */
+    using BacktrackAdvance =
+        std::variant<backtrack_advance::LowerBound, backtrack_advance::UpperBound, backtrack_advance::Exclude, backtrack_advance::Custom>;
+
+    /**
+     * \brief A single branching decision: what to branch on, plus how the node's
+     * backtrack constraint advances if that decision's subtree is refuted.
+     *
+     * An IntegerVariableCondition converts implicitly to a BranchDecision
+     * defaulting to backtrack_advance::Exclude, so an existing branch generator
+     * that yields bare conditions keeps compiling and, under the default advance,
+     * keeps its proof byte-identical.
+     *
+     * \ingroup BranchDecisions
+     */
+    struct BranchDecision final
+    {
+        IntegerVariableCondition guess;                             ///< What to branch on.
+        BacktrackAdvance on_refuted = backtrack_advance::Exclude{}; ///< How the node advances if refuted.
+
+        BranchDecision(IntegerVariableCondition c) : guess(c)
+        {
+        }
+
+        BranchDecision(IntegerVariableCondition c, BacktrackAdvance a) : guess(c), on_refuted(a)
+        {
+        }
+    };
+
+    /**
      * \brief Called by gcs::solve_with() to determine branching when
-     * searching, should return a generator of IntegerVariableCondition
-     * instances (which may be range conditions, for interval accept/reject
-     * branching) that corresponds to a complete branching choice, or that
-     * yields nothing if every variable is instantiated.
+     * searching, should return a generator of BranchDecision instances (each
+     * carrying an IntegerVariableCondition, which may be a range condition for
+     * interval accept/reject branching) that corresponds to a complete branching
+     * choice, or that yields nothing if every variable is instantiated.
      *
      * \warning The CurrentState and Propagators references are into live
      * solver internals, and are valid only for the duration of the call.
@@ -62,7 +160,7 @@ namespace gcs
      * \ingroup SolveCallbacks
      * \sa SearchHeuristics
      */
-    using BranchCallback = std::function<std::generator<IntegerVariableCondition>(const CurrentState &, const innards::Propagators &)>;
+    using BranchCallback = std::function<std::generator<BranchDecision>(const CurrentState &, const innards::Propagators &)>;
 
     /**
      * \brief The branching heuristic for gcs::solve_with(): given a search's


### PR DESCRIPTION
Part of #612.

Stacked on #605. Stages **A** and **B** of the step-2 Brancher-API refactor, plus the
rebase onto `main` and the regression it turned up.

`dev_docs/brancher-design.md` (added here) is the decided design and the authority on the
staging; this PR is its first two stages.

- **Stage A — types and plumbing, byte-identical.** `BranchDecision` and
  `BacktrackAdvance`, the implicit conversion from `IntegerVariableCondition`, the
  `BacktrackConstraint` fold, the widened `BranchValueGenerator`/`BranchCallback` yield
  type, every value order ported to `Exclude`, and the three scripted tests plus
  `auto_table` migrated. No proof byte moves.
- **Stage B — split-family bound advances.** `split_smallest_first` /
  `split_largest_first` / `split_random` tagged `Lower`/`UpperBound`, wired to the
  framework's consolidate → hoist → delete and the terminal-bound backtrack lemma,
  Literals-only. This is the stage that validated the advance-RUP proof level against
  VeriPB.
- **Magnitude-product operands kept resident** under Literals — divide/modulus `x, y,
  out` and multiply/power `x, y, z`. Their `ge`s are named by permanent rows
  (identity/remainder/magnitude-channel/sign clauses) and the `pol`/`rup` product
  reasons over them, so a deleted definition strands a live pin and the re-introduction's
  falsify witness collides with it. This was the divide/modulus seed-3072268882 bug — a
  ~10 %-of-seeds hole the fixed corpus missed; multiply/power share the mechanism and are
  fixed here as a latent-bug closure.

## The regression the rebase surfaced, and why the fix is shaped as it is

Upstream `834b7029` fused name introduction into line rendering, and its
`xliteral_for_ensuring` introduces a name **only when the atom is missing** — right for
every other mode, fatal here, where an atom's identity is permanent but its *definition*
is transient. The re-introduction hook sat in `need_gevar`'s fast path, so it was
bypassed: emitted lines named `ge` literals whose definitions had been deleted, with the
re-introduction appearing a few lines *later*. That took flag-induced VeriPB rejections
from 0 to **37** across the caps-off suite at `MIN_CHAIN=0` — and only 1 at the shipped
gate of 16, which is a good illustration of why the aggressive mode is the regression
gate.

The fix makes the rule **structural instead of a discipline**: deletion now *retires* the
atom out of `VariableAtoms::ge` into `retired_ge`, so `find_condition` stops answering and
the renderer's own "missing name" check does the enforcing; `need_gevar` takes the retired
`XLiteral` back on re-introduction, so identity and PB name survive delete/re-introduce
cycles. The mode-gated workaround, `reintroduce_order_literal` and
`order_literal_aliased_to_bit` (dead since #554 stopped aliasing `>= 1` to the bit) are
all gone — a net simplification.

Two traps it turned up, both recorded in the dev doc: re-introduction must
`insert_or_assign` into `ge_defs`, never `try_emplace` (the stale entry holds the deleted
lines every chain `pol` cites, and the entry must stay so `ge_defs` remains the gate's
monotone count); and identity must be reused rather than re-minted, because a fresh
xliteral renders as the same verbose name but a different `x<n>` with
`set_verbose_names(false)` — which would make proof semantics depend on a rendering flag.

## Gates

The standing set (suite in all three modes, `None`-mode byte-identity vs plain `main`,
seed sweeps at `MIN_CHAIN=0`), plus win preservation on the synthetic sweep.

> **Figures updated.** Re-measured on current hardware in #614, where the whole sweep was
> retaken in one contiguous sitting: ON d250 67 ms / d1000 507 ms / d2000 1.852 s, against
> d250 OFF 335 ms — **5.04×**, rising to 54.98× at d2000. The win is preserved; the
> original campaign's absolute times came from a machine this checkout can no longer
> reach and do not transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb9fgE3SAiASdwREZVrU3p


