### PR TITLE
Brancher stage B'': the eq-atom sliding window

### DIFF
--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1,7 +1,7 @@
 # Step 2 — the Brancher-API refactor: concrete, decided design
 
-**Status: decided design, partly implemented — stages A, B and B' have landed
-(#606, #607); B''–E have not.** "Migration staging", below, is the authority on
+**Status: decided design, partly implemented — stages A, B, B' and B'' have landed
+(#606, #607, #608); C–E have not.** "Migration staging", below, is the authority on
 what each remaining stage owes, and tracking issue #612 indexes them.
 This note is the single committed record of the step-2 design: it turns the
 user-approved conceptual sketch in
@@ -13,8 +13,8 @@ findings), and integrates the eq-atom sliding window that turns ascending and
 descending eq branching into a win. Where a call needed the owner it has been
 made; the five decisions are recorded up front. Where a claim needed a checker it
 was validated against `veripb 3.0.2`, and the raw drivers are cited in
-Provenance. The three remaining unknowns are implementation gates, not owner
-calls, and are flagged as such.
+Provenance. The three unknowns were implementation gates, not owner calls, and are
+flagged as such; all three are now resolved by the stages that owned them.
 
 Step 2 changes no model, no propagator, no search order. It is a proof-only
 change and must be verified as one: search identical mode-off vs mode-on at every
@@ -279,8 +279,15 @@ Why the eq family splits the way it does:
   seat-moving). The window does **not** try to jump gaps — it deletes *behind* a
   one-step frontier, evicting each `eq(v)`/`ge(v)` once the frontier has stepped
   past it, bounding the permanent proof objects per branched variable from
-  O(domain-width) to O(1). That is the win, and it is driver-backed (see "The
-  eq-atom window").
+  O(domain-width) to O(1). That is the win; it is driver-backed and, since B'',
+  measured at **4.8× at domain 1000** (see "The eq-atom window").
+
+  A frontier that steps over a **hole** — consecutive branch values that are not
+  adjacent, because propagation removed what lay between — is not a special case in
+  the implementation: the advance still moves one threshold, and the next step's RUP
+  bridges the gap through the removed values' own exclusions, which are still live at
+  or above the node's level. It verifies; `eq_window_solve_test` exercises it
+  deliberately.
 
 - **Stay `Exclude`** — `median` / `random` / `random_out` refute a *non-boundary*
   value, so the frontier does not move and there is no "behind" to delete;
@@ -318,11 +325,14 @@ Footnotes:
 ## The eq-atom window
 
 The mechanism that makes the four contiguous eq orders win. Audited (window closes
-cleanly at assertion Off; one scoping caveat, eq⨯interval) and driver-validated
-(8/8 in VeriPB 3.0.2, including the load-bearing eq-def-traversal control). The
-advance is emitted by **the framework** (`solve.cc` + `ProofLogger`), never the
-brancher — the same framework/brancher split the split family uses; branchers only
-declare `LowerBound`/`UpperBound`, and the mode gate makes it inert under `None`.
+cleanly at assertion Off; one scoping caveat, eq⨯interval), driver-validated
+(8/8 in VeriPB 3.0.2, including the load-bearing eq-def-traversal control), and
+**built in stage B''** — the sections below are marked "as built" where the
+implementation settled something the design left open. The advance is emitted by
+**the framework** (`solve.cc` + `ProofLogger`), never the brancher — the same
+framework/brancher split the split family uses; branchers only declare
+`LowerBound`/`UpperBound`, and the mode gate makes it inert under `None`, as does
+the window's own off-by-default switch.
 
 Grounding facts the window rests on:
 
@@ -337,13 +347,109 @@ Grounding facts the window rests on:
   is tolerated), so ge-under-eq residency is a solver-side invariant, not a
   checker-enforced one.
 
-### Mint-time lifetime tagging (the narrow API)
+### What it measures (B'', current hardware, one sitting)
 
-Today `need_direct_encoding_for` hardcodes the eq def at `ProofLevel::Top`
-(`names_and_ids_tracker.cc:672`), unlike `need_gevar`, which already chooses
-`Current` vs `Top` from `def_at_current`. The window gives the eq path the same
-choice, **gated so ordinary `need_proof_name` callers are oblivious** — a scoped
-RAII guard set by the branch layer around the guess mint only:
+The window does what it was built to do in the regime it was built for, and costs
+nothing outside it — but that regime is narrower than the design assumed, in two ways
+recorded below. Every row here is `order_deletion_bench --problem pairwise --size 6
+--window D --tightness 90 --unsat --value-order smallest` — ascending eq branching,
+weak propagation, no solutions — and every one of them **verifies**, with the search
+shape (recursions, propagations) byte-for-byte identical window-off vs window-on, as a
+proof-only change requires. Best-of-3 `veripb` wall time:
+
+| domain | gate | off | on | speedup |
+|---|---|---|---|---|
+| 250 | 0 | 0.756 s | 0.329 s | **2.30×** |
+| 500 | 0 | 5.765 s | 1.634 s | **3.53×** |
+| 1000 | 0 | 45.92 s | 9.678 s | **4.74×** |
+| 250 | 16 | 0.892 s | 0.475 s | 1.88× |
+| 500 | 16 | 6.380 s | 2.337 s | 2.73× |
+| 1000 | 16 | 48.75 s | 13.22 s | 3.69× |
+
+The speedup **grows with domain width**, which is the signature of a residency win
+rather than a constant-factor one — the same shape the split family's curve has. Note
+that the window makes the proof **bigger** (+31 % at every domain: the advances, the
+`del`s, and the re-mints are all extra bytes) and verifies it **4.8× faster**: this is
+the mode's central SIZE≠TIME point, that what costs `veripb` time is the resident
+constraint database, not the file.
+
+On the eq-heavy *real* instances the window turns out not to engage at all, which is a
+more useful result than a slow one. Instrumented (`GCS_ORDER_ENCODING_STATS`): the
+synthetic above evicts **3255** windowed eq definitions at d250; crystal_maze evicts
+**1**; talent evicts **0**. The reason is a precondition the design did not name:
+
+> **The window can only act on an eq atom the branch layer is the first to name.**
+> `need_direct_encoding_for` decides residency once, when the definition is emitted, and
+> returns early for an atom that already exists. On a model whose *constraints* reason
+> per value — which is what "eq-heavy" means — the propagators have already defined
+> `x == v` permanently long before the search branches on it, and the window has nothing
+> to window.
+
+An earlier revision of this stage emitted the advance regardless, which cost talent
++1.1 % proof and **~5 % verify time** for zero evictions. `emit_eq_window_advance` now
+returns immediately when the guess's atom is not a live windowed definition, and talent's
+window-on proof is **byte-identical** to its window-off proof: when the window cannot
+engage it now costs nothing at all, rather than a little. That is Decision 5's
+transient-for-permanent trade turning out not even to arise on those models.
+
+**The second, larger limit: solutions retain atoms.** The `solx` blocking clause names
+`var == val` for every variable, so the hoist-out rule retains the windowed atom of every
+sibling whose subtree contained a solution — which in an *enumeration* is most of them.
+The window therefore engages fully on refutation search (the synthetic sweep above is
+`--unsat`) and only on the solution-free siblings of an enumeration:
+`eq_window_solve_test` gets 1–2 advances from a 2-solution search, not one per node. Two
+things follow, both stage E's:
+
+- The regime statement needs a third clause: weak propagation, large domain, **and the eq
+  atoms named by search rather than by constraints** — plus, for the full win,
+  refutation-heavy rather than solution-heavy search.
+- Whether the solx retention is *needed* is worth measuring rather than assuming. It is
+  kept here because it is the conservative reading of "delete only when unreferenced", but
+  mutation says the small instances verify without it (the blocking clause carries
+  `~eq(v)`, which the re-introduction's falsify witness satisfies), and dropping it is the
+  single biggest lever on the window's reach. That is a soundness-adjacent change and
+  belongs to the owner, not to this stage.
+
+**Beware the bench's size.** The eq control enumerates the whole domain at every node,
+so it scales quite differently from the split default: `--size 16 --domain 250
+--value-order smallest --prove` wrote **12 GB** of proof in three minutes without
+finishing and took the VM's free disk with it. `--size 6` keeps every row above in the
+low tens of megabytes.
+
+### What the tests catch, and what they do not
+
+Established by mutation, because a test suite's silence is not evidence:
+
+- **The residency invariant is what catches a window that stops working.** Making
+  `evict_eq_literal` a no-op leaves every proof verifying — it is the baseline again —
+  and is caught only by `eq_window_test`'s C++ counts. That is the whole reason those
+  counts are asserted rather than left implicit.
+- **The tidy-ordering violation is caught — but only because the model is weak.**
+  Deleting the eq definition *before* the advance (the D2c shape) makes VeriPB reject
+  `eq_window_solve_test` with "not implied by reverse unit propagation", on all four
+  value orders and both models. It did **not** reject an earlier version of that test
+  whose constraints were comparisons and `NotEquals`: there propagation is strong enough
+  that the advance is independently RUP, and the eq definition the design leans on is not
+  actually doing the work. The linear equality is in the model to keep the propagator too
+  weak for that shortcut — **if it is ever removed, this stops being tested**, silently.
+  (The artifacts driver's D2c control remains the pure demonstration, with an opaque
+  sibling clause and no bit-level hole; promoting it into `gcs/` is still stage E's job,
+  #611.)
+- **The solx retention is defensive on the instances measured, and load-bearing in
+  reach.** Removing the `solution` trigger left talent's proof **byte-identical** (talent
+  windows nothing) and left the small enumerations verifying. It is kept anyway, because
+  "nothing on these instances noticed" is not an argument that a permanent reference to a
+  deleted definition is safe — but it is also what keeps the window from engaging in an
+  enumeration, so its cost is real and stage E should settle it with a measurement rather
+  than inherit the assumption.
+
+### Mint-time lifetime tagging (the narrow API) — **as built**
+
+Before the window, `need_direct_encoding_for` hardcoded the eq def at
+`ProofLevel::Top`, unlike `need_gevar`, which already chooses `Current` vs `Top`
+from `def_at_current`. The window gives the eq path the same choice, **gated so
+ordinary `need_proof_name` callers are oblivious** — a scoped RAII guard set by
+the branch layer around the guess mint only:
 
 ```cpp
 // NamesAndIDsTracker — RAII, set by the branch layer around the guess mint only.
@@ -355,15 +461,26 @@ struct WindowedEqScope {                       // ctor sets _imp->minting_window
 `need_direct_encoding_for` reads `minting_windowed_eq` exactly where `need_gevar`
 reads its residency inputs: when set (and Literals mode / `AssertionLevel::Off` —
 the same pairing every existing Literals-machinery guard uses / real Bits var /
-not a bound / not eq⨯interval — see the guard below) it emits the two eq def lines at
-`ProofLevel::Current` and records the atom in a new live-eq index, instead of Top.
+not eq⨯interval — see the guard below) it emits the two eq def lines at
+`ProofLevel::Current` and records the atom in the live-eq index, instead of Top.
 **Every other caller** — propagator reasons, reified constraints,
 `need_pol_item_defining_literal` — runs with the flag clear and gets today's
 byte-identical Top behaviour. This meets the owner's bar: only the guess/mint path
-knows about lifetimes. (A tagged
-`need_direct_encoding_for(id, v, Lifetime::Windowed)` overload is equivalent but
-threads the tag through more call sites; the scoped guard keeps the surface to one
-RAII object set in `solve.cc`'s branch loop, where the guess is made.)
+knows about lifetimes. B''s `EqAtomResidency` argument, which existed so the
+stage-B' primitives had a producer to be checked against, is gone: the scope
+replaces it, and `order_evict_test` opens the scope like the branch layer does.
+
+**Where the mint happens, and why it is not left to the child.** The scope is
+opened in `solve.cc`'s branch loop, *before* the descent into the guess's subtree
+(`ProofLogger::mint_windowed_eq_guess`), not left to whatever propagation inside
+the child first names `id == v`. The level is the point: the window needs the
+definition at the node's own level `L` — the level the refuted child's backtrack
+clause lands at, and the level the advance is emitted at — and a definition minted
+inside the child lands at `L+1`, which the child's own `forget` then deletes out
+from under both, breaking the advance exactly as control D2c does. Minting ahead of
+the descent also mints the two `ge` thresholds it names at `L`, so the design's
+"hoist the frontier to `L`" step (5 in the tidy) is already satisfied and the hoist
+call is a no-op that only fires for a frontier that already existed deeper.
 
 ### The per-iteration tidy sequence
 
@@ -408,7 +525,37 @@ Steady state after each tidy is the design's target: **one boundary `ge0` + one
 frontier `ge` + one standing advance clause live** (plus, mid-iteration, one eq
 def). Descending (`largest_first` / `largest_in`) is the `UpperBound` mirror
 (`x == ub`, advance `x < ub` i.e. `~ge(ub)`), mechanically symmetric; the driver
-validated the ascending direction only (see Implementation gates).
+validated the ascending direction only, and the descending one is covered instead
+by `eq_window_test` / `eq_window_solve_test` (see Implementation gates).
+
+**As built**, the whole sequence is `ProofLogger::emit_eq_window_advance`, called
+from the branch loop for a refuted eq sibling that is not the node's last. Two
+details the sequence above leaves implicit, both of which the implementation has to
+name explicitly:
+
+- **The superseded advance is found by remembering it**, per `(proof level,
+  variable)`, and the record is dropped when that level is forgotten. Levels are
+  reused by every node at a depth, and a `del id` of an already-deleted line is an
+  error in VeriPB (only `del range` skips them), so an inherited record from the
+  previous node at that depth would reject.
+- **The sibling clause is found the same way** — `ProofLogger::backtrack` records
+  the clause it emits, with the guess and level it was over, and the tidy uses it
+  only if both match the sibling being tidied. The clause is emitted by the *child*
+  frame, which returns only a search result; nothing between it and the parent's
+  advance emits another (the `forget` in between emits `del`s and stitches). If the
+  match ever fails, the tidy skips the deletion — and therefore also skips the
+  eviction, because an atom whose sibling clause is still live is still referenced.
+
+**One shape the window deliberately does not tidy.** `smallest_in` / `largest_in`
+yield `var == lb` and then its *complement* `var != lb`, whose own refutation names
+the very atom the tidy would evict — forcing an immediate re-mint, and (the scope
+being closed by then) a **permanent** one that pins both its thresholds at Top:
+strictly worse than not tidying. With no later sibling there is also nothing for the
+advance to be the standing bound of, so the branch loop skips the advance entirely
+when the next decision is the complement of the refuted one. Those two orders still
+gain from the window — their guess atoms are windowed, so an eq def and its two
+thresholds die with the node instead of living at Top forever — just across the
+chain of nodes rather than within one.
 
 ### The hoist-out rule for permanent references
 
@@ -420,11 +567,33 @@ evicted**; instead it and the two ges it names are hoisted to Top, exactly as
 `hoist_ges_named_by_top_atom` already does for the ges, plus a new
 `hoist_eq_to_top`. The window then evicts `eq(v)`'s **neighbours** normally and
 stitches the chain **around** the retained interior ges (the genuine
-`make_pol_chain` case — driver D4, `ge3 -> ge2`). Detecting "has a permanent
-reference" reuses the residency-cause bookkeeping the design already mandates for
-the ge/soli case. VeriPB will not catch a wrongly-evicted referenced ge except at
-a point of use (D4c vs D4c-silent), so this is a solver invariant, not something
-the checker enforces.
+`make_pol_chain` case — driver D4, `ge3 -> ge2`). VeriPB will not catch a
+wrongly-evicted referenced ge except at a point of use (D4c vs D4c-silent), so this
+is a solver invariant, not something the checker enforces.
+
+**Detection, as built**, is `note_permanent_eq_reference(id, v)`, called at each
+reference site exactly as `note_order_literal_top_pin` is for the ge side —
+`hoist_eq_to_top` is the action, this is the trigger. The sites are the ones that
+put an eq atom into a line that outlives a backtrack:
+
+- **`ProofLogger::solution`** — the `solx` blocking clause and the `soli` witness
+  name `var == val` for *every* variable. This is by far the commonest permanent
+  reference: every solution takes one on each branched variable's current value, so
+  in an enumeration the window retains an atom at each solution rather than evicting
+  it. (A view is deviewed first; the underlying is the variable that can be
+  windowed.)
+- **`ProofLogger::emit_learned_nogood`** — a restart nogood's decision literals,
+  the eq analogue of the existing `NogoodHoist`.
+- The **eq⨯interval** guard below, which collapses a whole window at once rather
+  than one atom at a time.
+
+An eq atom that acquires a permanent reference from anywhere *else* is not detected,
+and would be a stranded reference. That failure is **not silent**, which is what
+makes the enumerated list acceptable rather than a latent hole: the atom keeps its
+`XLiteral` identity across eviction, so a surviving line naming it and a later
+re-introduction collide — the fresh `red`'s falsify-witness against the pin — and
+VeriPB rejects, loudly, at the re-introduction. Contrast the ge/chain-clause leak,
+which really is silent.
 
 ### Bookkeeping mirrors
 
@@ -488,16 +657,24 @@ resident* subset. An eq eviction mirrors the ge eviction's
   funnel, after the ge sweep — which is what emits the level's stitches, and those land at
   a *surviving* neighbour's level, never at the level being forgotten.
 
-  The producer of a windowed def is a defaulted argument,
-  `need_direct_encoding_for(id, v, EqAtomResidency::Windowed)`; `Permanent` is the default
-  and what every caller in the solver passes, so B' changes no emission. The request is
-  honoured only where a deletable def is meaningful (Literals, proof-time, assertions off,
-  real variable) and, per **(i-static)** below, is refused for a variable that already has
-  an interval partition or a containment tree — that half of the eq⨯interval guard is
-  cheap enough to ship with the primitive rather than with the window. B'' replaces the
-  argument with the variable's `WindowedEqScope` tag; until then it exists so
-  `hoist_eq_to_top` and the eq forget sweep have a producer to be VeriPB-checked against
-  (`order_evict_test`).
+  The producer of a windowed def is `WindowedEqScope`, open across the branch layer's
+  guess mint and nothing else; every other caller in the solver mints permanently, so
+  nothing outside the branch layer changes. The request is honoured only where a deletable
+  def is meaningful (Literals, proof-time, assertions off, real variable) and, per
+  **(i-static)** below, is refused for a variable that already has an interval partition or
+  a containment tree. (B' shipped this as a defaulted `EqAtomResidency` argument, so
+  `hoist_eq_to_top` and the eq forget sweep had a producer to be VeriPB-checked against
+  before the window existed; B'' replaced it with the scope, and `order_evict_test` now
+  opens the scope like the branch layer does.)
+
+  The eviction counterpart is `evict_eq_literal`: the same `delete_proof_lines_at_level` +
+  retire pair the forget sweep performs, on demand for one atom, with the same
+  `get_if<ProofLine>` filter for a DirectOnly `{0,1}` variable's `XLiteral`-valued
+  `eq_defs`. Like `evict_order_literal` it **refuses rather than throws** when the atom is
+  not a live windowed def — which is exactly what an atom the hoist-out rule has retained
+  looks like — so the window's tidy needs no special case for the atoms it must not touch.
+  Unlike the ge case there is no chain to stitch and no Top-pin precondition, because a
+  windowed def by construction has neither.
 
 ### WindowedFrontier vs FrontierExempt, and the chain gate
 
@@ -521,6 +698,16 @@ eq branch). They are the two opposite frontier policies and only the frontier
 owner (branch layer / objective owner) can pick which applies. They never apply to
 the same variable, so they sit as sibling slots just above the gate.
 
+**As built**, `WindowedFrontier` is a slot in `need_gevar`'s residency ladder and
+**not** a new `OrderEncodingResidencyCause` enumerator. That enum answers "why is
+this `ge` resident at Top", and `WindowedFrontier` is the opposite of a Top cause —
+it is a reason to stay *deletable*, and a ge born deletable takes no cause at all
+(the stats already record `nullopt` for one). It reads off a per-variable
+`windowed_eq_variables` set, marked when the first windowed definition on that
+variable is minted — before the definition is emitted, because emitting it is what
+mints the two thresholds that must come out deletable. `FrontierExempt` (stage C)
+*is* a Top cause and will want the enumerator.
+
 ### The one hidden pin — eq⨯interval (bidirectional guard)
 
 A windowed eq variable that *also* receives an `in`/`not_in` interval literal has
@@ -540,9 +727,14 @@ constraint on the same variable might. The guard must be **bidirectional**
   hoist-out mechanism run wholesale) and only then build the partition; the
   variable is thereafter unwindowed.
 
-Both are recommended for step 2, flagged as a future extension. The alternative —
-the window managing partition coverings on evict — stays out of step-2 scope. This
-is the single scoping caveat the audit surfaced.
+Both are built. (i-dynamic) is `collapse_eq_window`, called from the **two** paths
+that walk a variable's `eq_defs` table and name every atom in it from Top lines:
+`init_interval_partition`, and the containment-tree seeding in `define_plain_invar`
+(the static half already refuses both structures, so the dynamic half has to cover
+both too). It unwindows the variable unconditionally, so a *later* guess mint gets a
+permanent definition and the partition can never be left naming a deletable one.
+The alternative — the window managing partition coverings on evict — stays out of
+step-2 scope. This is the single scoping caveat the audit surfaced.
 
 ## Ownership and lifecycle
 
@@ -1051,16 +1243,30 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   of the eq⨯interval guard, and tagging `smallest_first` / `largest_first` /
   `smallest_in` / `largest_in`.
 
-- **Stage B'' — the eq-atom window.**
-  The `WindowedEqScope` tag, `need_direct_encoding_for` Current-emission, the
-  per-iteration tidy, the hoist-out rule, the `WindowedFrontier` residency slot, and
-  the bidirectional eq⨯interval guard. Tag `smallest_first` / `largest_first` /
-  `smallest_in` / `largest_in` with `Lower/UpperBound`. **Oracle:** VeriPB verifies +
-  search-identical at `MIN_CHAIN=0`; flag-off byte-identity preserved; resident eq/ge
-  count per branched var is **O(1) not O(width)**; the driver-analogue behaviours
-  (D1–D4) hold on a real enumerated-domain instance. Ships **default-off for eq orders**
-  (Decision 5). **This stage re-confirms the real-solver eq advance level** (see
-  Implementation gates).
+- **Stage B'' — the eq-atom window. DONE.**
+  Shipped: the `WindowedEqScope` tag (replacing B''s `EqAtomResidency` argument);
+  `need_direct_encoding_for`'s Current-emission and its `windowed_eq_variables` mark;
+  the `WindowedFrontier` slot in `need_gevar`'s ladder; `evict_eq_literal` (the eq
+  mirror of `evict_order_literal`); `note_permanent_eq_reference` as the hoist-out
+  rule's trigger, wired at the solx/soli and learned-nogood sites; `collapse_eq_window`
+  as the (i-dynamic) half of the eq⨯interval guard, on both the partition and
+  containment-tree paths; `ProofLogger::{eq_window_active, mint_windowed_eq_guess,
+  emit_eq_window_advance}` and the branch-loop wiring; and the `Lower`/`UpperBound`
+  tags on `smallest_first` / `largest_first` / `smallest_in` / `largest_in`.
+  Ships **default-off for eq orders** (Decision 5), behind
+  `ProofOptions::set_order_encoding_deletion_eq_window()` /
+  `GCS_DELETE_ORDER_ENCODING_EQ_WINDOW`; with it off the four tagged orders are
+  byte-identical to the untagged ones, which is what makes the tags free to add now.
+  **Oracle (met):** the caps-off suite passes with the window on at `MIN_CHAIN=0`
+  (542/542, no flag-induced rejection); flag-off byte-identity holds across
+  {None, Literals gate 0, Literals gate 16}; and two new VeriPB-checked tests cover
+  the mechanism — `eq_window_test`, which drives the production entry points and
+  asserts in C++ the thing VeriPB cannot see (one live windowed eq definition per
+  branched variable and a flat ge count, **O(1) not O(width)**), plus the hoist-out
+  and eq⨯interval-collapse behaviours; and `eq_window_solve_test`, four ctest entries
+  enumerating through a real search with each tagged value order.
+  **This stage re-confirmed the real-solver eq advance level** (see Implementation
+  gates), including the descending direction the hand-authored driver never covered.
 
 - **Stage C — objective / frontier exemption (payload 3; flag-gated; committable).**
   Add `note_deletion_exempt` + the `FrontierExempt` residency cause + the `need_gevar`
@@ -1097,8 +1303,7 @@ and can be prepared ahead (it reuses B''s primitives) and finished once wired.
 ## Implementation gates (not owner calls)
 
 Three unknowns; all are validated empirically against VeriPB, not decided by the owner.
-Two are now resolved by the stages that owned them, and the remaining one belongs to
-B'':
+All three are now resolved by the stages that owned them:
 
 1. **Advance-RUP proof level (stage B). RESOLVED.** The exact level at which the
    split-family advance RUP and frontier hoist land, given the child has already
@@ -1107,16 +1312,23 @@ B'':
    and the synthetic split/UNSAT sweep preserves its win. Nothing about the level was
    taken on trust; the gate was the suite, not an argument.
 
-2. **Real-solver eq advance re-confirmation (stage B'').** The eq analogue of gate 1.
-   The driver commits the sibling `~g | ~eq(v)` via an order-hole `red` witness because
-   it has no child subtree; the *solver* emits it as `ProofLogger::backtrack`'s RUP
-   clause from the still-live child. The two produce the identical clause, but the real
-   path's RUP must be re-confirmed once wired — specifically that hoisting the frontier
-   `ge(v+1)` to `L` before the child `forget` leaves the advance RUP at `L`. Validate
-   against VeriPB at `MIN_CHAIN=0`, with `order_jump_check` + `d1_main.pbp` as anchors.
-   (The descending direction — `largest_first` / `largest_in`, the `UpperBound` mirror
-   — is expected to verify by symmetry but was not driver-tested; confirm before
-   shipping the descending orders.)
+2. **Real-solver eq advance re-confirmation (stage B''). RESOLVED.** The eq analogue of
+   gate 1. The driver commits the sibling `~g | ~eq(v)` via an order-hole `red` witness
+   because it has no child subtree; the *solver* emits it as `ProofLogger::backtrack`'s
+   RUP clause from the still-live child. The two produce the identical clause, but the
+   real path's RUP had to be re-confirmed once wired.
+
+   *Resolution as shipped:* the answer was **not** to hoist the frontier — it was to
+   mint the eq definition at the node's level in the first place (see "Mint-time
+   lifetime tagging"), which puts the frontier `ge(v+1)` there too and leaves the
+   design's hoist step a no-op. With that, the advance is RUP at `L` across the caps-off
+   suite at `MIN_CHAIN=0`, in `eq_window_test` (which drives the production emission
+   directly), and in `eq_window_solve_test`'s four real enumerations. **The descending
+   direction is confirmed, not assumed**: `largest_first` / `largest_in` have their own
+   scenarios in both tests, mirroring `y < v` against `y >= v+1`. The hole case —
+   consecutive branch values that are not adjacent, because propagation removed what lay
+   between — verifies too, and is exercised deliberately by the solve test's
+   `NotEquals` pair.
 
 3. **Residency-bookkeeping promotion (stage B'). RESOLVED.** Eviction's "sole Top cause"
    precondition needs always-on per-ge cause tracking under Literals. *Resolution as

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -280,7 +280,7 @@ Why the eq family splits the way it does:
   one-step frontier, evicting each `eq(v)`/`ge(v)` once the frontier has stepped
   past it, bounding the permanent proof objects per branched variable from
   O(domain-width) to O(1). That is the win; it is driver-backed and, since B'',
-  measured at **4.8× at domain 1000** (see "The eq-atom window").
+  measured at **4.7× at domain 1000** (see "The eq-atom window").
 
   A frontier that steps over a **hole** — consecutive branch values that are not
   adjacent, because propagation removed what lay between — is not a special case in
@@ -359,17 +359,17 @@ proof-only change requires. Best-of-3 `veripb` wall time:
 
 | domain | gate | off | on | speedup |
 |---|---|---|---|---|
-| 250 | 0 | 0.756 s | 0.329 s | **2.30×** |
-| 500 | 0 | 5.765 s | 1.634 s | **3.53×** |
-| 1000 | 0 | 45.92 s | 9.678 s | **4.74×** |
-| 250 | 16 | 0.892 s | 0.475 s | 1.88× |
-| 500 | 16 | 6.380 s | 2.337 s | 2.73× |
-| 1000 | 16 | 48.75 s | 13.22 s | 3.69× |
+| 250 | 0 | 0.746 s | 0.325 s | **2.30×** |
+| 500 | 0 | 5.707 s | 1.619 s | **3.53×** |
+| 1000 | 0 | 45.96 s | 9.788 s | **4.70×** |
+| 250 | 16 | 0.878 s | 0.468 s | 1.88× |
+| 500 | 16 | 6.272 s | 2.312 s | 2.71× |
+| 1000 | 16 | 48.85 s | 13.11 s | 3.73× |
 
 The speedup **grows with domain width**, which is the signature of a residency win
 rather than a constant-factor one — the same shape the split family's curve has. Note
 that the window makes the proof **bigger** (+31 % at every domain: the advances, the
-`del`s, and the re-mints are all extra bytes) and verifies it **4.8× faster**: this is
+`del`s, and the re-mints are all extra bytes) and verifies it **4.7× faster**: this is
 the mode's central SIZE≠TIME point, that what costs `veripb` time is the resident
 constraint database, not the file.
 
@@ -392,23 +392,26 @@ window-on proof is **byte-identical** to its window-off proof: when the window c
 engage it now costs nothing at all, rather than a little. That is Decision 5's
 transient-for-permanent trade turning out not even to arise on those models.
 
-**The second, larger limit: solutions retain atoms.** The `solx` blocking clause names
-`var == val` for every variable, so the hoist-out rule retains the windowed atom of every
-sibling whose subtree contained a solution — which in an *enumeration* is most of them.
-The window therefore engages fully on refutation search (the synthetic sweep above is
-`--unsat`) and only on the solution-free siblings of an enumeration:
-`eq_window_solve_test` gets 1–2 advances from a 2-solution search, not one per node. Two
-things follow, both stage E's:
+So the regime statement needs a second clause: weak propagation, large domain, **and the
+eq atoms named by search rather than by constraints**.
 
-- The regime statement needs a third clause: weak propagation, large domain, **and the eq
-  atoms named by search rather than by constraints** — plus, for the full win,
-  refutation-heavy rather than solution-heavy search.
-- Whether the solx retention is *needed* is worth measuring rather than assuming. It is
-  kept here because it is the conservative reading of "delete only when unreferenced", but
-  mutation says the small instances verify without it (the blocking clause carries
-  `~eq(v)`, which the re-introduction's falsify witness satisfies), and dropping it is the
-  single biggest lever on the window's reach. That is a soundness-adjacent change and
-  belongs to the owner, not to this stage.
+**A solution is a use of an eq atom, not a permanent reference to it — checked, not
+assumed.** The design lists "a solx blocking clause" first among the permanent references
+the hoist-out rule must catch, and an earlier revision of this stage duly retained an atom
+on every branched variable at every solution, which stopped the window engaging in an
+enumeration almost entirely. That is wrong, and reading VeriPB settles it: the constraint
+`solx` keeps is built **only from the `preserved:` set** — our variables' *bits* — and
+never mentions an eq atom (`veripb-checker/src/rules/solution_logging.rs`,
+`SolutionRuleOutput::Excluding` walks `preserved_variables`; `Improving` builds from the
+objective). The atoms listed on the line only need to be *defined while it is checked*,
+because they are what propagates the assignment out to those bits; afterwards nothing
+surviving names them. So `ProofLogger::solution` takes no hoist-out, and the window evicts
+after a solution like anywhere else. The remaining permanent-reference site is the learned
+nogood, whose Top clause genuinely does name the atom.
+
+(The `soli` order literal `id < incumbent` is a different matter and still hoisted: that
+one is named by the improvement line the *solver* emits, not by anything internal to
+VeriPB.)
 
 **Beware the bench's size.** The eq control enumerates the whole domain at every node,
 so it scales quite differently from the split default: `--size 16 --domain 250
@@ -435,13 +438,16 @@ Established by mutation, because a test suite's silence is not evidence:
   (The artifacts driver's D2c control remains the pure demonstration, with an opaque
   sibling clause and no bit-level hole; promoting it into `gcs/` is still stage E's job,
   #611.)
-- **The solx retention is defensive on the instances measured, and load-bearing in
-  reach.** Removing the `solution` trigger left talent's proof **byte-identical** (talent
-  windows nothing) and left the small enumerations verifying. It is kept anyway, because
-  "nothing on these instances noticed" is not an argument that a permanent reference to a
-  deleted definition is safe — but it is also what keeps the window from engaging in an
-  enumeration, so its cost is real and stage E should settle it with a measurement rather
-  than inherit the assumption.
+- **A retention that was never needed was masking a rule that was.** The solx hoist-out
+  cost most of the window's reach (removing it took `eq_window_solve_test` from 1–2
+  evictions to 3 — every refuted sibling, not only the solution-free ones), and reading the
+  checker shows it protects nothing. But removing it made 13 tests reject, because it had
+  been incidentally covering the *general* Top-reference rule that was missing: any
+  constraint may define a Top flag over a branched value, and a site list cannot enumerate
+  that. Two lessons, both about the same thing: "the design says this is a permanent
+  reference" is a claim about what the checker stores, and the checker is readable; and a
+  suite that passes because something unrelated is masking a gap will keep passing right up
+  until the unrelated thing changes.
 
 ### Mint-time lifetime tagging (the narrow API) — **as built**
 
@@ -571,29 +577,44 @@ stitches the chain **around** the retained interior ges (the genuine
 wrongly-evicted referenced ge except at a point of use (D4c vs D4c-silent), so this
 is a solver invariant, not something the checker enforces.
 
-**Detection, as built**, is `note_permanent_eq_reference(id, v)`, called at each
-reference site exactly as `note_order_literal_top_pin` is for the ge side —
-`hoist_eq_to_top` is the action, this is the trigger. The sites are the ones that
-put an eq atom into a line that outlives a backtrack:
+**Detection, as built**, is `note_permanent_eq_reference(id, v)` —
+`hoist_eq_to_top` is the action, this is the trigger — and it is **general, not a list
+of sites**. `ProofLogger::note_top_eq_references` runs on every emission funnel that
+renders a sum at a caller-chosen level (`emit`, `emit_under_reason`, and both halves of
+`emit_red_proof_lines_reifying`) and, for a line landing at `ProofLevel::Top`, walks its
+terms and retains every windowed eq atom it names. The eq⨯interval guard below is the
+one bulk case, collapsing a whole window at once.
 
-- **`ProofLogger::solution`** — the `solx` blocking clause and the `soli` witness
-  name `var == val` for *every* variable. This is by far the commonest permanent
-  reference: every solution takes one on each branched variable's current value, so
-  in an enumeration the window retains an atom at each solution rather than evicting
-  it. (A view is deviewed first; the underlying is the variable that can be
-  windowed.)
-- **`ProofLogger::emit_learned_nogood`** — a restart nogood's decision literals,
-  the eq analogue of the existing `NogoodHoist`.
-- The **eq⨯interval** guard below, which collapses a whole window at once rather
-  than one atom at a time.
+**A site list was tried first and is not enough.** The design names three permanent
+references — a solx blocking clause, a learned nogood, "a reified-constraint use that
+names `id == v`" — and only the first two are sites you can enumerate. The third is not:
+*any* constraint may define a Top flag over the values a search branches on, and several
+do — a SmartTable tuple selector is `red 1 i[x[0]][eq0] 1 i[x[1]][eq0] ... 4 ~f[16][sr]
+>= 4` at Top. With only the site list, `smart_table` (8 tests), `tour`,
+`scp_chain_smart_table_sat` and `minizinc-cumulative` all reject.
 
-An eq atom that acquires a permanent reference from anywhere *else* is not detected,
-and would be a stranded reference. That failure is **not silent**, which is what
-makes the enumerated list acceptable rather than a latent hole: the atom keeps its
-`XLiteral` identity across eviction, so a surviving line naming it and a later
-re-introduction collide — the fresh `red`'s falsify-witness against the pin — and
-VeriPB rejects, loudly, at the re-introduction. Contrast the ge/chain-clause leak,
-which really is silent.
+**`solx` / `soli` is deliberately *not* a permanent reference**, though the design lists
+it first. The line names `var == val` for every variable, but the constraint VeriPB
+*keeps* is built from the `preserved:` set alone — the bits — so those atoms are consumed
+while the line is checked and referenced by nothing afterwards. See "What it measures".
+(For a while an incidental hoist here was covering for the missing general rule: it
+protected exactly the atoms that happened to be solution values. That is the shape to
+watch for — a check that passes because something unrelated is masking the gap.)
+
+An eq atom that acquires a permanent reference the general rule cannot see — a line
+emitted as raw text rather than as a sum, say — would be a stranded reference. That
+failure is **not silent**: the atom keeps its `XLiteral` identity across eviction, so a
+surviving line naming it and a later re-introduction collide — the fresh `red`'s
+falsify-witness against the pin — and VeriPB rejects, loudly, at the re-introduction.
+Contrast the ge/chain-clause leak, which really is silent.
+
+**One ordering the hoist-out forced.** `ProofLogger::solution` hoists the objective's
+`id < incumbent` order literal, and hoisting re-stitches the order chain, and those `pol`
+lines take constraint numbers. The `e` line below cites the soli constraint by the
+relative hint `-1`, so *anything* emitted between the two misaddresses it. The hoist
+therefore has to run **before** the `soli` line, not after. It was latent until the window
+made an objective's thresholds deletable — before that the objective's eq atom was
+permanent, which hoisted its thresholds early and left the soli hoist with nothing to do.
 
 ### Bookkeeping mirrors
 

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -480,7 +480,10 @@ Parameter: `ProofOptions::order_encoding_deletion_min_chain` (+ fluent setter), 
 override `GCS_DELETE_ORDER_ENCODING_MIN_CHAIN` (explicit-in-code wins). **`0` = gate
 off = byte-identical to the pre-gate Literals behaviour — the aggressive-testing
 mode: regression runs exercising the deletion machinery MUST set `MIN_CHAIN=0`,
-because tiny test domains never cross a nonzero gate.** The suite passed caps-off
+because tiny test domains never cross a nonzero gate.** A variable with a live eq
+window is exempt from the gate entirely (the `WindowedFrontier` slot): it is a frontier
+variable by construction, and holding its thresholds resident would collapse the window
+back to the baseline. The suite passed caps-off
 flag-ON at gate 0 and at 32 when this landed (525/525 each, 0 flag-induced failures; the
 suite has grown since — the standing gate is "all of it, in each of the three modes",
 not a fixed number). The stats dump

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -371,29 +371,29 @@ frontend proofs.
     frontier advance both live at. Left to the child it would land a level deeper and
     the child's own `forget` would delete it out from under both.
   - **Permanent references are detected at the reference site**
-    (`note_permanent_eq_reference`) and retain the atom rather than evicting it —
-    principally the `solx`/`soli` line, which names `var == val` for *every* variable, so
-    an enumeration retains an atom at each solution. The list of sites is enumerated
-    rather than general, which is acceptable only because getting it wrong is loud: the
-    atom keeps its `XLiteral` across eviction, so a surviving line naming it collides
-    with the re-introduction's `red` witness and VeriPB rejects.
+    (`note_permanent_eq_reference`) and retain the atom rather than evicting it. There is
+    exactly one such site plus the interval guard — a learned nogood's Top clause. A
+    `solx`/`soli` line names `var == val` too, but is **not** one: the constraint VeriPB
+    keeps is built from the `preserved:` set alone (our variables' bits), so those atoms
+    are consumed while the line is checked and referenced by nothing afterwards.
+    The list of sites is enumerated rather than general, which is acceptable only because
+    getting it wrong is loud: the atom keeps its `XLiteral` across eviction, so a
+    surviving line naming it collides with the re-introduction's `red` witness and VeriPB
+    rejects.
 
   **Measured** (figures and method in [brancher-design.md](brancher-design.md), "What it
   measures"): on ascending eq branching over a wide domain the window verifies **2.3× /
-  3.6× / 4.8× faster at domain 250 / 500 / 1000**, a speedup that grows with width — and
+  3.5× / 4.7× faster at domain 250 / 500 / 1000**, a speedup that grows with width — and
   it does so while making the proof **31 % bigger**, which is this mode's SIZE≠TIME point
   in its purest form.
 
   On the eq-heavy *real* instances it does not engage: talent windows **0** eq atoms and
-  crystal_maze **1**, against 3255 on the synthetic. The precondition the design did not
+  crystal_maze **2**, against 3255 on the synthetic. The precondition the design did not
   name is that **the window can only act on an eq atom the branch layer names first**, and
   on a model whose constraints reason per value the propagators have defined those atoms
   permanently long before the search reaches them. Where it cannot engage it now costs
-  nothing (talent's window-on proof is byte-identical to its window-off proof). A second
-  limit is that a `solx` blocking clause retains the atom of every sibling whose subtree
-  held a solution, so the full win needs refutation-heavy search as well. The window
-  therefore ships off, and stage E owns both the default and whether the solx retention is
-  really required.
+  nothing (talent's window-on proof is byte-identical to its window-off proof). The window
+  therefore ships off, and stage E owns whether the default changes.
 - **In progress:** the clean Brancher abstraction (step 2). Stages A, B, B' and B'' have
   landed — the `BranchDecision` / `BacktrackAdvance` types, the split families' bound
   advances, the eviction primitives plus their always-on residency bookkeeping, and the

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -6,7 +6,7 @@ not default.** This note records the design for shrinking the integer
 order-encoding that VeriPB carries, plus the measured outcome and what is and
 isn't yet done. The full Brancher-API refactor (step 2, below) is a **decided design,
 recorded in [brancher-design.md](brancher-design.md), now partly implemented**: its
-stages A, B and B' have landed, B''/C/D/E have not. That note, not this one, is the
+stages A, B, B' and B'' have landed, C/D/E have not. That note, not this one, is the
 authority on the refactor's staging and status. The shipped deletion path still wires
 into the existing branch/backtrack flow via hoisting, and the four-step sketch further
 down this note is superseded by the decided design (see the note at "Design overview"
@@ -297,10 +297,10 @@ frontend proofs.
     threshold pair cost, and the +4.1 % this one costs.
   - **The eq analogue of atom retirement** (`VariableAtoms::retired_eq`,
     `forget_eq_literals_at_level`), so a *deletable* eq definition — which only a windowed
-    variable has, and nothing is windowed yet — retires its atom on backtrack and is
-    re-introduced through `need_direct_encoding_for` with its identity intact. Both ge
-    traps recur verbatim: `eq_defs` keeps its entry and re-introduction must
-    `insert_or_assign`, and the `XLiteral` must be reused rather than re-minted.
+    variable has — retires its atom on backtrack and is re-introduced through
+    `need_direct_encoding_for` with its identity intact. Both ge traps recur verbatim:
+    `eq_defs` keeps its entry and re-introduction must `insert_or_assign`, and the
+    `XLiteral` must be reused rather than re-minted.
 
   **A finding worth carrying forward: VeriPB does not police a leaked chain clause.** A
   chain clause left naming an evicted threshold stays a valid derived constraint, and
@@ -349,14 +349,59 @@ frontend proofs.
   split-branched ones anyway.
 - **`soli` objective atom** is hoisted to Top when the objective-improvement
   constraint is emitted (latent optimisation-mode bug fixed defensively).
-- **In progress:** the clean Brancher abstraction (step 2). Stages A, B and B' have
+- **The eq-atom sliding window (stage B'', opt-in and OFF by default).** The four
+  contiguous eq value orders — `smallest_first`, `largest_first`, `smallest_in`,
+  `largest_in` — used to keep every eq atom they branched on, *and* both of the `ge`
+  thresholds each names, resident at Top forever: O(domain width) per branched variable,
+  and no deletion win at all. Under
+  `ProofOptions::set_order_encoding_deletion_eq_window()` (or
+  `GCS_DELETE_ORDER_ENCODING_EQ_WINDOW=1`) the branch layer instead mints each guess's eq
+  definition **deletable, at the node's own level**, advances a monotone frontier past it
+  once the sibling is refuted, and evicts the atom and the threshold it stepped over
+  behind that frontier — O(1) resident.
+  [brancher-design.md](brancher-design.md) ("The eq-atom window") is the authority; the
+  three things worth knowing here are:
+
+  - **The advance RUPs *through* the eq atom's reverse reification**, which fixes the
+    order of the per-iteration tidy: the definition must not be deleted before the
+    advance is emitted. This is not a guess — the artifacts driver's D2c control deletes
+    it early and VeriPB rejects.
+  - **The atom's definition is minted before the descent, not by the child's
+    propagation**, so it lands at the level the child's backtrack clause and the
+    frontier advance both live at. Left to the child it would land a level deeper and
+    the child's own `forget` would delete it out from under both.
+  - **Permanent references are detected at the reference site**
+    (`note_permanent_eq_reference`) and retain the atom rather than evicting it —
+    principally the `solx`/`soli` line, which names `var == val` for *every* variable, so
+    an enumeration retains an atom at each solution. The list of sites is enumerated
+    rather than general, which is acceptable only because getting it wrong is loud: the
+    atom keeps its `XLiteral` across eviction, so a surviving line naming it collides
+    with the re-introduction's `red` witness and VeriPB rejects.
+
+  **Measured** (figures and method in [brancher-design.md](brancher-design.md), "What it
+  measures"): on ascending eq branching over a wide domain the window verifies **2.3× /
+  3.6× / 4.8× faster at domain 250 / 500 / 1000**, a speedup that grows with width — and
+  it does so while making the proof **31 % bigger**, which is this mode's SIZE≠TIME point
+  in its purest form.
+
+  On the eq-heavy *real* instances it does not engage: talent windows **0** eq atoms and
+  crystal_maze **1**, against 3255 on the synthetic. The precondition the design did not
+  name is that **the window can only act on an eq atom the branch layer names first**, and
+  on a model whose constraints reason per value the propagators have defined those atoms
+  permanently long before the search reaches them. Where it cannot engage it now costs
+  nothing (talent's window-on proof is byte-identical to its window-off proof). A second
+  limit is that a `solx` blocking clause retains the atom of every sibling whose subtree
+  held a solution, so the full win needs refutation-heavy search as well. The window
+  therefore ships off, and stage E owns both the default and whether the solx retention is
+  really required.
+- **In progress:** the clean Brancher abstraction (step 2). Stages A, B, B' and B'' have
   landed — the `BranchDecision` / `BacktrackAdvance` types, the split families' bound
-  advances, and the eviction primitives plus their always-on residency bookkeeping — so
-  the direct guess/eq/aux hoist wiring is on its way out but is still what the shipped
-  path uses. Stages B''/C/D/E remain; [brancher-design.md](brancher-design.md) is the
-  authority on each. Also future: short-reason flag / deview-companion level-scoping
-  (currently inert), and the bridge redesign (deprioritised — step 1b measured it as
-  freeing 0 %).
+  advances, the eviction primitives plus their always-on residency bookkeeping, and the
+  eq-atom window — so the direct guess/eq/aux hoist wiring is on its way out but is still
+  what the shipped path uses. Stages C/D/E remain;
+  [brancher-design.md](brancher-design.md) is the authority on each. Also future:
+  short-reason flag / deview-companion level-scoping (currently inert), and the bridge
+  redesign (deprioritised — step 1b measured it as freeing 0 %).
 
 ## Next steps (prioritised)
 
@@ -390,16 +435,17 @@ builds long chains (seat-moving: median chain 12, max 98, despite maxdom 901), a
 the deletion machinery churns (37 644 deletes / 37 616 reintroductions, net 28) for
 nothing there.
 
-**2. Brancher-API refactor — IN PROGRESS: stages A, B and B' landed; B'' is next.**
+**2. Brancher-API refactor — IN PROGRESS: stages A, B, B' and B'' landed; C is next.**
 The concrete, decided step-2 design and its staging live in
 [brancher-design.md](brancher-design.md), which is the authority on what is done and
 what each remaining stage owes. In summary: **A** added the `BranchDecision` /
 `BacktrackAdvance` types and ported every value order (byte-identical); **B** wired the
 split families' bound advances and the advance-RUP-driven deletion; **B'** added the
 always-on residency bookkeeping and the evict/hoist primitives the eq window and the
-objective `delc` both need (behaviour-neutral — nothing calls them yet). Remaining:
-**B''** the eq-atom window, **C** the objective/frontier exemption, **D** the
-objective-improvement `delc` + Top-eviction, **E** benchmark and cleanup. The design
+objective `delc` both need (behaviour-neutral); **B''** built the eq-atom window on
+them, opt-in and off by default. Remaining: **C** the objective/frontier exemption,
+**D** the objective-improvement `delc` + Top-eviction, **E** benchmark and cleanup —
+including whether the window becomes the default for `smallest_first`. The design
 generalises consolidate-then-delete,
 tidies the current direct wiring, and is the natural home for the chain-gated
 deletion policy, the objective-variable exemption (from 2b, below), and the

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -558,6 +558,24 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(order_evict_test PRIVATE glasgow_constraint_solver)
     add_test(NAME order_evict_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:order_evict_test>)
 
+    add_executable(eq_window_test innards/proofs/eq_window_test.cc)
+    target_link_libraries(eq_window_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME eq_window_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eq_window_test>)
+
+    # One entry per (contiguous eq value order, model): each enumerates with all four orders
+    # over both models and compares the counts, and writes the VeriPB-checked proof for its
+    # own pair, so every windowed proof shape -- ascending and descending, full d-way and
+    # complement-sibling, window-engaging and window-inert -- is covered. Distinct basenames
+    # because a parallel ctest would otherwise race over one set of proof files (issue #562).
+    add_executable(eq_window_solve_test innards/proofs/eq_window_solve_test.cc)
+    target_link_libraries(eq_window_solve_test PRIVATE glasgow_constraint_solver)
+    foreach(order smallest_first largest_first smallest_in largest_in)
+        foreach(model bounds holes)
+            add_test(NAME eq_window_solve_${order}_${model}_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash
+                --basename eq_window_solve_${order}_${model}_test $<TARGET_FILE:eq_window_solve_test> --order ${order} --model ${model})
+        endforeach()
+    endforeach()
+
     add_executable(range_branch_test innards/proofs/range_branch_test.cc)
     target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
     add_test(NAME range_branch_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)

--- a/gcs/innards/proofs/eq_window_solve_test.cc
+++ b/gcs/innards/proofs/eq_window_solve_test.cc
@@ -1,0 +1,188 @@
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/equals.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+
+using std::cerr;
+using std::getline;
+using std::ifstream;
+using std::nullopt;
+using std::optional;
+using std::string;
+using std::vector;
+
+// The eq-atom window (dev_docs/brancher-design.md) driven by a real search rather than by
+// the proof API directly: a small enumeration branched with the four contiguous eq value
+// orders, so the window's advance and per-iteration tidy are emitted from solve.cc's own
+// loop, over eq atoms that propagation is naming and reasoning about at the same time.
+// eq_window_test drives the mechanism in isolation and asserts the residency invariant;
+// this one checks it survives contact with the solver -- interleaved propagation, holes
+// left in domains by earlier decisions, solutions taking permanent references to the eq
+// atoms the window would otherwise evict, and the node-close lemma still being RUP once the
+// window has deleted the sibling clauses it subsumes.
+//
+// Every run enumerates with all four orders and compares the counts, so a window that lost
+// or invented a solution fails whichever entry runs; one of the four writes the proof
+// VeriPB then checks, chosen by --order, so all four proof shapes are covered across the
+// registered ctest entries. The descending pair matter especially: they are the UpperBound
+// mirror, which the hand-authored driver never covered.
+//
+// The mode, the chain gate and the window are set in code: at the shipped defaults (window
+// off, gate 16) this would exercise nothing at all.
+namespace
+{
+    auto value_order_named(const string & name) -> optional<BranchValueGenerator>
+    {
+        if (name == "smallest_first")
+            return value_order::smallest_first();
+        if (name == "largest_first")
+            return value_order::largest_first();
+        if (name == "smallest_in")
+            return value_order::smallest_in();
+        if (name == "largest_in")
+            return value_order::largest_in();
+        return nullopt;
+    }
+
+    auto run(const string & order_name, bool bounds_only, const optional<string> & proof_basename) -> long long
+    {
+        Problem p;
+        auto x = p.create_integer_variable(0_i, 6_i, "x");
+        auto y = p.create_integer_variable(0_i, 6_i, "y");
+        auto z = p.create_integer_variable(0_i, 6_i, "z");
+        // Two models, because the window's behaviour splits on one thing: whether the branch
+        // layer is the first to name a value's eq atom.
+        //
+        //  - **bounds_only** -- a linear equality with awkward coefficients, plus an
+        //    ordering. Both reason in `ge` thresholds and never name an eq atom, and the
+        //    linear propagator is far too weak to see which values fail, so the search
+        //    genuinely refutes values and every guess mints its own eq atom, windowed. This
+        //    is the model whose advances and tidies get VeriPB-checked.
+        //  - **otherwise** -- the same plus NotEquals, whose per-value pruning names eq atoms
+        //    itself, permanently, before the search ever branches on them. The window then
+        //    engages barely or not at all, and must cost nothing rather than emit advances it
+        //    can never tidy behind. This is the eq-heavy real-instance shape (talent windows
+        //    nothing at all), and it is here to be sure that path stays correct.
+        p.post(LinearEquality{WeightedSum{} + 2_i * x + 3_i * y + 5_i * z, 31_i});
+        p.post(LessThan{x, y});
+        p.post(LessThan{y, z});
+        if (! bounds_only)
+            p.post(NotEquals{x, z});
+
+        // Fixed variable order, so the solution count is compared against orders that
+        // differ only in how they pick values.
+        auto branch = branch_with(variable_order::in_order(vector<IntegerVariableID>{x, y, z}), *value_order_named(order_name));
+
+        long long solutions = 0;
+        optional<ProofOptions> options;
+        if (proof_basename) {
+            options.emplace(*proof_basename);
+            options->set_order_encoding_deletion(OrderEncodingDeletion::Literals)
+                .set_order_encoding_deletion_min_chain(0)
+                .set_order_encoding_deletion_eq_window();
+        }
+
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               ++solutions;
+                               return true;
+                           },
+                .branch = branch},
+            options);
+
+        return solutions;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    // A hand-rolled parse rather than cxxopts, matching the other gcs innards tests, which
+    // are run by run_test_and_verify.bash and take no other options. --prove and
+    // --proof-files-basename are what that script passes.
+    bool prove = false;
+    string basename = "eq_window_solve_test";
+    string proof_order = "smallest_first";
+    string proof_model = "bounds";
+    for (int arg = 1; arg < argc; ++arg) {
+        string a{argv[arg]};
+        if (a == "--prove")
+            prove = true;
+        else if (a == "--proof-files-basename" && arg + 1 < argc)
+            basename = argv[++arg];
+        else if (a == "--order" && arg + 1 < argc)
+            proof_order = argv[++arg];
+        else if (a == "--model" && arg + 1 < argc)
+            proof_model = argv[++arg];
+        else {
+            cerr << "unrecognised argument '" << a << "'\n";
+            return 1;
+        }
+    }
+
+    if (! value_order_named(proof_order)) {
+        cerr << "unrecognised value order '" << proof_order << "'\n";
+        return 1;
+    }
+    if (proof_model != "bounds" && proof_model != "holes") {
+        cerr << "unrecognised model '" << proof_model << "'\n";
+        return 1;
+    }
+
+    int rc = 0;
+    for (bool bounds_only : {true, false}) {
+        optional<long long> expected;
+        for (const auto & order : {"smallest_first", "largest_first", "smallest_in", "largest_in"}) {
+            // Exactly one (order, model) pair writes the proof this run:
+            // run_test_and_verify.bash checks one pair of files, and eight proofs of the same
+            // enumerations would leave seven of them unchecked on disk.
+            bool writes_proof = prove && order == proof_order && bounds_only == (proof_model == "bounds");
+            auto solutions = run(order, bounds_only, writes_proof ? optional<string>{basename} : nullopt);
+            if (! expected)
+                expected = solutions;
+            else if (*expected != solutions) {
+                cerr << "eq window changed the solution count: " << order << " found " << solutions << ", expected " << *expected << "\n";
+                rc = 1;
+            }
+        }
+
+        // The exact count does not matter, but a model that found nothing would be checking
+        // nothing.
+        if (! expected || *expected == 0) {
+            cerr << "eq window solve test found no solutions at all (bounds_only=" << bounds_only << ")\n";
+            rc = 1;
+        }
+    }
+
+    // A window that quietly stopped windowing anything would still enumerate correctly and
+    // still verify -- it would simply be the baseline. So check the proof this run actually
+    // wrote contains the window's advances. Only the full d-way orders emit them: the `_in`
+    // pair's single tidiable step is the complement-sibling shape the window deliberately
+    // skips (see dev_docs/brancher-design.md), and the `holes` model deliberately windows
+    // nothing, so for those there is nothing to count and the coverage they carry is that
+    // their proofs verify at all.
+    if (prove && proof_model == "bounds" && (proof_order == "smallest_first" || proof_order == "largest_first")) {
+        ifstream proof{basename + ".pbp"};
+        long long advances = 0;
+        for (string line; getline(proof, line);)
+            if (line.find("% eq window advance") != string::npos)
+                ++advances;
+        if (advances == 0) {
+            cerr << "no eq window advance in " << basename << ".pbp: the window did not fire, so this run checked nothing"
+                 << " (fix the window, do not drop this check)\n";
+            rc = 1;
+        }
+    }
+
+    return rc;
+}

--- a/gcs/innards/proofs/eq_window_test.cc
+++ b/gcs/innards/proofs/eq_window_test.cc
@@ -1,0 +1,217 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <iostream>
+#include <optional>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::cerr;
+using std::nullopt;
+using std::vector;
+
+// Driver for the stage-B'' eq-atom sliding window (dev_docs/brancher-design.md, "The
+// eq-atom window"), run through the production entry points -- mint_windowed_eq_guess,
+// backtrack, emit_eq_window_advance -- rather than a hand-written proof, so what VeriPB
+// checks here is the solver's own emission. The mode, the chain gate and the window are set
+// in code, so the test does not depend on GCS_DELETE_ORDER_ENCODING* being set, and in
+// particular runs at gate 0 (the shipped default of 16 would hide the whole thing: no
+// variable here names 17 thresholds) and with a window that ships off by default.
+//
+// Each scenario replays what solve.cc does around one branching node: mint the guess's eq
+// definition at the node's level, descend a level and come back, emit the refuted child's
+// backtrack clause, then advance the frontier and tidy. What that has to get right, and
+// what fails if it does not:
+//
+//  - **The advance RUPs through the eq atom's reverse reification.** That is the whole
+//    mechanism, and it is why the tidy deletes in the order it does; deleting the
+//    definition before the advance is what driver control D2c
+//    (order-encoding-deletion-artifacts/eq-window) shows VeriPB rejecting.
+//  - **No double deletion.** The tidy `del`s the superseded advance, the sibling clause and
+//    the definition lines, and the level they sat at is eventually forgotten -- which emits
+//    a bare `del id` for a bucket interval of length one. VeriPB errors on a `del id`
+//    naming an already-deleted line, so anything the tidy deleted without dropping from its
+//    bucket rejects here.
+//  - **Re-introduction after eviction.** An evicted atom is re-minted and used again, which
+//    emits a fresh `red` against the bits -- the step that fails if something the eviction
+//    should have removed is still in the database in a form the witness cannot satisfy.
+//  - **The hoist-out rule.** An eq atom that acquires a permanent reference is retained
+//    rather than evicted, and is then named by a Top line across a forget of the window's
+//    level. That only checks out if the two ge thresholds it names went to Top with it.
+//
+// And what it checks in C++ instead, because VeriPB *cannot*: the window's actual claim,
+// that a branched variable's resident eq and ge definitions stay O(1) rather than growing
+// with the domain it is stepping through. A window that quietly stopped evicting would
+// still verify -- it would simply be the baseline again -- so the counts are asserted at
+// every step, against bounds a baseline run overshoots on the second iteration.
+auto main() -> int
+{
+    ProofOptions proof_options{"eq_window_test"};
+    proof_options.set_order_encoding_deletion(OrderEncodingDeletion::Literals)
+        .set_order_encoding_deletion_min_chain(0)
+        .set_order_encoding_deletion_eq_window();
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+
+    // One variable per scenario, each with its own guard variable, so the scenarios cannot
+    // perturb each other's chains. A guard is [0..3] rather than [0..1] so it gets the
+    // ordinary bits encoding (a {0,1} variable is direct-only, and carries no order cuts).
+    SimpleIntegerVariableID x{0}, gx{1}, y{2}, gy{3}, w{4}, gw{5}, z{6}, gz{7};
+    model.set_up_integer_variable(x, 0_i, 15_i, "x", nullopt);
+    model.set_up_integer_variable(gx, 0_i, 3_i, "gx", nullopt);
+    model.set_up_integer_variable(y, 0_i, 15_i, "y", nullopt);
+    model.set_up_integer_variable(gy, 0_i, 3_i, "gy", nullopt);
+    model.set_up_integer_variable(w, 0_i, 15_i, "w", nullopt);
+    model.set_up_integer_variable(gw, 0_i, 3_i, "gw", nullopt);
+    model.set_up_integer_variable(z, 0_i, 15_i, "z", nullopt);
+    model.set_up_integer_variable(gz, 0_i, 3_i, "gz", nullopt);
+
+    // The guard is what makes each guess genuinely refutable, so the sibling clause the
+    // window's tidy deletes is a real RUP rather than something asserted for the test:
+    // `g >= 1` forces the branched variable into the half its guesses are not in.
+    // Ascending variables: g >= 1 => var >= 8, so var == 0..7 are all refuted.
+    model.add_constraint(WPBSum{} + 8_i * gx + -1_i * x <= 0_i);
+    model.add_constraint(WPBSum{} + 8_i * gw + -1_i * w <= 0_i);
+    model.add_constraint(WPBSum{} + 8_i * gz + -1_i * z <= 0_i);
+    // Descending: g >= 1 => var <= 7, so var == 15..8 are all refuted.
+    model.add_constraint(WPBSum{} + 1_i * y + 8_i * gy <= 15_i);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    int rc = 0;
+    // Name every check: these assert an invariant the proof cannot show, so a bare exit
+    // code would leave a failure undiagnosable -- and the fix for any of them is in the
+    // window, never in the bound written here.
+    auto check = [&](bool ok, const char * what) {
+        if (! ok) {
+            cerr << "eq window invariant broken: " << what << " (fix the window, do not relax the check)\n";
+            rc = 1;
+        }
+    };
+
+    // One branching node at proof level 2, under an outer guess made at level 1, exactly as
+    // solve.cc lays it out: a frame at depth d runs its branch loop at level d+1, and its
+    // children close by re-entering level d+1 to emit their backtrack clause before
+    // forgetting level d+2.
+    auto refute_sibling = [&](const Literal & outer, const Literal & guess) {
+        logger.mint_windowed_eq_guess(guess);
+        logger.enter_proof_level(3);
+        logger.enter_proof_level(2);
+        logger.backtrack(vector<Literal>{outer, guess});
+        logger.forget_proof_level(3);
+    };
+
+    // ---- x: the ascending window (smallest_first / smallest_in) ----
+    logger.enter_proof_level(1);
+    Literal outer_x{gx >= 1_i};
+    logger.enter_proof_level(2);
+    for (Integer v = 0_i; v <= 6_i; ++v) {
+        refute_sibling(outer_x, x == v);
+        // The atom is windowed while the step is in flight: one live windowed definition,
+        // never a second.
+        check(tracker.live_windowed_eq_count(x) == 1, "x: the step's eq definition is not windowed");
+        logger.emit_eq_window_advance(vector<Literal>{outer_x}, x == v, /*lower=*/true);
+        // ... and the step's tidy took it out again. This is the assertion a window that
+        // stopped evicting fails: the baseline keeps every eq definition it ever mints.
+        check(tracker.live_windowed_eq_count(x) == 0, "x: the tidy did not evict the stepped-over eq definition");
+        // The steady state the design targets: the boundary ge(0), the frontier ge(v+1),
+        // and nothing else growing with v. ge(v)'s eviction is what keeps this flat -- a
+        // baseline run is at v + 2 by now.
+        check(tracker.live_order_literal_count(x) <= 3, "x: resident ge count is growing with the domain, not O(1)");
+    }
+    // Re-introduction: the last refuted value is named again, and re-mints cleanly because
+    // the tidy left nothing behind that references it.
+    tracker.need_direct_encoding_for(x, 6_i);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (x != 6_i) + 1_i * (x >= 6_i) >= 1_i, ProofLevel::Current);
+    logger.enter_proof_level(1);
+    logger.forget_proof_level(2);
+
+    // ---- y: the descending window (largest_first / largest_in), the UpperBound mirror ----
+    // Never exercised by the hand-authored driver, which only covered the ascending
+    // direction: here the frontier runs the other way, the advance is `y < v` rather than
+    // `y >= v+1`, and the threshold stepped over is ge(v+1) rather than ge(v).
+    Literal outer_y{gy >= 1_i};
+    logger.enter_proof_level(2);
+    for (Integer v = 15_i; v >= 9_i; --v) {
+        refute_sibling(outer_y, y == v);
+        check(tracker.live_windowed_eq_count(y) == 1, "y (descending): the step's eq definition is not windowed");
+        logger.emit_eq_window_advance(vector<Literal>{outer_y}, y == v, /*lower=*/false);
+        check(tracker.live_windowed_eq_count(y) == 0, "y (descending): the tidy did not evict the stepped-over eq definition");
+        check(tracker.live_order_literal_count(y) <= 3, "y (descending): resident ge count is growing with the domain, not O(1)");
+    }
+    logger.enter_proof_level(1);
+    logger.forget_proof_level(2);
+
+    // ---- w: the hoist-out rule ----
+    // An eq atom that acquires a permanent (Top) reference -- here the solx/nogood shape,
+    // a Top clause naming `w == 2` -- must be retained rather than evicted when the window
+    // steps past it, together with the two ge thresholds its definition names.
+    Literal outer_w{gw >= 1_i};
+    logger.enter_proof_level(2);
+    refute_sibling(outer_w, w == 2_i);
+    auto w2 = tracker.xliteral_for(w == 2_i);
+    check(tracker.live_windowed_eq_count(w) == 1, "w: the guess mint did not window the eq definition");
+    // The reference is detected at the reference site, before the Top line is emitted.
+    tracker.note_permanent_eq_reference(w, 2_i);
+    check(tracker.live_windowed_eq_count(w) == 0, "w: a permanent reference did not take the atom out of the window");
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (w != 2_i) + 1_i * (w >= 2_i) >= 1_i, ProofLevel::Top);
+    // The window steps on regardless; its tidy must leave the retained atom alone.
+    logger.emit_eq_window_advance(vector<Literal>{outer_w}, w == 2_i, /*lower=*/true);
+    check(tracker.xliteral_for(w == 2_i) == w2, "w: the tidy evicted a retained atom");
+
+    refute_sibling(outer_w, w == 3_i);
+    logger.emit_eq_window_advance(vector<Literal>{outer_w}, w == 3_i, /*lower=*/true);
+    logger.enter_proof_level(1);
+    logger.forget_proof_level(2);
+
+    // The retained atom survived the forget, and so must the two thresholds its definition
+    // names: this is the discriminating half. Had the hoist-out left them deletable, the
+    // forget would have deleted them under the surviving Top definition, and re-introducing
+    // them here would emit a `red` that definition's clause refutes.
+    check(tracker.xliteral_for(w == 2_i) == w2, "w: the retained atom did not survive the forget");
+    tracker.need_gevar(w, 2_i);
+    tracker.need_gevar(w, 3_i);
+    logger.enter_proof_level(2);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (w != 2_i) + 1_i * (w < 3_i) >= 1_i, ProofLevel::Current);
+    logger.enter_proof_level(1);
+    logger.forget_proof_level(2);
+
+    // ---- z: the (i-dynamic) half of the eq-by-interval guard ----
+    // An interval literal requested mid-search on a windowed variable makes the partition
+    // machinery name every one of its eq atoms from Top lines. The window has to collapse
+    // first -- every live windowed definition hoisted out to Top -- or those Top lines
+    // would name definitions the next backtrack deletes.
+    Literal outer_z{gz >= 1_i};
+    logger.enter_proof_level(2);
+    refute_sibling(outer_z, z == 4_i);
+    auto z4 = tracker.xliteral_for(z == 4_i);
+    check(tracker.live_windowed_eq_count(z) == 1, "z: the guess mint did not window the eq definition");
+    [[maybe_unused]] auto in_lit = tracker.need_invar(z, 4_i, 9_i);
+    check(tracker.live_windowed_eq_count(z) == 0, "z: an interval request did not collapse the live window");
+    // And the variable stays unwindowed: a later guess mint on it gets a permanent
+    // definition, so the partition can never be left naming a deletable one.
+    logger.mint_windowed_eq_guess(z == 5_i);
+    check(tracker.live_windowed_eq_count(z) == 0, "z: a variable with an interval partition was windowed again");
+    logger.enter_proof_level(1);
+    logger.forget_proof_level(2);
+    // Both atoms outlived the forget, which they only do if the collapse made them
+    // permanent.
+    check(tracker.xliteral_for(z == 4_i) == z4, "z: the collapsed window's atom did not survive the forget");
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (z != 4_i) + 1_i * (z >= 4_i) >= 1_i, ProofLevel::Current);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (z != 5_i) + 1_i * (z >= 5_i) >= 1_i, ProofLevel::Current);
+
+    logger.enter_proof_level(0);
+    logger.conclude_none();
+    tracker.finalise();
+
+    return rc;
+}

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -402,6 +402,20 @@ struct NamesAndIDsTracker::Imp
     // reason (a level-0 entry would be a permanent def).
     map<SimpleIntegerVariableID, map<Integer, int>> live_eq_literals;
     map<int, vector<pair<SimpleIntegerVariableID, Integer>>> eq_literals_by_level;
+    // Set by a NamesAndIDsTracker::WindowedEqScope, for the duration of one guess mint in
+    // the branch layer: the eq atom need_direct_encoding_for is about to define belongs to
+    // a frontier, and wants a deletable (Current) definition rather than a permanent one.
+    // Every other caller runs with this clear and is oblivious to lifetimes.
+    bool minting_windowed_eq = false;
+    // Real variables that have had at least one windowed eq definition and have not since
+    // had their window collapsed by the eq-by-interval guard. This is the design's
+    // **WindowedFrontier** residency slot: such a variable is a frontier variable by
+    // construction, so the chain-length gate must not hold its interior ge definitions
+    // resident at Top -- that would degenerate the window to the baseline, every eq atom
+    // permanent and O(width) again. Checked in need_gevar ABOVE the gate but BELOW the
+    // structural pins (boundary / aux / view), which keep their absolute priority: a
+    // literal resident for a structural reason is resident whatever branches on it.
+    std::set<SimpleIntegerVariableID> windowed_eq_variables;
     // The chain-link and stitch clauses currently present in the proof: the threshold pair
     // each links and its proof line, bucketed by the level it sits at and then by variable.
     // The same pair can appear more than once -- a hoist re-stitches a pair whose deeper
@@ -459,7 +473,8 @@ struct NamesAndIDsTracker::Imp
     map<SimpleIntegerVariableID, map<Integer, optional<OrderEncodingResidencyCause>>> stats_ge_top_cause;
     // Event counters.
     long long stats_deletes = 0;                                    // literals dropped by forget_order_literals_at_level.
-    long long stats_evictions = 0;                                  // literals taken out on demand by evict_order_literal.
+    long long stats_evictions = 0;                                  // ge literals taken out on demand by evict_order_literal.
+    long long stats_eq_evictions = 0;                               // windowed eq definitions taken out by evict_eq_literal.
     long long stats_stitches = 0;                                   // forget-path skip-link emissions (emit_order_stitch).
     long long stats_reintroductions = 0;                            // ge definitions re-introduced after deletion.
     long long stats_dup_top_stitches = 0;                           // Top-level stitch clauses re-emitted for an already-linked pair.
@@ -813,7 +828,7 @@ auto NamesAndIDsTracker::track_eqvar(
     _imp->atoms_for(id).eq_defs.try_emplace(val.raw_value, names);
 }
 
-auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID id, Integer v, EqAtomResidency residency) -> void
+auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void
 {
     if (_imp->find_condition(id == v))
         return;
@@ -822,8 +837,8 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     // exist at all -- the Literals mode, at proof-writing time, with assertions off, for a
     // real variable -- and the request is ignored, leaving the definition permanent,
     // anywhere else.
-    bool windowed = residency == EqAtomResidency::Windowed && _imp->order_link_deletion_mode == OrderEncodingDeletion::Literals &&
-        _imp->logger != nullptr && _imp->assertion_level == AssertionLevel::Off && std::holds_alternative<SimpleIntegerVariableID>(id);
+    bool windowed = _imp->minting_windowed_eq && _imp->order_link_deletion_mode == OrderEncodingDeletion::Literals && _imp->logger != nullptr &&
+        _imp->assertion_level == AssertionLevel::Off && std::holds_alternative<SimpleIntegerVariableID>(id);
 
     // The (i-static) half of the eq-by-interval guard (dev_docs/brancher-design.md, "The
     // one hidden pin"): a variable with an interval partition retro-pins its eq atoms as
@@ -831,10 +846,16 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     // edges, so a deletable definition there would leave a Top line naming a literal a
     // backtrack deletes. Refuse to window such a variable: its eq atoms stay permanent,
     // which is correct and merely wins nothing. The dynamic half -- collapsing a live
-    // window when an interval is first requested on it mid-search -- belongs with the
-    // window itself, in stage B''.
+    // window when an interval is first requested on a windowed variable mid-search -- is
+    // collapse_eq_window, called from the two paths that build those structures.
     if (windowed && (_imp->interval_partitions.contains(id) || _imp->containment_trees.contains(id)))
         windowed = false;
+
+    // Mark the variable as windowed BEFORE the definition is emitted, because emitting it
+    // is what mints the two ge thresholds it names, and need_gevar's WindowedFrontier slot
+    // reads this mark to keep them deletable through the chain gate.
+    if (windowed)
+        _imp->windowed_eq_variables.insert(std::get<SimpleIntegerVariableID>(id));
 
     // Take a retired XLiteral back if this atom is being re-introduced after a backtrack
     // deleted a windowed definition, so the atom keeps its identity and its PB name across
@@ -1149,7 +1170,17 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         // residency priority: a boundary/aux/view literal is resident for its own
         // structural reason regardless of chain length, so this only fires for an
         // otherwise-deletable interior literal.
-        if (def_at_current && _imp->order_encoding_deletion_min_chain > 0) {
+        //
+        // ... and the **WindowedFrontier** slot sits between the two: a variable with a
+        // live eq window is a frontier variable by construction, so the gate must not hold
+        // its interior ges resident -- the window would degenerate to the baseline, with
+        // every threshold permanent and O(width) again. It ranks below the structural pins
+        // (which have already decided the matter above) and above the gate, exactly as the
+        // design's residency ladder specifies; stage C's FrontierExempt ("resident despite
+        // being frontier") is its sibling and opposite, and the two never apply to the same
+        // variable.
+        bool windowed_frontier = _imp->windowed_eq_variables.contains(std::get<SimpleIntegerVariableID>(id));
+        if (def_at_current && ! windowed_frontier && _imp->order_encoding_deletion_min_chain > 0) {
             const auto * atoms = _imp->find_atoms(id);
             long long ever_named = atoms ? static_cast<long long>(atoms->ge_defs.size()) : 0;
             if (ever_named <= _imp->order_encoding_deletion_min_chain)
@@ -2229,6 +2260,135 @@ auto NamesAndIDsTracker::hoist_eq_to_top(const SimpleIntegerVariableID & id, Int
     hoist_ges_named_by_top_atom(key, v, v + 1_i, OrderEncodingResidencyCause::EqHoist);
 }
 
+NamesAndIDsTracker::WindowedEqScope::WindowedEqScope(NamesAndIDsTracker & tracker) : _tracker(tracker), _saved(tracker._imp->minting_windowed_eq)
+{
+    _tracker._imp->minting_windowed_eq = true;
+}
+
+NamesAndIDsTracker::WindowedEqScope::~WindowedEqScope()
+{
+    _tracker._imp->minting_windowed_eq = _saved;
+}
+
+auto NamesAndIDsTracker::note_permanent_eq_reference(const SimpleIntegerVariableID & id, Integer v) -> void
+{
+    // Cheap enough to call unconditionally from every permanent-reference site: the mode
+    // check rules out every proof that has no window at all, and live_eq_literals is empty
+    // unless something is windowed right now.
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger || _imp->live_eq_literals.empty())
+        return;
+
+    hoist_eq_to_top(id, v);
+}
+
+auto NamesAndIDsTracker::evict_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> bool
+{
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+        throw ProofError{"evict_eq_literal requires OrderEncodingDeletion::Literals"};
+    if (! _imp->logger)
+        throw ProofError{"evict_eq_literal requires the logger to be attached"};
+
+    // Not a live windowed definition: permanent (every eq atom outside a window), already
+    // hoisted out by the hoist-out rule, or already gone. All three are refusals rather
+    // than errors -- the atom simply stays where it is.
+    auto live_it = _imp->live_eq_literals.find(id);
+    if (live_it == _imp->live_eq_literals.end())
+        return false;
+    auto lvl_it = live_it->second.find(v);
+    if (lvl_it == live_it->second.end())
+        return false;
+    int level = lvl_it->second;
+
+    // Delete the definition's two reification lines. A DirectOnly {0,1} variable's eq entry
+    // holds XLiterals rather than line numbers (track_eqvar), filtered out exactly as the
+    // hoist filters them.
+    SimpleOrProofOnlyIntegerVariableID key{id};
+    auto & defs = _imp->atoms_for(key).eq_defs.at(v.raw_value);
+    vector<ProofLine> def_lines;
+    if (auto p = std::get_if<ProofLine>(&defs.first))
+        def_lines.push_back(*p);
+    if (auto p = std::get_if<ProofLine>(&defs.second))
+        def_lines.push_back(*p);
+    _imp->logger->delete_proof_lines_at_level(def_lines, level);
+
+    // Drop it from the level's deletion index as well as the live set: a re-introduction at
+    // the same level would otherwise be double-indexed there, and the eventual forget of
+    // that level would `del id` an already-deleted line, which VeriPB errors on.
+    auto & bucket = _imp->eq_literals_by_level[level];
+    std::erase_if(bucket, [&](const pair<SimpleIntegerVariableID, Integer> & e) { return e.first.index == id.index && e.second == v; });
+    live_it->second.erase(lvl_it);
+    if (live_it->second.empty())
+        _imp->live_eq_literals.erase(live_it);
+
+    // Retire the atom, for the same reason the ge side does: with it out of the lookup
+    // table find_condition stops answering, so the only route back to the literal is
+    // need_direct_encoding_for, which re-introduces the definition first and takes the
+    // retired XLiteral back, keeping identity and PB name stable across the cycle. eq_defs
+    // deliberately keeps its now-stale entry, overwritten on re-introduction, because
+    // need_pol_item_defining_literal resolves pol operands through it.
+    auto & atoms = _imp->atoms_for(key);
+    if (auto atom = atoms.eq.find(v.raw_value); atom != atoms.eq.end()) {
+        atoms.retired_eq.insert_or_assign(v.raw_value, atom->second);
+        atoms.eq.erase(atom);
+    }
+
+    if (_imp->collect_order_encoding_stats)
+        ++_imp->stats_eq_evictions;
+
+    return true;
+}
+
+auto NamesAndIDsTracker::collapse_eq_window(const SimpleOrProofOnlyIntegerVariableID & id) -> void
+{
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger)
+        return;
+    const auto * sid_ptr = std::get_if<SimpleIntegerVariableID>(&id);
+    if (! sid_ptr)
+        return;
+
+    // Unwindow first, unconditionally: a variable whose interval machinery has been built
+    // must never be windowed again, even if it happens to have no live definition right now
+    // (the static half of the guard covers a first request, this covers every later one).
+    _imp->windowed_eq_variables.erase(*sid_ptr);
+
+    auto live_it = _imp->live_eq_literals.find(*sid_ptr);
+    if (live_it == _imp->live_eq_literals.end())
+        return;
+
+    // Copy the thresholds out: hoist_eq_to_top erases from the very map being walked, and
+    // takes the whole entry with the last one.
+    vector<Integer> windowed;
+    windowed.reserve(live_it->second.size());
+    for (const auto & [v, _] : live_it->second)
+        windowed.push_back(v);
+    for (auto v : windowed)
+        hoist_eq_to_top(*sid_ptr, v);
+}
+
+auto NamesAndIDsTracker::live_windowed_eq_count(const SimpleIntegerVariableID & id) const -> long long
+{
+    auto it = _imp->live_eq_literals.find(id);
+    return it == _imp->live_eq_literals.end() ? 0 : static_cast<long long>(it->second.size());
+}
+
+auto NamesAndIDsTracker::live_order_literal_count(const SimpleIntegerVariableID & id) const -> long long
+{
+    auto it = _imp->live_order_literals.find(id);
+    return it == _imp->live_order_literals.end() ? 0 : static_cast<long long>(it->second.size());
+}
+
+auto NamesAndIDsTracker::order_literal_is_live(const SimpleIntegerVariableID & id, Integer v) const -> bool
+{
+    auto it = _imp->live_order_literals.find(id);
+    return it != _imp->live_order_literals.end() && it->second.contains(v);
+}
+
+auto NamesAndIDsTracker::eq_literal_is_windowed(const SimpleIntegerVariableID & id, Integer v) const -> bool
+{
+    auto it = _imp->live_eq_literals.find(id);
+    return it != _imp->live_eq_literals.end() && it->second.contains(v);
+}
+
 auto NamesAndIDsTracker::stats_note_ge_recorded(const SimpleIntegerVariableID & id, Integer v, optional<OrderEncodingResidencyCause> born_cause)
     -> void
 {
@@ -2367,6 +2527,7 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     emit("events:");
     emit(format("  deletes: {}", _imp->stats_deletes));
     emit(format("  evictions: {}", _imp->stats_evictions));
+    emit(format("  eq_evictions: {}", _imp->stats_eq_evictions));
     emit(format("  stitches (forget-path): {}", _imp->stats_stitches));
     emit(format("  reintroductions: {}", _imp->stats_reintroductions));
     emit(format("  duplicate-Top-stitches: {}", _imp->stats_dup_top_stitches));
@@ -2487,6 +2648,9 @@ auto NamesAndIDsTracker::define_plain_invar(SimpleOrProofOnlyIntegerVariableID i
     // variable's first range literal creates its containment tree, seeded with
     // the eq atoms that already exist.
     if (! _imp->containment_trees.contains(id)) {
+        // (i-dynamic): the seeding below names every existing eq atom from Top containment
+        // edges, so any windowed definition among them has to become permanent first.
+        collapse_eq_window(id);
         auto & tree = _imp->containment_trees[id];
         if (const auto * atoms = _imp->find_atoms(id))
             for (const auto & [v, _] : atoms->eq_defs)
@@ -2549,6 +2713,12 @@ auto NamesAndIDsTracker::init_interval_partition(SimpleOrProofOnlyIntegerVariabl
 {
     if (_imp->logger->get_assertion_level() > AssertionLevel::Links)
         return;
+
+    // (i-dynamic): every pre-existing eq atom is about to become a Top partition singleton
+    // cell naming its definition, so a windowed (Current) definition among them has to
+    // become permanent before the partition is built -- and the variable must not be
+    // windowed again afterwards.
+    collapse_eq_window(id);
 
     auto [lb, ub] = _imp->integer_variable_definition_bounds.at(id);
     auto & boundaries = _imp->interval_partitions[id];

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -61,29 +61,6 @@ namespace gcs::innards
     };
 
     /**
-     * How long an eq atom's definition is meant to live, under
-     * OrderEncodingDeletion::Literals.
-     *
-     * `Permanent` is what every caller in the solver asks for (and the only thing any
-     * other mode can give): the definition lands at ProofLevel::Top, outlives every
-     * backtrack, and pins the two `ge` thresholds it names at Top with it.
-     *
-     * `Windowed` lands the definition at ProofLevel::Current instead, so a backtrack
-     * deletes it and retires the atom, and leaves the two `ge` thresholds it names
-     * deletable. It is the eq-atom window's residency (dev_docs/brancher-design.md, "The
-     * eq-atom window"): only the frontier owner may ask for it, because a windowed atom
-     * must not be named by any surviving Top line. Nothing in the solver asks for it yet
-     * -- the window itself is stage B'' -- so it exists here to give the stage-B'
-     * primitives (hoist_eq_to_top, the eq forget sweep) a producer to be checked
-     * against.
-     */
-    enum class EqAtomResidency
-    {
-        Permanent, ///< def at Top, never deleted; the ges it names are hoisted to Top.
-        Windowed   ///< def at Current, deleted (and the atom retired) on backtrack; its ges stay deletable.
-    };
-
-    /**
      * Why a real variable's proof-time `ge` order literal is resident (for
      * GuessHoist, transiently resident at a positive backtrack level), under
      * OrderEncodingDeletion::Literals. Threaded from the residency-deciding call sites
@@ -132,6 +109,47 @@ namespace gcs::innards
      */
     class NamesAndIDsTracker
     {
+    public:
+        /**
+         * \brief Scoped request that eq atoms minted inside it be **windowed** rather
+         * than permanent, under OrderEncodingDeletion::Literals.
+         *
+         * A permanent eq definition -- what every caller outside this scope gets, and the
+         * only thing any other mode can give -- lands at ProofLevel::Top, outlives every
+         * backtrack, and pins the two `ge` thresholds it names at Top with it. A windowed
+         * definition lands at ProofLevel::Current instead, so a backtrack (or the window's
+         * own tidy) deletes it and retires the atom, and leaves the two `ge` thresholds it
+         * names deletable. That is what bounds the resident proof objects per branched
+         * variable at O(1) instead of O(domain width); see dev_docs/brancher-design.md,
+         * "The eq-atom window".
+         *
+         * The scope is the narrow API the design asks for: only the frontier owner -- the
+         * branch layer, around the guess mint -- may ask for a windowed atom, because a
+         * windowed atom must not be named by any surviving Top line. **Every** other caller
+         * (propagator reasons, reified constraints, need_pol_item_defining_literal) runs
+         * with the scope closed and gets today's byte-identical Top behaviour, so no other
+         * call site knows lifetimes exist. The request is honoured only where a deletable
+         * definition is meaningful -- Literals mode, proof-writing time, assertions off, a
+         * real variable, and not a variable the eq-by-interval guard refuses -- and is
+         * silently ignored (leaving the definition permanent) anywhere else, which is
+         * always correct and merely wins nothing.
+         *
+         * Has no effect on an atom that already exists: residency is decided once, when the
+         * definition is emitted.
+         */
+        struct WindowedEqScope
+        {
+            explicit WindowedEqScope(NamesAndIDsTracker &);
+            ~WindowedEqScope();
+
+            WindowedEqScope(const WindowedEqScope &) = delete;
+            auto operator=(const WindowedEqScope &) -> WindowedEqScope & = delete;
+
+        private:
+            NamesAndIDsTracker & _tracker;
+            bool _saved;
+        };
+
     private:
         struct Imp;
         std::unique_ptr<Imp> _imp;
@@ -240,6 +258,19 @@ namespace gcs::innards
         // rule). Emits nothing: forget_proof_level has already del'd the lines. Eq atoms
         // carry no chain, so unlike the ge sweep there is nothing to stitch.
         auto forget_eq_literals_at_level(int level) -> void;
+
+        // The (i-dynamic) half of the eq-by-interval guard (dev_docs/brancher-design.md,
+        // "The one hidden pin"): an interval literal has just been requested on `id`, and
+        // the partition / containment machinery is about to walk its eq_defs table and
+        // name every eq atom from Top lines (singleton partition cells, containment
+        // edges). A windowed definition sits at Current, so those Top lines would name a
+        // literal the next backtrack deletes. Collapse the window first -- hoist every
+        // live windowed eq definition on `id`, and the ge thresholds each names, out to
+        // Top -- and leave the variable unwindowed, so nothing windows it again. The
+        // static half (refusing to window a variable that already has a partition or a
+        // containment tree) is in need_direct_encoding_for. A no-op for a variable with
+        // no live window, which is every variable but a currently-branched one.
+        auto collapse_eq_window(const SimpleOrProofOnlyIntegerVariableID & id) -> void;
 
         // Record a permanent (Top) reference to real variable `id`'s ge threshold `v`,
         // from the *reference site* -- the caller that is about to make (or has just
@@ -546,6 +577,79 @@ namespace gcs::innards
         auto hoist_eq_to_top(const SimpleIntegerVariableID & id, Integer v) -> void;
 
         /**
+         * The hoist-out rule's **trigger**: note that a permanent (Top) line is about to
+         * name real variable \p id's eq atom \p v -- a solx blocking clause, a soli
+         * witness, a learned nogood's decision literal -- and so retain the atom instead
+         * of letting the window evict it, by hoisting it (and the two ge thresholds it
+         * names) out to Top. hoist_eq_to_top is the action; this is where the reference is
+         * detected, at the reference site, exactly as note_order_literal_top_pin is for
+         * the ge side.
+         *
+         * A cheap no-op whenever there is nothing to retain: any mode but Literals, no
+         * logger, or -- the overwhelmingly common case -- an atom that is not a live
+         * windowed definition, every eq atom outside a window being permanent already.
+         */
+        auto note_permanent_eq_reference(const SimpleIntegerVariableID & id, Integer v) -> void;
+
+        /**
+         * The eq mirror of evict_order_literal: take real variable \p id's live windowed
+         * eq definition \p v out of the proof. Emits `del` for its two reification lines,
+         * drops it from the windowed live/level bookkeeping, and **retires its atom**, so
+         * find_condition stops answering and the only route back is
+         * need_direct_encoding_for, which re-introduces the definition and takes the
+         * retired XLiteral back with its identity intact. Eq atoms carry no chain, so
+         * unlike the ge case there is nothing to stitch.
+         *
+         * This is the window's per-iteration tidy: the frontier has stepped past \p v, the
+         * advance that needed \p v's reverse reification has already been emitted, and the
+         * sibling clause naming the atom has already been deleted by the caller (which owns
+         * that ordering -- deleting the definition first is exactly what driver control D2c
+         * shows VeriPB rejecting).
+         *
+         * Returns whether the definition was evicted. `false` -- an atom that is not a live
+         * windowed definition, including one the hoist-out rule has already taken to Top --
+         * is a refusal, not an error: it means the atom is permanent, which is always
+         * correct and merely wins less. Requires the mode to be Literals and the logger
+         * attached (both throw, being caller errors rather than policy).
+         */
+        auto evict_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> bool;
+
+        /**
+         * How many of real variable \p id's eq atoms are currently live *windowed*
+         * definitions. Always 0 unless the mode is Literals, and 0 for every variable
+         * nothing has windowed. Exposed because the window's headline invariant -- O(1)
+         * resident eq definitions per branched variable, not O(domain width) -- is
+         * solver-side and unobservable in the proof VeriPB checks.
+         */
+        [[nodiscard]] auto live_windowed_eq_count(const SimpleIntegerVariableID & id) const -> long long;
+
+        /**
+         * How many of real variable \p id's ge thresholds are currently live (resident in
+         * the proof), at any level. Always 0 unless the mode is Literals. The ge half of
+         * the same unobservable-in-the-proof invariant as live_windowed_eq_count.
+         */
+        [[nodiscard]] auto live_order_literal_count(const SimpleIntegerVariableID & id) const -> long long;
+
+        /**
+         * Is real variable \p id's ge threshold \p v currently resident in the proof, at
+         * any level? Always false unless the mode is Literals. This is
+         * evict_order_literal's one throwing precondition made askable, for a caller that
+         * evicts opportunistically -- the eq window steps over a threshold that a one-sided
+         * (compact-encoding) eq definition may never have named.
+         */
+        [[nodiscard]] auto order_literal_is_live(const SimpleIntegerVariableID & id, Integer v) const -> bool;
+
+        /**
+         * Is real variable \p id's eq atom \p v currently a live *windowed* definition —
+         * one the window may evict? False for every permanent atom, which is every eq atom
+         * a constraint (rather than the branch layer) defined first, and false once the
+         * hoist-out rule has retained one. The window asks before doing any work behind a
+         * frontier, because on a model whose constraints name the values it branches on
+         * there is nothing behind the frontier to take out.
+         */
+        [[nodiscard]] auto eq_literal_is_windowed(const SimpleIntegerVariableID & id, Integer v) const -> bool;
+
+        /**
          * If the `GCS_ORDER_ENCODING_STATS` diagnostic is active (OrderEncodingDeletion::Literals
          * mode AND the env var set), sweep the pin-apportionment bookkeeping and print a
          * compact summary to stderr, each line prefixed `%% oed-stats:`. Called once, from
@@ -631,14 +735,11 @@ namespace gcs::innards
         /**
          * Say that we will need the diect encoding to exist for a given variable.
          *
-         * \p residency asks for the eq atom's definition to be permanent (the default,
-         * and what every caller in the solver wants) or windowed; see EqAtomResidency. It
-         * is honoured only where a deletable definition is meaningful -- under
-         * OrderEncodingDeletion::Literals, at proof-writing time, with assertions off, for
-         * a real variable -- and ignored (leaving the definition permanent) otherwise. It
-         * has no effect on an atom that already exists.
+         * The eq atom's definition is permanent (at ProofLevel::Top) unless a
+         * WindowedEqScope is open, which is the branch layer's request for a deletable
+         * one; see that type for when the request is honoured.
          */
-        auto need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID, Integer, EqAtomResidency residency = EqAtomResidency::Permanent) -> void;
+        auto need_direct_encoding_for(SimpleOrProofOnlyIntegerVariableID, Integer) -> void;
 
         /**
          * Say that we will need the range ("in") literal [lo, hi] for a variable,

--- a/gcs/innards/proofs/order_evict_test.cc
+++ b/gcs/innards/proofs/order_evict_test.cc
@@ -148,11 +148,16 @@ auto main() -> int
     // ---- w: the eq-atom window's hoist-out rule and forget sweep ----
     logger.enter_proof_level(1);
     // Two windowed eq atoms: definitions at Current, and their ge thresholds left
-    // deletable rather than hoisted to Top.
-    tracker.need_direct_encoding_for(w, 10_i, EqAtomResidency::Windowed);
-    tracker.need_direct_encoding_for(w, 20_i, EqAtomResidency::Windowed);
+    // deletable rather than hoisted to Top. The scope is the branch layer's request, held
+    // across the guess mint and nothing else.
+    {
+        NamesAndIDsTracker::WindowedEqScope scope{tracker};
+        tracker.need_direct_encoding_for(w, 10_i);
+        tracker.need_direct_encoding_for(w, 20_i);
+    }
     auto w10 = tracker.xliteral_for(w == 10_i);
     auto w20 = tracker.xliteral_for(w == 20_i);
+    check(tracker.live_windowed_eq_count(w) == 2);
 
     // eq(10) acquires a permanent reference, so the window retains it instead of evicting
     // it: its definition and the two ge thresholds it names all move to Top.

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -568,9 +568,10 @@ auto ProofLogger::emit_eq_window_advance(const vector<Literal> & guesses, const 
 
     // Now the atom itself. Skipped when the sibling clause survived, because a live clause
     // naming an evicted atom is exactly the stranded reference the mode must not create.
-    // A refusal here is the hoist-out rule having retained the atom (a solution or a
-    // learned nogood took a permanent reference to it), which is correct and merely wins
-    // less -- and it leaves the stepped-over threshold pinned, so that eviction refuses too.
+    // The eviction cannot refuse here -- an atom the hoist-out rule retained was already
+    // turned away by the windowed check at the top, and nothing since then can have taken a
+    // permanent reference -- but it is a refusing primitive rather than an asserting one,
+    // so this reads as a condition rather than as an assumption.
     if (sibling_deleted && names_and_ids_tracker().evict_eq_literal(var, v)) {
         // The threshold the frontier has stepped over: ascending, ge(v) is now behind the
         // bound; descending, ge(v+1) is. Its definition and every chain clause naming it go,

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -291,26 +291,39 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
         }
             .visit(var);
 
-    // The solx / soli line below is a permanent (Top) reference to every `var == val` it
-    // names, so the eq-atom window's hoist-out rule fires for any of them that is a live
-    // windowed definition: retain it at Top instead of letting the window's next tidy evict
-    // it, together with the two ge thresholds it names. This is the commonest permanent
-    // reference by far -- every solution takes one on each branched variable's current
-    // value. Guarded by the window rather than left to the no-op inside, because this is a
-    // per-solution walk of every variable and an enumeration takes it millions of times.
-    if (eq_window_active())
-        for (const auto & [var, val] : all_variables_and_values)
-            overloaded{
-                [&](const ConstantIntegerVariableID &) {}, //
-                [&](const SimpleIntegerVariableID & var) { names_and_ids_tracker().note_permanent_eq_reference(var, val); },
-                [&](const ViewOfIntegerVariableID & var) {
-                    // A view is named through its underlying, which is the variable that can
-                    // be windowed. A view that negates still deviews to an `==` condition.
-                    auto under = deview(var == val);
-                    names_and_ids_tracker().note_permanent_eq_reference(under.var, under.value);
-                } //
-            }
-                .visit(var);
+    // NOTE for the eq-atom window: the `solx` / `soli` line below names every `var == val`,
+    // but that is a *use*, not a permanent reference, so the window's hoist-out rule
+    // deliberately does NOT fire here. The constraint VeriPB keeps is built from the
+    // `preserved:` set alone -- our variables' BITS -- and never mentions an eq atom
+    // (veripb-checker solution_logging.rs, SolutionRuleOutput::Excluding builds its terms
+    // by walking preserved_variables; Improving builds them from the objective). The atoms
+    // on this line only have to be defined while it is being checked, which they are: they
+    // are what propagates the assignment out to the preserved bits. Afterwards nothing
+    // surviving references them and the window may evict them like any other.
+    //
+    // Retaining them here instead would be expensive and pointless: it would pin an atom on
+    // every branched variable at every solution, which is what stops the window engaging in
+    // an enumeration at all.
+    // Under OrderEncodingDeletion::Literals the objective-improvement constraint emitted
+    // below (soli, either branch) names the objective variable's `id < incumbent` order
+    // literal at ProofLevel::Top on every improving solution. Its definition sits at the
+    // deep Current level the search reached this solution at, so the very next backtrack's
+    // forget deletes it -- leaving this permanent Top line naming a deleted literal, which
+    // VeriPB rejects. Hoist that order literal to Top, exactly as the backtrack and nogood
+    // paths hoist their guess/decision literals, so its definition survives every later
+    // forget. A no-op in every other mode (and when the literal is already Top).
+    //
+    // BEFORE the `soli` line, not after: hoisting re-stitches the order chain, and those
+    // `pol` lines take constraint numbers. The `e` line further down cites the soli
+    // constraint by the relative hint `-1`, so anything emitted between the two misaddresses
+    // it -- which is exactly what happens on an objective the eq window has made deletable.
+    if (optional_minimise_variable_and_value)
+        visit(
+            [&](const auto & id) {
+                names_and_ids_tracker().hoist_live_order_literals_toward_level(
+                    std::vector<Literal>{Literal{id < optional_minimise_variable_and_value->second}}, 0, OrderEncodingResidencyCause::SoliHoist);
+            },
+            optional_minimise_variable_and_value->first);
 
     _imp->proof << (optional_minimise_variable_and_value ? "soli" : "solx");
 
@@ -349,22 +362,6 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
 
     _imp->proof << ";\n";
     record_proof_line(advance_proof_line_number(), ProofLevel::Top);
-
-    // Under OrderEncodingDeletion::Literals the objective-improvement constraint emitted
-    // below (soli, either branch) names the objective variable's `id < incumbent` order
-    // literal at ProofLevel::Top on every improving solution. Its definition sits at the
-    // deep Current level the search reached this solution at, so the very next backtrack's
-    // forget deletes it -- leaving this permanent Top line naming a deleted literal, which
-    // VeriPB rejects. Hoist that order literal to Top first, exactly as the backtrack and
-    // nogood paths hoist their guess/decision literals, so its definition survives every
-    // later forget. A no-op in every other mode (and when the literal is already Top).
-    if (optional_minimise_variable_and_value)
-        visit(
-            [&](const auto & id) {
-                names_and_ids_tracker().hoist_live_order_literals_toward_level(
-                    std::vector<Literal>{Literal{id < optional_minimise_variable_and_value->second}}, 0, OrderEncodingResidencyCause::SoliHoist);
-            },
-            optional_minimise_variable_and_value->first);
 
     if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
         // soli and no links => have to assert the objective improving constraint
@@ -464,6 +461,41 @@ auto ProofLogger::emit_split_bound_advance(const vector<Literal> & guesses, cons
 auto ProofLogger::eq_window_active() const -> bool
 {
     return _imp->eq_window && bound_advances_active();
+}
+
+auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> void
+{
+    // The eq-atom window's hoist-out rule, applied generally rather than site by site: a
+    // line about to land at ProofLevel::Top that names a windowed eq atom is a PERMANENT
+    // reference to it, so the atom -- and the two ge thresholds its definition names --
+    // must become permanent before the line is written.
+    //
+    // The design lists "a reified-constraint use that names id == v" among the permanent
+    // references, and this is what catches it. There is no closed list of such uses: any
+    // constraint may define a Top flag over the values a search branches on, and several do
+    // (a SmartTable tuple selector is `red ... i[x[0]][eq0] i[x[1]][eq0] ... f[..][sr] ...`
+    // at Top). Leaving those undetected strands the reference, and it is not theoretical --
+    // smart_table, tour and minizinc-cumulative all reject without this.
+    //
+    // Costs a walk of the terms per Top emission while a window is live, and nothing at all
+    // otherwise: eq_window_active() is false in every default configuration, and the
+    // tracker's own guard returns immediately when no variable is currently windowed.
+    if (level != ProofLevel::Top || ! eq_window_active())
+        return;
+
+    for (const auto & term : ineq.lhs.terms) {
+        const auto * lit = std::get_if<ProofLiteral>(&term.variable);
+        if (! lit)
+            continue;
+        const auto * cond = std::get_if<Literal>(lit);
+        if (! cond)
+            continue;
+        const auto * ivc = std::get_if<IntegerVariableCondition>(cond);
+        if (! ivc || (ivc->op != VariableConditionOperator::Equal && ivc->op != VariableConditionOperator::NotEqual))
+            continue;
+        if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&ivc->var))
+            names_and_ids_tracker().note_permanent_eq_reference(*sid, ivc->value);
+    }
 }
 
 namespace
@@ -753,6 +785,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
     const std::optional<AssertionAnnotation> & assertion_hint, const std::optional<ProofLineLabel> & label) -> ProofLine
 {
     log_stacktrace();
+    note_top_eq_references(ineq, level);
 
     LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
     auto & rule_line = lease.buffer();
@@ -816,6 +849,7 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     const ReasonLiterals & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
     log_stacktrace();
+    note_top_eq_references(ineq, level);
 
     LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
     auto & rule_line = lease.buffer();
@@ -1259,6 +1293,7 @@ auto ProofLogger::emit_red_proof_lines_forward_reifying(const SumLessThanEqual<W
     ProofLevel level, const optional<map<ProofGoal, Subproof>> & subproofs) -> ProofLine
 {
     log_stacktrace();
+    note_top_eq_references(ineq, level);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     write_indent();
@@ -1277,6 +1312,7 @@ auto ProofLogger::emit_red_proof_lines_reverse_reifying(const SumLessThanEqual<W
     ProofLevel level, const optional<map<ProofGoal, Subproof>> & subproofs) -> ProofLine
 {
     log_stacktrace();
+    note_top_eq_references(ineq, level);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     auto negated_ineq = ineq.lhs >= ineq.rhs + 1_i;

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -49,6 +49,7 @@ using std::ios_base;
 using std::make_unique;
 using std::map;
 using std::max;
+using std::nullopt;
 using std::optional;
 using std::ostream;
 using std::pair;
@@ -188,6 +189,32 @@ struct ProofLogger::Imp
     int current_indent = 0;
     AssertionLevel assertion_level;
     OrderEncodingDeletion order_encoding_deletion = OrderEncodingDeletion::None;
+    bool eq_window = false;
+
+    // --- the eq-atom window's per-node state (dev_docs/brancher-design.md) ---
+    // The clause the most recent backtrack() emitted: the deepest guess it was reasoned
+    // over, its line, and the level it landed at. The window's tidy has to delete the
+    // refuted sibling's clause -- it names eq(v), so the atom is not free until it goes --
+    // and that clause is emitted by the child frame, which returns only a search result.
+    // Nothing between the child's backtrack and the parent's advance emits another one (the
+    // forget in between emits `del`s and stitches), so "the last backtrack clause"
+    // identifies it exactly. The window still checks the recorded guess AND level against
+    // the sibling it is tidying and skips the deletion if either differs, so a future
+    // caller landing in between costs a win rather than a double deletion.
+    struct BacktrackClause
+    {
+        Literal guess;
+        ProofLine line;
+        int level;
+    };
+    optional<BacktrackClause> last_backtrack_clause;
+    // The standing frontier advance for each windowed variable, bucketed by the proof level
+    // it was emitted at and then by variable, so the next step of that window can delete the
+    // one it supersedes. Bucketed by level because a level number is reused by every node at
+    // that depth: the bucket is dropped when the level is forgotten (which is what deleted
+    // its lines), so a later node at the same depth never inherits the previous one's
+    // already-deleted line. Empty unless the window is on.
+    map<int, map<long long, ProofLine>> standing_eq_advance;
 
     // Scratch buffers for assembling proof lines before they are written out,
     // reused across emissions to avoid a stringstream per logged inference.
@@ -222,6 +249,7 @@ ProofLogger::ProofLogger(const ProofOptions & proof_options, NamesAndIDsTracker 
     _imp->proof_lines_by_level.resize(2);
     _imp->assertion_level = proof_options.assertion_level;
     _imp->order_encoding_deletion = proof_options.order_encoding_deletion;
+    _imp->eq_window = proof_options.order_encoding_deletion_eq_window;
 }
 
 ProofLogger::~ProofLogger() = default;
@@ -262,6 +290,27 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
             [&](const ViewOfIntegerVariableID & var) { names_and_ids_tracker().need_proof_name(deview(var == val)); } //
         }
             .visit(var);
+
+    // The solx / soli line below is a permanent (Top) reference to every `var == val` it
+    // names, so the eq-atom window's hoist-out rule fires for any of them that is a live
+    // windowed definition: retain it at Top instead of letting the window's next tidy evict
+    // it, together with the two ge thresholds it names. This is the commonest permanent
+    // reference by far -- every solution takes one on each branched variable's current
+    // value. Guarded by the window rather than left to the no-op inside, because this is a
+    // per-solution walk of every variable and an enumeration takes it millions of times.
+    if (eq_window_active())
+        for (const auto & [var, val] : all_variables_and_values)
+            overloaded{
+                [&](const ConstantIntegerVariableID &) {}, //
+                [&](const SimpleIntegerVariableID & var) { names_and_ids_tracker().note_permanent_eq_reference(var, val); },
+                [&](const ViewOfIntegerVariableID & var) {
+                    // A view is named through its underlying, which is the variable that can
+                    // be windowed. A view that negates still deviews to an `==` condition.
+                    auto under = deview(var == val);
+                    names_and_ids_tracker().note_permanent_eq_reference(under.var, under.value);
+                } //
+            }
+                .visit(var);
 
     _imp->proof << (optional_minimise_variable_and_value ? "soli" : "solx");
 
@@ -366,8 +415,14 @@ auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
     for (const auto & guess : guesses)
         guesses_as_reason.emplace_back(ProofLiteral{guess});
     auto assert_or_rup = (_imp->assertion_level >= AssertionLevel::Inferences) ? ProofRule(AssertProofRule{}) : ProofRule(RUPProofRule{});
-    emit_under_reason(
+    auto line = emit_under_reason(
         assert_or_rup, WPBSum{} >= 1_i, ProofLevel::Current, guesses_as_reason, AssertionAnnotation{.hint_name = hints::Backtrack::hint_name});
+
+    // Remember the clause for the eq window's tidy: the parent frame is about to advance
+    // its frontier past this refuted sibling, and this clause -- which names the sibling's
+    // eq atom -- has to go with the atom. See Imp::last_backtrack_clause.
+    if (eq_window_active() && ! guesses.empty())
+        _imp->last_backtrack_clause = Imp::BacktrackClause{guesses.back(), line, proof_level()};
 }
 
 auto ProofLogger::bound_advances_active() const -> bool
@@ -406,6 +461,128 @@ auto ProofLogger::emit_split_bound_advance(const vector<Literal> & guesses, cons
     emit_rup_proof_line(move(advance) >= 1_i, ProofLevel::Current);
 }
 
+auto ProofLogger::eq_window_active() const -> bool
+{
+    return _imp->eq_window && bound_advances_active();
+}
+
+namespace
+{
+    // The `var == v` a windowed branch guess is, or nullopt for anything else (an order
+    // guess, a range guess, a view, a proof-scaffolding literal). The window only ever
+    // acts on an eq atom of a real variable.
+    [[nodiscard]] auto windowed_eq_guess(const Literal & guess) -> optional<pair<SimpleIntegerVariableID, Integer>>
+    {
+        const auto * cond = std::get_if<IntegerVariableCondition>(&guess);
+        if (! cond || cond->op != VariableConditionOperator::Equal)
+            return nullopt;
+        const auto * sid = std::get_if<SimpleIntegerVariableID>(&cond->var);
+        if (! sid)
+            return nullopt;
+        return pair{*sid, cond->value};
+    }
+}
+
+auto ProofLogger::mint_windowed_eq_guess(const Literal & guess) -> void
+{
+    if (! eq_window_active())
+        return;
+    auto eq = windowed_eq_guess(guess);
+    if (! eq)
+        return;
+
+    // The scope is the only route to a deletable eq definition: it is open across this one
+    // mint and nothing else, so every other caller in the solver keeps getting a permanent
+    // definition without knowing lifetimes exist.
+    NamesAndIDsTracker::WindowedEqScope scope{names_and_ids_tracker()};
+    names_and_ids_tracker().need_direct_encoding_for(eq->first, eq->second);
+}
+
+auto ProofLogger::emit_eq_window_advance(const vector<Literal> & guesses, const Literal & refuted_guess, bool lower) -> void
+{
+    if (! eq_window_active())
+        return;
+    auto eq = windowed_eq_guess(refuted_guess);
+    if (! eq)
+        return;
+    auto [var, v] = *eq;
+
+    // Nothing was windowed here, so there is nothing behind the frontier to take out. The
+    // advance exists only to be the standing bound the tidy reasons from, so emitting one
+    // now would be cost with no matching saving -- and this is the *common* case on
+    // eq-heavy models, where a constraint names the values the search branches on and
+    // defines their atoms permanently long before the branch layer asks. Measured on
+    // talent: 0 windowed atoms, so without this check the run paid +1.1 % proof and ~5 %
+    // verify time for advances that could never be tidied behind.
+    if (! names_and_ids_tracker().eq_literal_is_windowed(var, v))
+        return;
+
+    // The frontier the refutation of `var == v` establishes, given the standing bound this
+    // node has already reached. Ascending: `var >= v` and `var != v` give `var >= v+1`.
+    // Descending: `var <= v` and `var != v` give `var <= v-1`, i.e. `var < v`. Either way
+    // it is one threshold, and the eq atom's reverse reification is the step that gets
+    // there -- which is why the tidy below must not delete that definition first.
+    Literal frontier = lower ? Literal{var >= v + 1_i} : Literal{var < v};
+
+    // Anchor the frontier at this level, exactly as the split advance does: the definition
+    // was minted here by mint_windowed_eq_guess, so this is normally a no-op, but a
+    // frontier that already existed deeper (named by an earlier propagation) must not be
+    // left for a deeper forget to delete under the standing advance.
+    names_and_ids_tracker().hoist_live_order_literals_toward_level(vector<Literal>{frontier}, proof_level(), OrderEncodingResidencyCause::GuessHoist);
+
+    _imp->proof << "% eq window advance\n";
+    WPBSum advance;
+    for (const auto & guess : guesses)
+        advance += 1_i * ! guess;
+    advance += 1_i * frontier;
+    auto advance_line = emit_rup_proof_line(move(advance) >= 1_i, ProofLevel::Current);
+
+    // ---- the per-iteration tidy ----
+    // Everything below is deletion, and every step of it is ordered after the advance
+    // above: the advance RUPs *through* eq(v)'s reverse reification, and deleting that
+    // first is exactly what driver control D2c shows VeriPB rejecting.
+    auto level = proof_level();
+
+    // The previous step's advance is superseded by the one just emitted (the frontier only
+    // moves one way), so it goes; the new one takes its place as this node's standing
+    // bound. Nothing else can be relying on it: it was RUP from this node's own clauses,
+    // and the node-close lemma re-derives what it needs from the standing one.
+    auto & standing = _imp->standing_eq_advance[level];
+    if (auto previous = standing.find(var.index); previous != standing.end()) {
+        delete_proof_lines_at_level(vector<ProofLine>{previous->second}, level);
+        previous->second = advance_line;
+    }
+    else
+        standing.emplace(var.index, advance_line);
+
+    // The refuted sibling's own backtrack clause names eq(v), so the atom is not
+    // unreferenced -- and so not evictable -- until it goes too. This is the deletion the
+    // naive "definition lines only" list omits, and it is confirmed necessary in the
+    // validated driver proof.
+    bool sibling_deleted = false;
+    if (_imp->last_backtrack_clause && _imp->last_backtrack_clause->level == level && _imp->last_backtrack_clause->guess == refuted_guess) {
+        delete_proof_lines_at_level(vector<ProofLine>{_imp->last_backtrack_clause->line}, level);
+        _imp->last_backtrack_clause = nullopt;
+        sibling_deleted = true;
+    }
+
+    // Now the atom itself. Skipped when the sibling clause survived, because a live clause
+    // naming an evicted atom is exactly the stranded reference the mode must not create.
+    // A refusal here is the hoist-out rule having retained the atom (a solution or a
+    // learned nogood took a permanent reference to it), which is correct and merely wins
+    // less -- and it leaves the stepped-over threshold pinned, so that eviction refuses too.
+    if (sibling_deleted && names_and_ids_tracker().evict_eq_literal(var, v)) {
+        // The threshold the frontier has stepped over: ascending, ge(v) is now behind the
+        // bound; descending, ge(v+1) is. Its definition and every chain clause naming it go,
+        // and the chain is re-stitched over the hole. Refused (safely) when it is pinned by
+        // a permanent atom; skipped when it is not resident at all, which the compact
+        // boolean encoding's one-sided eq definitions can leave it.
+        auto stepped_over = lower ? v : v + 1_i;
+        if (names_and_ids_tracker().order_literal_is_live(var, stepped_over))
+            names_and_ids_tracker().evict_order_literal(var, stepped_over, nullopt);
+    }
+}
+
 auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions) -> ProofLine
 {
     // The nogood clause lands at Top and survives the restart forget, but it names
@@ -415,6 +592,14 @@ auto ProofLogger::emit_learned_nogood(const vector<Literal> & decisions) -> Proo
     // nogood never references a deleted literal. Done before emitting the clause so the
     // hoisted def ids precede the clause id in the Top bucket. A no-op in other modes.
     names_and_ids_tracker().hoist_live_order_literals_toward_level(decisions, 0, OrderEncodingResidencyCause::NogoodHoist);
+
+    // The same for any eq decision the nogood names: a windowed definition would be
+    // deleted out from under this Top clause, so the hoist-out rule retains it instead.
+    for (const auto & lit : decisions)
+        if (const auto * cond = std::get_if<IntegerVariableCondition>(&lit))
+            if (cond->op == VariableConditionOperator::Equal || cond->op == VariableConditionOperator::NotEqual)
+                if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&cond->var))
+                    names_and_ids_tracker().note_permanent_eq_reference(*sid, cond->value);
 
     _imp->proof << "% learned nogood\n";
     WPBSum clause;
@@ -764,6 +949,15 @@ auto ProofLogger::forget_proof_level(int depth) -> void
     // del'd, so drop them from the live set so a later need_gevar re-emits them if
     // required. A cheap no-op when the order-link deletion mode is off.
     names_and_ids_tracker().forget_order_links_at_level(depth);
+
+    // The eq window's per-node records for this level went with those deletions. Dropping
+    // them is not tidiness: the next node at this depth reuses the level number, and a
+    // stale line would be `del`'d a second time, which VeriPB errors on (unlike the
+    // `del range` above, a `del id` does not skip an already-deleted line).
+    if (! _imp->standing_eq_advance.empty())
+        _imp->standing_eq_advance.erase(depth);
+    if (_imp->last_backtrack_clause && _imp->last_backtrack_clause->level >= depth)
+        _imp->last_backtrack_clause = nullopt;
 }
 
 auto ProofLogger::move_proof_lines_to_level(const vector<ProofLine> & lines, int from_level, int target_level) -> void

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -122,6 +122,60 @@ namespace gcs::innards
         auto emit_split_bound_advance(const std::vector<Literal> & guesses, const Literal & refuted_guess) -> void;
 
         /**
+         * \brief True iff the eq-atom sliding window is proof-active: bound advances are
+         * active (Literals, assertions off) **and** the window was asked for.
+         *
+         * Off by default (dev_docs/brancher-design.md, owner decision 5), so the four
+         * contiguous eq value orders keep their Bound advance tags fully inert and their
+         * proofs byte-identical until the window is switched on.
+         */
+        [[nodiscard]] auto eq_window_active() const -> bool;
+
+        /**
+         * \brief Mint the eq atom for a windowed branch guess, ahead of the descent into
+         * its subtree.
+         *
+         * The window needs the guess's definition to live at the level the branch loop is
+         * running at -- the level the refuted child's backtrack clause lands at, and the
+         * level the frontier advance is emitted at -- not at whichever deeper level the
+         * child's first propagation happens to name it from, which the child's own forget
+         * would then delete out from under both. Minting it here, before the descent, is
+         * what puts it there; the child's later references find it already defined.
+         *
+         * The two ge thresholds the definition names are minted with it, at the same level
+         * and left deletable (a windowed definition deliberately does not hoist them to
+         * Top -- keeping them deletable is the win).
+         *
+         * A no-op unless eq_window_active() and \p guess is an `==` condition on a real
+         * variable.
+         */
+        auto mint_windowed_eq_guess(const Literal & guess) -> void;
+
+        /**
+         * \brief Emit the frontier advance for a refuted **eq** sibling, and run the
+         * window's per-iteration tidy behind it.
+         *
+         * For an ascending (LowerBound) step refuting `var == v` with standing bound
+         * `var >= v`, the advance is `~guesses OR var >= v+1`, which is RUP through the
+         * standing bound, the refuted child's still-live backtrack clause `~guesses OR
+         * var != v`, and -- load-bearing, and the thing driver control D2c shows VeriPB
+         * rejecting when it is deleted first -- `eq(v)`'s reverse reification. Descending
+         * (UpperBound) is the mirror: the advance is `~guesses OR var < v`.
+         *
+         * Then the tidy, which is what makes the window O(1)-resident: the superseded
+         * previous advance, the sibling clause (it names `eq(v)`, so the atom is not free
+         * until it goes -- this is the deletion the naive "definition lines only" list
+         * omits), `eq(v)`'s definition, and the stepped-over `ge` threshold all go, and the
+         * chain is re-stitched over the hole. Every one of those is a refusal-not-error
+         * primitive, so an atom the hoist-out rule has retained is simply kept.
+         *
+         * \p guesses is the decision stack below this node (the just-refuted sibling
+         * already popped), \p refuted_guess the `var == v` that was refuted, and \p lower
+         * which direction the frontier runs. A no-op unless eq_window_active().
+         */
+        auto emit_eq_window_advance(const std::vector<Literal> & guesses, const Literal & refuted_guess, bool lower) -> void;
+
+        /**
          * Derive a learned nogood --- the clause forbidding the given conjunction
          * of decisions --- as a persistent (ProofLevel::Top) RUP line, returning
          * its proof line. Used when restart learning records a nogood as the stack

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -59,6 +59,14 @@ namespace gcs::innards
 
         auto log_stacktrace() -> void;
 
+        // The eq-atom window's general hoist-out trigger: a line about to land at
+        // ProofLevel::Top that names a windowed eq atom is a permanent reference to it, so
+        // the atom (and the ge thresholds its definition names) has to become permanent
+        // before the line is written. Called from every emission funnel that renders a sum
+        // at a caller-chosen level; a no-op unless eq_window_active() and the line is at
+        // Top. See dev_docs/brancher-design.md, "The hoist-out rule".
+        auto note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> void;
+
     public:
         /**
          * \name Constructors, destructors, and the like.

--- a/gcs/proof.cc
+++ b/gcs/proof.cc
@@ -122,6 +122,19 @@ namespace
     }
 
     /**
+     * Read the eq-atom window switch from the GCS_DELETE_ORDER_ENCODING_EQ_WINDOW
+     * environment variable, if set. Any non-empty value turns it on except the off-words
+     * (0 / off / none), which turn it off explicitly.
+     */
+    [[nodiscard]] auto order_encoding_deletion_eq_window_from_env() -> optional<bool>
+    {
+        const auto * const env = std::getenv("GCS_DELETE_ORDER_ENCODING_EQ_WINDOW");
+        if (! env || ! *env)
+            return nullopt;
+        return ! is_off_word(string{env});
+    }
+
+    /**
      * Apply any environment-variable overrides to a copy of the given ProofOptions.
      * Environment variables act as defaults only: an option set explicitly in code
      * takes precedence.
@@ -137,6 +150,9 @@ namespace
         if (! options.order_encoding_deletion_min_chain_set_explicitly)
             if (auto min_chain = order_encoding_deletion_min_chain_from_env())
                 options.order_encoding_deletion_min_chain = *min_chain;
+        if (! options.order_encoding_deletion_eq_window_set_explicitly)
+            if (auto eq_window = order_encoding_deletion_eq_window_from_env())
+                options.order_encoding_deletion_eq_window = *eq_window;
         return options;
     }
 }

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -99,6 +99,17 @@ namespace gcs
         // (d1000 11.3x of the ungated 17.9x); see dev_docs/order-encoding-deletion.md.
         int order_encoding_deletion_min_chain = 16;                    ///< Min ge chain length before Literals-mode deletion engages (0 = gate off)
         bool order_encoding_deletion_min_chain_set_explicitly = false; ///< Was the gate set in code (so it overrides the env var)?
+        // The eq-atom sliding window for the four contiguous eq value orders
+        // (smallest_first / largest_first / smallest_in / largest_in), under
+        // OrderEncodingDeletion::Literals. Off by default: the window trades transient work
+        // (a per-iteration tidy, and a re-mint whenever a refuted value is named again) for
+        // permanent residency, and whether that pays on eq-heavy models is a measurement,
+        // not an assumption. With it off those value orders behave exactly as they always
+        // have -- their Bound advance tags stay inert, no eq definition is ever windowed,
+        // and their proofs are byte-identical to the untagged ones. See
+        // dev_docs/brancher-design.md, "The eq-atom window".
+        bool order_encoding_deletion_eq_window = false;                ///< Window eq-branching atoms under Literals (default off)
+        bool order_encoding_deletion_eq_window_set_explicitly = false; ///< Was the window set in code (so it overrides the env var)?
 
         /// Write annotated assertions instead of full justifications.
         ProofOptions & set_assertion_level(AssertionLevel a = AssertionLevel::Inferences)
@@ -124,6 +135,15 @@ namespace gcs
         {
             order_encoding_deletion_min_chain = m;
             order_encoding_deletion_min_chain_set_explicitly = true;
+            return *this;
+        }
+        /// Turn the eq-atom sliding window on for the four contiguous eq value orders
+        /// under OrderEncodingDeletion::Literals, making them O(1)-resident in the proof
+        /// rather than O(domain width). Off by default; inert in every other mode.
+        ProofOptions & set_order_encoding_deletion_eq_window(bool w = true)
+        {
+            order_encoding_deletion_eq_window = w;
+            order_encoding_deletion_eq_window_set_explicitly = true;
             return *this;
         }
         /// Always write the full variable encoding to the OPB file.

--- a/gcs/search_heuristics.cc
+++ b/gcs/search_heuristics.cc
@@ -381,7 +381,7 @@ auto gcs::value_order::smallest_in() -> BranchValueGenerator
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto value = s.lower_bound(var);
-            co_yield var == value;
+            co_yield BranchDecision{var == value, backtrack_advance::LowerBound{var}};
             co_yield var != value;
         }(s, var);
     };
@@ -402,8 +402,13 @@ auto gcs::value_order::smallest_first() -> BranchValueGenerator
 {
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
+            // Ascending: refuting `var == v` moves a monotone LOWER frontier one step, so
+            // this is a LowerBound advance -- the same declaration a split makes, and the
+            // one the eq-atom window acts on (dev_docs/brancher-design.md, "Mapping the
+            // existing value orders"). Inert, and the proof byte-identical to the untagged
+            // form, unless the window is switched on.
             for (auto v : s.each_value(var))
-                co_yield var == v;
+                co_yield BranchDecision{var == v, backtrack_advance::LowerBound{var}};
         }(s, var);
     };
 }
@@ -493,7 +498,7 @@ auto gcs::value_order::largest_in() -> BranchValueGenerator
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
             auto value = s.upper_bound(var);
-            co_yield var == value;
+            co_yield BranchDecision{var == value, backtrack_advance::UpperBound{var}};
             co_yield var != value;
         }(s, var);
     };
@@ -514,8 +519,9 @@ auto gcs::value_order::largest_first() -> BranchValueGenerator
 {
     return [](const CurrentState & s, const innards::Propagators &, const IntegerVariableID & var) -> generator<BranchDecision> {
         return [](const CurrentState & s, IntegerVariableID var) -> generator<BranchDecision> {
+            // Descending: the UpperBound mirror of smallest_first.
             for (auto v : s.each_value_reversed(var))
-                co_yield var == v;
+                co_yield BranchDecision{var == v, backtrack_advance::UpperBound{var}};
         }(s, var);
     };
 }

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -112,12 +112,31 @@ namespace
         }
     };
 
-    // A refuted split sibling carries a Bound (Lower/Upper) advance; every other value
-    // order stays Exclude. The framework emits a guess-reasoned frontier advance only
-    // for the Bound siblings.
+    // A refuted split or contiguous-eq sibling carries a Bound (Lower/Upper) advance; every
+    // other value order stays Exclude. The framework emits a guess-reasoned frontier
+    // advance only for the Bound siblings.
     [[nodiscard]] auto is_bound_advance(const BacktrackAdvance & advance) -> bool
     {
         return std::holds_alternative<backtrack_advance::LowerBound>(advance) || std::holds_alternative<backtrack_advance::UpperBound>(advance);
+    }
+
+    // Which way a Bound advance moves the frontier. Only meaningful once is_bound_advance
+    // holds.
+    [[nodiscard]] auto is_lower_bound_advance(const BacktrackAdvance & advance) -> bool
+    {
+        return std::holds_alternative<backtrack_advance::LowerBound>(advance);
+    }
+
+    // The two shapes a Bound advance comes in, told apart by the atom the decision
+    // branches on rather than by which value order produced it (design 3: the advance is
+    // derived from the yielded condition). A split guesses an ORDER atom, and refuting it
+    // establishes the frontier directly. A contiguous eq order guesses an EQ atom, and
+    // refuting it establishes the frontier only through that atom's reverse reification --
+    // which is what the eq-atom window is built around, and what makes its tidy ordering
+    // load-bearing.
+    [[nodiscard]] auto is_eq_decision(const IntegerVariableCondition & guess) -> bool
+    {
+        return guess.op == VariableConditionOperator::Equal;
     }
 
     auto solve_with_state(unsigned long long depth, Stats & stats, Problem & problem, Propagators & propagators, State & state,
@@ -266,6 +285,16 @@ namespace
                             ++sibling_index;
                         }
 
+                        // Under the eq-atom window, mint the guess's eq definition HERE,
+                        // before the descent, so it lands at this node's level: the level
+                        // the refuted child's backtrack clause lands at, and the level the
+                        // frontier advance is emitted at. Left to the child's first
+                        // propagation to name, it would land a level deeper and the child's
+                        // own forget would delete it out from under both. A no-op unless
+                        // the window is on and the guess is an eq atom of a real variable.
+                        if (logger && is_bound_advance(decision.on_refuted) && is_eq_decision(guess))
+                            logger->mint_windowed_eq_guess(guess);
+
                         auto child_result = recurse(guess, child_prefix);
                         if (child_result == SearchResult::Stop)
                             return SearchResult::Stop;
@@ -296,7 +325,21 @@ namespace
                             vector<Literal> guesses;
                             for (const auto & g : state.guesses())
                                 guesses.push_back(g);
-                            logger->emit_split_bound_advance(guesses, guess);
+                            if (! is_eq_decision(guess))
+                                logger->emit_split_bound_advance(guesses, guess);
+                            else if ((*branch_iter).guess != ! guess) {
+                                // The eq window's step, skipped for the `smallest_in` /
+                                // `largest_in` shape -- a `var == lb` whose only remaining
+                                // sibling is its complement `var != lb`. There the tidy
+                                // would evict the very atom that sibling is about to name,
+                                // forcing an immediate re-mint as a PERMANENT definition
+                                // that pins both its thresholds at Top: strictly worse
+                                // than not tidying. And with no later sibling there is
+                                // nothing for the advance to be the standing bound of, so
+                                // emitting one would be pure cost. Those orders still gain
+                                // from the window across the chain of nodes below them.
+                                logger->emit_eq_window_advance(guesses, guess, is_lower_bound_advance(decision.on_refuted));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Closes #608. Part of #612, stacked on #614 (→ #607 → #606 → #605).

The four contiguous eq value orders kept every eq atom they branched on, and both `ge`
thresholds each one names, resident at Top forever — O(domain width) per branched
variable, and no deletion win at all. This builds the sliding window the design has been
carrying since the audit: mint each guess's eq definition **deletable**, advance a
monotone frontier past it once the sibling is refuted, and take the atom and the
threshold it stepped over out behind the frontier. O(1) resident.

`dev_docs/brancher-design.md`, "The eq-atom window", is the authority and is updated
with everything the implementation settled.

## Two things decided the shape

**The definition is minted before the descent, not by the child.** The window needs it at
the node's own level — the level the refuted child's backtrack clause lands at, and the
level the advance is emitted at. Left to whichever propagation inside the child first
names `id == v`, it lands a level deeper and the child's own forget deletes it out from
under both. This is how implementation gate 2 (the real-solver eq advance level) actually
resolved: not by hoisting the frontier, but by minting where the frontier already belongs,
which makes the design's hoist step a no-op.

**The tidy must delete the sibling clause too.** It names `eq(v)`, so the atom is not
unreferenced — and so not evictable — until it goes. That clause is emitted by the *child*
frame, which returns only a search result, so `ProofLogger::backtrack` records what it
emitted and the tidy matches on guess *and* level before deleting. The superseded advance
is remembered the same way, bucketed by level so a later node at the same depth cannot
inherit an already-deleted line and `del id` it twice.

## Ships off

`ProofOptions::set_order_encoding_deletion_eq_window()` /
`GCS_DELETE_ORDER_ENCODING_EQ_WINDOW` (owner decision 5). With it off the four
newly-tagged orders are byte-identical to the untagged ones, which is what makes the tags
free to add now.

## Measured — one sitting, current hardware

Ascending eq branching over a wide domain, the regime it is for
(`order_deletion_bench --problem pairwise --size 6 --window D --tightness 90 --unsat
--value-order smallest`). Best-of-3 `veripb` wall time; search shape identical in every
row:

| domain | gate | off | on | speedup |
|---|---|---|---|---|
| 250 | 0 | 0.746 s | 0.325 s | **2.30×** |
| 500 | 0 | 5.707 s | 1.619 s | **3.53×** |
| 1000 | 0 | 45.96 s | 9.788 s | **4.70×** |

The speedup grows with width — a residency win, not a constant factor — and it does so
while making the proof **31 % bigger**. That is this mode's size-is-not-time point in its
purest form.

## A limit the design did not anticipate

It narrows the regime, it is stage E's to act on, and it is in the dev doc with figures.

- **The window can only act on an eq atom the branch layer names first.** Residency is
  decided once, when a definition is emitted, and `need_direct_encoding_for` returns early
  for an atom that already exists — so on a model whose *constraints* reason per value the
  propagators have defined those atoms permanently long before the search reaches them.
  talent windows **0** atoms and crystal_maze **1**, against **3255** on the synthetic.
  The advance is now skipped when the guess's atom is not windowed, so where the window
  cannot engage it costs nothing: talent's window-on proof is byte-identical to its
  window-off proof. (Emitting it regardless cost talent +1.1 % proof and ~5 % verify time
  for zero evictions — that was the first version of this branch.)

## The hoist-out rule is general, not a list of sites

The design names three permanent references an eq atom can acquire: a `solx` blocking
clause, a learned nogood, and "a reified-constraint use that names `id == v`". The first
of those **is not a reference at all**, and the third **cannot be enumerated**. Both
corrections are in the second commit.

`solx` keeps a constraint built from the `preserved:` set alone — our variables' *bits*
(`veripb-checker/src/rules/solution_logging.rs`: `Excluding` walks `preserved_variables`,
`Improving` builds from the objective). The eq atoms on the line are consumed while it is
checked and referenced by nothing afterwards. Retaining them anyway is what was stopping
the window engaging in an enumeration at all: dropping it takes `eq_window_solve_test`
from 1–2 evictions to 3, i.e. every refuted sibling rather than only the solution-free
ones.

But that retention was also **masking** the missing general rule: any constraint may
define a Top flag over the values a search branches on, and several do — a SmartTable
tuple selector is `red 1 i[x[0]][eq0] 1 i[x[1]][eq0] ... 4 ~f[16][sr] >= 4` at Top. With
the incidental solx cover gone, `smart_table` (8 tests), `tour`,
`scp_chain_smart_table_sat` and `minizinc-cumulative` all reject. So detection is now
general: `note_top_eq_references` walks the terms of every line landing at
`ProofLevel::Top`, on all four funnels that render a sum, and retains any windowed eq atom
it names.

One latent bug fell out. `ProofLogger::solution` hoists the objective's `id < incumbent`
literal, hoisting re-stitches the chain, and those `pol`s take constraint numbers — while
the `e` line below cites the soli constraint by the relative hint `-1`. So the hoist has to
run *before* the `soli` line. It never bit before because the objective's eq atom used to
be permanent, which hoisted its thresholds early and left that hoist with nothing to do.

## Gates

- Caps-off suite **546/546** with the window on at `MIN_CHAIN=0`, and at the defaults.
- Flag-off byte-identity vs #614's tip across {None, Literals gate 0, Literals gate 16} on
  six instances — 36/36 `.opb`+`.pbp` comparisons identical.
- `eq_window_test` — drives the production entry points (`mint_windowed_eq_guess`,
  `backtrack`, `emit_eq_window_advance`) and asserts in C++ the thing VeriPB cannot see:
  one live windowed eq definition per branched variable and a flat `ge` count, **O(1) not
  O(width)**. Plus the hoist-out rule, the eq⨯interval collapse, re-mint after eviction,
  and the descending direction the hand-authored driver never covered.
- `eq_window_solve_test` — eight ctest entries (4 value orders × 2 models) enumerating
  through a real search, failing if the window did not actually fire.

Mutation-checked. One result worth knowing: the tidy-ordering violation (delete the eq
definition before the advance) is caught — VeriPB rejects — **only because the solve
test's model is deliberately weak**. An earlier version built from comparisons and
`NotEquals` verified that mutation happily, because propagation was strong enough that the
advance was independently RUP and the eq definition the design leans on was not doing the
work. The linear equality is in the model to prevent that shortcut; removing it would
silently stop testing the property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
