### PR TITLE
Regular, Knapsack: make the proof-strategy dispatch a prepare() decision

### DIFF
--- a/dev_docs/regular.md
+++ b/dev_docs/regular.md
@@ -32,9 +32,10 @@ solutions found.
 
 The public `Regular` front-end (`gcs/constraints/regular/regular.{cc,hh}`)
 *is* the `Upfront` implementation; for `PerCall` and `Bacchus` its
-`install()` constructs and delegates to the sibling implementations,
-which are internal to the constraint (not part of the public API — they
-are no longer named in `gcs/constraints/regular.hh`). Everything posts
+`prepare()` constructs the sibling implementation, installs it in full,
+and returns false so none of `Regular`'s own phases run. Those siblings
+are internal to the constraint (not part of the public API — they are no
+longer named in `gcs/constraints/regular.hh`). Everything posts
 `Regular`; benchmarking picks a strategy with `with_proof_strategy(...)`.
 
 ## Default: `proof_strategy::Upfront`

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -576,75 +576,94 @@ namespace
     }
 }
 
-namespace
+auto Knapsack::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    auto install_knapsack_percall(Propagators & propagators, State & initial_state, ProofModel * const optional_model, const ConstraintID & owner,
-        vector<vector<Integer>> coeffs, vector<IntegerVariableID> vars, vector<IntegerVariableID> totals) -> void
-    {
-        if (coeffs.size() != totals.size())
-            throw InvalidProblemDefinitionException{"mismatch between coefficients and totals sizes for knapsack"};
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
 
-        if (coeffs.empty())
-            throw InvalidProblemDefinitionException{"empty knapsack coefficients"};
-        unsigned n_vars = coeffs.begin()->size();
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
 
-        for (auto & c : coeffs)
-            if (c.size() != n_vars)
-                throw InvalidProblemDefinitionException{"not sure what to do about different coefficient array sizes for knapsack"};
+    install_propagators(propagators);
+}
 
-        for (auto & cc : coeffs)
-            for (auto & c : cc)
-                if (c < 0_i)
-                    throw InvalidProblemDefinitionException{"not sure what to do about negative coefficients for knapsack"};
+auto Knapsack::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    // The two strategies draw the same inferences and share this OPB encoding;
+    // they differ only in the proof scaffolding, so each has its own three-phase
+    // implementation over the same arguments. Validation lives in whichever one
+    // runs, since the messages differ.
+    if (holds_alternative<proof_strategy::Upfront>(_proof_strategy)) {
+        _upfront = knapsack_upfront_prepare(initial_state, move(_coeffs), move(_vars), move(_totals));
+        return true;
+    }
 
-        for (auto & v : vars)
-            if (initial_state.lower_bound(v) < 0_i)
-                throw InvalidProblemDefinitionException{"can only support non-negative variables for knapsack"};
+    if (_coeffs.size() != _totals.size())
+        throw InvalidProblemDefinitionException{"mismatch between coefficients and totals sizes for knapsack"};
 
-        for (auto & t : totals)
-            if (initial_state.lower_bound(t) < 0_i)
-                throw InvalidProblemDefinitionException{"not sure what to do about negative permitted totals for knapsack"};
+    if (_coeffs.empty())
+        throw InvalidProblemDefinitionException{"empty knapsack coefficients"};
+    unsigned n_vars = _coeffs.begin()->size();
 
-        vector<pair<ProofLine, ProofLine>> eqns_lines;
-        if (optional_model) {
-            for (const auto & [cc_idx, cc] : enumerate(coeffs)) {
-                WPBSum sum_eq;
-                for (const auto & [idx, v] : enumerate(vars))
-                    sum_eq += cc.at(idx) * v;
-                // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
-                // the row index lives in the annotation tag, not the constraint name (a
-                // name-embedded row could collide with a sibling constraint's name). Match
-                // that so the propagator's pol steps, which cite these lines by label,
-                // resolve against cake's OPB. The bodies are identical.
-                auto [eq1, eq2] = optional_model->add_labelled_constraint(
-                    owner, std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * totals.at(cc_idx));
-                eqns_lines.emplace_back(eq1, eq2);
-            }
-        }
+    for (auto & c : _coeffs)
+        if (c.size() != n_vars)
+            throw InvalidProblemDefinitionException{"not sure what to do about different coefficient array sizes for knapsack"};
 
-        Triggers triggers;
-        triggers.on_change = {vars.begin(), vars.end()};
-        triggers.on_change.insert(triggers.on_change.end(), totals.begin(), totals.end());
+    for (auto & cc : _coeffs)
+        for (auto & c : cc)
+            if (c < 0_i)
+                throw InvalidProblemDefinitionException{"not sure what to do about negative coefficients for knapsack"};
 
-        propagators.install(
-            owner,
-            [coeffs = move(coeffs), vars = move(vars), totals = move(totals), eqns_lines = move(eqns_lines), owner](
-                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                return knapsack(state, logger, inference, owner, coeffs, vars, totals, eqns_lines);
-            },
-            triggers);
+    for (auto & v : _vars)
+        if (initial_state.lower_bound(v) < 0_i)
+            throw InvalidProblemDefinitionException{"can only support non-negative variables for knapsack"};
+
+    for (auto & t : _totals)
+        if (initial_state.lower_bound(t) < 0_i)
+            throw InvalidProblemDefinitionException{"not sure what to do about negative permitted totals for knapsack"};
+
+    return true;
+}
+
+auto Knapsack::define_proof_model(ProofModel & model, const State &) -> void
+{
+    if (_upfront) {
+        knapsack_upfront_define_proof_model(model, constraint_id(), *_upfront);
+        return;
+    }
+
+    for (const auto & [cc_idx, cc] : enumerate(_coeffs)) {
+        WPBSum sum_eq;
+        for (const auto & [idx, v] : enumerate(_vars))
+            sum_eq += cc.at(idx) * v;
+        // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
+        // the row index lives in the annotation tag, not the constraint name (a
+        // name-embedded row could collide with a sibling constraint's name). Match
+        // that so the propagator's pol steps, which cite these lines by label,
+        // resolve against cake's OPB. The bodies are identical.
+        auto [eq1, eq2] = model.add_labelled_constraint(
+            constraint_id(), std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * _totals.at(cc_idx));
+        _eqns_lines.emplace_back(eq1, eq2);
     }
 }
 
-auto Knapsack::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+auto Knapsack::install_propagators(Propagators & propagators) -> void
 {
-    overloaded{[&](const proof_strategy::PerCall &) {
-                   install_knapsack_percall(propagators, initial_state, optional_model, constraint_id(), move(_coeffs), move(_vars), move(_totals));
-               },
-        [&](const proof_strategy::Upfront &) {
-            install_knapsack_upfront(propagators, initial_state, optional_model, constraint_id(), move(_coeffs), move(_vars), move(_totals));
-        }}
-        .visit(_proof_strategy);
+    if (_upfront) {
+        knapsack_upfront_install_propagators(propagators, constraint_id(), _upfront);
+        return;
+    }
+
+    Triggers triggers;
+    triggers.on_change = {_vars.begin(), _vars.end()};
+    triggers.on_change.insert(triggers.on_change.end(), _totals.begin(), _totals.end());
+
+    propagators.install(
+        constraint_id(),
+        [coeffs = _coeffs, vars = _vars, totals = _totals, eqns_lines = move(_eqns_lines), owner = constraint_id()](const State & state,
+            auto & inference,
+            ProofLogger * const logger) -> PropagatorState { return knapsack(state, logger, inference, owner, coeffs, vars, totals, eqns_lines); },
+        triggers);
 }
 
 auto Knapsack::constraint_type() const -> std::string

--- a/gcs/constraints/knapsack/knapsack.hh
+++ b/gcs/constraints/knapsack/knapsack.hh
@@ -2,9 +2,13 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_KNAPSACK_KNAPSACK_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/constraints/knapsack/knapsack_upfront.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/proof_strategy.hh>
 #include <gcs/variable_id.hh>
 
+#include <memory>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -48,6 +52,16 @@ namespace gcs
         std::vector<IntegerVariableID> _vars;
         std::vector<IntegerVariableID> _totals;
         KnapsackProofStrategy _proof_strategy = proof_strategy::PerCall{};
+
+        // Set by prepare() under proof_strategy::Upfront: that strategy's own
+        // three-phase implementation, opaque here. Unset means the per-call
+        // strategy, whose state is the _eqns_lines below.
+        std::shared_ptr<innards::KnapsackUpfrontData> _upfront;
+        std::vector<std::pair<innards::ProofLine, innards::ProofLine>> _eqns_lines;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Knapsack(std::vector<Integer> weights, std::vector<Integer> profits, std::vector<IntegerVariableID> vars, IntegerVariableID weight,

--- a/gcs/constraints/knapsack/knapsack_upfront.cc
+++ b/gcs/constraints/knapsack/knapsack_upfront.cc
@@ -841,8 +841,19 @@ namespace
     };
 }
 
-auto gcs::innards::install_knapsack_upfront(Propagators & propagators, State & initial_state, ProofModel * const optional_model,
-    const ConstraintID & owner, vector<vector<Integer>> coeffs, vector<IntegerVariableID> vars, vector<IntegerVariableID> totals) -> void
+// Everything the three phases share. Opaque to knapsack.cc, which only holds it
+// by shared_ptr and hands it back.
+struct gcs::innards::KnapsackUpfrontData
+{
+    vector<vector<Integer>> coeffs;
+    vector<IntegerVariableID> vars;
+    vector<IntegerVariableID> totals;
+    shared_ptr<KnapsackUpfrontBridge> bridge;
+    ConstraintStateHandle dead_cache;
+};
+
+auto gcs::innards::knapsack_upfront_prepare(State & initial_state, vector<vector<Integer>> coeffs, vector<IntegerVariableID> vars,
+    vector<IntegerVariableID> totals) -> shared_ptr<KnapsackUpfrontData>
 {
     if (coeffs.size() != totals.size())
         throw InvalidProblemDefinitionException{"KnapsackUpfront: coefficients and totals must have the same number of equations"};
@@ -881,21 +892,34 @@ auto gcs::innards::install_knapsack_upfront(Propagators & propagators, State & i
         vector<set<vector<Integer>>>(vars.size() + 1), vector<vector<set<long long>>>(vars.size() + 1, vector<set<long long>>(totals.size()))};
     auto dead_cache_handle = initial_state.add_constraint_state(move(initial_cache));
 
-    if (optional_model) {
-        for (const auto & [cc_idx, cc] : enumerate(coeffs)) {
-            WPBSum sum_eq;
-            for (const auto & [idx, v] : enumerate(vars))
-                sum_eq += cc.at(idx) * v;
-            // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
-            // the row index lives in the annotation tag, not the constraint name (a
-            // name-embedded row could collide with a sibling constraint's name). Match
-            // that so the propagator's pol steps, which cite these lines by label,
-            // resolve against cake's OPB. The bodies are identical.
-            auto [eq1, eq2] = optional_model->add_labelled_constraint(
-                owner, std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * totals.at(cc_idx));
-            bridge->opb_lines.emplace_back(eq1, eq2);
-        }
+    return make_shared<KnapsackUpfrontData>(move(coeffs), move(vars), move(totals), move(bridge), dead_cache_handle);
+}
+
+auto gcs::innards::knapsack_upfront_define_proof_model(ProofModel & model, const ConstraintID & owner, KnapsackUpfrontData & data) -> void
+{
+    for (const auto & [cc_idx, cc] : enumerate(data.coeffs)) {
+        WPBSum sum_eq;
+        for (const auto & [idx, v] : enumerate(data.vars))
+            sum_eq += cc.at(idx) * v;
+        // cake_pb_cp labels each row's totals equality @c[<id>][<row>_le]/[<row>_ge]:
+        // the row index lives in the annotation tag, not the constraint name (a
+        // name-embedded row could collide with a sibling constraint's name). Match
+        // that so the propagator's pol steps, which cite these lines by label,
+        // resolve against cake's OPB. The bodies are identical.
+        auto [eq1, eq2] = model.add_labelled_constraint(
+            owner, std::to_string(cc_idx) + "_le", std::to_string(cc_idx) + "_ge", sum_eq == 1_i * data.totals.at(cc_idx));
+        data.bridge->opb_lines.emplace_back(eq1, eq2);
     }
+}
+
+auto gcs::innards::knapsack_upfront_install_propagators(
+    Propagators & propagators, const ConstraintID & owner, const shared_ptr<KnapsackUpfrontData> & data) -> void
+{
+    auto vars = data->vars;
+    auto coeffs = data->coeffs;
+    auto totals = data->totals;
+    auto bridge = data->bridge;
+    auto dead_cache_handle = data->dead_cache;
 
     Triggers triggers;
     triggers.on_change = {vars.begin(), vars.end()};

--- a/gcs/constraints/knapsack/knapsack_upfront.hh
+++ b/gcs/constraints/knapsack/knapsack_upfront.hh
@@ -6,6 +6,7 @@
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
+#include <memory>
 #include <vector>
 
 namespace gcs::innards
@@ -24,8 +25,28 @@ namespace gcs::innards
      * proof differs (3–6× smaller, but 3.6–18× slower to verify). See
      * `dev_docs/knapsack.md`.
      */
-    auto install_knapsack_upfront(Propagators & propagators, State & initial_state, ProofModel * const optional_model, const ConstraintID & owner,
-        std::vector<std::vector<Integer>> coeffs, std::vector<IntegerVariableID> vars, std::vector<IntegerVariableID> totals) -> void;
+    struct KnapsackUpfrontData;
+
+    /**
+     * \brief Validate the arguments, build the statically-reduced DAG from the
+     * initial domains, and allocate the dead-state cache. Knapsack::prepare() calls
+     * this; the returned data carries everything the other two phases need.
+     */
+    [[nodiscard]] auto knapsack_upfront_prepare(State & initial_state, std::vector<std::vector<Integer>> coeffs, std::vector<IntegerVariableID> vars,
+        std::vector<IntegerVariableID> totals) -> std::shared_ptr<KnapsackUpfrontData>;
+
+    /**
+     * \brief Emit the per-equation totals equalities, recording their lines for the
+     * propagator's pol steps. Knapsack::define_proof_model() calls this.
+     */
+    auto knapsack_upfront_define_proof_model(ProofModel & model, const ConstraintID & owner, KnapsackUpfrontData & data) -> void;
+
+    /**
+     * \brief Install the root scaffolding initialiser and the propagator.
+     * Knapsack::install_propagators() calls this.
+     */
+    auto knapsack_upfront_install_propagators(
+        Propagators & propagators, const ConstraintID & owner, const std::shared_ptr<KnapsackUpfrontData> & data) -> void;
 }
 
 #endif

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -516,44 +516,48 @@ auto Regular::clone() const -> unique_ptr<Constraint>
 
 auto Regular::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
+}
+
+auto Regular::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
+{
     // The three strategies share this constraint's OPB encoding and its
     // inferences; they differ only in the proof scaffolding, so each is a
     // distinct install path over the same automaton. Upfront is this class's
-    // own path; PerCall and Bacchus delegate to the sibling implementations,
-    // which are internal to this constraint (not part of the public API).
-    overloaded{[&](const proof_strategy::Upfront &) {
-                   if (! prepare(propagators, initial_state, optional_model))
-                       return;
-                   if (optional_model)
-                       define_proof_model(*optional_model, initial_state);
-                   install_propagators(propagators);
-               },
-        [&](const proof_strategy::PerCall &) {
-            RegularLegacy legacy{_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex};
-            legacy.set_constraint_id(constraint_id());
-            move(legacy).install(propagators, initial_state, optional_model);
-        },
-        [&](const proof_strategy::Bacchus &) {
-            if (_regex)
-                throw UnimplementedException{"the Bacchus proof strategy for Regular does not support regular-expression / NFA input"};
-            // Recover the deterministic transition map the Bacchus encoding
-            // needs from the shared (possibly non-deterministic) representation.
-            vector<unordered_map<Integer, long>> dfa(_transitions.size());
-            for (size_t q = 0; q < _transitions.size(); ++q)
-                for (const auto & [val, targets] : _transitions[q]) {
-                    if (targets.size() != 1)
-                        throw UnimplementedException{"the Bacchus proof strategy for Regular requires a deterministic automaton"};
-                    dfa[q][val] = *targets.begin();
-                }
-            RegularBacchus bacchus{_vars, _num_states, dfa, _final_states, _short_reasons};
-            bacchus.set_constraint_id(constraint_id());
-            move(bacchus).install(propagators, initial_state, optional_model);
-        }}
-        .visit(_proof_strategy);
-}
+    // own path, and falls through to the rest of prepare(). PerCall and Bacchus
+    // delegate in full to the sibling implementations -- internal to this
+    // constraint, not part of the public API -- and so return false.
+    if (holds_alternative<proof_strategy::PerCall>(_proof_strategy)) {
+        RegularLegacy legacy{_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex};
+        legacy.set_constraint_id(constraint_id());
+        move(legacy).install(propagators, initial_state, optional_model);
+        return false;
+    }
 
-auto Regular::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
-{
+    if (holds_alternative<proof_strategy::Bacchus>(_proof_strategy)) {
+        if (_regex)
+            throw UnimplementedException{"the Bacchus proof strategy for Regular does not support regular-expression / NFA input"};
+        // Recover the deterministic transition map the Bacchus encoding
+        // needs from the shared (possibly non-deterministic) representation.
+        vector<unordered_map<Integer, long>> dfa(_transitions.size());
+        for (size_t q = 0; q < _transitions.size(); ++q)
+            for (const auto & [val, targets] : _transitions[q]) {
+                if (targets.size() != 1)
+                    throw UnimplementedException{"the Bacchus proof strategy for Regular requires a deterministic automaton"};
+                dfa[q][val] = *targets.begin();
+            }
+        RegularBacchus bacchus{_vars, _num_states, dfa, _final_states, _short_reasons};
+        bacchus.set_constraint_id(constraint_id());
+        move(bacchus).install(propagators, initial_state, optional_model);
+        return false;
+    }
+
     if (_regex) {
         // Alphabet for "." and "[^...]": the contiguous min..max range over the
         // union of the variables' domains, mirroring MiniZinc's semantics.


### PR DESCRIPTION
Stacked on #625.

Both constraints chose between alternative implementations from `install()` — the last shape the three-phase split does not cover.

## Regular

Already had the right structure: `PerCall` and `Bacchus` build the sibling `RegularLegacy` / `RegularBacchus`, which are themselves three-phase, while `Upfront` is this class's own path. That dispatch moves wholesale into `prepare()`: the two delegating arms install the sibling and return false, and `Upfront` falls through to the rest of `prepare()` as before.

## Knapsack

Could not do the same, because its two arms were free functions rather than constraints — there was nothing to delegate *to*.

Rather than shove the whole install into `prepare()` (which would satisfy the letter of the split and none of its point), the upfront arm is now itself split into `knapsack_upfront_{prepare,define_proof_model,install_propagators}` over a shared `KnapsackUpfrontData`. The parent holds it by `shared_ptr` and hands it back to each phase; the data type stays opaque outside `knapsack_upfront.cc`. The per-call arm folds into the parent's own three phases.

Validation stays in whichever arm runs — the two have different messages, and I did not want to change what a user sees.

## Verification

The two knapsack strategies draw the same inferences and find the same solutions, so a silent fallback from `Upfront` to per-call would leave the whole suite green. So I instrumented both paths rather than trusting it:

```
knapsack_upfront_test lane:  67 × upfront,   0 × per-call
knapsack_test lane:           0 × upfront,  66 × per-call
```

For `Regular` the OPB itself distinguishes the strategies, and `nonogram-bacchus` / `nonogram-legacy` come out byte-identical.

- 531/531 ctest pass.
- OPB and `.scp` byte-identical across all 60 captured example models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD