### PR TITLE
Circuit: split install() into the three phases

### DIFF
--- a/gcs/constraints/circuit/circuit.cc
+++ b/gcs/constraints/circuit/circuit.cc
@@ -119,7 +119,7 @@ auto Circuit::with_short_reasons(optional<bool> enable) -> Circuit &
     return *this;
 }
 
-auto Circuit::set_up(Propagators & propagators, State & initial_state, ProofModel * const model) -> PosVarDataMap
+auto Circuit::prepare(Propagators & propagators, State & initial_state, ProofModel * const model) -> bool
 {
     // Can't have negative values
     for (const auto & s : _succ)
@@ -129,69 +129,87 @@ auto Circuit::set_up(Propagators & propagators, State & initial_state, ProofMode
     for (const auto & s : _succ)
         propagators.define_bound(initial_state, model, s, Bound::Upper, Integer(static_cast<long long>(_succ.size() - 1)));
 
-    // Define all different, either gac or non-gac
+    // The GAC all-different is a child constraint, which needs propagators, state and
+    // model together, so it can only be installed from here. The non-GAC alternative
+    // is pure encoding and lives in define_proof_model(); either way the rows land
+    // before the position encoding, as they did before.
     if (_gac_all_different) {
         AllDifferent all_diff{_succ};
         std::move(all_diff).install(propagators, initial_state, model);
     }
-    else {
-        // Still need to define the all different encoding.
-        if (model)
-            define_clique_not_equals_encoding(*model, _constraint_id, _succ);
-    }
+
+    // Backtrackable state for whichever algorithm install_propagators() picks. Both
+    // track the unassigned successors; only Prevent keeps the incremental chain
+    // endpoints, so only Prevent pays for that slot.
+    NonGacAllDifferentUnassigned unassigned{};
+    for (auto v : _succ)
+        unassigned.emplace_back(v);
+    _state_handles.unassigned = initial_state.add_constraint_state(unassigned);
+
+    if (std::holds_alternative<Prevent>(_algorithm))
+        _state_handles.chain = initial_state.add_constraint_state(make_prevent_chain_data(_succ.size()));
+
+    return true;
+}
+
+auto Circuit::define_proof_model(ProofModel & model, const State &) -> void
+{
+    // The all-different encoding. Under the GAC option the child AllDifferent that
+    // prepare() installed has already emitted it.
+    if (! _gac_all_different)
+        define_clique_not_equals_encoding(model, _constraint_id, _succ);
 
     // Define encoding to eliminate sub-cycles
-    PosVarDataMap pos_var_data{};
+    auto & pos_var_data = _pos_var_data;
 
-    if (model) {
-        auto n = static_cast<long long>(_succ.size());
-        // Define encoding to eliminate sub-cycles
-        // Need extra proof variable: pos[i] = j means "the ith node visited in the circuit is the jth var"
-        // WLOG start at node 0, so pos[0] = 0
-        pos_var_data.emplace(0,
-            PosVarData{"p[0]", model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
+    auto n = static_cast<long long>(_succ.size());
+    // Need extra proof variable: pos[i] = j means "the ith node visited in the circuit is the jth var"
+    // WLOG start at node 0, so pos[0] = 0
+    pos_var_data.emplace(0,
+        PosVarData{"p[0]", model.create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
+            map<long, PosVarLineData>{}});
+    model.add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
+    // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
+    // cake_pb_cp labels these position relations @c[id][pos_suc_<i>_<j>_le/ge].
+    auto [leq_line, geq_line] = model.add_labelled_constraint(
+        _constraint_id, "pos_suc_0_0_le", "pos_suc_0_0_ge", WPBSum{} == Integer{n - 1}, HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
+
+    pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
+
+    for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
+        pos_var_data.emplace(idx,
+            PosVarData{format("p[{}]", idx),
+                model.create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
                 map<long, PosVarLineData>{}});
-        model->add_constraint(WPBSum{} + 1_i * pos_var_data.at(0).var <= 0_i);
-        // Hence we can only have succ[0] = 0 (self cycle) if there is only one node i.e. n - 1 = 0
-        // cake_pb_cp labels these position relations @c[id][pos_suc_<i>_<j>_le/ge].
-        auto [leq_line, geq_line] = model->add_labelled_constraint(
-            _constraint_id, "pos_suc_0_0_le", "pos_suc_0_0_ge", WPBSum{} == Integer{n - 1}, HalfReifyOnConjunctionOf{{_succ[0] == 0_i}});
-
-        pos_var_data.at(0).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
-
-        for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
-            pos_var_data.emplace(idx,
-                PosVarData{format("p[{}]", idx),
-                    model->create_proof_only_integer_variable(0_i, Integer{n - 1}, "pos0", IntegerVariableProofRepresentation::Bits),
-                    map<long, PosVarLineData>{}});
-        }
-
-        for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
-            // (succ[0] = i) -> pos[i] - pos[0] = 1
-            tie(leq_line, geq_line) =
-                model->add_labelled_constraint(_constraint_id, "pos_suc_0_" + std::to_string(idx) + "_le", "pos_suc_0_" + std::to_string(idx) + "_ge",
-                    WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i, HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
-            pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line, geq_line});
-
-            // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
-            tie(leq_line, geq_line) =
-                model->add_labelled_constraint(_constraint_id, "pos_suc_" + std::to_string(idx) + "_0_le", "pos_suc_" + std::to_string(idx) + "_0_ge",
-                    WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
-                    HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
-            pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
-
-            // (succ[i] = j) -> pos[j] = pos[i] + 1
-            for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
-                tie(leq_line, geq_line) =
-                    model->add_labelled_constraint(_constraint_id, "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_le",
-                        "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_ge",
-                        WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
-                        HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
-                pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});
-            }
-        }
     }
 
+    for (unsigned int idx = 1; idx < _succ.size(); ++idx) {
+        // (succ[0] = i) -> pos[i] - pos[0] = 1
+        tie(leq_line, geq_line) =
+            model.add_labelled_constraint(_constraint_id, "pos_suc_0_" + std::to_string(idx) + "_le", "pos_suc_0_" + std::to_string(idx) + "_ge",
+                WPBSum{} + 1_i * pos_var_data.at(idx).var + -1_i * 1_c == 0_i, HalfReifyOnConjunctionOf{{_succ[0] == Integer{idx}}});
+        pos_var_data.at(0).plus_one_lines.emplace(idx, PosVarLineData{leq_line, geq_line});
+
+        // (succ[i] = 0) -> pos[0] - pos[i] = 1-n
+        tie(leq_line, geq_line) = model.add_labelled_constraint(_constraint_id, "pos_suc_" + std::to_string(idx) + "_0_le",
+            "pos_suc_" + std::to_string(idx) + "_0_ge", WPBSum{} + 1_i * pos_var_data.at(0).var + -1_i * pos_var_data.at(idx).var == Integer{1 - n},
+            HalfReifyOnConjunctionOf{{_succ[idx] == 0_i}});
+        pos_var_data.at(idx).plus_one_lines.emplace(0, PosVarLineData{leq_line, geq_line});
+
+        // (succ[i] = j) -> pos[j] = pos[i] + 1
+        for (unsigned int jdx = 1; jdx < _succ.size(); ++jdx) {
+            tie(leq_line, geq_line) =
+                model.add_labelled_constraint(_constraint_id, "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_le",
+                    "pos_suc_" + std::to_string(idx) + "_" + std::to_string(jdx) + "_ge",
+                    WPBSum{} + 1_i * pos_var_data.at(jdx).var + -1_i * pos_var_data.at(idx).var == 1_i,
+                    HalfReifyOnConjunctionOf{{_succ[idx] == Integer{jdx}}});
+            pos_var_data.at(idx).plus_one_lines.emplace(jdx, PosVarLineData{leq_line, geq_line});
+        }
+    }
+}
+
+auto Circuit::install_propagators(Propagators & propagators) -> void
+{
     // Infer succ[i] != i at top of search, but no other propagation defined here: use circuit::Prevent or circuit::SCC
     if (_succ.size() > 1) {
         propagators.install(
@@ -206,16 +224,21 @@ auto Circuit::set_up(Propagators & propagators, State & initial_state, ProofMode
             Triggers{});
     }
 
-    return pos_var_data;
+    overloaded{
+        [&](const SCC &) { install_circuit_scc(propagators, constraint_id(), _succ, _scc_options, std::move(_pos_var_data), _state_handles); }, //
+        [&](const Prevent &) { install_circuit_prevent(propagators, constraint_id(), _succ, std::move(_pos_var_data), _state_handles); }}
+        .visit(_algorithm);
 }
 
-auto Circuit::install(Propagators & propagators, State & initial_state, ProofModel * const model) && -> void
+auto Circuit::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    auto pos_var_data = set_up(propagators, initial_state, model);
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-    overloaded{[&](const SCC &) { install_circuit_scc(propagators, initial_state, constraint_id(), _succ, _scc_options, std::move(pos_var_data)); },
-        [&](const Prevent &) { install_circuit_prevent(propagators, initial_state, constraint_id(), _succ, std::move(pos_var_data)); }}
-        .visit(_algorithm);
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
 }
 
 auto Circuit::clone() const -> unique_ptr<Constraint>

--- a/gcs/constraints/circuit/circuit.hh
+++ b/gcs/constraints/circuit/circuit.hh
@@ -70,7 +70,17 @@ namespace gcs
         bool _gac_all_different = false;
         SCCOptions _scc_options{};
 
-        auto set_up(innards::Propagators &, innards::State &, innards::ProofModel * const) -> innards::circuit::PosVarDataMap;
+        // Backtrackable state allocated by prepare(), consumed by install_propagators().
+        innards::circuit::CircuitStateHandles _state_handles;
+
+        // The position-variable encoding, built by define_proof_model() and captured by
+        // the algorithm's propagator. Empty when proof logging is off, which is what
+        // both algorithms expect.
+        innards::circuit::PosVarDataMap _pos_var_data;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Circuit(std::vector<IntegerVariableID> succ);

--- a/gcs/constraints/circuit/circuit_base.hh
+++ b/gcs/constraints/circuit/circuit_base.hh
@@ -45,6 +45,21 @@ namespace gcs::innards::circuit
     using ProofFlagDataMap = std::map<long, std::map<long, ProofFlagData>>;
     using PosVarDataMap = std::map<long, PosVarData>;
 
+    /**
+     * \brief The backtrackable state the circuit propagators keep, allocated by
+     * Circuit::prepare() -- allocating is a prepare-phase job -- and handed to
+     * whichever algorithm is installed.
+     *
+     * `chain` holds the incremental small-cycle chain endpoints, which only
+     * circuit::Prevent uses, so it is only allocated when that algorithm is
+     * selected: every constraint-state slot is deep-copied at every search node.
+     */
+    struct CircuitStateHandles
+    {
+        ConstraintStateHandle unassigned;
+        std::optional<ConstraintStateHandle> chain;
+    };
+
     struct ShiftedPosDataMaps
     {
         std::map<long, ProofFlagData> greater_than;

--- a/gcs/constraints/circuit/circuit_prevent.cc
+++ b/gcs/constraints/circuit/circuit_prevent.cc
@@ -20,20 +20,6 @@ using std::vector;
 
 namespace
 {
-    // Incremental "prevent" state: the fixed successor edges partition the nodes into
-    // simple paths (chains). For each node we record the chain it belongs to by its
-    // endpoints. These are maintained in O(1) as edges are fixed and restored on
-    // backtrack (held as backtrackable constraint state), rather than recomputed from
-    // scratch each call. orig[v] is valid when v is a chain *end*, dest[v]/len[v] when
-    // v is a chain *start* -- which is exactly how they are queried below.
-    struct PreventChainData
-    {
-        std::vector<long> orig;      // start node of the chain ending at this node
-        std::vector<long> dest;      // end node of the chain starting at this node
-        std::vector<long> len;       // number of fixed edges in the chain starting at this node
-        std::vector<long> unspliced; // node indices whose fixed successor edge is not yet folded in
-    };
-
     // Fold every newly-fixed edge into the chain endpoints and make the same inferences
     // the from-scratch prevent_small_cycles would: forbid a short chain from closing
     // (succ[end] != start), force the full chain to close (succ[end] == start), and
@@ -137,19 +123,8 @@ template auto gcs::innards::circuit::propagate_circuit_using_prevent(const std::
     const PosVarDataMap & pos_var_data, const ConstraintStateHandle & unassigned_handle, const ConstraintStateHandle & chain_handle,
     const State & state, EagerProofLoggingInferenceTracker & inference, ProofLogger * const logger) -> void;
 
-auto gcs::innards::circuit::install_circuit_prevent(Propagators & propagators, State & initial_state, const ConstraintID & owner,
-    const vector<IntegerVariableID> & succ, PosVarDataMap pos_var_data) -> void
+auto gcs::innards::circuit::make_prevent_chain_data(size_t num_nodes) -> PreventChainData
 {
-    // Keep track of unassigned vars
-    NonGacAllDifferentUnassigned unassigned{};
-    for (auto v : succ) {
-        unassigned.emplace_back(v);
-    }
-    auto unassigned_handle = initial_state.add_constraint_state(unassigned);
-
-    // Backtrackable chain endpoints for the incremental small-cycle prevention. Each
-    // node starts as its own length-zero chain; edges fold in as successors are fixed.
-    auto num_nodes = succ.size();
     PreventChainData chain;
     chain.orig.resize(num_nodes);
     chain.dest.resize(num_nodes);
@@ -160,7 +135,14 @@ auto gcs::innards::circuit::install_circuit_prevent(Propagators & propagators, S
         chain.dest[i] = static_cast<long>(i);
         chain.unspliced[i] = static_cast<long>(i);
     }
-    auto chain_handle = initial_state.add_constraint_state(std::move(chain));
+    return chain;
+}
+
+auto gcs::innards::circuit::install_circuit_prevent(Propagators & propagators, const ConstraintID & owner, const vector<IntegerVariableID> & succ,
+    PosVarDataMap pos_var_data, const CircuitStateHandles & handles) -> void
+{
+    auto unassigned_handle = handles.unassigned;
+    auto chain_handle = handles.chain.value();
 
     Triggers triggers;
     triggers.on_instantiated = {succ.begin(), succ.end()};

--- a/gcs/constraints/circuit/circuit_prevent.hh
+++ b/gcs/constraints/circuit/circuit_prevent.hh
@@ -16,12 +16,34 @@ namespace gcs::innards::circuit
         ProofLogger * const logger) -> void;
 
     /**
-     * \brief Set up the backtrackable state for the "prevent" circuit propagator (unassigned set
-     * plus the incremental chain endpoints) and install it, given the position-variable proof data
-     * already produced by Circuit::set_up. Called from Circuit::install when the circuit::Prevent
-     * algorithm is selected. Defined in circuit_prevent.cc.
+     * \brief Install the "prevent" circuit propagator over the backtrackable state
+     * Circuit::prepare() allocated (the unassigned set plus the incremental chain endpoints)
+     * and the position-variable proof data Circuit::define_proof_model() produced. Called from
+     * Circuit::install_propagators() when the circuit::Prevent algorithm is selected. Defined
+     * in circuit_prevent.cc.
      */
-    auto install_circuit_prevent(Propagators & propagators, State & initial_state, const ConstraintID & owner,
-        const std::vector<IntegerVariableID> & succ, PosVarDataMap pos_var_data) -> void;
+    auto install_circuit_prevent(Propagators & propagators, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ,
+        PosVarDataMap pos_var_data, const CircuitStateHandles & handles) -> void;
+
+    // Incremental "prevent" state: the fixed successor edges partition the nodes into
+    // simple paths (chains). For each node we record the chain it belongs to by its
+    // endpoints. These are maintained in O(1) as edges are fixed and restored on
+    // backtrack (held as backtrackable constraint state), rather than recomputed from
+    // scratch each call. orig[v] is valid when v is a chain *end*, dest[v]/len[v] when
+    // v is a chain *start* -- which is exactly how they are queried below.
+    struct PreventChainData
+    {
+        std::vector<long> orig;      // start node of the chain ending at this node
+        std::vector<long> dest;      // end node of the chain starting at this node
+        std::vector<long> len;       // number of fixed edges in the chain starting at this node
+        std::vector<long> unspliced; // node indices whose fixed successor edge is not yet folded in
+    };
+
+    /**
+     * \brief The initial incremental small-cycle chain endpoints for n nodes: each node
+     * starts as its own length-zero chain, and edges fold in as successors are fixed.
+     * Built here so Circuit::prepare() can allocate the constraint state that holds it.
+     */
+    [[nodiscard]] auto make_prevent_chain_data(std::size_t n) -> PreventChainData;
 }
 #endif // GLASGOW_CONSTRAINT_SOLVER_CIRCUIT_PREVENT_HH

--- a/gcs/constraints/circuit/circuit_scc.cc
+++ b/gcs/constraints/circuit/circuit_scc.cc
@@ -1091,15 +1091,10 @@ template auto gcs::innards::circuit::propagate_circuit_using_scc(const State & s
     ProofLogger * const logger, const ReasonLiterals & reason, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ,
     const SCCOptions & scc_options, SCCPersistentData & persistent, const ConstraintStateHandle & unassigned_handle) -> void;
 
-auto gcs::innards::circuit::install_circuit_scc(Propagators & propagators, State & initial_state, const ConstraintID & owner,
-    const vector<IntegerVariableID> & succ, const SCCOptions & scc_options, PosVarDataMap pos_var_data) -> void
+auto gcs::innards::circuit::install_circuit_scc(Propagators & propagators, const ConstraintID & owner, const vector<IntegerVariableID> & succ,
+    const SCCOptions & scc_options, PosVarDataMap pos_var_data, const CircuitStateHandles & handles) -> void
 {
-    // Keep track of unassigned vars
-    NonGacAllDifferentUnassigned unassigned{};
-    for (auto v : succ) {
-        unassigned.emplace_back(v);
-    }
-    auto unassigned_handle = initial_state.add_constraint_state(unassigned);
+    auto unassigned_handle = handles.unassigned;
 
     // The position definitions and the two proof caches do not backtrack, so they are
     // captured rather than held in the State: the propagator mutates the caches through

--- a/gcs/constraints/circuit/circuit_scc.hh
+++ b/gcs/constraints/circuit/circuit_scc.hh
@@ -61,12 +61,13 @@ namespace gcs::innards::circuit
         const ConstraintStateHandle & unassigned_handle) -> void;
 
     /**
-     * \brief Set up the backtrackable state for the SCC circuit propagator and install it, given
-     * the position-variable proof data already produced by Circuit::set_up. Called from
-     * Circuit::install when the circuit::SCC algorithm is selected. Defined in circuit_scc.cc.
+     * \brief Install the SCC circuit propagator over the backtrackable state
+     * Circuit::prepare() allocated and the position-variable proof data
+     * Circuit::define_proof_model() produced. Called from Circuit::install_propagators() when
+     * the circuit::SCC algorithm is selected. Defined in circuit_scc.cc.
      */
-    auto install_circuit_scc(Propagators & propagators, State & initial_state, const ConstraintID & owner,
-        const std::vector<IntegerVariableID> & succ, const SCCOptions & scc_options, PosVarDataMap pos_var_data) -> void;
+    auto install_circuit_scc(Propagators & propagators, const ConstraintID & owner, const std::vector<IntegerVariableID> & succ,
+        const SCCOptions & scc_options, PosVarDataMap pos_var_data, const CircuitStateHandles & handles) -> void;
 }
 
 #endif // GLASGOW_CONSTRAINT_SOLVER_CIRCUIT_SCC_HH


### PR DESCRIPTION
Stacked on #623.

`Circuit::install()` was a `set_up()` helper doing four unrelated jobs followed by an algorithm dispatch. Each job belongs to exactly one phase:

| phase | work |
|---|---|
| `prepare()` | definitional bounds on the successors; the child `AllDifferent` under the GAC option (a child install needs propagators, state and model together, so only `prepare()` can do it); the backtrackable state both algorithms keep |
| `define_proof_model()` | the non-GAC clique-of-not-equals encoding, and the position-variable encoding that eliminates sub-cycles |
| `install_propagators()` | the `succ[i] != i` initialiser, then `install_circuit_scc` or `install_circuit_prevent` |

The two algorithm installers no longer take a `State`: their constraint state is allocated in `prepare()` and passed as a `CircuitStateHandles`. Only `Prevent` uses the incremental chain endpoints, so only `Prevent` allocates that slot — every constraint-state slot is deep-copied at every search node. `PreventChainData` and its initial value move to the header for that.

OPB row order is unchanged: the all-different rows still precede the position encoding either way, because `prepare()` runs before `define_proof_model()`.

## A coverage gap worth knowing about

The GAC all-different option is exercised by **nothing** in the suite — `circuit_random` hard-codes `use_gac_all_different = false` (line 62) and exposes no flag to turn it on. That is pre-existing, not introduced here, but it meant this change touched an untested branch.

So I checked it by hand: with the flag forced on, `circuit_random -n 6 --seed 7` produces a **byte-identical OPB** before and after, and its proof verifies under VeriPB. Might be worth a follow-up issue to give that option a lane.

## Verification

- 531/531 ctest pass. `Prevent` is covered — `circuit_test`'s prevent lane, plus `tour` and `circuit_small`.
- OPB and `.scp` byte-identical across all 60 captured example models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD