### PR TITLE
Multiply, Power: split install() into the three phases

### DIFF
--- a/gcs/constraints/innards/linear_stages.cc
+++ b/gcs/constraints/innards/linear_stages.cc
@@ -34,28 +34,39 @@ auto gcs::innards::stage_gate_holds(const State & state, const IntegerVariableCo
     }
 }
 
-auto gcs::innards::add_equality_stage(vector<LinearStage> & stages, ProofModel * const model, const ConstraintID & id, const WeightedSum & sum,
-    Integer value, const string & role) -> void
+auto gcs::innards::add_equality_stage(vector<StageSpec> & specs, const WeightedSum & sum, Integer value, const string & role) -> void
 {
-    pair<optional<ProofLine>, optional<ProofLine>> lines;
-    if (model) {
-        auto ll = model->add_labelled_constraint(id, role + "le", role + "ge", as_wpb(sum) == value);
-        lines = pair{optional{ll.first}, optional{ll.second}};
-    }
-    auto [tidied, modifier] = tidy_up_linear(sum);
-    stages.emplace_back(LinearStage{tidied, value + modifier, true, lines, nullopt});
+    specs.emplace_back(StageSpec{sum, value, true, role, nullopt});
 }
 
-auto gcs::innards::add_le_stage(vector<LinearStage> & stages, ProofModel * const model, const ConstraintID & id, const WeightedSum & sum,
-    Integer value, const string & role, const optional<IntegerVariableCondition> & gate) -> void
+auto gcs::innards::add_le_stage(
+    vector<StageSpec> & specs, const WeightedSum & sum, Integer value, const string & role, const optional<IntegerVariableCondition> & gate) -> void
 {
-    pair<optional<ProofLine>, optional<ProofLine>> lines;
-    if (model) {
-        if (gate)
-            lines.first = model->add_labelled_constraint(id, role, as_wpb(sum) <= value, HalfReifyOnConjunctionOf{Literal{*gate}});
+    specs.emplace_back(StageSpec{sum, value, false, role, gate});
+}
+
+auto gcs::innards::emit_stage_rows(ProofModel & model, const ConstraintID & id, vector<StageSpec> & specs) -> void
+{
+    for (auto & spec : specs) {
+        if (spec.equality) {
+            auto ll = model.add_labelled_constraint(id, spec.role + "le", spec.role + "ge", as_wpb(spec.sum) == spec.value);
+            spec.lines = pair{optional{ll.first}, optional{ll.second}};
+        }
+        else if (spec.gate)
+            spec.lines.first =
+                model.add_labelled_constraint(id, spec.role, as_wpb(spec.sum) <= spec.value, HalfReifyOnConjunctionOf{Literal{*spec.gate}});
         else
-            lines.first = model->add_labelled_constraint(id, role, as_wpb(sum) <= value);
+            spec.lines.first = model.add_labelled_constraint(id, spec.role, as_wpb(spec.sum) <= spec.value);
     }
-    auto [tidied, modifier] = tidy_up_linear(sum);
-    stages.emplace_back(LinearStage{tidied, value + modifier, false, lines, gate});
+}
+
+auto gcs::innards::make_stages(const vector<StageSpec> & specs) -> vector<LinearStage>
+{
+    vector<LinearStage> stages;
+    stages.reserve(specs.size());
+    for (const auto & spec : specs) {
+        auto [tidied, modifier] = tidy_up_linear(spec.sum);
+        stages.emplace_back(LinearStage{tidied, spec.value + modifier, spec.equality, spec.lines, spec.gate});
+    }
+    return stages;
 }

--- a/gcs/constraints/innards/linear_stages.hh
+++ b/gcs/constraints/innards/linear_stages.hh
@@ -28,9 +28,10 @@ namespace gcs::innards
      * gate is also the extra reason literal, and the emitted OPB line is
      * half-reified on it.
      *
-     * A compound constraint that emits one flat OPB block (issue #448) builds
-     * a list of these with add_equality_stage() / add_le_stage(), and its
-     * propagator runs them with propagate_stages().
+     * A compound constraint that emits one flat OPB block (issue #448) decides on
+     * a list of StageSpecs, has define_proof_model() emit their rows and
+     * install_propagators() turn them into these, and its propagator runs them
+     * with propagate_stages().
      *
      * \ingroup Innards
      */
@@ -44,6 +45,30 @@ namespace gcs::innards
     };
 
     /**
+     * \brief One stage as decided on, before its OPB rows exist: the untidied sum
+     * and value the rows state, the role naming them, and the gate they are
+     * half-reified on.
+     *
+     * The rows and the LinearStage are wanted in different install phases -- the
+     * rows only with proofs on, the stage always -- so a constraint decides on
+     * these in prepare(), emits the rows from define_proof_model() with
+     * emit_stage_rows(), and builds the stages from make_stages() in
+     * install_propagators().
+     *
+     * \ingroup Innards
+     */
+    struct StageSpec
+    {
+        WeightedSum sum;
+        Integer value;
+        bool equality;
+        std::string role;
+        std::optional<IntegerVariableCondition> gate;
+        /// Filled in by emit_stage_rows(); empty with proofs off.
+        std::pair<std::optional<ProofLine>, std::optional<ProofLine>> lines{};
+    };
+
+    /**
      * \brief Is a stage's gating condition currently established? Only the
      * operators the fused constraints gate on are supported.
      *
@@ -51,24 +76,28 @@ namespace gcs::innards
      */
     [[nodiscard]] auto stage_gate_holds(const State & state, const IntegerVariableCondition & cond) -> bool;
 
-    /**
-     * \brief Append an ungated equality stage, emitting its OPB lines
-     * `@c[label][<role>le]` / `@c[label][<role>ge]` when model is non-null.
-     *
-     * \ingroup Innards
-     */
-    auto add_equality_stage(std::vector<LinearStage> & stages, ProofModel * const model, const ConstraintID & id, const WeightedSum & sum,
-        Integer value, const std::string & role) -> void;
+    /// Decide on an ungated equality stage, whose rows are `@c[label][<role>le]` / `@c[label][<role>ge]`.
+    auto add_equality_stage(std::vector<StageSpec> & specs, const WeightedSum & sum, Integer value, const std::string & role) -> void;
+
+    /// Decide on a less-than-or-equal stage, whose row is `@c[label][<role>]`, half-reified on the gate if one is given.
+    auto add_le_stage(std::vector<StageSpec> & specs, const WeightedSum & sum, Integer value, const std::string & role,
+        const std::optional<IntegerVariableCondition> & gate) -> void;
 
     /**
-     * \brief Append a less-than-or-equal stage, emitting its OPB line
-     * `@c[label][<role>]` when model is non-null, half-reified on the gate if
-     * one is given.
+     * \brief Emit every spec's OPB rows, in order, keeping the line handles on the
+     * specs. define_proof_model()'s half.
      *
      * \ingroup Innards
      */
-    auto add_le_stage(std::vector<LinearStage> & stages, ProofModel * const model, const ConstraintID & id, const WeightedSum & sum, Integer value,
-        const std::string & role, const std::optional<IntegerVariableCondition> & gate) -> void;
+    auto emit_stage_rows(ProofModel & model, const ConstraintID & id, std::vector<StageSpec> & specs) -> void;
+
+    /**
+     * \brief Turn the specs into the propagator's stages, citing whatever rows
+     * emit_stage_rows() left on them. install_propagators()'s half.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto make_stages(const std::vector<StageSpec> & specs) -> std::vector<LinearStage>;
 
     /**
      * \brief Run each currently-active stage once through propagate_linear.

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -75,7 +75,7 @@ auto Multiply::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto Multiply::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+auto Multiply::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     auto a1 = affine_of(_v1), a2 = affine_of(_v2), a3 = affine_of(_result);
 
@@ -94,7 +94,8 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
                 // This mirrors want_tabulation's Auto rule, which cannot be
                 // called directly because LinearEqualityConsistency has no
                 // Auto to delegate; keep the two in step.
-                auto tidied = tidy_up_linear(sum).first;
+                auto tidied_and_modifier = tidy_up_linear(sum);
+                const auto & tidied = tidied_and_modifier.first;
                 return visit(
                     [&](const auto & cv) -> LinearEqualityConsistency {
                         Integer largest = 0_i;
@@ -123,7 +124,7 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
         resolved.with_consistency(linear_level);
         resolved.set_constraint_id(constraint_id());
         move(resolved).install(propagators, initial_state, optional_model);
-        return;
+        return false;
     }
 
     // Both operands are genuine variables, possibly through views, aliased
@@ -135,29 +136,7 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
     // exact square and square-root hull filtering (issue #232).
     auto u1 = *a1.var, u2 = *a2.var;
 
-    auto product_data =
-        make_shared<signed_multiply::Data>(signed_multiply::make_data(optional_model, initial_state, constraint_id(), _v1, _v2, _result));
-
-    Triggers triggers;
-    for (const auto & v : {_v1, _v2, _result})
-        if ((! is_constant_variable(v)) && triggers.on_bounds.end() == std::find(triggers.on_bounds.begin(), triggers.on_bounds.end(), v))
-            triggers.on_bounds.emplace_back(v);
-
-    propagators.install(
-        constraint_id(),
-        [product_data = product_data, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            do {
-                signed_multiply::propagate(*product_data, state, inference, logger, owner);
-            } while (inference.made_progress_since_last_check());
-            // Idempotent: the do-while ran signed_multiply::propagate to quiescence
-            // (it exits only when a whole pass inferred nothing), so an immediate
-            // re-run is a single no-op pass. This needs no 1:1-trigger / non-aliasing
-            // assumption -- the loop reaches whatever fixpoint the true relation has,
-            // aliased or repeated operands (the square case) included, per the note at
-            // the scope above.
-            return PropagatorState::EnableButIdempotent;
-        },
-        triggers);
+    _data = make_shared<signed_multiply::Data>(signed_multiply::make_data(initial_state, _v1, _v2, _result));
 
     // Tabulation for GAC: enumerate over the distinct underlying variables,
     // mapping values back through the affine forms. The auxiliary variables
@@ -191,9 +170,54 @@ auto Multiply::install(Propagators & propagators, State & initial_state, ProofMo
             return product && *product == v3val;
         };
 
-        install_tabulation<hints::Multiply>(
-            propagators, constraint_id(), enum_vars.vars(), move(determined), nullopt, accept, "multtab", "building GAC table for multiplication");
+        _tabulation = TabulationPlan{enum_vars.vars(), move(determined), accept};
     }
+
+    return true;
+}
+
+auto Multiply::define_proof_model(ProofModel & model, const State & initial_state) -> void
+{
+    signed_multiply::emit_encoding(model, initial_state, constraint_id(), *_data);
+}
+
+auto Multiply::install_propagators(Propagators & propagators) -> void
+{
+    Triggers triggers;
+    for (const auto & v : {_v1, _v2, _result})
+        if ((! is_constant_variable(v)) && triggers.on_bounds.end() == std::find(triggers.on_bounds.begin(), triggers.on_bounds.end(), v))
+            triggers.on_bounds.emplace_back(v);
+
+    propagators.install(
+        constraint_id(),
+        [product_data = _data, owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            do {
+                signed_multiply::propagate(*product_data, state, inference, logger, owner);
+            } while (inference.made_progress_since_last_check());
+            // Idempotent: the do-while ran signed_multiply::propagate to quiescence
+            // (it exits only when a whole pass inferred nothing), so an immediate
+            // re-run is a single no-op pass. This needs no 1:1-trigger / non-aliasing
+            // assumption -- the loop reaches whatever fixpoint the true relation has,
+            // aliased or repeated operands (the square case) included, per the note in
+            // prepare().
+            return PropagatorState::EnableButIdempotent;
+        },
+        triggers);
+
+    if (_tabulation)
+        install_tabulation<hints::Multiply>(propagators, constraint_id(), move(_tabulation->enum_vars), move(_tabulation->determined), nullopt,
+            move(_tabulation->accept), "multtab", "building GAC table for multiplication");
+}
+
+auto Multiply::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
 }
 
 auto Multiply::constraint_type() const -> std::string

--- a/gcs/constraints/multiply/multiply.hh
+++ b/gcs/constraints/multiply/multiply.hh
@@ -3,8 +3,12 @@
 
 #include <gcs/consistency.hh>
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/tabulation.hh>
+#include <gcs/constraints/multiply/signed_multiply.hh>
 #include <gcs/variable_id.hh>
 
+#include <memory>
+#include <optional>
 #include <variant>
 
 namespace gcs
@@ -52,6 +56,19 @@ namespace gcs
     private:
         IntegerVariableID _v1, _v2, _result;
         MultiplyConsistency _level = consistency::Auto{};
+
+        // The multiplication's operand handles and initial bounds, captured by
+        // prepare(); define_proof_model() adds cake's encoding handles, and the
+        // propagator holds the result. Unset when a constant operand made this a
+        // linear equality instead, which prepare() installs as a child.
+        std::shared_ptr<innards::signed_multiply::Data> _data;
+
+        /// Unset when the constraint is not tabulating.
+        std::optional<innards::TabulationPlan> _tabulation;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Multiply(IntegerVariableID v1, IntegerVariableID v2, IntegerVariableID result);

--- a/gcs/constraints/multiply/signed_multiply.cc
+++ b/gcs/constraints/multiply/signed_multiply.cc
@@ -25,32 +25,35 @@ using std::vector;
 
 namespace pj = gcs::innards::product_justify;
 
-auto gcs::innards::signed_multiply::make_data(ProofModel * const optional_model, const State & initial_state, const ConstraintID & constraint_id,
-    IntegerVariableID x, IntegerVariableID y, IntegerVariableID z, optional<long long> link) -> Data
+auto gcs::innards::signed_multiply::make_data(
+    const State & initial_state, IntegerVariableID x, IntegerVariableID y, IntegerVariableID z, optional<long long> link) -> Data
 {
     Data data;
     data.x = x;
     data.y = y;
     data.z = z;
+    data.link = link;
     std::tie(data.x_init_lo, data.x_init_hi) = initial_state.bounds(x);
     std::tie(data.y_init_lo, data.y_init_hi) = initial_state.bounds(y);
 
-    if (optional_model) {
-        // cake_pb_cp's multiplication encoding: a magnitude channel per
-        // operand slot (axis 0 -> "X", 1 -> "Y", a fresh proof-only magnitude
-        // each, even for a repeated operand), the bit-product grid, the
-        // result channel pinning |z| to the grid sum, and the six sign
-        // clauses (all entailed for non-negative operands, but cake always
-        // emits them, so the labels resolve in the chain).
-        product_enc::LinkNaming naming{link};
-        data.chan_x = product_enc::emit_magnitude_channel(*optional_model, initial_state, constraint_id, x, 0, "X", naming);
-        data.chan_y = product_enc::emit_magnitude_channel(*optional_model, initial_state, constraint_id, y, 1, "Y", naming);
-        data.grid = product_enc::emit_bit_product_grid(*optional_model, constraint_id, data.chan_x->mag, data.chan_y->mag, naming);
-        data.zchan = product_enc::emit_result_channel(*optional_model, constraint_id, z, data.grid, naming);
-        data.sign_lines = product_enc::emit_sign_clauses(*optional_model, constraint_id, x, y, z, naming);
-    }
-
     return data;
+}
+
+auto gcs::innards::signed_multiply::emit_encoding(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id, Data & data)
+    -> void
+{
+    // cake_pb_cp's multiplication encoding: a magnitude channel per
+    // operand slot (axis 0 -> "X", 1 -> "Y", a fresh proof-only magnitude
+    // each, even for a repeated operand), the bit-product grid, the
+    // result channel pinning |z| to the grid sum, and the six sign
+    // clauses (all entailed for non-negative operands, but cake always
+    // emits them, so the labels resolve in the chain).
+    product_enc::LinkNaming naming{data.link};
+    data.chan_x = product_enc::emit_magnitude_channel(model, initial_state, constraint_id, data.x, 0, "X", naming);
+    data.chan_y = product_enc::emit_magnitude_channel(model, initial_state, constraint_id, data.y, 1, "Y", naming);
+    data.grid = product_enc::emit_bit_product_grid(model, constraint_id, data.chan_x->mag, data.chan_y->mag, naming);
+    data.zchan = product_enc::emit_result_channel(model, constraint_id, data.z, data.grid, naming);
+    data.sign_lines = product_enc::emit_sign_clauses(model, constraint_id, data.x, data.y, data.z, naming);
 }
 
 namespace

--- a/gcs/constraints/multiply/signed_multiply.hh
+++ b/gcs/constraints/multiply/signed_multiply.hh
@@ -28,6 +28,9 @@ namespace gcs::innards::signed_multiply
         IntegerVariableID x = 0_c, y = 0_c, z = 0_c;
         Integer x_init_lo{0}, x_init_hi{0};
         Integer y_init_lo{0}, y_init_hi{0};
+        /// Which multiplication of a chain sharing a constraint id this is; unset when the
+        /// constraint owns just the one.
+        std::optional<long long> link{};
         std::optional<product_enc::MagnitudeChannel> chan_x, chan_y;
         product_enc::BitProductGrid grid{};
         std::optional<product_enc::ResultChannel> zchan;
@@ -35,16 +38,25 @@ namespace gcs::innards::signed_multiply
     };
 
     /**
-     * \brief Capture the operands and, when there is a model, emit cake's
-     * multiplication encoding for x * y = z: two magnitude channels, the
-     * bit-product grid, the result channel and the six sign clauses, exactly
-     * as cake_pb_cp does. `link` disambiguates one multiplication of a chain
-     * sharing a constraint id (Power's base^k).
+     * \brief Capture the operand handles and their initial bounds, which the
+     * propagation needs whether or not there are proofs. `link` disambiguates one
+     * multiplication of a chain sharing a constraint id (Power's base^k).
+     *
+     * This is prepare()'s half; emit_encoding() is define_proof_model()'s.
      *
      * \ingroup Innards
      */
-    [[nodiscard]] auto make_data(ProofModel * const optional_model, const State & initial_state, const ConstraintID & constraint_id,
-        IntegerVariableID x, IntegerVariableID y, IntegerVariableID z, std::optional<long long> link = std::nullopt) -> Data;
+    [[nodiscard]] auto make_data(const State & initial_state, IntegerVariableID x, IntegerVariableID y, IntegerVariableID z,
+        std::optional<long long> link = std::nullopt) -> Data;
+
+    /**
+     * \brief Emit cake's multiplication encoding for x * y = z -- two magnitude
+     * channels, the bit-product grid, the result channel and the six sign clauses,
+     * exactly as cake_pb_cp does -- filling in the handles the justifications cite.
+     *
+     * \ingroup Innards
+     */
+    auto emit_encoding(ProofModel & model, const State & initial_state, const ConstraintID & constraint_id, Data & data) -> void;
 
     /**
      * \brief One pass of bounds consistent multiplication filtering for

--- a/gcs/constraints/power/power.cc
+++ b/gcs/constraints/power/power.cc
@@ -15,6 +15,7 @@
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <util/enumerate.hh>
 #include <util/overloaded.hh>
 
 #include <algorithm>
@@ -76,7 +77,7 @@ auto Power::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto Power::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+auto Power::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     auto a1 = affine_of(_base), a2 = affine_of(_exponent), a3 = affine_of(_result);
 
@@ -86,17 +87,14 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
         PowerTable table{_base, _exponent, _result};
         table.set_constraint_id(constraint_id());
         move(table).install(propagators, initial_state, optional_model);
-        return;
+        return false;
     }
 
     auto k = a2.offset;
 
-    vector<LinearStage> stages;
-    auto add_equality = [&](const WeightedSum & sum, Integer value, const string & role) {
-        add_equality_stage(stages, optional_model, constraint_id(), sum, value, role);
-    };
+    auto add_equality = [&](const WeightedSum & sum, Integer value, const string & role) { add_equality_stage(_specs, sum, value, role); };
     auto add_le = [&](const WeightedSum & sum, Integer value, const string & role, const optional<IntegerVariableCondition> & gate) {
-        add_le_stage(stages, optional_model, constraint_id(), sum, value, role, gate);
+        add_le_stage(_specs, sum, value, role, gate);
     };
     auto add_gated_equality = [&](const IntegerVariableCondition & gate, Integer value, const string & role) {
         // an equality under a gate, as its two half-reified halves
@@ -104,17 +102,14 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
         add_le(WeightedSum{} + -1_i * _result, -value, role + "lo", gate);
     };
 
-    // One multiplication link of the chain, with its own encoding block
-    // (role-prefixed) and persistent bit-product state.
-    auto links = make_shared<vector<signed_multiply::Data>>();
+    // One multiplication link of the chain: each is a signed multiplication encoded with
+    // cake's magnitude scheme, the same one Multiply uses, and `link` disambiguates the
+    // per-link flags. (cake has no power encoder, so this self-verifies rather than
+    // chain-verifying.) define_proof_model() emits the encoding blocks.
+    _links = make_shared<vector<signed_multiply::Data>>();
     auto add_link = [&](long long link, IntegerVariableID a, IntegerVariableID b, IntegerVariableID product) {
-        // Each chain link is a signed multiplication encoded with cake's magnitude scheme, the
-        // same one Multiply uses; `link` disambiguates the per-link flags. (cake has no power
-        // encoder, so this self-verifies rather than chain-verifying.)
-        links->emplace_back(signed_multiply::make_data(optional_model, initial_state, constraint_id(), a, b, product, link));
+        _links->emplace_back(signed_multiply::make_data(initial_state, a, b, product, link));
     };
-
-    bool prune_zero_base = false;
 
     if (! a1.var) {
         // Both base and exponent constant: the result is a single value, or
@@ -124,11 +119,11 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
         else {
             // No representable result value exists (an overflowing power, or
             // zero to a negative power), so the constraint itself is the
-            // empty relation, like a Table with no tuples.
-            if (optional_model)
-                optional_model->add_constraint(WPBSum{} >= 1_i);
-            propagators.install_initial_contradiction("no representable power result", JustifyUsingRUP{hints::Power{constraint_id()}});
-            return;
+            // empty relation, like a Table with no tuples: define_proof_model()
+            // writes the trivially false row and install_propagators() installs a
+            // contradiction initialiser. Nothing else, tabulation included, runs.
+            _no_representable_result = true;
+            return true;
         }
     }
     else if (k == 0_i) {
@@ -146,9 +141,8 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
         // representable power.
         auto parity = ((k.raw_value % 2) == 0) ? 1_i : -1_i;
         if (k < 0_i) {
-            if (optional_model)
-                optional_model->add_labelled_constraint(constraint_id(), "nonzero", WPBSum{} + 1_i * (_base >= 1_i) + 1_i * (_base < 0_i) >= 1_i);
-            prune_zero_base = true;
+            // The nonzero row is define_proof_model()'s, and precedes the stage rows there.
+            _prune_zero_base = true;
 
             add_gated_equality(_base >= 2_i, 0_i, "bigpos");
             add_gated_equality(_base < -1_i, 0_i, "bigneg");
@@ -189,8 +183,7 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
                 auto hi = max({saturating_product(plo, xlo, m), saturating_product(plo, xhi, m), saturating_product(phi, xlo, m),
                     saturating_product(phi, xhi, m)});
                 auto aux = initial_state.allocate_integer_variable_with_state(lo, hi);
-                if (optional_model)
-                    optional_model->set_up_integer_variable(aux, lo, hi, "aux_power" + to_string(aux.index), nullopt);
+                _aux_chain.emplace_back(aux, lo, hi);
                 t = aux;
             }
 
@@ -199,45 +192,12 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
         }
     }
 
-    if ((! stages.empty()) || (! links->empty()) || prune_zero_base) {
-        Triggers triggers;
-        vector<IntegerVariableID> watched;
-        auto watch = [&](const IntegerVariableID & v) {
-            if (! holds_alternative<ConstantIntegerVariableID>(v) && std::find(watched.begin(), watched.end(), v) == watched.end())
-                watched.push_back(v);
-        };
-        watch(_base);
-        watch(_result);
-        for (const auto & link : *links) {
-            watch(link.x);
-            watch(link.y);
-            watch(link.z);
-        }
-        triggers.on_bounds = watched;
-
-        propagators.install(
-            constraint_id(),
-            [stages = stages, links = links, prune_zero_base = prune_zero_base, base = _base, owner = constraint_id()](
-                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-                do {
-                    if (prune_zero_base && state.in_domain(base, 0_i))
-                        inference.infer(logger, base != 0_i, JustifyUsingRUP{hints::Power{owner}}, ExplicitReason{ReasonLiterals{}});
-
-                    if (! propagate_stages(stages, state, inference, logger, owner))
-                        return PropagatorState::Enable;
-
-                    for (auto & link : *links)
-                        signed_multiply::propagate(link, state, inference, logger, owner);
-                } while (inference.made_progress_since_last_check());
-
-                // Idempotent: the do-while ran the stages and multiply links to
-                // quiescence, so an immediate re-run is one no-op pass (see multiply.cc
-                // for the same argument). The mid-loop return above is the contradiction
-                // path and its state is ignored.
-                return PropagatorState::EnableButIdempotent;
-            },
-            triggers);
-    }
+    // A structurally constant base leaves nothing to enumerate: the case
+    // analysis above pinned the result to its one value, and that equality is
+    // already GAC. It also has no a1.var to enumerate over, so the tabulation
+    // below must not be reached -- it dereferenced the empty optional.
+    if (! a1.var)
+        return true;
 
     // Tabulation for GAC over the base and result (the exponent is constant
     // here). The auxiliary chain variables are not enumerated; they pin by
@@ -267,9 +227,97 @@ auto Power::install(Propagators & propagators, State & initial_state, ProofModel
             return want && *want == zv;
         };
 
-        install_tabulation<hints::Power>(
-            propagators, constraint_id(), enum_vars.vars(), move(determined), nullopt, accept, "powtab", "building GAC table for power");
+        _tabulation = TabulationPlan{enum_vars.vars(), move(determined), accept};
     }
+
+    return true;
+}
+
+auto Power::define_proof_model(ProofModel & model, const State & initial_state) -> void
+{
+    if (_no_representable_result) {
+        // Morally what an empty result domain encodes.
+        model.add_constraint(WPBSum{} >= 1_i);
+        return;
+    }
+
+    if (_prune_zero_base)
+        model.add_labelled_constraint(constraint_id(), "nonzero", WPBSum{} + 1_i * (_base >= 1_i) + 1_i * (_base < 0_i) >= 1_i);
+
+    emit_stage_rows(model, constraint_id(), _specs);
+
+    // Each link declares the intermediate variable it writes, then emits its
+    // encoding block, in the chain's order.
+    for (const auto & [index, link] : enumerate(*_links)) {
+        if (index < _aux_chain.size()) {
+            const auto & [aux, lo, hi] = _aux_chain[index];
+            model.set_up_integer_variable(aux, lo, hi, "aux_power" + to_string(aux.index), nullopt);
+        }
+        signed_multiply::emit_encoding(model, initial_state, constraint_id(), link);
+    }
+}
+
+auto Power::install_propagators(Propagators & propagators) -> void
+{
+    if (_no_representable_result) {
+        propagators.install_initial_contradiction("no representable power result", JustifyUsingRUP{hints::Power{constraint_id()}});
+        return;
+    }
+
+    if ((! _specs.empty()) || (! _links->empty()) || _prune_zero_base) {
+        Triggers triggers;
+        vector<IntegerVariableID> watched;
+        auto watch = [&](const IntegerVariableID & v) {
+            if (! holds_alternative<ConstantIntegerVariableID>(v) && std::find(watched.begin(), watched.end(), v) == watched.end())
+                watched.push_back(v);
+        };
+        watch(_base);
+        watch(_result);
+        for (const auto & link : *_links) {
+            watch(link.x);
+            watch(link.y);
+            watch(link.z);
+        }
+        triggers.on_bounds = watched;
+
+        propagators.install(
+            constraint_id(),
+            [stages = make_stages(_specs), links = _links, prune_zero_base = _prune_zero_base, base = _base, owner = constraint_id()](
+                const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+                do {
+                    if (prune_zero_base && state.in_domain(base, 0_i))
+                        inference.infer(logger, base != 0_i, JustifyUsingRUP{hints::Power{owner}}, ExplicitReason{ReasonLiterals{}});
+
+                    if (! propagate_stages(stages, state, inference, logger, owner))
+                        return PropagatorState::Enable;
+
+                    for (auto & link : *links)
+                        signed_multiply::propagate(link, state, inference, logger, owner);
+                } while (inference.made_progress_since_last_check());
+
+                // Idempotent: the do-while ran the stages and multiply links to
+                // quiescence, so an immediate re-run is one no-op pass (see multiply.cc
+                // for the same argument). The mid-loop return above is the contradiction
+                // path and its state is ignored.
+                return PropagatorState::EnableButIdempotent;
+            },
+            triggers);
+    }
+
+    if (_tabulation)
+        install_tabulation<hints::Power>(propagators, constraint_id(), move(_tabulation->enum_vars), move(_tabulation->determined), nullopt,
+            move(_tabulation->accept), "powtab", "building GAC table for power");
+}
+
+auto Power::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
 }
 
 auto Power::constraint_type() const -> std::string

--- a/gcs/constraints/power/power.hh
+++ b/gcs/constraints/power/power.hh
@@ -3,9 +3,16 @@
 
 #include <gcs/consistency.hh>
 #include <gcs/constraint.hh>
+#include <gcs/constraints/innards/linear_stages.hh>
+#include <gcs/constraints/innards/tabulation.hh>
+#include <gcs/constraints/multiply/signed_multiply.hh>
 #include <gcs/variable_id.hh>
 
+#include <memory>
+#include <optional>
+#include <tuple>
 #include <variant>
+#include <vector>
 
 namespace gcs
 {
@@ -46,6 +53,31 @@ namespace gcs
     private:
         IntegerVariableID _base, _exponent, _result;
         PowerConsistency _level = consistency::Auto{};
+
+        // The case analysis prepare() settles on. The linear pieces travel as specs
+        // because their rows and their stages are wanted in different phases; the
+        // multiplication links of a base^k chain carry their operands from prepare()
+        // and their encoding handles from define_proof_model().
+        std::vector<innards::StageSpec> _specs;
+        std::shared_ptr<std::vector<innards::signed_multiply::Data>> _links;
+
+        // The chain's intermediate variables with the ranges to declare them by,
+        // one per link bar the last (which writes the result handle), so link i has
+        // _aux_chain[i] exactly when i is a valid index.
+        std::vector<std::tuple<SimpleIntegerVariableID, Integer, Integer>> _aux_chain;
+
+        /// A negative exponent has no support for a zero base, and says so by propagation.
+        bool _prune_zero_base = false;
+
+        /// Constant base and exponent with no representable power: the empty relation.
+        bool _no_representable_result = false;
+
+        /// Unset when the constraint is not tabulating.
+        std::optional<innards::TabulationPlan> _tabulation;
+
+        virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
 
     public:
         explicit Power(IntegerVariableID base, IntegerVariableID exponent, IntegerVariableID result);

--- a/gcs/constraints/power/power_test.cc
+++ b/gcs/constraints/power/power_test.cc
@@ -189,6 +189,48 @@ auto run_power_pinned_test(
         verify_proof_and_clean_up(*proof_name);
 }
 
+// A structurally constant base and exponent: the result is one value, or the
+// power is not representable at all (zero to a negative power, or an
+// overflowing one) and the constraint is the empty relation.
+auto run_power_both_constant_test(bool proofs, Integer base, Integer exp, pair<long long, long long> result_range, optional<Integer> expected_result)
+    -> void
+{
+    print(cerr, "power both constant base={} exp={} result_range={} expected={} {}", base, exp, result_range,
+        expected_result ? std::to_string(expected_result->raw_value) : "<none>", proofs ? "with proofs:" : ":");
+    cerr << flush;
+
+    Problem p;
+    auto v3 = p.create_integer_variable(Integer(result_range.first), Integer(result_range.second));
+    p.post(Power{constant_variable(base), constant_variable(exp), v3});
+
+    auto proof_name = proofs ? make_optional<string>("power_test" + test_proof_suffix) : nullopt;
+
+    set<long long> actual_results;
+    solve_with(p,      //
+        SolveCallbacks{//
+            .solution = [&](const CurrentState & s) -> bool {
+                actual_results.insert(s(v3).raw_value);
+                return true;
+            }},
+        proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+
+    println(cerr, " got {} solutions", actual_results.size());
+
+    if (expected_result) {
+        if (actual_results.size() != 1 || *actual_results.begin() != expected_result->raw_value) {
+            println(cerr, "expected solution {}, got {}", expected_result->raw_value, actual_results);
+            throw UnexpectedException{"power both-constant test produced wrong result"};
+        }
+    }
+    else if (! actual_results.empty()) {
+        println(cerr, "expected no solutions, got {}", actual_results);
+        throw UnexpectedException{"power both-constant test produced unexpected solutions"};
+    }
+
+    if (proof_name)
+        verify_proof_and_clean_up(*proof_name);
+}
+
 // A constant base with a view exponent still goes through PowerTable, and
 // negative exponents in the view's range now mean zero results, not gaps.
 auto run_power_const_base_view_exp_test(bool proofs, int base, pair<int, int> exp_range, int exp_offset, pair<int, int> result_range) -> void
@@ -325,6 +367,13 @@ auto main(int argc, char * argv[]) -> int
         run_power_const_base_view_exp_test(proofs, 2, {0, 5}, 1, {0, 64});
         run_power_const_base_view_exp_test(proofs, 2, {0, 5}, 0, {0, 20});
         run_power_const_base_view_exp_test(proofs, 2, {0, 5}, -2, {-2, 8});
+
+        // Both base and exponent structurally constant: one pinned value, or no
+        // representable power at all.
+        run_power_both_constant_test(proofs, 2_i, 3_i, {-10, 10}, make_optional(8_i));
+        run_power_both_constant_test(proofs, Integer{-2}, 3_i, {-10, 10}, make_optional(Integer{-8}));
+        run_power_both_constant_test(proofs, 0_i, Integer{-2}, {-10, 10}, nullopt);
+        run_power_both_constant_test(proofs, 3_i, 100_i, {-10, 10}, nullopt);
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Eleventh of the `install()` split stack, on top of #629. These are the last two constraints doing all three jobs in `install()`; after this only the finale is left — making `Constraint::install()` non-virtual and deleting every override.

Both hang off the same signed multiplication encoding, so they split together.

| | |
|---|---|
| **Multiply** | `prepare()` resolves a constant operand into the delegated `LinearEquality` and returns false; otherwise it captures the operand handles and initial bounds and decides the tabulation. `define_proof_model()` emits the encoding, `install_propagators()` installs the propagator and the tabulation. |
| **Power** | `prepare()` delegates a variable exponent to `PowerTable` and returns false, then settles the case analysis: the linear pieces as `StageSpec`s, the `base^k` chain's links and its intermediate variables, whether to prune a zero base, and whether a constant base and exponent have no representable power at all. `define_proof_model()` writes the nonzero row, the stage rows, and per link the intermediate variable's declaration followed by the link's encoding block — the same order as before, which is what keeps the OPB unchanged. `install_propagators()` builds the stages and installs the propagator and the tabulation. |

Two shared helpers split along the same seam as divide/modulus's `make_cake_magnitude()`:

- `signed_multiply::make_data()` captured the operands and their initial bounds (which the propagation needs with proofs off) *and* emitted the encoding. It is now `make_data()` for `prepare()` and `emit_encoding()` for `define_proof_model()`. `Data` carries its own chain link number, so the caller no longer has to hand it back.
- `add_equality_stage()` / `add_le_stage()` appended a `LinearStage` and emitted its rows in one call, which cannot be split across two phases because the rows are stated in terms of the untidied sum a `LinearStage` no longer keeps. They now append a `StageSpec` — the decision, no rows — and `emit_stage_rows()` and `make_stages()` are the two phases' halves of it. Power is the only user.

Power's no-representable-result case follows `Table`, `In` and now divide/modulus: `prepare()` sets a flag rather than returning false, so `define_proof_model()` still writes the trivially false row and `install_propagators()` installs the contradiction initialiser, with the tabulation skipped exactly as before.

`Multiply::prepare()`'s Auto budget now binds the `tidy_up_linear()` pair to a local instead of taking `.first` off the temporary: GCC 15 reports a `-Wmaybe-uninitialized` false positive on the variant's storage otherwise, in this inlining context but not the old one.

`power_test` gains four both-constant cases, because **nothing in the suite reached the no-representable-result path** this moves between phases: a structurally constant base and exponent only ever arrived as singleton *variables*, which dispatch elsewhere. Two of the four are representable and two are not (zero to a negative power, and an overflowing power).

## ⚠️ The bug those cases found — pre-existing, and this PR fixes it

A structurally constant base whose power *is* representable fell through to the tabulation, which dereferences `*a1.var` — and a constant base has no `a1.var`. Dereferencing an empty `std::optional` is undefined, and it behaved like it:

| | |
|---|---|
| macOS, MSVC | segfault |
| any build with `_GLIBCXX_ASSERTIONS` | `optional::operator*: Assertion 'this->_M_is_engaged()' failed` |
| Linux clang, release | **no crash, silently wrong answer** — `2 ^ 3 = 8` solved as unsatisfiable, because the tabulation then enumerated a garbage variable |
| GCC, release | happened to give the right answer, which is why nothing showed locally |

**This is pre-existing, not a consequence of the split** — the same dereference is there before it (`power.cc:246` on the parent commit). It survived because it is only reachable by posting `Power{constant_variable(b), constant_variable(k), r}` with `b ^ k` representable, and nothing did: the suite's "pinned" cases use singleton *variables*, which take the `a1.var` path.

The fix is to return from `prepare()` before the tabulation when there is no base variable to enumerate — the case analysis has already pinned the result to its one value, and that equality is GAC on its own.

It is in this PR because this PR's new test is what fails without it, so the commit would otherwise be red on its own. It is also a self-contained four-line fix plus its test cases, so say the word if you would rather have it as a standalone PR against `main` that can merge ahead of the refactor.

## Verification

531/531 ctest pass under GCC 15, and 426/426 under clang 21 with `_GLIBCXX_ASSERTIONS` on — which is what makes an empty-optional dereference abort rather than read garbage. **Without the fix that clang build aborts on the new case**, so it is a real reproducer rather than a lucky pass.

OPB and `.scp` are byte-identical across all 60 captured example models; the guard changes no encoding. Four of them post `Multiply` (`n_fractions`, `shikaku`, `multiply_random`, `random_polynomial`) but **none posts `Power`**, so both sides were also checked per-instance against the test binaries, instrumented to name their proof files per instance and to report each install's decisions, with the seed pinned either side of the change:

- **multiply_test**: all 69 instances' `.opb` and `.scp` byte-identical, and all 137 decision lines identical (delegated-or-not, the captured initial bounds, and tabulate-or-not with its counts).
- **power_test**: all 56 instances' `.opb` and `.scp` byte-identical, including the four new both-constant ones, and identical decisions throughout — 104 case analyses (which branch, the spec/link/aux counts, the zero-base and no-representable-result flags, the tabulation), 84 chain-variable allocations with their indices and ranges, and 74 stage lists with each stage's equality, value, gate and *attached line handles*, which is what pins down the rows still reaching the stages that cite them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD