### PR TITLE
Divide, Modulus: split install() into the three phases

### DIFF
--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/divide_modulus/divide_modulus.hh>
 #include <gcs/constraints/divide_modulus/hints.hh>
+#include <gcs/constraints/divide_modulus/install_state.hh>
 #include <gcs/constraints/innards/arithmetic_utils.hh>
 #include <gcs/constraints/innards/linear_stages.hh>
 #include <gcs/constraints/innards/product_bounds.hh>
@@ -36,6 +37,9 @@
 
 using namespace gcs;
 using namespace gcs::innards;
+using namespace gcs::innards::divide_modulus;
+
+namespace pj = gcs::innards::product_justify;
 
 using std::make_shared;
 using std::make_unique;
@@ -54,49 +58,8 @@ using std::tuple;
 using std::unique_ptr;
 using std::vector;
 
-namespace
+namespace gcs::innards::divide_modulus
 {
-    // Is (x, y, q, r) in the truncated-division relation? That is, y is not
-    // zero, x / y = q rounding towards zero, and r is the remainder (which
-    // therefore takes the sign of x). Everything else in this file is
-    // scaffolding to propagate exactly this.
-    auto is_in_relation(Integer x, Integer y, Integer q, Integer r) -> bool
-    {
-        if (y == 0_i)
-            return false;
-        if (x.raw_value == numeric_limits<long long>::min() && y == -1_i)
-            return false;
-        return x.raw_value / y.raw_value == q.raw_value && x.raw_value % y.raw_value == r.raw_value;
-    }
-
-    // A non-negative magnitude STATE variable equal to |v|, channelled to v by cake's
-    // <letter>ge0/<letter>lt0 channel (four half-reified rows @c[id][<letter>{ge0,lt0}_{ge,le}])
-    // and carrying axis-<axis> free magnitude bits x[id][<axis>_*][bin]. mult_bc multiplies
-    // these magnitudes, so its operands are always non-negative.
-    struct CakeMagnitude
-    {
-        SimpleIntegerVariableID var;
-        Integer num_bits;
-        optional<ProofLine> pos_ge, pos_le, neg_ge, neg_le;
-    };
-
-    // The magnitude STATE variable and its bit count are allocated unconditionally so the
-    // propagation runs with or without proofs; the channel rows and bit registration are only
-    // emitted when there is a model (proofs on), leaving the channel lines nullopt otherwise.
-    auto make_cake_magnitude(ProofModel * const model, State & state, const ConstraintID & owner, IntegerVariableID v, long long axis,
-        const std::string & letter, const std::string & aux_name) -> CakeMagnitude
-    {
-        auto mag_ub = max(abs(state.lower_bound(v)), abs(state.upper_bound(v)));
-        auto bits = 0_i;
-        while (power2(bits) <= mag_ub)
-            bits += 1_i;
-        auto mag = state.allocate_integer_variable_with_state(0_i, power2(bits) - 1_i);
-        if (! model)
-            return {mag, bits, nullopt, nullopt, nullopt, nullopt};
-        auto chan = product_enc::emit_magnitude_channel(*model, owner, v, mag, power2(bits) - 1_i, axis, letter, aux_name + to_string(mag.index));
-        return {mag, bits, chan.pos_ge, chan.pos_le, chan.neg_ge, chan.neg_le};
-    }
-
     // Everything the default (cake) divide/modulus propagation shares with its
     // justifications: the two non-negative magnitude operands, their bit-product
     // grid, and the remainder/identity row handles. The product w = |q| * |y|
@@ -104,24 +67,10 @@ namespace
     // computes its interval locally each call, and every justification talks
     // about the grid sum directly through the rem/id rows, which contain it
     // verbatim (cake's no-materialised-remainder design).
-    // The local product interval, remembering which side established each
-    // bound so the justifications can rebuild exactly that chain.
-    enum class WSide
-    {
-        Mag,   // corner products of the magnitudes' bounds
-        XPos,  // through the [x>=0]-gated rem/id rows
-        XNeg,  // through the [x<1]-gated rem/id rows
-        XDisj, // x's sign undecided: the two gated rows' disjunction, resolved by sign cases
-    };
-
-    struct WInterval
-    {
-        Integer lo, hi;
-        WSide lo_side, hi_side;
-    };
-
-    namespace pj = gcs::innards::product_justify;
-
+    //
+    // Named rather than file-local because InstallState holds one: prepare()
+    // creates it, define_proof_model() fills in the line handles, and
+    // install_propagators() hands it to the propagator.
     struct DefaultProductData
     {
         SimpleIntegerVariableID mag_a{0}, mag_b{0}; // |q| (or the free quotient magnitude) and |y|
@@ -156,6 +105,64 @@ namespace
         map<tuple<bool, Integer, Integer>, ProofLine> mag_chain_lines;
         // filter grid bounds: (lower, target, excluded bound, other bound)
         map<tuple<bool, IntegerVariableID, Integer, Integer>, pj::ConditionalBound> filter_grid_lines;
+    };
+}
+
+namespace
+{
+    // Is (x, y, q, r) in the truncated-division relation? That is, y is not
+    // zero, x / y = q rounding towards zero, and r is the remainder (which
+    // therefore takes the sign of x). Everything else in this file is
+    // scaffolding to propagate exactly this.
+    auto is_in_relation(Integer x, Integer y, Integer q, Integer r) -> bool
+    {
+        if (y == 0_i)
+            return false;
+        if (x.raw_value == numeric_limits<long long>::min() && y == -1_i)
+            return false;
+        return x.raw_value / y.raw_value == q.raw_value && x.raw_value % y.raw_value == r.raw_value;
+    }
+
+    // prepare()'s half of a CakeMagnitude: the STATE variable and its bit count, sized
+    // from v's declared domain, so the propagation runs with or without proofs.
+    auto allocate_cake_magnitude(State & state, IntegerVariableID v) -> CakeMagnitude
+    {
+        auto mag_ub = max(abs(state.lower_bound(v)), abs(state.upper_bound(v)));
+        auto bits = 0_i;
+        while (power2(bits) <= mag_ub)
+            bits += 1_i;
+        auto mag = state.allocate_integer_variable_with_state(0_i, power2(bits) - 1_i);
+        return {mag, bits, nullopt, nullopt, nullopt, nullopt};
+    }
+
+    // define_proof_model()'s half: register the magnitude's bits and channel them to v,
+    // filling in the four line handles. Not called at all when proofs are off, so they
+    // stay nullopt and the stages built from them filter on their terms alone.
+    auto emit_cake_magnitude_channel(ProofModel & model, const ConstraintID & owner, IntegerVariableID v, CakeMagnitude & mag, long long axis,
+        const std::string & letter, const std::string & aux_name) -> void
+    {
+        auto chan = product_enc::emit_magnitude_channel(
+            model, owner, v, mag.var, power2(mag.num_bits) - 1_i, axis, letter, aux_name + to_string(mag.var.index));
+        mag.pos_ge = chan.pos_ge;
+        mag.pos_le = chan.pos_le;
+        mag.neg_ge = chan.neg_ge;
+        mag.neg_le = chan.neg_le;
+    }
+
+    // The local product interval, remembering which side established each
+    // bound so the justifications can rebuild exactly that chain.
+    enum class WSide
+    {
+        Mag,   // corner products of the magnitudes' bounds
+        XPos,  // through the [x>=0]-gated rem/id rows
+        XNeg,  // through the [x<1]-gated rem/id rows
+        XDisj, // x's sign undecided: the two gated rows' disjunction, resolved by sign cases
+    };
+
+    struct WInterval
+    {
+        Integer lo, hi;
+        WSide lo_side, hi_side;
     };
 
     // The per-pass cache for the x-side chain lines, at ProofLevel::Current
@@ -906,21 +913,28 @@ namespace
     // #483). Once the user's variables are fixed, the multiplication must pin
     // the unbranched auxiliary (or fail) by propagation alone, and the
     // quotient filtering does exactly that.
-    template <typename Hint_>
-    auto install_divide_modulus(const ConstraintID & owner, bool expose_quotient, const IntegerVariableID & x, const IntegerVariableID & y,
-        const IntegerVariableID & out, const std::variant<consistency::Auto, consistency::BC, consistency::Tabulated> & level,
-        Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> void
+    //
+    // The three install phases below are shared the same way, parameterised on
+    // which slot is exposed, with InstallState travelling between them.
+
+    // Read the declared domains: which slot is the auxiliary and how wide it is, the
+    // magnitude state variables the grid multiplies, and whether to tabulate.
+    auto prepare_divide_modulus(InstallState & st, bool expose_quotient, const IntegerVariableID & x, const IntegerVariableID & y,
+        const IntegerVariableID & out, const std::variant<consistency::Auto, consistency::BC, consistency::Tabulated> & level, State & initial_state)
+        -> void
     {
         auto ax = affine_of(x), ay = affine_of(y), aout = affine_of(out);
 
         auto [xlo, xhi] = initial_state.bounds(x);
 
         // A structurally constant zero divisor makes the whole constraint
-        // unsatisfiable, relationally rather than as an error.
+        // unsatisfiable, relationally rather than as an error: define_proof_model()
+        // writes the trivially false row and install_propagators() installs the
+        // contradiction initialiser. Nothing is allocated for it -- the propagator
+        // never runs, so its auxiliary and magnitudes would be dead slots deep-copied
+        // at every search node.
         if ((! ay.var) && ay.offset == 0_i) {
-            if (optional_model)
-                optional_model->add_constraint(WPBSum{} >= 1_i);
-            propagators.install_initial_contradiction("division by constant zero", JustifyUsingRUP{Hint_{owner}});
+            st.zero_divisor = true;
             return;
         }
 
@@ -928,261 +942,51 @@ namespace
         // |y| >= 1 whenever the relation holds at all).
         auto mx = max(xlo < 0_i ? -xlo : xlo, xhi < 0_i ? -xhi : xhi);
 
-        // Both routes emit cake_pb_cp's encoding: the product |q|*|y| lives only in the
-        // bit-product grid feeding the remainder/identity rows, with no w (and, for
-        // divide, no r) anywhere -- not in the OPB, not in the State, not in the proof.
-        // Both directions multiply the two NON-NEGATIVE magnitudes, split the
-        // identity/remainder on sign(x), and recover signed values in the tabulation -- a
-        // single magnitude machinery covering every sign of both operands, views and
-        // constants included: a constant operand's channel folds the constant into the
-        // rows and gates on its pinned n[k][...] atoms, exactly as cake encodes a
-        // constant slot (issue #483).
-        //
-        // Divide: the exposed slot is q. magq = |q| (a state var channelled to q by
-        // cake's Zge0/Zlt0 channel) and absy = |y| (channelled by Yge0/Ylt0) are the
-        // grid operands; cake's rem_* rows range 0 <= x - w < |y| over the grid sum and x
-        // directly (rem_pos gated [x>=0], rem_neg gated [x<1]), so no remainder is
-        // materialised at all. The exposed quotient's sign is pinned off the five sgn_*
-        // clauses by RUP in the propagator. The tabulation enumerates only x, y, q; a
-        // rejected leaf pins magq/absy by unit propagation from the assigned q, y and the
-        // rem rows refute it.
-        //
-        // Modulus: the exposed slot is r, and cake leaves the quotient's
-        // magnitude a FREE axis-0 bit-sum with no i[Q] channel (no Zge0/Zlt0, no sgn_*). The
-        // aux is the quotient magnitude |q|; absy = |y| is the second grid operand. cake
-        // splits the identity r = x -/+ |q||y| on sign(x), the range/sign rows bound r, and
-        // the tabulation recovers the signed quotient sign(x)sign(y)|q|.
-
-        // The exposed slot is the user's; the other is an auxiliary.
-        IntegerVariableID q = 0_c, r = 0_c;
-        SimpleIntegerVariableID aux = SimpleIntegerVariableID{0};
+        // The exposed slot is the user's; the other is an auxiliary. Allocation order is
+        // load-bearing: an auxiliary's index appears in its proof variable names.
         if (expose_quotient) {
-            q = out;
+            st.q = out;
             // The divide path materialises no remainder (neither in the OPB nor in the
             // proof): cake's rem_* rows range x - w directly, so the aux is an inert state
             // slot, never introduced, enumerated, or meaningfully watched.
-            aux = initial_state.allocate_integer_variable_with_state(0_i, 0_i);
-            r = aux;
+            st.aux = initial_state.allocate_integer_variable_with_state(0_i, 0_i);
         }
         else {
-            r = out;
             // The aux is the quotient MAGNITUDE |q|, a free axis-0 bit-sum sized by the
             // dividend's magnitude (|q| <= |x| since |y| >= 1). Its provable range is the
-            // bit-implied [0, 2^n - 1]; give the state that range (like divide's product w)
-            // and register its bits in cake's x[id][0_*][bin] naming with no OPB bounds, so
-            // they ARE the magnitude the bit products multiply. The signed quotient is never
-            // materialised: the propagation is in magnitude space and the tabulation recovers
-            // sign(x)sign(y)|q| for its relation check.
+            // bit-implied [0, 2^n - 1]; give the state that range (like divide's product w),
+            // and define_proof_model() registers its bits in cake's x[id][0_*][bin] naming
+            // with no OPB bounds, so they ARE the magnitude the bit products multiply. The
+            // signed quotient is never materialised: the propagation is in magnitude space
+            // and the tabulation recovers sign(x)sign(y)|q| for its relation check.
             auto q_bits = 0_i;
             while (power2(q_bits) <= mx)
                 q_bits += 1_i;
-            auto q_bit_max = power2(q_bits) - 1_i;
-            aux = initial_state.allocate_integer_variable_with_state(0_i, q_bit_max);
-            if (optional_model)
-                optional_model->register_state_variable_bits_in_proof(
-                    aux, 0_i, q_bit_max, "aux_modulus_quotient" + to_string(aux.index), CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
-            q = aux;
+            st.aux_bit_max = power2(q_bits) - 1_i;
+            st.aux = initial_state.allocate_integer_variable_with_state(0_i, st.aux_bit_max);
+            st.q = st.aux;
         }
 
-        shared_ptr<DefaultProductData> default_data;
-        shared_ptr<vector<LinearStage>> default_stages;
+        st.data = make_shared<DefaultProductData>();
+        st.data->x = x;
+        st.data->y = y;
 
         if (expose_quotient) {
-            // Divide, any sign of the dividend. BOTH the x >= 0 and x < 0 remainder rows
-            // are live, each gated on sign(x) so only the matching regime fires once x is
-            // branched. The quotient's sign is pinned off the sgn_* clauses (for whichever
-            // signs of x and y are established). No remainder is materialised, and neither
-            // is the product w = |q||y|: cake's rem_* rows range x against the bit-product
-            // grid sum directly, the propagator computes w's interval locally each call,
-            // and the justifications cite the rows and the grid (no in-proof
-            // reformulation). The tabulation enumerates only x, y, q.
-            auto q_eff = q, y_eff = y, x_eff = x;
-
             // magq = |q| (Z channel to the exposed quotient) and absy = |y| (channelled by
             // Yge0/Ylt0) are the two non-negative grid operands. The magnitude state vars
             // are allocated regardless of proofs.
-            auto zchan = make_cake_magnitude(optional_model, initial_state, owner, q_eff, 0, "Z", "aux_divide_qmag");
-            auto ychan = make_cake_magnitude(optional_model, initial_state, owner, y_eff, 1, "Y", "aux_divide_absdivisor");
-            auto magq = zchan.var, absy = ychan.var;
-
-            default_data = make_shared<DefaultProductData>();
-            default_data->mag_a = magq;
-            default_data->mag_b = absy;
-            default_data->x = x_eff;
-            default_data->y = y_eff;
-            default_data->ychan_pos_ge = ychan.pos_ge;
-            default_data->ychan_neg_le = ychan.neg_le;
-
-            // Stages: just the magq (0-3) and absy (4-7) channels; the x/product coupling
-            // lives in propagate_default_product.
-            default_stages = make_shared<vector<LinearStage>>();
-            append_magnitude_stages(*default_stages, magq, q_eff, zchan, 0_i);
-            append_magnitude_stages(*default_stages, absy, y_eff, ychan, 1_i);
-
-            if (optional_model) {
-                default_data->grid = product_enc::emit_bit_product_grid(*optional_model, owner, magq, absy, product_enc::LinkNaming{});
-                const auto & product_sum = default_data->grid.sum;
-                const auto & neg_product = default_data->grid.neg_sum;
-
-                auto xa = operand_sign_atoms(*optional_model, x);
-                auto ya = operand_sign_atoms(*optional_model, y);
-                auto qa = operand_sign_atoms(*optional_model, q);
-
-                // Both remainder-row sets: 0 <= x - |q||y| < |y| (rem_pos, gated [x>=0]) and
-                // 0 <= -x - |q||y| < |y| (rem_neg, gated [x<1]).
-                default_data->rem_pos_lo =
-                    optional_model->add_labelled_constraint(owner, "rem_pos_lo", neg_product + 1_i * x_eff >= 0_i, xa.ge0_gate);
-                default_data->rem_pos_hi =
-                    optional_model->add_labelled_constraint(owner, "rem_pos_hi", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xa.ge0_gate);
-                default_data->rem_neg_hi =
-                    optional_model->add_labelled_constraint(owner, "rem_neg_hi", neg_product + -1_i * x_eff >= 0_i, xa.lt1_gate);
-                default_data->rem_neg_lo =
-                    optional_model->add_labelled_constraint(owner, "rem_neg_lo", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xa.lt1_gate);
-
-                optional_model->add_labelled_constraint(owner, "sgn_pp", WPBSum{} + 1_i * xa.lt1 + 1_i * ya.lt1 + 1_i * qa.ge0 >= 1_i);
-                optional_model->add_labelled_constraint(owner, "sgn_nn", WPBSum{} + 1_i * xa.ge0 + 1_i * ya.ge0 + 1_i * qa.ge0 >= 1_i);
-                optional_model->add_labelled_constraint(owner, "sgn_pn", WPBSum{} + 1_i * xa.lt1 + 1_i * ya.ge0 + 1_i * qa.lt1 >= 1_i);
-                optional_model->add_labelled_constraint(owner, "sgn_np", WPBSum{} + 1_i * xa.ge0 + 1_i * ya.lt1 + 1_i * qa.lt1 >= 1_i);
-                optional_model->add_labelled_constraint(owner, "sgn_x0", WPBSum{} + 1_i * xa.ne0 + 1_i * qa.lt1 >= 1_i);
-                optional_model->add_labelled_constraint(owner, "nonzero", WPBSum{} + 1_i * ya.ge1 + 1_i * ya.lt0 >= 1_i);
-            }
+            st.quotient_mag = allocate_cake_magnitude(initial_state, st.q);
+            st.divisor_mag = allocate_cake_magnitude(initial_state, y);
+            st.data->mag_a = st.quotient_mag.var;
+            st.data->mag_b = st.divisor_mag.var;
         }
         else {
-            // The default modulus path: the exposed slot is r; the quotient magnitude |q| (the
-            // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, pinned to |y| by
-            // cake's Yge0/Ylt0 channel) multiply through the bit-product grid. The identity
-            // splits on sign(x): r = x - Sum off id_pos_* (gated [x>=0]) and r = x + Sum off
-            // id_neg_* (gated [x<0]); the range/sign rows bound 0 <= r < |y| (x>=0) or
-            // -|y| < r <= 0 (x<0). Both grid operands are non-negative, so the quotient
-            // filtering needs no signed reasoning. The product w = |q||y| exists nowhere:
-            // the propagator computes its interval locally from the magnitudes and from
-            // x and r through the identity rows, and the justifications cite those rows
-            // and the grid directly.
-            //
-            // r and the operands are the plain underlying *aout.var / *a*.var, not view
-            // wrappers: the identity inferences propagate the exposed r off the wide grid
-            // interval, and deviewing that defeats the reverse unit propagation.
-            auto y_eff = y, x_eff = x, r_eff = out;
-            auto q_eff = aux; // the free quotient magnitude
-
-            auto ychan = make_cake_magnitude(optional_model, initial_state, owner, y_eff, 1, "Y", "aux_modulus_absdivisor");
-            auto absy = ychan.var;
-
-            default_data = make_shared<DefaultProductData>();
-            default_data->mag_a = q_eff;
-            default_data->mag_b = absy;
-            default_data->x = x_eff;
-            default_data->y = y_eff;
-            default_data->ychan_pos_ge = ychan.pos_ge;
-            default_data->ychan_neg_le = ychan.neg_le;
-
-            // The range/sign OPB lines feed their stages below; they exist only proofs-on, so
-            // the stages carry nullopt lines (and filter on their terms) proofs-off.
-            optional<ProofLine> rng_hi, rng_lo, sgn_pos, sgn_neg;
-            default_stages = make_shared<vector<LinearStage>>();
-
-            if (optional_model) {
-                default_data->grid = product_enc::emit_bit_product_grid(*optional_model, owner, q_eff, absy, product_enc::LinkNaming{});
-                const auto & product_sum = default_data->grid.sum;
-                const auto & neg_product = default_data->grid.neg_sum;
-
-                auto xa = operand_sign_atoms(*optional_model, x);
-                auto ya = operand_sign_atoms(*optional_model, y);
-
-                optional_model->add_labelled_constraint(owner, "nonzero", WPBSum{} + 1_i * ya.ge1 + 1_i * ya.lt0 >= 1_i);
-
-                // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0], r = x - Sum) and
-                // id_neg_* (gated [x<0], r = x + Sum -- since for x < 0 the quotient product
-                // q*y has sign(x), i.e. q*y = -Sum).
-                default_data->id_pos_ge =
-                    optional_model->add_labelled_constraint(owner, "id_pos_ge", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xa.ge0_gate);
-                default_data->id_pos_le =
-                    optional_model->add_labelled_constraint(owner, "id_pos_le", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xa.ge0_gate);
-                default_data->id_neg_ge =
-                    optional_model->add_labelled_constraint(owner, "id_neg_ge", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xa.lt1_gate);
-                default_data->id_neg_le =
-                    optional_model->add_labelled_constraint(owner, "id_neg_le", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xa.lt1_gate);
-
-                // |r| < |y| = absy: rng_hi (r < absy) and rng_lo (r > -absy), plus the r-sign
-                // rows (r takes x's sign; sgn_pos gated [x>=0], sgn_neg gated [x<0]).
-                rng_hi = optional_model->add_labelled_constraint(owner, "rng_hi", WPBSum{} + -1_i * r_eff + 1_i * absy >= 1_i);
-                rng_lo = optional_model->add_labelled_constraint(owner, "rng_lo", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
-                sgn_pos = optional_model->add_labelled_constraint(owner, "sgn_pos", WPBSum{} + 1_i * r_eff >= 0_i, xa.ge0_gate);
-                sgn_neg = optional_model->add_labelled_constraint(owner, "sgn_neg", WPBSum{} + -1_i * r_eff >= 0_i, xa.lt1_gate);
-            }
-
-            // Stages (built regardless of proofs): the range 0 <= r < absy (x>=0) /
-            // -absy < r <= 0 (x<0) via rng_hi/rng_lo (ungated, valid for either sign), the
-            // r-sign stages sgn_pos/sgn_neg, and absy = |y| off the Yge0/Ylt0 channel. The
-            // identity coupling of r, x and the grid lives in propagate_default_product.
-            auto [t_rhi, m_rhi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff + -1_i * absy);
-            default_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {rng_hi, nullopt}, nullopt});
-            auto [t_rlo, m_rlo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff + -1_i * absy);
-            default_stages->emplace_back(LinearStage{t_rlo, -1_i + m_rlo, false, {rng_lo, nullopt}, nullopt});
-            auto [t_slo, m_slo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff);
-            default_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {sgn_pos, nullopt}, optional{x_eff >= 0_i}});
-            auto [t_shi, m_shi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff);
-            default_stages->emplace_back(LinearStage{t_shi, 0_i + m_shi, false, {sgn_neg, nullopt}, optional{x_eff < 1_i}});
-            // absy = |y| off the Y channel, split on sign(y).
-            append_magnitude_stages(*default_stages, absy, y_eff, ychan, 1_i);
+            // The quotient magnitude is the aux itself, a free bit-sum with no channel;
+            // only the divisor gets one.
+            st.divisor_mag = allocate_cake_magnitude(initial_state, y);
+            st.data->mag_a = st.aux;
+            st.data->mag_b = st.divisor_mag.var;
         }
-
-        Triggers triggers;
-        vector<IntegerVariableID> watched;
-        auto watch = [&](const IntegerVariableID & v) {
-            if (! holds_alternative<ConstantIntegerVariableID>(v) && std::find(watched.begin(), watched.end(), v) == watched.end())
-                watched.push_back(v);
-        };
-        watch(x);
-        watch(y);
-        watch(out);
-        watch(aux);
-        watch(default_data->mag_a);
-        watch(default_data->mag_b);
-        triggers.on_bounds = watched;
-
-        propagators.install(
-            owner,
-            [data = default_data, stg = default_stages, y = y, q = q, x = x, pin_q_sign = expose_quotient,
-                modulus_r = expose_quotient ? optional<IntegerVariableID>{} : optional{out},
-                owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                do {
-                    if (state.in_domain(y, 0_i))
-                        inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
-
-                    if (pin_q_sign) {
-                        // The grid carries no signed reasoning, so the exposed quotient's
-                        // sign is pinned off the sgn_* clauses by RUP once the signs of x
-                        // and y are both established. sgn_pp: x>0 & y>0 -> q>=0; sgn_pn:
-                        // x>0 & y<0 -> q<=0; sgn_nn: x<0 & y<0 -> q>=0; sgn_np: x<0 & y>0
-                        // -> q<=0.
-                        if (state.lower_bound(x) >= 1_i) {
-                            if (state.lower_bound(y) >= 1_i && state.lower_bound(q) < 0_i)
-                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y >= 1_i}});
-                            else if (state.upper_bound(y) < 0_i && state.upper_bound(q) > 0_i)
-                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y < 0_i}});
-                        }
-                        else if (state.upper_bound(x) < 0_i) {
-                            if (state.upper_bound(y) < 0_i && state.lower_bound(q) < 0_i)
-                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y < 0_i}});
-                            else if (state.lower_bound(y) >= 1_i && state.upper_bound(q) > 0_i)
-                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y >= 1_i}});
-                        }
-                    }
-
-                    if (! propagate_stages(*stg, state, inference, logger, owner))
-                        return PropagatorState::Enable;
-
-                    propagate_default_product<Hint_>(*data, modulus_r, state, inference, logger, owner);
-                } while (inference.made_progress_since_last_check());
-
-                // Idempotent: the do-while ran the stages (and the default product)
-                // to quiescence, so an immediate re-run is one no-op pass (see
-                // multiply.cc for the same argument). The mid-loop return above is
-                // the contradiction path and its state is ignored.
-                return PropagatorState::EnableButIdempotent;
-            },
-            triggers);
 
         // Tabulation for GAC: enumerate the distinct underlying variables and
         // the auxiliary slot, so a complete assignment fixes x, y, q and r and
@@ -1200,7 +1004,7 @@ namespace
         // sign(x)sign(y)|q| (a magnitude 0 keeps sign 0).
         std::size_t paux = 0;
         if (! expose_quotient)
-            paux = enum_vars.position_of(aux);
+            paux = enum_vars.position_of(st.aux);
 
         auto recover_q = [](Integer auxv, Integer xv, Integer yv) -> Integer { return ((xv >= 0_i) != (yv >= 0_i)) ? -auxv : auxv; };
 
@@ -1248,9 +1052,237 @@ namespace
                 return is_in_relation(xv, yv, recover_q(vals[paux], xv, yv), outv);
             };
 
-            install_tabulation<Hint_>(propagators, owner, enum_vars.vars(), move(determined), nullopt, accept, expose_quotient ? "divtab" : "modtab",
-                expose_quotient ? "building GAC table for division" : "building GAC table for modulus");
+            st.tabulation = TabulationPlan{enum_vars.vars(), move(determined), accept};
         }
+    }
+
+    // Both routes emit cake_pb_cp's encoding: the product |q|*|y| lives only in the
+    // bit-product grid feeding the remainder/identity rows, with no w (and, for
+    // divide, no r) anywhere -- not in the OPB, not in the State, not in the proof.
+    // Both directions multiply the two NON-NEGATIVE magnitudes, split the
+    // identity/remainder on sign(x), and recover signed values in the tabulation -- a
+    // single magnitude machinery covering every sign of both operands, views and
+    // constants included: a constant operand's channel folds the constant into the
+    // rows and gates on its pinned n[k][...] atoms, exactly as cake encodes a
+    // constant slot (issue #483).
+    //
+    // Divide: the exposed slot is q. magq = |q| (a state var channelled to q by
+    // cake's Zge0/Zlt0 channel) and absy = |y| (channelled by Yge0/Ylt0) are the
+    // grid operands; cake's rem_* rows range 0 <= x - w < |y| over the grid sum and x
+    // directly (rem_pos gated [x>=0], rem_neg gated [x<1]), so no remainder is
+    // materialised at all. The exposed quotient's sign is pinned off the five sgn_*
+    // clauses by RUP in the propagator. The tabulation enumerates only x, y, q; a
+    // rejected leaf pins magq/absy by unit propagation from the assigned q, y and the
+    // rem rows refute it.
+    //
+    // Modulus: the exposed slot is r, and cake leaves the quotient's
+    // magnitude a FREE axis-0 bit-sum with no i[Q] channel (no Zge0/Zlt0, no sgn_*). The
+    // aux is the quotient magnitude |q|; absy = |y| is the second grid operand. cake
+    // splits the identity r = x -/+ |q||y| on sign(x), the range/sign rows bound r, and
+    // the tabulation recovers the signed quotient sign(x)sign(y)|q|.
+    auto define_proof_model_divide_modulus(InstallState & st, const ConstraintID & owner, bool expose_quotient, const IntegerVariableID & x,
+        const IntegerVariableID & y, const IntegerVariableID & out, ProofModel & model) -> void
+    {
+        if (st.zero_divisor) {
+            // Morally what an empty divisor domain encodes.
+            model.add_constraint(WPBSum{} >= 1_i);
+            return;
+        }
+
+        if (expose_quotient) {
+            // Divide, any sign of the dividend. BOTH the x >= 0 and x < 0 remainder rows
+            // are live, each gated on sign(x) so only the matching regime fires once x is
+            // branched. The quotient's sign is pinned off the sgn_* clauses (for whichever
+            // signs of x and y are established). No remainder is materialised, and neither
+            // is the product w = |q||y|: cake's rem_* rows range x against the bit-product
+            // grid sum directly, the propagator computes w's interval locally each call,
+            // and the justifications cite the rows and the grid (no in-proof
+            // reformulation). The tabulation enumerates only x, y, q.
+            auto q_eff = st.q, y_eff = y, x_eff = x;
+
+            emit_cake_magnitude_channel(model, owner, q_eff, st.quotient_mag, 0, "Z", "aux_divide_qmag");
+            emit_cake_magnitude_channel(model, owner, y_eff, st.divisor_mag, 1, "Y", "aux_divide_absdivisor");
+            auto magq = st.quotient_mag.var, absy = st.divisor_mag.var;
+            st.data->ychan_pos_ge = st.divisor_mag.pos_ge;
+            st.data->ychan_neg_le = st.divisor_mag.neg_le;
+
+            st.data->grid = product_enc::emit_bit_product_grid(model, owner, magq, absy, product_enc::LinkNaming{});
+            const auto & product_sum = st.data->grid.sum;
+            const auto & neg_product = st.data->grid.neg_sum;
+
+            auto xa = operand_sign_atoms(model, x);
+            auto ya = operand_sign_atoms(model, y);
+            auto qa = operand_sign_atoms(model, st.q);
+
+            // Both remainder-row sets: 0 <= x - |q||y| < |y| (rem_pos, gated [x>=0]) and
+            // 0 <= -x - |q||y| < |y| (rem_neg, gated [x<1]).
+            st.data->rem_pos_lo = model.add_labelled_constraint(owner, "rem_pos_lo", neg_product + 1_i * x_eff >= 0_i, xa.ge0_gate);
+            st.data->rem_pos_hi = model.add_labelled_constraint(owner, "rem_pos_hi", product_sum + -1_i * x_eff + 1_i * absy >= 1_i, xa.ge0_gate);
+            st.data->rem_neg_hi = model.add_labelled_constraint(owner, "rem_neg_hi", neg_product + -1_i * x_eff >= 0_i, xa.lt1_gate);
+            st.data->rem_neg_lo = model.add_labelled_constraint(owner, "rem_neg_lo", product_sum + 1_i * x_eff + 1_i * absy >= 1_i, xa.lt1_gate);
+
+            model.add_labelled_constraint(owner, "sgn_pp", WPBSum{} + 1_i * xa.lt1 + 1_i * ya.lt1 + 1_i * qa.ge0 >= 1_i);
+            model.add_labelled_constraint(owner, "sgn_nn", WPBSum{} + 1_i * xa.ge0 + 1_i * ya.ge0 + 1_i * qa.ge0 >= 1_i);
+            model.add_labelled_constraint(owner, "sgn_pn", WPBSum{} + 1_i * xa.lt1 + 1_i * ya.ge0 + 1_i * qa.lt1 >= 1_i);
+            model.add_labelled_constraint(owner, "sgn_np", WPBSum{} + 1_i * xa.ge0 + 1_i * ya.lt1 + 1_i * qa.lt1 >= 1_i);
+            model.add_labelled_constraint(owner, "sgn_x0", WPBSum{} + 1_i * xa.ne0 + 1_i * qa.lt1 >= 1_i);
+            model.add_labelled_constraint(owner, "nonzero", WPBSum{} + 1_i * ya.ge1 + 1_i * ya.lt0 >= 1_i);
+        }
+        else {
+            // The default modulus path: the exposed slot is r; the quotient magnitude |q| (the
+            // aux, axis-0 free magnitude) and the divisor magnitude |y| (absy, pinned to |y| by
+            // cake's Yge0/Ylt0 channel) multiply through the bit-product grid. The identity
+            // splits on sign(x): r = x - Sum off id_pos_* (gated [x>=0]) and r = x + Sum off
+            // id_neg_* (gated [x<0]); the range/sign rows bound 0 <= r < |y| (x>=0) or
+            // -|y| < r <= 0 (x<0). Both grid operands are non-negative, so the quotient
+            // filtering needs no signed reasoning. The product w = |q||y| exists nowhere:
+            // the propagator computes its interval locally from the magnitudes and from
+            // x and r through the identity rows, and the justifications cite those rows
+            // and the grid directly.
+            //
+            // r and the operands are the plain underlying *aout.var / *a*.var, not view
+            // wrappers: the identity inferences propagate the exposed r off the wide grid
+            // interval, and deviewing that defeats the reverse unit propagation.
+            auto y_eff = y, x_eff = x, r_eff = out;
+            auto q_eff = st.aux; // the free quotient magnitude
+
+            model.register_state_variable_bits_in_proof(st.aux, 0_i, st.aux_bit_max, "aux_modulus_quotient" + to_string(st.aux.index),
+                CakeBitNaming{owner, {0}, "bin", nullopt, false, true});
+
+            emit_cake_magnitude_channel(model, owner, y_eff, st.divisor_mag, 1, "Y", "aux_modulus_absdivisor");
+            auto absy = st.divisor_mag.var;
+            st.data->ychan_pos_ge = st.divisor_mag.pos_ge;
+            st.data->ychan_neg_le = st.divisor_mag.neg_le;
+
+            st.data->grid = product_enc::emit_bit_product_grid(model, owner, q_eff, absy, product_enc::LinkNaming{});
+            const auto & product_sum = st.data->grid.sum;
+            const auto & neg_product = st.data->grid.neg_sum;
+
+            auto xa = operand_sign_atoms(model, x);
+            auto ya = operand_sign_atoms(model, y);
+
+            model.add_labelled_constraint(owner, "nonzero", WPBSum{} + 1_i * ya.ge1 + 1_i * ya.lt0 >= 1_i);
+
+            // r = x - |q||y|, split on sign(x): id_pos_* (gated [x>=0], r = x - Sum) and
+            // id_neg_* (gated [x<0], r = x + Sum -- since for x < 0 the quotient product
+            // q*y has sign(x), i.e. q*y = -Sum).
+            st.data->id_pos_ge = model.add_labelled_constraint(owner, "id_pos_ge", neg_product + 1_i * x_eff + -1_i * r_eff >= 0_i, xa.ge0_gate);
+            st.data->id_pos_le = model.add_labelled_constraint(owner, "id_pos_le", product_sum + -1_i * x_eff + 1_i * r_eff >= 0_i, xa.ge0_gate);
+            st.data->id_neg_ge = model.add_labelled_constraint(owner, "id_neg_ge", neg_product + -1_i * x_eff + 1_i * r_eff >= 0_i, xa.lt1_gate);
+            st.data->id_neg_le = model.add_labelled_constraint(owner, "id_neg_le", product_sum + 1_i * x_eff + -1_i * r_eff >= 0_i, xa.lt1_gate);
+
+            // |r| < |y| = absy: rng_hi (r < absy) and rng_lo (r > -absy), plus the r-sign
+            // rows (r takes x's sign; sgn_pos gated [x>=0], sgn_neg gated [x<0]). They feed
+            // stages built in install_propagators(), which must exist proofs-off too.
+            st.rng_hi = model.add_labelled_constraint(owner, "rng_hi", WPBSum{} + -1_i * r_eff + 1_i * absy >= 1_i);
+            st.rng_lo = model.add_labelled_constraint(owner, "rng_lo", WPBSum{} + 1_i * r_eff + 1_i * absy >= 1_i);
+            st.sgn_pos = model.add_labelled_constraint(owner, "sgn_pos", WPBSum{} + 1_i * r_eff >= 0_i, xa.ge0_gate);
+            st.sgn_neg = model.add_labelled_constraint(owner, "sgn_neg", WPBSum{} + -1_i * r_eff >= 0_i, xa.lt1_gate);
+        }
+    }
+
+    // Build the stages, then install the one propagator running them and the default
+    // product, and the tabulation prepare() decided on. The stages are built here
+    // rather than alongside the rows they cite because they must exist with proofs
+    // off, where those line handles are nullopt and the stages filter on their terms
+    // alone.
+    template <typename Hint_>
+    auto install_propagators_divide_modulus(InstallState & st, const ConstraintID & owner, bool expose_quotient, const IntegerVariableID & x,
+        const IntegerVariableID & y, const IntegerVariableID & out, Propagators & propagators) -> void
+    {
+        if (st.zero_divisor) {
+            propagators.install_initial_contradiction("division by constant zero", JustifyUsingRUP{Hint_{owner}});
+            return;
+        }
+
+        auto default_stages = make_shared<vector<LinearStage>>();
+
+        if (expose_quotient) {
+            // Stages: just the magq (0-3) and absy (4-7) channels; the x/product coupling
+            // lives in propagate_default_product.
+            append_magnitude_stages(*default_stages, st.quotient_mag.var, st.q, st.quotient_mag, 0_i);
+            append_magnitude_stages(*default_stages, st.divisor_mag.var, y, st.divisor_mag, 1_i);
+        }
+        else {
+            // Stages: the range 0 <= r < absy (x>=0) / -absy < r <= 0 (x<0) via
+            // rng_hi/rng_lo (ungated, valid for either sign), the r-sign stages
+            // sgn_pos/sgn_neg, and absy = |y| off the Yge0/Ylt0 channel. The identity
+            // coupling of r, x and the grid lives in propagate_default_product.
+            auto r_eff = out, x_eff = x, y_eff = y;
+            auto absy = st.divisor_mag.var;
+            auto [t_rhi, m_rhi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff + -1_i * absy);
+            default_stages->emplace_back(LinearStage{t_rhi, -1_i + m_rhi, false, {st.rng_hi, nullopt}, nullopt});
+            auto [t_rlo, m_rlo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff + -1_i * absy);
+            default_stages->emplace_back(LinearStage{t_rlo, -1_i + m_rlo, false, {st.rng_lo, nullopt}, nullopt});
+            auto [t_slo, m_slo] = tidy_up_linear(WeightedSum{} + -1_i * r_eff);
+            default_stages->emplace_back(LinearStage{t_slo, 0_i + m_slo, false, {st.sgn_pos, nullopt}, optional{x_eff >= 0_i}});
+            auto [t_shi, m_shi] = tidy_up_linear(WeightedSum{} + 1_i * r_eff);
+            default_stages->emplace_back(LinearStage{t_shi, 0_i + m_shi, false, {st.sgn_neg, nullopt}, optional{x_eff < 1_i}});
+            // absy = |y| off the Y channel, split on sign(y).
+            append_magnitude_stages(*default_stages, absy, y_eff, st.divisor_mag, 1_i);
+        }
+
+        Triggers triggers;
+        vector<IntegerVariableID> watched;
+        auto watch = [&](const IntegerVariableID & v) {
+            if (! holds_alternative<ConstantIntegerVariableID>(v) && std::find(watched.begin(), watched.end(), v) == watched.end())
+                watched.push_back(v);
+        };
+        watch(x);
+        watch(y);
+        watch(out);
+        watch(st.aux);
+        watch(st.data->mag_a);
+        watch(st.data->mag_b);
+        triggers.on_bounds = watched;
+
+        propagators.install(
+            owner,
+            [data = st.data, stg = default_stages, y = y, q = st.q, x = x, pin_q_sign = expose_quotient,
+                modulus_r = expose_quotient ? optional<IntegerVariableID>{} : optional{out},
+                owner = owner](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                do {
+                    if (state.in_domain(y, 0_i))
+                        inference.infer(logger, y != 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{}});
+
+                    if (pin_q_sign) {
+                        // The grid carries no signed reasoning, so the exposed quotient's
+                        // sign is pinned off the sgn_* clauses by RUP once the signs of x
+                        // and y are both established. sgn_pp: x>0 & y>0 -> q>=0; sgn_pn:
+                        // x>0 & y<0 -> q<=0; sgn_nn: x<0 & y<0 -> q>=0; sgn_np: x<0 & y>0
+                        // -> q<=0.
+                        if (state.lower_bound(x) >= 1_i) {
+                            if (state.lower_bound(y) >= 1_i && state.lower_bound(q) < 0_i)
+                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y >= 1_i}});
+                            else if (state.upper_bound(y) < 0_i && state.upper_bound(q) > 0_i)
+                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x >= 1_i, y < 0_i}});
+                        }
+                        else if (state.upper_bound(x) < 0_i) {
+                            if (state.upper_bound(y) < 0_i && state.lower_bound(q) < 0_i)
+                                inference.infer(logger, q >= 0_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y < 0_i}});
+                            else if (state.lower_bound(y) >= 1_i && state.upper_bound(q) > 0_i)
+                                inference.infer(logger, q < 1_i, JustifyUsingRUP{Hint_{owner}}, ExplicitReason{ReasonLiterals{x < 0_i, y >= 1_i}});
+                        }
+                    }
+
+                    if (! propagate_stages(*stg, state, inference, logger, owner))
+                        return PropagatorState::Enable;
+
+                    propagate_default_product<Hint_>(*data, modulus_r, state, inference, logger, owner);
+                } while (inference.made_progress_since_last_check());
+
+                // Idempotent: the do-while ran the stages (and the default product)
+                // to quiescence, so an immediate re-run is one no-op pass (see
+                // multiply.cc for the same argument). The mid-loop return above is
+                // the contradiction path and its state is ignored.
+                return PropagatorState::EnableButIdempotent;
+            },
+            triggers);
+
+        if (st.tabulation)
+            install_tabulation<Hint_>(propagators, owner, move(st.tabulation->enum_vars), move(st.tabulation->determined), nullopt,
+                move(st.tabulation->accept), expose_quotient ? "divtab" : "modtab",
+                expose_quotient ? "building GAC table for division" : "building GAC table for modulus");
     }
 }
 
@@ -1271,9 +1303,31 @@ auto Divide::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
+auto Divide::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    prepare_divide_modulus(_install, true, _x, _y, _quotient, _level, initial_state);
+    return true;
+}
+
+auto Divide::define_proof_model(ProofModel & model, const State &) -> void
+{
+    define_proof_model_divide_modulus(_install, constraint_id(), true, _x, _y, _quotient, model);
+}
+
+auto Divide::install_propagators(Propagators & propagators) -> void
+{
+    install_propagators_divide_modulus<hints::Divide>(_install, constraint_id(), true, _x, _y, _quotient, propagators);
+}
+
 auto Divide::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    install_divide_modulus<hints::Divide>(constraint_id(), true, _x, _y, _quotient, _level, propagators, initial_state, optional_model);
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
 }
 
 auto Divide::constraint_type() const -> std::string
@@ -1306,9 +1360,31 @@ auto Modulus::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
+auto Modulus::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
+{
+    prepare_divide_modulus(_install, false, _x, _y, _remainder, _level, initial_state);
+    return true;
+}
+
+auto Modulus::define_proof_model(ProofModel & model, const State &) -> void
+{
+    define_proof_model_divide_modulus(_install, constraint_id(), false, _x, _y, _remainder, model);
+}
+
+auto Modulus::install_propagators(Propagators & propagators) -> void
+{
+    install_propagators_divide_modulus<hints::Modulus>(_install, constraint_id(), false, _x, _y, _remainder, propagators);
+}
+
 auto Modulus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
 {
-    install_divide_modulus<hints::Modulus>(constraint_id(), false, _x, _y, _remainder, _level, propagators, initial_state, optional_model);
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
 }
 
 auto Modulus::constraint_type() const -> std::string

