### PR TITLE
linear: move the incremental state and slack decision into prepare()

### DIFF
--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -177,12 +177,31 @@ auto ReifiedLinearEquality::install(Propagators & propagators, State & initial_s
     if (optional_model)
         define_proof_model(*optional_model, initial_state);
 
-    install_propagators(propagators, initial_state);
+    install_propagators(propagators);
 }
 
 auto ReifiedLinearEquality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _evaluated_cond = test_reification_condition(initial_state, _reif_cond);
+
+    std::tie(_sanitised, _modifier) = tidy_up_linear(_coeff_vars);
+
+    // The incremental (fixed-term-folding) propagator needs a backtrackable fold
+    // state, and allocating one is prepare()'s job. Allocate it only for a
+    // constraint that can actually run it: not tabulating, wide enough for the
+    // folding to pay off, and with a branch the dispatcher can reach. Only the
+    // must-hold branch folds -- must-not-hold is a different (not-equals) algorithm
+    // and the undecided branch only inspects a single residual variable -- so the
+    // state is reachable exactly when the condition may hold. Skipping the
+    // unreachable cases is not just tidiness: State::new_epoch deep-copies every
+    // constraint-state slot at every search node.
+    if (! holds_alternative<consistency::Tabulated>(_level)) {
+        auto n_terms = visit([](const auto & cv) { return cv.terms.size(); }, _sanitised);
+        auto may_hold = holds_alternative<evaluated_reif::MustHold>(_evaluated_cond) || holds_alternative<evaluated_reif::Undecided>(_evaluated_cond);
+        if (may_hold && n_terms >= _incremental_threshold.value_or(default_linear_incremental_threshold()))
+            _incremental_handle = initial_state.add_constraint_state(LinearIncrementalState{n_terms, 0_i});
+    }
+
     return true;
 }
 
@@ -233,9 +252,10 @@ auto ReifiedLinearEquality::define_proof_model(ProofModel & model, const State &
         .visit(_reif_cond);
 }
 
-auto ReifiedLinearEquality::install_propagators(Propagators & propagators, State & initial_state) -> void
+auto ReifiedLinearEquality::install_propagators(Propagators & propagators) -> void
 {
-    auto [sanitised_cv, modifier] = tidy_up_linear(_coeff_vars);
+    const auto & sanitised_cv = _sanitised;
+    const auto modifier = _modifier;
 
     vector<IntegerVariableID> all_vars;
     visit(
@@ -322,11 +342,11 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators, State
                         // Wide enough? Use the incremental propagator (folds instantiated terms
                         // out), which needs backtrackable constraint state set up here. Otherwise
                         // the cheaper stateless path, where folding bookkeeping does not pay off.
-                        if (lin.terms.size() >= _incremental_threshold.value_or(default_linear_incremental_threshold())) {
+                        if (_incremental_handle) {
                             auto active = make_shared<vector<std::size_t>>(lin.terms.size());
                             for (std::size_t i = 0; i != lin.terms.size(); ++i)
                                 (*active)[i] = i;
-                            auto handle = initial_state.add_constraint_state(LinearIncrementalState{lin.terms.size(), 0_i});
+                            auto handle = *_incremental_handle;
                             propagators.install(
                                 constraint_id(),
                                 [modifier = modifier, lin = lin, value = _value, proof_line = _proof_line, reason_from_cond = reif.cond,
@@ -400,12 +420,11 @@ auto ReifiedLinearEquality::install_propagators(Propagators & propagators, State
                         // while the condition is decided true in a subtree, backtracks on its own
                         // handle, and re-folds any terms instantiated while another branch was active.
                         std::optional<std::pair<std::shared_ptr<vector<std::size_t>>, ConstraintStateHandle>> inc_must_hold;
-                        if (sanitised_cv.terms.size() >= _incremental_threshold.value_or(default_linear_incremental_threshold())) {
+                        if (_incremental_handle) {
                             auto active = make_shared<vector<std::size_t>>(sanitised_cv.terms.size());
                             for (std::size_t i = 0; i != sanitised_cv.terms.size(); ++i)
                                 (*active)[i] = i;
-                            auto handle = initial_state.add_constraint_state(LinearIncrementalState{sanitised_cv.terms.size(), 0_i});
-                            inc_must_hold = std::pair{active, handle};
+                            inc_must_hold = std::pair{active, *_incremental_handle};
                         }
 
                         // Whole-scope reason built once here and captured, not

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -4,9 +4,11 @@
 #include <gcs/consistency.hh>
 #include <gcs/constraint.hh>
 #include <gcs/constraints/innards/reified_state.hh>
+#include <gcs/constraints/linear/utils.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/reification.hh>
 
 #include <cstddef>
@@ -51,11 +53,22 @@ namespace gcs
         std::optional<std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>>> _proof_line;
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
 
+        // tidy_up_linear() of _coeff_vars: computed once in prepare(), because both
+        // the incremental-state decision below and install_propagators() need it.
+        innards::TidiedUpLinear _sanitised;
+        Integer _modifier = 0_i;
+
+        // The incremental propagator's backtrackable fold state, allocated in
+        // prepare() and consumed by install_propagators(). Unset means this
+        // constraint is not folding: either it is too narrow to pay for it, or the
+        // dispatcher can never reach a branch that would use it. Keeping that
+        // conditional matters -- every constraint-state slot is deep-copied at every
+        // search node, so one allocated for an unreachable branch is a real cost.
+        std::optional<innards::ConstraintStateHandle> _incremental_handle;
+
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
-        // Takes State (unlike the base's Propagators-only hook) because the incremental
-        // equality path registers backtrackable constraint state at install time.
-        auto install_propagators(innards::Propagators &, innards::State &) -> void;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         // flipped_cond is internal reification plumbing, set by the derived NotEqualsIff

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -97,12 +97,63 @@ auto ReifiedLinearInequality::install(Propagators & propagators, State & initial
     if (optional_model)
         define_proof_model(*optional_model, initial_state);
 
-    install_propagators(propagators, initial_state);
+    install_propagators(propagators);
 }
 
 auto ReifiedLinearInequality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _evaluated_cond = test_reification_condition(initial_state, _reif_cond);
+
+    std::tie(_sanitised, _modifier) = tidy_up_linear(_coeff_vars);
+
+    auto neg_coeff_vars = _coeff_vars;
+    for (auto & v : neg_coeff_vars.terms)
+        v.coefficient = -v.coefficient;
+    std::tie(_sanitised_neg, _neg_modifier) = tidy_up_linear(neg_coeff_vars);
+
+    auto n_terms = [](const TidiedUpLinear & cv) { return visit([](const auto & c) { return c.terms.size(); }, cv); };
+
+    // Give a direction a fold state only if the dispatcher can reach it: must-hold
+    // for everything but an unconditional must-not-hold; must-not-hold only for an
+    // unconditional must-not-hold or a full Iff (a half-reified If/NotIf deactivates
+    // rather than enforcing the negation). Within a subtree only one direction runs,
+    // and each state backtracks on its own handle, so an under-folded state is still
+    // correct -- it just re-folds on its next run. Allocating one for a direction
+    // that can never run would not be free: State::new_epoch deep-copies every
+    // constraint-state slot at every search node.
+    const auto threshold = _incremental_threshold.value_or(default_linear_incremental_threshold());
+    const bool und = holds_alternative<evaluated_reif::Undecided>(_evaluated_cond);
+    const bool may_must_hold = holds_alternative<evaluated_reif::MustHold>(_evaluated_cond) || und;
+    const bool may_must_not_hold =
+        holds_alternative<evaluated_reif::MustNotHold>(_evaluated_cond) || (und && holds_alternative<reif::Iff>(_reif_cond));
+
+    if (may_must_hold && n_terms(_sanitised) >= threshold)
+        _incremental_must_hold = initial_state.add_constraint_state(LinearIncrementalState{n_terms(_sanitised), 0_i});
+    if (may_must_not_hold && n_terms(_sanitised_neg) >= threshold)
+        _incremental_must_not_hold = initial_state.add_constraint_state(LinearIncrementalState{n_terms(_sanitised_neg), 0_i});
+
+    // Slack-based waking, for a direction already decided at install time that is
+    // long enough and loose enough that most coarse wakes could not propagate
+    // anyway. Sizing the covering set reads the initial domains, so the decision
+    // belongs here; install_propagators() just acts on it.
+    const auto slack_threshold = default_linear_slack_watch_threshold();
+    const auto slack_cover_percent = default_linear_slack_watch_cover_percent();
+    auto want_slack = [&](const TidiedUpLinear & cv, Integer val) -> bool {
+        return visit(
+            [&](const auto & c) {
+                const auto len = c.terms.size();
+                if (len < slack_threshold)
+                    return false;
+                return linear_slack_cover_size(c, val, initial_state) * 100 <= slack_cover_percent * len;
+            },
+            cv);
+    };
+
+    if (holds_alternative<evaluated_reif::MustHold>(_evaluated_cond))
+        _slack_watch_must_hold = want_slack(_sanitised, _value + _modifier);
+    if (holds_alternative<evaluated_reif::MustNotHold>(_evaluated_cond))
+        _slack_watch_must_not_hold = want_slack(_sanitised_neg, -_value + _neg_modifier - 1_i);
+
     return true;
 }
 
@@ -140,17 +191,15 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model, const State
         .visit(_reif_cond);
 }
 
-auto ReifiedLinearInequality::install_propagators(Propagators & propagators, State & initial_state) -> void
+auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> void
 {
     auto proof_lines = _proof_lines;
     auto proof_lines_swapped = pair{_proof_lines.second, _proof_lines.first};
 
-    auto [sanitised_cv, modifier] = tidy_up_linear(_coeff_vars);
-
-    auto neg_coeff_vars = _coeff_vars;
-    for (auto & v : neg_coeff_vars.terms)
-        v.coefficient = -v.coefficient;
-    auto [sanitised_neg_cv, neg_modifier] = tidy_up_linear(neg_coeff_vars);
+    const auto & sanitised_cv = _sanitised;
+    const auto & sanitised_neg_cv = _sanitised_neg;
+    const auto modifier = _modifier;
+    const auto neg_modifier = _neg_modifier;
 
     vector<IntegerVariableID> vars;
     visit(
@@ -187,29 +236,20 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
             // one subtree only one direction runs, and each state backtracks on its own
             // ConstraintStateHandle, so an under-folded state (vars instantiated while the
             // other direction was active) is still correct -- it just re-folds them on its
-            // next run. Set up a state only for a direction the dispatcher can actually
-            // reach: must-hold for everything but an unconditional must-not-hold; must-not-
-            // hold only for an unconditional must-not-hold or a full Iff (a half-reified
-            // If/NotIf deactivates rather than enforcing the negation).
-            const auto threshold = _incremental_threshold.value_or(default_linear_incremental_threshold());
-            const bool und = std::holds_alternative<evaluated_reif::Undecided>(_evaluated_cond);
-            const bool may_must_hold = std::holds_alternative<evaluated_reif::MustHold>(_evaluated_cond) || und;
-            const bool may_must_not_hold =
-                std::holds_alternative<evaluated_reif::MustNotHold>(_evaluated_cond) || (und && std::holds_alternative<reif::Iff>(_reif_cond));
-
-            auto setup_inc = [&](const auto & cv) -> std::pair<std::shared_ptr<std::vector<std::size_t>>, ConstraintStateHandle> {
+            // next run. prepare() decided which directions get one, and allocated them.
+            auto setup_inc = [&](const auto & cv,
+                                 ConstraintStateHandle handle) -> std::pair<std::shared_ptr<std::vector<std::size_t>>, ConstraintStateHandle> {
                 auto active = make_shared<std::vector<std::size_t>>(cv.terms.size());
                 for (std::size_t i = 0; i != cv.terms.size(); ++i)
                     (*active)[i] = i;
-                auto handle = initial_state.add_constraint_state(LinearIncrementalState{cv.terms.size(), 0_i});
                 return std::pair{active, handle};
             };
 
             std::optional<std::pair<std::shared_ptr<std::vector<std::size_t>>, ConstraintStateHandle>> inc_must_hold, inc_must_not_hold;
-            if (may_must_hold && sanitised_cv.terms.size() >= threshold)
-                inc_must_hold = setup_inc(sanitised_cv);
-            if (may_must_not_hold && sanitised_neg_cv.terms.size() >= threshold)
-                inc_must_not_hold = setup_inc(sanitised_neg_cv);
+            if (_incremental_must_hold)
+                inc_must_hold = setup_inc(sanitised_cv, *_incremental_must_hold);
+            if (_incremental_must_not_hold)
+                inc_must_not_hold = setup_inc(sanitised_neg_cv, *_incremental_must_not_hold);
 
             auto enforce_constraint_must_hold = [sanitised_cv, value = _value, modifier = modifier, proof_lines, inc_must_hold](const State & state,
                                                     auto & inference, ProofLogger * const logger, const Literal & cond) -> PropagatorState {
@@ -276,14 +316,8 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
             // bypass the dispatcher for that single direction and run the sweep
             // directly, re-arming the covering set after each clean wake. The
             // genuinely-undecided reified case (and equality) keep the coarse path.
-            const auto slack_threshold = default_linear_slack_watch_threshold();
-            const auto slack_cover_percent = default_linear_slack_watch_cover_percent();
-            auto want_slack = [&](const auto & cv, Integer val) -> bool {
-                const auto len = cv.terms.size();
-                if (len < slack_threshold)
-                    return false;
-                return linear_slack_cover_size(cv, val, initial_state) * 100 <= slack_cover_percent * len;
-            };
+            // prepare() made the decision, since sizing the covering set needs the
+            // initial domains.
             auto install_slack_watched = [&](const auto & cv, Integer val, const Literal & cond, const auto & dir_proof_lines) {
                 Triggers slack_triggers;
                 for (const auto & term : cv.terms)
@@ -303,12 +337,11 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators, Sta
                     std::move(slack_triggers));
             };
 
-            if (auto mh = std::get_if<evaluated_reif::MustHold>(&_evaluated_cond); mh && want_slack(sanitised_cv, _value + modifier)) {
+            if (auto mh = std::get_if<evaluated_reif::MustHold>(&_evaluated_cond); mh && _slack_watch_must_hold) {
                 install_slack_watched(sanitised_cv, _value + modifier, mh->cond, proof_lines);
                 return;
             }
-            if (auto mnh = std::get_if<evaluated_reif::MustNotHold>(&_evaluated_cond);
-                mnh && want_slack(sanitised_neg_cv, -_value + neg_modifier - 1_i)) {
+            if (auto mnh = std::get_if<evaluated_reif::MustNotHold>(&_evaluated_cond); mnh && _slack_watch_must_not_hold) {
                 install_slack_watched(sanitised_neg_cv, -_value + neg_modifier - 1_i, mnh->cond, proof_lines_swapped);
                 return;
             }

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -3,10 +3,12 @@
 
 #include <gcs/constraint.hh>
 #include <gcs/constraints/innards/reified_state.hh>
+#include <gcs/constraints/linear/utils.hh>
 #include <gcs/expression.hh>
 #include <gcs/innards/literal.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/state.hh>
 #include <gcs/reification.hh>
 
 #include <cstddef>
@@ -37,11 +39,28 @@ namespace gcs
         // means use innards::default_linear_incremental_threshold().
         std::optional<std::size_t> _incremental_threshold;
 
+        // tidy_up_linear() of _coeff_vars and of its negation, computed once in
+        // prepare(), because the decisions below and install_propagators() all need
+        // them.
+        innards::TidiedUpLinear _sanitised, _sanitised_neg;
+        Integer _modifier = 0_i, _neg_modifier = 0_i;
+
+        // The two directions' backtrackable fold states, allocated in prepare() and
+        // consumed by install_propagators(). Each is set only for a direction the
+        // dispatcher can actually reach and that is wide enough to pay for folding:
+        // every constraint-state slot is deep-copied at every search node, so one
+        // allocated for an unreachable direction is a real cost.
+        std::optional<innards::ConstraintStateHandle> _incremental_must_hold, _incremental_must_not_hold;
+
+        // Whether a direction is decided at install time and loose enough to wake on
+        // slack watches rather than on every bound of every term. Deciding needs the
+        // initial domains (linear_slack_cover_size sizes the covering set against
+        // them), so it happens in prepare().
+        bool _slack_watch_must_hold = false, _slack_watch_must_not_hold = false;
+
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
-        // Takes State (unlike the base's Propagators-only hook) because the incremental
-        // must-hold path registers backtrackable constraint state at install time.
-        auto install_propagators(innards::Propagators &, innards::State &) -> void;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit ReifiedLinearInequality(


### PR DESCRIPTION
Stacked on #621.

`ReifiedLinearEquality` and `ReifiedLinearInequality` were the two constraints that did not fit `install_propagators(Propagators &)`. Both declared a **non-virtual** `install_propagators(Propagators &, State &)` that hid the base's hook — GCC has been warning `-Woverloaded-virtual` about it on every build — because they needed the `State` for two things: allocating the incremental propagator's backtrackable fold state, and sizing the slack-watch covering set.

Both are *decisions*, and `prepare()` is where decisions that need a `State` belong. It now computes `tidy_up_linear` once (the sanitised terms and the negated form are stored, so `install_propagators` no longer recomputes them), allocates the fold states, and evaluates `want_slack`. `install_propagators` consumes the results and matches the base signature again, so the hiding warning is gone.

## The conditionality is preserved on purpose

It would be simpler to allocate the fold state unconditionally. It would also be a regression: `State::new_epoch` deep-copies every constraint-state slot at **every search node**, so a slot allocated for a direction the dispatcher can never reach is a real per-node cost, not just untidiness. The reachability rules move across unchanged — must-hold except for an unconditional must-not-hold; must-not-hold only for an unconditional must-not-hold or a full `Iff`.

## How I verified it

Both the incremental fold and slack watching are *silent* performance paths: losing one leaves every solution correct and every test green. So a green suite proves nothing here.

Instead I instrumented each of the six decision sites on both sides and diffed which paths are actually taken, across 11 fixed-instance examples × 6 threshold/cover settings, plus 11 reified `linear_test` lanes. **Identical.** All six kinds are covered by the probe:

```
EQ_INC_MUSTHOLD      EQ_INC_UNDECIDED
INEQ_INC_MUSTHOLD    INEQ_INC_MUSTNOTHOLD
INEQ_SLACK_MUSTHOLD  INEQ_SLACK_MUSTNOTHOLD
```

(Worth knowing for future work: `linear_test` generates a varying number of random instances per run even with `--seed` pinned, so its counts are not comparable run-to-run. The probe uses fixed-instance examples for exact counts and only compares decision-kind *sets* for the `linear_test` lanes.)

- 531/531 ctest pass.
- OPB and `.scp` byte-identical across all 60 captured example models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD