### PR TITLE
value_precede: key the ub/ex roles by value, and reject duplicate @labels at the source (#604)

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -113,6 +113,28 @@ that does install a child directly (`SeqPrecedeChain`'s `ValuePrecede`)
 must give it an identity, or id-keyed proof flags collide across
 instances (issue #449).
 
+The `role` half of `@c[id][role]` must name **everything the surrounding
+loops vary over**, not just the innermost thing. A role built from a
+position index inside a loop over values gives every value after the
+first the same labels as the first — several genuinely different rows
+under one name, none of them citable unambiguously (issue #604, where
+`ValuePrecede` spelled its upper-bound role `<i>ub` rather than
+`<i>ub_<v>`). This is a hard error, not a first-wins pick:
+`ProofModel::claim_labels` throws on a repeated label, so a role that is
+missing a key fails loudly at model-definition time rather than becoming
+an `.opb` with repeated names that nothing dereferences. It also means
+you cannot work around a collision by ordering the emissions; fix the
+role. The `role_le`/`role_ge` pair of the equality overload is covered
+too, and claimed together, so passing the same role for both halves is
+caught as well.
+
+The check is confined to the `c[id][role]` namespace — it runs in the
+`ConstraintID`-taking `add_labelled_constraint` overloads, which is what
+every constraint uses. The variable-encoding namespaces (`@i[name][...]`
+for a real variable, `@po[index][...]` for a proof-only one) are out of
+scope deliberately: those rows may be deleted and re-emitted to keep the
+proof database small, so a repeat there is by design.
+
 ## The header
 
 ```cpp

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -499,6 +499,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(proof_model_tautology_test PRIVATE glasgow_constraint_solver)
     add_test(NAME proof_model_tautology_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:proof_model_tautology_test>)
 
+    add_executable(duplicate_label_test innards/proofs/duplicate_label_test.cc)
+    target_link_libraries(duplicate_label_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME duplicate_label_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:duplicate_label_test>)
+
     add_executable(eqvar_polarity_test innards/proofs/eqvar_polarity_test.cc)
     target_link_libraries(eqvar_polarity_test PRIVATE glasgow_constraint_solver)
     add_test(NAME eqvar_polarity_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eqvar_polarity_test>)

--- a/gcs/constraints/value_precede/value_precede.cc
+++ b/gcs/constraints/value_precede/value_precede.cc
@@ -108,18 +108,22 @@ auto ValuePrecede::define_proof_model(ProofModel & model) -> void
                 "pge", WPBSum{} + 1_i * pos_v >= Integer{static_cast<long long>(k)}));
         pge.emplace(v, move(ges));
 
-        // Upper bound: (vars[i] = v) -> pos[v] <= i.
+        // Upper bound: (vars[i] = v) -> pos[v] <= i. The role is keyed by both the
+        // position i and the value v: these rows live inside the per-value loop, so a
+        // position-only role would collide across values (#604), giving the .opb several
+        // different rows under one name. cake keys them the same way ("<i>ub_<v>").
         for (size_t i = 0; i < n; ++i)
-            model.add_labelled_constraint(_constraint_id, std::to_string(i) + "ub", WPBSum{} + 1_i * pos_v <= Integer{static_cast<long long>(i)},
-                HalfReifyOnConjunctionOf{{_vars[i] == v}});
+            model.add_labelled_constraint(_constraint_id, std::to_string(i) + "ub_" + v.to_string(),
+                WPBSum{} + 1_i * pos_v <= Integer{static_cast<long long>(i)}, HalfReifyOnConjunctionOf{{_vars[i] == v}});
 
-        // Existence: [pos[v] >= i+1] OR (exists k <= i. vars[k] = v).
+        // Existence: [pos[v] >= i+1] OR (exists k <= i. vars[k] = v). Value-keyed for
+        // the same reason as the upper bound above.
         for (size_t i = 0; i < n; ++i) {
             WPBSum existence;
             existence += 1_i * pge.at(v)[i]; // [pos[v] >= i+1]
             for (size_t k = 0; k <= i; ++k)
                 existence += 1_i * (_vars[k] == v);
-            model.add_labelled_constraint(_constraint_id, std::to_string(i) + "ex", move(existence) >= 1_i);
+            model.add_labelled_constraint(_constraint_id, std::to_string(i) + "ex_" + v.to_string(), move(existence) >= 1_i);
         }
     }
 

--- a/gcs/innards/proofs/duplicate_label_test.cc
+++ b/gcs/innards/proofs/duplicate_label_test.cc
@@ -1,0 +1,107 @@
+#include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <string>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::string;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+#else
+using fmt::print;
+#endif
+
+// Issue #604: a label is how a proof step cites an OPB row, so no two rows in the
+// c[id][role] namespace may carry the same one -- a duplicate makes both uncitable,
+// and opbdiff --match-labels pairs the two encoders' rows by label. ProofModel
+// rejects the second row rather than picking a winner.
+//
+// Both overloads a constraint can reach are covered here, because they emit
+// independently: the single-inequality one, and the equality one, whose two halves
+// are claimed together so that a colliding pair leaves no LE row behind and so that
+// the same role passed twice is caught.
+//
+// Distinct roles must still be accepted, and the .opb left behind must still be
+// well-formed with every surviving row citable -- a rejected row must not leave a
+// half-written line in the file. The pol steps at the end are what pin that; VeriPB
+// fails the test if any label is missing or its row malformed.
+namespace
+{
+    auto expect_throw(const string & what, auto && f) -> bool
+    {
+        try {
+            f();
+        }
+        catch (const ProofError &) {
+            return true;
+        }
+        print(stderr, "{} was accepted\n", what);
+        return false;
+    }
+}
+
+auto main() -> int
+{
+    ProofOptions proof_options{"duplicate_label_test"};
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+
+    ConstraintID id{NumberedConstraint{1}};
+    auto x = model.create_proof_only_integer_variable(0_i, 10_i, "x", IntegerVariableProofRepresentation::Bits);
+
+    // Distinct roles: accepted.
+    model.add_labelled_constraint(id, "first", WPBSum{} + 1_i * x <= 5_i);
+    model.add_labelled_constraint(id, "second", WPBSum{} + 1_i * x <= 6_i);
+    model.add_labelled_constraint(id, "eqle", "eqge", WPBSum{} + 1_i * x == 4_i);
+
+    auto ok = true;
+
+    // The same role again, naming a genuinely different row: rejected.
+    ok &= expect_throw("a second row under role 'first'", [&] { model.add_labelled_constraint(id, "first", WPBSum{} + 1_i * x <= 7_i); });
+
+    // The equality overload emits its two halves itself rather than delegating, so
+    // it needs its own claim: a half colliding with an earlier row must be caught
+    // there too, whichever half it is.
+    ok &= expect_throw(
+        "an equality whose LE half reuses role 'eqle'", [&] { model.add_labelled_constraint(id, "eqle", "freshge", WPBSum{} + 1_i * x == 3_i); });
+    ok &= expect_throw(
+        "an equality whose GE half reuses role 'second'", [&] { model.add_labelled_constraint(id, "freshle", "second", WPBSum{} + 1_i * x == 3_i); });
+
+    // Both halves under one role: the pair collides with itself.
+    ok &= expect_throw("an equality using role 'samesame' for both halves",
+        [&] { model.add_labelled_constraint(id, "samesame", "samesame", WPBSum{} + 1_i * x == 2_i); });
+
+    // A different constraint may reuse a role: the id is part of the label.
+    model.add_labelled_constraint(ConstraintID{NumberedConstraint{2}}, "first", WPBSum{} + 1_i * x <= 8_i);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    // Every accepted row is still there and still citable. A rejected row must not
+    // have left a partial line behind, or these fail to parse.
+    for (const auto & label : {"c[_1][first]", "c[_1][second]", "c[_1][eqle]", "c[_1][eqge]", "c[_2][first]"})
+        logger.emit_proof_line("pol @" + string{label} + " ;", ProofLevel::Current);
+
+    logger.conclude_none();
+    tracker.finalise();
+
+    return ok ? 0 : 1;
+}

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -39,6 +39,7 @@ using std::nullopt;
 using std::ofstream;
 using std::optional;
 using std::pair;
+using std::set;
 using std::string;
 using std::variant;
 using std::vector;
@@ -76,6 +77,11 @@ struct ProofModel::Imp
 
     map<Integer, ProofModel::CakeConstantAtoms> cake_constant_atoms;
 
+    // Every c[id][role] label emitted so far. A label is how a proof step cites
+    // a row, so two constraint rows must never share one; see claim_labels, and
+    // note the variable-encoding namespaces are deliberately not tracked here.
+    set<string> emitted_labels;
+
     string opb_file;
     // Text not yet written out. Until write_preamble() runs this holds
     // everything emitted so far (the variable set-up rows); afterwards each
@@ -109,6 +115,35 @@ ProofModel::~ProofModel()
 auto ProofModel::advance_constraint_counter() -> ProofLineNumber
 {
     return ProofLineNumber{++_imp->number_of_constraints.number};
+}
+
+auto ProofModel::claim_labels(const vector<string> & labels) -> void
+{
+    // A label exists so that a proof step can cite this row, so no two rows in
+    // the c[id][role] namespace may carry the same one: with both spelled
+    // @c[id][role], a reference to either is ambiguous, and opbdiff
+    // --match-labels pairs the two encoders' rows by label. A duplicate is
+    // always a bug in the emitting define_proof_model -- a role that does not
+    // name everything the surrounding loops vary over (#604: ValuePrecede keyed
+    // its ub/ex roles by position but not by chain value, inside a loop over
+    // values) -- so it is a hard error rather than a first-wins or last-wins
+    // pick.
+    //
+    // Only the ConstraintID-taking overloads claim, which is what confines this
+    // to c[id][role]. The variable-encoding namespaces -- @i[name][...] for a
+    // real variable, @po[index] for a proof-only one -- are deliberately left
+    // out: a variable's encoding rows can be deleted and re-emitted to keep the
+    // proof database small, so a repeat there is by design rather than a naming
+    // bug. Their uniqueness is the namer's business, not this check's.
+    //
+    // The whole pack is claimed before any of it is emitted, so that the
+    // equality overload's two halves are all-or-nothing: a rejected pair must
+    // not leave its LE row behind in the OPB. Claiming them together is also
+    // what catches a caller passing the same role for both halves.
+    for (const auto & label : labels)
+        if (! _imp->emitted_labels.insert(label).second)
+            throw ProofError{"two OPB rows emitted under the same label '@" + label +
+                "': a role must name everything that varies, so that each row can be cited unambiguously"};
 }
 
 auto ProofModel::emit_constraint_label(const string & constraint_id, const string & role) -> ProofLineLabel
@@ -195,7 +230,11 @@ auto ProofModel::add_labelled_constraint(const ConstraintID & constraint_id, con
     const optional<HalfReifyOnConjunctionOf> & half_reif) -> pair<ProofLine, ProofLine>
 {
     auto id = as_string(constraint_id);
-    return add_labelled_constraint(emit_constraint_label(id, role_le).label, emit_constraint_label(id, role_ge).label, eq, half_reif);
+    auto label_le = emit_constraint_label(id, role_le).label;
+    auto label_ge = emit_constraint_label(id, role_ge).label;
+    // Both halves up front: a colliding pair must not leave its LE row behind.
+    claim_labels({label_le, label_ge});
+    return add_labelled_constraint(label_le, label_ge, eq, half_reif);
 }
 
 auto ProofModel::add_labelled_constraint(const string & label_le, const string & label_ge, const WPBSumEq & eq,
@@ -271,7 +310,9 @@ auto ProofModel::add_labelled_constraint(const string & label, const Literals & 
 auto ProofModel::add_labelled_constraint(
     const ConstraintID & constraint_id, const string & role, const WPBSumLE & ineq, const optional<HalfReifyOnConjunctionOf> & half_reif) -> ProofLine
 {
-    return add_labelled_constraint(emit_constraint_label(as_string(constraint_id), role).label, ineq, half_reif);
+    auto label = emit_constraint_label(as_string(constraint_id), role).label;
+    claim_labels({label});
+    return add_labelled_constraint(label, ineq, half_reif);
 }
 
 auto ProofModel::add_two_way_reified_constraint(const WPBSumLE & ineq, const ProofFlag & flag) -> pair<ProofLine, ProofLine>

--- a/gcs/innards/proofs/proof_model.hh
+++ b/gcs/innards/proofs/proof_model.hh
@@ -64,6 +64,19 @@ namespace gcs::innards
         // it is never a numeric line.
         auto emit_constraint_label(const std::string & constraint_id, const std::string & role) -> ProofLineLabel;
 
+        // Claim each of these labels for the rows about to be emitted, throwing
+        // ProofError if any is already taken (or if the pack repeats one): a label
+        // is how a proof step cites a row, so two rows sharing one leaves both
+        // uncitable. Called with the whole pack up front, rather than once per row,
+        // so a rejected pair does not leave its first row behind in the OPB.
+        //
+        // Called only from the ConstraintID-taking add_labelled_constraint
+        // overloads, so it covers the c[id][role] namespace and nothing else. The
+        // variable-encoding namespaces (@i[name][...], @po[index][...]) are out of
+        // scope on purpose: those rows may be deleted and re-emitted to keep the
+        // proof database small.
+        auto claim_labels(const std::vector<std::string> & labels) -> void;
+
         // Register a bits encoding (allocate/name the bit literals, track bounds)
         // without emitting anything to the OPB. The shared "register" half of
         // set_up_bits_variable_encoding and create_proof_only_integer_variable_in_proof;
@@ -140,6 +153,11 @@ namespace gcs::innards
          *
          * Returns `{LE-half, GE-half}`, as the unlabelled overload does.
          *
+         * Claims both labels through \ref claim_labels before emitting either, so
+         * a pair whose roles collide with an earlier row of the same constraint ---
+         * or with each other --- is rejected whole, rather than leaving the LE half
+         * behind in the OPB.
+         *
          * Part of moving every constraint reference off line numbers and onto
          * labels.
          */
@@ -151,6 +169,11 @@ namespace gcs::innards
          * that label as the ProofLine. `label` is the full label body (e.g.
          * \c i[X][ge0][f]); used for the variable-encoding @i labels, whose shape
          * (\c i[name][...][f|r]) the caller builds rather than the c[id][role] form.
+         *
+         * Does no label-uniqueness checking: that lives in the ConstraintID
+         * overload below, which is what every constraint uses. A caller reaching
+         * this overload directly is naming a row in some other namespace (a
+         * variable encoding, a flag definition), where a repeat may be deliberate.
          */
         auto add_labelled_constraint(
             const std::string & label, const WPBSumLE & ineq, const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;
@@ -160,6 +183,9 @@ namespace gcs::innards
          * half, each the full label body. For callers whose labels are not
          * c[id][role]-shaped (the tracker's view-link definitions); constraints
          * use the ConstraintID overload instead.
+         *
+         * As the single-label overload above, this does no uniqueness checking;
+         * the ConstraintID overload is where a constraint's roles are checked.
          */
         auto add_labelled_constraint(const std::string & label_le, const std::string & label_ge, const WPBSumEq & eq,
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> std::pair<ProofLine, ProofLine>;
@@ -177,6 +203,11 @@ namespace gcs::innards
          * \brief Like add_constraint for a single inequality, but emits @c[id][role]
          * and returns that label as the ProofLine, so the proof references it by
          * label. The role must match what \c cake_pb_cp emits.
+         *
+         * Claims the label through \ref claim_labels, so a role that does not name
+         * everything its loops vary over --- and therefore repeats --- throws
+         * ProofError at model-definition time rather than producing an .opb with
+         * repeated names (see #604).
          */
         auto add_labelled_constraint(const ConstraintID & constraint_id, const std::string & role, const WPBSumLE & ineq,
             const std::optional<HalfReifyOnConjunctionOf> & half_reif = std::nullopt) -> ProofLine;

--- a/verified_encodings/scp_cases/CMakeLists.txt
+++ b/verified_encodings/scp_cases/CMakeLists.txt
@@ -511,6 +511,22 @@ add_scp_chain_test(element_2d_unsat            none)
 # whose all-absent solutions only pin pos[v] via that bound. value_precede_unsat
 # pins a leading value with no legal predecessor; seq_precede_chain_unsat starts
 # the sequence at 2 (1 absent).
+# Why these stay none, measured rather than assumed (#604, which value-keyed the
+# ub/ex roles and so made the label sets comparable at all). The three
+# value_precede cases now have *label sets identical to cake's*, and every one of
+# the constraint's own rows compares equal; opbdiff --match-labels reports 60
+# matches / 3 differing / 0 only-in-A / 0 only-in-B on value_precede_sat, and all
+# three differing rows are the variables' boundary reifications @i[X][ge0][r] --
+# cake pins the always-true ge0 with a zero coefficient where the solver reifies
+# it, the lazy-vs-eager variable-encoding divergence of #358 that puts every case
+# in this file's `none` section here. So strict/aux is one #358 away, not one
+# constraint fix away. seq_precede_chain has a second, smaller gap: cake emits a
+# per-position clamp row @c[id][<i>cl] whenever m >= 1, while the solver clamps
+# only when the declared domains actually exceed m (they do not, in these cases),
+# so cake's OPB carries 3-4 rows the solver's does not -- harmless, since they are
+# redundant there and the chain verifies, but a label-set difference on top of
+# #358. Recurrence of #604 itself is guarded at the source instead: ProofModel
+# now throws on a duplicate @label, so it no longer depends on this mode.
 add_scp_chain_test(value_precede_sat            none)
 add_scp_chain_test(value_precede_nonexact_sat   none)
 add_scp_chain_test(value_precede_unsat          none)


### PR DESCRIPTION
Fixes #604.

## The fix

`ValuePrecede::define_proof_model` built its upper-bound and existence roles from the position index alone, inside a loop over chain values, so every value after the first reused the first value's labels — two genuinely different rows, over different values' `pos` variables, under one name:

```
@c[_1][0ub] -1 v[_1][0_0][pos] -2 v[_1][0_1][pos] 3 ~i[A][eq0] >= 0;
@c[_1][0ub] -1 v[_1][1_0][pos] -2 v[_1][1_1][pos] 3 ~i[A][eq1] >= 0;
```

The roles are now `<i>ub_<v>` and `<i>ex_<v>`, matching `ubn_<v>` on line 102 and, more to the point, matching cake: `vp_ub_pins` / `vp_ex_pins` in `cp_to_ilp_lexicographicalScript.sml` spell them exactly that way. So this moves back onto cake's scheme rather than inventing one. `seq_precede_chain` delegates here and comes along.

With the roles value-keyed, the label sets of the three `value_precede` cases are **identical to cake's**, and no case in the whole 160-case scp corpus has a repeated label.

## The second question: can these come off opbdiff mode `none`?

No — and for a reason that has nothing to do with this constraint. Measured on `value_precede_sat`:

```
Summary (label-matched, ordered fallback): 60 matches, 3 differing, 0 only in A, 0 only in B.
```

Every one of the constraint's own rows compares equal. All three differing rows are the variables' boundary reifications `@i[X][ge0][r]`, where cake pins the always-true `ge0` with a zero coefficient and the solver reifies it:

```
A: @i[A][ge0][r] 1 i[A][b0] 2 i[A][b1] 1 ~i[A][ge0] >= 0;
B: @i[A][ge0][r] 1 i[A][b0] 2 i[A][b1] 0 ~i[A][ge0] >= 0 ;
```

That is the lazy-vs-eager variable-encoding divergence of #358, which is why *every* case in that section of `scp_cases/CMakeLists.txt` is `none`. `strict`/`aux` here is one #358 away, not one constraint fix away. `seq_precede_chain` has a second, smaller gap on top: cake emits a per-position clamp row `@c[id][<i>cl]` unconditionally, the solver only when the declared domains actually exceed the chain length (they do not, in these cases), so cake's OPB carries 3–4 rows the solver's does not. Harmless — they are redundant there and the chain verifies — but a label-set difference. Both findings are now recorded in the CMakeLists comment, so the next person doesn't have to re-derive them.

## So the guard goes at the source instead

The issue's "the thing that stops it recurring" was the opbdiff oracle, which is unavailable. `ProofModel::add_labelled_constraint` is the funnel every labelled row passes through — including the two-way-reified and equality-half overloads — so it is the one place that sees the whole `.opb`'s naming. It now **throws on a repeated label**, with a message that names it and says what to fix. A duplicate is always a bug in the emitting `define_proof_model`, so it's a hard error rather than a first-wins pick.

This is not per-case opt-in: it covers every constraint, whether or not it has an scp case.

## Testing

Full suite **537/537**. That is also where the confidence in "no constraint legitimately reuses a label" comes from — those runs cover 160 scp chain cases, 36 XCSP models and 74 MiniZinc models, all with `--prove`, plus every constraint test.

Both directions checked by mutation, rather than assumed:

| mutation | result |
|---|---|
| revert the label fix, keep the guard | **10 ctest tests red** — `value_precede_constraint`, `seq_precede_chain_constraint`, their view-mixed twins, all six `scp_chain_*` cases |
| stub the guard out, keep the fix | **`duplicate_label_test` red**: "a second OPB row was accepted under the label 'first'" |

New `duplicate_label_test` pins the guard in two halves, since a check that rejected everything would pass the first alone: distinct labels are still accepted, and the `.opb` left behind stays well-formed with both surviving rows citable from a `pol` step under VeriPB — the rejected row must not leave a half-written line in the file.

Cost is one `set` insert per OPB row at model-definition time, not per proof step. Bounded by row count rather than by a wall-clock A/B: the largest models to hand emit ~8.5k–13.5k labelled rows (`ortho_latin 7` and `8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
