### PR TITLE
Brancher stage B': order-encoding eviction primitives and residency bookkeeping

### DIFF
--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -477,6 +477,27 @@ resident* subset. An eq eviction mirrors the ge eviction's
   (or a sibling `forget_eq_literals_at_level`), called from the same
   `forget_proof_level` funnel.
 
+  **As implemented in B'**, with one deliberate asymmetry: these hold **only windowed
+  (deletable) eq defs**. Absence means "permanent, resident forever", which is what every
+  eq atom outside a window is — so both structures stay empty until something windows a
+  variable, and the index costs nothing on the eq-heavy instances whose eq atoms are not
+  branched on. (`live_order_literals` cannot do this: it records level-0 ge thresholds
+  because the chain walk and the stitch need them.) `forget_eq_literals_at_level` and
+  `forget_chain_lines_at_level` both hang off the same `forget_order_links_at_level`
+  funnel, after the ge sweep — which is what emits the level's stitches, and those land at
+  a *surviving* neighbour's level, never at the level being forgotten.
+
+  The producer of a windowed def is a defaulted argument,
+  `need_direct_encoding_for(id, v, EqAtomResidency::Windowed)`; `Permanent` is the default
+  and what every caller in the solver passes, so B' changes no emission. The request is
+  honoured only where a deletable def is meaningful (Literals, proof-time, assertions off,
+  real variable) and, per **(i-static)** below, is refused for a variable that already has
+  an interval partition or a containment tree — that half of the eq⨯interval guard is
+  cheap enough to ship with the primitive rather than with the window. B'' replaces the
+  argument with the variable's `WindowedEqScope` tag; until then it exists so
+  `hoist_eq_to_top` and the eq forget sweep have a producer to be VeriPB-checked against
+  (`order_evict_test`).
+
 ### WindowedFrontier vs FrontierExempt, and the chain gate
 
 The chain gate (`order_encoding_deletion_min_chain`) keeps *short-chain
@@ -752,48 +773,101 @@ Two load-bearing caveats:
    acceptance is not evidence the discipline held.
 
 These are two instances of the same fact — **VeriPB polices order-encoding soundness
-only at a point of use, not at deletion** — and the two solver-side invariants it
-will not police are:
+only at a point of use, not at deletion** — and the solver-side invariants it will not
+police are:
 
 - **Eviction ordering** (delc the improvement constraint before evicting its ge).
 - **ge-under-eq residency** (do not evict a ge a live Top eq atom names; the eq
   window's hoist-out rule).
+- **Chain-clause deletion on evict** (leave no clause naming an evicted threshold).
+  Added in stage B' once it was measured: a leftover clause stays *valid*, so the proof
+  verifies and the only loss is the shrinkage. See "The evict primitive" below.
 
 Both are exactly why the always-on residency-cause bookkeeping (below) is mandatory,
 not optional.
 
-### The evict-from-Top primitive — mirror of hoist
+### The evict primitive — mirror of hoist
 
-Hoist moves a def *to* Top and stitches it *in*. Evict moves a def *off* Top and
-stitches the chain *over* it:
+**Implemented in stage B'.** Hoist moves a def *to* a level and stitches it *in*.
+Evict deletes it and stitches the chain *over* it. As shipped:
 
 ```cpp
 // NamesAndIDsTracker
-// Evict a real variable's Top-resident ge threshold v: emit `del` for its two
-// reification def lines and its two Top chain links, stitch the surviving Top
-// neighbours lo,hi with a skip link ge(hi) -> ge(lo) (the run-stitch of
-// forget_order_literals_at_level, run for a single Top literal on demand), and drop
-// v from live_order_literals (leaving the atom and its ge_defs slot) so a later need_gevar reintroduces
-// it as a deletable interior literal. Precondition (asserted): v's only Top
-// residency cause is the one the caller names (e.g. SoliHoist).
-auto evict_order_literal_from_top(const SimpleIntegerVariableID & id, Integer v,
-    OrderEncodingResidencyCause expected_sole_cause) -> void;
+// Delete v's two reification def lines and every chain clause naming it, stitch its
+// surviving immediate neighbours lo,hi with a skip link ge(hi) -> ge(lo) (the run-stitch
+// of forget_order_literals_at_level, run for one literal on demand, landing at the deeper
+// neighbour's level exactly as there), drop v from live_order_literals and its level
+// index, release its Top pin, and RETIRE its atom -- so a later need_gevar re-introduces
+// it as a deletable interior literal and takes the retired XLiteral back.
+// Returns whether it was evicted; a refusal emits nothing and changes nothing.
+auto evict_order_literal(const SimpleIntegerVariableID & id, Integer v,
+    std::optional<OrderEncodingResidencyCause> expected_sole_top_cause) -> bool;
 ```
 
-This **requires the residency-cause bookkeeping to be always-on under Literals**,
-not stats-gated. Today `stats_ge_top_cause` is populated only when
-`collect_order_encoding_stats` (Literals *and* the env var). Payload 2's safety
-assertion needs a per-Top-ge cause record — a minimal cause set or a Top-pin
-refcount — populated whenever the mode is Literals, with the existing stats map
-layered on top; without it, eviction cannot safely fire and must conservatively skip
-(leaving the ge resident — correct, no win). This promotion is now stage B'
-(shared with the eq window), not a stage-D prerequisite.
+Three deltas from the sketch this replaces, each for a reason worth keeping:
+
+- **It retires the atom** rather than "leaving the atom and its `ge_defs` slot". The
+  sketch predates `a15d5757`, which made the naming rule structural on the ge side;
+  eviction is a second deletion path and must enforce it the same way.
+- **It returns a bool instead of asserting.** The precondition is *checked*, so a
+  caller whose bookkeeping disagrees with the tracker's gets a safe refusal (the
+  literal stays resident, costing only the win) rather than an abort. `nullopt` is the
+  mid-level (window tidy) case: a deletable literal has no Top pin by construction, so
+  naming a cause for one is refused too.
+- **It handles any level, not just Top**, because the window's per-iteration tidy
+  evicts Current-level defs. Hence the name loses `_from_top`.
+
+It **required the residency-cause bookkeeping to become always-on under Literals**,
+not stats-gated (`ge_top_pins`; `stats_ge_top_cause` stays as the diagnostic's
+first-cause-wins map, layered on top and still covering the born-Top structural
+causes that never hoist). It also required a **single-line deletion API**,
+`ProofLogger::delete_proof_lines_at_level`, which drops the lines from the level's
+bucket as well as `del`-ing them: `forget_proof_level` ends a bucket's final interval
+with a bare `del id`, and VeriPB errors on a `del id` naming an already-deleted line
+(only `del range` skips them), so a line evicted from a level that is later forgotten
+would otherwise be deleted twice.
+
+**A third thing VeriPB will not police.** A chain clause left naming an evicted
+threshold is still a *valid derived constraint* — it was derived from definitions the
+atom's stable identity lets a later `need_gevar` restore, and re-introducing that
+definition **verifies with the stale clause present** (measured by mutation against
+veripb 3.0.2: the negated half of the reification forces the neighbour's atom through
+its own definition, so the leftover clause is implied under the witness). So a missed
+chain-clause deletion is silent and costs exactly the resident-DB shrinkage the mode
+exists for. `chain_clauses_naming(id, v)` exists to make that postcondition
+observable, and `order_evict_test` checks it in C++ — the third solver-side invariant
+listed above, alongside eviction ordering and ge-under-eq residency.
 
 The evict primitive has **two consumers**: payload 2 (evict a superseded soli
 threshold) and the eq window's per-iteration tidy (evict a Current-level eq/ge def +
 re-stitch). Its hoist-out path needs the same always-on residency bookkeeping. So the
-primitive and the bookkeeping promotion are a shared stage B' (below), rather than
+primitive and the bookkeeping promotion were a shared stage B' (below), rather than
 payload 2 owning them.
+
+#### The Top-pin bookkeeping, and its two counter-intuitive rules
+
+`ge_top_pins`: per real variable, per ge threshold, a per-cause refcount of the
+permanent references pinning it at Top. Both rules were found by getting them wrong
+first (2026-07-29), and both are checked by mutation in `order_evict_test`:
+
+1. **Count at the reference site, not inside the hoist.**
+   `hoist_order_literal_to_level` early-returns when the def is already at the target
+   level, and `hoist_order_literal_to_top_if_live` early-returns at level 0 — so a
+   second permanent atom naming an already-Top ge does no hoisting at all, and would
+   record no pin. This is not a corner case: `eq(v)` and `eq(v+1)` both name
+   `ge(v+1)`. First-cause-wins is right for a diagnostic and *fatal* for an eviction
+   precondition, which is exactly a count.
+2. **Only a ge whose Top residency a hoist caused gets an entry.** A hoist never
+   fires on a level-0 ge, so "level 0 with no entry" means structurally resident
+   (model-time / boundary / aux / view / gate) — never evictable, and needing no
+   record. That keeps the map proportional to hoists rather than to the resident
+   majority, and it is load-bearing in the other direction too: recording pins for
+   structurally resident thresholds would make a *boundary* literal — a permanent
+   chain anchor — look evictable.
+
+A `GuessHoist` to level 0 deliberately takes no pin (it targets a positive level and
+is not a permanent reference), which leaves such a literal looking structurally
+resident. Eviction then refuses it: a lost win at worst, never wrong.
 
 ### Payload 3 — objective / frontier deletion exemption
 
@@ -927,13 +1001,55 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   validates the advance-RUP proof level against VeriPB.**
 
 - **Stage B' (shared prerequisite) — residency-cause bookkeeping + evict/hoist
-  primitives, always-on under Literals.**
-  Promote `stats_ge_top_cause` to a minimal always-on per-ge cause set/refcount; add
-  `evict_order_literal_from_top`, `hoist_eq_to_top`, and the eq analogues of the
-  live/level indices (`live_eq_literals` / `eq_literals_by_level`). **No behaviour
-  change yet** — the primitives are unused; **Oracle:** byte-identity + unit coverage
-  of the bookkeeping. This is the shared foundation for both the window (B'') and
-  payload 2 (D).
+  primitives, always-on under Literals. DONE.**
+  Shipped: `ge_top_pins` (the always-on per-ge Top-pin refcount, counted at the
+  reference sites — see "The Top-pin bookkeeping" above); `chain_clauses_by_level` (the
+  chain clauses currently in the proof, bucketed by level then variable, which eviction
+  needs and nothing previously recorded);
+  `evict_order_literal` (any level, refusing rather than asserting, retiring the atom);
+  `chain_clauses_naming` (its postcondition, made observable because VeriPB will not
+  police it); `hoist_eq_to_top`; `live_eq_literals` + `eq_literals_by_level` +
+  `forget_eq_literals_at_level` + `VariableAtoms::retired_eq` (the eq analogue of ge
+  retirement, so a windowed def's atom is retired on backtrack and re-introduced with
+  its identity intact); `EqAtomResidency` on `need_direct_encoding_for` as the minimal
+  producer of a windowed def; and `ProofLogger::delete_proof_lines_at_level`.
+  **No behaviour change**: nothing in the solver evicts, windows an eq atom, or passes a
+  non-default residency, so every emission is unchanged.
+  **Oracle (met):** caps-off suite in each of {None, Literals gate 0, Literals gate 16};
+  `None`-mode byte-identity vs plain main; the flag-ON seed sweeps; and a new
+  VeriPB-checked driver, `gcs/innards/proofs/order_evict_test.cc` (mode and gate set in
+  code, so it does not depend on the environment — and in particular runs at gate 0,
+  which the shipped default of 16 would make vacuous). It covers mid-level evict,
+  evict-from-Top under a sole pin, the three refusals (no cause / wrong cause /
+  two-eq-atoms-pinning-one-ge), the structurally-resident (boundary) refusal,
+  `hoist_eq_to_top` across a forget of the window's level, the eq forget sweep and
+  identity-preserving re-introduction, and the bucket-erasure shape that would otherwise
+  double-delete. Each of those was confirmed discriminating by mutation (8 of 9 mutations
+  caught; the ninth — erasing a chain clause's record without emitting its `del` — is
+  invisible to both VeriPB and the tracker, and was checked by reading the emitted
+  proof). This is the shared foundation for both the window (B'') and payload 2 (D).
+
+  **Cost.** The stage emits not one different byte (checked by `cmp` on a 15 MB proof as
+  well as by the byte-identity gate), so `veripb` time cannot move. The solver's own
+  proof-writing time does: the chain-clause index takes an insert per chain clause. On the
+  deletion-heaviest synthetic (`order_deletion_bench`, pairwise, d1000, gate 0, pinned and
+  solo) that is **+4.7 %** — 211.6 ms → 221.6 ms — of which the pin map, eq indices and
+  retirement plumbing account for +1.0 % and the index for the rest. Keying that index by
+  variable and then by threshold pair instead cost +12.0 %, which is why it is bucketed
+  level-first and flat. In end-to-end terms at d1000 the solver is ~0.22 s against
+  `veripb`'s ~1.55 s, so this is well under 1 %. Numbers and the rejected further
+  optimisation are in `.../order-encoding-deletion-artifacts/stage-bprime/NOTES.md`.
+
+  **What B'' still owes on top of it:** the `WindowedEqScope` tag (replacing the
+  `EqAtomResidency` argument), the per-iteration tidy that actually calls
+  `evict_order_literal`, the **eq-side eviction** (B' ships only the eq *forget* sweep and
+  `hoist_eq_to_top`; taking a windowed eq def out on demand needs the same
+  `delete_proof_lines_at_level` + retire pair, with the `get_if<ProofLine>` filter for a
+  DirectOnly `{0,1}` variable's `XLiteral`-valued `eq_defs`), the hoist-out rule's
+  *detection* of a permanent reference (`hoist_eq_to_top` is the action, not the trigger),
+  the `WindowedFrontier` residency slot in `need_gevar`'s ladder, the **(i-dynamic)** half
+  of the eq⨯interval guard, and tagging `smallest_first` / `largest_first` /
+  `smallest_in` / `largest_in`.
 
 - **Stage B'' — the eq-atom window.**
   The `WindowedEqScope` tag, `need_direct_encoding_for` Current-emission, the
@@ -1000,9 +1116,13 @@ the owner:
    — is expected to verify by symmetry but was not driver-tested; confirm before
    shipping the descending orders.)
 
-3. **Residency-bookkeeping promotion (stage B').** Eviction's "sole Top cause"
-   assertion needs always-on per-ge cause tracking under Literals. *Resolution:* ship a
-   minimal refcount/cause-set in stage B'; the stats map layers on top.
+3. **Residency-bookkeeping promotion (stage B'). RESOLVED.** Eviction's "sole Top cause"
+   precondition needs always-on per-ge cause tracking under Literals. *Resolution as
+   shipped:* `ge_top_pins`, a per-cause refcount counted at the reference sites and only
+   for hoisted thresholds (see "The Top-pin bookkeeping" for why each of those two
+   qualifiers is load-bearing); the diagnostic's `stats_ge_top_cause` layers on top,
+   unchanged. Eviction *checks* it and refuses rather than asserting, so a disagreement
+   costs a win instead of aborting.
 
 ## Deferred / future work
 

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1096,14 +1096,16 @@ and can be prepared ahead (it reuses B''s primitives) and finished once wired.
 
 ## Implementation gates (not owner calls)
 
-Three unknowns remain; all are validated empirically against VeriPB, not decided by
-the owner:
+Three unknowns; all are validated empirically against VeriPB, not decided by the owner.
+Two are now resolved by the stages that owned them, and the remaining one belongs to
+B'':
 
-1. **Advance-RUP proof level (stage B).** The exact level at which the split-family
-   advance RUP and frontier hoist land, given the child has already
-   emitted-and-forgotten its own levels. *Resolution:* validate empirically in stage B
-   against VeriPB with the `order_jump_check` foundation as the anchor and
-   `MIN_CHAIN=0`; do not trust the level until a wide-gap split instance verifies.
+1. **Advance-RUP proof level (stage B). RESOLVED.** The exact level at which the
+   split-family advance RUP and frontier hoist land, given the child has already
+   emitted-and-forgotten its own levels. *Resolution:* settled empirically when stage B
+   landed — the caps-off suite verifies at `MIN_CHAIN=0` with the split families tagged,
+   and the synthetic split/UNSAT sweep preserves its win. Nothing about the level was
+   taken on trust; the gate was the suite, not an argument.
 
 2. **Real-solver eq advance re-confirmation (stage B'').** The eq analogue of gate 1.
    The driver commits the sibling `~g | ~eq(v)` via an order-hole `red` witness because

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -160,7 +160,7 @@ owns the MiniZinc frontend proofs.
 ## Implementation status
 
 - **Done, suite-safe:** the full caps-off test suite passes with the flag on (0
-  flag-induced VeriPB rejections; mode-off byte-identical; flag-off 536/536). The
+  flag-induced VeriPB rejections; mode-off byte-identical; flag-off 537/537). The
   hoist primitive, guess/eq/partition-atom hoisting, and the aux/view dispositions
   below are all in `gcs/innards/proofs/{names_and_ids_tracker,proof_logger,proof_model}.*`.
 - **A line must never name a literal whose definition has been deleted — and that is now
@@ -199,6 +199,46 @@ owns the MiniZinc frontend proofs.
     aliasing a DirectOnly `{0,1}` variable's `>= 1` atom to its bit, so every `ge` owns its
     own reification and `order_literal_aliased_to_bit` — which existed only to keep such a
     literal out of the re-introduction path — became dead and has been removed.
+- **Eviction: taking a definition out on demand, rather than waiting for a backtrack.**
+  Stage B' of the Brancher work ([brancher-design.md](brancher-design.md)) adds the mirror
+  of the hoist primitive — `NamesAndIDsTracker::evict_order_literal` — together with the
+  bookkeeping it needs, all **always-on under Literals** and all inert until something
+  calls it (nothing in the solver does yet; its consumers are the eq-atom window and the
+  objective-improvement `delc`). Three parts are worth knowing about even outside that
+  work:
+
+  - **`ge_top_pins`**, a per-threshold per-cause refcount of the *permanent* references
+    holding a `ge` at Top, which is what makes "may I delete this?" answerable. It is
+    counted **at the reference sites** rather than inside the hoist (which early-returns
+    for a threshold already at Top, so the second of two permanent atoms naming one `ge`
+    would be invisible — and `eq(v)` and `eq(v+1)` both name `ge(v+1)`), and **only for
+    thresholds a hoist put at Top**, so "level 0 with no entry" reads as structurally
+    resident and unevictable. `stats_ge_top_cause` remains the diagnostic's separate
+    first-cause-wins map.
+  - **`chain_clauses_by_level`**, the chain clauses currently present in the proof,
+    bucketed by proof level and then by variable. Nothing recorded these before, because
+    forgetting a level deleted them wholesale; eviction has to delete just the ones naming
+    one threshold. Recording is on the hot path of every chain emission, which is why the
+    shape is level-first and flat — see the stage-B' notes for the +12 % that keying it by
+    threshold pair cost, and the +4.7 % this one costs.
+  - **The eq analogue of atom retirement** (`VariableAtoms::retired_eq`,
+    `forget_eq_literals_at_level`), so a *deletable* eq definition — which only a windowed
+    variable has, and nothing is windowed yet — retires its atom on backtrack and is
+    re-introduced through `need_direct_encoding_for` with its identity intact. Both ge
+    traps recur verbatim: `eq_defs` keeps its entry and re-introduction must
+    `insert_or_assign`, and the `XLiteral` must be reused rather than re-minted.
+
+  **A finding worth carrying forward: VeriPB does not police a leaked chain clause.** A
+  chain clause left naming an evicted threshold stays a valid derived constraint, and
+  re-introducing that threshold's definition verifies with the stale clause still in the
+  database (measured by mutation against veripb 3.0.2 — the negated half of the
+  reification forces the neighbour's atom through its own definition, so the leftover
+  clause is implied under the witness). A missed deletion is therefore silent and costs
+  precisely the resident-database shrinkage this whole mode exists for, which is why
+  `chain_clauses_naming` exists and why `gcs/innards/proofs/order_evict_test.cc` asserts
+  it in C++ rather than trusting the checker. This is the same lesson as the two
+  solver-side invariants the design already records: **VeriPB polices the order encoding
+  only at a point of use.**
 - **Gate — randomized-test seed sweeps are part of the flag-ON gate.** A single caps-off
   suite run exercises only *one* random seed per data-driven test, and the fixed corpus
   missed a ~10 %-of-seeds VeriPB-rejection hole in divide/modulus (seed 3072268882 was one

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -4,12 +4,13 @@
 measured on synthetic AND real instances; suite-safe; committed on this branch;
 not default.** This note records the design for shrinking the integer
 order-encoding that VeriPB carries, plus the measured outcome and what is and
-isn't yet done. The full Brancher-API refactor (step 2, below) is now a
-**decided design, recorded in [brancher-design.md](brancher-design.md)** but not
-yet implemented; the current implementation wires deletion into the existing
-branch/backtrack flow via hoisting, and the sketch of the refactor further down
-this note is superseded by that decided design (see the note at "Design
-overview").
+isn't yet done. The full Brancher-API refactor (step 2, below) is a **decided design,
+recorded in [brancher-design.md](brancher-design.md), now partly implemented**: its
+stages A, B and B' have landed, B''/C/D/E have not. That note, not this one, is the
+authority on the refactor's staging and status. The shipped deletion path still wires
+into the existing branch/backtrack flow via hoisting, and the four-step sketch further
+down this note is superseded by the decided design (see the note at "Design overview"
+and at "Implementation staging").
 
 ## Results (measured)
 
@@ -276,10 +277,14 @@ owns the MiniZinc frontend proofs.
   split-branched ones anyway.
 - **`soli` objective atom** is hoisted to Top when the objective-improvement
   constraint is emitted (latent optimisation-mode bug fixed defensively).
-- **Not yet done:** the clean Brancher abstraction (below) — the current wiring
-  hoists guess/eq/aux references directly; the abstraction generalises and tidies
-  it. Also future: short-reason flag / deview-companion level-scoping (currently
-  inert), and the bridge redesign.
+- **In progress:** the clean Brancher abstraction (step 2). Stages A, B and B' have
+  landed — the `BranchDecision` / `BacktrackAdvance` types, the split families' bound
+  advances, and the eviction primitives plus their always-on residency bookkeeping — so
+  the direct guess/eq/aux hoist wiring is on its way out but is still what the shipped
+  path uses. Stages B''/C/D/E remain; [brancher-design.md](brancher-design.md) is the
+  authority on each. Also future: short-reason flag / deview-companion level-scoping
+  (currently inert), and the bridge redesign (deprioritised — step 1b measured it as
+  freeing 0 %).
 
 ## Next steps (prioritised)
 
@@ -312,9 +317,17 @@ builds long chains (seat-moving: median chain 12, max 98, despite maxdom 901), a
 the deletion machinery churns (22 857 deletes / 22 829 reintroductions, net 28) for
 nothing there.
 
-**2. Brancher-API refactor — DESIGN DECIDED (see
-[brancher-design.md](brancher-design.md)); not yet implemented.** The concrete,
-decided step-2 design lives in that note; it generalises consolidate-then-delete,
+**2. Brancher-API refactor — IN PROGRESS: stages A, B and B' landed; B'' is next.**
+The concrete, decided step-2 design and its staging live in
+[brancher-design.md](brancher-design.md), which is the authority on what is done and
+what each remaining stage owes. In summary: **A** added the `BranchDecision` /
+`BacktrackAdvance` types and ported every value order (byte-identical); **B** wired the
+split families' bound advances and the advance-RUP-driven deletion; **B'** added the
+always-on residency bookkeeping and the evict/hoist primitives the eq window and the
+objective `delc` both need (behaviour-neutral — nothing calls them yet). Remaining:
+**B''** the eq-atom window, **C** the objective/frontier exemption, **D** the
+objective-improvement `delc` + Top-eviction, **E** benchmark and cleanup. The design
+generalises consolidate-then-delete,
 tidies the current direct wiring, and is the natural home for the chain-gated
 deletion policy, the objective-variable exemption (from 2b, below), and the
 objective-improvement `delc` lifecycle. Five owner decisions are settled there:
@@ -348,8 +361,10 @@ Parameter: `ProofOptions::order_encoding_deletion_min_chain` (+ fluent setter), 
 override `GCS_DELETE_ORDER_ENCODING_MIN_CHAIN` (explicit-in-code wins). **`0` = gate
 off = byte-identical to the pre-gate Literals behaviour — the aggressive-testing
 mode: regression runs exercising the deletion machinery MUST set `MIN_CHAIN=0`,
-because tiny test domains never cross a nonzero gate.** The suite passes caps-off
-flag-ON at gate 0 and at 32 (525/525 each, 0 flag-induced failures). The stats dump
+because tiny test domains never cross a nonzero gate.** The suite passed caps-off
+flag-ON at gate 0 and at 32 when this landed (525/525 each, 0 flag-induced failures; the
+suite has grown since — the standing gate is "all of it, in each of the three modes",
+not a fixed number). The stats dump
 gains a `gate-held` cause and a per-variable chain-length distribution.
 
 **Default 16, chosen from measurement** (full tables in
@@ -392,9 +407,9 @@ win-recovery motivation is gone. Revisit only if a view/product-heavy
 *weak-propagation large-domain bound-split* workload appears — the only regime where
 freed chains would be long enough to matter.
 
-**Ordering decided (2026-07): 2b first (done, above), then step 2.** Step 2 is the
-next piece of work, and inherits the objective-variable-exemption follow-up from 2b;
-3 stays parked.
+**Ordering decided (2026-07): 2b first (done, above), then step 2.** Step 2 is under
+way — A, B and B' are in — and it inherits the objective-variable-exemption follow-up
+from 2b as its stage C; 3 stays parked.
 
 **Also:** decide productionisation (keep flag-gated vs default-on — current verdict:
 flag-gated), and — cleanup — the superseded dormant `Links` mode can be removed.
@@ -641,6 +656,12 @@ ship the internal helpers plus `Custom` and leave a polished power-user surface 
 a real use case lands.
 
 ## Implementation staging
+
+> **Superseded.** This was the original four-step sketch, written before the step-2
+> design was decided. Steps 1 and 2 are done (the hoist primitive, and the Brancher
+> abstraction through stage B'), and step 3's "replace the experimental Literals mode"
+> is now stage E's cleanup. Use **[brancher-design.md](brancher-design.md), "Migration
+> staging"** for what is actually left. Kept here for provenance.
 
 1. **Hoist primitive first.** It is foundational, independently testable, and needed
    by everything downstream. Build `hoist_literal_to_level` / `hoist_literal_to_top`

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -554,6 +554,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(invar_test PRIVATE glasgow_constraint_solver)
     add_test(NAME invar_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:invar_test>)
 
+    add_executable(order_evict_test innards/proofs/order_evict_test.cc)
+    target_link_libraries(order_evict_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME order_evict_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:order_evict_test>)
+
     add_executable(range_branch_test innards/proofs/range_branch_test.cc)
     target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
     add_test(NAME range_branch_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -134,6 +134,15 @@ namespace
         // re-introduction) entry, so it stays monotone and remains the chain gate's
         // "thresholds ever named" count.
         std::unordered_map<long long, XLiteral> retired_ge;
+        // The same, for the eq atoms of a windowed variable (EqAtomResidency::Windowed):
+        // the forget sweep retires the atom out of `eq` into here, and
+        // need_direct_encoding_for's existing "does the condition exist" guard is the
+        // re-introduction path, taking the XLiteral back so identity and PB name survive
+        // the cycle. Everything the comment above says about `retired_ge` applies verbatim,
+        // including that `eq_defs` keeps its entry (need_pol_item_defining_literal resolves
+        // pol operands through it) and that re-introduction must overwrite rather than
+        // try_emplace those line numbers. Empty unless something windows a variable.
+        std::unordered_map<long long, XLiteral> retired_eq;
     };
 
     struct HashView
@@ -385,6 +394,55 @@ struct NamesAndIDsTracker::Imp
     // bucket (O(deleted)) to stitch and prune, instead of scanning every variable.
     // Level-0 (Top) literals are never indexed here, so they are never forgotten.
     map<int, vector<pair<SimpleIntegerVariableID, Integer>>> order_literals_by_level;
+    // The eq analogues of the two structures above, holding only the *windowed*
+    // (EqAtomResidency::Windowed) eq definitions -- those emitted at Current and deleted
+    // on backtrack. A permanent eq def is not recorded at all: absence means "resident
+    // forever", so both stay empty until something windows a variable, and every eq atom
+    // in the solver today is permanent. Levels here are always positive for the same
+    // reason (a level-0 entry would be a permanent def).
+    map<SimpleIntegerVariableID, map<Integer, int>> live_eq_literals;
+    map<int, vector<pair<SimpleIntegerVariableID, Integer>>> eq_literals_by_level;
+    // The chain-link and stitch clauses currently present in the proof: the threshold pair
+    // each links and its proof line, bucketed by the level it sits at and then by variable.
+    // The same pair can appear more than once -- a hoist re-stitches a pair whose deeper
+    // copy stays until that level is forgotten, and a Top re-stitch of an already-Top-linked
+    // pair duplicates it (the diagnostic's dup_top_stitches) -- so this is a flat list per
+    // (level, variable), not a keyed map.
+    //
+    // Eviction needs every clause naming the threshold it removes, and VeriPB will not
+    // notice if it misses one: a chain clause left naming an evicted threshold stays a
+    // *valid* derived constraint (it was derived from definitions that the atom's stable
+    // identity lets a later need_gevar restore, and re-introducing the definition verifies
+    // with the clause present -- measured, not assumed). A leak is therefore silent, and
+    // costs exactly the resident-database shrinkage the whole mode exists for. See
+    // chain_clauses_naming, which makes eviction's postcondition observable.
+    //
+    // **Level-first, and flat, because recording is the hot path**: every chain clause
+    // emitted inserts here. Keying by variable and then by threshold pair instead cost
+    // +11% of solver-side proof-writing time on the deletion-heavy synthetic (two map-node
+    // allocations and a vector allocation per clause, plus a second structure to keep the
+    // forget sweep off a full scan); this shape is two map lookups and a push_back, and a
+    // forget is one bucket erase. Eviction pays instead, scanning one small vector per
+    // level, which is the right way round: clauses are emitted in millions and evicted in
+    // handfuls.
+    //
+    // Level 0 is an ordinary bucket that nothing forgets -- eviction is what empties it.
+    // Only proof-time emissions are recorded, which is exactly the set eviction can be
+    // asked about: a model-time chain link joins two model-time thresholds, both born Top
+    // and structurally resident, and eviction refuses those.
+    struct ChainClause
+    {
+        Integer lo, hi;
+        ProofLine line;
+    };
+    map<int, map<SimpleIntegerVariableID, vector<ChainClause>>> chain_clauses_by_level;
+    // For each real variable's ge threshold whose Top residency a HOIST caused, how many
+    // permanent references of each cause pin it there. Always populated under Literals
+    // (unlike the diagnostic below): it is evict_order_literal's precondition, and VeriPB
+    // will not catch a wrongly-evicted literal except at a later point of use. See
+    // note_order_literal_top_pin for the two rules that make it trustworthy -- counted at
+    // the reference site, and only for hoisted thresholds.
+    map<SimpleIntegerVariableID, map<Integer, map<OrderEncodingResidencyCause, long long>>> ge_top_pins;
 
     // --- GCS_ORDER_ENCODING_STATS pin-apportionment diagnostic (Literals mode only) ---
     // Everything below is touched ONLY when collect_order_encoding_stats is true
@@ -401,6 +459,7 @@ struct NamesAndIDsTracker::Imp
     map<SimpleIntegerVariableID, map<Integer, optional<OrderEncodingResidencyCause>>> stats_ge_top_cause;
     // Event counters.
     long long stats_deletes = 0;                                    // literals dropped by forget_order_literals_at_level.
+    long long stats_evictions = 0;                                  // literals taken out on demand by evict_order_literal.
     long long stats_stitches = 0;                                   // forget-path skip-link emissions (emit_order_stitch).
     long long stats_reintroductions = 0;                            // ge definitions re-introduced after deletion.
     long long stats_dup_top_stitches = 0;                           // Top-level stitch clauses re-emitted for an already-linked pair.
@@ -754,13 +813,50 @@ auto NamesAndIDsTracker::track_eqvar(
     _imp->atoms_for(id).eq_defs.try_emplace(val.raw_value, names);
 }
 
-auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
+auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID id, Integer v, EqAtomResidency residency) -> void
 {
     if (_imp->find_condition(id == v))
         return;
 
-    auto eqvar = allocate_xliteral_meaning(id, EqualsOrGreaterEqual::Equals, v);
+    // A windowed (deletable) definition is only meaningful where deletable definitions
+    // exist at all -- the Literals mode, at proof-writing time, with assertions off, for a
+    // real variable -- and the request is ignored, leaving the definition permanent,
+    // anywhere else.
+    bool windowed = residency == EqAtomResidency::Windowed && _imp->order_link_deletion_mode == OrderEncodingDeletion::Literals &&
+        _imp->logger != nullptr && _imp->assertion_level == AssertionLevel::Off && std::holds_alternative<SimpleIntegerVariableID>(id);
+
+    // The (i-static) half of the eq-by-interval guard (dev_docs/brancher-design.md, "The
+    // one hidden pin"): a variable with an interval partition retro-pins its eq atoms as
+    // Top partition singleton cells, and a containment tree names them from Top containment
+    // edges, so a deletable definition there would leave a Top line naming a literal a
+    // backtrack deletes. Refuse to window such a variable: its eq atoms stay permanent,
+    // which is correct and merely wins nothing. The dynamic half -- collapsing a live
+    // window when an interval is first requested on it mid-search -- belongs with the
+    // window itself, in stage B''.
+    if (windowed && (_imp->interval_partitions.contains(id) || _imp->containment_trees.contains(id)))
+        windowed = false;
+
+    // Take a retired XLiteral back if this atom is being re-introduced after a backtrack
+    // deleted a windowed definition, so the atom keeps its identity and its PB name across
+    // the cycle (a fresh allocation would render as the same verbose name but a different
+    // `x<n>` with verbose names off); otherwise mint a fresh one. Only a windowed variable
+    // ever retires an eq atom.
+    auto eqvar = [&]() {
+        if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals) {
+            auto & atoms = _imp->atoms_for(id);
+            if (auto retired = atoms.retired_eq.find(v.raw_value); retired != atoms.retired_eq.end()) {
+                auto reused = retired->second;
+                atoms.retired_eq.erase(retired);
+                return reused;
+            }
+        }
+        return allocate_xliteral_meaning(id, EqualsOrGreaterEqual::Equals, v);
+    }();
     _imp->store_condition(id == v, eqvar);
+
+    // Where this atom's definition lands: Top for the permanent case (everything in the
+    // solver today), Current for a windowed one, so a backtrack deletes it.
+    auto eq_def_level = windowed ? ProofLevel::Current : ProofLevel::Top;
 
     auto bounds = _imp->integer_variable_definition_bounds.find(id);
     ProofLine forwards_line, reverse_line;
@@ -788,7 +884,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
             visit(
                 [&](const auto & id) {
                     auto [_f_line, _r_line] =
-                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, id == v, ProofLevel::Top);
+                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * ! (id >= (v + 1_i)) >= 1_i, id == v, eq_def_level);
                     forwards_line = _f_line;
                     reverse_line = _r_line;
                 },
@@ -809,8 +905,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links) {
             visit(
                 [&](const auto & id) {
-                    auto [_f_line, _r_line] =
-                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, ProofLevel::Top);
+                    auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + 1_i * (id >= v) >= 1_i, id == v, eq_def_level);
                     forwards_line = _f_line;
                     reverse_line = _r_line;
                 },
@@ -831,8 +926,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         if (_imp->logger && _imp->assertion_level <= AssertionLevel::Links)
             visit(
                 [&](const auto & id) {
-                    auto [_f_line, _r_line] = _imp->logger->emit_red_proof_lines_reifying(
-                        WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i, id == v, ProofLevel::Top);
+                    auto [_f_line, _r_line] =
+                        _imp->logger->emit_red_proof_lines_reifying(WPBSum{} + (1_i * (id >= v)) + (1_i * ! (id > v)) >= 2_i, id == v, eq_def_level);
                     forwards_line = _f_line;
                     reverse_line = _r_line;
                 },
@@ -848,17 +943,32 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
         }
     }
 
-    _imp->atoms_for(id).eq_defs.try_emplace(v.raw_value, pair{forwards_line, reverse_line});
+    // insert_or_assign, not try_emplace: on the re-introduction of a retired atom the
+    // eq_defs entry is still present but holds the line numbers of the definition the
+    // backtrack deleted, and need_pol_item_defining_literal resolves pol operands through
+    // those numbers. This is the trap the ge side hit; the entry is deliberately never
+    // erased.
+    _imp->atoms_for(id).eq_defs.insert_or_assign(v.raw_value, pair{forwards_line, reverse_line});
 
-    // Literals order-encoding-deletion mode: this eq atom's definition was emitted at
-    // ProofLevel::Top (permanent) above, and names ge(v) and ge(v+1). The
-    // need_all_proof_names_in inside that emission has made both live; but for an
-    // interior threshold their def lands at Current, so a later backtrack forget would
-    // delete it -- leaving this surviving Top eq def (and any solx / backtrack clause /
-    // value-branch guess over the eq atom) naming a deleted ge, which rejects in VeriPB
-    // (the failure this mode showed on eq-heavy instances). Hoist both ge defs to Top so
-    // they stay resident for the eq atom's whole lifetime.
-    hoist_ges_named_by_top_atom(id, v, v + 1_i, OrderEncodingResidencyCause::EqHoist);
+    if (windowed) {
+        // Index the definition under the level it was just emitted at, so the backtrack
+        // that deletes it also retires the atom.
+        record_live_eq_literal(std::get<SimpleIntegerVariableID>(id), v);
+    }
+    else {
+        // Literals order-encoding-deletion mode: this eq atom's definition was emitted at
+        // ProofLevel::Top (permanent) above, and names ge(v) and ge(v+1). The
+        // need_all_proof_names_in inside that emission has made both live; but for an
+        // interior threshold their def lands at Current, so a later backtrack forget would
+        // delete it -- leaving this surviving Top eq def (and any solx / backtrack clause /
+        // value-branch guess over the eq atom) naming a deleted ge, which rejects in VeriPB
+        // (the failure this mode showed on eq-heavy instances). Hoist both ge defs to Top so
+        // they stay resident for the eq atom's whole lifetime.
+        //
+        // A windowed definition deliberately does none of this: leaving its two thresholds
+        // deletable is the whole point of the window, and its own def dies with them.
+        hoist_ges_named_by_top_atom(id, v, v + 1_i, OrderEncodingResidencyCause::EqHoist);
+    }
 
     // If `id` is a view's proof-only var, eagerly emit the
     // eq-atom-level link `V=v <=> X=k_x` as two RUP lines. The GE-atom
@@ -1418,6 +1528,13 @@ auto NamesAndIDsTracker::forget_order_links_at_level(int level) -> void
 {
     if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals) {
         forget_order_literals_at_level(level);
+        // The eq and chain-clause analogues, from the same funnel. Both are pure
+        // bookkeeping (the `del`s were emitted by forget_proof_level's own loop), and both
+        // run after the ge sweep because that is what emits this level's stitches -- which
+        // land at a *surviving* neighbour's level, never at the level being forgotten, so
+        // they are not swept away again here.
+        forget_eq_literals_at_level(level);
+        forget_chain_clauses_at_level(level);
         return;
     }
 
@@ -1450,6 +1567,80 @@ auto NamesAndIDsTracker::record_live_order_literal(const SimpleIntegerVariableID
         _imp->order_literals_by_level[level].emplace_back(id, v);
 }
 
+auto NamesAndIDsTracker::record_live_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> void
+{
+    // Windowed eq defs only; a permanent one is left unrecorded (see the header).
+    int level = _imp->logger->proof_level();
+    _imp->live_eq_literals[id][v] = level;
+    _imp->eq_literals_by_level[level].emplace_back(id, v);
+}
+
+auto NamesAndIDsTracker::note_order_literal_top_pin(const SimpleIntegerVariableID & id, Integer v, OrderEncodingResidencyCause cause) -> void
+{
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+        return;
+
+    auto live_it = _imp->live_order_literals.find(id);
+    if (live_it == _imp->live_order_literals.end())
+        return;
+    auto lvl_it = live_it->second.find(v);
+    if (lvl_it == live_it->second.end())
+        return; // not a tracked threshold of id: there is nothing here to pin.
+
+    if (lvl_it->second == 0 && ! (_imp->ge_top_pins.contains(id) && _imp->ge_top_pins[id].contains(v)))
+        return; // structurally resident, so never evictable and needing no record.
+
+    ++_imp->ge_top_pins[id][v][cause];
+}
+
+auto NamesAndIDsTracker::record_live_chain_line(const SimpleIntegerVariableID & id, Integer lo, Integer hi, int at_level, const ProofLine & line)
+    -> void
+{
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+        return;
+
+    _imp->chain_clauses_by_level[at_level][id].emplace_back(Imp::ChainClause{lo, hi, line});
+}
+
+auto NamesAndIDsTracker::forget_chain_clauses_at_level(int level) -> void
+{
+    // The lines themselves were del'd by forget_proof_level's own loop; this just drops the
+    // whole level's records in one go.
+    _imp->chain_clauses_by_level.erase(level);
+}
+
+auto NamesAndIDsTracker::forget_eq_literals_at_level(int level) -> void
+{
+    auto bucket_it = _imp->eq_literals_by_level.find(level);
+    if (bucket_it == _imp->eq_literals_by_level.end())
+        return;
+
+    for (const auto & [id, v] : bucket_it->second) {
+        auto live_it = _imp->live_eq_literals.find(id);
+        if (live_it == _imp->live_eq_literals.end())
+            continue;
+        auto lvl_it = live_it->second.find(v);
+        if (lvl_it == live_it->second.end() || lvl_it->second != level)
+            continue; // hoisted out to Top since, so not this level's to delete.
+        live_it->second.erase(lvl_it);
+        if (live_it->second.empty())
+            _imp->live_eq_literals.erase(live_it);
+
+        // The def lines were del'd by forget_proof_level's own loop. Retire the atom, so
+        // a later reference cannot name a literal whose definition is gone: find_condition
+        // stops answering, and the only route back is need_direct_encoding_for, which
+        // re-introduces the definition and takes the retired XLiteral back. eq_defs keeps
+        // its now-stale entry, overwritten on re-introduction.
+        auto & atoms = _imp->atoms_for(SimpleOrProofOnlyIntegerVariableID{id});
+        if (auto atom = atoms.eq.find(v.raw_value); atom != atoms.eq.end()) {
+            atoms.retired_eq.insert_or_assign(v.raw_value, atom->second);
+            atoms.eq.erase(atom);
+        }
+    }
+
+    _imp->eq_literals_by_level.erase(bucket_it);
+}
+
 auto NamesAndIDsTracker::link_order_literal_to_live_neighbours(const SimpleIntegerVariableID & id, Integer v) -> void
 {
     // Emit the two chain links joining v to its immediate live neighbours. A link between
@@ -1477,16 +1668,18 @@ auto NamesAndIDsTracker::link_order_literal_to_live_neighbours(const SimpleInteg
     // lo < hi is the threshold pair the link is over (for the stats dup-Top check).
     auto emit_link = [&](const shared_ptr<PolBuilder> & pol, int neighbour_level, Integer lo, Integer hi) {
         int landed;
+        ProofLine line;
         if (v_level == 0 && neighbour_level == 0 && current != 0) {
             _imp->logger->enter_proof_level(0);
-            pol->emit(*_imp->logger, ProofLevel::Current);
+            line = pol->emit(*_imp->logger, ProofLevel::Current);
             _imp->logger->enter_proof_level(current);
             landed = 0;
         }
         else {
-            pol->emit(*_imp->logger, ProofLevel::Current);
+            line = pol->emit(*_imp->logger, ProofLevel::Current);
             landed = current;
         }
+        record_live_chain_line(id, lo, hi, landed, line);
         if (_imp->collect_order_encoding_stats)
             stats_note_stitch_emitted(id, lo, hi, landed, /*forget_path=*/false);
     };
@@ -1521,9 +1714,10 @@ auto NamesAndIDsTracker::emit_order_stitch(const SimpleIntegerVariableID & id, I
     _imp->building_order_link = saved;
 
     _imp->logger->enter_proof_level(at_level);
-    pol->emit(*_imp->logger, ProofLevel::Current);
+    auto line = pol->emit(*_imp->logger, ProofLevel::Current);
     _imp->logger->enter_proof_level(restore_level);
 
+    record_live_chain_line(id, lo, hi, at_level, line);
     if (_imp->collect_order_encoding_stats)
         stats_note_stitch_emitted(id, lo, hi, at_level, /*forget_path=*/true);
 }
@@ -1654,7 +1848,8 @@ auto NamesAndIDsTracker::stitch_hoisted_order_literal(const SimpleIntegerVariabl
         auto pol = make_pol_chain_line(id >= *lo, ! (id >= v));
         auto landed = max(target_level, lo_level);
         _imp->logger->enter_proof_level(landed);
-        pol->emit(*_imp->logger, ProofLevel::Current);
+        auto line = pol->emit(*_imp->logger, ProofLevel::Current);
+        record_live_chain_line(id, *lo, v, landed, line);
         if (_imp->collect_order_encoding_stats)
             stats_note_stitch_emitted(id, *lo, v, landed, /*forget_path=*/false);
     }
@@ -1663,7 +1858,8 @@ auto NamesAndIDsTracker::stitch_hoisted_order_literal(const SimpleIntegerVariabl
         auto pol = make_pol_chain_line(id >= v, ! (id >= *hi));
         auto landed = max(target_level, hi_level);
         _imp->logger->enter_proof_level(landed);
-        pol->emit(*_imp->logger, ProofLevel::Current);
+        auto line = pol->emit(*_imp->logger, ProofLevel::Current);
+        record_live_chain_line(id, v, *hi, landed, line);
         if (_imp->collect_order_encoding_stats)
             stats_note_stitch_emitted(id, v, *hi, landed, /*forget_path=*/false);
     }
@@ -1729,10 +1925,16 @@ auto NamesAndIDsTracker::hoist_order_literal_to_level(const SimpleIntegerVariabl
     stitch_hoisted_order_literal(id, v, target_level, immediate_neighbours);
 }
 
-auto NamesAndIDsTracker::hoist_order_literal_to_top(const SimpleIntegerVariableID & id, Integer v, optional<OrderEncodingResidencyCause> stats_cause)
+auto NamesAndIDsTracker::hoist_order_literal_to_top(const SimpleIntegerVariableID & id, Integer v, optional<OrderEncodingResidencyCause> cause)
     -> void
 {
-    hoist_order_literal_to_level(id, v, 0, /*immediate_neighbours=*/false, stats_cause);
+    // This entry point *is* a reference site (its caller is about to name the literal in a
+    // line that outlives every backtrack), so the Top pin is counted here, before
+    // delegating: hoist_order_literal_to_level early-returns for a threshold already at
+    // Top and would record nothing.
+    if (cause)
+        note_order_literal_top_pin(id, v, *cause);
+    hoist_order_literal_to_level(id, v, 0, /*immediate_neighbours=*/false, cause);
 }
 
 auto NamesAndIDsTracker::hoist_order_literal_to_top_if_live(
@@ -1759,20 +1961,29 @@ auto NamesAndIDsTracker::hoist_order_literal_to_top_if_live(
 }
 
 auto NamesAndIDsTracker::hoist_ges_named_by_top_atom(
-    SimpleOrProofOnlyIntegerVariableID id, Integer lower_ge, Integer upper_ge, optional<OrderEncodingResidencyCause> stats_cause) -> void
+    SimpleOrProofOnlyIntegerVariableID id, Integer lower_ge, Integer upper_ge, optional<OrderEncodingResidencyCause> cause) -> void
 {
     // Same guard the ge-def deletion in need_gevar uses: only proof-time, real-variable,
     // assertions-off Literals mode tracks deletable ge defs at all.
     if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger || _imp->assertion_level != AssertionLevel::Off)
         return;
     if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
-        hoist_order_literal_to_top_if_live(*sid_ptr, lower_ge, stats_cause);
-        hoist_order_literal_to_top_if_live(*sid_ptr, upper_ge, stats_cause);
+        // Count both Top pins here, at the reference site, and before the hoists: the
+        // permanent atom being defined names both thresholds whether or not either needs
+        // moving, and the hoist early-returns for one already at Top. This is exactly the
+        // case that made reference-site counting necessary -- eq(v) and eq(v+1) both name
+        // ge(v+1), so the second eq atom's pin is invisible to the hoist.
+        if (cause) {
+            note_order_literal_top_pin(*sid_ptr, lower_ge, *cause);
+            note_order_literal_top_pin(*sid_ptr, upper_ge, *cause);
+        }
+        hoist_order_literal_to_top_if_live(*sid_ptr, lower_ge, cause);
+        hoist_order_literal_to_top_if_live(*sid_ptr, upper_ge, cause);
     }
 }
 
 auto NamesAndIDsTracker::hoist_live_order_literals_toward_level(
-    const std::vector<Literal> & lits, int target_level, optional<OrderEncodingResidencyCause> stats_cause) -> void
+    const std::vector<Literal> & lits, int target_level, optional<OrderEncodingResidencyCause> cause) -> void
 {
     // Only the Literals mode has anything to hoist; other modes keep the whole
     // encoding resident at Top, and with no logger there is nothing emitted yet.
@@ -1805,9 +2016,217 @@ auto NamesAndIDsTracker::hoist_live_order_literals_toward_level(
         auto lvl_it = live_it->second.find(cond->value);
         if (lvl_it == live_it->second.end())
             continue;
+
+        // A hoist to Top is a permanent reference: this caller's line (a learned nogood,
+        // an objective-improvement constraint) survives every backtrack, so count the pin
+        // here at the reference site, before the hoist, which early-returns for a literal
+        // already at Top. A GuessHoist targets a positive level and is not permanent; if
+        // it happens to be called at level 0 it takes no pin, which leaves the literal
+        // looking structurally resident -- eviction then refuses it, which costs a win at
+        // worst and is never wrong.
+        if (target_level == 0 && cause && *cause != OrderEncodingResidencyCause::GuessHoist)
+            note_order_literal_top_pin(*sid, cond->value, *cause);
+
         if (lvl_it->second > target_level)
-            hoist_order_literal_to_level(*sid, cond->value, target_level, /*immediate_neighbours=*/false, stats_cause);
+            hoist_order_literal_to_level(*sid, cond->value, target_level, /*immediate_neighbours=*/false, cause);
     }
+}
+
+auto NamesAndIDsTracker::chain_clauses_naming(const SimpleIntegerVariableID & id, Integer v) const -> long long
+{
+    long long count = 0;
+    for (const auto & [level, by_var] : _imp->chain_clauses_by_level) {
+        auto var_it = by_var.find(id);
+        if (var_it == by_var.end())
+            continue;
+        for (const auto & clause : var_it->second)
+            if (clause.lo == v || clause.hi == v)
+                ++count;
+    }
+    return count;
+}
+
+auto NamesAndIDsTracker::evict_order_literal(
+    const SimpleIntegerVariableID & id, Integer v, optional<OrderEncodingResidencyCause> expected_sole_top_cause) -> bool
+{
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+        throw ProofError{"evict_order_literal requires OrderEncodingDeletion::Literals"};
+    if (! _imp->logger)
+        throw ProofError{"evict_order_literal requires the logger to be attached"};
+
+    auto live_it = _imp->live_order_literals.find(id);
+    if (live_it == _imp->live_order_literals.end())
+        throw ProofError{"eviction of an order literal for an untracked variable"};
+    auto lvl_it = live_it->second.find(v);
+    if (lvl_it == live_it->second.end())
+        throw ProofError{"eviction of a non-live order literal"};
+    int level = lvl_it->second;
+
+    // The residency precondition, checked rather than asserted: VeriPB accepts a
+    // wrongly-evicted literal at the deletion and only rejects at a later point of use, so
+    // getting this wrong would show up far from its cause. A refusal is always safe -- the
+    // literal stays resident and the caller simply wins nothing.
+    const map<OrderEncodingResidencyCause, long long> * pins = nullptr;
+    if (auto pins_it = _imp->ge_top_pins.find(id); pins_it != _imp->ge_top_pins.end())
+        if (auto pin_v_it = pins_it->second.find(v); pin_v_it != pins_it->second.end())
+            pins = &pin_v_it->second;
+
+    if (level == 0) {
+        // Top-resident: evict only if the caller's cause is the sole pin, held once. No pin
+        // record at all means structurally resident (boundary / model-time / aux / view /
+        // gate, none of which hoist), which is never evictable.
+        if (! expected_sole_top_cause || ! pins)
+            return false;
+        if (pins->size() != 1 || pins->begin()->first != *expected_sole_top_cause || pins->begin()->second != 1)
+            return false;
+    }
+    else if (expected_sole_top_cause || pins) {
+        // Deletable: no Top line can be naming it (anything that would have hoisted it),
+        // so a caller naming a Top cause, or a pin record existing at all, is a bug in the
+        // caller or in the bookkeeping rather than a policy refusal -- but refusing is
+        // still the safe answer.
+        return false;
+    }
+
+    // The immediate live neighbours to stitch over, read before v is dropped. std::map
+    // iterators survive the insertions the emissions below can make, so lvl_it stays valid.
+    optional<Integer> lo, hi;
+    int lo_level = 0, hi_level = 0;
+    if (lvl_it != live_it->second.begin()) {
+        auto p = prev(lvl_it);
+        lo = p->first;
+        lo_level = p->second;
+    }
+    if (auto n = next(lvl_it); n != live_it->second.end()) {
+        hi = n->first;
+        hi_level = n->second;
+    }
+
+    // Delete ge(v)'s two reification lines. A DirectOnly {0,1} variable's entry holds
+    // XLiterals rather than line numbers, filtered exactly as the hoist filters them.
+    SimpleOrProofOnlyIntegerVariableID key{id};
+    auto & defs = _imp->atoms_for(key).ge_defs.at(v.raw_value);
+    vector<ProofLine> def_lines;
+    if (auto p = std::get_if<ProofLine>(&defs.first))
+        def_lines.push_back(*p);
+    if (auto p = std::get_if<ProofLine>(&defs.second))
+        def_lines.push_back(*p);
+    _imp->logger->delete_proof_lines_at_level(def_lines, level);
+
+    // Delete every chain clause naming v, each at the level it sits at. This is the half of
+    // eviction that VeriPB does not police (see chain_clauses_by_level): a clause left
+    // behind stays valid, so a leak is silent and simply costs the shrinkage.
+    // chain_clauses_naming is what the driver test checks it against.
+    auto names_v = [&](const Imp::ChainClause & c) { return c.lo == v || c.hi == v; };
+    for (auto & [clause_level, by_var] : _imp->chain_clauses_by_level) {
+        auto var_it = by_var.find(id);
+        if (var_it == by_var.end())
+            continue;
+        auto & clauses = var_it->second;
+        vector<ProofLine> naming_v;
+        for (const auto & clause : clauses)
+            if (names_v(clause))
+                naming_v.push_back(clause.line);
+        if (naming_v.empty())
+            continue;
+        _imp->logger->delete_proof_lines_at_level(naming_v, clause_level);
+        std::erase_if(clauses, names_v);
+        if (clauses.empty())
+            by_var.erase(var_it);
+    }
+
+    // Drop v from the live set and, if it was deletable, from its level's deletion index --
+    // a re-introduction at the same level would otherwise be double-indexed there.
+    if (level != 0) {
+        auto & bucket = _imp->order_literals_by_level[level];
+        std::erase_if(bucket, [&](const pair<SimpleIntegerVariableID, Integer> & e) { return e.first.index == id.index && e.second == v; });
+    }
+    live_it->second.erase(lvl_it);
+    if (live_it->second.empty())
+        _imp->live_order_literals.erase(live_it);
+
+    // Release the Top pin: the reference that held it is gone (its own line was deleted by
+    // the caller, which owns the ordering -- see the delc-before-evict discipline in
+    // dev_docs/brancher-design.md).
+    if (auto pins_it = _imp->ge_top_pins.find(id); pins_it != _imp->ge_top_pins.end()) {
+        pins_it->second.erase(v);
+        if (pins_it->second.empty())
+            _imp->ge_top_pins.erase(pins_it);
+    }
+
+    // Retire the atom, for the same reason the backtrack sweep does: with it out of the
+    // lookup table, find_condition stops answering and the only route back to the literal
+    // is need_gevar, which re-introduces the definition first and takes the retired
+    // XLiteral back, so identity and PB name survive the cycle. ge_defs keeps its now-stale
+    // entry (overwritten on re-introduction, and the chain gate's monotone count).
+    auto & atoms = _imp->atoms_for(key);
+    if (auto atom = atoms.ge.find(v.raw_value); atom != atoms.ge.end()) {
+        atoms.retired_ge.insert_or_assign(v.raw_value, atom->second);
+        atoms.ge.erase(atom);
+    }
+
+    // Only now stitch the survivors, by the forget sweep's rule: the skip link lands at the
+    // deeper of the two, so it is deleted together with the first of them to go, and a run
+    // at a chain end (no survivor on one side) gets no stitch -- again exactly as there.
+    // Emitting it last, after the retirement above, means that at every point where a line
+    // is emitted "the atom exists" still implies "its definition does": the stitch's own
+    // pol re-enters need_gevar for lo and hi, and there is now no window in which it could
+    // reach a v whose definition has gone.
+    if (lo && hi)
+        emit_order_stitch(id, *lo, *hi, max(lo_level, hi_level), _imp->logger->proof_level());
+
+    if (_imp->collect_order_encoding_stats) {
+        ++_imp->stats_evictions;
+        // No longer Top-resident: clear the first-cause attribution but keep the "seen"
+        // entry, so the diagnostic's distinct-atom count and chain-length distribution stay
+        // right across an evict/re-introduce cycle.
+        if (auto id_it = _imp->stats_ge_top_cause.find(id); id_it != _imp->stats_ge_top_cause.end())
+            if (auto v_it = id_it->second.find(v); v_it != id_it->second.end())
+                v_it->second = nullopt;
+    }
+
+    return true;
+}
+
+auto NamesAndIDsTracker::hoist_eq_to_top(const SimpleIntegerVariableID & id, Integer v) -> void
+{
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+        throw ProofError{"hoist_eq_to_top requires OrderEncodingDeletion::Literals"};
+    if (! _imp->logger)
+        throw ProofError{"hoist_eq_to_top requires the logger to be attached"};
+
+    auto live_it = _imp->live_eq_literals.find(id);
+    if (live_it == _imp->live_eq_literals.end())
+        return; // nothing windowed on this variable: its eq atoms are already permanent.
+    auto lvl_it = live_it->second.find(v);
+    if (lvl_it == live_it->second.end())
+        return;
+    int level = lvl_it->second;
+
+    // Relocate the eq definition's two reification lines to Top -- pure bookkeeping,
+    // emitting nothing, exactly as the ge hoist does and for the same reason (re-emitting
+    // the `red` is what collides with a pin). A DirectOnly {0,1} variable's eq entry holds
+    // XLiterals rather than lines (track_eqvar), and those are filtered out here as
+    // everywhere else.
+    SimpleOrProofOnlyIntegerVariableID key{id};
+    auto & defs = _imp->atoms_for(key).eq_defs.at(v.raw_value);
+    vector<ProofLine> def_lines;
+    if (auto p = std::get_if<ProofLine>(&defs.first))
+        def_lines.push_back(*p);
+    if (auto p = std::get_if<ProofLine>(&defs.second))
+        def_lines.push_back(*p);
+    _imp->logger->move_proof_lines_to_level(def_lines, level, 0);
+
+    auto & bucket = _imp->eq_literals_by_level[level];
+    std::erase_if(bucket, [&](const pair<SimpleIntegerVariableID, Integer> & e) { return e.first.index == id.index && e.second == v; });
+    live_it->second.erase(lvl_it);
+    if (live_it->second.empty())
+        _imp->live_eq_literals.erase(live_it);
+
+    // eq(v) <=> ge(v) & ~ge(v+1): now that the definition is permanent, the two thresholds
+    // it names must be too, and each takes an EqHoist pin so a later eviction knows this
+    // atom is holding them.
+    hoist_ges_named_by_top_atom(key, v, v + 1_i, OrderEncodingResidencyCause::EqHoist);
 }
 
 auto NamesAndIDsTracker::stats_note_ge_recorded(const SimpleIntegerVariableID & id, Integer v, optional<OrderEncodingResidencyCause> born_cause)
@@ -1947,6 +2366,7 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     emit(format("  gate-held (below min_chain gate): {} ({:.1f}%)", gate_resident, pct(gate_resident)));
     emit("events:");
     emit(format("  deletes: {}", _imp->stats_deletes));
+    emit(format("  evictions: {}", _imp->stats_evictions));
     emit(format("  stitches (forget-path): {}", _imp->stats_stitches));
     emit(format("  reintroductions: {}", _imp->stats_reintroductions));
     emit(format("  duplicate-Top-stitches: {}", _imp->stats_dup_top_stitches));

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -61,16 +61,51 @@ namespace gcs::innards
     };
 
     /**
+     * How long an eq atom's definition is meant to live, under
+     * OrderEncodingDeletion::Literals.
+     *
+     * `Permanent` is what every caller in the solver asks for (and the only thing any
+     * other mode can give): the definition lands at ProofLevel::Top, outlives every
+     * backtrack, and pins the two `ge` thresholds it names at Top with it.
+     *
+     * `Windowed` lands the definition at ProofLevel::Current instead, so a backtrack
+     * deletes it and retires the atom, and leaves the two `ge` thresholds it names
+     * deletable. It is the eq-atom window's residency (dev_docs/brancher-design.md, "The
+     * eq-atom window"): only the frontier owner may ask for it, because a windowed atom
+     * must not be named by any surviving Top line. Nothing in the solver asks for it yet
+     * -- the window itself is stage B'' -- so it exists here to give the stage-B'
+     * primitives (hoist_eq_to_top, the eq forget sweep) a producer to be checked
+     * against.
+     */
+    enum class EqAtomResidency
+    {
+        Permanent, ///< def at Top, never deleted; the ges it names are hoisted to Top.
+        Windowed   ///< def at Current, deleted (and the atom retired) on backtrack; its ges stay deletable.
+    };
+
+    /**
      * Why a real variable's proof-time `ge` order literal is resident (for
-     * GuessHoist, transiently resident at a positive backtrack level), used only by
-     * the `GCS_ORDER_ENCODING_STATS` pin-apportionment diagnostic under
+     * GuessHoist, transiently resident at a positive backtrack level), under
      * OrderEncodingDeletion::Literals. Threaded from the residency-deciding call sites
-     * (creation in need_gevar, and the hoist primitives) so the end-of-proof dump can
-     * attribute each Top-resident literal to the cause that pinned it -- first-cause-wins
-     * -- and split the pins into the classes the bridge-lifetime redesign (dev_docs
-     * step 3) would free (view_pin, aux_pin) versus those it would not (eq/invar/nogood/
-     * soli hoists) versus structural ones (boundary, model_time). Attribution is exact
-     * (set at the deciding site), never inferred from level numbers.
+     * (creation in need_gevar, and the hoist primitives).
+     *
+     * Two consumers, with different rules:
+     *
+     *  - The **always-on Top-pin bookkeeping** (`ge_top_pins`), which counts how many
+     *    permanent references of each cause pin a *hoisted* ge at Top. This is
+     *    `evict_order_literal`'s precondition -- "the cause the caller names is the only
+     *    one" -- so it cannot be diagnostic-gated, and it counts every reference rather
+     *    than only the first.
+     *  - The `GCS_ORDER_ENCODING_STATS` **pin-apportionment diagnostic**, which
+     *    attributes each Top-resident literal to the cause that pinned it *first*, and
+     *    also covers the born-Top structural causes (boundary, model_time, aux/view pin,
+     *    gate) that never hoist and so never take a pin. It splits the pins into the
+     *    classes the bridge-lifetime redesign (dev_docs step 3) would free (view_pin,
+     *    aux_pin) versus those it would not (eq/invar/nogood/soli hoists) versus
+     *    structural ones.
+     *
+     * Attribution is exact (set at the deciding site) in both, never inferred from level
+     * numbers.
      */
     enum class OrderEncodingResidencyCause
     {
@@ -189,6 +224,55 @@ namespace gcs::innards
         // level and indexed under it, so a forget of that level deletes and stitches it.
         auto record_live_order_literal(const SimpleIntegerVariableID & id, Integer v, bool top) -> void;
 
+        // Record a real variable's eq atom v as a live *deletable* (windowed) definition,
+        // tagged with the active proof level and indexed under it, so a forget of that
+        // level deletes its def lines and retires the atom. A permanent (Top) eq
+        // definition is deliberately NOT recorded: absence from live_eq_literals means
+        // "resident forever", which is what every eq atom outside a window is, so the
+        // index costs nothing until something windows a variable.
+        auto record_live_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> void;
+
+        // Retirement pass for windowed eq definitions, driven from
+        // forget_order_links_at_level alongside the ge sweep: for every eq atom whose def
+        // was recorded at `level`, drop it from the live set and retire its atom out of
+        // the lookup table (mirroring the ge sweep -- see forget_order_literals_at_level
+        // for why retirement, rather than liveness tracking, is what enforces the naming
+        // rule). Emits nothing: forget_proof_level has already del'd the lines. Eq atoms
+        // carry no chain, so unlike the ge sweep there is nothing to stitch.
+        auto forget_eq_literals_at_level(int level) -> void;
+
+        // Record a permanent (Top) reference to real variable `id`'s ge threshold `v`,
+        // from the *reference site* -- the caller that is about to make (or has just
+        // made) a Top line name the literal. `evict_order_literal` refuses to evict a
+        // Top-resident literal unless the cause the caller names is the only one counted
+        // here, so this must run on every reference, always-on under Literals.
+        //
+        // Two rules, both of which cost a debugging cycle to find:
+        //
+        //  - It runs at the reference site, NOT inside the hoist. Both
+        //    hoist_order_literal_to_level (when the def is already at the target level)
+        //    and hoist_order_literal_to_top_if_live (at level 0) early-return, so a
+        //    second permanent atom naming an already-Top ge does no hoisting at all --
+        //    and eq(v) and eq(v+1) both name ge(v+1). First-cause-wins is right for the
+        //    diagnostic and fatal for an eviction precondition.
+        //  - Only a ge whose Top residency a hoist *caused* gets an entry. A hoist never
+        //    fires on a level-0 ge, so "level 0 with no entry" means structurally
+        //    resident (model-time / boundary / aux / view / gate) -- never evictable, and
+        //    needing no record. That keeps this map proportional to hoists rather than to
+        //    the resident majority.
+        auto note_order_literal_top_pin(const SimpleIntegerVariableID & id, Integer v, OrderEncodingResidencyCause cause) -> void;
+
+        // Record that a chain-link (or stitch) clause over real variable `id`'s threshold
+        // pair (lo, hi) was just emitted as `line`, landing at proof level `at_level`, so
+        // eviction can delete every clause that names an evicted threshold. Top clauses are
+        // recorded too: eviction, not forgetting, is what removes them. Always-on under
+        // Literals, on the hot path of every chain emission, and emits nothing.
+        auto record_live_chain_line(const SimpleIntegerVariableID & id, Integer lo, Integer hi, int at_level, const ProofLine & line) -> void;
+
+        // Drop the record of every chain clause recorded at `level`, called from the forget
+        // sweep once forget_proof_level has del'd that level's lines.
+        auto forget_chain_clauses_at_level(int level) -> void;
+
         // Emit, at ProofLevel::Current, the two chain links joining a real variable's
         // ge threshold v to its immediate *live* neighbours (below and above). Call
         // with v not yet in the live set. Used both for a fresh proof-time literal and
@@ -249,7 +333,7 @@ namespace gcs::innards
         // id is a real SimpleIntegerVariableID; harmlessly skips a threshold that is a
         // boundary/model-time literal (already Top) or not live.
         auto hoist_ges_named_by_top_atom(SimpleOrProofOnlyIntegerVariableID id, Integer lower_ge, Integer upper_ge,
-            std::optional<OrderEncodingResidencyCause> stats_cause = std::nullopt) -> void;
+            std::optional<OrderEncodingResidencyCause> cause = std::nullopt) -> void;
 
         // --- GCS_ORDER_ENCODING_STATS pin-apportionment diagnostic (Literals mode only) ---
         // Every one of these is a pure-bookkeeping no-op unless _imp->collect_order_encoding_stats
@@ -368,7 +452,7 @@ namespace gcs::innards
          * nogoods and parallel-search shared nogoods want.
          */
         auto hoist_order_literal_to_top(
-            const SimpleIntegerVariableID & id, Integer v, std::optional<OrderEncodingResidencyCause> stats_cause = std::nullopt) -> void;
+            const SimpleIntegerVariableID & id, Integer v, std::optional<OrderEncodingResidencyCause> cause = std::nullopt) -> void;
 
         /**
          * Hoist every literal in \p lits that is a live, deletable real-variable
@@ -386,7 +470,80 @@ namespace gcs::innards
          * replace the old delete-then-reintroduce path for the pinned case.
          */
         auto hoist_live_order_literals_toward_level(
-            const std::vector<Literal> & lits, int target_level, std::optional<OrderEncodingResidencyCause> stats_cause = std::nullopt) -> void;
+            const std::vector<Literal> & lits, int target_level, std::optional<OrderEncodingResidencyCause> cause = std::nullopt) -> void;
+
+        /**
+         * The mirror of hoist: take real variable \p id's live ge threshold \p v out of
+         * the proof. Hoist moves a definition *to* a level and stitches it *in*; eviction
+         * deletes it and stitches the chain *over* it.
+         *
+         * Emits `del` for the threshold's two reification lines and for every chain
+         * clause naming it, then stitches its surviving immediate neighbours with a skip
+         * link `ge(hi) -> ge(lo)` (the run-stitch of the forget sweep, run for one
+         * literal on demand, landing at the deeper neighbour's level exactly as there).
+         * Drops \p v from the live/level bookkeeping and **retires its atom**, so
+         * `find_condition` stops answering and the only route back to the literal is
+         * `need_gevar`, which re-introduces the definition as a deletable interior one and
+         * takes the retired `XLiteral` back -- the same structural enforcement of the
+         * naming rule the backtrack sweep relies on.
+         *
+         * \p expected_sole_top_cause is the residency precondition, checked against the
+         * always-on Top-pin bookkeeping rather than asserted blindly, because VeriPB
+         * polices a wrongly-evicted literal only at a later point of use:
+         *
+         *  - For a Top-resident (level 0) \p v the caller must name the cause it believes
+         *    pins it, and eviction happens only if that cause is the *only* pin and it is
+         *    held exactly once. A ge that two permanent atoms name, or one that is
+         *    structurally resident (boundary / model-time / aux / view / gate, which take
+         *    no pin), is refused.
+         *  - For a deletable (level > 0) \p v -- the eq-atom window's mid-level tidy --
+         *    pass `std::nullopt`: no Top line can name it, and eviction just deletes it
+         *    early instead of waiting for the backtrack that would.
+         *
+         * Returns whether \p v was evicted. A refusal emits nothing and changes nothing:
+         * the literal stays resident, which is always correct and merely wins less.
+         * Requires the mode to be Literals, the logger attached, and \p v to be currently
+         * live for \p id (all three throw, being caller errors rather than policy).
+         */
+        auto evict_order_literal(const SimpleIntegerVariableID & id, Integer v, std::optional<OrderEncodingResidencyCause> expected_sole_top_cause)
+            -> bool;
+
+        /**
+         * How many order-encoding chain clauses currently present in the proof name real
+         * variable \p id's ge threshold \p v. Always 0 unless the mode is Literals.
+         *
+         * This exists because it is `evict_order_literal`'s postcondition -- it must leave
+         * none -- and because **VeriPB cannot check that postcondition**. A chain clause
+         * left naming an evicted threshold is still a valid derived constraint: it was
+         * derived from definitions that the atom's stable identity lets a later
+         * `need_gevar` restore, and re-introducing that definition verifies with the stale
+         * clause present (measured against veripb 3.0.2, not assumed). So a missed
+         * deletion is silent, and costs exactly the resident-database shrinkage the mode
+         * exists for. This is a third instance of the pattern the design records for
+         * eviction ordering and ge-under-eq residency: VeriPB polices the order encoding
+         * only at a point of use, so the discipline has to be checked solver-side.
+         */
+        [[nodiscard]] auto chain_clauses_naming(const SimpleIntegerVariableID & id, Integer v) const -> long long;
+
+        /**
+         * Make a windowed (ProofLevel::Current) eq atom definition permanent: relocate its
+         * two reification lines to Top, exactly as hoist_order_literal_to_level relocates
+         * a ge definition (pure bookkeeping, emitting nothing -- re-emitting the `red` is
+         * what collides with a pin), and hoist the two ge thresholds it names to Top with
+         * it, so the now-permanent eq definition cannot be left naming a deleted literal.
+         *
+         * This is the eq-atom window's hoist-out rule (dev_docs/brancher-design.md): an
+         * `eq(v)` that acquires a permanent reference -- a solx blocking clause, a learned
+         * nogood's decision literal, a reified constraint naming `id == v` -- must be
+         * retained instead of evicted when the window steps past it. Eq atoms carry no
+         * chain, so there is nothing to re-stitch; the ges it names are re-stitched by
+         * their own hoists.
+         *
+         * A no-op for an atom that is not a live windowed definition (every eq atom
+         * outside a window is already permanent). Requires the mode to be Literals and the
+         * logger attached.
+         */
+        auto hoist_eq_to_top(const SimpleIntegerVariableID & id, Integer v) -> void;
 
         /**
          * If the `GCS_ORDER_ENCODING_STATS` diagnostic is active (OrderEncodingDeletion::Literals
@@ -473,8 +630,15 @@ namespace gcs::innards
 
         /**
          * Say that we will need the diect encoding to exist for a given variable.
+         *
+         * \p residency asks for the eq atom's definition to be permanent (the default,
+         * and what every caller in the solver wants) or windowed; see EqAtomResidency. It
+         * is honoured only where a deletable definition is meaningful -- under
+         * OrderEncodingDeletion::Literals, at proof-writing time, with assertions off, for
+         * a real variable -- and ignored (leaving the definition permanent) otherwise. It
+         * has no effect on an atom that already exists.
          */
-        auto need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID, Integer) -> void;
+        auto need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID, Integer, EqAtomResidency residency = EqAtomResidency::Permanent) -> void;
 
         /**
          * Say that we will need the range ("in") literal [lo, hi] for a variable,

--- a/gcs/innards/proofs/order_evict_test.cc
+++ b/gcs/innards/proofs/order_evict_test.cc
@@ -1,0 +1,198 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <optional>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::nullopt;
+using std::vector;
+
+using Cause = OrderEncodingResidencyCause;
+
+// Driver for the stage-B' order-encoding eviction primitives (see
+// dev_docs/brancher-design.md), with the deletion mode and the chain gate set in code so
+// the test does not depend on GCS_DELETE_ORDER_ENCODING* being set -- and, in particular,
+// so it runs at the aggressive gate 0, which the shipped default of 16 would otherwise
+// hide entirely (four small variables never name 17 thresholds, so every definition would
+// stay resident and nothing here would be exercised).
+//
+// What VeriPB is checking, beyond the return values:
+//
+//  - **Re-introduction after eviction.** Each eviction is followed by a `need_gevar` /
+//    `need_direct_encoding_for` for the same atom, which re-emits its `red` reification
+//    pair against the bits -- the step that fails if anything the eviction should have
+//    removed is still in the constraint database in a form the witness cannot satisfy.
+//  - **No double deletion.** Every level an eviction has taken lines out of is eventually
+//    forgotten, and forget_proof_level emits a bare `del id` for a bucket interval of
+//    length one. VeriPB errors on a `del id` naming an already-deleted line, so an
+//    eviction that deleted a line without dropping it from its level bucket rejects (the
+//    `u` scenario is shaped to put an evicted line in exactly that position).
+//  - **The eq hoist-out rule.** eq(10) on `w` is hoisted out of the window to Top and then
+//    named by a Top line across a forget of the window's level. That only checks out if
+//    hoist_eq_to_top brought the two ge thresholds the eq definition names to Top with it.
+//
+// And what it deliberately checks in C++ instead, because VeriPB *cannot*: that eviction
+// leaves no chain clause naming the threshold it removed. A leftover clause stays a valid
+// derived constraint, so the proof still verifies with one -- measured, by mutation -- and
+// the loss is silent: exactly the resident-database shrinkage the mode exists for. See
+// NamesAndIDsTracker::chain_clauses_naming.
+auto main() -> int
+{
+    ProofOptions proof_options{"order_evict_test"};
+    proof_options.set_order_encoding_deletion(OrderEncodingDeletion::Literals).set_order_encoding_deletion_min_chain(0);
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+
+    // One variable per scenario, so the scenarios cannot perturb each other's chains.
+    SimpleIntegerVariableID x{0}, y{1}, z{2}, w{3}, u{4};
+    model.set_up_integer_variable(x, 0_i, 100_i, "x", nullopt);
+    model.set_up_integer_variable(y, 0_i, 100_i, "y", nullopt);
+    model.set_up_integer_variable(z, 0_i, 100_i, "z", nullopt);
+    model.set_up_integer_variable(w, 0_i, 100_i, "w", nullopt);
+    model.set_up_integer_variable(u, 0_i, 100_i, "u", nullopt);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    int rc = 0;
+    auto check = [&](bool ok) {
+        if (! ok)
+            rc = 1;
+    };
+
+    // ---- x: mid-level eviction (the eq window's per-iteration tidy shape) ----
+    logger.enter_proof_level(1);
+    tracker.need_gevar(x, 20_i);
+    tracker.need_gevar(x, 40_i);
+    tracker.need_gevar(x, 60_i);
+    auto x40 = tracker.xliteral_for(x >= 40_i);
+
+    // Two chain clauses over 40 (to 20 and to 60), and one over 20.
+    check(tracker.chain_clauses_naming(x, 40_i) == 2);
+    check(tracker.chain_clauses_naming(x, 20_i) == 1);
+
+    // A deletable threshold has no Top pin, so naming a Top cause for it is refused.
+    check(! tracker.evict_order_literal(x, 40_i, Cause::SoliHoist));
+    // With no cause named it goes: its definition and the two chain clauses over it are
+    // deleted now instead of at the backtrack that would have deleted them, and its
+    // surviving neighbours 20 and 60 are stitched.
+    check(tracker.evict_order_literal(x, 40_i, nullopt));
+    // Eviction retires the atom, so nothing can name it until it is re-introduced.
+    check(! tracker.find_xliteral_for(x >= 40_i).has_value());
+    // Nothing names it any more, and 20 has traded its clause to 40 for the skip link.
+    check(tracker.chain_clauses_naming(x, 40_i) == 0);
+    check(tracker.chain_clauses_naming(x, 20_i) == 1);
+
+    tracker.need_gevar(x, 40_i);
+    // Re-introduction takes the retired XLiteral back: a fresh one would render as the
+    // same verbose name but a different x<n> with verbose names off.
+    check(tracker.xliteral_for(x >= 40_i) == x40);
+    // Multi-hop order propagation over the re-stitched chain.
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (x < 60_i) + 1_i * (x >= 20_i) >= 1_i, ProofLevel::Current);
+    logger.forget_proof_level(1);
+
+    // ---- y: eviction from Top under a sole pin (payload 2's shape) ----
+    logger.enter_proof_level(1);
+    tracker.need_gevar(y, 30_i);
+    tracker.need_gevar(y, 50_i);
+    tracker.need_gevar(y, 70_i);
+    auto y50 = tracker.xliteral_for(y >= 50_i);
+
+    // What ProofLogger::solution does for the objective threshold of a new incumbent:
+    // hoist it to Top, where the improvement constraint can name it permanently.
+    tracker.hoist_live_order_literals_toward_level(vector<Literal>{y >= 50_i}, 0, Cause::SoliHoist);
+
+    // A Top-resident threshold is only evictable against a named cause that is its sole
+    // pin: no cause, or the wrong cause, is refused.
+    check(! tracker.evict_order_literal(y, 50_i, nullopt));
+    check(! tracker.evict_order_literal(y, 50_i, Cause::NogoodHoist));
+    check(tracker.evict_order_literal(y, 50_i, Cause::SoliHoist));
+    check(! tracker.find_xliteral_for(y >= 50_i).has_value());
+    // The clauses over it go with it -- including the ones the hoist to Top emitted, which
+    // sit at a different level from the ones its introduction did.
+    check(tracker.chain_clauses_naming(y, 50_i) == 0);
+
+    tracker.need_gevar(y, 50_i);
+    check(tracker.xliteral_for(y >= 50_i) == y50);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (y < 70_i) + 1_i * (y >= 30_i) >= 1_i, ProofLevel::Current);
+    logger.forget_proof_level(1);
+
+    // ---- z: what the Top-pin bookkeeping must refuse ----
+    logger.enter_proof_level(1);
+    // eq(50) names ge(50) and ge(51); eq(51) names ge(51) and ge(52). ge(51) is therefore
+    // pinned at Top by two distinct permanent atoms, and both pins have the same cause --
+    // which is why the count is kept at the reference site rather than inside the hoist,
+    // whose early return for an already-Top threshold sees the second one not at all.
+    tracker.need_direct_encoding_for(z, 50_i);
+    tracker.need_direct_encoding_for(z, 51_i);
+    check(! tracker.evict_order_literal(z, 51_i, Cause::EqHoist));
+    check(! tracker.evict_order_literal(z, 51_i, Cause::SoliHoist));
+    // ge(0) is the lower boundary literal: resident from birth, never hoisted, so it takes
+    // no pin -- and "Top with no pin" must read as structurally resident and unevictable,
+    // not as unpinned and free. Evicting a chain anchor would be far worse than not
+    // winning.
+    tracker.need_direct_encoding_for(z, 0_i);
+    check(! tracker.evict_order_literal(z, 0_i, Cause::EqHoist));
+    check(! tracker.evict_order_literal(z, 0_i, nullopt));
+    logger.forget_proof_level(1);
+
+    // ---- w: the eq-atom window's hoist-out rule and forget sweep ----
+    logger.enter_proof_level(1);
+    // Two windowed eq atoms: definitions at Current, and their ge thresholds left
+    // deletable rather than hoisted to Top.
+    tracker.need_direct_encoding_for(w, 10_i, EqAtomResidency::Windowed);
+    tracker.need_direct_encoding_for(w, 20_i, EqAtomResidency::Windowed);
+    auto w10 = tracker.xliteral_for(w == 10_i);
+    auto w20 = tracker.xliteral_for(w == 20_i);
+
+    // eq(10) acquires a permanent reference, so the window retains it instead of evicting
+    // it: its definition and the two ge thresholds it names all move to Top.
+    tracker.hoist_eq_to_top(w, 10_i);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (w != 10_i) + 1_i * (w >= 10_i) >= 1_i, ProofLevel::Top);
+
+    logger.forget_proof_level(1);
+
+    // eq(20) stayed windowed, so the forget deleted its definition and retired it.
+    check(! tracker.find_xliteral_for(w == 20_i).has_value());
+    tracker.need_direct_encoding_for(w, 20_i);
+    check(tracker.xliteral_for(w == 20_i) == w20);
+
+    // eq(10) survived, and so must its two ge thresholds: these need_gevar calls are the
+    // discriminating half of the hoist-out check. Had hoist_eq_to_top left them deletable,
+    // the forget would have deleted them under the surviving Top eq definition, and
+    // re-introducing them here would emit a `red` that the eq definition's clause refutes.
+    check(tracker.xliteral_for(w == 10_i) == w10);
+    tracker.need_gevar(w, 10_i);
+    tracker.need_gevar(w, 11_i);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (w != 10_i) + 1_i * (w < 11_i) >= 1_i, ProofLevel::Current);
+    logger.forget_proof_level(1);
+
+    // ---- u: eviction must take its lines out of the level's bucket, not just delete them ----
+    // Evicting the deepest threshold of the chain gives it no upper neighbour and so no
+    // stitch, which leaves the evicted chain clause as the last line recorded at level 1.
+    // forget_proof_level deletes a bucket's final interval with a trailing bare `del id`
+    // (`del range`'s exclusive upper has no negative encoding there) -- and unlike
+    // `del range`, `del id` does not skip an already-deleted line but errors on it. So this
+    // is the shape in which forgetting a level an eviction has touched rejects the proof
+    // unless the eviction dropped its lines from the bucket as well as deleting them.
+    logger.enter_proof_level(1);
+    tracker.need_gevar(u, 50_i);
+    tracker.need_gevar(u, 60_i);
+    check(tracker.evict_order_literal(u, 60_i, nullopt));
+    logger.forget_proof_level(1);
+
+    logger.enter_proof_level(0);
+    logger.conclude_none();
+    tracker.finalise();
+
+    return rc;
+}

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -792,6 +792,22 @@ auto ProofLogger::move_proof_lines_to_level(const vector<ProofLine> & lines, int
         }
 }
 
+auto ProofLogger::delete_proof_lines_at_level(const vector<ProofLine> & lines, int level) -> void
+{
+    auto & bucket = _imp->proof_lines_by_level.at(level);
+    // Same relative (negative) encoding forget_proof_level uses, and for the same reason:
+    // a constraint-count difference between our OPB and cake_pb_cp's re-derived one would
+    // misaddress an absolute id. `current` is taken once -- a `del` is not a numbered
+    // line, so emitting these does not move it.
+    auto current = _imp->proof_line.number;
+    for (const auto & l : lines)
+        if (const auto * n = std::get_if<ProofLineNumber>(&l)) {
+            bucket.erase(n->number);
+            write_indent();
+            _imp->proof << "del id " << (n->number - current - 1) << ";\n";
+        }
+}
+
 auto ProofLogger::hoist_literal_to_level(const SimpleIntegerVariableID & id, Integer v, int target_level) -> void
 {
     names_and_ids_tracker().hoist_order_literal_to_level(id, v, target_level);

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -274,6 +274,27 @@ namespace gcs::innards
         auto move_proof_lines_to_level(const std::vector<ProofLine> & lines, int from_level, int target_level) -> void;
 
         /**
+         * \brief Emit a deletion for each of the given proof lines, which must all
+         * currently be tagged at \p level, and drop them from that level's bucket.
+         *
+         * The single-line counterpart of \c forget_proof_level, for the eviction
+         * primitive (see NamesAndIDsTracker::evict_order_literal): a definition and the
+         * clauses naming it go now, rather than when their level is eventually forgotten.
+         *
+         * Dropping them from the bucket is not just tidiness. \c forget_proof_level emits
+         * a bare `del id` for a bucket interval of length one, and VeriPB errors on a
+         * `del id` naming an already-deleted line (only `del range` skips them), so a
+         * line deleted here must not be left for the eventual forget to delete again.
+         *
+         * Lines that are labels rather than ids are skipped, as everywhere else. Passing
+         * a line that is *not* at \p level would leave it in its real bucket and get it
+         * deleted twice, so the caller owns that precondition -- for order literals it is
+         * the level the tracker records for the threshold, which the hoist keeps in step
+         * with the bucket the lines actually sit in.
+         */
+        auto delete_proof_lines_at_level(const std::vector<ProofLine> & lines, int level) -> void;
+
+        /**
          * Hoist a search-introduced order literal `id >= v` to \p target_level:
          * a thin wrapper over NamesAndIDsTracker::hoist_order_literal_to_level.
          */


### PR DESCRIPTION
Part of #612.

Stacked on #606. Stage **B'** of the step-2 refactor: the mirror of the hoist primitive,
plus the bookkeeping it needs. **Nothing calls it yet** — its consumers are the eq-atom
window (B'') and the objective-improvement `delc` (D) — so this emits not one different
byte, which the byte-identity gate and a direct `cmp` on a 15 MB proof both confirm.

## What is here

- **`evict_order_literal(id, v, expected_sole_top_cause) -> bool`** — deletes a
  threshold's definition and every chain clause naming it, stitches the surviving
  neighbours by the forget sweep's rule, and **retires the atom**, so the naming rule
  stays self-enforcing on this second deletion path exactly as on the backtrack sweep. It
  *checks* its precondition and refuses rather than asserting: a refusal leaves the
  literal resident, which is always correct and merely wins nothing. It handles any level,
  because the window's per-iteration tidy evicts `Current`-level definitions.
- **`ge_top_pins`** — the always-on (under Literals) per-cause refcount of what pins a
  `ge` at Top, which is what makes "may I delete this?" answerable.
- **`chain_clauses_by_level`** — the chain clauses currently in the proof. Nothing
  recorded these before, because forgetting a level deleted them wholesale.
- **The eq side**: `live_eq_literals` / `eq_literals_by_level`, a forget sweep,
  `retired_eq` with re-introduction through `need_direct_encoding_for`'s existing guard,
  and `hoist_eq_to_top` for the window's hoist-out rule. `EqAtomResidency` is the minimal
  producer of a deletable eq definition — a defaulted argument nobody passes — so those
  primitives have something to be checked against before the window itself lands.
- **`ProofLogger::delete_proof_lines_at_level`**, which drops the lines from the level's
  bucket as well as `del`-ing them: `forget_proof_level` ends a bucket's final interval
  with a bare `del id`, and VeriPB errors on a `del id` naming an already-deleted line.
- **`gcs/innards/proofs/order_evict_test.cc`**, driving all of it under VeriPB.

## Two things worth a reviewer's attention

**The pin count is taken at the reference site, not inside the hoist.** Both hoists
early-return when there is nothing to move, so a second permanent atom naming an
already-Top threshold would record nothing — and `eq(v)` and `eq(v+1)` both name
`ge(v+1)`. First-cause-wins is right for a diagnostic and *fatal* for an eviction
precondition, which is a count. The mirror rule: only thresholds a hoist put at Top get an
entry, so "level 0 with no entry" reads as structurally resident and unevictable, which is
what a boundary literal — a permanent chain anchor — needs.

**VeriPB does not police a leaked chain clause.** A clause left naming an evicted
threshold stays a *valid derived constraint*, and re-introducing that threshold's
definition verifies with the stale clause still in the database — measured by mutation,
not argued: the negated half of the reification forces the neighbour's atom through its
own definition, so the leftover clause is implied under the witness. A missed deletion is
therefore silent, and costs exactly the resident-database shrinkage the mode exists for.
`chain_clauses_naming` makes the postcondition observable and the test asserts it in C++.
This is a third instance of the pattern the design already records for eviction ordering
and `ge`-under-`eq` residency: **VeriPB polices the order encoding only at a point of
use.**

## On the test

The mode and the chain gate are set in code, so it does not depend on the environment and
in particular runs at gate 0 — the shipped default of 16 would make it vacuous, since five
small variables never name 17 thresholds.

Every check in it was confirmed discriminating by **mutation**: reintroducing one bug at a
time and requiring the test to fail. 8 of 9 caught. The ninth — erasing a chain clause's
record without emitting its `del` — is invisible to both oracles (VeriPB accepts the
leftover clause, per the finding above, and the observable reads the bookkeeping the
mutation updates); the emit and the erase are one statement in one loop, so that split is
a deliberate half-edit rather than a plausible omission, and it was checked instead by
reading the emitted proof.

## Cost

The stage emits no different bytes, so `veripb` time cannot move. Solver-side
proof-writing does, since the chain-clause index takes an insert per chain clause: **+4.1 %**
on the deletion-heaviest synthetic (pinned, solo, d1000, gate 0), of which the pin map, eq
indices and retirement plumbing are +1.0 % and the index is the rest. Keying that index by
variable and then by threshold pair instead cost +12.0 %, which is why it is bucketed
level-first and flat. End-to-end at d1000 the solver is ~0.22 s against `veripb`'s ~1.55 s.

## Gates

Caps-off suite **537/537** in each of {`None`, `Literals` gate 0, `Literals` gate 16};
`None`-mode byte-identity vs plain `main` 26/26, 0 mismatch; seed sweeps 5 tests × 100
seeds, 0 rejections. Win preservation was not re-run — it times `veripb` on a proof this
stage does not change, and that byte-identity was checked directly with `cmp` rather than
assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb9fgE3SAiASdwREZVrU3p


