### PR TITLE
Plus, Minus, ArgSort: move the rest of install() into the phases

### DIFF
--- a/gcs/constraints/innards/tabulation.hh
+++ b/gcs/constraints/innards/tabulation.hh
@@ -257,6 +257,27 @@ namespace gcs::innards
         -> bool;
 
     /**
+     * \brief A tabulation that has been decided on: the enumeration scope, the
+     * determined-variable claims, and the acceptance test.
+     *
+     * Deciding needs the initial State (want_tabulation() sizes the enumeration
+     * against the domains) but installing does not. A constraint therefore builds
+     * this in prepare(), where the State is available, and hands it to
+     * install_tabulation() from install_propagators(), where it is not. An empty
+     * optional means the constraint is not tabulating.
+     *
+     * \ingroup Innards
+     * \sa gcs::innards::want_tabulation()
+     * \sa gcs::innards::install_tabulation()
+     */
+    struct TabulationPlan
+    {
+        std::vector<IntegerVariableID> enum_vars;
+        std::vector<DeterminedVariable> determined;
+        std::function<auto(const std::vector<Integer> &)->bool> accept;
+    };
+
+    /**
      * \brief The standard wiring for tabulated GAC: an expensive initialiser
      * that derives the table in-proof via build_table_in_proof() (inferring
      * FalseLiteral when no assignment is accepted), and an extensional

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -152,9 +152,13 @@ auto Minus::install(Propagators & propagators, State & initial_state, ProofModel
         define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
+}
 
+auto Minus::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
     // Tabulation for GAC: enumerate the distinct underlying variables, mapping
-    // values back through the affine forms.
+    // values back through the affine forms. Deciding needs the initial domains,
+    // so it happens here; the installing is install_propagators()'s job.
     auto aa = affine_of(_a), ab = affine_of(_b), ac = affine_of(_result);
     TabulationVariables enum_vars;
     optional<size_t> pa = aa.var ? optional{enum_vars.position_of(*aa.var)} : nullopt;
@@ -195,9 +199,10 @@ auto Minus::install(Propagators & propagators, State & initial_state, ProofModel
             return sum == cv.raw_value;
         };
 
-        install_tabulation<hints::Minus>(
-            propagators, constraint_id(), enum_vars.vars(), move(determined), nullopt, accept, "minustab", "building GAC table for minus");
+        _tabulation = TabulationPlan{enum_vars.vars(), move(determined), accept};
     }
+
+    return true;
 }
 
 auto Minus::define_proof_model(ProofModel & model, const State &) -> void
@@ -220,6 +225,10 @@ auto Minus::install_propagators(Propagators & propagators) -> void
         [a = _a, b = _b, result = _result, sum_line = _sum_line, owner = constraint_id()](const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState { return propagate_minus(a, b, result, state, inference, logger, sum_line, owner); },
         triggers);
+
+    if (_tabulation)
+        install_tabulation<hints::Minus>(propagators, constraint_id(), move(_tabulation->enum_vars), move(_tabulation->determined), nullopt,
+            move(_tabulation->accept), "minustab", "building GAC table for minus");
 }
 
 auto Minus::constraint_type() const -> std::string

--- a/gcs/constraints/plus_minus/minus.hh
+++ b/gcs/constraints/plus_minus/minus.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/consistency.hh>
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/tabulation.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/variable_id.hh>
 
@@ -31,6 +32,11 @@ namespace gcs
         MinusConsistency _level = consistency::Auto{};
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
 
+        // Decided by prepare() (it needs the initial domains), installed by
+        // install_propagators(). Empty means bounds consistency only.
+        std::optional<innards::TabulationPlan> _tabulation;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -142,9 +142,13 @@ auto Plus::install(Propagators & propagators, State & initial_state, ProofModel 
         define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
+}
 
+auto Plus::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
     // Tabulation for GAC: enumerate the distinct underlying variables, mapping
-    // values back through the affine forms.
+    // values back through the affine forms. Deciding needs the initial domains,
+    // so it happens here; the installing is install_propagators()'s job.
     auto aa = affine_of(_a), ab = affine_of(_b), ac = affine_of(_result);
     TabulationVariables enum_vars;
     optional<size_t> pa = aa.var ? optional{enum_vars.position_of(*aa.var)} : nullopt;
@@ -185,9 +189,10 @@ auto Plus::install(Propagators & propagators, State & initial_state, ProofModel 
             return sum == cv.raw_value;
         };
 
-        install_tabulation<hints::Plus>(
-            propagators, constraint_id(), enum_vars.vars(), move(determined), nullopt, accept, "plustab", "building GAC table for plus");
+        _tabulation = TabulationPlan{enum_vars.vars(), move(determined), accept};
     }
+
+    return true;
 }
 
 auto Plus::define_proof_model(ProofModel & model, const State &) -> void
@@ -210,6 +215,10 @@ auto Plus::install_propagators(Propagators & propagators) -> void
         [a = _a, b = _b, result = _result, sum_line = _sum_line, owner = constraint_id()](const State & state, auto & inference,
             ProofLogger * const logger) -> PropagatorState { return propagate_plus(a, b, result, state, inference, logger, sum_line, owner); },
         triggers);
+
+    if (_tabulation)
+        install_tabulation<hints::Plus>(propagators, constraint_id(), move(_tabulation->enum_vars), move(_tabulation->determined), nullopt,
+            move(_tabulation->accept), "plustab", "building GAC table for plus");
 }
 
 auto Plus::constraint_type() const -> std::string

--- a/gcs/constraints/plus_minus/plus.hh
+++ b/gcs/constraints/plus_minus/plus.hh
@@ -5,6 +5,7 @@
 #include <gcs/constraint.hh>
 #include <gcs/variable_id.hh>
 
+#include <gcs/constraints/innards/tabulation.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 
 #include <optional>
@@ -39,6 +40,11 @@ namespace gcs
         PlusConsistency _level = consistency::Auto{};
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _sum_line;
 
+        // Decided by prepare() (it needs the initial domains), installed by
+        // install_propagators(). Empty means bounds consistency only.
+        std::optional<innards::TabulationPlan> _tabulation;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
 

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -68,29 +68,6 @@ auto ArgSort::install(Propagators & propagators, State & initial_state, ProofMod
     if (! prepare(propagators, initial_state, optional_model))
         return;
 
-    // Set up the internal sorted-value variables in the proof, then run the
-    // shared sortedness helpers on {x, y} to reuse the Mehlhorn-Thiel bounds(Z)
-    // propagator and its fully-certified proof of y = sort(x). Keeping the
-    // witness lets ArgSort channel its permutation p to the stable rank pos.
-    vector<IntegerVariableID> y_ids{_y.begin(), _y.end()};
-    if (optional_model) {
-        // cake encodes each sorted-value y[j] as a proof-only, always-signed free
-        // bit-sum (v[id][j_b][y] value bits + a forced v[id][j][ysgn] sign bit even
-        // when the range is non-negative), with no OPB bound lines. Name y's bits to
-        // match, so the in-proof introduction of y's atoms lines up with cake's.
-        for (size_t j = 0; j < _y.size(); ++j)
-            optional_model->set_up_integer_variable(_y[j], _lowest_x, _highest_x, "argsort_y_" + std::to_string(j),
-                IntegerVariableProofRepresentation::Bits,
-                CakeBitNaming{.id = _constraint_id,
-                    .indices = {static_cast<long long>(j)},
-                    .value_annotation = "y",
-                    .sign_annotation = "ysgn",
-                    .add_a_pointless_sign_bit_only_because_cake_argsort_wastefully_always_does = true});
-        _witness = define_sortedness_proof_model(*optional_model, _constraint_id, _x, y_ids, /*arg_sort_labels=*/true);
-    }
-
-    install_sortedness_propagator(propagators, constraint_id(), _x, y_ids, _witness);
-
     if (optional_model)
         define_proof_model(*optional_model, initial_state);
 
@@ -150,6 +127,26 @@ auto ArgSort::prepare(Propagators & propagators, State & initial_state, ProofMod
 
 auto ArgSort::define_proof_model(ProofModel & model, const State &) -> void
 {
+    // First, the internal sorted-value variables and the shared sortedness
+    // encoding over {x, y}, which reuses the Mehlhorn-Thiel bounds(Z) proof of
+    // y = sort(x). Keeping the witness lets the channel below tie the
+    // permutation p to the stable rank pos, and lets install_propagators()
+    // hand it to the sortedness propagator.
+    //
+    // cake encodes each sorted-value y[j] as a proof-only, always-signed free
+    // bit-sum (v[id][j_b][y] value bits + a forced v[id][j][ysgn] sign bit even
+    // when the range is non-negative), with no OPB bound lines. Name y's bits to
+    // match, so the in-proof introduction of y's atoms lines up with cake's.
+    vector<IntegerVariableID> y_ids{_y.begin(), _y.end()};
+    for (size_t j = 0; j < _y.size(); ++j)
+        model.set_up_integer_variable(_y[j], _lowest_x, _highest_x, "argsort_y_" + std::to_string(j), IntegerVariableProofRepresentation::Bits,
+            CakeBitNaming{.id = _constraint_id,
+                .indices = {static_cast<long long>(j)},
+                .value_annotation = "y",
+                .sign_annotation = "ysgn",
+                .add_a_pointless_sign_bit_only_because_cake_argsort_wastefully_always_does = true});
+    _witness = define_sortedness_proof_model(model, _constraint_id, _x, y_ids, /*arg_sort_labels=*/true);
+
     // These constraints conform to cake_pb_cp's cencode_argsort
     // (cp_to_ilp_sortingScript.sml); the inner sortedness blocks (before flags,
     // rank equation, non-decreasing chain @c[id][yle<i>], position channel
@@ -206,8 +203,14 @@ auto ArgSort::install_propagators(Propagators & propagators) -> void
     auto n = _x.size();
     vector<IntegerVariableID> y_ids{_y.begin(), _y.end()};
 
+    // The shared sortedness propagator over {x, y}: the Mehlhorn-Thiel bounds(Z)
+    // algorithm enforcing y = sort(x), justified against the witness
+    // define_proof_model() built. Installed first, as it was before this was a
+    // phase, so the propagator ordering is unchanged.
+    install_sortedness_propagator(propagators, constraint_id(), _x, y_ids, _witness);
+
     // cake leaves each sorted value y[j] as an unbounded free bit-sum (see
-    // set_up_integer_variable in install()): y[j] in [lowest_x, highest_x] is
+    // set_up_integer_variable in define_proof_model()): y[j] in [lowest_x, highest_x] is
     // entailed -- every y[j] equals some x[p[j] - offset], all within that range --
     // but it is not reverse-unit-propagatable, because pinning it needs a case split
     // on p[j]'s value that unit propagation cannot make. So make that case split once,


### PR DESCRIPTION
Stacked on #620.

Three constraints that were split, then had further work bolted onto the end (or the middle) of `install()`.

## Plus and Minus

Each ended `install()` with a 45-line tabulation tail. It splits along a seam that already existed: `want_tabulation()` reads the initial domains to size the enumeration, but `install_tabulation()` needs no `State` at all.

So `prepare()` now decides — building the enumeration scope, the determined-variable claims and the acceptance test — and `install_propagators()` installs. The decision travels in a new `innards::TabulationPlan`; `Multiply` and `Power` will want the same type later in the stack.

## ArgSort

Had a block wedged between `prepare()` and `define_proof_model()` doing two unrelated things: registering the internal sorted-value variables in the model and emitting the shared sortedness encoding, then installing the sortedness propagator.

Those are one per phase. The first goes to the head of `define_proof_model()`, the second to the head of `install_propagators()` — which keeps both the OPB row order and the propagator installation order exactly as they were. The `_witness` member already carried data between the two.

## Verification

Tabulation is an *optional* strengthening, so silently losing it would leave every solution correct and every test green. I checked it still fires rather than assuming: `plus_sat.scp` and `minus_sat.scp` both still emit their "building GAC table" initialiser and their `plustab`/`minustab` selectors into the proof.

- 531/531 ctest pass.
- OPB and `.scp` byte-identical across all 60 captured example models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD