### PR TITLE
Abs, AtMostOne, GlobalCardinality: conform to the three-phase install

### DIFF
--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -83,6 +83,9 @@ auto Abs::clone() const -> unique_ptr<Constraint>
 
 auto Abs::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
     if (optional_model)
         define_proof_model(*optional_model, initial_state);
 

--- a/gcs/constraints/at_most_one/at_most_one.cc
+++ b/gcs/constraints/at_most_one/at_most_one.cc
@@ -57,13 +57,17 @@ auto AtMostOne::install(Propagators & propagators, State & initial_state, ProofM
     if (! prepare(propagators, initial_state, optional_model))
         return;
 
-    if (_vars.size() < 2)
-        return;
-
     if (optional_model)
         define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
+}
+
+auto AtMostOne::prepare(Propagators &, State &, ProofModel * const) -> bool
+{
+    // "at most one of fewer than two variables equals val" is vacuously true:
+    // nothing to encode and nothing to propagate.
+    return _vars.size() >= 2;
 }
 
 auto AtMostOne::define_proof_model(ProofModel & model, const State &) -> void

--- a/gcs/constraints/at_most_one/at_most_one.hh
+++ b/gcs/constraints/at_most_one/at_most_one.hh
@@ -36,6 +36,7 @@ namespace gcs
         IntegerVariableID _val;
         std::vector<std::tuple<innards::ProofFlag, innards::ProofFlag, innards::ProofFlag>> _flags;
 
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 

--- a/gcs/constraints/global_cardinality/global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/global_cardinality.cc
@@ -77,16 +77,29 @@ auto GlobalCardinality::clone() const -> unique_ptr<Constraint>
 
 auto GlobalCardinality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
     if (optional_model)
         define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
+}
 
+auto GlobalCardinality::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
     // The closed restriction (every variable takes a cover value) is delegated
-    // to a certified In constraint per variable.
+    // to a certified In constraint per variable. Installing a child needs all
+    // three of propagators, state and model at once, so prepare() is the only
+    // phase that can do it; the children's OPB rows therefore now precede this
+    // constraint's own count rows rather than following them. The OPB is a
+    // conjunction, so that is a reordering and nothing more -- every line is
+    // still cited by the number it was actually emitted with.
     if (_closed)
         for (const auto & var : _vars)
             In{var, _values}.install(propagators, initial_state, optional_model);
+
+    return true;
 }
 
 auto GlobalCardinality::define_proof_model(ProofModel & model, const State &) -> void

--- a/gcs/constraints/global_cardinality/global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/global_cardinality.hh
@@ -51,6 +51,7 @@ namespace gcs
         // Sum_i (x_i == values[j]) == counts[j], stored as {LE-half, GE-half}.
         std::vector<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _count_lines;
 
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 


### PR DESCRIPTION
Stacked on #619.

Three constraints that were split but did not quite follow the shape.

- **`Abs`** never called `prepare()` at all. It has no override, so the base's `return true` made this invisible; adding the call is a no-op today and stops the omission from becoming a bug the moment `Abs` grows a `prepare()`.
- **`AtMostOne`** had its "fewer than two variables is vacuously true" early-out sitting *between* `prepare()` and `define_proof_model()`, where the shape says there is nothing. That is exactly what `prepare()` returning false means.
- **`GlobalCardinality`** skipped `prepare()` and installed its per-variable `In` children *after* `install_propagators()`. Installing a child needs propagators, state and model at once, so `prepare()` is the only phase that can do it.

## The one behavioural note

That last one moves OPB rows: the children's rows now precede this constraint's own count rows instead of following them.

I checked this directly rather than assuming, by dumping the OPB for `global_cardinality_closed_sat.scp` before and after. It is a reordering and nothing else — same lines, same labels, and every line still cited by the number it was actually emitted with:

```
> @i[X][ge2][r] ...          # child In rows, now earlier
> 1 i[X][eq0] 1 i[X][eq1] >= 1;
< @c[_1][0_le] ...           # count rows, now later
```

`scp_chain_global_cardinality_closed_{sat,unsat}`, which chain-verify against `cake_pb_cp`, both still pass, as does `minizinc-globalcardinalityclosed`.

## Verification

- 531/531 ctest pass.
- OPB byte-identical across all 60 captured example models — none of which posts a *closed* global cardinality, which is why the reorder above needed checking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD