### PR TITLE
Brancher stage D: retire the superseded incumbent

### DIFF
--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1,7 +1,7 @@
 # Step 2 — the Brancher-API refactor: concrete, decided design
 
-**Status: decided design, partly implemented — stages A, B, B', B'' and C have landed
-(#606, #607, #615, #617); D and E have not.** The whole stack stays unmerged until the plan
+**Status: decided design, partly implemented — stages A, B, B', B'', C and D have landed
+(#606, #607, #615, #617, #618); E has not.** The whole stack stays unmerged until the plan
 is complete: stage E's benchmarking is the go/no-go gate for all of it (owner, 2026-07-30).
 "Migration staging", below, is the authority on what each remaining stage owes, and
 tracking issue #612 indexes them.
@@ -902,40 +902,54 @@ optimisation descent this accumulates **O(#incumbents)** resident unit clauses p
 O(#incumbents) Top-pinned thresholds. Payloads 2 and 3 convert this to O(1)
 resident.
 
-`solution()` gains a small **incumbent record** (in `ProofLogger::Imp`, or threaded
-from the tracker):
+`solution()` gains a small **incumbent record**, in `ProofLogger::Imp`. As shipped it
+carries *two* lines rather than the one the sketch drew, because an improving solution
+leaves two permanent lines behind and they are in different constraint sets:
 
 ```cpp
 struct IncumbentRecord {
-    Integer value;             // the incumbent objective value
-    ProofLine improvement_line; // the Top RUP `~ge(value) >= 1` just emitted
+    Integer value;              // the incumbent objective value
+    ProofLine improvement_line; // the CORE constraint the `soli` itself produces
+    ProofLine unit_line;        // the DERIVED Top RUP `~ge(value) >= 1` after it
 };
 std::optional<IncumbentRecord> last_incumbent;   // per objective, per solve
 ```
 
-Today `emit_rup_proof_line(... id < value ...)`'s return is discarded
-(`proof_logger.cc:235`); the `soli` improvement constraint lands in **core** at the
-next sequential ID (`IDmax+1`), which is exactly the ID to capture here.
+Both returns were previously discarded (`proof_logger.cc`). The `soli` improvement
+constraint lands in **core** at the next sequential ID (`IDmax+1`); the unit that follows
+it is derived, which is what decides the instrument each one is retired with.
 
 ### Payload 2 — delc the superseded improvement constraint + evict its threshold
 
-When solution `k+1` lands (value `v' < v`, minimisation), `solution()`:
+**Implemented in stage D.** When solution `k+1` lands (value `v' < v`, minimisation),
+`solution()`:
 
 1. Emit the new `soli`, hoist `ge(v')` to Top, emit the new improvement constraint
-   `~ge(v') >= 1` (as today), and set `last_incumbent = {v', line'}`.
-2. **Delc the old improvement constraint** `~ge(v) >= 1`. It is implied by the new
-   one plus the resident order chain: `v' < v` gives the chain link
-   `ge(v) → ge(v')`, so `~ge(v')` (the new unit) RUP-derives `~ge(v)` (the old
-   unit).
-3. **Evict `ge(v)` from Top** — the new evict-from-Top primitive (below), *iff* the
-   residency bookkeeping says the `soli` pin was `ge(v)`'s **only** Top cause. If
-   `ge(v)` is also pinned by an eq atom, an invar atom, a nogood, or the objective
-   exemption, it stays resident and only the improvement constraint is delc'd.
+   `~ge(v') >= 1` (as today), and set `last_incumbent = {v', core line, unit line}`.
+2. **Delc the old improvement constraint** — the *core* one, produced by the old `soli`.
+   `v' < v` makes the new one the same objective under a strictly tighter bound, so the
+   autoproof's RUP shortcut discharges it directly over the bits; the order chain is not
+   needed for this half.
+3. **Del the old Top unit** `~ge(v) >= 1`. Derived, so `delc` is rejected outright and
+   plain `del id` is the instrument. Nothing downstream loses by it: the new unit
+   `~ge(v')` plus the resident chain links (binary clauses, `ge(hi) → ge(lo)`)
+   unit-propagates back up to `~ge(v)`, so a later RUP that wanted the old bound still
+   gets it.
+4. **Evict `ge(v)` from Top** — the evict primitive (below), *iff* the residency
+   bookkeeping says the `soli` pin was `ge(v)`'s **only** Top cause. If `ge(v)` is also
+   pinned by an eq atom, an invar atom, or a nogood, it stays resident and only the
+   constraints go. **And unconditionally if the variable is deletion-exempt**, which
+   under the shipped configuration the objective always is — see the composition note
+   under payload 3, and note that this refusal had to be *added*: a `SoliHoist` pin over
+   an exempt variable's Top threshold is otherwise indistinguishable from the sole-pin
+   case this step acts on.
 
-**Ordering is load-bearing:** delc the old constraint (step 2) *before* evicting
-`ge(v)` (step 3), because the delc's subproof needs `ge(v)` and its chain link still
-resident. This delc-before-evict discipline is a **solver-side invariant** — see the
-validated mechanics below.
+**Ordering is load-bearing:** retire the two constraints (steps 2 and 3) *before*
+evicting `ge(v)` (step 4), so that nothing permanent is left naming a deleted atom and
+the delc is checked against a database that still holds everything its implication might
+need. This discipline is a **solver-side invariant** — see the validated mechanics below —
+and `incumbent_retire_test` asserts the emitted order line by line, since VeriPB will
+accept either.
 
 `-n 1` / find-first optimisation: only one incumbent is ever produced, so
 `last_incumbent` is set once and payload 2 never fires — a clean no-op. Full
@@ -947,14 +961,17 @@ skipped — the `blocking_sum` / `SolxBlock` path is untouched.
 Interaction with `solution()`'s existing hoist: unchanged for the *current*
 incumbent (still `SoliHoist` to Top so the fresh improvement constraint does not
 name a to-be-deleted literal); payload 2 only adds the *retirement* of the *previous*
-incumbent's hoist. Measured benefit is TBD and stated honestly: this converts
-O(#incumbents) resident constraints to O(1), matching the "shrink the resident DB"
-thesis, but its verify-time payoff is unproven until the stage-E optimisation sweep.
+incumbent's hoist. Measured benefit, stated honestly now that it has been measured: the
+residency claim holds — `incumbent_retire_test` shows one resident improvement constraint
+after a 21-incumbent descent instead of 21 — but the **verify time does not move** at
+tour/talent scale (0.50s and 1.30s either side of the change, three runs each in one
+sitting). That is what twenty constraints out of thousands should do. Whether it converts
+at seat-moving scale is the stage-E optimisation sweep's to answer.
 
 #### Validated delc mechanics (veripb 3.0.2)
 
-The `delc` syntax and its obligations are validated against `veripb 3.0.2` (9/9
-driver checks, independently re-run by the supervisor; see Provenance):
+The `delc` syntax and its obligations are validated against `veripb 3.0.2` (15/15
+driver checks, the first nine independently re-run by the supervisor; see Provenance):
 
 - **Autoproof form (the one to emit): `delc <id> ;`** — succeeds via veripb's RUP
   shortcut for the weaker-from-tighter implication (the empty witness fires the
@@ -966,6 +983,18 @@ driver checks, independently re-run by the supervisor; see Provenance):
 - The `soli` improvement constraint lands in **core** at the next sequential ID
   (delc-able); `delc` on a *derived* constraint is rejected outright, so it cannot be
   misapplied to ge defs by accident.
+- **Relative (negative) ids work, and resolve exactly** (Q7, added at stage D). The
+  other two deleters emit relatively so a constraint-count difference between our OPB
+  and cake_pb_cp's re-derived one cannot misaddress them; `delc` needs no exception.
+  Aiming the same relative id one line further on is rejected under `-c`, so this is
+  addressing evidence rather than tolerance.
+- **The checking follows the core set, not the spelling** (Q8, added at stage D). An
+  unchecked `del id` aimed at a *core* constraint is checked exactly as a `delc` is —
+  `DeletionChecker::check` enters the checked path on whether the deleted IDs are in
+  core, and `DeletionOrigin` only decides which origins are permitted. So what `delc`
+  buys over `del id` is **not** the check; it is the **origin assertion**, which is
+  worth having for an emitter deleting by remembered line number: get the two the wrong
+  way round and it fails loudly rather than silently.
 
 Two load-bearing caveats:
 
@@ -1133,11 +1162,19 @@ length-based and cannot tell a **win-regime long chain** (a weak-prop split vari
 keep it resident). Only the frontier owner knows which is which.
 
 **Composition with payload 2.** If the objective is exempt, its ges are resident by
-`FrontierExempt`, so payload 2's *ge*-eviction never fires for them (soli is not the
-only cause) — but payload 2's *improvement-constraint* delc still fires and still
-matters (those O(#incumbents) unit clauses exist regardless of ge residency). So the
-two compose cleanly: **payload 3 owns the objective's ge residency; payload 2 owns
-the improvement constraints.** The measured objective chain (median a dozen, max 98)
+`FrontierExempt`, so payload 2's *ge*-eviction never fires for them — but payload 2's
+*improvement-constraint* delc still fires and still matters (those O(#incumbents) unit
+clauses exist regardless of ge residency). So the two compose cleanly: **payload 3 owns
+the objective's ge residency; payload 2 owns the improvement constraints.**
+
+The parenthetical this sentence used to carry — "soli is not the only cause" — was wrong,
+and stage D had to fix the code rather than the sentence. On an exempt variable the
+threshold is born Top and takes *no* pin; the `soli` hoist then records a `SoliHoist` pin
+over it and becomes the only cause, which is precisely the shape `evict_order_literal`
+acts on. The exemption is therefore checked explicitly, above the pin check, and
+`deletion_exempt_test` pins both directions: exempt refuses, ordinary still evicts. A
+policy that holds only until the first improving solution, on the one variable it exists
+for, is not a policy. The measured objective chain (median a dozen, max 98)
 is short, so keeping it resident is cheap and the ge-eviction half of payload 2 buys
 little on the objective — its value is for a future long-objective-chain regime or a
 non-exempt configuration. Per Decision 3, ship both.
@@ -1337,16 +1374,46 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   are byte-identical. That asymmetry *is* the feature: the exemption should be invisible to
   everything without an objective.
 
-- **Stage D — objective-improvement delc + Top-eviction (payload 2; flag-gated;
-  committable). Reuses B''s evict primitive** rather than introducing it.
-  Add the incumbent record + the delc + the evict call. **Oracle:** VeriPB verifies,
-  with **`-c` (`--force-checked-deletion`) in suites and gates from this stage on** —
-  not for soundness (veripb's guarantee machinery already rejects deletion-endangered
-  sat/enumeration conclusions) but as a **fail-fast discipline**: `-c` errors at the
-  delc site, catching a broken implication in our emission even when the conclusion
-  would still check. Plus search-identical on an optimisation instance with many
-  incumbents (colour, knapsack, seat-moving); resident improvement-constraint count at
-  proof end **O(1) not O(#incumbents)**; `-n 1` and no-objective paths proven inert.
+- **Stage D — objective-improvement delc + Top-eviction (payload 2). LANDED (#618).**
+  Reuses B''s evict primitive rather than introducing it: the incumbent record, the
+  delc, and the evict call. `-c` (`--force-checked-deletion`) is now passed by both
+  verification funnels — `run_test_and_verify.bash` and `verify_proof_and_dispose` — so
+  it applies to the whole suite from here, and the full 549-test suite passes with it.
+  Not for soundness (veripb's guarantee machinery already rejects deletion-endangered
+  sat/enumeration conclusions) but as a **fail-fast discipline**: `-c` errors at the delc
+  site rather than at a distant conclusion.
+
+  Three things the design did not have right, each worth carrying:
+
+  1. **There are two accumulating lines per incumbent, not one, and they need different
+     instruments.** The `soli` itself produces the improvement constraint, in *core*, and
+     that is what `delc` is for. The `~ge(v) >= 1` unit emitted just after it is *derived*,
+     so `delc` on it is rejected outright ("Deletion of derived constraint ID … using
+     deletion from core set") and it goes by plain `del id`. The prose above conflates the
+     two; the code does not.
+  2. **The exemption did not actually outrank the pin.** Stage C's claim that an exempt
+     objective's ge-eviction "never fires" was not enforced anywhere: the `soli` hoist takes
+     a `SoliHoist` pin over the already-Top threshold, which is exactly the sole-pin shape
+     `evict_order_literal` evicts on, so the exemption would have held only until the first
+     improving solution. `evict_order_literal` now refuses a `deletion_exempt` variable
+     above the pin check, with `deletion_exempt_test` asserting both directions.
+  3. **`delc` takes relative ids, and resolves them exactly.** Confirmed by aiming one at
+     its neighbour and watching `-c` reject the autoproof, so the relative encoding the
+     other two deleters use for cake_pb_cp's benefit needs no exception here.
+
+  **Oracle, as measured.** VeriPB verifies under `-c`; `incumbent_retire_test` asserts from
+  the proof text that `#soli - #delc == 1` over a 21-incumbent descent (so the resident
+  count is O(1), not O(#incumbents)), that each retirement emitted its two deletions in the
+  load-bearing order, and that a find-first run emits nothing at all. Search is identical
+  mode-on vs mode-off on tour and talent; mode-off proofs and Literals-mode `solx` proofs
+  (crystal_maze, langford) are byte-identical to the stack's previous tip.
+
+  **What it does not yet buy.** Verify time on tour and talent is unchanged (0.50s and
+  1.30s either side, three runs each in one sitting): twenty constraints out of a database
+  of thousands is not measurable, exactly as the payload-2 section predicts. The claim this
+  stage establishes is the residency one. Whether it converts to verify time at seat-moving
+  scale is **stage E's measurement**, and it is the kind of thing stage E's go/no-go has to
+  weigh against the complexity.
 
 - **Stage E — benchmark + cleanup.**
   Re-run the eq-free large-domain sweep and the optimisation sweep for the step-2
@@ -1357,9 +1424,9 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   `live_order_links` and the `_links_`-named machinery the tracker header flags as
   "left unchanged until the planned Brancher refactor renames it."
 
-Stages A, B, B', B'', C have no external dependency and can land in sequence. Stage D
-is the only one gated on work outside this task (the delc mechanics, now validated),
-and can be prepared ahead (it reuses B''s primitives) and finished once wired.
+Stages A, B, B', B'', C and D have all landed in sequence. Stage D was the only one gated
+on work outside this task (the delc mechanics), and that gate is closed. Stage E is the
+only stage left, and it is the go/no-go for the whole stack.
 
 ## Implementation gates (not owner calls)
 

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1405,8 +1405,17 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   the proof text that `#soli - #delc == 1` over a 21-incumbent descent (so the resident
   count is O(1), not O(#incumbents)), that each retirement emitted its two deletions in the
   load-bearing order, and that a find-first run emits nothing at all. Search is identical
-  mode-on vs mode-off on tour and talent; mode-off proofs and Literals-mode `solx` proofs
-  (crystal_maze, langford) are byte-identical to the stack's previous tip.
+  mode-on vs mode-off on colour, tour and talent; mode-off proofs and Literals-mode `solx`
+  proofs (crystal_maze, langford) are byte-identical to the stack's previous tip.
+
+  One correction to this stage's own oracle: **colour and knapsack are not many-incumbent
+  instances**, so they cannot carry the O(1) claim. Colour's objective is the largest colour
+  index and its first greedy colouring is already near-optimal, so it produces **2**
+  incumbents on graphs from 22 to 60 vertices alike (1321 to 227k recursions — the descent
+  length does not move it), and the knapsack example produces **1**. The instances that
+  actually exercise a descent are talent (**23**), `incumbent_retire_test` itself (**21**)
+  and tour (**4**). Colour and knapsack are still worth running, as different model shapes
+  under search-identity and `-c`; they are just not where the accumulation lives.
 
   **What it does not yet buy.** Verify time on tour and talent is unchanged (0.50s and
   1.30s either side, three runs each in one sitting): twenty constraints out of a database

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -405,11 +405,21 @@ frontend proofs.
   stranded without it — and it deliberately applies to the objective only, because
   exempting a bound-branched variable would defeat the split win, which *is* deleting its
   stepped-over chain.
-- **In progress:** the clean Brancher abstraction (step 2). Stages A, B, B', B'' and C have
-  landed — the `BranchDecision` / `BacktrackAdvance` types, the split families' bound
-  advances, the eviction primitives plus their always-on residency bookkeeping, and the
-  eq-atom window — so the direct guess/eq/aux hoist wiring is on its way out but is still
-  what the shipped path uses. Stages C/D/E remain;
+- **Incumbent retirement (stage D).** Each improving solution leaves two permanent lines
+  behind — the *core* improvement constraint the `soli` produces, and the *derived* Top unit
+  `~ge(v) >= 1` after it — so an optimisation descent accumulated O(#incumbents) of each.
+  The next improving solution now retires both: checked deletion (`delc`) for the core one,
+  since the tighter bound implies it, and plain deletion for the derived one, since the
+  order chain still propagates the old bound from the new. Resident count is O(1) whatever
+  the descent's length. From this stage on both verification funnels pass **`-c`
+  (`--force-checked-deletion`)**, so a deletion whose implication does not hold fails at the
+  deletion rather than at a distant conclusion.
+- **In progress:** the clean Brancher abstraction (step 2). Stages A, B, B', B'', C and D
+  have landed — the `BranchDecision` / `BacktrackAdvance` types, the split families' bound
+  advances, the eviction primitives plus their always-on residency bookkeeping, the
+  eq-atom window, the objective exemption and the incumbent retirement — so the direct
+  guess/eq/aux hoist wiring is on its way out but is still what the shipped path uses.
+  Only stage E remains, and it is the go/no-go gate for the whole stack;
   [brancher-design.md](brancher-design.md) is the authority on each. Also future:
   short-reason flag / deview-companion level-scoping (currently inert), and the bridge
   redesign (deprioritised — step 1b measured it as freeing 0 %).
@@ -547,8 +557,8 @@ win-recovery motivation is gone. Revisit only if a view/product-heavy
 freed chains would be long enough to matter.
 
 **Ordering decided (2026-07): 2b first (done, above), then step 2.** Step 2 is under
-way — A, B and B' are in — and it inherits the objective-variable-exemption follow-up
-from 2b as its stage C; 3 stays parked.
+way — A, B, B', B'', C and D are in — and it inherited the objective-variable-exemption
+follow-up from 2b as its stage C; 3 stays parked.
 
 **Also:** decide productionisation (keep flag-gated vs default-on — current verdict:
 flag-gated), and — cleanup — the superseded dormant `Links` mode can be removed.

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -562,6 +562,17 @@ if(GCS_BUILD_TESTS)
     target_link_libraries(deletion_exempt_test PRIVATE glasgow_constraint_solver)
     add_test(NAME deletion_exempt_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:deletion_exempt_test>)
 
+    # One entry per scenario: a descent with many incumbents, where every improvement but the
+    # first must retire its predecessor, and a find-first run, where there is nothing to
+    # supersede and the machinery must stay entirely inert. Distinct basenames because a
+    # parallel ctest would otherwise race over one set of proof files (issue #562).
+    add_executable(incumbent_retire_test innards/proofs/incumbent_retire_test.cc)
+    target_link_libraries(incumbent_retire_test PRIVATE glasgow_constraint_solver)
+    foreach(scenario many first)
+        add_test(NAME incumbent_retire_${scenario}_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash
+            --basename incumbent_retire_${scenario}_test $<TARGET_FILE:incumbent_retire_test> --scenario ${scenario})
+    endforeach()
+
     add_executable(eq_window_test innards/proofs/eq_window_test.cc)
     target_link_libraries(eq_window_test PRIVATE glasgow_constraint_solver)
     add_test(NAME eq_window_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eq_window_test>)

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -173,7 +173,12 @@ namespace gcs::test_innards
      */
     [[nodiscard]] inline auto verify_proof_and_dispose(const std::string & proof_name) -> bool
     {
-        if (! run_veripb(proof_name + ".opb", proof_name + ".pbp"))
+        // -c (--force-checked-deletion) for the same reason run_test_and_verify.bash passes
+        // it: not soundness (VeriPB downgrades rather than accepts, and enforces the
+        // downgrade at the conclusions that need it) but diagnosability, so a deletion whose
+        // implication does not hold fails at the deletion instead of at some distant
+        // conclusion. See dev_docs/brancher-design.md, "Validated delc mechanics".
+        if (! run_veripb("-c", proof_name + ".opb", proof_name + ".pbp"))
             return false;
         cake_probe_chain(proof_name); // PROBE: measure workflow-2 chain (no-op unless GCS_TEST_CAKE)
         dispose_of_proof_files(proof_name);

--- a/gcs/innards/proofs/deletion_exempt_test.cc
+++ b/gcs/innards/proofs/deletion_exempt_test.cc
@@ -4,12 +4,14 @@
 
 #include <iostream>
 #include <optional>
+#include <vector>
 
 using namespace gcs;
 using namespace gcs::innards;
 
 using std::cerr;
 using std::nullopt;
+using std::vector;
 
 // Driver for the stage-C frontier deletion exemption (dev_docs/brancher-design.md,
 // "Payload 3"), with the mode and the chain gate set in code so the test does not depend on
@@ -79,6 +81,22 @@ auto main() -> int
     check(tracker.live_order_literal_count(ord) < ord_before, "the exemption held an ORDINARY variable resident too, which would suppress the win");
     for (Integer v = 10_i; v <= 40_i; v += 10_i)
         check(tracker.order_literal_is_live(obj, v), "an exempt threshold went missing across the forget");
+
+    // The exemption against payload 2's pin. Every improving solution hoists the objective's
+    // new threshold to Top with a SoliHoist cause, and on an exempt variable that threshold is
+    // already Top-resident, so the hoist contributes nothing but the pin -- leaving exactly the
+    // sole-pin shape eviction otherwise acts on. The exemption has to outrank it, or it would
+    // hold only until the first improving solution, and only for the objective, which is the
+    // one variable it exists for. The ordinary variable is the control: the same pin over it
+    // must still evict, or the refusal would be a blanket one and stage D's eviction half
+    // would be dead everywhere rather than deferring to stage C here.
+    tracker.need_gevar(ord, 20_i); // the forget above took the control's copy out
+    tracker.hoist_live_order_literals_toward_level(vector<Literal>{obj < 20_i, ord < 20_i}, 0, OrderEncodingResidencyCause::SoliHoist);
+    check(! tracker.evict_order_literal(obj, 20_i, OrderEncodingResidencyCause::SoliHoist),
+        "an exempt variable's threshold was evicted once a soli pinned it");
+    check(tracker.order_literal_is_live(obj, 20_i), "the refused eviction took the threshold out anyway");
+    check(tracker.evict_order_literal(ord, 20_i, OrderEncodingResidencyCause::SoliHoist),
+        "the same pin over an ORDINARY variable was refused too, so the refusal is not the exemption");
 
     // ... and the definitions really are still there, not just believed to be: multi-hop
     // order propagation over a chain the forget would otherwise have taken out.

--- a/gcs/innards/proofs/incumbent_retire_test.cc
+++ b/gcs/innards/proofs/incumbent_retire_test.cc
@@ -1,0 +1,199 @@
+#include <gcs/constraints/all_different.hh>
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/current_state.hh>
+#include <gcs/problem.hh>
+#include <gcs/search_heuristics.hh>
+#include <gcs/solve.hh>
+
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+
+using std::cerr;
+using std::getline;
+using std::ifstream;
+using std::nullopt;
+using std::optional;
+using std::string;
+using std::vector;
+
+// Driver for payload 2 of the Brancher refactor (dev_docs/brancher-design.md, "Payload 2"):
+// each improving solution retires the one it supersedes, so a branch-and-bound descent leaves
+// O(1) resident objective-improvement constraints rather than O(#incumbents).
+//
+// What VeriPB can tell you here is narrow, and it is worth being precise about which half is
+// which. It checks that the deletions are *legitimate* -- run under `-c` the `delc` has to
+// autoprove, so a retirement of something the survivors do not imply fails at the deletion
+// itself. It cannot tell you the retirement happened at all: a build that simply stopped
+// emitting them produces a perfectly good proof, just a bigger one, and it cannot tell you the
+// order was right either, because it polices the order encoding only at a point of use.
+//
+// So the counting below is not decoration. It asserts, from the proof text, that every
+// incumbent after the first was retired (the O(1) claim, as `#soli - #delc == 1`), and that
+// each retirement emitted its two deletions in the load-bearing order -- the core improvement
+// constraint by checked deletion first, its Top unit second. The `first` scenario is the other
+// half of the same claim: with a single incumbent there is nothing to supersede, and the
+// machinery must emit nothing at all.
+//
+// The mode is set in code, not through GCS_DELETE_ORDER_ENCODING, so the test does not depend
+// on the environment; the chain gate goes to 0 for the same reason it does in the other
+// drivers, since at the shipped gate of 16 these short chains stay resident anyway.
+namespace
+{
+    // A model that improves in small steps rather than jumping to the optimum: four
+    // all-different values summing to the objective, branched largest-value-first so the first
+    // solution found is the worst one and branch-and-bound has to walk down. Nothing here is
+    // load-bearing except that it produces plenty of incumbents, which the test checks.
+    auto run(bool stop_at_first, const optional<string> & proof_basename) -> std::pair<long long, long long>
+    {
+        Problem p;
+        vector<IntegerVariableID> x;
+        for (int i = 0; i < 4; ++i)
+            x.push_back(p.create_integer_variable(0_i, 8_i, "x" + std::to_string(i)));
+        auto obj = p.create_integer_variable(0_i, 32_i, "obj");
+
+        p.post(AllDifferent{x});
+        // Two orderings, to keep propagation from collapsing the whole descent into one step.
+        p.post(LessThan{x[0], x[1]});
+        p.post(LessThan{x[2], x[3]});
+        p.post(LinearEquality{WeightedSum{} + 1_i * x[0] + 1_i * x[1] + 1_i * x[2] + 1_i * x[3] + -1_i * obj, 0_i});
+        p.minimise(obj);
+
+        optional<ProofOptions> options;
+        if (proof_basename) {
+            options.emplace(*proof_basename);
+            options->set_order_encoding_deletion(OrderEncodingDeletion::Literals).set_order_encoding_deletion_min_chain(0);
+        }
+
+        long long incumbents = 0, best = -1;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               ++incumbents;
+                               best = s(obj).raw_value;
+                               return ! stop_at_first;
+                           },
+                .branch = branch_with(variable_order::in_order(x), value_order::largest_first())},
+            options);
+
+        return {incumbents, best};
+    }
+
+    struct ProofCounts
+    {
+        long long solutions = 0;   // `soli` lines: one core improvement constraint each.
+        long long retirements = 0; // `% retire the superseded incumbent` markers.
+        long long checked = 0;     // `delc` lines: core improvement constraints taken back out.
+        long long unchecked = 0;   // the `del id` retiring a Top unit, counted only inside a marker.
+        long long misordered = 0;  // retirements whose two deletions did not arrive in the right order.
+    };
+
+    // Walk the proof, pairing each retirement marker with the two deletion lines that must
+    // immediately follow it. Reading the text rather than instrumenting the logger is
+    // deliberate: what is being asserted is what the proof ended up containing.
+    auto count_proof(const string & basename) -> ProofCounts
+    {
+        ProofCounts counts;
+        ifstream proof{basename + ".pbp"};
+        for (string line; getline(proof, line);) {
+            if (line.starts_with("soli"))
+                ++counts.solutions;
+            else if (line.find("% retire the superseded incumbent") != string::npos) {
+                ++counts.retirements;
+                string checked_line, unchecked_line;
+                if (! getline(proof, checked_line) || ! getline(proof, unchecked_line)) {
+                    ++counts.misordered;
+                    break;
+                }
+                if (checked_line.starts_with("delc "))
+                    ++counts.checked;
+                if (unchecked_line.starts_with("del id "))
+                    ++counts.unchecked;
+                if (! checked_line.starts_with("delc ") || ! unchecked_line.starts_with("del id "))
+                    ++counts.misordered;
+            }
+        }
+        return counts;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    // Hand-rolled parse, matching the other gcs innards drivers; --prove and
+    // --proof-files-basename are what run_test_and_verify.bash passes.
+    bool prove = false;
+    string basename = "incumbent_retire_test";
+    string scenario = "many";
+    for (int arg = 1; arg < argc; ++arg) {
+        string a{argv[arg]};
+        if (a == "--prove")
+            prove = true;
+        else if (a == "--proof-files-basename" && arg + 1 < argc)
+            basename = argv[++arg];
+        else if (a == "--scenario" && arg + 1 < argc)
+            scenario = argv[++arg];
+        else {
+            cerr << "unrecognised argument '" << a << "'\n";
+            return 1;
+        }
+    }
+    if (scenario != "many" && scenario != "first") {
+        cerr << "unrecognised scenario '" << scenario << "'\n";
+        return 1;
+    }
+
+    int rc = 0;
+    auto check = [&](bool ok, const string & what) {
+        if (! ok) {
+            cerr << "incumbent retirement broken: " << what << " (fix the retirement, do not update the number)\n";
+            rc = 1;
+        }
+    };
+
+    bool stop_at_first = scenario == "first";
+    auto [incumbents, best] = run(stop_at_first, prove ? optional<string>{basename} : nullopt);
+
+    // 0+1+2+3 is the only way four distinct values from 0..8 can sum to 6, and the two
+    // orderings admit it, so a complete descent must reach exactly 6. Independent of anything
+    // the proof machinery does, and the point of checking it: deletions that were not implied
+    // are the failure mode that would silently change the answer.
+    if (! stop_at_first)
+        check(best == 6, "the descent did not reach the known optimum of 6, but found " + std::to_string(best));
+
+    if (! prove)
+        return rc;
+
+    auto counts = count_proof(basename);
+    check(counts.solutions == incumbents,
+        "the proof holds " + std::to_string(counts.solutions) + " soli lines for " + std::to_string(incumbents) + " incumbents");
+
+    if (stop_at_first) {
+        // One incumbent supersedes nothing, so payload 2 must be entirely inert. Find-first
+        // optimisation and `-n 1` take exactly this path.
+        check(incumbents == 1, "the find-first scenario did not stop at one incumbent");
+        check(counts.retirements == 0, "a single incumbent retired something, with nothing to supersede");
+    }
+    else {
+        // A model that improved once or twice would satisfy everything below by accident, so
+        // insist there was a descent worth measuring in the first place.
+        check(incumbents >= 5, "only " + std::to_string(incumbents) + " incumbents: too few for the O(1) claim to mean anything");
+        check(counts.retirements == incumbents - 1,
+            std::to_string(counts.retirements) + " retirements for " + std::to_string(incumbents) + " incumbents, expected one per improvement");
+        // The headline: resident core improvement constraints at proof end, which is one
+        // whatever the descent's length, rather than one per incumbent.
+        check(counts.solutions - counts.checked == 1,
+            std::to_string(counts.solutions - counts.checked) + " improvement constraints left resident, expected 1 regardless of descent length");
+        check(counts.solutions - counts.unchecked == 1,
+            std::to_string(counts.solutions - counts.unchecked) + " Top units left resident, expected 1 regardless of descent length");
+    }
+
+    // Checked deletion first, then the Top unit: VeriPB accepts either order (it rejects at a
+    // point of use, not at a deletion), so nothing but this check stands behind the ordering.
+    check(counts.misordered == 0, std::to_string(counts.misordered) + " retirements emitted their deletions in the wrong order");
+
+    return rc;
+}

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -2124,6 +2124,16 @@ auto NamesAndIDsTracker::evict_order_literal(
         throw ProofError{"eviction of a non-live order literal"};
     int level = lvl_it->second;
 
+    // The frontier exemption outranks any pin: note_deletion_exempt says this variable's
+    // whole encoding stays resident, and need_gevar honours that when the definition is
+    // born. An eviction would be the one route that took a definition back out afterwards,
+    // and it is a route a pin can open -- the objective's ge is Top-resident by exemption,
+    // and then payload 2's `soli` hoist records a SoliHoist pin over it, which is exactly
+    // the sole-pin shape the check below evicts on. So refuse here, above that check, or
+    // stage C's exemption would hold only until the first improving solution.
+    if (_imp->deletion_exempt.contains(SimpleOrProofOnlyIntegerVariableID{id}))
+        return false;
+
     // The residency precondition, checked rather than asserted: VeriPB accepts a
     // wrongly-evicted literal at the deletion and only rejects at a later point of use, so
     // getting this wrong would show up far from its cause. A refusal is always safe -- the

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -208,6 +208,24 @@ struct ProofLogger::Imp
         int level;
     };
     optional<BacktrackClause> last_backtrack_clause;
+
+    // --- the incumbent record (dev_docs/brancher-design.md, payload 2) ---
+    // What the previous improving solution left permanently resident, so the next one can
+    // retire it: an optimisation descent otherwise accumulates O(#incumbents) Top lines
+    // (and, without stage C's exemption, O(#incumbents) pinned objective thresholds).
+    // `improvement_line` is the core constraint the `soli` itself produces -- the one
+    // `delc` is for, and the only one of the two that is in core. `unit_line` is the Top
+    // `~ge(value) >= 1` emitted just after it, which is derived and so goes by plain `del`.
+    // Set on every improving solution under Literals; nullopt in every other mode and on
+    // the `solx` path, so the whole of payload 2 is skipped there.
+    struct IncumbentRecord
+    {
+        Integer value;
+        ProofLine improvement_line;
+        ProofLine unit_line;
+    };
+    optional<IncumbentRecord> last_incumbent;
+
     // The standing frontier advance for each windowed variable, bucketed by the proof level
     // it was emitted at and then by variable, so the next step of that window can delete the
     // one it supersedes. Bucketed by level because a level number is reused by every node at
@@ -361,13 +379,17 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
     }
 
     _imp->proof << ";\n";
-    record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+    // The `soli` itself produces the objective-improvement constraint, in *core* at this id.
+    // Payload 2 needs it by number; on the `solx` path nothing reads it back.
+    auto improvement_line = record_proof_line(advance_proof_line_number(), ProofLevel::Top);
+
+    optional<ProofLine> unit_line;
 
     if (optional_minimise_variable_and_value && _imp->assertion_level > AssertionLevel::Definitions)
         // soli and no links => have to assert the objective improving constraint
         visit(
             [&](const auto & id) {
-                emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top,
+                unit_line = emit(AssertProofRule{}, WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top,
                     AssertionAnnotation{.hint_name = hints::SoliImprove::hint_name});
             },
             optional_minimise_variable_and_value->first);
@@ -379,7 +401,7 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
                 emit_inequality_to(names_and_ids_tracker(), WPBSum{} + 1_i * id <= optional_minimise_variable_and_value->second - 1_i, _imp->proof);
                 _imp->proof << ":" << relative_proof_line(_imp->proof_line, _imp->proof_line.number) << ";\n";
 
-                emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
+                unit_line = emit_rup_proof_line(WPBSum{} + 1_i * (id < optional_minimise_variable_and_value->second) >= 1_i, ProofLevel::Top);
             },
             optional_minimise_variable_and_value->first);
     else if (_imp->assertion_level > AssertionLevel::Definitions) {
@@ -387,6 +409,74 @@ auto ProofLogger::solution(const vector<pair<IntegerVariableID, Integer>> & all_
         emit(AssertProofRule{}, blocking_sum >= 1_i, ProofLevel::Top, AssertionAnnotation{.hint_name = hints::SolxBlock::hint_name});
     }
     // nothing needs done for solx below AssertionLevel::Links
+
+    // Literals with assertions off -- the pairing every guard over this machinery uses (see
+    // bound_advances_active). With assertions on there are no ge definitions to evict and no
+    // residency bookkeeping over them, so the retirement has nothing to be right about; that
+    // is also why `unit_line` is certainly the emit_rup_proof_line above rather than the
+    // asserted form.
+    if (optional_minimise_variable_and_value && bound_advances_active())
+        retire_superseded_incumbent(
+            optional_minimise_variable_and_value->first, optional_minimise_variable_and_value->second, improvement_line, unit_line.value());
+}
+
+auto ProofLogger::retire_superseded_incumbent(const IntegerVariableID & objective, Integer value, ProofLine improvement_line, ProofLine unit_line)
+    -> void
+{
+    // Payload 2 (dev_docs/brancher-design.md): the incumbent just recorded supersedes the
+    // previous one, whose improvement constraint, Top unit and pinned threshold would
+    // otherwise stay resident for the rest of the solve -- O(#incumbents) of each over a
+    // branch-and-bound descent, which is exactly the accumulation this mode exists to stop.
+    //
+    // Only reached on the `soli` path, so `-n 1` / find-first (one incumbent, so the swap
+    // below records and retires nothing) and `--all` enumeration (the `solx` path, which
+    // never gets here) are both inert.
+    auto previous = std::exchange(_imp->last_incumbent, Imp::IncumbentRecord{value, improvement_line, unit_line});
+    if (! previous)
+        return;
+
+    write_indent();
+    _imp->proof << "% retire the superseded incumbent\n";
+
+    // 1. The improvement constraint, by *checked* deletion: it is in core, and what remains
+    //    resident implies it -- the new constraint is the same objective bounded by a
+    //    strictly smaller value, so VeriPB's RUP shortcut autoproves it. This must happen
+    //    before anything below is deleted, while the database it is checked against still
+    //    holds everything the implication may need.
+    checked_delete_proof_lines_at_level(vector<ProofLine>{previous->improvement_line}, 0);
+
+    // 2. The Top unit `~ge(previous) >= 1`. Derived, not core, so `delc` would be rejected
+    //    for its origin and plain deletion is the right instrument. Nothing later loses by it:
+    //    the new unit `~ge(current) >= 1` plus the resident order chain unit-propagates
+    //    back up to `~ge(previous)`, every chain link being a binary clause, so a later RUP
+    //    that wanted the old bound still gets it.
+    delete_proof_lines_at_level(vector<ProofLine>{previous->unit_line}, 0);
+
+    // 3. The threshold itself, now that the only permanent line naming it is gone. Strictly
+    //    after step 2 -- VeriPB will not police this ordering (it rejects at a point of use,
+    //    not at a deletion), so it is a solver-side invariant, and the reverse order leaves
+    //    a Top unit naming a deleted atom for as long as it takes something to trip over it.
+    //
+    //    In the shipped configuration this always refuses, and that is stage C's doing
+    //    rather than a gap here: `ProofModel::minimise` marks the objective deletion-exempt,
+    //    so its thresholds are resident by policy and eviction declines them. The call is
+    //    still the right one to make -- C owns the objective's ge residency and D owns its
+    //    improvement constraints -- and steps 1 and 2 are the half that fires regardless.
+    //
+    //    Only a real variable, mirroring the hoist that took the pin in the first place: it
+    //    reads the threshold off a `SimpleIntegerVariableID` condition and skips a view or a
+    //    constant, so for those there is no pin to release and nothing to evict. A view
+    //    objective is doubly covered, being resident as a view underlying as well.
+    overloaded{
+        //
+        [&](const SimpleIntegerVariableID & id) {
+            if (names_and_ids_tracker().order_literal_is_live(id, previous->value))
+                names_and_ids_tracker().evict_order_literal(id, previous->value, OrderEncodingResidencyCause::SoliHoist);
+        },
+        [&](const ViewOfIntegerVariableID &) {},  //
+        [&](const ConstantIntegerVariableID &) {} //
+    }
+        .visit(objective);
 }
 
 auto ProofLogger::backtrack(const vector<Literal> & guesses) -> void
@@ -1034,6 +1124,22 @@ auto ProofLogger::delete_proof_lines_at_level(const vector<ProofLine> & lines, i
             bucket.erase(n->number);
             write_indent();
             _imp->proof << "del id " << (n->number - current - 1) << ";\n";
+        }
+}
+
+auto ProofLogger::checked_delete_proof_lines_at_level(const vector<ProofLine> & lines, int level) -> void
+{
+    auto & bucket = _imp->proof_lines_by_level.at(level);
+    // The same relative (negative) encoding, taken once, as the two unchecked deleters above,
+    // and for the same reason. Relative addressing is not merely accepted by `delc`: it
+    // resolves to exactly the constraint it names, confirmed by pointing one at its
+    // neighbour and watching `-c` reject the autoproof.
+    auto current = _imp->proof_line.number;
+    for (const auto & l : lines)
+        if (const auto * n = std::get_if<ProofLineNumber>(&l)) {
+            bucket.erase(n->number);
+            write_indent();
+            _imp->proof << "delc " << (n->number - current - 1) << ";\n";
         }
 }
 

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -67,6 +67,14 @@ namespace gcs::innards
         // Top. See dev_docs/brancher-design.md, "The hoist-out rule".
         auto note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> void;
 
+        // Record the incumbent an improving solution has just left resident, and take the
+        // one it supersedes back out of the proof: `delc` its improvement constraint, `del`
+        // its Top unit, and evict the threshold that unit was pinning. Called from
+        // solution() on the `soli` path under OrderEncodingDeletion::Literals only; the
+        // first incumbent records and retires nothing. See dev_docs/brancher-design.md,
+        // "Payload 2".
+        auto retire_superseded_incumbent(const IntegerVariableID & objective, Integer value, ProofLine improvement_line, ProofLine unit_line) -> void;
+
     public:
         /**
          * \name Constructors, destructors, and the like.
@@ -355,6 +363,30 @@ namespace gcs::innards
          * with the bucket the lines actually sit in.
          */
         auto delete_proof_lines_at_level(const std::vector<ProofLine> & lines, int level) -> void;
+
+        /**
+         * \brief The *checked* counterpart of \c delete_proof_lines_at_level: emit a `delc`
+         * for each line, which must be a **core** constraint currently tagged at \p level,
+         * and drop it from that level's bucket.
+         *
+         * VeriPB requires deletion from core to be justified; the autoproof form `delc <id>;`
+         * emitted here discharges that through its RUP shortcut, which is enough whenever
+         * what remains resident implies what is going -- the superseded objective-improvement
+         * constraint of payload 2 being the case this exists for.
+         *
+         * Note that VeriPB decides whether to check a deletion from the *constraint set the
+         * target is in*, not from which of the two spellings was used, so `del id` on a core
+         * constraint is checked just the same. What this form adds is the **origin
+         * assertion**: `delc` on a derived constraint is rejected outright. So the two
+         * deleters are not interchangeable -- use \c delete_proof_lines_at_level for
+         * everything the proof itself derived, and let a mix-up fail loudly.
+         *
+         * A failed autoproof **downgrades rather than rejects** without
+         * `--force-checked-deletion`, and the downgrade only bites at a later conclusion.
+         * That is sound (VeriPB enforces it at exactly the conclusions that need it) but it
+         * is not diagnosable, which is why the suites run `-c` from stage D on.
+         */
+        auto checked_delete_proof_lines_at_level(const std::vector<ProofLine> & lines, int level) -> void;
 
         /**
          * Hoist a search-introduced order literal `id >= v` to \p target_level:

--- a/run_test_and_verify.bash
+++ b/run_test_and_verify.bash
@@ -52,7 +52,15 @@ else
     "$prog" --prove "$@" || exit 1
 fi
 
-veripb "${proofname}.opb" "${proofname}.pbp" || exit 1
+# -c (--force-checked-deletion) is not a soundness requirement: VeriPB's default is to
+# downgrade a failed deletion check rather than accept it, and it then enforces the downgrade
+# at exactly the conclusions that need it. It is a DIAGNOSTIC requirement. Without it a bad
+# deletion surfaces at some later conclusion -- "claimed upper bound mismatches the best
+# recorded", or a constraint that has already been deleted -- a long way from the line that
+# caused it. With it, the run stops at the deletion. Order-encoding deletion emits deletions
+# by the thousand, so that distance is the difference between a diagnosable failure and a
+# puzzle. See dev_docs/brancher-design.md, "Validated delc mechanics".
+veripb -c "${proofname}.opb" "${proofname}.pbp" || exit 1
 
 # Verification passed, so dispose of the proof unless asked to preserve it.
 dispose_proof "$proofname"


### PR DESCRIPTION
Stage **D** of the step-2 Brancher refactor (payload 2), closing #610. Part of #612, stacked
on #617 (stage C). Design: `dev_docs/brancher-design.md`, "Payload 2".

Per the stack merge policy this is **not for merging**: the whole stack stays on the branch
until stage E's benchmarking gives a go/no-go on all of it.

## What it does

Every improving solution left two permanent lines behind for the rest of the solve — the
objective-improvement constraint the `soli` produces, and the Top unit `~ge(v) >= 1` after
it — so an optimisation descent accumulated **O(#incumbents)** of each. The next improving
solution now retires both, plus the threshold that unit pinned. Resident count is **O(1)**
however long the descent is.

The two lines need different instruments, which the design had conflated:

| line | set | instrument | why |
|---|---|---|---|
| the `soli` improvement constraint | **core** | `delc` (autoproof) | `v' < v` makes the new one the same objective under a strictly tighter bound, so the RUP shortcut discharges it over the bits |
| the `~ge(v) >= 1` unit | **derived** | `del id` | `delc` rejects it for its origin; the new unit plus the resident chain links unit-propagate back up to the old bound, so nothing downstream loses by it |

## The stage-C exemption was not actually enforced

Stage C claimed that an exempt objective's ge-eviction "never fires (soli is not the only
cause)". It would have. On an exempt variable the threshold is born Top with *no* pin, and
the `soli` hoist then makes `SoliHoist` the only cause — exactly the sole-pin shape
`evict_order_literal` acts on. The exemption would have held only until the first improving
solution, on the one variable it exists for.

`evict_order_literal` now refuses a `deletion_exempt` variable above the pin check, and
`deletion_exempt_test` asserts both directions: exempt refuses, ordinary still evicts (so
the refusal is the exemption, not a blanket one).

## `-c` in the suites, from this stage on

Both verification funnels — `run_test_and_verify.bash` and `verify_proof_and_dispose` — now
pass `-c` (`--force-checked-deletion`). Not for soundness: veripb downgrades rather than
accepts, and enforces the downgrade at exactly the conclusions that need it. For
diagnosability, so a bad deletion fails *at* the deletion rather than at a distant "claimed
upper bound mismatches the best recorded". **The full 549-test suite passes with it.**

## Two new veripb 3.0.2 facts

Both found while writing the emission, both now in the artifact driver (15/15) and the
design note:

- **Relative ids work in `delc`, and resolve exactly.** Aiming one a line further on is
  rejected under `-c`, so this is addressing evidence rather than tolerance, and the
  relative encoding the other deleters use for cake_pb_cp's benefit needs no exception here.
- **The checking follows the core set, not the spelling.** `del id` on a *core* constraint
  is checked just as a `delc` is — `DeletionChecker::check` enters the checked path on where
  the target lives, and `DeletionOrigin` only decides which origins are permitted. So what
  `delc` buys over `del id` is not the check; it is the **origin assertion**. That is worth
  having for an emitter deleting by remembered line number: get the two the wrong way round
  and it fails loudly rather than silently.

## Oracle, as measured

- **VeriPB verifies under `-c`**, on the new tests and the whole suite.
- **`incumbent_retire_test`** (two ctest entries) reads the proof back and asserts
  `#soli - #delc == 1` over a 21-incumbent descent, that each retirement emitted its two
  deletions in the load-bearing order — VeriPB accepts either, so nothing else stands behind
  that — and that a find-first run emits nothing at all. Both assertions were checked by
  mutation: disabling the retirement, and swapping the two deletions, each turn it red.
- **Search identical** mode-on vs mode-off on tour and talent.
- **Byte-identical**: mode-off proofs, and Literals-mode `solx` proofs (crystal_maze,
  langford), against the previous tip.

## What this does not buy

**Verify time does not move**: 0.50s and 1.30s on tour and talent either side of the change,
three runs each in one sitting. Twenty constraints out of a database of thousands should not
be measurable. This stage establishes the *residency* claim; whether it converts to verify
time at seat-moving scale is stage E's to answer, and is one of the things stage E's go/no-go
has to weigh against the complexity this stack is adding to a central proofs feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p