### PR TITLE
Constraint: give define_proof_model the initial State, as const

### DIFF
--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -38,7 +38,20 @@ namespace gcs
         ConstraintID _constraint_id;
         Constraint() : _constraint_id(CurrentlyUnnamedConstraint{}) {};
         explicit Constraint(ConstraintID constraint_id) : _constraint_id(std::move(constraint_id)) {};
-        virtual auto define_proof_model(innards::ProofModel &) -> void {};
+        /**
+         * \brief Write this constraint's OPB definition, and nothing else.
+         *
+         * The State is the *declared* domains: install runs before search, and
+         * nothing at install time narrows an existing domain (Propagators::define_bound
+         * takes a const State and installs a RUP initialiser rather than trimming).
+         * So an encoding whose shape depends on the domains -- bit widths, a row per
+         * value, a flag per tuple -- can read them directly here, instead of having
+         * prepare() snapshot them into members first.
+         *
+         * It is const because this phase must only describe the constraint, never
+         * allocate: variables and constraint state belong to prepare().
+         */
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void {};
         virtual auto install_propagators(innards::Propagators &) -> void {};
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool
         {

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -81,15 +81,15 @@ auto Abs::clone() const -> unique_ptr<Constraint>
     return make_unique<Abs>(_v1, _v2);
 }
 
-auto Abs::install(Propagators & propagators, State &, ProofModel * const optional_model) && -> void
+auto Abs::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
 
-auto Abs::define_proof_model(ProofModel & model) -> void
+auto Abs::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Labels match cake_pb_cp's. cake names the V2 >= V1 half [posle] and the
     // V2 <= V1 half [posge] (i.e. its le/ge track the slack direction, opposite

--- a/gcs/constraints/abs/abs.hh
+++ b/gcs/constraints/abs/abs.hh
@@ -26,7 +26,7 @@ namespace gcs
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _abs_nonneg_lines;
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _abs_neg_lines;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -98,7 +98,7 @@ auto AllDifferent::install(Propagators & propagators, State & initial_state, Pro
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -143,7 +143,7 @@ auto AllDifferent::prepare(Propagators &, State & initial_state, ProofModel * co
     return true;
 }
 
-auto AllDifferent::define_proof_model(ProofModel & model) -> void
+auto AllDifferent::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Identical for both consistency levels: the choice is a propagation-strength
     // knob and never changes the encoding.

--- a/gcs/constraints/all_different/all_different.hh
+++ b/gcs/constraints/all_different/all_different.hh
@@ -46,7 +46,7 @@ namespace gcs
         AllDifferentConsistency _level = consistency::GAC{};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -65,7 +65,7 @@ auto AllDifferentExcept::install(Propagators & propagators, State & initial_stat
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -123,7 +123,7 @@ auto AllDifferentExcept::prepare(Propagators &, State & initial_state, ProofMode
     return true;
 }
 
-auto AllDifferentExcept::define_proof_model(ProofModel & model) -> void
+auto AllDifferentExcept::define_proof_model(ProofModel & model, const State &) -> void
 {
     _value_am1_constraint_numbers = make_shared<map<Integer, ProofLine>>();
     // Encode from the original exception list, matching cake_pb_cp: an

--- a/gcs/constraints/all_different/all_different_except.hh
+++ b/gcs/constraints/all_different/all_different_except.hh
@@ -40,7 +40,7 @@ namespace gcs
         std::map<IntegerVariableID, innards::ProofFlag> _duplicate_selectors;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -62,7 +62,7 @@ auto SymmetricAllDifferent::install(Propagators & propagators, State & initial_s
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -97,7 +97,7 @@ auto SymmetricAllDifferent::prepare(Propagators & propagators, State & initial_s
     return true;
 }
 
-auto SymmetricAllDifferent::define_proof_model(ProofModel & model) -> void
+auto SymmetricAllDifferent::define_proof_model(ProofModel & model, const State &) -> void
 {
     auto n = _vars.size();
 

--- a/gcs/constraints/all_different/symmetric_all_different.hh
+++ b/gcs/constraints/all_different/symmetric_all_different.hh
@@ -39,7 +39,7 @@ namespace gcs
         bool _has_duplicate_vars = false;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/all_equal/all_equal.cc
+++ b/gcs/constraints/all_equal/all_equal.cc
@@ -52,7 +52,7 @@ auto AllEqual::install(Propagators & propagators, State & initial_state, ProofMo
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -62,7 +62,7 @@ auto AllEqual::prepare(Propagators &, State &, ProofModel * const) -> bool
     return _vars.size() > 1;
 }
 
-auto AllEqual::define_proof_model(ProofModel & model) -> void
+auto AllEqual::define_proof_model(ProofModel & model, const State &) -> void
 {
     // cake_pb_cp labels each consecutive-pair equality's two halves
     // @c[id][<i>le] (vars[i+1] - vars[i] >= 0) and @c[id][<i>ge]

--- a/gcs/constraints/all_equal/all_equal.hh
+++ b/gcs/constraints/all_equal/all_equal.hh
@@ -26,7 +26,7 @@ namespace gcs
         std::vector<IntegerVariableID> _vars;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -81,12 +81,12 @@ auto Among::install(Propagators & propagators, State & initial_state, ProofModel
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
 
-auto Among::define_proof_model(ProofModel & model) -> void
+auto Among::define_proof_model(ProofModel & model, const State &) -> void
 {
     // very easy PB encoding: sum up over the condition that each variable equals one of the
     // value of interest options, and make that equal the how many variable.

--- a/gcs/constraints/among/among.hh
+++ b/gcs/constraints/among/among.hh
@@ -25,7 +25,7 @@ namespace gcs
         IntegerVariableID _how_many;
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/at_most_one/at_most_one.cc
+++ b/gcs/constraints/at_most_one/at_most_one.cc
@@ -61,12 +61,12 @@ auto AtMostOne::install(Propagators & propagators, State & initial_state, ProofM
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
 
-auto AtMostOne::define_proof_model(ProofModel & model) -> void
+auto AtMostOne::define_proof_model(ProofModel & model, const State &) -> void
 {
     // For each var_i: define flag_i ⇔ (var_i = _val) via a Count-style
     // gt/lt/eq triple, then post sum_i flag_i ≤ 1.

--- a/gcs/constraints/at_most_one/at_most_one.hh
+++ b/gcs/constraints/at_most_one/at_most_one.hh
@@ -36,7 +36,7 @@ namespace gcs
         IntegerVariableID _val;
         std::vector<std::tuple<innards::ProofFlag, innards::ProofFlag, innards::ProofFlag>> _flags;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/bin_packing/bin_packing.cc
+++ b/gcs/constraints/bin_packing/bin_packing.cc
@@ -1080,7 +1080,7 @@ auto BinPacking::install(Propagators & propagators, State & initial_state, Proof
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -1159,7 +1159,7 @@ auto BinPacking::prepare(Propagators &, State & initial_state, ProofModel * cons
     return true;
 }
 
-auto BinPacking::define_proof_model(ProofModel & model) -> void
+auto BinPacking::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Natural definition: for each bin b,
     //   sum_i { sizes[i] * [items[i] == b] } == loads[b]   (variable-load form)

--- a/gcs/constraints/bin_packing/bin_packing.hh
+++ b/gcs/constraints/bin_packing/bin_packing.hh
@@ -103,7 +103,7 @@ namespace gcs
         std::optional<innards::ConstraintStateHandle> _dead_cache_idx;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -75,7 +75,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::install(Propagators & propagators, Stat
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -88,7 +88,7 @@ auto ReifiedCompareLessThanOrMaybeEqual::prepare(Propagators &, State & initial_
     return true;
 }
 
-auto ReifiedCompareLessThanOrMaybeEqual::define_proof_model(ProofModel & model) -> void
+auto ReifiedCompareLessThanOrMaybeEqual::define_proof_model(ProofModel & model, const State &) -> void
 {
     // `role` is the cake_pb_cp @c label role, or "" for the lines cake leaves
     // unlabelled (an unconditional comparison is a single bare inequality).

--- a/gcs/constraints/comparison/comparison.hh
+++ b/gcs/constraints/comparison/comparison.hh
@@ -39,7 +39,7 @@ namespace gcs
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -55,12 +55,12 @@ auto Count::install(Propagators & propagators, State & initial_state, ProofModel
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
 
-auto Count::define_proof_model(ProofModel & model) -> void
+auto Count::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Conform to cake_pb_cp's count encoding (#354): per position i, the
     // flags x[id][i][ge] ⇔ var ≥ val, x[id][i][le] ⇔ var ≤ val, and

--- a/gcs/constraints/count/count.hh
+++ b/gcs/constraints/count/count.hh
@@ -23,7 +23,7 @@ namespace gcs
         IntegerVariableID _value_of_interest, _how_many;
         std::vector<std::tuple<innards::ProofFlag, innards::ProofFlag, innards::ProofFlag>> _flags;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -105,7 +105,7 @@ auto Cumulative::install(Propagators & propagators, State & initial_state, Proof
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -177,7 +177,7 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
     return true;
 }
 
-auto Cumulative::define_proof_model(ProofModel & model) -> void
+auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Time-table OPB encoding:
     //   for each task i and each time point t in its possible-active range:

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -84,7 +84,7 @@ namespace gcs
         std::map<Integer, innards::ProofLine> _capacity_lines; // t -> proof line for the per-t time-table constraint
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -84,7 +84,7 @@ auto Disjunctive::install(Propagators & propagators, State & initial_state, Proo
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -135,7 +135,7 @@ auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * con
     return true;
 }
 
-auto Disjunctive::define_proof_model(ProofModel & model) -> void
+auto Disjunctive::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Declarative pairwise OPB encoding:
     //   for each unordered pair (i, j) of participating tasks:

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -84,7 +84,7 @@ namespace gcs
         std::vector<std::optional<innards::ProofFlag>> _zero;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -90,7 +90,7 @@ auto Disjunctive2D::install(Propagators & propagators, State & initial_state, Pr
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -165,7 +165,7 @@ auto Disjunctive2D::prepare(Propagators &, State & initial_state, ProofModel * c
     return true;
 }
 
-auto Disjunctive2D::define_proof_model(ProofModel & model) -> void
+auto Disjunctive2D::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Declarative pairwise OPB encoding (the diffn definition itself):
     //   for each axis d in {x, y} and ordered pair (i, j):

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
@@ -87,7 +87,7 @@ namespace gcs
         std::vector<std::optional<innards::ProofFlag>> _zero_w, _zero_h;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -172,7 +172,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::install(
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -205,7 +205,7 @@ auto NDimensionalElement<EntryType_, dimensions_>::prepare(Propagators & propaga
 }
 
 template <typename EntryType_, unsigned dimensions_>
-auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel & model) -> void
+auto NDimensionalElement<EntryType_, dimensions_>::define_proof_model(ProofModel & model, const State &) -> void
 {
     if (_has_empty_dim) {
         // No valid assignment: emit a trivially-false constraint so the OPB

--- a/gcs/constraints/element/element.hh
+++ b/gcs/constraints/element/element.hh
@@ -62,7 +62,7 @@ namespace gcs
 
     private:
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
         // install_propagators dispatches here on the concrete type of the index

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -209,7 +209,7 @@ auto ReifiedEquals::install(Propagators & propagators, State & initial_state, Pr
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -220,7 +220,7 @@ auto ReifiedEquals::prepare(Propagators &, State & initial_state, ProofModel * c
     return true;
 }
 
-auto ReifiedEquals::define_proof_model(ProofModel & model) -> void
+auto ReifiedEquals::define_proof_model(ProofModel & model, const State &) -> void
 {
     overloaded{
         [&](const reif::MustHold &) {

--- a/gcs/constraints/equals/equals.hh
+++ b/gcs/constraints/equals/equals.hh
@@ -33,7 +33,7 @@ namespace gcs
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/global_cardinality/global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/global_cardinality.cc
@@ -78,7 +78,7 @@ auto GlobalCardinality::clone() const -> unique_ptr<Constraint>
 auto GlobalCardinality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 
@@ -89,7 +89,7 @@ auto GlobalCardinality::install(Propagators & propagators, State & initial_state
             In{var, _values}.install(propagators, initial_state, optional_model);
 }
 
-auto GlobalCardinality::define_proof_model(ProofModel & model) -> void
+auto GlobalCardinality::define_proof_model(ProofModel & model, const State &) -> void
 {
     for (const auto & [j, value] : enumerate(_values)) {
         WPBSum sum;

--- a/gcs/constraints/global_cardinality/global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/global_cardinality.hh
@@ -51,7 +51,7 @@ namespace gcs
         // Sum_i (x_i == values[j]) == counts[j], stored as {LE-half, GE-half}.
         std::vector<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _count_lines;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
         // The bounds propagator's Hall-interval reasoning ranges over contiguous

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -75,7 +75,7 @@ auto In::install(Propagators & propagators, State & initial_state, ProofModel * 
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -103,7 +103,7 @@ auto In::prepare(Propagators &, State & initial_state, ProofModel * const) -> bo
     return true;
 }
 
-auto In::define_proof_model(ProofModel & model) -> void
+auto In::define_proof_model(ProofModel & model, const State &) -> void
 {
     WPBSum sum;
 

--- a/gcs/constraints/in/in.hh
+++ b/gcs/constraints/in/in.hh
@@ -29,7 +29,7 @@ namespace gcs
         bool _has_no_values = false;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/increasing/increasing.cc
+++ b/gcs/constraints/increasing/increasing.cc
@@ -53,7 +53,7 @@ auto IncreasingChain::install(Propagators & propagators, State & initial_state, 
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -68,7 +68,7 @@ auto IncreasingChain::prepare(Propagators &, State &, ProofModel * const) -> boo
     return _ordered_vars.size() > 1;
 }
 
-auto IncreasingChain::define_proof_model(ProofModel & model) -> void
+auto IncreasingChain::define_proof_model(ProofModel & model, const State &) -> void
 {
     auto offset = _strict ? -1_i : 0_i;
     for (size_t i = 0; i + 1 < _ordered_vars.size(); ++i)

--- a/gcs/constraints/increasing/increasing.hh
+++ b/gcs/constraints/increasing/increasing.hh
@@ -33,7 +33,7 @@ namespace gcs
         std::vector<IntegerVariableID> _ordered_vars;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -80,7 +80,7 @@ auto Inverse::install(Propagators & propagators, State & initial_state, ProofMod
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -103,7 +103,7 @@ auto Inverse::prepare(Propagators & propagators, State & initial_state, ProofMod
     return true;
 }
 
-auto Inverse::define_proof_model(ProofModel & model) -> void
+auto Inverse::define_proof_model(ProofModel & model, const State &) -> void
 {
     for (const auto & [i, x_i] : enumerate(_x))
         for (const auto & [j, y_j] : enumerate(_y)) {

--- a/gcs/constraints/inverse/inverse.hh
+++ b/gcs/constraints/inverse/inverse.hh
@@ -26,7 +26,7 @@ namespace gcs
         std::shared_ptr<std::map<Integer, innards::ProofLine>> _x_value_am1s;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/lex/lex.cc
+++ b/gcs/constraints/lex/lex.cc
@@ -477,7 +477,7 @@ auto LexCompareGreaterThanOrMaybeEqual::install(Propagators & propagators, State
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -489,7 +489,7 @@ auto LexCompareGreaterThanOrMaybeEqual::prepare(Propagators &, State & initial_s
     return true;
 }
 
-auto LexCompareGreaterThanOrMaybeEqual::define_proof_model(ProofModel & model) -> void
+auto LexCompareGreaterThanOrMaybeEqual::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Decide which directions of the encoding we need based on the
     // reification type. If always picks just the constraint direction;

--- a/gcs/constraints/lex/lex.hh
+++ b/gcs/constraints/lex/lex.hh
@@ -92,7 +92,7 @@ namespace gcs
         std::shared_ptr<std::vector<innards::ProofFlag>> _decision_at_lt_flags;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -175,7 +175,7 @@ auto ReifiedLinearEquality::install(Propagators & propagators, State & initial_s
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators, initial_state);
 }
@@ -186,7 +186,7 @@ auto ReifiedLinearEquality::prepare(Propagators &, State & initial_state, ProofM
     return true;
 }
 
-auto ReifiedLinearEquality::define_proof_model(ProofModel & model) -> void
+auto ReifiedLinearEquality::define_proof_model(ProofModel & model, const State &) -> void
 {
     WPBSum terms;
     for (auto & [c, v] : _coeff_vars.terms)

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -52,7 +52,7 @@ namespace gcs
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         // Takes State (unlike the base's Propagators-only hook) because the incremental
         // equality path registers backtrackable constraint state at install time.
         auto install_propagators(innards::Propagators &, innards::State &) -> void;

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -95,7 +95,7 @@ auto ReifiedLinearInequality::install(Propagators & propagators, State & initial
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators, initial_state);
 }
@@ -106,7 +106,7 @@ auto ReifiedLinearInequality::prepare(Propagators &, State & initial_state, Proo
     return true;
 }
 
-auto ReifiedLinearInequality::define_proof_model(ProofModel & model) -> void
+auto ReifiedLinearInequality::define_proof_model(ProofModel & model, const State &) -> void
 {
     WPBSum terms;
     for (auto & [c, v] : _coeff_vars.terms)

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -38,7 +38,7 @@ namespace gcs
         std::optional<std::size_t> _incremental_threshold;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         // Takes State (unlike the base's Propagators-only hook) because the incremental
         // must-hold path registers backtrackable constraint state at install time.
         auto install_propagators(innards::Propagators &, innards::State &) -> void;

--- a/gcs/constraints/logical/logical.cc
+++ b/gcs/constraints/logical/logical.cc
@@ -237,7 +237,7 @@ auto And::install(Propagators & propagators, State & initial_state, ProofModel *
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -248,7 +248,7 @@ auto And::prepare(Propagators &, State & initial_state, ProofModel * const) -> b
     return true;
 }
 
-auto And::define_proof_model(ProofModel & model) -> void
+auto And::define_proof_model(ProofModel & model, const State &) -> void
 {
     define_cake_logical(model, _constraint_id, _lits, _full_reif, true);
 }
@@ -291,7 +291,7 @@ auto Or::install(Propagators & propagators, State & initial_state, ProofModel * 
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -302,7 +302,7 @@ auto Or::prepare(Propagators &, State & initial_state, ProofModel * const) -> bo
     return true;
 }
 
-auto Or::define_proof_model(ProofModel & model) -> void
+auto Or::define_proof_model(ProofModel & model, const State &) -> void
 {
     define_cake_logical(model, _constraint_id, _lits, _full_reif, false);
 }

--- a/gcs/constraints/logical/logical.hh
+++ b/gcs/constraints/logical/logical.hh
@@ -25,7 +25,7 @@ namespace gcs
         innards::LiteralIs _reif_state = innards::LiteralIs::Undecided;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
@@ -57,7 +57,7 @@ namespace gcs
         innards::LiteralIs _reif_state = innards::LiteralIs::Undecided;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/mdd/mdd.cc
+++ b/gcs/constraints/mdd/mdd.cc
@@ -459,7 +459,7 @@ auto MDD::install(Propagators & propagators, State & initial_state, ProofModel *
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -485,7 +485,7 @@ auto MDD::prepare(Propagators &, State & initial_state, ProofModel * const) -> b
     return true;
 }
 
-auto MDD::define_proof_model(ProofModel & model) -> void
+auto MDD::define_proof_model(ProofModel & model, const State &) -> void
 {
     // state_at_pos_flags[i][q] means "the MDD path passes through node q in layer i".
     auto & flags = _bridge->state_at_pos_flags;

--- a/gcs/constraints/mdd/mdd.hh
+++ b/gcs/constraints/mdd/mdd.hh
@@ -71,7 +71,7 @@ namespace gcs
         std::vector<std::set<Integer>> _opb_alphabet;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -48,7 +48,7 @@ auto MinDistance::install(Propagators & propagators, State & initial_state, Proo
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -127,7 +127,7 @@ auto MinDistance::prepare(Propagators & propagators, State & initial_state, Proo
     return true;
 }
 
-auto MinDistance::define_proof_model(ProofModel & model) -> void
+auto MinDistance::define_proof_model(ProofModel & model, const State &) -> void
 {
     const auto p = _x.size();
     const auto & D = *_distances;

--- a/gcs/constraints/min_distance/min_distance.hh
+++ b/gcs/constraints/min_distance/min_distance.hh
@@ -102,7 +102,7 @@ namespace gcs
         Integer _z_lower = 0_i, _z_upper = 0_i;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
         auto install_check_only_propagator(innards::Propagators &) -> void;
         auto install_forward_propagator(innards::Propagators &, bool pair_support) -> void;

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -44,7 +44,7 @@ auto ArrayMinMax::install(Propagators & propagators, State & initial_state, Proo
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -56,7 +56,7 @@ auto ArrayMinMax::prepare(Propagators &, State &, ProofModel * const) -> bool
     return true;
 }
 
-auto ArrayMinMax::define_proof_model(ProofModel & model) -> void
+auto ArrayMinMax::define_proof_model(ProofModel & model, const State &) -> void
 {
     // (for min) each var >= result, i.e. var - result >= 0
     for (const auto & v : _vars) {

--- a/gcs/constraints/min_max/min_max.hh
+++ b/gcs/constraints/min_max/min_max.hh
@@ -31,7 +31,7 @@ namespace gcs
             std::vector<innards::ProofFlag> _selectors;
 
             virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-            virtual auto define_proof_model(innards::ProofModel &) -> void override;
+            virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
             virtual auto install_propagators(innards::Propagators &) -> void override;
 
         public:

--- a/gcs/constraints/n_value/n_value.cc
+++ b/gcs/constraints/n_value/n_value.cc
@@ -54,7 +54,7 @@ auto NValue::install(Propagators & propagators, State & initial_state, ProofMode
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -68,7 +68,7 @@ auto NValue::prepare(Propagators &, State & initial_state, ProofModel * const) -
     return true;
 }
 
-auto NValue::define_proof_model(ProofModel & model) -> void
+auto NValue::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Conform to cake_pb_cp's nvalue encoding (#354): for each value v in the
     // union of the variables' domains, a fully-reified per-value occurrence flag

--- a/gcs/constraints/n_value/n_value.hh
+++ b/gcs/constraints/n_value/n_value.hh
@@ -25,7 +25,7 @@ namespace gcs
         std::map<Integer, std::list<IntegerVariableID>> _possible_values;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/nogoods/nogoods.cc
+++ b/gcs/constraints/nogoods/nogoods.cc
@@ -83,12 +83,12 @@ auto Nogoods::install(Propagators & propagators, State & initial_state, ProofMod
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
 
-auto Nogoods::define_proof_model(ProofModel & model) -> void
+auto Nogoods::define_proof_model(ProofModel & model, const State &) -> void
 {
     // A nogood forbids a conjunction of literals, so its definition is the clause
     // of their negations. Only the nogoods present at install are declared here;

--- a/gcs/constraints/nogoods/nogoods.hh
+++ b/gcs/constraints/nogoods/nogoods.hh
@@ -78,7 +78,7 @@ namespace gcs
         // growable catch-up is converted (issue #335, stage C-2).
         bool _refined;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/parity/parity.cc
+++ b/gcs/constraints/parity/parity.cc
@@ -72,12 +72,12 @@ auto ParityOdd::install(Propagators & propagators, State & initial_state, ProofM
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
 
-auto ParityOdd::define_proof_model(ProofModel & model) -> void
+auto ParityOdd::define_proof_model(ProofModel & model, const State &) -> void
 {
     // cake_pb_cp's accumulator scheme, over the literals as cake reads them
     // (each operand tuple maps to the same ge / eq atom our proof uses):

--- a/gcs/constraints/parity/parity.hh
+++ b/gcs/constraints/parity/parity.hh
@@ -20,7 +20,7 @@ namespace gcs
     private:
         const innards::Literals _lits;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -149,7 +149,7 @@ auto Minus::install(Propagators & propagators, State & initial_state, ProofModel
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 
@@ -200,7 +200,7 @@ auto Minus::install(Propagators & propagators, State & initial_state, ProofModel
     }
 }
 
-auto Minus::define_proof_model(ProofModel & model) -> void
+auto Minus::define_proof_model(ProofModel & model, const State &) -> void
 {
     // cake_pb_cp labels the two halves of the sum: @c[id][le] on the a - b <= c
     // half (-a + b + c >= 0) and @c[id][ge] on the a - b >= c half (a - b - c >= 0).

--- a/gcs/constraints/plus_minus/minus.hh
+++ b/gcs/constraints/plus_minus/minus.hh
@@ -31,7 +31,7 @@ namespace gcs
         MinusConsistency _level = consistency::Auto{};
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -139,7 +139,7 @@ auto Plus::install(Propagators & propagators, State & initial_state, ProofModel 
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 
@@ -190,7 +190,7 @@ auto Plus::install(Propagators & propagators, State & initial_state, ProofModel 
     }
 }
 
-auto Plus::define_proof_model(ProofModel & model) -> void
+auto Plus::define_proof_model(ProofModel & model, const State &) -> void
 {
     // cake_pb_cp labels the two halves of the sum: @c[id][le] on the Z >= a + b
     // half (the LE half of the equality) and @c[id][ge] on the Z <= a + b half.

--- a/gcs/constraints/plus_minus/plus.hh
+++ b/gcs/constraints/plus_minus/plus.hh
@@ -39,7 +39,7 @@ namespace gcs
         PlusConsistency _level = consistency::Auto{};
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
 
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -525,7 +525,7 @@ auto Regular::install(Propagators & propagators, State & initial_state, ProofMod
                    if (! prepare(propagators, initial_state, optional_model))
                        return;
                    if (optional_model)
-                       define_proof_model(*optional_model);
+                       define_proof_model(*optional_model, initial_state);
                    install_propagators(propagators);
                },
         [&](const proof_strategy::PerCall &) {
@@ -592,7 +592,7 @@ auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) 
     return true;
 }
 
-auto Regular::define_proof_model(ProofModel & model) -> void
+auto Regular::define_proof_model(ProofModel & model, const State &) -> void
 {
     // state_at_pos_flags[i][q] means "after reading the first i symbols, the
     // automaton's chosen accepting run is in state q". Layer i takes input

--- a/gcs/constraints/regular/regular.hh
+++ b/gcs/constraints/regular/regular.hh
@@ -86,7 +86,7 @@ namespace gcs
             std::vector<long> final_states, std::vector<Integer> symbols, bool short_reasons, std::optional<std::string> regex);
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/regular/regular_bacchus.cc
+++ b/gcs/constraints/regular/regular_bacchus.cc
@@ -263,7 +263,7 @@ auto RegularBacchus::install(Propagators & propagators, State & initial_state, P
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -281,7 +281,7 @@ auto RegularBacchus::prepare(Propagators &, State & initial_state, ProofModel * 
     return true;
 }
 
-auto RegularBacchus::define_proof_model(ProofModel & model) -> void
+auto RegularBacchus::define_proof_model(ProofModel & model, const State &) -> void
 {
     // OPB stays identical to Regular: the human reads DFA semantics, not
     // Bacchus internals. The Bacchus encoding is derived in the initialiser

--- a/gcs/constraints/regular/regular_bacchus.hh
+++ b/gcs/constraints/regular/regular_bacchus.hh
@@ -52,7 +52,7 @@ namespace gcs
         std::set<Integer> _opb_alphabet;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/regular/regular_legacy.cc
+++ b/gcs/constraints/regular/regular_legacy.cc
@@ -444,7 +444,7 @@ auto RegularLegacy::install(Propagators & propagators, State & initial_state, Pr
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -487,7 +487,7 @@ auto RegularLegacy::prepare(Propagators &, State & initial_state, ProofModel * c
     return true;
 }
 
-auto RegularLegacy::define_proof_model(ProofModel & model) -> void
+auto RegularLegacy::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Make 2D array of flags: state_at_pos_flags[i][q] means the DFA is in state q when it receives the
     // input value from vars[i], with an extra row of flags for the state after the last transition.

--- a/gcs/constraints/regular/regular_legacy.hh
+++ b/gcs/constraints/regular/regular_legacy.hh
@@ -52,7 +52,7 @@ namespace gcs
             std::vector<long> final_states, std::vector<Integer> symbols, bool short_reasons, std::optional<std::string> regex);
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -92,7 +92,7 @@ auto ArgSort::install(Propagators & propagators, State & initial_state, ProofMod
     install_sortedness_propagator(propagators, constraint_id(), _x, y_ids, _witness);
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -148,7 +148,7 @@ auto ArgSort::prepare(Propagators & propagators, State & initial_state, ProofMod
     return true;
 }
 
-auto ArgSort::define_proof_model(ProofModel & model) -> void
+auto ArgSort::define_proof_model(ProofModel & model, const State &) -> void
 {
     // These constraints conform to cake_pb_cp's cencode_argsort
     // (cp_to_ilp_sortingScript.sml); the inner sortedness blocks (before flags,

--- a/gcs/constraints/sort/arg_sort.hh
+++ b/gcs/constraints/sort/arg_sort.hh
@@ -40,7 +40,7 @@ namespace gcs
         Integer _lowest_x{0_i}, _highest_x{0_i};
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -72,7 +72,7 @@ auto Sort::install(Propagators & propagators, State & initial_state, ProofModel 
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -173,7 +173,7 @@ auto gcs::innards::define_sortedness_proof_model(ProofModel & model, const Const
     return w;
 }
 
-auto Sort::define_proof_model(ProofModel & model) -> void
+auto Sort::define_proof_model(ProofModel & model, const State &) -> void
 {
     _witness = define_sortedness_proof_model(model, _constraint_id, _x, _y);
 }

--- a/gcs/constraints/sort/sort.hh
+++ b/gcs/constraints/sort/sort.hh
@@ -30,7 +30,7 @@ namespace gcs
         innards::SortednessWitness _witness;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -135,7 +135,7 @@ auto NegativeTable::install(Propagators & propagators, State & initial_state, Pr
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -152,7 +152,7 @@ auto NegativeTable::prepare(Propagators &, State &, ProofModel * const) -> bool
     return true;
 }
 
-auto NegativeTable::define_proof_model(ProofModel & model) -> void
+auto NegativeTable::define_proof_model(ProofModel & model, const State &) -> void
 {
     visit(
         [&](auto & tuples) {

--- a/gcs/constraints/table/negative_table.hh
+++ b/gcs/constraints/table/negative_table.hh
@@ -23,7 +23,7 @@ namespace gcs
         ExtensionalTuples _tuples;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -114,7 +114,7 @@ auto Table::install(Propagators & propagators, State & initial_state, ProofModel
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -143,7 +143,7 @@ auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) ->
     return true;
 }
 
-auto Table::define_proof_model(ProofModel & model) -> void
+auto Table::define_proof_model(ProofModel & model, const State &) -> void
 {
     if (_has_no_tuples) {
         // Morally equivalent to a selector with empty domain (`0 ≥ 1`).

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -28,7 +28,7 @@ namespace gcs
         explicit Table(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
 
         virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;

--- a/gcs/constraints/value_precede/value_precede.cc
+++ b/gcs/constraints/value_precede/value_precede.cc
@@ -46,7 +46,7 @@ auto ValuePrecede::install(Propagators & propagators, State & initial_state, Pro
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
@@ -56,7 +56,7 @@ auto ValuePrecede::prepare(Propagators &, State &, ProofModel * const) -> bool
     return _chain.size() >= 2;
 }
 
-auto ValuePrecede::define_proof_model(ProofModel & model) -> void
+auto ValuePrecede::define_proof_model(ProofModel & model, const State &) -> void
 {
     auto n = _vars.size();
     if (n == 0)

--- a/gcs/constraints/value_precede/value_precede.hh
+++ b/gcs/constraints/value_precede/value_precede.hh
@@ -35,7 +35,7 @@ namespace gcs
         std::vector<IntegerVariableID> _vars;
 
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
-        virtual auto define_proof_model(innards::ProofModel &) -> void override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:


### PR DESCRIPTION
Stacked on #618.

## What

`define_proof_model()` gains a `const innards::State &`.

Several constraints write an OPB encoding whose shape depends on the declared domains — bit widths for the multiplication channels, a row per value, a flag per tuple. With `define_proof_model` taking only a `ProofModel`, the only way to reach that was to snapshot it into members during `prepare()` first. `MinDistance::prepare()` does exactly that, with a comment saying it is "for the proof model (which does not receive the State)".

## Why this is sound

`install()` runs before search, and nothing at install time narrows an existing domain — `Propagators::define_bound` takes a `const State &` and installs a RUP initialiser rather than trimming. So the State this phase sees is exactly the *declared* domains: stable, and independent of the order constraints were posted in. That is precisely what a domain-shaped encoding is entitled to read.

It is `const` on purpose. This phase must only describe the constraint, never allocate — variables and constraint state stay `prepare()`'s job, which is why `prepare()` keeps the mutable `State &`.

## Scope

Mechanical. No override reads the new parameter yet, so it is unnamed in all 40 definitions. The constraints that motivated the change (`SmartTable`, and the `signed_multiply` family behind `Multiply`/`Power`/`Divide`/`Modulus`) are split later in the stack.

One incidental fix: `Abs::install` had an unnamed `State &` parameter and now names it.

## Verification

- 531/531 ctest pass.
- OPB and `.scp` byte-identical across all 60 captured example models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD