### PR TITLE
Delegating constraints: move the delegation into prepare()

### DIFF
--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -53,6 +53,25 @@ namespace gcs
          */
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void {};
         virtual auto install_propagators(innards::Propagators &) -> void {};
+        /**
+         * \brief Everything that has to happen before the constraint can be described
+         * and propagated: argument validation, reading the initial domains, allocating
+         * auxiliary variables and backtrackable constraint state, and installing child
+         * constraints.
+         *
+         * This is the only phase holding all three of the propagators, the mutable
+         * State and the model at once, so it is the only one that can allocate or
+         * install a child.
+         *
+         * Return false to say that the other two phases must not run. That covers both
+         * "there is nothing to do" -- the constraint is trivially satisfied, or a
+         * contradiction initialiser has already been installed -- and "this constraint
+         * has delegated itself to a child, which has been installed in full".
+         *
+         * When allocating constraint state, allocate it only for a branch that can
+         * actually be reached: State::new_epoch deep-copies every slot at every search
+         * node, so a slot for an unreachable branch costs on every node of the search.
+         */
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool
         {
             return true;

--- a/gcs/constraints/at_most_one/at_most_one.cc
+++ b/gcs/constraints/at_most_one/at_most_one.cc
@@ -178,11 +178,26 @@ auto AtMostOneSmartTable::clone() const -> unique_ptr<Constraint>
 
 auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
+}
+
+auto AtMostOneSmartTable::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    // Delegates entirely: the SmartTable below is this constraint. Building and
+    // installing it needs all three of propagators, state and model, so it happens
+    // here, and returning false stops the empty define_proof_model/install_propagators
+    // from running afterwards.
     // 0 or 1 vars: "at most 1 of n equals val" is vacuously true. The
     // SmartTable below would build empty tuples for n == 0, which means
     // "no row matches" i.e. UNSAT — wrong for the trivial case. Skip.
     if (_vars.size() < 2)
-        return;
+        return false;
 
     SmartTuples tuples;
     for (int i = 0; cmp_less(i, _vars.size()); ++i) {
@@ -200,6 +215,8 @@ auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_sta
 
     SmartTable smt_table{all_vars, tuples};
     move(smt_table).install(propagators, initial_state, optional_model);
+
+    return false;
 }
 
 auto AtMostOneSmartTable::constraint_type() const -> std::string

--- a/gcs/constraints/at_most_one/at_most_one.hh
+++ b/gcs/constraints/at_most_one/at_most_one.hh
@@ -64,6 +64,8 @@ namespace gcs
         std::vector<IntegerVariableID> _vars;
         IntegerVariableID _val;
 
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+
     public:
         explicit AtMostOneSmartTable(std::vector<IntegerVariableID> vars, IntegerVariableID val);
 

--- a/gcs/constraints/lex/lex_smart_table.cc
+++ b/gcs/constraints/lex/lex_smart_table.cc
@@ -44,6 +44,19 @@ auto LexSmartTable::clone() const -> unique_ptr<Constraint>
 
 auto LexSmartTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
+}
+
+auto LexSmartTable::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    // Delegates entirely to the SmartTable built below; see the note on
+    // Constraint::prepare about returning false.
     SmartTuples tuples;
 
     for (unsigned int i = 0; i < min(_vars_1.size(), _vars_2.size()); ++i) {
@@ -62,6 +75,8 @@ auto LexSmartTable::install(Propagators & propagators, State & initial_state, Pr
 
     auto smt_table = SmartTable{all_vars, tuples};
     move(smt_table).install(propagators, initial_state, optional_model);
+
+    return false;
 }
 
 auto LexSmartTable::constraint_type() const -> std::string

--- a/gcs/constraints/lex/lex_smart_table.hh
+++ b/gcs/constraints/lex/lex_smart_table.hh
@@ -26,6 +26,8 @@ namespace gcs
         std::vector<IntegerVariableID> _vars_1;
         std::vector<IntegerVariableID> _vars_2;
 
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+
     public:
         explicit LexSmartTable(std::vector<IntegerVariableID> vars_1, std::vector<IntegerVariableID> vars_2);
 

--- a/gcs/constraints/power/power_table.cc
+++ b/gcs/constraints/power/power_table.cc
@@ -30,6 +30,19 @@ auto PowerTable::clone() const -> unique_ptr<Constraint>
 
 auto PowerTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
+}
+
+auto PowerTable::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    // Delegates entirely to a materialised Table over the reachable triples, which
+    // is why this reads the initial domains here.
     vector<vector<Integer>> permitted;
     for (const auto & v1 : initial_state.each_value_immutable(_base))
         for (const auto & v2 : initial_state.each_value_immutable(_exponent)) {
@@ -43,6 +56,8 @@ auto PowerTable::install(Propagators & propagators, State & initial_state, Proof
     Table table{vector<IntegerVariableID>{_base, _exponent, _result}, move(permitted)};
     table.set_constraint_id(constraint_id());
     move(table).install(propagators, initial_state, optional_model);
+
+    return false;
 }
 
 auto PowerTable::constraint_type() const -> std::string

--- a/gcs/constraints/power/power_table.hh
+++ b/gcs/constraints/power/power_table.hh
@@ -25,6 +25,8 @@ namespace gcs::innards
     private:
         IntegerVariableID _base, _exponent, _result;
 
+        virtual auto prepare(Propagators &, State &, ProofModel * const) -> bool override;
+
     public:
         explicit PowerTable(IntegerVariableID base, IntegerVariableID exponent, IntegerVariableID result);
 

--- a/gcs/constraints/seq_precede_chain/seq_precede_chain.cc
+++ b/gcs/constraints/seq_precede_chain/seq_precede_chain.cc
@@ -45,9 +45,22 @@ auto SeqPrecedeChain::clone() const -> unique_ptr<Constraint>
 
 auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
+}
+
+auto SeqPrecedeChain::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
+    // Either trivially satisfied, or delegated entirely to the ValuePrecede chain
+    // built below; see the note on Constraint::prepare about returning false.
     auto n = _vars.size();
     if (n == 0)
-        return;
+        return false;
 
     Integer max_upper = 0_i;
     for (const auto & v : _vars) {
@@ -57,7 +70,7 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
     }
 
     if (max_upper < 1_i)
-        return;
+        return false;
 
     Integer n_as_int{static_cast<long long>(n)};
     Integer effective_max = (max_upper < n_as_int) ? max_upper : n_as_int;
@@ -73,7 +86,7 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
     }
 
     if (effective_max < 2_i)
-        return;
+        return false;
 
     vector<Integer> chain;
     for (Integer i = 1_i; i <= effective_max; ++i)
@@ -86,6 +99,8 @@ auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, 
     ValuePrecede child{move(chain), move(_vars)};
     child.set_constraint_id(constraint_id());
     move(child).install(propagators, initial_state, optional_model);
+
+    return false;
 }
 
 auto SeqPrecedeChain::constraint_type() const -> std::string

--- a/gcs/constraints/seq_precede_chain/seq_precede_chain.hh
+++ b/gcs/constraints/seq_precede_chain/seq_precede_chain.hh
@@ -32,6 +32,8 @@ namespace gcs
     private:
         std::vector<IntegerVariableID> _vars;
 
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+
     public:
         /**
          * \brief Construct from an array of variables.


### PR DESCRIPTION
Stacked on #624.

Four constraints exist only to build a *different* constraint and install it:

- `AtMostOneSmartTable` and `LexSmartTable` → a `SmartTable`
- `PowerTable` → a `Table` over the reachable triples
- `SeqPrecedeChain` → a `ValuePrecede` chain

All four did that straight from `install()`, which is the last thing standing between them and a non-virtual `install()`.

Installing a child needs propagators, state and model together, so `prepare()` is the only phase that can do it. Each now delegates there and returns false.

## The design call

That gives `prepare()`'s false return a second meaning, so I wrote it down on the base class: **false means "the other two phases must not run"**, covering both "nothing to do" (trivially satisfied, or a contradiction initialiser is already installed) and "delegated in full to a child".

The alternative was a fourth phase existing only for delegation. It buys nothing — the work is identical, and it would still have to run before the other two.

While documenting `prepare()` I also wrote down the two rules this stack has been following:

- it is the only phase holding all three of propagators, a mutable `State` and the model, hence the only one that can allocate or install a child;
- constraint state should only be allocated for a branch that can actually be reached, because `State::new_epoch` deep-copies every slot at every search node.

## Verification

- 531/531 ctest pass.
- OPB and `.scp` byte-identical across all 60 captured example models. That is the real check here: a delegation that silently stopped happening would leave an empty encoding behind, and it doesn't — `smart_table_am1` still writes 36 constraint rows, `smart_table_lex` 68.
- `PowerTable`'s variable-exponent path is covered by `power_test`'s own case (`power_test.cc:84`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD