### PR TITLE
Brancher stage E: cleanup, and the campaign that decides the stack

### DIFF
--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -55,6 +55,12 @@ The supervisor reviews this before any code is written.
    same measure-first discipline as the chain gate's default. The split family is
    likewise flag-gated.
 
+   **Settled by that measurement (stage E): the window now follows `Literals`**, so a
+   caller who has opted into deletion gets both halves of it. It is worth up to 4.87×
+   where it engages, and where it cannot engage it is byte-identical (talent, langford)
+   or costs +0.30 % on a seventy-three-second real verify. `Literals` itself stays
+   flag-gated and off, unchanged.
+
 Two of these (4, 5) supersede the "map the eq orders to `Exclude`, only split
 wins" stance that an earlier iteration of this design held; the eq-atom window
 (below) is what changed the calculus, and it is validated (8/8 in VeriPB 3.0.2).
@@ -1316,10 +1322,12 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   containment-tree paths; `ProofLogger::{eq_window_active, mint_windowed_eq_guess,
   emit_eq_window_advance}` and the branch-loop wiring; and the `Lower`/`UpperBound`
   tags on `smallest_first` / `largest_first` / `smallest_in` / `largest_in`.
-  Ships **default-off for eq orders** (Decision 5), behind
+  Shipped **default-off for eq orders** (Decision 5), behind
   `ProofOptions::set_order_encoding_deletion_eq_window()` /
   `GCS_DELETE_ORDER_ENCODING_EQ_WINDOW`; with it off the four tagged orders are
-  byte-identical to the untagged ones, which is what makes the tags free to add now.
+  byte-identical to the untagged ones, which is what made the tags free to add. **Stage
+  E's measurement moved that default on**, under `Literals` only — see Decision 5 above
+  and the stage E entry below; the flag and its off-switch are unchanged.
   **Oracle (met):** the caps-off suite passes with the window on at `MIN_CHAIN=0`
   (542/542, no flag-induced rejection); flag-off byte-identity holds across
   {None, Literals gate 0, Literals gate 16}; and two new VeriPB-checked tests cover
@@ -1424,18 +1432,62 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   scale is **stage E's measurement**, and it is the kind of thing stage E's go/no-go has to
   weigh against the complexity.
 
-- **Stage E — benchmark + cleanup.**
-  Re-run the eq-free large-domain sweep and the optimisation sweep for the step-2
-  numbers; **measure the eq window on the eq-heavy instances (crystal_maze, talent)
-  and the ascending-eq large-domain case to decide whether it becomes the default for
-  `smallest_first`** (Decision 5's transient-for-permanent trade). Remove the dormant
-  `OrderEncodingDeletion::Links` mode; rename `forget_order_links_at_level` /
-  `live_order_links` and the `_links_`-named machinery the tracker header flags as
-  "left unchanged until the planned Brancher refactor renames it."
+- **Stage E — benchmark + cleanup. DONE, and the stack's go/no-go.**
+  Cleanup shipped: the dormant `OrderEncodingDeletion::Links` mode is gone (with
+  `ensure_order_chain_connected`, the `live_order_links` / `order_links_by_level` index,
+  the legacy `GCS_DELETE_ORDER_LINKS` variable, and `building_order_link`, whose only
+  reader was the Links branch — the four Literals sites that set it were protecting
+  nothing); `forget_order_links_at_level` is `forget_order_encoding_at_level` and
+  `order_link_deletion_mode` is `order_encoding_deletion_mode`; and the two verified
+  foundations are real tests, `order_jump_test` and `order_hoist_test`, with their
+  must-fail controls running through a new `run_test_and_expect_rejection.bash` that
+  asserts the rejection *message*, not just the exit code.
+  **Oracle (met):** caps-off suite **557/557** in each of {None, Literals gate 0,
+  Literals gate 16}, and `.opb`/`.pbp` byte-identical to stage D's tip for every
+  deterministic example in all three configurations (75/75).
 
-Stages A, B, B', B'', C and D have all landed in sequence. Stage D was the only one gated
-on work outside this task (the delc mechanics), and that gate is closed. Stage E is the
-only stage left, and it is the go/no-go for the whole stack.
+  **The campaign, in one sitting at the tip.** The full tables are in
+  [order-encoding-deletion.md](order-encoding-deletion.md), "Results"; what stage E was
+  for is the four answers.
+
+  1. **The later stages cost the headline win nothing.** The eq-free split sweep
+     reproduces the pre-B″ figures to a couple of percent: **5.03× / 9.89× / 19.87× /
+     58.03×** at d250/500/1000/2000, gate 0 (3.18×/6.18×/12.44×/38.64× at the shipped
+     gate 16), peak `veripb` RSS −30 % to −56 %, every row search-identical and VERIFIED
+     under `-c`.
+  2. **The stack opened a second win regime.** Ascending eq branching had no frontier to
+     advance before B″; with the window it goes **5.31× / 9.05× / 15.50×** against mode
+     None at d250/500/1000, of which the window itself is 2.32×/3.54×/4.87×. Same
+     grows-with-domain signature, same SIZE≠TIME shape (+31 % proof, 4.9× faster).
+  3. **It still does not generalise, and stages C and D did not change that.**
+     seat-moving — the lone deep-yet-verifiable real split case, and the instance whose
+     churn motivated stage C — is **124.63 s OFF against 126.82 s / 126.80 s ON**, i.e.
+     neutral-to-2 %-negative, where the pre-stack sitting had it 2-5 % the other way.
+     Stage C *does* fire (79.9 % of the optimisation synthetic's Top residency is now
+     attributed to the exemption; seat-moving's proof growth fell from +2.3 % to +1.3 %)
+     and stage D's residency claim holds, but neither converts to verify time even here.
+     tour, colour and knapsack are exact no-ops; talent is 0.97×/1.00×.
+  4. **Decision 5, settled by measurement rather than argument: the eq window follows
+     `Literals`.** Where it engages it is worth up to 4.87×. Where it cannot — which is
+     every real eq model, because the window needs the branch layer to name an eq atom
+     *first* and a per-value propagator always gets there before it — the cost is a
+     small-proof effect that washes out: **byte-identical** on talent and langford,
+     **+0.30 %** on colour's 73-second verify, +3.4 % on its three-second one. Requiring
+     a second flag to get the eq half of a feature you have already opted into is a
+     tunable, not a design input, so the default moved rather than the mechanism.
+
+  **Verdict: GO, flag-gated and off by default — which is where it already was.** The
+  case for keeping the stack is that the win is large, reproducible, and now covers both
+  branching families, while the cost of carrying it is provably zero when the flag is
+  off (byte-identity, in all three configurations, over the whole example set). The case
+  against — that a lot of machinery in a central proofs path buys nothing on any real
+  model anyone has found — is real and is not answered by this campaign; it is answered
+  by the flag. Nothing measured here argues for default-on, and the honest headline is
+  unchanged: **this is a feature for weak-propagation, large-domain search, and real
+  MiniZinc-shaped models are not that.**
+
+Stages A, B, B', B'', C, D and E have all landed in sequence. Stage D was the only one
+gated on work outside this task (the delc mechanics), and that gate is closed.
 
 ## Implementation gates (not owner calls)
 

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -676,7 +676,7 @@ resident* subset. An eq eviction mirrors the ge eviction's
   variable, and the index costs nothing on the eq-heavy instances whose eq atoms are not
   branched on. (`live_order_literals` cannot do this: it records level-0 ge thresholds
   because the chain walk and the stitch need them.) `forget_eq_literals_at_level` and
-  `forget_chain_lines_at_level` both hang off the same `forget_order_links_at_level`
+  `forget_chain_clauses_at_level` both hang off the same `forget_order_encoding_at_level`
   funnel, after the ge sweep — which is what emits the level's stitches, and those land at
   a *surviving* neighbour's level, never at the level being forgotten.
 

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1513,9 +1513,16 @@ around it. Both `.pbp` drivers are self-contained — they need only `veripb` 3.
   at point of use" result), the `q*.pbp` scenarios, and `run.sh`.
 
 The two verified foundations `order_jump_check.cc` (guess-reasoned bound jump + its
-two must-fail controls) and `order_hoist_check.cc` sit at the top of that directory,
-still uncommitted; stage E owns promoting them to proper `gcs/` tests, and until it
-does they are one `rm -rf` from being lost. The phase-2 real-instance campaign that
+two must-fail controls) and `order_hoist_check.cc` sat at the top of that directory,
+uncommitted, until stage E promoted them to `gcs/innards/proofs/order_jump_test.cc`
+and `order_hoist_test.cc`. The copies there are now provenance; the tests are the
+live record, and their must-fail controls run through the new
+`run_test_and_expect_rejection.bash`. Promotion changed two things beyond
+packaging: the controls capture their probe's text while the atom is still live
+(deletion now *retires* the atom, so naming it afterwards throws instead of
+producing a line for VeriPB to reject), and the `multi` hoist scenario gained a
+second hoist, without which the corrupted level bucket it exists to catch is never
+queried and the scenario passes against the broken code. The phase-2 real-instance campaign that
 motivated the objective exemption and the chain gate is under `real-instance-bench/`,
 with the gate study in `chain-gate/`. Its headline figures have since been re-measured
 from scratch on current hardware — see

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -5,8 +5,9 @@ measured on synthetic AND real instances; suite-safe; committed on this branch;
 not default.** This note records the design for shrinking the integer
 order-encoding that VeriPB carries, plus the measured outcome and what is and
 isn't yet done. The full Brancher-API refactor (step 2, below) is a **decided design,
-recorded in [brancher-design.md](brancher-design.md), now partly implemented**: its
-stages A, B, B', B'' and C have landed, D/E have not. That note, not this one, is the
+recorded in [brancher-design.md](brancher-design.md), now fully implemented**: stages
+A, B, B', B'', C, D and E have all landed, and stage E's campaign — the go/no-go for
+the whole stack — is the source of the figures below. That note, not this one, is the
 authority on the refactor's staging and status. The shipped deletion path still wires
 into the existing branch/backtrack flow via hoisting, and the four-step sketch further
 down this note is superseded by the decided design (see the note at "Design overview"
@@ -16,10 +17,11 @@ and at "Implementation staging").
 
 All numbers below were measured on the development VM (KVM guest, AMD Ryzen 9
 9950X3D, 32 vCPUs, 30 GB RAM, `veripb` 3.0.2): each timed run pinned to one core
-with `taskset` and ASLR off via `setarch -R`, all timed proof I/O on the `/tmp`
-tmpfs, every verify run **solo** on an otherwise idle machine, and each figure the
-**minimum of three runs** (two above a minute, one for the multi-minute depth-point
-rows). The guest exposes no `cpufreq` interface, so turbo cannot be pinned off;
+with `taskset` and ASLR off via `setarch -R`, all timed proof I/O on tmpfs
+(`/dev/shm`), every verify run **solo** on an otherwise idle machine, and each figure
+the **minimum of three runs** (five for the solve-side times, which are small enough
+that process startup is a visible share of them). The guest exposes no `cpufreq`
+interface, so turbo cannot be pinned off;
 taking a minimum rather than a mean is the compensation. Peak RSS via
 `/usr/bin/time -v`. **The whole synthetic sweep was taken in one contiguous
 sitting**, because this machine drifts by up to ~18 % between sittings on the
@@ -36,6 +38,11 @@ both proofs VeriPB-**VERIFIED**.
 > in turn been replaced by the figures below, re-measured from scratch on the
 > current machine. Only one set of numbers is kept, because absolute verify times do
 > not transfer between machines and two sets invite comparing across them.
+>
+> Every table below was taken again at the **end of the step-2 stack** (stage E's
+> go/no-go campaign, one sitting), with stages B″, C and D all in. They reproduce
+> the pre-stack figures to a couple of percent, which is itself a result: **the
+> later stages cost the headline win nothing.**
 
 ### Synthetic win curve (committed driver)
 
@@ -51,16 +58,23 @@ tree must be searched.) ON rows are `GCS_DELETE_ORDER_ENCODING=literals` at
 
 | D    | recursions | verify OFF | verify ON | speedup    | pbp OFF | pbp ON  | pbp growth |
 |-----:|-----------:|-----------:|----------:|-----------:|--------:|--------:|-----------:|
-| 250  |        393 | 0.335 s    | 0.067 s   | **5.04×**  | 1.13 MB | 2.32 MB | +105 %     |
-| 500  |        919 | 1.669 s    | 0.171 s   | **9.79×**  | 2.59 MB | 5.74 MB | +121 %     |
-| 1000 |      2 397 | 10.576 s   | 0.507 s   | **20.87×** | 6.34 MB | 15.3 MB | +141 %     |
-| 2000 |      6 979 | 101.81 s   | 1.852 s   | **54.98×** | 17.1 MB | 44.9 MB | +163 %     |
+| 250  |        393 | 0.337 s    | 0.067 s   | **5.03×**  | 1.13 MB | 2.32 MB | +105 %     |
+| 500  |        919 | 1.711 s    | 0.173 s   | **9.89×**  | 2.59 MB | 5.74 MB | +121 %     |
+| 1000 |      2 397 | 10.015 s   | 0.504 s   | **19.87×** | 6.34 MB | 15.3 MB | +141 %     |
+| 2000 |      6 979 | 107.88 s   | 1.859 s   | **58.03×** | 17.1 MB | 44.9 MB | +163 %     |
+
+At the **shipped gate of 16** rather than the gate-off ceiling, the same rows give
+0.106 s / 0.277 s / 0.805 s / 2.792 s — **3.18× / 6.18× / 12.44× / 38.64×**. The gate
+costs roughly a third of the win and buys strictly-no-harm on short-chain models,
+which is the trade it was chosen for.
 
 The speedup **grows monotonically with domain**, at least doubling per domain
 doubling. A depth point isolates search depth from domain: same domain 1000 but
 `--tightness 95`, **72 341 recursions** (~30× deeper than the 2 397 at tightness 90),
 gives **26.41×** (443.78 s → 16.81 s) — above the tightness-90 d1000 point, so deeper
-search at the same domain also wins; the effect is not merely a domain artefact.
+search at the same domain also wins; the effect is not merely a domain artefact. (That
+row is the one figure in this section carried over from the pre-stack sitting rather
+than re-taken at the tip.)
 
 **The d2000 row is superlinear, and it is the least portable number here.** The
 smaller rows double per domain doubling; d1000→d2000 gains 2.6×. The asymmetry is
@@ -78,10 +92,18 @@ verify across machines or across sittings.
 ON proofs are **+105 %…+224 % larger** (the +224 % is the tightness-95 depth point)
 yet verify far faster — the design's central claim confirmed: **resident chain
 length, not proof line count, dominates VeriPB's cost.** The honest cost on the win
-rows: solver-side proof-*writing* overhead is **+101 % at d1000 and +123 % at d2000**
-(and +200 % on the depth point) — largest exactly where the verify win is largest, a
-genuine trade rather than a free one. It stays a good trade in absolute terms: at
-d2000 the solver pays 0.087 s → 0.194 s to save 100 s of verification.
+rows: solver-side proof-*writing* overhead is **+109 % at d1000 and +132 % at d2000**
+(re-measured at the stack tip; +67 % at d250 and +88 % at d500) — largest exactly
+where the verify win is largest, a genuine trade rather than a free one. It stays a
+good trade in absolute terms: at d2000 the solver pays 0.084 s → 0.195 s to save 106 s
+of verification.
+
+**The whole stack's solver-side cost is that trade and nothing more.** Stage E
+re-measured it end to end, which nobody had done since stage A. With the mode **off**
+the stack is byte-identical to its predecessor across every deterministic example in
+each of the three live configurations (75/75 comparisons), so there is nothing for it
+to cost; with the mode on, the figures above are the cost, and they are the same
+figures the pre-B″ stack had.
 
 **Peak `veripb` RSS falls, and the saving grows with domain** — the "resident
 database is smaller" prediction confirmed directly, and more strongly than the
@@ -89,16 +111,16 @@ earlier campaign found:
 
 | D | RSS OFF | RSS ON | change |
 |--:|--:|--:|--:|
-| 250  | 14.6 MB | 10.2 MB | −30 % |
-| 500  | 21.6 MB | 12.3 MB | −43 % |
-| 1000 | 39.6 MB | 20.7 MB | −48 % |
-| 2000 | 73.4 MB | 31.9 MB | −57 % |
+| 250  | 14.3 MB | 10.0 MB | −30 % |
+| 500  | 21.2 MB | 12.0 MB | −43 % |
+| 1000 | 38.5 MB | 20.3 MB | −47 % |
+| 2000 | 71.2 MB | 31.4 MB | −56 % |
 | 1000 @ t95 | 74.8 MB | 50.7 MB | −32 % |
 
 The earlier campaign reported a smaller saving that **inverted** at d2000, on the
 model that peak RSS = (the proof `veripb` must hold) + (the resident order database),
 so a several-fold-larger ON proof would swamp the database saving. That model does
-not hold here: at d2000 the ON proof is 44.9 MB but ON peak RSS is 31.9 MB, and at
+not hold here: at d2000 the ON proof is 44.9 MB but ON peak RSS is 31.4 MB, and at
 the depth point the ON proof is 373 MB against 50.7 MB of RSS. `veripb` **streams**
 the proof rather than holding it, so RSS tracks the resident constraint database
 alone — which is exactly the quantity this mode shrinks, and why the saving grows
@@ -112,6 +134,40 @@ the string did not change across that commit — so **the version number is not 
 to tell the two behaviours apart**. If an RSS figure ever has to be compared against
 an older one, check the `veripb` build date against 2026-05-28 first.
 
+### The second win regime: ascending eq branching (the eq-atom window)
+
+Everything above is the **split** family: the branch layer advances a bound, and what
+gets deleted is a `ge` definition. Step 2's stage B″ added the **eq-atom sliding
+window**, which does the same for the contiguous eq value orders (`smallest_first` /
+`largest_first` / `smallest_in` / `largest_in`) — one live windowed eq definition per
+branched variable instead of one per value tried. Before it, eq branching had no
+frontier to advance and deletion did nothing for it.
+
+Same driver, eq-minting value order, `--size 6` (the eq control enumerates the whole
+domain at every node, so it scales quite differently — `--size 16 --domain 250` wrote
+12 GB of proof in three minutes without finishing):
+
+    order_deletion_bench --problem pairwise --size 6 --domain D --window D \
+        --tightness 90 --unsat --value-order smallest
+
+| D    | recursions | mode None | Literals, window off | window on | window's win | vs None    |
+|-----:|-----------:|----------:|---------------------:|----------:|-------------:|-----------:|
+| 250  |      3 280 | 1.736 s   | 0.760 s              | 0.327 s   | **2.32×**    | **5.31×**  |
+| 500  |     12 527 | 14.569 s  | 5.698 s              | 1.610 s   | **3.54×**    | **9.05×**  |
+| 1000 |     49 352 | 142.82 s  | 44.931 s             | 9.216 s   | **4.87×**    | **15.50×** |
+
+(gate 0; at the shipped gate of 16 the window is worth 1.87× / 2.70× / 3.77×, and
+3.69× / 6.28× / 11.27× against mode None.) The same signature as the split curve —
+**the win grows with domain width**, which is what a residency win looks like and a
+constant-factor one does not — and the same SIZE≠TIME shape: the window makes the
+proof **+31 %…+33 % larger** at every domain and verifies it up to 4.9× faster.
+
+Two thirds of the 15.5× is deletion itself and one third is the window, so this is not
+a separate feature so much as the eq half of the same one. It is also the one place
+where the step-2 stack **opened ground the pre-stack feature did not have**: without
+the window, `--value-order smallest` at d1000 verifies in 44.9 s against mode None's
+142.8 s; with it, 9.2 s.
+
 ### Real instances — the win did NOT generalise
 
 On **no reachable real instance** did the synthetic win materialise. The rows below
@@ -120,37 +176,64 @@ propagation counts equal OFF vs ON) and VeriPB-VERIFIED in every mode.
 
 - **seat-moving 2018** (`2018/seat-moving/sm-10-12-00.dzn`, flattened and run under
   `fzn-glasgow -n 1`) — the one deep-yet-verifiable real split case: 15 610-node
-  find-first, `indomain_split`, maxdom 901. **Neutral.**
+  find-first, `indomain_split`, maxdom 901. **Neutral, and it stayed neutral through
+  stages C and D**, which were the stages that could have moved it.
 
-  | mode | verify | vs OFF | pbp | `del` lines |
-  |---|--:|--:|--:|--:|
-  | OFF          | 126.17 s | —          | 629.4 MB | 931 708 |
-  | gate 0       | 119.52 s | **1.06×**  | 643.8 MB (+2.3 %) | 938 632 |
-  | gate 16      | 121.24 s | **1.04×**  | 639.3 MB (+1.6 %) | 935 062 |
-  | gate 64      | 120.55 s | **1.05×**  | 636.2 MB (+1.1 %) | 935 295 |
+  | mode | verify | vs OFF | pbp |
+  |---|--:|--:|--:|
+  | OFF     | 124.63 s | —         | 629.4 MB |
+  | gate 0  | 126.82 s | **0.98×** | 637.5 MB (+1.3 %) |
+  | gate 16 | 126.80 s | **0.98×** | 633.0 MB (+0.6 %) |
 
-  A few percent either way is inside what an unpinnable-turbo VM can resolve, so read
-  this as neutral rather than as a small win. The del-count proxy says why: ON emits
-  only **+0.7 %** more `del` lines even at the aggressive gate — deletion barely
-  fires. Not because the model lacks long chains (it has maxdom-901 split variables)
-  but because it is reif/element/view-heavy and its order encoding is **pinned
-  resident by design** (viewed variables held by the always-at-Top view bridges,
-  product/aux magnitudes by the product-justification caches — the "delete only when
-  unreferenced" rule).
+  Measured at the stack tip; the pre-stack sitting had the same instance at 126.17 s
+  OFF against 119.52 s / 121.24 s ON, i.e. a few percent the *other* way. Two percent
+  either way is inside what an unpinnable-turbo VM can resolve, so the honest reading
+  of both sittings together is **neutral** — and specifically that stage C's objective
+  exemption and stage D's incumbent retirement, both of which do measurably fire, buy
+  **no verify time here**. What stage C did buy is visible in the proof: the ON growth
+  fell from +2.3 %/+1.6 % to +1.3 %/+0.6 %, which is the suppressed objective churn.
+
+  Why deletion cannot win here is unchanged and is the important part: the model is
+  reif/element/view-heavy and its order encoding is **pinned resident by design**
+  (viewed variables held by the always-at-Top view bridges, product/aux magnitudes by
+  the product-justification caches — the "delete only when unreferenced" rule), and
+  its chains are tiny whatever its domains are (see "Pin apportionment" below).
 
 - **Expected-bad, confirmed and bounded.** The two eq-enumeration examples:
 
-  | instance | OFF verify | gate 0 | pbp growth, gate 0 / 16 / 32 / 64 |
-  |---|--:|--:|---|
-  | `crystal_maze` | 0.0306 s | 0.0322 s (**0.95×**) | +48.5 % / **0 %** / 0 % / 0 % |
-  | `talent`       | 1.2649 s | 1.3197 s (**0.96×**) | +35.8 % / +5.8 % / +1.6 % / **0 %** |
+  | instance | OFF verify | gate 0 | gate 16 | pbp growth, gate 0 / 16 |
+  |---|--:|--:|--:|---|
+  | `crystal_maze` | 0.030 s | 0.032 s (**0.94×**) | 0.030 s (**1.00×**) | +48.5 % / **0 %** |
+  | `talent`       | 1.258 s | 1.294 s (**0.97×**) | 1.259 s (**1.00×**) | +31.9 % / +2.8 % |
 
-  The `0 %` entries are not rounding: the proof is **byte-identical to `None`**
-  (checked by digest), which is the strongest strictly-no-harm form. crystal_maze
-  reaches it already at the shipped gate of 16 because its longest chain is 16;
-  talent needs 64. So the downside on eq/small-domain models is a low-single-digit
-  verify slowdown and +35–50 % proof size **at gate 0 only**, and the shipped gate
-  removes most of it.
+  The `0 %` entry is not rounding: the proof is **byte-identical to `None`**, which is
+  the strongest strictly-no-harm form. crystal_maze reaches it already at the shipped
+  gate of 16 because its longest chain is 16; talent needs 64. So the downside on
+  eq/small-domain models is a low-single-digit verify slowdown and +32–50 % proof size
+  **at gate 0 only**, and the shipped gate removes most of it. The churn counters say
+  why the gate works: at gate 16 talent's deletes fall from 7 646 to 365, and
+  crystal_maze's to **zero**.
+
+- **The eq window on real eq models: it barely engages, and costs accordingly.** The
+  window needs the *branch layer* to be the first to name an eq atom, and on a model
+  whose constraints reason per value the propagators got there first (see
+  brancher-design.md, "What it measures"). Measured directly: the d1000 synthetic above
+  evicts **49 260** windowed eq definitions, crystal_maze evicts **2**, talent **0**.
+  What that costs where it cannot engage:
+
+  | instance | window off | window on | cost |
+  |---|--:|--:|--:|
+  | `talent`, `langford`   | — | — | **byte-identical** |
+  | `colour` (40 vertices, 131 741 recursions, 188 MB proof) | 72.750 s | 72.971 s | **+0.30 %** |
+  | `colour` (30 vertices, 12 151 recursions, 13 MB proof)   | 3.199 s  | 3.310 s  | +3.4 % |
+  | `crystal_maze` / `sudoku` / `money` proof size | — | — | +0.1 %…+1.4 % |
+
+  Min-of-3 each. The cost is a **small-proof effect that washes out with scale** —
+  +3.4 % on a three-second verify, +0.30 % on a seventy-three-second one — and on the
+  models where the window cannot engage at all it is exactly nothing. That is the
+  measurement owner decision 5 was deferred to, and it is why the window now defaults
+  **on** wherever `Literals` is on (`GCS_DELETE_ORDER_ENCODING_EQ_WINDOW=0` turns it
+  back off).
 
 - **Not re-measured on this machine**, and carried over as qualitative findings only:
   mrcpsp 2023 and the `tour` circuit example (both recorded as exact no-ops — eq
@@ -234,7 +317,8 @@ frontend proofs.
 ## Implementation status
 
 - **Done, suite-safe:** the full caps-off test suite passes with the flag on (0
-  flag-induced VeriPB rejections; mode-off byte-identical; flag-off 537/537). The
+  flag-induced VeriPB rejections; mode-off byte-identical; 557/557 in each of {None,
+  Literals gate 0, Literals gate 16} at the end of the step-2 stack). The
   hoist primitive, guess/eq/partition-atom hoisting, and the aux/view dispositions
   below are all in `gcs/innards/proofs/{names_and_ids_tracker,proof_logger,proof_model}.*`.
 - **A line must never name a literal whose definition has been deleted — and that is now
@@ -393,7 +477,9 @@ frontend proofs.
   on a model whose constraints reason per value the propagators have defined those atoms
   permanently long before the search reaches them. Where it cannot engage it now costs
   nothing (talent's window-on proof is byte-identical to its window-off proof). The window
-  therefore ships off, and stage E owns whether the default changes.
+  therefore shipped off, and **stage E's measurement turned it on** wherever `Literals` is
+  on: up to 4.87x where it engages, +0.30 % on a seventy-three-second real verify where it
+  cannot. `GCS_DELETE_ORDER_ENCODING_EQ_WINDOW=0` turns it back off.
 - **The frontier deletion exemption (stage C).** `ProofModel::minimise` marks the objective
   `note_deletion_exempt`, so under Literals its whole `ge` encoding stays resident however
   long its chain grows. Branch-and-bound re-tightens the objective at every improving
@@ -414,12 +500,12 @@ frontend proofs.
   the descent's length. From this stage on both verification funnels pass **`-c`
   (`--force-checked-deletion`)**, so a deletion whose implication does not hold fails at the
   deletion rather than at a distant conclusion.
-- **In progress:** the clean Brancher abstraction (step 2). Stages A, B, B', B'', C and D
-  have landed — the `BranchDecision` / `BacktrackAdvance` types, the split families' bound
-  advances, the eviction primitives plus their always-on residency bookkeeping, the
-  eq-atom window, the objective exemption and the incumbent retirement — so the direct
-  guess/eq/aux hoist wiring is on its way out but is still what the shipped path uses.
-  Only stage E remains, and it is the go/no-go gate for the whole stack;
+- **Complete:** the clean Brancher abstraction (step 2). Stages A, B, B', B'', C, D and E
+  have all landed — the `BranchDecision` / `BacktrackAdvance` types, the split families'
+  bound advances, the eviction primitives plus their always-on residency bookkeeping, the
+  eq-atom window, the objective exemption, the incumbent retirement, and stage E's cleanup
+  and go/no-go campaign — so the direct guess/eq/aux hoist wiring is on its way out but is
+  still what the shipped path uses.
   [brancher-design.md](brancher-design.md) is the authority on each. Also future:
   short-reason flag / deview-companion level-scoping (currently inert), and the bridge
   redesign (deprioritised — step 1b measured it as freeing 0 %).
@@ -428,13 +514,16 @@ frontend proofs.
 
 **1. Real-instance benchmarking — DONE.** Completed as the phase-2 campaign, and
 re-measured from scratch on the current machine (see Results above). Verdict:
-- The **synthetic mechanism is validated**, **5.0×→55× across domain d250→d2000**
+- The **synthetic mechanism is validated**, **5.0×→58× across domain d250→d2000**
   (and 26× at the depth point), driven by resident-chain shrinkage — the design's
-  central claim holds.
+  central claim holds. Step 2's eq window extends it to the eq branching families,
+  **5.3×→15.5×** on the ascending-eq control.
 - The **real-instance win is unproven**: no reachable real instance triggered it. The
   one deep-yet-verifiable real case (seat-moving) is neutral because its chains are
   pinned resident by view/reif bridges, and the tractable-real-win hunt found nothing
-  (real instances are either shallow-neutral or intractably deep).
+  (real instances are either shallow-neutral or intractably deep). Stage E re-took that
+  row with the objective exemption and incumbent retirement in, and it is still
+  neutral.
 - The **downside is bounded**: a few-percent verify slowdown and +20–50 % proof size
   on eq/small-domain models, and roughly a doubling of solver-side proof-writing on
   the win rows.
@@ -442,11 +531,10 @@ re-measured from scratch on the current machine (see Results above). Verdict:
 - **Conclusion: keep the feature flag-gated; default-on is NOT justified by these
   numbers** (real win unproven, measurable overhead on eq/value-heavy models) — but
   the mechanism is sound and correctness is solid.
-- The verification-only drivers `order_jump_check.cc` / `order_hoist_check.cc` are
-  still uncommitted, in the artifacts directory (see Provenance). Stage E owns
-  promoting them to proper `gcs/` tests — they regression-check the two verified
-  foundations this whole design rests on, and until they are in-tree they survive only
-  by luck.
+- The verification-only drivers `order_jump_check.cc` / `order_hoist_check.cc` are now
+  in-tree as `order_jump_test` and `order_hoist_test` (stage E), with their must-fail
+  controls, so the two verified foundations this whole design rests on are
+  regression-checked rather than surviving by luck.
 
 **1b. Pin-apportionment instrumentation — DONE.** Implemented as the
 `GCS_ORDER_ENCODING_STATS` diagnostic and measured (see "Pin apportionment" above).
@@ -556,12 +644,18 @@ win-recovery motivation is gone. Revisit only if a view/product-heavy
 *weak-propagation large-domain bound-split* workload appears — the only regime where
 freed chains would be long enough to matter.
 
-**Ordering decided (2026-07): 2b first (done, above), then step 2.** Step 2 is under
-way — A, B, B', B'', C and D are in — and it inherited the objective-variable-exemption
-follow-up from 2b as its stage C; 3 stays parked.
+**Ordering decided (2026-07): 2b first (done, above), then step 2.** Step 2 is
+complete — A, B, B', B'', C, D and E are all in — and it inherited the
+objective-variable-exemption follow-up from 2b as its stage C; 3 stays parked.
 
-**Also:** decide productionisation (keep flag-gated vs default-on — current verdict:
-flag-gated). The superseded dormant `Links` mode has now been removed, in stage E.
+**Productionisation, settled by stage E's campaign: the feature stays flag-gated and
+off by default.** No reachable real instance wins, and the one deep-yet-verifiable
+real case (seat-moving) is neutral even with stages C and D in, so there is nothing to
+justify making everyone pay the +105 %…+163 % proof and the doubled proof-writing time.
+With the flag off the whole stack is byte-identical, so nothing is paid for keeping it.
+The one default that *did* change is the eq-atom window, which now follows `Literals`
+rather than needing a second flag — see "The eq window on real eq models" above for the
+measurement that decided it. The superseded dormant `Links` mode has been removed.
 
 ## The problem
 
@@ -806,11 +900,12 @@ a real use case lands.
 
 ## Implementation staging
 
-> **Superseded.** This was the original four-step sketch, written before the step-2
-> design was decided. Steps 1 and 2 are done (the hoist primitive, and the Brancher
-> abstraction through stage B'), and step 3's "replace the experimental Literals mode"
-> is now stage E's cleanup. Use **[brancher-design.md](brancher-design.md), "Migration
-> staging"** for what is actually left. Kept here for provenance.
+> **Superseded, and now finished.** This was the original four-step sketch, written
+> before the step-2 design was decided. All four are done: the hoist primitive, the
+> Brancher abstraction (stages A through D), the deletion wiring, and the benchmark —
+> which became stage E's go/no-go campaign. Use
+> **[brancher-design.md](brancher-design.md), "Migration staging"** for the record of
+> each stage. Kept here for provenance.
 
 1. **Hoist primitive first.** It is foundational, independently testable, and needed
    by everything downstream. Build `hoist_literal_to_level` / `hoist_literal_to_top`
@@ -843,7 +938,8 @@ unchanged mode-off vs mode-on (a proof-only change must not perturb search).
 - **The artifacts directory** — currently `~/claude/tmp/order-encoding-deletion-artifacts/`.
   Not version controlled and it does not travel with a clone, so check it is present
   before relying on it. It holds `order_jump_check.cc` / `order_hoist_check.cc` (the two
-  verified foundations, still uncommitted — stage E promotes them), the phase-2 campaign
+  verified foundations, promoted in stage E to `order_jump_test` / `order_hoist_test`
+  and kept here as provenance), the phase-2 campaign
   (`real-instance-bench/`, with the gate study in `chain-gate/`), the seed-bug sweep
   (`divide-modulus-seed-bug/`), the per-stage gate logs (`stage-b/`, `stage-bprime/`,
   `rebase-to-main-20260729/`), and the two self-contained VeriPB drivers the unbuilt

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -17,8 +17,10 @@ and at "Implementation staging").
 
 All numbers below were measured on the development VM (KVM guest, AMD Ryzen 9
 9950X3D, 32 vCPUs, 30 GB RAM, `veripb` 3.0.2): each timed run pinned to one core
-with `taskset` and ASLR off via `setarch -R`, all timed proof I/O on tmpfs
-(`/dev/shm`), every verify run **solo** on an otherwise idle machine, and each figure
+with `taskset` and ASLR off via `setarch -R`, all timed proof I/O on tmpfs (both
+`/tmp` and `/dev/shm` are one, 16 GB each and sharing the guest's 30 GB of RAM — so a
+multi-gigabyte proof does not belong on either), every verify run **solo** on an
+otherwise idle machine, and each figure
 the **minimum of three runs** (five for the solve-side times, which are small enough
 that process startup is a visible share of them). The guest exposes no `cpufreq`
 interface, so turbo cannot be pinned off;

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -561,7 +561,7 @@ way — A, B, B', B'', C and D are in — and it inherited the objective-variabl
 follow-up from 2b as its stage C; 3 stays parked.
 
 **Also:** decide productionisation (keep flag-gated vs default-on — current verdict:
-flag-gated), and — cleanup — the superseded dormant `Links` mode can be removed.
+flag-gated). The superseded dormant `Links` mode has now been removed, in stage E.
 
 ## The problem
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -591,6 +591,40 @@ if(GCS_BUILD_TESTS)
         endforeach()
     endforeach()
 
+    # The two verified foundations the order-encoding-deletion design rests on: that a bound
+    # jump over a run of holes is RUP from a guesses-only reason, and that hoisting a `ge`
+    # definition to a shallower level leaves it live AND chained. Both were established with
+    # standalone VeriPB drivers while the design was being written; these are those drivers,
+    # promoted, so that a checker or an encoding change that stopped closing them is caught
+    # here rather than as a mystery rejection somewhere in the suite.
+    #
+    # Each carries its must-fail controls, and a control is a separate ctest entry through
+    # run_test_and_expect_rejection.bash rather than a mode of the positive test, because
+    # what it asserts is a property of veripb's verdict, not of the binary's exit code.
+    # Distinct basenames throughout: a parallel ctest would otherwise race over one set of
+    # proof files (issue #562).
+    add_executable(order_jump_test innards/proofs/order_jump_test.cc)
+    target_link_libraries(order_jump_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME order_jump_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash
+        $<TARGET_FILE:order_jump_test> --scenario jump)
+    foreach(scenario no_flag over_jump)
+        add_test(NAME order_jump_${scenario}_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_rejection.bash
+            --basename order_jump_${scenario}_test --expect "not implied by reverse unit propagation"
+            $<TARGET_FILE:order_jump_test> --scenario ${scenario})
+    endforeach()
+
+    add_executable(order_hoist_test innards/proofs/order_hoist_test.cc)
+    target_link_libraries(order_hoist_test PRIVATE glasgow_constraint_solver)
+    foreach(scenario top level multi)
+        add_test(NAME order_hoist_${scenario}_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash
+            --basename order_hoist_${scenario}_test $<TARGET_FILE:order_hoist_test> --scenario ${scenario})
+    endforeach()
+    foreach(scenario no_hoist level_gone)
+        add_test(NAME order_hoist_${scenario}_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_rejection.bash
+            --basename order_hoist_${scenario}_test --expect "not implied by reverse unit propagation"
+            $<TARGET_FILE:order_hoist_test> --scenario ${scenario})
+    endforeach()
+
     add_executable(range_branch_test innards/proofs/range_branch_test.cc)
     target_link_libraries(range_branch_test PRIVATE glasgow_constraint_solver)
     add_test(NAME range_branch_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:range_branch_test>)

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -358,13 +358,13 @@ struct NamesAndIDsTracker::Imp
     AssertionLevel assertion_level = AssertionLevel::Off;
 
     // Whether (and how) order-encoding chain links are deleted on backtrack.
-    OrderEncodingDeletion order_link_deletion_mode = OrderEncodingDeletion::None;
+    OrderEncodingDeletion order_encoding_deletion_mode = OrderEncodingDeletion::None;
     // Chain-length gate for OrderEncodingDeletion::Literals (order_encoding_deletion_min_chain):
     // a real variable's interior ge def is only emitted deletable-at-Current once the number
     // of ge thresholds ever named for it exceeds this value; at or below the gate the def is
     // kept resident at Top, exactly like the boundary/view/aux paths. 0 disables the gate --
     // deletion fires from the first threshold, byte-identically to the pre-gate behaviour.
-    // Read once here (not re-read per call), like order_link_deletion_mode.
+    // Read once here (not re-read per call), like order_encoding_deletion_mode.
     int order_encoding_deletion_min_chain = 0;
 
     // --- Literals mode (OrderEncodingDeletion::Literals) ---
@@ -476,14 +476,14 @@ NamesAndIDsTracker::NamesAndIDsTracker(const ProofOptions & proof_options) : _im
     _imp->verbose_names = proof_options.verbose_names;
     _imp->use_compact_boolean_encoding = proof_options.use_compact_boolean_encoding;
     _imp->assertion_level = proof_options.assertion_level;
-    _imp->order_link_deletion_mode = proof_options.order_encoding_deletion;
+    _imp->order_encoding_deletion_mode = proof_options.order_encoding_deletion;
     _imp->order_encoding_deletion_min_chain = proof_options.order_encoding_deletion_min_chain;
 
     // The pin-apportionment diagnostic collects only under OrderEncodingDeletion::Literals
     // (the only mode with deletable/hoistable order literals) AND when GCS_ORDER_ENCODING_STATS
     // holds any non-empty value. Cached once here; gates every stats hook so nothing runs on
     // the default (deletion-off) path or when the diagnostic is not requested.
-    if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals) {
+    if (_imp->order_encoding_deletion_mode == OrderEncodingDeletion::Literals) {
         const auto * const stats_env = std::getenv("GCS_ORDER_ENCODING_STATS");
         _imp->collect_order_encoding_stats = stats_env != nullptr && *stats_env != '\0';
     }
@@ -824,7 +824,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     // exist at all -- the Literals mode, at proof-writing time, with assertions off, for a
     // real variable -- and the request is ignored, leaving the definition permanent,
     // anywhere else.
-    bool windowed = _imp->minting_windowed_eq && _imp->order_link_deletion_mode == OrderEncodingDeletion::Literals && _imp->logger != nullptr &&
+    bool windowed = _imp->minting_windowed_eq && _imp->order_encoding_deletion_mode == OrderEncodingDeletion::Literals && _imp->logger != nullptr &&
         _imp->assertion_level == AssertionLevel::Off && std::holds_alternative<SimpleIntegerVariableID>(id);
 
     // The (i-static) half of the eq-by-interval guard (dev_docs/brancher-design.md, "The
@@ -861,7 +861,7 @@ auto NamesAndIDsTracker::need_direct_encoding_for(SimpleOrProofOnlyIntegerVariab
     // `x<n>` with verbose names off); otherwise mint a fresh one. Only a windowed variable
     // ever retires an eq atom.
     auto eqvar = [&]() {
-        if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals) {
+        if (_imp->order_encoding_deletion_mode == OrderEncodingDeletion::Literals) {
             auto & atoms = _imp->atoms_for(id);
             if (auto retired = atoms.retired_eq.find(v.raw_value); retired != atoms.retired_eq.end()) {
                 auto reused = retired->second;
@@ -1096,7 +1096,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     // otherwise mint a fresh one. Only Literals mode ever retires anything.
     bool reintroducing = false;
     auto gevar = [&]() {
-        if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals) {
+        if (_imp->order_encoding_deletion_mode == OrderEncodingDeletion::Literals) {
             auto & atoms = _imp->atoms_for(id);
             if (auto retired = atoms.retired_ge.find(v.raw_value); retired != atoms.retired_ge.end()) {
                 auto reused = retired->second;
@@ -1117,7 +1117,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
     // trivially true/false and which serve as permanent chain anchors) and model-time
     // atoms (logger not yet attached) keep their def resident at Top, tagged level 0.
     // Computed here because the def is emitted just below, before the fix_bound block.
-    bool literals_real = _imp->order_link_deletion_mode == OrderEncodingDeletion::Literals && _imp->assertion_level == AssertionLevel::Off &&
+    bool literals_real = _imp->order_encoding_deletion_mode == OrderEncodingDeletion::Literals && _imp->assertion_level == AssertionLevel::Off &&
         std::holds_alternative<SimpleIntegerVariableID>(id);
     bool literals_proof_time = literals_real && _imp->logger != nullptr;
     bool def_at_current = false;
@@ -1512,9 +1512,9 @@ auto NamesAndIDsTracker::emit_order_link(const SimpleIntegerVariableID & id, Int
     emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
 }
 
-auto NamesAndIDsTracker::forget_order_links_at_level(int level) -> void
+auto NamesAndIDsTracker::forget_order_encoding_at_level(int level) -> void
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals)
         return;
 
     forget_order_literals_at_level(level);
@@ -1549,7 +1549,7 @@ auto NamesAndIDsTracker::record_live_eq_literal(const SimpleIntegerVariableID & 
 
 auto NamesAndIDsTracker::note_order_literal_top_pin(const SimpleIntegerVariableID & id, Integer v, OrderEncodingResidencyCause cause) -> void
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals)
         return;
 
     auto live_it = _imp->live_order_literals.find(id);
@@ -1568,7 +1568,7 @@ auto NamesAndIDsTracker::note_order_literal_top_pin(const SimpleIntegerVariableI
 auto NamesAndIDsTracker::record_live_chain_line(const SimpleIntegerVariableID & id, Integer lo, Integer hi, int at_level, const ProofLine & line)
     -> void
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals)
         return;
 
     _imp->chain_clauses_by_level[at_level][id].emplace_back(Imp::ChainClause{lo, hi, line});
@@ -1692,7 +1692,7 @@ auto NamesAndIDsTracker::emit_order_stitch(const SimpleIntegerVariableID & id, I
 
 auto NamesAndIDsTracker::forget_order_literals_at_level(int level) -> void
 {
-    // Called from forget_order_links_at_level, itself called by
+    // Called from forget_order_encoding_at_level, itself called by
     // ProofLogger::forget_proof_level after it has emitted the `del`s for every line
     // recorded at `level` (which include the deleted literals' def and link lines).
     auto bucket_it = _imp->order_literals_by_level.find(level);
@@ -1835,7 +1835,7 @@ auto NamesAndIDsTracker::stitch_hoisted_order_literal(const SimpleIntegerVariabl
 auto NamesAndIDsTracker::hoist_order_literal_to_level(const SimpleIntegerVariableID & id, Integer v, int target_level, bool immediate_neighbours,
     optional<OrderEncodingResidencyCause> stats_cause) -> void
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals)
         throw ProofError{"hoist_order_literal_to_level requires OrderEncodingDeletion::Literals"};
     if (! _imp->logger)
         throw ProofError{"hoist_order_literal_to_level requires the logger to be attached"};
@@ -1930,7 +1930,7 @@ auto NamesAndIDsTracker::hoist_ges_named_by_top_atom(
 {
     // Same guard the ge-def deletion in need_gevar uses: only proof-time, real-variable,
     // assertions-off Literals mode tracks deletable ge defs at all.
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger || _imp->assertion_level != AssertionLevel::Off)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger || _imp->assertion_level != AssertionLevel::Off)
         return;
     if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id)) {
         // Count both Top pins here, at the reference site, and before the hoists: the
@@ -1952,7 +1952,7 @@ auto NamesAndIDsTracker::hoist_live_order_literals_toward_level(
 {
     // Only the Literals mode has anything to hoist; other modes keep the whole
     // encoding resident at Top, and with no logger there is nothing emitted yet.
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger)
         return;
 
     for (const auto & lit : lits) {
@@ -2014,7 +2014,7 @@ auto NamesAndIDsTracker::chain_clauses_naming(const SimpleIntegerVariableID & id
 auto NamesAndIDsTracker::evict_order_literal(
     const SimpleIntegerVariableID & id, Integer v, optional<OrderEncodingResidencyCause> expected_sole_top_cause) -> bool
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals)
         throw ProofError{"evict_order_literal requires OrderEncodingDeletion::Literals"};
     if (! _imp->logger)
         throw ProofError{"evict_order_literal requires the logger to be attached"};
@@ -2165,7 +2165,7 @@ auto NamesAndIDsTracker::evict_order_literal(
 
 auto NamesAndIDsTracker::hoist_eq_to_top(const SimpleIntegerVariableID & id, Integer v) -> void
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals)
         throw ProofError{"hoist_eq_to_top requires OrderEncodingDeletion::Literals"};
     if (! _imp->logger)
         throw ProofError{"hoist_eq_to_top requires the logger to be attached"};
@@ -2219,7 +2219,7 @@ auto NamesAndIDsTracker::note_permanent_eq_reference(const SimpleIntegerVariable
     // Cheap enough to call unconditionally from every permanent-reference site: the mode
     // check rules out every proof that has no window at all, and live_eq_literals is empty
     // unless something is windowed right now.
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger || _imp->live_eq_literals.empty())
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger || _imp->live_eq_literals.empty())
         return;
 
     hoist_eq_to_top(id, v);
@@ -2227,7 +2227,7 @@ auto NamesAndIDsTracker::note_permanent_eq_reference(const SimpleIntegerVariable
 
 auto NamesAndIDsTracker::evict_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> bool
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals)
         throw ProofError{"evict_eq_literal requires OrderEncodingDeletion::Literals"};
     if (! _imp->logger)
         throw ProofError{"evict_eq_literal requires the logger to be attached"};
@@ -2284,7 +2284,7 @@ auto NamesAndIDsTracker::evict_eq_literal(const SimpleIntegerVariableID & id, In
 
 auto NamesAndIDsTracker::collapse_eq_window(const SimpleOrProofOnlyIntegerVariableID & id) -> void
 {
-    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger)
+    if (_imp->order_encoding_deletion_mode != OrderEncodingDeletion::Literals || ! _imp->logger)
         return;
     const auto * sid_ptr = std::get_if<SimpleIntegerVariableID>(&id);
     if (! sid_ptr)

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -366,26 +366,6 @@ struct NamesAndIDsTracker::Imp
     // deletion fires from the first threshold, byte-identically to the pre-gate behaviour.
     // Read once here (not re-read per call), like order_link_deletion_mode.
     int order_encoding_deletion_min_chain = 0;
-    // Set while a chain-link pol is being built. Building the pol re-enters
-    // need_gevar (via add_for_literal -> need_pol_item_defining_literal) for the
-    // two thresholds it references; this guard stops the fast path from cascading
-    // link re-emission back through those calls. The pol only needs the resident
-    // (Top) ge definitions, which the suppressed need_gevar still returns.
-    bool building_order_link = false;
-    // When order-link deletion is on: for each real variable, the adjacent-threshold
-    // chain links currently present in the proof, keyed by the (lower, higher)
-    // threshold pair and tagged with the proof level they were emitted at. Model-time
-    // links are tagged 0 (Top, never forgotten); proof-time links are tagged with the
-    // active proof level, so forget_proof_level deletes and forget_order_links_at_level
-    // drops them together. Left empty and untouched when the mode is off.
-    map<SimpleIntegerVariableID, map<pair<Integer, Integer>, int>> live_order_links;
-    // Level index over live_order_links: for each proof level, the (id, {lo, hi})
-    // links recorded at it, appended on emit. forget_order_links_at_level walks only
-    // the bucket for the forgotten level (O(links-at-level)) instead of scanning every
-    // variable. A link is only re-emitted after being forgotten (removed from both
-    // structures), so it is never double-indexed within a level's bucket. Bucket 0
-    // holds Top links and is never forgotten.
-    map<int, vector<pair<SimpleIntegerVariableID, pair<Integer, Integer>>>> order_links_by_level;
 
     // --- Literals mode (OrderEncodingDeletion::Literals) ---
     // For each real variable, the currently-live ge thresholds, each tagged with the
@@ -1103,21 +1083,11 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
 {
     if (_imp->find_condition(id >= v)) {
         // Fast path: the ge atom and its definition already exist, so they are never
-        // recreated. With order-link deletion on, though, a previous backtrack may
-        // have deleted some of this variable's chain links; reconnect its whole order
-        // chain so any order reasoning a RUP needs is available. Only real variables
-        // carry deletable chain links. building_order_link suppresses this while a
-        // chain-link pol is being built (those need_gevar calls only want the resident
-        // definitions).
-        //
-        // Under Literals there is deliberately nothing to do here: a ge whose definition
-        // was deleted has had its atom retired out of the lookup table, so it does not
-        // reach this branch at all -- it falls through to the introduction path below,
-        // which re-introduces the definition and takes the retired XLiteral back.
-        if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Links && _imp->logger && ! _imp->building_order_link) {
-            if (auto sid_ptr = std::get_if<SimpleIntegerVariableID>(&id))
-                ensure_order_chain_connected(*sid_ptr);
-        }
+        // recreated. Under Literals there is deliberately nothing to do here either: a
+        // ge whose definition was deleted has had its atom retired out of the lookup
+        // table, so it does not reach this branch at all -- it falls through to the
+        // introduction path below, which re-introduces the definition and takes the
+        // retired XLiteral back.
         return;
     }
 
@@ -1380,7 +1350,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                         [c = chain_con, link_hint](ProofLogger * const logger) { logger->emit(AssertProofRule{}, c, ProofLevel::Top, link_hint); });
                 }
                 else if (! literals_proof_time) {
-                    emit_and_maybe_track_order_link(id, v, *higher_gevar);
+                    emit_order_link(id, v, *higher_gevar);
                 }
                 // In Literals mode at proof time, this real variable's ge literal is
                 // linked to its live neighbours (not its gevars neighbours, which may
@@ -1414,7 +1384,7 @@ auto NamesAndIDsTracker::need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integ
                     });
                 }
                 else if (! literals_proof_time) {
-                    emit_and_maybe_track_order_link(id, *prev(this_gevar), v);
+                    emit_order_link(id, *prev(this_gevar), v);
                 }
                 // Literals-mode proof-time linking is handled once, below.
             } //
@@ -1530,91 +1500,31 @@ auto NamesAndIDsTracker::make_pol_chain_line(IntegerVariableCondition cond1, Int
     return b;
 }
 
-auto NamesAndIDsTracker::emit_and_maybe_track_order_link(const SimpleIntegerVariableID & id, Integer lo, Integer hi) -> void
+auto NamesAndIDsTracker::emit_order_link(const SimpleIntegerVariableID & id, Integer lo, Integer hi) -> void
 {
-    // During proof logging with the mode on, land the link at Current so a backtrack
-    // deletes it; otherwise (mode off, or model building where the logger is not yet
-    // attached and the emission is deferred to proof start) keep it at Top exactly as
-    // before -- hence the _imp->logger guard.
-    auto level = (_imp->order_link_deletion_mode == OrderEncodingDeletion::Links && _imp->logger) ? ProofLevel::Current : ProofLevel::Top;
-
     // The adjacent-threshold chain link is the clause (id >= lo) OR ~(id >= hi),
     // i.e. ge(hi) -> ge(lo); make_pol_chain_line derives it from the two resident
-    // (Top) ge definitions, so it stays sound to (re-)emit at any level even after
-    // the previous copy was deleted. Suppress fast-path re-emission while the pol is
-    // built (it re-enters need_gevar for lo and hi) so it does not recurse back here.
-    auto saved = _imp->building_order_link;
-    _imp->building_order_link = true;
+    // (Top) ge definitions. This is the permanent (Top) link, emitted either with
+    // deletion off or at model-building time, when the logger is not yet attached and
+    // the emission is deferred to proof start. Literals mode's deletable links come
+    // from link_order_literal_to_live_neighbours instead.
     auto pol = make_pol_chain_line(id >= lo, ! (id >= hi));
-    _imp->building_order_link = saved;
-
-    emit_proof_line_now_or_at_start([pol, level](ProofLogger * const logger) { pol->emit(*logger, level); });
-
-    // Record the link as live, tagged with the level it was emitted at, so the fast
-    // path can tell it is present and forget_order_links_at_level can drop it when
-    // that level is forgotten. Top links are tagged 0 (never forgotten) so the fast
-    // path does not needlessly re-emit a permanent link. Also index it under its level
-    // so forget is O(links-at-level). Only track when the mode is on, to keep the
-    // mode-off path a pure no-op.
-    if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Links) {
-        auto tag = (level == ProofLevel::Current) ? _imp->logger->proof_level() : 0;
-        _imp->live_order_links[id][pair{lo, hi}] = tag;
-        _imp->order_links_by_level[tag].emplace_back(id, pair{lo, hi});
-    }
-}
-
-auto NamesAndIDsTracker::ensure_order_chain_connected(const SimpleIntegerVariableID & id) -> void
-{
-    auto gevars_it = _imp->gevar_values.find(SimpleOrProofOnlyIntegerVariableID{id});
-    if (gevars_it == _imp->gevar_values.end())
-        return;
-    const auto & gevars = gevars_it->second;
-    if (gevars.size() < 2)
-        return;
-
-    // Reconnect the variable's entire order chain: every consecutive threshold pair
-    // whose link is not currently live gets re-emitted, so a RUP that needs multi-hop
-    // order propagation across this variable has the full chain available (matching
-    // what the baseline keeps permanently resident). Emission only fires for
-    // genuinely-missing links, so this stays cheap once the chain is connected.
-    // gevar_values is not modified here (the atoms already exist), and inserting
-    // into live_order_links never invalidates `links`, so both references stay valid
-    // across the emissions below.
-    auto & links = _imp->live_order_links[id];
-    for (auto lower = gevars.begin(), higher = next(lower); higher != gevars.end(); ++lower, ++higher)
-        if (! links.contains(pair{*lower, *higher}))
-            emit_and_maybe_track_order_link(id, *lower, *higher);
+    emit_proof_line_now_or_at_start([pol](ProofLogger * const logger) { pol->emit(*logger, ProofLevel::Top); });
 }
 
 auto NamesAndIDsTracker::forget_order_links_at_level(int level) -> void
 {
-    if (_imp->order_link_deletion_mode == OrderEncodingDeletion::Literals) {
-        forget_order_literals_at_level(level);
-        // The eq and chain-clause analogues, from the same funnel. Both are pure
-        // bookkeeping (the `del`s were emitted by forget_proof_level's own loop), and both
-        // run after the ge sweep because that is what emits this level's stitches -- which
-        // land at a *surviving* neighbour's level, never at the level being forgotten, so
-        // they are not swept away again here.
-        forget_eq_literals_at_level(level);
-        forget_chain_clauses_at_level(level);
-        return;
-    }
-
-    if (_imp->order_link_deletion_mode == OrderEncodingDeletion::None)
+    if (_imp->order_link_deletion_mode != OrderEncodingDeletion::Literals)
         return;
 
-    // Links mode: walk only the links recorded at this level (their `del`s are emitted
-    // by ProofLogger::forget_proof_level's own loop). Drop each from the live set so a
-    // later need_gevar re-emits it if needed, then clear the level's bucket (keeping
-    // its capacity for when the level is re-entered). Bucket 0 (Top) is never passed
-    // here.
-    auto bucket_it = _imp->order_links_by_level.find(level);
-    if (bucket_it == _imp->order_links_by_level.end())
-        return;
-    for (const auto & [id, lohi] : bucket_it->second)
-        if (auto links_it = _imp->live_order_links.find(id); links_it != _imp->live_order_links.end())
-            links_it->second.erase(lohi);
-    bucket_it->second.clear();
+    forget_order_literals_at_level(level);
+    // The eq and chain-clause analogues, from the same funnel. Both are pure
+    // bookkeeping (the `del`s were emitted by forget_proof_level's own loop), and both
+    // run after the ge sweep because that is what emits this level's stitches -- which
+    // land at a *surviving* neighbour's level, never at the level being forgotten, so
+    // they are not swept away again here.
+    forget_eq_literals_at_level(level);
+    forget_chain_clauses_at_level(level);
 }
 
 auto NamesAndIDsTracker::record_live_order_literal(const SimpleIntegerVariableID & id, Integer v, bool top) -> void
@@ -1717,8 +1627,9 @@ auto NamesAndIDsTracker::link_order_literal_to_live_neighbours(const SimpleInteg
     // proof of an instance with no resident interior chain, e.g. an eq-free bound-branching
     // one, is byte-for-byte unchanged). v must already be present in live_order_literals
     // (recorded by the caller before this call), so its neighbours are prev(v) and next(v)
-    // in the live map. building_order_link suppresses re-introduction while
-    // make_pol_chain_line re-enters need_gevar for v and each neighbour (all resident/live).
+    // in the live map. make_pol_chain_line re-enters need_gevar for v and each neighbour,
+    // but every one of those is live, so each such call takes the fast path and
+    // re-introduces nothing.
     auto & live = _imp->live_order_literals[id];
     auto it = live.find(v);
     if (it == live.end())
@@ -1746,8 +1657,6 @@ auto NamesAndIDsTracker::link_order_literal_to_live_neighbours(const SimpleInteg
             stats_note_stitch_emitted(id, lo, hi, landed, /*forget_path=*/false);
     };
 
-    auto saved = _imp->building_order_link;
-    _imp->building_order_link = true;
     if (auto higher = next(it); higher != live.end()) {
         // ge(hi) -> ge(v): clause ge(v) OR ~ge(hi).
         auto pol = make_pol_chain_line(id >= v, ! (id >= higher->first));
@@ -1759,7 +1668,6 @@ auto NamesAndIDsTracker::link_order_literal_to_live_neighbours(const SimpleInteg
         auto pol = make_pol_chain_line(id >= lower->first, ! (id >= v));
         emit_link(pol, lower->second, lower->first, v);
     }
-    _imp->building_order_link = saved;
 }
 
 auto NamesAndIDsTracker::emit_order_stitch(const SimpleIntegerVariableID & id, Integer lo, Integer hi, int at_level, int restore_level) -> void
@@ -1768,12 +1676,10 @@ auto NamesAndIDsTracker::emit_order_stitch(const SimpleIntegerVariableID & id, I
     // survivors' resident defs, exactly as an adjacent chain link -- it is sound for a
     // skip (lo, hi more than one threshold apart) identically. Record it at at_level =
     // max(level(lo), level(hi)) so it is deleted together with the deeper of its two
-    // endpoints (levels are forgotten deepest-first). building_order_link suppresses
-    // re-introduction while make_pol_chain_line re-enters need_gevar for lo and hi.
-    auto saved = _imp->building_order_link;
-    _imp->building_order_link = true;
+    // endpoints (levels are forgotten deepest-first). make_pol_chain_line re-enters
+    // need_gevar for lo and hi, but both are survivors and so still live, meaning those
+    // calls take the fast path and re-introduce nothing.
     auto pol = make_pol_chain_line(id >= lo, ! (id >= hi));
-    _imp->building_order_link = saved;
 
     _imp->logger->enter_proof_level(at_level);
     auto line = pol->emit(*_imp->logger, ProofLevel::Current);
@@ -1899,12 +1805,10 @@ auto NamesAndIDsTracker::stitch_hoisted_order_literal(const SimpleIntegerVariabl
         }
 
     // Emit each link at max(target_level, neighbour_level): enter that level, emit at
-    // Current, restore. building_order_link suppresses re-introduction while
-    // make_pol_chain_line re-enters need_gevar for v and each neighbour (all resident
-    // and live).
+    // Current, restore. make_pol_chain_line re-enters need_gevar for v and each
+    // neighbour, but all of those are resident and live, so each such call takes the
+    // fast path and re-introduces nothing.
     auto restore_level = _imp->logger->proof_level();
-    auto saved = _imp->building_order_link;
-    _imp->building_order_link = true;
     if (lo) {
         // ge(lo) -> nothing; the link is ge(lo) OR ~ge(v), i.e. ge(v) -> ge(lo).
         auto pol = make_pol_chain_line(id >= *lo, ! (id >= v));
@@ -1926,7 +1830,6 @@ auto NamesAndIDsTracker::stitch_hoisted_order_literal(const SimpleIntegerVariabl
             stats_note_stitch_emitted(id, v, *hi, landed, /*forget_path=*/false);
     }
     _imp->logger->enter_proof_level(restore_level);
-    _imp->building_order_link = saved;
 }
 
 auto NamesAndIDsTracker::hoist_order_literal_to_level(const SimpleIntegerVariableID & id, Integer v, int target_level, bool immediate_neighbours,

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -216,24 +216,15 @@ namespace gcs::innards
         // Build the pol line deriving the order-encoding chain link clause
         // (cond1 OR cond2) from the resident (Top) bit-definitions of ~cond1 and
         // ~cond2. Shared by the initial chain-link emission in need_gevar and the
-        // on-demand re-emission used by the order-link deletion mode.
+        // deletable links, stitches and hoists of the order-encoding deletion mode.
         [[nodiscard]] auto make_pol_chain_line(IntegerVariableCondition cond1, IntegerVariableCondition cond2) -> std::shared_ptr<PolBuilder>;
 
-        // Emit the adjacent-threshold (lo < hi) order-encoding chain link
-        // ge(hi) -> ge(lo) for a real variable. With order-link deletion on and the
-        // logger attached the link lands at ProofLevel::Current (so a backtrack
-        // deletes it) and is recorded as live tagged with the active proof level;
-        // otherwise it lands at Top exactly as before. Model-building emissions
-        // (logger not yet attached) always land at Top.
-        auto emit_and_maybe_track_order_link(const SimpleIntegerVariableID & id, Integer lo, Integer hi) -> void;
-
-        // Fast-path helper for need_gevar when a real variable's ge atom already
-        // exists: reconnect the variable's entire order chain by re-emitting every
-        // currently-missing adjacent-threshold link across its existing thresholds,
-        // so a RUP needing multi-hop order propagation has the full chain available
-        // (as the baseline keeps permanently resident). Emission fires only for
-        // genuinely-missing links. No-op unless the order-link deletion mode is on.
-        auto ensure_order_chain_connected(const SimpleIntegerVariableID & id) -> void;
+        // Emit the permanent (Top) adjacent-threshold (lo < hi) order-encoding chain
+        // link ge(hi) -> ge(lo) for a real variable. This is the emission used with
+        // deletion off, and at model-building time (logger not yet attached) in every
+        // mode. Literals mode's deletable links come from
+        // link_order_literal_to_live_neighbours instead.
+        auto emit_order_link(const SimpleIntegerVariableID & id, Integer lo, Integer hi) -> void;
 
         // --- Literals mode (OrderEncodingDeletion::Literals) ---
 
@@ -430,18 +421,17 @@ namespace gcs::innards
         auto need_gevar(SimpleOrProofOnlyIntegerVariableID id, Integer v) -> void;
 
         /**
-         * Drop from the live order-link structure every order-encoding chain link
-         * tagged with the given proof level. Emits nothing: the matching `del` lines
-         * are produced by ProofLogger::forget_proof_level's own deletion loop (the
-         * links were recorded at Current == that level). This just keeps the live
-         * structure in sync so a later need_gevar re-emits any that are needed again.
-         * A cheap no-op when the order-link deletion mode is off. Intended to be
+         * Sweep the order encoding recorded at the given proof level, which is about to
+         * be forgotten: forget_order_literals_at_level (which retires each deleted ge
+         * literal and re-stitches the chain around each deleted run), then the eq and
+         * chain-clause analogues. The `del` lines themselves are produced by
+         * ProofLogger::forget_proof_level's own deletion loop; what happens here is the
+         * bookkeeping that has to stay in step with them, plus the stitches. A cheap
+         * no-op unless the order-encoding deletion mode is `Literals`. Intended to be
          * called from ProofLogger::forget_proof_level.
          *
-         * Note: in `Literals` mode this dispatches to forget_order_literals_at_level
-         * (which deletes literals and re-stitches the chain around each deleted run),
-         * not links. The `_links_` in this name predates the Literals mode; it is left
-         * unchanged until the planned Brancher refactor renames it.
+         * Note: the `_links_` in this name predates the Literals mode -- it sweeps
+         * literals, not links -- and is left unchanged until the rename that follows.
          */
         auto forget_order_links_at_level(int level) -> void;
 

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -243,7 +243,7 @@ namespace gcs::innards
         auto record_live_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> void;
 
         // Retirement pass for windowed eq definitions, driven from
-        // forget_order_links_at_level alongside the ge sweep: for every eq atom whose def
+        // forget_order_encoding_at_level alongside the ge sweep: for every eq atom whose def
         // was recorded at `level`, drop it from the live set and retire its atom out of
         // the lookup table (mirroring the ge sweep -- see forget_order_literals_at_level
         // for why retirement, rather than liveness tracking, is what enforces the naming
@@ -309,7 +309,7 @@ namespace gcs::innards
         auto emit_order_stitch(const SimpleIntegerVariableID & id, Integer lo, Integer hi, int at_level, int restore_level) -> void;
 
         // Deletion + stitch pass for the Literals mode, driven from
-        // forget_order_links_at_level: for every threshold whose def was recorded at
+        // forget_order_encoding_at_level: for every threshold whose def was recorded at
         // `level`, stitch the surviving neighbours around each deleted run and drop the
         // thresholds from the live set.
         auto forget_order_literals_at_level(int level) -> void;
@@ -429,11 +429,8 @@ namespace gcs::innards
          * bookkeeping that has to stay in step with them, plus the stitches. A cheap
          * no-op unless the order-encoding deletion mode is `Literals`. Intended to be
          * called from ProofLogger::forget_proof_level.
-         *
-         * Note: the `_links_` in this name predates the Literals mode -- it sweeps
-         * literals, not links -- and is left unchanged until the rename that follows.
          */
-        auto forget_order_links_at_level(int level) -> void;
+        auto forget_order_encoding_at_level(int level) -> void;
 
         /**
          * Hoist a search-introduced ge threshold `v` of real variable `id`

--- a/gcs/innards/proofs/order_hoist_test.cc
+++ b/gcs/innards/proofs/order_hoist_test.cc
@@ -1,0 +1,197 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <gcs/integer.hh>
+#include <gcs/proof.hh>
+#include <gcs/variable_id.hh>
+
+#include <iostream>
+#include <string>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::cerr;
+using std::string;
+
+// The second of the two verified foundations the order-encoding-deletion design rests on
+// (dev_docs/brancher-design.md, "Bookkeeping mirrors"): the HOIST primitive. Moving a
+// search-introduced `ge` definition to a shallower proof level must leave it both live
+// *and chained*, so that a later backtrack past its original level does not strand it.
+//
+// Everything that survives a backtrack in this design -- the backtrack clause's guess
+// literals, a learned nogood's decisions, the objective threshold a `soli` names -- gets
+// there by hoisting, so a hoist that relocated the definition but lost the chain would
+// silently cost every one of those a re-introduction, or worse, leave a Top line naming a
+// literal unit propagation can no longer reach.
+//
+// The variable is a genuine bits-encoded SimpleIntegerVariableID (which is what the
+// Literals mode tracks) in [0, 63], with the boundaries and one interior survivor s = ge(10)
+// introduced at Top. The deep threshold h = ge(30) is introduced at level 3, and is placed
+// with NO deletable literal between it and s, so the forget-time re-stitch never fires a
+// stitch that would re-chain h by accident: the only thing that can keep h chained across
+// the backtrack is the hoist's own re-stitch. That is what makes the hoist load-bearing
+// here rather than decorative.
+//
+// The probe is a chain-closure RUP ~(x >= h) OR (x >= s) -- reason {x >= h} |- x >= s --
+// which VeriPB can close only through a surviving chain link. It is emitted as a raw line
+// on purpose: naming x >= h through the normal path would trigger the Literals mode's
+// on-demand re-introduction and resurrect exactly the definition the control is trying to
+// observe the absence of.
+//
+// Five scenarios, of which two are controls that must be REJECTED (registered through
+// run_test_and_expect_rejection.bash):
+//
+//   top        hoist h to Top, forget 3/2/1, probe          -> VERIFIED
+//   no_hoist   identical but no hoist: the forget deletes h -> REJECTED
+//   level      hoist h to level 1, forget 3/2, probe        -> VERIFIED
+//   level_gone as level, then forget level 1 as well        -> REJECTED
+//   multi      out-of-order hoists into, then out of, a level -> VERIFIED
+//
+// `multi` covers the bucket-ordering half of the primitive: two deep literals h1 = ge(25)
+// < h2 = ge(45) are introduced at level 3 (so h1's definition line ids precede h2's) and
+// then hoisted to level 1 in the REVERSE order, h2 first, so h1's smaller ids have to slot
+// in front of ids already in that bucket rather than be appended past them
+// (ProofLogger::move_proof_lines_to_level's general-position insert, not insert_at_end).
+// Then -- and this is the part that makes the invariant observable rather than notional --
+// h1 is hoisted on again, to Top, so something finally has to *find* its ids in that
+// bucket. Replacing the sorted insert with insert_at_end leaves the bucket unsorted, the
+// erase misses, h1's definition stays behind at level 1 and is deleted by the forget, and
+// the probe rejects with "constraint ... has already been deleted". Confirmed by mutation:
+// without that final hoist, the corrupted bucket is never queried and the scenario passes
+// against the broken code.
+auto main(int argc, char * argv[]) -> int
+{
+    bool prove = false;
+    string basename = "order_hoist_test";
+    string scenario = "top";
+    for (int arg = 1; arg < argc; ++arg) {
+        string a{argv[arg]};
+        if (a == "--prove")
+            prove = true;
+        else if (a == "--proof-files-basename" && arg + 1 < argc)
+            basename = argv[++arg];
+        else if (a == "--scenario" && arg + 1 < argc)
+            scenario = argv[++arg];
+        else {
+            cerr << "unrecognised argument '" << a << "'\n";
+            return 1;
+        }
+    }
+    if (scenario != "top" && scenario != "no_hoist" && scenario != "level" && scenario != "level_gone" && scenario != "multi") {
+        cerr << "unrecognised scenario '" << scenario << "'\n";
+        return 1;
+    }
+
+    // Nothing here exists outside the proof, so with proving off there is nothing to do.
+    if (! prove)
+        return 0;
+
+    const SimpleIntegerVariableID x{0ull};
+    const Integer s{10_i}; // surviving interior threshold, resident at Top
+    const Integer h{30_i}; // deep threshold, hoisted or (control) deleted
+
+    ProofOptions proof_options{basename};
+    // Mode and gate set in code, not through GCS_DELETE_ORDER_ENCODING, so the test does
+    // not depend on the environment -- and in particular so it runs at gate 0, which the
+    // shipped default of 16 would make vacuous here (one variable naming a handful of
+    // thresholds would never cross it, and every definition would stay resident).
+    proof_options.set_order_encoding_deletion(OrderEncodingDeletion::Literals).set_order_encoding_deletion_min_chain(0);
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+    tracker.start_writing_model(&model);
+
+    model.set_up_integer_variable(x, 0_i, 63_i, "x", IntegerVariableProofRepresentation::Bits);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    // The probe is built as raw text, and -- crucially -- built while both of its atoms are
+    // still live, then emitted later. Naming an atom through the tracker after the forget
+    // would not work at all in a control: deletion *retires* the atom out of the naming
+    // table, so pb_file_string_for would throw rather than produce the line VeriPB is meant
+    // to reject. Capturing first is also what makes the pairing honest -- a control emits
+    // the identical probe to its positive twin, so the hoist is the only difference between
+    // the two runs.
+    auto probe_text = [&](Integer from, Integer to) {
+        return "rup 1 " + tracker.pb_file_string_for(x < from) + " 1 " + tracker.pb_file_string_for(x >= to) + " >= 1 ;";
+    };
+
+    // Level 0 (Top): the boundaries and the surviving interior threshold.
+    tracker.need_gevar(x, 0_i);  // ge(lower): pinned true
+    tracker.need_gevar(x, 64_i); // ge(ub + 1): pinned false
+    tracker.need_gevar(x, s);
+
+    // Descend and introduce the deep threshold, so its definition and its chain links to
+    // its neighbours all land at level 3.
+    logger.enter_proof_level(1);
+    logger.enter_proof_level(2);
+    logger.enter_proof_level(3);
+    tracker.need_gevar(x, h);
+
+    if (scenario == "top" || scenario == "no_hoist") {
+        auto probe = probe_text(h, s);
+        // The only difference between the two: with the hoist, ge(h) moves to Top and
+        // survives; without it the backtrack deletes it and stitches s..ge(64) over it.
+        if (scenario == "top")
+            tracker.hoist_order_literal_to_top(x, h);
+        logger.forget_proof_level(3);
+        logger.forget_proof_level(2);
+        logger.forget_proof_level(1);
+        logger.enter_proof_level(0);
+        logger.emit_proof_line(probe, ProofLevel::Current);
+    }
+    else if (scenario == "level" || scenario == "level_gone") {
+        auto probe = probe_text(h, s);
+        tracker.hoist_order_literal_to_level(x, h, 1);
+        logger.forget_proof_level(3);
+        logger.forget_proof_level(2);
+        // level_gone goes one further and forgets the level ge(h) was hoisted TO: hoisting
+        // delays deletion, it does not prevent it, so the literal must really go there.
+        if (scenario == "level_gone") {
+            logger.forget_proof_level(1);
+            logger.enter_proof_level(0);
+        }
+        else
+            logger.enter_proof_level(1);
+        logger.emit_proof_line(probe, ProofLevel::Current);
+    }
+    else {
+        const Integer h1{25_i}, h2{45_i};
+        tracker.need_gevar(x, h1);
+        tracker.need_gevar(x, h2);
+        auto probe_h1_s = probe_text(h1, s);
+
+        // Hoist to a common shallower level in the corrupting order: h2 (whose definition
+        // line ids are larger) first, so h1's smaller ids must then slot in front of it.
+        tracker.hoist_order_literal_to_level(x, h2, 1);
+        tracker.hoist_order_literal_to_level(x, h1, 1);
+
+        // Now take h1 out of that bucket again, by hoisting it on to Top. This is the step
+        // that makes the ordering load-bearing rather than cosmetic: an unsorted bucket is
+        // harmless until something has to *find* a line in it, and this is that something.
+        // If h1's ids were appended past h2's instead of slotted in front, the erase here
+        // misses them, they stay behind in level 1, and the forget below deletes the
+        // definition of a literal that is supposed to be resident at Top.
+        tracker.hoist_order_literal_to_top(x, h1);
+
+        logger.forget_proof_level(3);
+        logger.forget_proof_level(2);
+        logger.forget_proof_level(1);
+        logger.enter_proof_level(0);
+
+        // h1 survived two hoists and three forgets, and is still chained to the survivor.
+        logger.emit_proof_line(probe_h1_s, ProofLevel::Current);
+    }
+
+    logger.conclude_none();
+    tracker.finalise();
+
+    return 0;
+}

--- a/gcs/innards/proofs/order_jump_test.cc
+++ b/gcs/innards/proofs/order_jump_test.cc
@@ -1,0 +1,114 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <gcs/integer.hh>
+
+#include <iostream>
+#include <string>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::cerr;
+using std::string;
+
+// The first of the two verified foundations the order-encoding-deletion design rests on
+// (dev_docs/order-encoding-deletion.md; dev_docs/brancher-design.md, "The decision and its
+// backtrack advance"): a bound jump over a run of holes is RUP from a reason naming only
+// the *guesses* that created the holes, not the holes themselves.
+//
+// That is what lets the framework justify a bound advance with a short reason instead of
+// one literal per removed value, and it is the reason the order encoding can be deleted at
+// all: the surviving chain plus the eq reverse-reification axioms are enough for unit
+// propagation to climb the bound one hole at a time. If VeriPB ever stopped closing this,
+// every advance in the design would need re-deriving, so it is checked here rather than
+// left to a scratch driver.
+//
+// The model is built purely at the proof-logging layer (like invar_test): a Bits-encoded
+// proof-only variable x in [0, 63], a proof flag g, and the holes posted as *reified* model
+// axioms ~g OR (x != v) for every v in [L, H). Reified, not unconditional, is the whole
+// point -- the eliminations have to be derivable from g rather than baked into the model,
+// or the jump would be trivial and the test would prove nothing.
+//
+// Two controls, because the positive scenario alone would pass against a checker that
+// accepted anything: `no_flag` drops g from the reason (so the holes are no longer
+// derivable and the jump is unsound), and `over_jump` claims one value too many (x = H is
+// still in the domain). Both must be REJECTED by VeriPB, which is why they are registered
+// through run_test_and_expect_rejection.bash with the message they must reject with.
+namespace
+{
+    const Integer hole_run_lo{10_i}; // first eliminated value
+    const Integer hole_run_hi{20_i}; // first surviving value above the run
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    bool prove = false;
+    string basename = "order_jump_test";
+    string scenario = "jump";
+    for (int arg = 1; arg < argc; ++arg) {
+        string a{argv[arg]};
+        if (a == "--prove")
+            prove = true;
+        else if (a == "--proof-files-basename" && arg + 1 < argc)
+            basename = argv[++arg];
+        else if (a == "--scenario" && arg + 1 < argc)
+            scenario = argv[++arg];
+        else {
+            cerr << "unrecognised argument '" << a << "'\n";
+            return 1;
+        }
+    }
+    if (scenario != "jump" && scenario != "no_flag" && scenario != "over_jump") {
+        cerr << "unrecognised scenario '" << scenario << "'\n";
+        return 1;
+    }
+
+    // Nothing here exists outside the proof, so with proving off there is nothing to do.
+    if (! prove)
+        return 0;
+
+    ProofOptions proof_options{basename};
+
+    NamesAndIDsTracker tracker(proof_options);
+    ProofModel model(proof_options, tracker);
+    tracker.start_writing_model(&model);
+
+    auto x = model.create_proof_only_integer_variable(0_i, 63_i, "x", IntegerVariableProofRepresentation::Bits);
+    auto g = model.create_proof_flag("g");
+
+    // The holes, reified on g: g -> (x != v), i.e. ~g OR (x != v).
+    for (Integer v = hole_run_lo; v < hole_run_hi; v = v + 1_i)
+        model.add_constraint(WPBSum{} + 1_i * (! g) + 1_i * (x != v) >= 1_i);
+
+    model.finalise();
+
+    ProofLogger logger(proof_options, tracker);
+    tracker.switch_from_model_to_proof(&logger);
+    logger.start_proof(model);
+    tracker.emit_delayed_proof_steps();
+
+    if (scenario == "jump") {
+        // reason {g, x >= lo} |- x >= hi. Sound: each (x >= v) with (x != v) unit-propagates
+        // to (x >= v+1) through the eq atom's reverse-reification axiom, so the bound climbs
+        // the whole run without the reason ever naming a hole.
+        logger.emit_rup_proof_line(WPBSum{} + 1_i * (! g) + 1_i * ! (x >= hole_run_lo) + 1_i * (x >= hole_run_hi) >= 1_i, ProofLevel::Current);
+    }
+    else if (scenario == "no_flag") {
+        // reason {x >= lo}, with g dropped: the holes are no longer derivable, so nothing
+        // stops x from sitting inside the run. Must be REJECTED.
+        logger.emit_rup_proof_line(WPBSum{} + 1_i * ! (x >= hole_run_lo) + 1_i * (x >= hole_run_hi) >= 1_i, ProofLevel::Current);
+    }
+    else {
+        // reason {g, x >= lo} |- x >= hi + 1: one value too far, since x = hi survives.
+        // Must be REJECTED.
+        logger.emit_rup_proof_line(
+            WPBSum{} + 1_i * (! g) + 1_i * ! (x >= hole_run_lo) + 1_i * (x >= (hole_run_hi + 1_i)) >= 1_i, ProofLevel::Current);
+    }
+
+    logger.conclude_none();
+    tracker.finalise();
+
+    return 0;
+}

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -1073,7 +1073,7 @@ auto ProofLogger::forget_proof_level(int depth) -> void
     // emitted: the ge definitions, eq definitions and chain clauses recorded at this
     // level have now been del'd, so retire their atoms and stitch the chain back over
     // the survivors. A cheap no-op unless the order-encoding deletion mode is Literals.
-    names_and_ids_tracker().forget_order_links_at_level(depth);
+    names_and_ids_tracker().forget_order_encoding_at_level(depth);
 
     // The eq window's per-node records for this level went with those deletions. Dropping
     // them is not tidiness: the next node at this depth reuses the level number, and a

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -568,8 +568,9 @@ auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoB
     // smart_table, tour and minizinc-cumulative all reject without this.
     //
     // Costs a walk of the terms per Top emission while a window is live, and nothing at all
-    // otherwise: eq_window_active() is false in every default configuration, and the
-    // tracker's own guard returns immediately when no variable is currently windowed.
+    // otherwise: eq_window_active() is false unless order-encoding deletion is on (which it
+    // is not by default), and the tracker's own guard returns immediately when no variable
+    // is currently windowed.
     if (level != ProofLevel::Top || ! eq_window_active())
         return;
 

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -1069,10 +1069,10 @@ auto ProofLogger::forget_proof_level(int depth) -> void
     }
     lines.clear();
 
-    // Keep the tracker's live order-link structure in sync with the deletions just
-    // emitted: any order-encoding chain links recorded at this level have now been
-    // del'd, so drop them from the live set so a later need_gevar re-emits them if
-    // required. A cheap no-op when the order-link deletion mode is off.
+    // Keep the tracker's live order-encoding structures in sync with the deletions just
+    // emitted: the ge definitions, eq definitions and chain clauses recorded at this
+    // level have now been del'd, so retire their atoms and stitch the chain back over
+    // the survivors. A cheap no-op unless the order-encoding deletion mode is Literals.
     names_and_ids_tracker().forget_order_links_at_level(depth);
 
     // The eq window's per-node records for this level went with those deletions. Dropping

--- a/gcs/proof.cc
+++ b/gcs/proof.cc
@@ -64,12 +64,9 @@ namespace
     }
 
     /**
-     * Read an OrderEncodingDeletion from the environment, if set. The primary
-     * selector is GCS_DELETE_ORDER_ENCODING=literals|links|none (case-insensitive on
-     * the first letter); it picks the mode by name. The legacy GCS_DELETE_ORDER_LINKS
-     * variable is still honoured (any non-empty non-off value turns the old Links mode
-     * on), so existing tests keep working, but GCS_DELETE_ORDER_ENCODING takes
-     * precedence when both are set.
+     * Read an OrderEncodingDeletion from the environment, if set:
+     * GCS_DELETE_ORDER_ENCODING=literals|none (case-insensitive on the first letter),
+     * picking the mode by name. An unrecognised value falls through to the default.
      */
     [[nodiscard]] auto order_encoding_deletion_from_env() -> optional<OrderEncodingDeletion>
     {
@@ -77,18 +74,8 @@ namespace
             string value{env};
             if (value == "literals" || value == "Literals")
                 return OrderEncodingDeletion::Literals;
-            if (value == "links" || value == "Links")
-                return OrderEncodingDeletion::Links;
             if (is_off_word(value))
                 return OrderEncodingDeletion::None;
-            // Unrecognised value: fall through to the legacy variable / default.
-        }
-
-        if (const auto * const env = std::getenv("GCS_DELETE_ORDER_LINKS"); env && *env) {
-            string value{env};
-            if (is_off_word(value))
-                return OrderEncodingDeletion::None;
-            return OrderEncodingDeletion::Links;
         }
 
         return nullopt;

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -97,15 +97,21 @@ namespace gcs
         int order_encoding_deletion_min_chain = 16;                    ///< Min ge chain length before Literals-mode deletion engages (0 = gate off)
         bool order_encoding_deletion_min_chain_set_explicitly = false; ///< Was the gate set in code (so it overrides the env var)?
         // The eq-atom sliding window for the four contiguous eq value orders
-        // (smallest_first / largest_first / smallest_in / largest_in), under
-        // OrderEncodingDeletion::Literals. Off by default: the window trades transient work
-        // (a per-iteration tidy, and a re-mint whenever a refuted value is named again) for
-        // permanent residency, and whether that pays on eq-heavy models is a measurement,
-        // not an assumption. With it off those value orders behave exactly as they always
-        // have -- their Bound advance tags stay inert, no eq definition is ever windowed,
-        // and their proofs are byte-identical to the untagged ones. See
-        // dev_docs/brancher-design.md, "The eq-atom window".
-        bool order_encoding_deletion_eq_window = false;                ///< Window eq-branching atoms under Literals (default off)
+        // (smallest_first / largest_first / smallest_in / largest_in). Inert in every mode
+        // but OrderEncodingDeletion::Literals, and ON with it: the window trades transient
+        // work (a per-iteration tidy, and a re-mint whenever a refuted value is named
+        // again) for permanent residency, and stage E measured that trade rather than
+        // arguing it. Where it engages -- ascending eq branching over a large domain -- it
+        // is worth 2.3x to 4.9x of veripb time; where it cannot, it costs +0.30 % on a
+        // 73 s real verify and nothing at all (byte-identical) on talent and langford. A
+        // caller who has turned Literals on is in the regime the window was built for, so
+        // making them turn on a second flag to get the eq half of the same feature would be
+        // a tunable rather than a design input. Set it to false, or
+        // GCS_DELETE_ORDER_ENCODING_EQ_WINDOW=0, to go back to the untagged behaviour --
+        // with it off those value orders are byte-identical to the untagged ones, which is
+        // what made the tags free to add. See dev_docs/brancher-design.md, "The eq-atom
+        // window", and dev_docs/order-encoding-deletion.md, "Results".
+        bool order_encoding_deletion_eq_window = true;                 ///< Window eq-branching atoms under Literals (default on)
         bool order_encoding_deletion_eq_window_set_explicitly = false; ///< Was the window set in code (so it overrides the env var)?
 
         /// Write annotated assertions instead of full justifications.
@@ -134,9 +140,10 @@ namespace gcs
             order_encoding_deletion_min_chain_set_explicitly = true;
             return *this;
         }
-        /// Turn the eq-atom sliding window on for the four contiguous eq value orders
-        /// under OrderEncodingDeletion::Literals, making them O(1)-resident in the proof
-        /// rather than O(domain width). Off by default; inert in every other mode.
+        /// Turn the eq-atom sliding window on or off for the four contiguous eq value
+        /// orders under OrderEncodingDeletion::Literals, which makes them O(1)-resident in
+        /// the proof rather than O(domain width). On by default under that mode, and inert
+        /// in every other; pass false to get the untagged behaviour back.
         ProofOptions & set_order_encoding_deletion_eq_window(bool w = true)
         {
             order_encoding_deletion_eq_window = w;

--- a/gcs/proof.hh
+++ b/gcs/proof.hh
@@ -48,9 +48,7 @@ namespace gcs
      * ProofLevel::Current (and so deleted on backtrack and re-emitted on demand)
      * rather than resident at ProofLevel::Top.
      *
-     * \c None keeps everything resident at Top, as always. \c Links (the earlier,
-     * unsound experiment) emits only the derived adjacent-threshold chain links at
-     * Current, keeping the ge atom definitions resident. \c Literals deletes whole
+     * \c None keeps everything resident at Top, as always. \c Literals deletes whole
      * search-introduced order literals -- each real variable's non-boundary ge
      * *definition* together with its chain links is emitted at Current, so a
      * backtrack deletes it; when an interior literal between two surviving
@@ -62,7 +60,6 @@ namespace gcs
     enum class OrderEncodingDeletion
     {
         None,     /// Everything resident at Top, as always (the default)
-        Links,    /// Emit the order-encoding chain links at Current; delete on backtrack, re-emit on demand (unsound; dormant)
         Literals, /// Delete whole search-introduced order literals (def + links) on backtrack, stitching the chain over survivors
     };
 
@@ -129,8 +126,8 @@ namespace gcs
         }
         /// Set the chain-length gate for OrderEncodingDeletion::Literals: interior ge
         /// definitions are only made deletable once a variable has named more than \p m
-        /// ge thresholds. 0 (the default) disables the gate, deleting from the first
-        /// threshold exactly as the pre-gate Literals mode did.
+        /// ge thresholds. 0 disables the gate, deleting from the first threshold exactly
+        /// as the pre-gate Literals mode did; the default is 16.
         ProofOptions & set_order_encoding_deletion_min_chain(int m)
         {
             order_encoding_deletion_min_chain = m;

--- a/run_test_and_expect_rejection.bash
+++ b/run_test_and_expect_rejection.bash
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Usage: run_test_and_expect_rejection.bash [--basename NAME] --expect SUBSTRING PROGRAM [ARGS...]
+#
+# Runs PROGRAM with --prove, then checks that veripb REJECTS the resulting proof,
+# with SUBSTRING somewhere in its output.
+#
+# This is the must-fail control harness. A test that only ever checks that a proof
+# verifies cannot tell a working mechanism from one that has quietly stopped
+# constraining anything: the proof of a solver that deleted nothing, or hoisted
+# nothing, verifies perfectly well. A control pairs the positive scenario with a
+# deliberately broken one and insists VeriPB says so.
+#
+# Both halves of the check matter. The exit code alone would be satisfied by a
+# crash in PROGRAM, a missing input file, or a proof VeriPB could not even parse,
+# any of which would let a genuinely broken mechanism sit green forever; hence
+# --expect, which pins the rejection to the reason the control was written for.
+# (This is the discipline the standalone drivers under
+# order-encoding-deletion-artifacts/ use -- see their run.sh -- brought into the
+# suite.) PROGRAM itself must still exit 0: it is expected to write a proof, not
+# to fail.
+#
+# See run_test_and_verify.bash for --basename, which exists for the same reason
+# here: a scenario-per-ctest-entry test would otherwise race over one set of proof
+# files under a parallel ctest (issue #562).
+#
+# Proof-file disposal follows the same policy as the positive harness, with the
+# outcomes the other way up: the proof is deleted once it has been rejected as
+# expected, and kept when it was not, which is the case someone will want to
+# inspect.
+
+set -u
+
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=proof_file_disposal.bash
+. "$(dirname "$0")/proof_file_disposal.bash"
+
+basename_override=
+if [[ ${1:-} == --basename ]] ; then
+    basename_override=$2
+    shift 2
+fi
+
+if [[ ${1:-} != --expect ]] ; then
+    echo "$0: --expect SUBSTRING is required: a control must say what it expects to be rejected with" 1>&2
+    exit 1
+fi
+expect=$2
+shift 2
+
+prog=$1
+shift
+
+progname=$(basename "$prog")
+progname=${progname%.exe}
+
+proofname=${basename_override:-$progname}
+
+export PATH=$HOME/.cargo/bin:$PATH
+
+if [[ -n $basename_override ]] ; then
+    "$prog" --prove --proof-files-basename "$proofname" "$@" || exit 1
+else
+    "$prog" --prove "$@" || exit 1
+fi
+
+# -c for the same reason the positive harness passes it: a failed deletion stops at the
+# deletion rather than at some distant conclusion. See run_test_and_verify.bash.
+output=$(veripb -c "${proofname}.opb" "${proofname}.pbp" 2>&1)
+status=$?
+
+if [[ $status -eq 0 ]] ; then
+    echo "$0: veripb ACCEPTED ${proofname}.pbp, but this is a control that must be rejected." 1>&2
+    echo "$0: the mechanism under test has stopped constraining anything -- fix the code, do not relax the control." 1>&2
+    echo "$output" 1>&2
+    exit 1
+fi
+
+if ! grep -qF -- "$expect" <<< "$output" ; then
+    echo "$0: veripb rejected ${proofname}.pbp, but not for the expected reason." 1>&2
+    echo "$0: wanted output containing: $expect" 1>&2
+    echo "$output" 1>&2
+    exit 1
+fi
+
+# Rejected, as intended, so dispose of the proof unless asked to preserve it.
+dispose_proof "$proofname"


### PR DESCRIPTION
Part of #612; closes #611.

Stage **E** is the last stage of the step-2 Brancher refactor, and — per the standing
merge policy on this stack — the **go/no-go gate for the whole thing**. Two halves:
the cleanup the earlier stages deferred, and the campaign that decides the stack.

## Verdict: GO, flag-gated and off by default — which is where it already was

The win is large, reproducible, and now covers **both** branching families; carrying
the stack costs nothing when the flag is off (byte-identity, in all three live
configurations, over the whole example set). The case against — a lot of machinery in
a central proofs path that buys nothing on any real model anyone has found — is real,
is not answered by this campaign, and is answered by the flag. Nothing measured here
argues for default-on.

## The campaign (one sitting, at the tip, pinned, tmpfs, min-of-3/5)

**1. The later stages cost the headline win nothing.** The eq-free split sweep
reproduces the pre-B″ figures to a couple of percent:

| D | verify OFF | gate 0 | gate 16 | RSS OFF → ON |
|--:|--:|--:|--:|--:|
| 250  | 0.337 s  | 0.067 s (**5.03×**)  | 0.106 s (3.18×)  | −30 % |
| 500  | 1.711 s  | 0.173 s (**9.89×**)  | 0.277 s (6.18×)  | −43 % |
| 1000 | 10.015 s | 0.504 s (**19.87×**) | 0.805 s (12.44×) | −47 % |
| 2000 | 107.88 s | 1.859 s (**58.03×**) | 2.792 s (38.64×) | −56 % |

**2. The stack opened a second win regime.** Ascending eq branching had no frontier to
advance before stage B″. With the window, against mode None: **5.31× / 9.05× / 15.50×**
at d250/500/1000 — of which the window itself is 2.32× / 3.54× / 4.87×. Same
grows-with-domain signature, same SIZE≠TIME shape (+31 % proof, 4.9× faster).

**3. It still does not generalise, and stages C and D did not change that.**
seat-moving — the lone deep-yet-verifiable real split case, and the instance whose
churn motivated stage C — is **124.63 s OFF against 126.82 s / 126.80 s ON**, where the
pre-stack sitting had it a few percent the other way; read the pair as neutral. Stage C
*does* fire (79.9 % of the optimisation synthetic's Top residency is now attributed to
the exemption; seat-moving's proof growth fell +2.3 % → +1.3 %) and stage D's residency
claim holds — neither converts to verify time even here. tour, colour, knapsack are
exact no-ops; talent 0.97×/1.00×.

**4. Owner decision 5, settled by measurement: the eq window now follows `Literals`.**
It shipped wired-but-off precisely so this could decide it. Where it engages: up to
4.87×. Where it cannot — every real eq model, because the window needs the branch layer
to name an eq atom *first* and a per-value propagator always gets there before it —
**byte-identical** on talent and langford, **+0.30 %** on colour's 73-second verify,
+3.4 % on its three-second one. `GCS_DELETE_ORDER_ENCODING_EQ_WINDOW=0` restores the
old behaviour exactly.

## Cleanup

- **Remove the dormant `OrderEncodingDeletion::Links` mode** — the superseded
  experiment, unselected by anything. Takes with it `ensure_order_chain_connected`, the
  `live_order_links` / `order_links_by_level` index, and `GCS_DELETE_ORDER_LINKS`.
  `building_order_link` goes too: its only reader was the Links branch, so the four
  Literals sites that set it were protecting nothing.
- **Rename the `_links_`-named machinery** — `forget_order_links_at_level`, which sweeps
  ge definitions, eq definitions and chain clauses and not one thing called a link,
  becomes `forget_order_encoding_at_level`.
- **Promote the two verified-foundation drivers to tests** — `order_jump_test` and
  `order_hoist_test`, with their must-fail controls running through a new
  `run_test_and_expect_rejection.bash` that asserts the rejection *message*, not just
  the exit code. Two things had to change to make them work against current code, both
  in the commit message; notably the `multi` hoist scenario needed a second hoist —
  measured, the inherited version still passed against a `move_proof_lines_to_level`
  mutated to `insert_at_end`.

## Oracle, as measured

- Caps-off suite **557/557** in each of {`None`, `Literals` gate 0, `Literals` gate 16},
  run twice: once for the cleanup commits, once with the window defaulted on.
- Cleanup commits: `.opb`/`.pbp` **byte-identical** to stage D's tip for every
  deterministic example in all three configurations — **75/75**, zero mismatches.
- Default flip: mode `None` byte-identical (25/25), and `Literals` at both gates
  byte-identical when the window is explicitly suppressed (25/25 each) — so the flip
  changes exactly what it claims to and nothing else.

Raw campaign data, scripts and logs under
`order-encoding-deletion-artifacts/stage-e/` (not version controlled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p