--- a/gcs/constraints/divide_modulus/divide_modulus.hh
+++ b/gcs/constraints/divide_modulus/divide_modulus.hh
@@ -3,6 +3,7 @@
 
 #include <gcs/consistency.hh>
 #include <gcs/constraint.hh>
+#include <gcs/constraints/divide_modulus/install_state.hh>
 #include <gcs/variable_id.hh>
 
 #include <variant>
@@ -56,6 +57,14 @@ namespace gcs
         IntegerVariableID _x, _y, _quotient;
         DivideConsistency _level = consistency::Auto{};
 
+        // The shared decomposition's install-time working state; the three phases
+        // themselves are shared code too, parameterised on the exposed slot.
+        innards::divide_modulus::InstallState _install;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
     public:
         explicit Divide(IntegerVariableID x, IntegerVariableID y, IntegerVariableID quotient);
 
@@ -87,6 +96,13 @@ namespace gcs
     private:
         IntegerVariableID _x, _y, _remainder;
         ModulusConsistency _level = consistency::Auto{};
+
+        // As for Divide: the same three shared phases, with r exposed instead of q.
+        innards::divide_modulus::InstallState _install;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Modulus(IntegerVariableID x, IntegerVariableID y, IntegerVariableID remainder);

--- a/gcs/constraints/divide_modulus/install_state.hh
+++ b/gcs/constraints/divide_modulus/install_state.hh
@@ -1,0 +1,79 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIVIDE_MODULUS_INSTALL_STATE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_DIVIDE_MODULUS_INSTALL_STATE_HH
+
+#include <gcs/constraints/innards/tabulation.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <memory>
+#include <optional>
+
+namespace gcs::innards::divide_modulus
+{
+    /**
+     * \brief A non-negative magnitude STATE variable equal to |v|, channelled to v
+     * by cake's <letter>ge0/<letter>lt0 channel (four half-reified rows
+     * @c[id][<letter>{ge0,lt0}_{ge,le}]) and carrying axis-<axis> free magnitude
+     * bits x[id][<axis>_*][bin]. mult_bc multiplies these magnitudes, so its
+     * operands are always non-negative.
+     *
+     * The variable and its bit count are allocated by prepare(), so the
+     * propagation runs with or without proofs; the four line handles are filled in
+     * by define_proof_model(), and stay empty when proofs are off.
+     *
+     * \ingroup Innards
+     */
+    struct CakeMagnitude
+    {
+        SimpleIntegerVariableID var{0};
+        Integer num_bits = 0_i;
+        std::optional<ProofLine> pos_ge, pos_le, neg_ge, neg_le;
+    };
+
+    /// Everything the propagator and its justifications share; defined in divide_modulus.cc.
+    struct DefaultProductData;
+
+    /**
+     * \brief What prepare() works out for Divide and Modulus, and the other two
+     * phases consume.
+     *
+     * Divide and Modulus are one decomposition with the exposed slot swapped, so
+     * all three phases are shared code parameterised on which slot that is; this
+     * is what travels between them.
+     *
+     * \ingroup Innards
+     */
+    struct InstallState
+    {
+        /// A structurally constant zero divisor: nothing is allocated, and the other two
+        /// phases write the trivially false row and install a contradiction instead.
+        bool zero_divisor = false;
+
+        /// The quotient, which is the user's variable for Divide and the auxiliary
+        /// magnitude |q| for Modulus.
+        IntegerVariableID q = 0_c;
+
+        /// Modulus's quotient magnitude, or Divide's inert remainder slot, with the
+        /// bit-implied upper bound the proof registers its bits against.
+        SimpleIntegerVariableID aux{0};
+        Integer aux_bit_max = 0_i;
+
+        /// The bit-product grid's two non-negative operands. Divide channels both (|q|
+        /// and |y|); Modulus channels only the divisor, its quotient magnitude being a
+        /// free axis-0 bit-sum, so quotient_mag is unused there.
+        CakeMagnitude quotient_mag{}, divisor_mag{};
+
+        std::shared_ptr<DefaultProductData> data;
+
+        /// Unset when the constraint is not tabulating.
+        std::optional<TabulationPlan> tabulation;
+
+        /// Modulus's range and remainder-sign rows. They feed stages that must exist
+        /// with proofs off too, so the stages are built in install_propagators() from
+        /// these handles rather than alongside the rows.
+        std::optional<ProofLine> rng_hi, rng_lo, sgn_pos, sgn_neg;
+    };
+}
+
+#endif


### PR DESCRIPTION
Tenth of the `install()` split stack, on top of #627. Two constraints left after this: Multiply + Power, then making `Constraint::install()` non-virtual and deleting every override.

`install_divide_modulus()` was the last big templated free function doing all three jobs at once: 360 lines shared by `Divide` and `Modulus` with the exposed slot as a parameter. The three phases are shared the same way, so they are three free functions with an `InstallState` travelling between them, and each class holds one and forwards to them.

| phase | what |
|---|---|
| `prepare()` | the affine analysis and the constant-zero-divisor verdict; the auxiliary slot (Divide's inert remainder, Modulus's quotient magnitude) and the magnitude state variables, in the same allocation order as before, because an auxiliary's index appears in its proof variable names; and the tabulation decision, which needs the initial domains, as a `TabulationPlan` |
| `define_proof_model()` | the aux bit registration, the magnitude channels, the bit-product grid and the `rem_*` / `id_*` / `sgn_*` / `rng_*` rows |
| `install_propagators()` | the `LinearStage`s, the triggers, the propagator, and the tabulation `prepare()` decided on |

`make_cake_magnitude()` was the one genuinely joint operation — it sized the bit width from the domains, allocated the magnitude in the State *and* emitted the channel — so it splits into `allocate_cake_magnitude()` for `prepare()` and `emit_cake_magnitude_channel()` for `define_proof_model()`, filling in the four line handles `CakeMagnitude` already had as optionals.

The stages are deliberately built in `install_propagators()` rather than beside the rows they cite: they carry Modulus's `rng_hi`/`rng_lo`/`sgn_pos`/`sgn_neg` and the channel lines, which are `nullopt` with proofs off, and the stages must exist either way.

The constant-zero-divisor case follows `Table` and `In` rather than returning false from `prepare()`: the flag is set there, `define_proof_model()` writes the trivially false row and `install_propagators()` installs the contradiction initialiser, which keeps every model write in the one phase that describes the constraint.

`DefaultProductData` moves out of the anonymous namespace, since `InstallState` holds one; `CakeMagnitude` and `InstallState` go in the new `install_state.hh`. Incidentally, the local `r` was write-only — assigned from both branches and never read, the remainder being reached as `out` or not at all — so it is gone.

## Verification

531/531 ctest pass, and OPB and `.scp` are byte-identical across all 60 captured example models. `ortho_latin-5` posts both constraints with a constant divisor, so the magnitude channels, the grid, the aux bit registration and every labelled row are covered by that diff.

That leaves the shapes only the test binary reaches — variable divisors, the aliased forms, a constant in each slot, tabulation on — and the decisions that are silent, so those were checked directly. `divide_modulus_test` was patched to name its proof files per instance and to report each install's decisions, then run either side of the change with the seed pinned:

- all 158 instances' `.opb` and `.scp` byte-identical, including the 12 constant-zero-divisor installs, so the trivially false row still lands in the same place;
- all 316 `prepare()`-phase decision lines identical: the auxiliary's index and bit-implied maximum, both magnitudes' indices and bit widths, the grid's two operands, and tabulate-or-not with its enumeration and determined-slot counts;
- all 304 `install_propagators()` lines identical: the stage count and the watched-variable count, over both proofs-on and proofs-off runs, which is what pins down the stages having moved phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD