### PR TITLE
state: drop persistent constraint state, capture CircuitSCC's data instead

### DIFF
--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -86,8 +86,8 @@ namespace
     struct SCCProofData
     {
         PosVarDataMap & pos_var_data;
-        ConstraintStateHandle proof_flag_data_handle;
-        ConstraintStateHandle pos_alldiff_data_handle;
+        map<long, ShiftedPosDataMaps> & proof_flag_data;
+        PosAllDiffData & pos_alldiff_data;
     };
 
     struct SCCProofContext
@@ -106,9 +106,7 @@ namespace
         SCCProofContext(const State & state, ProofLogger & logger, const ReasonLiterals & reason, const vector<IntegerVariableID> & succ,
             SCCProofData & proof_data, const long root, const SCCOptions & options) :
             state(state), logger(logger), reason(reason), succ(succ), root(root), pos_var_data(proof_data.pos_var_data),
-            flag_data(any_cast<map<long, ShiftedPosDataMaps> &>(state.get_persistent_constraint_state(proof_data.proof_flag_data_handle))),
-            root_flag_data(flag_data[root]),
-            pos_alldiff_data(any_cast<PosAllDiffData &>(state.get_persistent_constraint_state(proof_data.pos_alldiff_data_handle))), options(options)
+            flag_data(proof_data.proof_flag_data), root_flag_data(flag_data[root]), pos_alldiff_data(proof_data.pos_alldiff_data), options(options)
         {
         }
 
@@ -1065,13 +1063,12 @@ namespace
 
 auto gcs::innards::circuit::propagate_circuit_using_scc(const State & state, auto & inference, ProofLogger * const logger,
     const ReasonLiterals & reason, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
-    const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
-    const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void
+    SCCPersistentData & persistent, const ConstraintStateHandle & unassigned_handle) -> void
 {
-    auto & pos_var_data = any_cast<PosVarDataMap &>(state.get_persistent_constraint_state(pos_var_data_handle));
+    auto & pos_var_data = persistent.pos_var_data;
     if (! propagate_non_gac_alldifferent(unassigned_handle, state, inference, logger, owner))
         return; // contradiction: the SCC check below would read junk state; the loop sees contradicted()
-    auto proof_data = SCCProofData{pos_var_data, proof_flag_data_handle, pos_alldiff_data_handle};
+    auto proof_data = SCCProofData{pos_var_data, persistent.proof_flag_data, persistent.pos_alldiff_data};
     check_sccs(state, inference, logger, reason, owner, succ, scc_options, proof_data);
     auto & unassigned = any_cast<NonGacAllDifferentUnassigned &>(state.get_constraint_state(unassigned_handle));
     // Remove any newly assigned vals from unassigned (swap-and-pop; order is irrelevant).
@@ -1088,13 +1085,11 @@ auto gcs::innards::circuit::propagate_circuit_using_scc(const State & state, aut
 
 template auto gcs::innards::circuit::propagate_circuit_using_scc(const State & state, SimpleInferenceTracker & inference, ProofLogger * const logger,
     const ReasonLiterals & reason, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
-    const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
-    const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
+    SCCPersistentData & persistent, const ConstraintStateHandle & unassigned_handle) -> void;
 
 template auto gcs::innards::circuit::propagate_circuit_using_scc(const State & state, EagerProofLoggingInferenceTracker & inference,
     ProofLogger * const logger, const ReasonLiterals & reason, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ,
-    const SCCOptions & scc_options, const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
-    const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
+    const SCCOptions & scc_options, SCCPersistentData & persistent, const ConstraintStateHandle & unassigned_handle) -> void;
 
 auto gcs::innards::circuit::install_circuit_scc(Propagators & propagators, State & initial_state, const ConstraintID & owner,
     const vector<IntegerVariableID> & succ, const SCCOptions & scc_options, PosVarDataMap pos_var_data) -> void
@@ -1104,18 +1099,19 @@ auto gcs::innards::circuit::install_circuit_scc(Propagators & propagators, State
     for (auto v : succ) {
         unassigned.emplace_back(v);
     }
-    auto pos_var_data_handle = initial_state.add_persistent_constraint_state(std::move(pos_var_data));
     auto unassigned_handle = initial_state.add_constraint_state(unassigned);
-    auto proof_flag_data_handle = initial_state.add_persistent_constraint_state(map<long, ShiftedPosDataMaps>{});
-    auto pos_alldiff_data_handle = initial_state.add_persistent_constraint_state(PosAllDiffData{});
+
+    // The position definitions and the two proof caches do not backtrack, so they are
+    // captured rather than held in the State: the propagator mutates the caches through
+    // the shared_ptr and they stay valid at every later node.
+    auto persistent = std::make_shared<SCCPersistentData>(std::move(pos_var_data), map<long, ShiftedPosDataMaps>{}, PosAllDiffData{});
 
     Triggers triggers;
     triggers.on_change = {succ.begin(), succ.end()};
     propagators.install(
         owner,
-        [succ, owner, pos_var_data_handle = pos_var_data_handle, proof_flag_data_handle = proof_flag_data_handle,
-            pos_alldiff_data_handle = pos_alldiff_data_handle, unassigned_handle = unassigned_handle,
-            options = scc_options](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+        [succ, owner, persistent = persistent, unassigned_handle = unassigned_handle, options = scc_options](
+            const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             ReasonLiterals reason = eager_reason(generic_reason(succ), state);
 
             if (logger && options.short_reasons) {
@@ -1130,8 +1126,7 @@ auto gcs::innards::circuit::install_circuit_scc(Propagators & propagators, State
                 reason = eager_reason(singleton_reason(reason_short), state);
             }
 
-            propagate_circuit_using_scc(state, inference, logger, reason, owner, succ, options, pos_var_data_handle, proof_flag_data_handle,
-                pos_alldiff_data_handle, unassigned_handle);
+            propagate_circuit_using_scc(state, inference, logger, reason, owner, succ, options, *persistent, unassigned_handle);
             return PropagatorState::Enable;
         },
         triggers);

--- a/gcs/constraints/circuit/circuit_scc.hh
+++ b/gcs/constraints/circuit/circuit_scc.hh
@@ -6,6 +6,8 @@
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/state.hh>
 #include <gcs/variable_id.hh>
+#include <map>
+#include <memory>
 #include <vector>
 
 namespace gcs
@@ -30,15 +32,33 @@ namespace gcs
 namespace gcs::innards::circuit
 {
     /**
+     * \brief The SCC propagator's non-backtrackable data: the position-variable proof
+     * definitions built once at install time, plus the two caches of proof lines and
+     * flags already emitted for a position or an at-most-one fact.
+     *
+     * All three deliberately survive backtracking -- a proof line, once written, stays
+     * valid at any later node, and re-deriving it would just bloat the proof -- so the
+     * propagator holds this by shared_ptr and mutates through it, exactly as
+     * signed_multiply::Data and the tabulation table do. It is proof-only: the caches
+     * are reached solely through SCCProofContext, which is constructed only when a
+     * ProofLogger is present.
+     */
+    struct SCCPersistentData
+    {
+        PosVarDataMap pos_var_data;
+        std::map<long, ShiftedPosDataMaps> proof_flag_data;
+        PosAllDiffData pos_alldiff_data;
+    };
+
+    /**
      * \brief The SCC-based circuit propagator, used by the Circuit constraint when the
      * circuit::SCC algorithm is selected. Runs the value-consistent all-different, checks
      * strongly connected components (pruning edges that cannot lie on a Hamiltonian cycle),
      * and prevents small cycles. Defined in circuit_scc.cc.
      */
     auto propagate_circuit_using_scc(const State & state, auto & inference, ProofLogger * const logger, const ReasonLiterals & reason,
-        const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options,
-        const ConstraintStateHandle & pos_var_data_handle, const ConstraintStateHandle & proof_flag_data_handle,
-        const ConstraintStateHandle & pos_alldiff_data_handle, const ConstraintStateHandle & unassigned_handle) -> void;
+        const ConstraintID & owner, const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options, SCCPersistentData & persistent,
+        const ConstraintStateHandle & unassigned_handle) -> void;
 
     /**
      * \brief Set up the backtrackable state for the SCC circuit propagator and install it, given

--- a/gcs/innards/state.cc
+++ b/gcs/innards/state.cc
@@ -93,7 +93,6 @@ struct State::Imp
 
     list<vector<IntervalSet<Integer>>> integer_variable_states{};
     list<vector<ConstraintState>> constraint_states{};
-    vector<ConstraintState> persistent_constraint_states{};
     list<vector<function<auto()->void>>> on_backtracks{};
     vector<Literal> guesses{};
     vector<Literal> extra_proof_conditions{};
@@ -120,7 +119,6 @@ auto State::clone() const -> State
     auto result = State{};
     result._imp->integer_variable_states = _imp->integer_variable_states;
     result._imp->constraint_states = _imp->constraint_states;
-    result._imp->persistent_constraint_states = _imp->persistent_constraint_states;
     result._imp->on_backtracks = _imp->on_backtracks;
     result._imp->optional_minimise_variable = _imp->optional_minimise_variable;
     result._imp->optional_objective_incumbent = _imp->optional_objective_incumbent;
@@ -796,20 +794,9 @@ auto innards::State::add_constraint_state(const ConstraintState c) -> Constraint
     return ConstraintStateHandle{static_cast<unsigned long>(_imp->constraint_states.back().size() - 1)};
 }
 
-auto innards::State::add_persistent_constraint_state(const ConstraintState c) -> ConstraintStateHandle
-{
-    _imp->persistent_constraint_states.push_back(c);
-    return ConstraintStateHandle{static_cast<unsigned long>(_imp->persistent_constraint_states.size() - 1)};
-}
-
 auto innards::State::get_constraint_state(const ConstraintStateHandle h) const -> ConstraintState &
 {
     return _imp->constraint_states.back()[h.index];
-}
-
-auto innards::State::get_persistent_constraint_state(const ConstraintStateHandle h) const -> ConstraintState &
-{
-    return _imp->persistent_constraint_states[h.index];
 }
 
 namespace gcs

--- a/gcs/innards/state.hh
+++ b/gcs/innards/state.hh
@@ -555,25 +555,19 @@ namespace gcs::innards
         /**
          * Store a given std::any value as a constraint state that is accessible via
          * the returned handle and restores on backtrack.
+         *
+         * Every slot added here is deep-copied on entry to each search node, so only
+         * add state that genuinely has to backtrack. Data that must survive
+         * backtracking (a cache of proof lines already emitted, say) or that never
+         * changes after install is not constraint state at all: capture it in the
+         * propagator, by shared_ptr if it is mutable.
          */
         [[nodiscard]] auto add_constraint_state(const ConstraintState c) -> ConstraintStateHandle;
-
-        /**
-         * Store a given std::any value as a constraint state that is accessible via
-         * the returned handle and does not restore on backtrack.
-         */
-        [[nodiscard]] auto add_persistent_constraint_state(const ConstraintState c) -> ConstraintStateHandle;
 
         /**
          * Return the constraint state for the given handle.
          */
         [[nodiscard]] auto get_constraint_state(const ConstraintStateHandle h) const -> ConstraintState &;
-
-        /**
-         * Return the persistent constraint state for the given handle.
-         *
-         */
-        [[nodiscard]] auto get_persistent_constraint_state(const ConstraintStateHandle h) const -> ConstraintState &;
 
         ///@}
     };

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,6 +3,29 @@
 Scripts that support development but are not built, installed, or run by
 the test suite.
 
+## opb_snapshot.bash
+
+Snapshots every registered example test's OPB definition, for byte-diffing a
+refactor that is meant to leave the encoding alone. Runs each test with
+`--prove`, keeps that run's `.opb` and `.scp`, and deletes the `.pbp` and
+`.varmap` immediately: neither the `.opb` nor the `.scp` is branching-seed
+dependent, so two snapshots either side of an output-preserving change should
+diff empty, while the proof itself would differ on seed alone. Any binary whose
+help mentions `--seed` is given one, so the examples that build a random
+instance are pinned rather than skipped.
+
+Run from the repository root after a build, once either side of the change:
+
+```shell
+./tools/opb_snapshot.bash /tmp/opb-before
+# make the change, rebuild
+./tools/opb_snapshot.bash /tmp/opb-after
+diff -rq /tmp/opb-before /tmp/opb-after
+```
+
+Naming ctest targets as extra arguments snapshots only those. This is a
+developer tool, not a ctest: it is never run by the test suite.
+
 ## capture_encodings.py
 
 Runs the data-driven constraint test binaries found under `./build` and

--- a/tools/opb_snapshot.bash
+++ b/tools/opb_snapshot.bash
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Usage: opb_snapshot.bash OUTDIR [ctest-name ...]
+#
+# Runs the registered example (and scp-chain) tests with --prove, keeps only
+# each run's .opb and .scp, and deletes the .pbp/.varmap immediately. The point
+# is a byte-diffable snapshot of every constraint's OPB definition: .opb and
+# .scp are NOT branching-seed dependent, so a diff across a refactor that is
+# meant to be output-preserving should be empty.
+#
+# With no test names, snapshots every example test.
+#
+# This is a developer tool for refactor verification; it is not a ctest.
+
+set -u
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+build=$root/build
+outdir=$1
+shift
+
+mkdir -p "$outdir"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# Pull "name;binary;args..." out of the generated CTestTestfile.cmake files,
+# rewriting the run_test_and_verify.bash wrapper into a direct call.
+list_tests()
+{
+    python3 - "$build" <<'PYEOF'
+import pathlib, re, shlex, sys
+build = pathlib.Path(sys.argv[1])
+for f in sorted(build.rglob('CTestTestfile.cmake')):
+    for m in re.finditer(r'^add_test\(\[=*\[([^\]]+)\]=*\] (.*)\)$', f.read_text(), re.M):
+        name, rest = m.group(1), m.group(2)
+        try:
+            argv = shlex.split(rest)
+        except ValueError:
+            continue
+        if not argv or 'run_test_and_verify.bash' not in argv[0]:
+            continue
+        argv = argv[1:]
+        if argv[:1] == ['--basename']:
+            argv = argv[2:]
+        print(';'.join([name] + argv))
+PYEOF
+}
+
+want=$*
+n_ok=0 n_fail=0 n_skip=0
+
+while IFS= read -r line; do
+    name=${line%%;*}
+    rest=${line#*;}
+    IFS=';' read -r -a argv <<< "$rest"
+
+    if [[ -n $want ]] && ! grep -qw -- "$name" <<< "$want" ; then
+        continue
+    fi
+
+    # The five *_random harnesses generate a fresh instance per run, so their
+    # .opb differs run-to-run on an unchanged binary and is worthless for a
+    # byte-diff. Pin any binary that takes a seed, rather than dropping the
+    # coverage.
+    seed=()
+    if "${argv[0]}" --help 2>&1 | grep -q -- '--seed' ; then
+        seed=(--seed 42)
+    fi
+
+    ( cd "$work" && rm -f -- *.opb *.pbp *.varmap *.scp
+      timeout 300 "${argv[@]}" "${seed[@]}" --prove --proof-files-basename "$name" >/dev/null 2>&1 )
+    rc=$?
+
+    if [[ -f $work/$name.opb ]] ; then
+        cp "$work/$name.opb" "$outdir/"
+        [[ -f $work/$name.scp ]] && cp "$work/$name.scp" "$outdir/"
+        n_ok=$((n_ok + 1))
+    else
+        # Binaries that take no --proof-files-basename, or that failed before
+        # writing a model, are simply not part of the snapshot.
+        echo "skip: $name (rc=$rc, no .opb)" >&2
+        n_skip=$((n_skip + 1))
+        [[ $rc -ne 0 ]] && n_fail=$((n_fail + 1))
+    fi
+    rm -f "$work"/*.pbp "$work"/*.varmap
+done < <(list_tests)
+
+echo "snapshot: $n_ok captured, $n_skip skipped ($n_fail nonzero exit) -> $outdir" >&2
+# A snapshot that captured nothing is a broken harness, not a clean result.
+[[ $n_ok -gt 0 ]]


### PR DESCRIPTION
First of a stack finishing the `install()` → `prepare()` / `define_proof_model()` / `install_propagators()` split. This one clears the way: it removes the only case where a constraint's backtrackable-state payload was produced by the proof-model phase, which is what made `Circuit` awkward to split.

## What

`State` had two constraint-state stores: the backtrackable one, and a persistent one that deliberately did not restore on backtrack. `CircuitSCC` was its only user, for three things — the position-variable proof definitions built once at install time, and two caches of proof lines and flags already emitted.

None of those is state in any useful sense:

- The position map is written once and only ever read afterwards. All 47 uses are reads (`.at(i).var`, `.plus_one_lines.at(...)`, `.comment_name`); it was held by non-const reference only because `get_persistent_constraint_state` hands back a mutable `any &`. `circuit_prevent` already captures the same map directly in its propagator rather than routing it through `State`.
- The two caches hold `ProofLine` numbers into the single global proof stream. Sharing them is not merely acceptable but required — a per-search copy would re-emit or mis-cite lines.

So all three move into a `shared_ptr<SCCPersistentData>` captured by the propagator, the same way `signed_multiply::Data` and the tabulation table are already held, and the persistent store goes.

## Why the diff is small

`SCCProofData` already carried the position map by reference, so the propagator's internals are untouched — every `ctx.pos_var_data` / `ctx.flag_data` use, `SCCProofContext`, `check_sccs`. Only the three `any_cast`s at the boundary change, plus `propagate_circuit_using_scc`'s signature (three handles → one reference; `unassigned_handle` stays, being genuinely backtrackable).

`State::clone()` is unaffected in practice: its two callers clone the pristine pre-install state (`solve.cc:285`, before `create_propagators` at :299) and a solution snapshot, neither of which has ever had a persistent slot to copy.

I also took the chance to document on `add_constraint_state` that every slot is deep-copied per search node, so it should only hold things that genuinely backtrack.

## Verification

- 531/531 ctest pass, including the circuit proof-verification lanes.
- OPB and `.scp` byte-identical across all 60 captured example models (`tools/opb_snapshot.bash`, added here).
- The snapshot harness was checked to actually bite: renaming the OPB block-header comment flags 55 of the 60 models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD