### PR TITLE
Brancher stage C: exempt the objective from order-encoding deletion

### DIFF
--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -712,7 +712,8 @@ gate keeps its job for the **non-frontier short-chain tail**
 (crystal_maze / talent eq atoms that are *not* branched on), which the window
 never touches.
 
-This composes with payload 3's `FrontierExempt` (below) as its exact opposite:
+This composes with payload 3's `FrontierExempt` (below, **built in stage C**) as its exact
+opposite:
 `FrontierExempt` says "resident *despite* being frontier" (the churn-regime
 objective); `WindowedFrontier` says "deletable *because* frontier" (the win-regime
 eq branch). They are the two opposite frontier policies and only the frontier
@@ -727,7 +728,9 @@ it is a reason to stay *deletable*, and a ge born deletable takes no cause at al
 `windowed_eq_variables` set, marked when the first windowed definition on that
 variable is minted — before the definition is emitted, because emitting it is what
 mints the two thresholds that must come out deletable. `FrontierExempt` (stage C)
-*is* a Top cause and will want the enumerator.
+*is* a Top cause and duly took the enumerator, plus its own line in the stats dump and its
+own per-variable class there — otherwise the gate would be credited with variables the
+exemption held.
 
 ### The one hidden pin — eq⨯interval (bidirectional guard)
 
@@ -1289,13 +1292,41 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   **This stage re-confirmed the real-solver eq advance level** (see Implementation
   gates), including the descending direction the hand-authored driver never covered.
 
-- **Stage C — objective / frontier exemption (payload 3; flag-gated; committable).**
-  Add `note_deletion_exempt` + the `FrontierExempt` residency cause + the `need_gevar`
-  priority slot (now reusing B''s residency ladder; `FrontierExempt` and
-  `WindowedFrontier` are sibling slots); `solve_with` exempts the objective.
-  **Oracle:** VeriPB verifies + search-identical; on seat-moving 2018 the
-  objective/cost churn (~20.8k delete/reintroduce at gate 16) drops toward 0 at no win
-  cost on the synthetic sweep (the exemption must not touch non-objective wins).
+- **Stage C — objective / frontier exemption (payload 3). DONE.**
+  Shipped: `NamesAndIDsTracker::note_deletion_exempt`, the `FrontierExempt` residency
+  cause and its slot in `need_gevar`'s ladder (**boundary > aux > view > exempt > gate**,
+  reusing B'''s ladder, with `WindowedFrontier` as `exempt`'s opposite-signed sibling), the
+  stats dump's exempt class, and `ProofModel::minimise` exempting the objective. The
+  brancher-facing half is deliberately **not** built: the design offers it "optionally...
+  but not by default", and an API with no caller is speculation — a brancher that wants it
+  can call `note_deletion_exempt` when a use appears.
+  Unlike every other stage this one is **policy, not correctness**: nothing is stranded
+  without it, so no proof can reject to say it stopped working. That is why its test asserts
+  the residency fact in C++ **both ways round** — an exempt variable's thresholds survive a
+  forget, an ordinary variable's do not — since an exemption that quietly held everything
+  resident would suppress the churn *and* the win.
+  **Oracle (met):** caps-off suite in each of {None, Literals gate 0, Literals gate 16};
+  mode-None byte-identity; `deletion_exempt_test` (VeriPB-checked, and it uses the exempt
+  literals *after* the forget that would have deleted them, so a bookkeeping-only lie
+  rejects; mutation-checked, a no-op `note_deletion_exempt` fails it); and the measurements
+  below.
+
+  **Measured.** The exemption's own oracle is two-sided, and both sides hold. It **must not
+  touch non-objective wins**: the synthetic split sweep (`order_deletion_bench --unsat`,
+  d250, gate 0) is **byte-identical** to the stack's previous tip, because that instance has
+  no objective and the note is never made. And it **must suppress the objective's churn**:
+  on the same synthetic with `--optimise`, deletes fall 812 → 726 at gate 0 and 656 → 591 at
+  gate 16 (~10 % each), reintroductions 180 → 172 and 141 → 137, and the proof shrinks
+  slightly (463 839 → 460 736 bytes) — while **78 Top-resident `ge` atoms**, 97.5 % of all
+  Top residency at gate 0, are now attributed to the exemption. On the real optimisation
+  examples the churn goes to zero outright (tour 4 → 0 deletes, colour 2/1 → 0/0 at gate 0),
+  though those are small enough that the absolute numbers say little.
+
+  Under Literals this stage deliberately **does** move the proof — but only for
+  optimisation. Of six instances compared against the stack's previous tip, colour and
+  talent differ (in `.pbp` only, never `.opb`) and crystal_maze, langford, money and sudoku
+  are byte-identical. That asymmetry *is* the feature: the exemption should be invisible to
+  everything without an objective.
 
 - **Stage D — objective-improvement delc + Top-eviction (payload 2; flag-gated;
   committable). Reuses B''s evict primitive** rather than introducing it.

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1,8 +1,10 @@
 # Step 2 — the Brancher-API refactor: concrete, decided design
 
-**Status: decided design, partly implemented — stages A, B, B' and B'' have landed
-(#606, #607, #608); C–E have not.** "Migration staging", below, is the authority on
-what each remaining stage owes, and tracking issue #612 indexes them.
+**Status: decided design, partly implemented — stages A, B, B', B'' and C have landed
+(#606, #607, #615, #617); D and E have not.** The whole stack stays unmerged until the plan
+is complete: stage E's benchmarking is the go/no-go gate for all of it (owner, 2026-07-30).
+"Migration staging", below, is the authority on what each remaining stage owes, and
+tracking issue #612 indexes them.
 This note is the single committed record of the step-2 design: it turns the
 user-approved conceptual sketch in
 [order-encoding-deletion.md](order-encoding-deletion.md) ("Design overview"

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1324,6 +1324,13 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   examples the churn goes to zero outright (tour 4 → 0 deletes, colour 2/1 → 0/0 at gate 0),
   though those are small enough that the absolute numbers say little.
 
+  **Not measured here: seat-moving 2018 itself**, the instance whose ~20.8k churn at gate 16
+  motivated the exemption. Its proof passes 8 GB and the solve runs well past half an hour,
+  so it belongs in stage E's benchmarking rather than in a per-stage gate — and stage E,
+  being the stack's go/no-go, re-measures every figure anyway. What is established here is
+  that the mechanism does what it claims, on an instance small enough to check both sides of
+  the oracle.
+
   Under Literals this stage deliberately **does** move the proof — but only for
   optimisation. Of six instances compared against the stack's previous tip, colour and
   talent differ (in `.pbp` only, never `.opb`) and crystal_maze, langford, money and sudoku

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -6,7 +6,7 @@ not default.** This note records the design for shrinking the integer
 order-encoding that VeriPB carries, plus the measured outcome and what is and
 isn't yet done. The full Brancher-API refactor (step 2, below) is a **decided design,
 recorded in [brancher-design.md](brancher-design.md), now partly implemented**: its
-stages A, B, B' and B'' have landed, C/D/E have not. That note, not this one, is the
+stages A, B, B', B'' and C have landed, D/E have not. That note, not this one, is the
 authority on the refactor's staging and status. The shipped deletion path still wires
 into the existing branch/backtrack flow via hoisting, and the four-step sketch further
 down this note is superseded by the decided design (see the note at "Design overview"
@@ -394,7 +394,18 @@ frontend proofs.
   permanently long before the search reaches them. Where it cannot engage it now costs
   nothing (talent's window-on proof is byte-identical to its window-off proof). The window
   therefore ships off, and stage E owns whether the default changes.
-- **In progress:** the clean Brancher abstraction (step 2). Stages A, B, B' and B'' have
+- **The frontier deletion exemption (stage C).** `ProofModel::minimise` marks the objective
+  `note_deletion_exempt`, so under Literals its whole `ge` encoding stays resident however
+  long its chain grows. Branch-and-bound re-tightens the objective at every improving
+  solution and every backtrack relaxes it again, so without this its thresholds are deleted
+  and re-introduced forever, verify-neutrally, for zero shrinkage — on seat-moving 2018
+  essentially all of the residual churn at the default gate. The chain gate cannot suppress
+  it: the gate measures *length*, and the objective's chain is long for a churn reason
+  rather than a win reason. This is a **policy** hook, not a correctness one — nothing is
+  stranded without it — and it deliberately applies to the objective only, because
+  exempting a bound-branched variable would defeat the split win, which *is* deleting its
+  stepped-over chain.
+- **In progress:** the clean Brancher abstraction (step 2). Stages A, B, B', B'' and C have
   landed — the `BranchDecision` / `BacktrackAdvance` types, the split families' bound
   advances, the eviction primitives plus their always-on residency bookkeeping, and the
   eq-atom window — so the direct guess/eq/aux hoist wiring is on its way out but is still
@@ -435,7 +446,7 @@ builds long chains (seat-moving: median chain 12, max 98, despite maxdom 901), a
 the deletion machinery churns (37 644 deletes / 37 616 reintroductions, net 28) for
 nothing there.
 
-**2. Brancher-API refactor — IN PROGRESS: stages A, B, B' and B'' landed; C is next.**
+**2. Brancher-API refactor — IN PROGRESS: stages A, B, B', B'' and C landed; D is next.**
 The concrete, decided step-2 design and its staging live in
 [brancher-design.md](brancher-design.md), which is the authority on what is done and
 what each remaining stage owes. In summary: **A** added the `BranchDecision` /
@@ -443,7 +454,7 @@ what each remaining stage owes. In summary: **A** added the `BranchDecision` /
 split families' bound advances and the advance-RUP-driven deletion; **B'** added the
 always-on residency bookkeeping and the evict/hoist primitives the eq window and the
 objective `delc` both need (behaviour-neutral); **B''** built the eq-atom window on
-them, opt-in and off by default. Remaining: **C** the objective/frontier exemption,
+them, opt-in and off by default; **C** exempted the objective from deletion. Remaining:
 **D** the objective-improvement `delc` + Top-eviction, **E** benchmark and cleanup —
 including whether the window becomes the default for `smallest_first`. The design
 generalises consolidate-then-delete,

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -558,6 +558,10 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(order_evict_test PRIVATE glasgow_constraint_solver)
     add_test(NAME order_evict_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:order_evict_test>)
 
+    add_executable(deletion_exempt_test innards/proofs/deletion_exempt_test.cc)
+    target_link_libraries(deletion_exempt_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME deletion_exempt_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:deletion_exempt_test>)
+
     add_executable(eq_window_test innards/proofs/eq_window_test.cc)
     target_link_libraries(eq_window_test PRIVATE glasgow_constraint_solver)
     add_test(NAME eq_window_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eq_window_test>)

--- a/gcs/innards/proofs/deletion_exempt_test.cc
+++ b/gcs/innards/proofs/deletion_exempt_test.cc
@@ -1,0 +1,94 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <iostream>
+#include <optional>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::cerr;
+using std::nullopt;
+
+// Driver for the stage-C frontier deletion exemption (dev_docs/brancher-design.md,
+// "Payload 3"), with the mode and the chain gate set in code so the test does not depend on
+// GCS_DELETE_ORDER_ENCODING* -- and in particular runs at gate 0, because at the shipped
+// gate of 16 a short chain is held resident anyway and the exemption would be doing nothing
+// distinguishable.
+//
+// The exemption is a POLICY note, not a correctness one: nothing is stranded without it, so
+// there is no proof VeriPB could reject to tell you it stopped working. What it claims is a
+// residency fact -- an exempt variable's `ge` definitions survive a backtrack that deletes
+// an ordinary variable's -- and that is what is asserted here, in C++, both ways round. The
+// second half matters as much as the first: an exemption that quietly held *everything*
+// resident would suppress the churn it targets and the deletion win with it.
+//
+// VeriPB still runs over the emitted proof, because the exempt literals are used after the
+// forget that would have deleted them: if the exemption ever became a bookkeeping-only lie,
+// leaving the definitions deleted while the tracker thought them live, that use would name a
+// deleted literal and reject.
+auto main() -> int
+{
+    ProofOptions proof_options{"deletion_exempt_test"};
+    proof_options.set_order_encoding_deletion(OrderEncodingDeletion::Literals).set_order_encoding_deletion_min_chain(0);
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+
+    // `obj` stands in for the objective: exempt, so its whole encoding stays resident.
+    // `ord` is an ordinary variable and must keep deleting exactly as before.
+    SimpleIntegerVariableID obj{0}, ord{1};
+    model.set_up_integer_variable(obj, 0_i, 100_i, "obj", nullopt);
+    model.set_up_integer_variable(ord, 0_i, 100_i, "ord", nullopt);
+
+    // Model-time note, exactly as ProofModel::minimise makes it for a real objective.
+    tracker.note_deletion_exempt(obj);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    int rc = 0;
+    auto check = [&](bool ok, const char * what) {
+        if (! ok) {
+            cerr << "deletion exemption broken: " << what << " (fix the exemption, do not relax the check)\n";
+            rc = 1;
+        }
+    };
+
+    // Interior thresholds only: a boundary literal is resident for its own structural
+    // reason and would prove nothing either way.
+    logger.enter_proof_level(1);
+    for (Integer v = 10_i; v <= 40_i; v += 10_i) {
+        tracker.need_gevar(obj, v);
+        tracker.need_gevar(ord, v);
+    }
+    auto obj_before = tracker.live_order_literal_count(obj);
+    auto ord_before = tracker.live_order_literal_count(ord);
+    check(obj_before >= 4, "the exempt variable did not record its thresholds at all");
+    check(ord_before >= 4, "the ordinary variable did not record its thresholds at all");
+
+    logger.forget_proof_level(1);
+
+    // The claim, both ways round.
+    check(tracker.live_order_literal_count(obj) == obj_before, "an exempt variable's thresholds were deleted by a backtrack");
+    check(tracker.live_order_literal_count(ord) < ord_before, "the exemption held an ORDINARY variable resident too, which would suppress the win");
+    for (Integer v = 10_i; v <= 40_i; v += 10_i)
+        check(tracker.order_literal_is_live(obj, v), "an exempt threshold went missing across the forget");
+
+    // ... and the definitions really are still there, not just believed to be: multi-hop
+    // order propagation over a chain the forget would otherwise have taken out.
+    logger.enter_proof_level(1);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (obj < 40_i) + 1_i * (obj >= 10_i) >= 1_i, ProofLevel::Current);
+    logger.forget_proof_level(1);
+
+    logger.enter_proof_level(0);
+    logger.conclude_none();
+    tracker.finalise();
+
+    return rc;
+}

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -281,6 +281,13 @@ struct NamesAndIDsTracker::Imp
     // view-bridge pol lines -- is detected directly from views_of_variable in need_gevar,
     // not carried here.
     std::set<SimpleOrProofOnlyIntegerVariableID> order_encoding_stays_resident;
+    // Variables the frontier owner has exempted from Literals-mode deletion
+    // (note_deletion_exempt): every ge definition stays resident at Top however long the
+    // chain grows. Unlike order_encoding_stays_resident above this is a POLICY note, not a
+    // correctness one -- nothing is stranded if it is missing, the variable just churns --
+    // and it exists because the chain-length gate cannot tell a win-regime long chain from
+    // a churn-regime one. Populated by ProofModel::minimise for the objective.
+    std::set<SimpleOrProofOnlyIntegerVariableID> deletion_exempt;
     // The values with ge atoms, per variable, in value order: need_gevar's
     // order-encoding chain links join each new atom to its neighbours, which
     // needs ordered iteration. The atoms' literals and defining lines live in
@@ -851,6 +858,17 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     if (windowed && (_imp->interval_partitions.contains(id) || _imp->containment_trees.contains(id)))
         windowed = false;
 
+    // A deletion-exempt variable is not windowed either. `FrontierExempt` and
+    // `WindowedFrontier` are opposite answers to the same question -- resident *despite*
+    // being frontier, versus deletable *because* frontier -- and the design says they never
+    // apply to the same variable. Nothing stopped them: a branched objective is both, which
+    // happens (`tour` branches on its objective). Making the exemption win here keeps that
+    // claim true by construction rather than by hope, and it is the right way round:
+    // exempting a variable says "do not churn this encoding", and windowing its eq atoms is
+    // churning it.
+    if (windowed && _imp->deletion_exempt.contains(id))
+        windowed = false;
+
     // Mark the variable as windowed BEFORE the definition is emitted, because emitting it
     // is what mints the two ge thresholds it names, and need_gevar's WindowedFrontier slot
     // reads this mark to keep them deletable through the chain gate.
@@ -1156,6 +1174,17 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
         bool view_resident = _imp->views_of_variable.contains(std::get<SimpleIntegerVariableID>(id));
         if (def_at_current && (aux_resident || view_resident))
             def_at_current = false;
+        // Frontier exemption (note_deletion_exempt): the frontier owner has said this
+        // variable's chain is a CHURN-regime one -- re-tightened and relaxed forever, so
+        // deletion pays its whole cost and returns no shrinkage. Keep the whole encoding
+        // resident, exactly like the aux/view classes above, but for a policy reason rather
+        // than a correctness one. Ranks below them (they force residency whatever anyone
+        // wants) and above the gate (the exemption holds however long the chain grows,
+        // which is the entire point -- the gate is length-based and cannot see the
+        // difference).
+        bool frontier_exempt = _imp->deletion_exempt.contains(id);
+        if (def_at_current && frontier_exempt)
+            def_at_current = false;
         // Chain-length gate (order_encoding_deletion_min_chain): below/at the gate keep
         // this interior ge resident at Top -- exactly like the boundary/view/aux paths --
         // so a propagation-strong model that never builds a long chain pays no deletion
@@ -1187,9 +1216,9 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 def_at_current = false;
         }
         // Stats attribution, matching the branches just taken. Priority (first-cause-wins):
-        // boundary > aux > view > gate; every case is reached only when the earlier ones
-        // did not fire, and (boundary, aux, view, gate) are the only ways !def_at_current
-        // holds here, so the trailing else is exactly the gate case.
+        // boundary > aux > view > exempt > gate; every case is reached only when the earlier
+        // ones did not fire, and those five are the only ways !def_at_current holds here, so
+        // the trailing else is exactly the gate case.
         if (_imp->collect_order_encoding_stats && ! def_at_current) {
             if (boundary)
                 stats_born_cause = OrderEncodingResidencyCause::Boundary;
@@ -1197,6 +1226,8 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                 stats_born_cause = OrderEncodingResidencyCause::AuxPin;
             else if (view_resident)
                 stats_born_cause = OrderEncodingResidencyCause::ViewPin;
+            else if (frontier_exempt)
+                stats_born_cause = OrderEncodingResidencyCause::FrontierExempt;
             else
                 stats_born_cause = OrderEncodingResidencyCause::GateResident;
         }
@@ -2462,7 +2493,7 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     // whether any of their ges are hoist-pinned (eq/invar/nogood/soli); a variable with
     // no hoist pins but some gate-held (below-min_chain-resident) ge is its own class, so
     // the fully-deletable count is not inflated by gate-held variables.
-    long long n_view = 0, n_aux = 0, n_mixed = 0, n_gate_held = 0, n_deletable = 0;
+    long long n_view = 0, n_aux = 0, n_exempt = 0, n_mixed = 0, n_gate_held = 0, n_deletable = 0;
     for (const auto & [id, vs] : _imp->stats_ge_top_cause) {
         if (_imp->views_of_variable.contains(id)) {
             ++n_view;
@@ -2470,6 +2501,10 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
         }
         if (_imp->order_encoding_stays_resident.contains(SimpleOrProofOnlyIntegerVariableID{id})) {
             ++n_aux;
+            continue;
+        }
+        if (_imp->deletion_exempt.contains(SimpleOrProofOnlyIntegerVariableID{id})) {
+            ++n_exempt;
             continue;
         }
         bool any_hoist_pin = false, any_gate = false;
@@ -2498,6 +2533,7 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     long long nogood_h = get(by_cause, Cause::NogoodHoist), soli_h = get(by_cause, Cause::SoliHoist);
     long long boundary = get(by_cause, Cause::Boundary), model_time = get(by_cause, Cause::ModelTime);
     long long gate_resident = get(by_cause, Cause::GateResident);
+    long long frontier_exempt = get(by_cause, Cause::FrontierExempt);
     long long would_free = view_pin + aux_pin;
     long long would_not_free = eq_h + invar_h + nogood_h + soli_h;
     long long structural = boundary + model_time;
@@ -2523,6 +2559,7 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     emit(format("  structural (boundary + model_time): {} ({:.1f}%)", structural, pct(structural)));
     emit(format("      boundary:     {} ({:.1f}%)", boundary, pct(boundary)));
     emit(format("      model_time:   {} ({:.1f}%)", model_time, pct(model_time)));
+    emit(format("  frontier-exempt (note_deletion_exempt): {} ({:.1f}%)", frontier_exempt, pct(frontier_exempt)));
     emit(format("  gate-held (below min_chain gate): {} ({:.1f}%)", gate_resident, pct(gate_resident)));
     emit("events:");
     emit(format("  deletes: {}", _imp->stats_deletes));
@@ -2537,6 +2574,7 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     emit("variables by class:");
     emit(format("  fully-resident-by-view: {}", n_view));
     emit(format("  fully-resident-by-aux:  {}", n_aux));
+    emit(format("  fully-resident-by-exemption: {}", n_exempt));
     emit(format("  mixed (some eq/invar/nogood/soli-hoisted resident): {}", n_mixed));
     emit(format("  gate-held (no hoist pins, some ge below min_chain gate): {}", n_gate_held));
     emit(format("  fully-deletable (no hoist pins): {}", n_deletable));
@@ -3032,6 +3070,11 @@ auto NamesAndIDsTracker::note_bounds_not_trivially_derivable(const SimpleOrProof
 auto NamesAndIDsTracker::note_order_encoding_stays_resident(const SimpleOrProofOnlyIntegerVariableID & id) -> void
 {
     _imp->order_encoding_stays_resident.insert(id);
+}
+
+auto NamesAndIDsTracker::note_deletion_exempt(const SimpleOrProofOnlyIntegerVariableID & id) -> void
+{
+    _imp->deletion_exempt.insert(id);
 }
 
 auto NamesAndIDsTracker::note_recover_atom_labels_in_proof(const SimpleOrProofOnlyIntegerVariableID & id) -> void

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -75,8 +75,8 @@ namespace gcs::innards
      *    than only the first.
      *  - The `GCS_ORDER_ENCODING_STATS` **pin-apportionment diagnostic**, which
      *    attributes each Top-resident literal to the cause that pinned it *first*, and
-     *    also covers the born-Top structural causes (boundary, model_time, aux/view pin,
-     *    gate) that never hoist and so never take a pin. It splits the pins into the
+     *    also covers the born-Top causes (boundary, model_time, aux/view pin, frontier
+     *    exemption, gate) that never hoist and so never take a pin. It splits the pins into the
      *    classes the bridge-lifetime redesign (dev_docs step 3) would free (view_pin,
      *    aux_pin) versus those it would not (eq/invar/nogood/soli hoists) versus
      *    structural ones.
@@ -86,16 +86,17 @@ namespace gcs::innards
      */
     enum class OrderEncodingResidencyCause
     {
-        ModelTime,    ///< born Top: the ge atom was created before the logger attached.
-        Boundary,     ///< born Top: a trivially-derivable boundary literal (need_gevar's `boundary`).
-        ViewPin,      ///< born Top: whole encoding resident because the variable is a view underlying (views_of_variable).
-        AuxPin,       ///< born Top: whole encoding resident via order_encoding_stays_resident (aux magnitudes).
-        GateResident, ///< born Top: the variable had not crossed the min-chain gate (order_encoding_deletion_min_chain).
-        EqHoist,      ///< hoisted to Top from an eq atom's Top def (need_direct_encoding_for).
-        InvarHoist,   ///< hoisted to Top from an interval-partition atom's Top def (define_plain_invar).
-        NogoodHoist,  ///< hoisted to Top by emit_learned_nogood.
-        SoliHoist,    ///< hoisted to Top by the objective-improvement hoist in ProofLogger::solution.
-        GuessHoist    ///< hoisted to a positive backtrack level by ProofLogger::backtrack (transient; never a Top cause).
+        ModelTime,      ///< born Top: the ge atom was created before the logger attached.
+        Boundary,       ///< born Top: a trivially-derivable boundary literal (need_gevar's `boundary`).
+        ViewPin,        ///< born Top: whole encoding resident because the variable is a view underlying (views_of_variable).
+        AuxPin,         ///< born Top: whole encoding resident via order_encoding_stays_resident (aux magnitudes).
+        FrontierExempt, ///< born Top: the frontier owner exempted the variable from deletion (note_deletion_exempt).
+        GateResident,   ///< born Top: the variable had not crossed the min-chain gate (order_encoding_deletion_min_chain).
+        EqHoist,        ///< hoisted to Top from an eq atom's Top def (need_direct_encoding_for).
+        InvarHoist,     ///< hoisted to Top from an interval-partition atom's Top def (define_plain_invar).
+        NogoodHoist,    ///< hoisted to Top by emit_learned_nogood.
+        SoliHoist,      ///< hoisted to Top by the objective-improvement hoist in ProofLogger::solution.
+        GuessHoist      ///< hoisted to a positive backtrack level by ProofLogger::backtrack (transient; never a Top cause).
     };
 
     /**
@@ -981,6 +982,34 @@ namespace gcs::innards
          * unless the Literals mode is later active.
          */
         auto note_order_encoding_stays_resident(const SimpleOrProofOnlyIntegerVariableID & id) -> void;
+
+        /**
+         * Note that this variable is **exempt from order-encoding deletion**: under
+         * OrderEncodingDeletion::Literals every one of its `ge` definitions stays resident
+         * at Top, as in mode None, however long its chain grows.
+         *
+         * This is the frontier owner's call, and it is a *policy* note rather than a
+         * correctness one — unlike note_order_encoding_stays_resident, nothing breaks if it
+         * is omitted; the variable simply churns. It exists because the chain-length gate
+         * cannot distinguish the two kinds of long chain: a **win-regime** one (a
+         * weak-propagation split variable, whose stepped-over thresholds are exactly what
+         * deletion should remove) from a **churn-regime** one (a perpetually re-tightened
+         * bound, deleted and re-introduced forever for no shrinkage at all). Only whoever
+         * owns the frontier knows which it is looking at.
+         *
+         * The measured instance is the **objective**: on seat-moving 2018 its objective and
+         * cost variables carry essentially all of the residual 20 784 delete/reintroduce
+         * churn at the default gate, verify-neutrally and for zero saving, because
+         * branch-and-bound re-tightens the objective at every improving solution and every
+         * backtrack relaxes it again. ProofModel::minimise exempts it.
+         *
+         * A pure note; a no-op unless the Literals mode is later active. Its residency slot
+         * (`FrontierExempt`) sits just above the chain gate and just below the structural
+         * pins, and is the exact opposite of the eq window's `WindowedFrontier` -- "resident
+         * *despite* being frontier" against "deletable *because* frontier". The two never
+         * apply to the same variable; see dev_docs/brancher-design.md.
+         */
+        auto note_deletion_exempt(const SimpleOrProofOnlyIntegerVariableID & id) -> void;
 
         /**
          * Note that this variable's order-encoding (ge) atom definitions carry @i[..][ge]

--- a/gcs/innards/proofs/proof_model.cc
+++ b/gcs/innards/proofs/proof_model.cc
@@ -842,6 +842,25 @@ auto ProofModel::minimise(const IntegerVariableID & var) -> void
     if (_imp->streaming)
         throw UnexpectedException{"objective must be set before the OPB preamble is written"};
     _imp->optional_minimise_variable = var;
+
+    // Exempt the objective from order-encoding deletion (dev_docs/brancher-design.md,
+    // payload 3). Branch-and-bound re-tightens it at every improving solution and every
+    // backtrack relaxes it again, so under Literals its thresholds are deleted and
+    // re-introduced forever -- on seat-moving 2018 that is essentially all of the residual
+    // churn at the default gate, verify-neutrally and for zero shrinkage. The chain gate
+    // cannot suppress it, because the objective's chain is long for a churn reason rather
+    // than a win reason and the gate only measures length.
+    //
+    // Here rather than in solve_with because this is where the objective is declared to the
+    // proof machinery, so every path that sets one gets the exemption. A view objective is
+    // exempted through its underlying, which is the variable whose `ge` definitions the
+    // deletion machinery tracks (and which is already resident as a view underlying anyway).
+    overloaded{
+        [&](const SimpleIntegerVariableID & v) { names_and_ids_tracker().note_deletion_exempt(v); },                 //
+        [&](const ViewOfIntegerVariableID & v) { names_and_ids_tracker().note_deletion_exempt(v.actual_variable); }, //
+        [&](const ConstantIntegerVariableID &) {}                                                                    //
+    }
+        .visit(var);
 }
 
 auto ProofModel::preserve(vector<IntegerVariableID> vars) -> void


### PR DESCRIPTION
Closes #609. Part of #612, stacked on #615 (→ #614 → #607 → #606 → #605).

Branch-and-bound re-tightens the objective at every improving solution and every backtrack
relaxes it again, so under `Literals` its `ge` thresholds are deleted and re-introduced
forever. On seat-moving 2018 that is essentially all of the residual delete/reintroduce
churn at the default gate, and it is churn in the exact sense: **verify-neutral, for zero
shrinkage**. The chain-length gate cannot suppress it, and that is the point — the gate
measures *length*, and the objective's chain is long for a churn reason rather than a win
reason. Only whoever owns the frontier can tell those apart.

So the frontier owner says so. `note_deletion_exempt` on the tracker, a `FrontierExempt`
residency cause, and its slot in `need_gevar`'s ladder, which becomes
**boundary > aux > view > exempt > gate** — below the structural pins (they force residency
whatever anyone wants), above the gate (the exemption holds *however long* the chain grows).
`ProofModel::minimise` makes the note rather than `solve_with`, so every path that declares
an objective gets it; a view objective is exempted through its underlying.

146 lines, most of it comment.

## Two departures from the design

**The exemption also refuses to *window* a variable.** `FrontierExempt` and B''s
`WindowedFrontier` are opposite answers to the same question — resident *despite* being
frontier, versus deletable *because* frontier — and the design says they never apply to the
same variable. Nothing stopped them: a branched objective is both, and `tour` branches on
its objective, so this was not hypothetical. Making the exemption win in
`need_direct_encoding_for` keeps that claim true by construction, and it is the right way
round — exempting a variable says "do not churn this encoding", and windowing its eq atoms
is churning it.

**The brancher-facing half is not built.** The design offers it "optionally… but not by
default"; an API with no caller is speculation, and a brancher that wants it can call
`note_deletion_exempt` when a use appears. Exempting a bound-branched variable would defeat
the split win anyway — that win *is* deleting its stepped-over chain.

## Measured — the oracle is two-sided and both sides hold

**It must not touch non-objective wins.** The synthetic split sweep
(`order_deletion_bench --unsat`, d250, gate 0) is **byte-identical** to the stack's previous
tip: no objective, so the note is never made and nothing changes.

**It must suppress the objective's churn.** Same synthetic with `--optimise`:

| | deletes | reintroductions |
|---|---|---|
| before, gate 0 | 812 | 180 |
| after, gate 0 | **726** | **172** |
| before, gate 16 | 656 | 141 |
| after, gate 16 | **591** | **137** |

with the proof slightly smaller (463 839 → 460 736 bytes), and **78 Top-resident `ge`
atoms — 97.5 % of all Top residency at gate 0 — now attributed to the exemption**. On the
real optimisation examples the churn goes to zero outright (tour 4 → 0 deletes, colour 2/1
→ 0/0 at gate 0), though those are small enough that the absolute numbers say little.

## Byte-identity

Mode `None` is untouched. Under `Literals` this stage deliberately **does** move the proof —
but only for optimisation instances, and only their `.pbp`, never the `.opb`. Of six
instances compared against the stack's previous tip: colour and talent differ; crystal_maze,
langford, money and sudoku are byte-identical. That asymmetry is the feature — the exemption
should be invisible to everything without an objective.

## Policy, not correctness

Unlike every other stage in this stack, nothing is stranded without this one, so there is no
proof that could reject to tell you it stopped working. `deletion_exempt_test` therefore
asserts the residency fact in C++ **both ways round** — an exempt variable's thresholds
survive a forget, an ordinary variable's do not — because an exemption that quietly held
*everything* resident would suppress the churn and the deletion win together. Mutation-
checked: a no-op `note_deletion_exempt` fails it. VeriPB still runs over the proof, and the
test uses the exempt literals *after* the forget that would have deleted them, so a
bookkeeping-only lie rejects rather than passing.

## Gates

Caps-off suite **547/547** in each of {None, Literals gate 0, Literals gate 16}.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
