### PR TITLE
Constraint: make install() non-virtual, and the three phases the only shape

### DIFF
--- a/benchmarks/slack_watch/slack_watch.cc
+++ b/benchmarks/slack_watch/slack_watch.cc
@@ -107,7 +107,7 @@ namespace
             return SExpr::atom("sum_leq_watched"); // unused: proofs are off
         }
 
-        auto install(Propagators & propagators, State &, ProofModel * const) && -> void override
+        auto install_propagators(Propagators & propagators) -> void override
         {
             if (_watched)
                 install_watched(propagators);

--- a/benchmarks/wake_cost/wake_cost.cc
+++ b/benchmarks/wake_cost/wake_cost.cc
@@ -83,7 +83,7 @@ namespace
             return SExpr::atom("observer");
         }
 
-        auto install(Propagators & propagators, State &, ProofModel * const) && -> void override
+        auto install_propagators(Propagators & propagators) -> void override
         {
             auto wakes = _wakes;
             if (_mode == Mode::Coarse) {

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -24,7 +24,7 @@ library. For an introduction to *using* the solver, start with the top-level
   introduced in-proof. Read when choosing how to create an auxiliary for a
   proof-logged constraint.
 - [Implementing a constraint](constraints.md) — the structural pattern every
-  constraint follows: class shape, the `install` method, the propagator
+  constraint follows: class shape, the three install phases, the propagator
   framework, triggers, the inference and justification APIs, OPB encoding
   building blocks, and the testing pattern. Start here when adding any new
   constraint.

--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -17,17 +17,19 @@ For exposing a finished constraint to MiniZinc, see
 ## The big picture
 
 A `Constraint` is a user-facing object posted on a `Problem`. When the
-solver starts, each constraint's `install` method runs once. It does two
-things:
+solver starts, each constraint is installed once, in three phases:
 
-1. Optionally describes the constraint in PB terms by calling
-   `optional_model->add_constraint(...)` zero or more times. This
-   block is guarded by `if (optional_model)` and is what VeriPB sees.
-2. Registers one or more propagators with the `Propagators` object. A
-   propagator is a callable that gets invoked at search time to enforce
-   the constraint by tightening variable domains.
+1. `prepare` validates the arguments, reads the initial domains, and allocates
+   whatever the other two phases need — auxiliary variables, backtrackable
+   constraint state, child constraints.
+2. `define_proof_model` describes the constraint in PB terms by calling
+   `model.add_constraint(...)` zero or more times. It runs only when proofs are
+   being logged, and is what VeriPB sees.
+3. `install_propagators` registers one or more propagators with the
+   `Propagators` object. A propagator is a callable that gets invoked at search
+   time to enforce the constraint by tightening variable domains.
 
-After install, the constraint object itself is gone — only the
+After installing, the constraint object itself is gone — only the
 propagators (with their captured state) and the OPB definition remain.
 
 ## File layout
@@ -38,7 +40,7 @@ Every constraint lives in its own directory. For a constraint named
 ```
 gcs/constraints/foo.hh             public umbrella header
 gcs/constraints/foo/foo.hh         public class declaration
-gcs/constraints/foo/foo.cc         install method + propagator
+gcs/constraints/foo/foo.cc         install phases + propagator
 gcs/constraints/foo/foo_test.cc    enumeration tests
 ```
 
@@ -128,11 +130,16 @@ namespace gcs
     private:
         // Captured arguments (vars and constants).
 
+        // The three install phases, in the order they run.
+        virtual auto prepare(innards::Propagators &, innards::State &,
+            innards::ProofModel * const) -> bool override;
+        virtual auto define_proof_model(innards::ProofModel &,
+            const innards::State &) -> void override;
+        virtual auto install_propagators(innards::Propagators &) -> void override;
+
     public:
         explicit Foo(/* arguments */);
 
-        virtual auto install(innards::Propagators &, innards::State &,
-            innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(
             const innards::ProofModel * const) const -> innards::SExpr override;
@@ -140,42 +147,59 @@ namespace gcs
 }
 ```
 
-`install` is rvalue-qualified (`&&`) — it consumes the Constraint
-object. `clone` produces a fresh independent copy (used by some search
+`clone` produces a fresh independent copy (used by some search
 strategies). `s_expr` returns the constraint's `.scp` entry as a structured
 s-expression term `(name op args...)` (built with `innards::SExpr::list`/`atom`
 and `NamesAndIDsTracker::s_expr_term_of`); `innards::write_scp` serialises it.
 
-## install: the entry point
+## The three install phases
 
-The recommended shape splits `install` into three phases, each
-override-able as a protected virtual on `Constraint`:
+`Constraint::install` is not virtual and is not yours to write. It is
+rvalue-qualified (`&&`) — it consumes the Constraint object — and all it does is
+run the three phases:
 
 ```cpp
-auto Foo::install(Propagators & propagators, State & initial_state,
+auto Constraint::install(Propagators & propagators, State & initial_state,
     ProofModel * const optional_model) && -> void
 {
     if (! prepare(propagators, initial_state, optional_model))
         return;
 
     if (optional_model)
-        define_proof_model(*optional_model);
+        define_proof_model(*optional_model, initial_state);
 
     install_propagators(propagators);
 }
+```
 
+A constraint overrides the phases it needs; each has a do-nothing default, so a
+constraint with no OPB definition simply does not override
+`define_proof_model`.
+
+```cpp
 auto Foo::prepare(Propagators &, State & initial_state,
     ProofModel * const) -> bool
 {
-    // Early-out for trivial cases; precompute state shared by the
-    // next two phases. Return false to skip them.
+    // Validate the arguments; read the initial domains; allocate auxiliary
+    // variables and backtrackable constraint state; install child constraints.
+    // This is the only phase holding all three of the propagators, the mutable
+    // State and the model at once, so it is the only one that can allocate or
+    // install a child. Return false to say the other two must not run --
+    // whether because the constraint is trivially satisfied, because a
+    // contradiction initialiser has been installed, or because the whole
+    // constraint has been delegated to a child.
     return /* not trivially satisfied */;
 }
 
-auto Foo::define_proof_model(ProofModel & model) -> void
+auto Foo::define_proof_model(ProofModel & model,
+    const State & initial_state) -> void
 {
-    // OPB definition only. State precomputed in prepare() may be
-    // referenced via private members.
+    // The OPB definition, and nothing else. The State is the *declared*
+    // domains -- nothing at install time narrows one -- so an encoding whose
+    // shape depends on them (bit widths, a row per value, a flag per tuple)
+    // can read them here rather than having prepare() snapshot them first. It
+    // is const because this phase must only describe the constraint, never
+    // allocate.
 }
 
 auto Foo::install_propagators(Propagators & propagators) -> void
@@ -782,10 +806,11 @@ in `constraints_test_utils.hh`.
 
 ## Adding a new constraint: checklist
 
-1. Header file with class declaration, Doxygen comments, the standard
-   trio of virtual methods.
-2. `.cc` file with constructor, `install` method (OPB block + propagator
-   registration), `clone`, `s_expr`.
+1. Header file with class declaration, Doxygen comments, the phases it
+   overrides, and `clone` / `s_expr` / `constraint_type`.
+2. `.cc` file with constructor, the three phases (`prepare`,
+   `define_proof_model` for the OPB block, `install_propagators`), `clone`,
+   `s_expr`.
 3. Test file with the standard `for (bool proofs : {false, true})`
    loop and a `can_run_veripb()` gate on the proofs leg. Split into
    multiple ctest entries via an argv mode if the test gets slow.

--- a/dev_docs/reification.md
+++ b/dev_docs/reification.md
@@ -221,7 +221,8 @@ re-dispatch inside the Undecided arm.
 
 ## Worked example: `LessThan` (in `comparison/comparison.cc`)
 
-A boiled-down outline of `ReifiedCompareLessThanOrMaybeEqual::install`:
+A boiled-down outline of `ReifiedCompareLessThanOrMaybeEqual`'s
+`define_proof_model` and `install_propagators`:
 
 ```cpp
 // 1. OPB encoding (one or two add_constraint calls per reif kind)
@@ -297,12 +298,12 @@ being inferred. Lex currently only fully supports the Iff polarity for
 its scaffolded inferences; the NotIf case is latent (and not exposed in
 the public API).
 
-### Capture-by-reference inside the install function
+### Capture-by-reference inside install_propagators
 
 The three callables passed to `install_reified_dispatcher` are stored
 inside the propagator's lambda (which lives until the constraint is torn
-down). They must capture by *value* (not reference) anything from the
-install function's local scope — the install function returns long
+down). They must capture by *value* (not reference) anything from
+`install_propagators`'s local scope — that phase returns long
 before the propagator first runs. Look for `[v1 = _v1, v2 = _v2, ...]`
 init-capture style.
 

--- a/gcs/constraint.cc
+++ b/gcs/constraint.cc
@@ -2,8 +2,20 @@
 #include <gcs/exception.hh>
 
 using namespace gcs;
+using namespace gcs::innards;
 
 Constraint::~Constraint() = default;
+
+auto Constraint::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
+{
+    if (! prepare(propagators, initial_state, optional_model))
+        return;
+
+    if (optional_model)
+        define_proof_model(*optional_model, initial_state);
+
+    install_propagators(propagators);
+}
 
 auto gcs::as_string(const ConstraintID & constraint_id) -> std::string
 {

--- a/gcs/constraint.hh
+++ b/gcs/constraint.hh
@@ -110,13 +110,16 @@ namespace gcs
          */
         [[nodiscard]] virtual auto constraint_type() const -> std::string = 0;
         /**
-         * Called internally to install the constraint. A Constraint is expected
-         * to define zero or more propagators, and to provide a description of
-         * its meaning for proof logging. This is a destructive operation which
-         * can only be called once, and after calling it neither install() nor
-         * clone() may be called on this instance.
+         * Called internally to install the constraint, by running its three
+         * phases in order: prepare(), then define_proof_model() if proofs are
+         * being logged, then install_propagators(). A Constraint is expected to
+         * define zero or more propagators, and to provide a description of its
+         * meaning for proof logging; it does so by overriding those phases, not
+         * this. This is a destructive operation which can only be called once,
+         * and after calling it neither install() nor clone() may be called on
+         * this instance.
          */
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void = 0;
+        auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void;
 
         /**
          * Create a copy of the constraint. To be used internally.

--- a/gcs/constraints/abs/abs.cc
+++ b/gcs/constraints/abs/abs.cc
@@ -81,17 +81,6 @@ auto Abs::clone() const -> unique_ptr<Constraint>
     return make_unique<Abs>(_v1, _v2);
 }
 
-auto Abs::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Abs::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Labels match cake_pb_cp's. cake names the V2 >= V1 half [posle] and the

--- a/gcs/constraints/abs/abs.hh
+++ b/gcs/constraints/abs/abs.hh
@@ -32,7 +32,6 @@ namespace gcs
     public:
         explicit Abs(const IntegerVariableID v1, const IntegerVariableID v2);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
 
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;

--- a/gcs/constraints/all_different/all_different.cc
+++ b/gcs/constraints/all_different/all_different.cc
@@ -92,17 +92,6 @@ auto AllDifferent::with_consistency(AllDifferentConsistency level) -> AllDiffere
     return *this;
 }
 
-auto AllDifferent::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto AllDifferent::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _sanitised_vars = move(_vars);

--- a/gcs/constraints/all_different/all_different.hh
+++ b/gcs/constraints/all_different/all_different.hh
@@ -57,7 +57,6 @@ namespace gcs
         /// error, and the choice never changes the OPB encoding.
         auto with_consistency(AllDifferentConsistency level) -> AllDifferent &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/all_different/all_different_except.cc
+++ b/gcs/constraints/all_different/all_different_except.cc
@@ -59,17 +59,6 @@ auto AllDifferentExcept::clone() const -> unique_ptr<Constraint>
     return make_unique<AllDifferentExcept>(_vars, _excluded);
 }
 
-auto AllDifferentExcept::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto AllDifferentExcept::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _sanitised_vars = move(_vars);

--- a/gcs/constraints/all_different/all_different_except.hh
+++ b/gcs/constraints/all_different/all_different_except.hh
@@ -46,7 +46,6 @@ namespace gcs
     public:
         explicit AllDifferentExcept(std::vector<IntegerVariableID> vars, std::vector<Integer> excluded);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/all_different/symmetric_all_different.cc
+++ b/gcs/constraints/all_different/symmetric_all_different.cc
@@ -56,17 +56,6 @@ auto SymmetricAllDifferent::clone() const -> unique_ptr<Constraint>
     return make_unique<SymmetricAllDifferent>(_vars, _start);
 }
 
-auto SymmetricAllDifferent::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto SymmetricAllDifferent::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     auto n = _vars.size();

--- a/gcs/constraints/all_different/symmetric_all_different.hh
+++ b/gcs/constraints/all_different/symmetric_all_different.hh
@@ -45,7 +45,6 @@ namespace gcs
     public:
         explicit SymmetricAllDifferent(std::vector<IntegerVariableID> vars, Integer start = 0_i);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/all_equal/all_equal.cc
+++ b/gcs/constraints/all_equal/all_equal.cc
@@ -46,17 +46,6 @@ auto AllEqual::clone() const -> unique_ptr<Constraint>
     return make_unique<AllEqual>(_vars);
 }
 
-auto AllEqual::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto AllEqual::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     return _vars.size() > 1;

--- a/gcs/constraints/all_equal/all_equal.hh
+++ b/gcs/constraints/all_equal/all_equal.hh
@@ -32,7 +32,6 @@ namespace gcs
     public:
         explicit AllEqual(std::vector<IntegerVariableID> vars);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/among/among.cc
+++ b/gcs/constraints/among/among.cc
@@ -75,17 +75,6 @@ auto Among::clone() const -> unique_ptr<Constraint>
     return make_unique<Among>(_vars, _values_of_interest, _how_many);
 }
 
-auto Among::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Among::define_proof_model(ProofModel & model, const State &) -> void
 {
     // very easy PB encoding: sum up over the condition that each variable equals one of the

--- a/gcs/constraints/among/among.hh
+++ b/gcs/constraints/among/among.hh
@@ -31,7 +31,6 @@ namespace gcs
     public:
         explicit Among(std::vector<IntegerVariableID>, const std::vector<Integer> & values_of_interest, const IntegerVariableID & how_many);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/at_most_one/at_most_one.cc
+++ b/gcs/constraints/at_most_one/at_most_one.cc
@@ -52,17 +52,6 @@ auto AtMostOne::clone() const -> unique_ptr<Constraint>
     return make_unique<AtMostOne>(_vars, _val);
 }
 
-auto AtMostOne::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto AtMostOne::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     // "at most one of fewer than two variables equals val" is vacuously true:
@@ -174,17 +163,6 @@ AtMostOneSmartTable::AtMostOneSmartTable(vector<IntegerVariableID> vars, Integer
 auto AtMostOneSmartTable::clone() const -> unique_ptr<Constraint>
 {
     return make_unique<AtMostOneSmartTable>(_vars, _val);
-}
-
-auto AtMostOneSmartTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
 }
 
 auto AtMostOneSmartTable::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool

--- a/gcs/constraints/at_most_one/at_most_one.hh
+++ b/gcs/constraints/at_most_one/at_most_one.hh
@@ -43,7 +43,6 @@ namespace gcs
     public:
         explicit AtMostOne(std::vector<IntegerVariableID> vars, IntegerVariableID val);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
@@ -69,7 +68,6 @@ namespace gcs
     public:
         explicit AtMostOneSmartTable(std::vector<IntegerVariableID> vars, IntegerVariableID val);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/bin_packing/bin_packing.cc
+++ b/gcs/constraints/bin_packing/bin_packing.cc
@@ -1074,17 +1074,6 @@ auto BinPacking::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto BinPacking::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto BinPacking::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     if (_items.size() != _sizes.size())

--- a/gcs/constraints/bin_packing/bin_packing.hh
+++ b/gcs/constraints/bin_packing/bin_packing.hh
@@ -133,7 +133,6 @@ namespace gcs
         /// effect under consistency::BC or with proof logging off.
         auto with_proof_strategy(BinPackingProofStrategy strategy) -> BinPacking &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/circuit/circuit.cc
+++ b/gcs/constraints/circuit/circuit.cc
@@ -230,17 +230,6 @@ auto Circuit::install_propagators(Propagators & propagators) -> void
         .visit(_algorithm);
 }
 
-auto Circuit::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Circuit::clone() const -> unique_ptr<Constraint>
 {
     auto cloned = make_unique<Circuit>(_succ);

--- a/gcs/constraints/circuit/circuit.hh
+++ b/gcs/constraints/circuit/circuit.hh
@@ -111,7 +111,6 @@ namespace gcs
         /// SCC-only: reify a short "reason" flag rather than citing the full reason each time. No-op under circuit::Prevent.
         auto with_short_reasons(std::optional<bool> enable = true) -> Circuit &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/comparison/comparison.cc
+++ b/gcs/constraints/comparison/comparison.cc
@@ -69,17 +69,6 @@ auto ReifiedCompareLessThanOrMaybeEqual::clone() const -> unique_ptr<Constraint>
     return make_unique<ReifiedCompareLessThanOrMaybeEqual>(_v1, _v2, _reif_cond, _or_equal, _vars_swapped);
 }
 
-auto ReifiedCompareLessThanOrMaybeEqual::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ReifiedCompareLessThanOrMaybeEqual::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _v1_is_constant = initial_state.optional_single_value(_v1);

--- a/gcs/constraints/comparison/comparison.hh
+++ b/gcs/constraints/comparison/comparison.hh
@@ -46,7 +46,6 @@ namespace gcs
         explicit ReifiedCompareLessThanOrMaybeEqual(
             const IntegerVariableID v1, const IntegerVariableID v2, ReificationCondition cond, bool or_equal, bool vars_swapped = false);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/count/count.cc
+++ b/gcs/constraints/count/count.cc
@@ -49,17 +49,6 @@ auto Count::clone() const -> unique_ptr<Constraint>
     return make_unique<Count>(_vars, _value_of_interest, _how_many);
 }
 
-auto Count::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Count::define_proof_model(ProofModel & model, const State &) -> void
 {
     // Conform to cake_pb_cp's count encoding (#354): per position i, the

--- a/gcs/constraints/count/count.hh
+++ b/gcs/constraints/count/count.hh
@@ -29,7 +29,6 @@ namespace gcs
     public:
         explicit Count(std::vector<IntegerVariableID>, const IntegerVariableID & value_of_interest, const IntegerVariableID & how_many);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -99,17 +99,6 @@ auto Cumulative::clone() const -> unique_ptr<Constraint>
     return make_unique<Cumulative>(_starts, _lengths, _heights, _capacity);
 }
 
-auto Cumulative::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     auto n = _starts.size();

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -102,7 +102,6 @@ namespace gcs
          */
         explicit Cumulative(std::vector<IntegerVariableID> starts, std::vector<Integer> lengths, std::vector<Integer> heights, Integer capacity);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/disjunctive/disjunctive.cc
+++ b/gcs/constraints/disjunctive/disjunctive.cc
@@ -78,17 +78,6 @@ auto Disjunctive::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto Disjunctive::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Disjunctive::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     auto n = _starts.size();

--- a/gcs/constraints/disjunctive/disjunctive.hh
+++ b/gcs/constraints/disjunctive/disjunctive.hh
@@ -105,7 +105,6 @@ namespace gcs
         /// can be passed straight through.
         auto with_strict(std::optional<bool> strict = true) -> Disjunctive &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.cc
@@ -84,17 +84,6 @@ auto Disjunctive2D::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto Disjunctive2D::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Disjunctive2D::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     // In non-strict mode, a zero-area rectangle (width 0 or height 0) cannot

--- a/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
+++ b/gcs/constraints/disjunctive_2d/disjunctive_2d.hh
@@ -110,7 +110,6 @@ namespace gcs
         /// runtime flag can be passed straight through.
         auto with_strict(std::optional<bool> strict = true) -> Disjunctive2D &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/divide_modulus/divide_modulus.cc
+++ b/gcs/constraints/divide_modulus/divide_modulus.cc
@@ -1319,17 +1319,6 @@ auto Divide::install_propagators(Propagators & propagators) -> void
     install_propagators_divide_modulus<hints::Divide>(_install, constraint_id(), true, _x, _y, _quotient, propagators);
 }
 
-auto Divide::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Divide::constraint_type() const -> std::string
 {
     return "divide";
@@ -1374,17 +1363,6 @@ auto Modulus::define_proof_model(ProofModel & model, const State &) -> void
 auto Modulus::install_propagators(Propagators & propagators) -> void
 {
     install_propagators_divide_modulus<hints::Modulus>(_install, constraint_id(), false, _x, _y, _remainder, propagators);
-}
-
-auto Modulus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
 }
 
 auto Modulus::constraint_type() const -> std::string

--- a/gcs/constraints/divide_modulus/divide_modulus.hh
+++ b/gcs/constraints/divide_modulus/divide_modulus.hh
@@ -72,7 +72,6 @@ namespace gcs
         /// domains are small. Requesting an unsupported level is a compile-time error.
         auto with_consistency(DivideConsistency level) -> Divide &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
@@ -111,7 +110,6 @@ namespace gcs
         /// domains are small. Requesting an unsupported level is a compile-time error.
         auto with_consistency(ModulusConsistency level) -> Modulus &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/element/element.cc
+++ b/gcs/constraints/element/element.cc
@@ -165,19 +165,6 @@ namespace
 }
 
 template <typename EntryType_, unsigned dimensions_>
-auto NDimensionalElement<EntryType_, dimensions_>::install(
-    Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
-template <typename EntryType_, unsigned dimensions_>
 auto NDimensionalElement<EntryType_, dimensions_>::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model)
     -> bool
 {

--- a/gcs/constraints/element/element.hh
+++ b/gcs/constraints/element/element.hh
@@ -86,7 +86,6 @@ namespace gcs
             return *this;
         }
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/equals/equals.cc
+++ b/gcs/constraints/equals/equals.cc
@@ -203,17 +203,6 @@ auto ReifiedEquals::clone() const -> unique_ptr<Constraint>
     return make_unique<ReifiedEquals>(_v1, _v2, _cond);
 }
 
-auto ReifiedEquals::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ReifiedEquals::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _evaluated_cond = test_reification_condition(initial_state, _cond);

--- a/gcs/constraints/equals/equals.hh
+++ b/gcs/constraints/equals/equals.hh
@@ -39,7 +39,6 @@ namespace gcs
     public:
         ReifiedEquals(const IntegerVariableID v1, const IntegerVariableID v2, ReificationCondition cond, bool neq = false);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/global_cardinality/global_cardinality.cc
+++ b/gcs/constraints/global_cardinality/global_cardinality.cc
@@ -75,17 +75,6 @@ auto GlobalCardinality::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto GlobalCardinality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto GlobalCardinality::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     // The closed restriction (every variable takes a cover value) is delegated

--- a/gcs/constraints/global_cardinality/global_cardinality.hh
+++ b/gcs/constraints/global_cardinality/global_cardinality.hh
@@ -76,7 +76,6 @@ namespace gcs
         /// straight through; nullopt or no argument closes it.
         auto with_closed(std::optional<bool> closed = true) -> GlobalCardinality &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/in/in.cc
+++ b/gcs/constraints/in/in.cc
@@ -69,17 +69,6 @@ auto In::clone() const -> unique_ptr<Constraint>
     return make_unique<In>(_var, _var_vals, _val_vals);
 }
 
-auto In::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto In::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     erase_if(_var_vals, [&](const IntegerVariableID & v) -> bool {

--- a/gcs/constraints/in/in.hh
+++ b/gcs/constraints/in/in.hh
@@ -37,7 +37,6 @@ namespace gcs
         explicit In(IntegerVariableID var, std::vector<IntegerVariableID> vals);
         explicit In(IntegerVariableID var, std::vector<Integer> vals);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/increasing/increasing.cc
+++ b/gcs/constraints/increasing/increasing.cc
@@ -47,17 +47,6 @@ auto IncreasingChain::clone() const -> unique_ptr<Constraint>
     return make_unique<IncreasingChain>(_vars, _strict, _descending);
 }
 
-auto IncreasingChain::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto IncreasingChain::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     // Reverse for descending so the rest of install is single-direction.

--- a/gcs/constraints/increasing/increasing.hh
+++ b/gcs/constraints/increasing/increasing.hh
@@ -39,7 +39,6 @@ namespace gcs
     public:
         explicit IncreasingChain(std::vector<IntegerVariableID> vars, bool strict, bool descending);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/innards/product_justify_test.cc
+++ b/gcs/constraints/innards/product_justify_test.cc
@@ -38,6 +38,7 @@ using std::nullopt;
 using std::optional;
 using std::pair;
 using std::set;
+using std::shared_ptr;
 using std::tuple;
 using std::unique_ptr;
 using std::vector;
@@ -107,6 +108,9 @@ namespace
         SimpleIntegerVariableID _v1, _v2, _v3;
         Fragment _fragment;
 
+        // Empty when proofs are off, which is what the fragment runner checks for.
+        shared_ptr<optional<FragmentEncoding>> _encoding = make_shared<optional<FragmentEncoding>>(nullopt);
+
     public:
         ProductFragmentForTest(SimpleIntegerVariableID v1, SimpleIntegerVariableID v2, SimpleIntegerVariableID v3, Fragment fragment) :
             _v1(v1), _v2(v2), _v3(v3), _fragment(fragment)
@@ -118,21 +122,21 @@ namespace
             return make_unique<ProductFragmentForTest>(_v1, _v2, _v3, _fragment);
         }
 
-        auto install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void override
+        auto define_proof_model(ProofModel & model, const State & initial_state) -> void override
         {
-            auto encoding = make_shared<optional<FragmentEncoding>>(nullopt);
-            if (optional_model) {
-                auto naming = product_enc::LinkNaming{};
-                auto chan1 = product_enc::emit_magnitude_channel(*optional_model, initial_state, constraint_id(), _v1, 0, "X", naming);
-                auto chan2 = product_enc::emit_magnitude_channel(*optional_model, initial_state, constraint_id(), _v2, 1, "Y", naming);
-                auto grid = product_enc::emit_bit_product_grid(*optional_model, constraint_id(), chan1.mag, chan2.mag, naming);
-                auto zchan = product_enc::emit_result_channel(*optional_model, constraint_id(), _v3, grid, naming);
-                auto signs = product_enc::emit_sign_clauses(*optional_model, constraint_id(), _v1, _v2, _v3, naming);
-                *encoding = FragmentEncoding{chan1, chan2, grid, zchan, signs};
-            }
+            auto naming = product_enc::LinkNaming{};
+            auto chan1 = product_enc::emit_magnitude_channel(model, initial_state, constraint_id(), _v1, 0, "X", naming);
+            auto chan2 = product_enc::emit_magnitude_channel(model, initial_state, constraint_id(), _v2, 1, "Y", naming);
+            auto grid = product_enc::emit_bit_product_grid(model, constraint_id(), chan1.mag, chan2.mag, naming);
+            auto zchan = product_enc::emit_result_channel(model, constraint_id(), _v3, grid, naming);
+            auto signs = product_enc::emit_sign_clauses(model, constraint_id(), _v1, _v2, _v3, naming);
+            *_encoding = FragmentEncoding{chan1, chan2, grid, zchan, signs};
+        }
 
+        auto install_propagators(Propagators & propagators) -> void override
+        {
             propagators.install_initialiser(
-                [encoding = encoding, v1 = _v1, v2 = _v2, v3 = _v3, fragment = _fragment](State & state, auto &, ProofLogger * const logger) {
+                [encoding = _encoding, v1 = _v1, v2 = _v2, v3 = _v3, fragment = _fragment](State & state, auto &, ProofLogger * const logger) {
                     if (! logger)
                         return;
                     auto & enc = **encoding;

--- a/gcs/constraints/innards/tabulation_test.cc
+++ b/gcs/constraints/innards/tabulation_test.cc
@@ -83,7 +83,7 @@ namespace
             return make_unique<TabulateProductForTest>(_v1, _v2, _v3, _claim_determined);
         }
 
-        auto install(Propagators & propagators, State &, ProofModel * const) && -> void override
+        auto install_propagators(Propagators & propagators) -> void override
         {
             Triggers triggers;
             triggers.on_change = {_v1, _v2, _v3};

--- a/gcs/constraints/inverse/inverse.cc
+++ b/gcs/constraints/inverse/inverse.cc
@@ -74,17 +74,6 @@ auto Inverse::clone() const -> unique_ptr<Constraint>
     return make_unique<Inverse>(_x, _y, _x_start, _y_start);
 }
 
-auto Inverse::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Inverse::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     if (_x.size() != _y.size())

--- a/gcs/constraints/inverse/inverse.hh
+++ b/gcs/constraints/inverse/inverse.hh
@@ -32,7 +32,6 @@ namespace gcs
     public:
         explicit Inverse(std::vector<IntegerVariableID> x, std::vector<IntegerVariableID> y, Integer x_start = 0_i, Integer y_start = 0_i);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/knapsack/knapsack.cc
+++ b/gcs/constraints/knapsack/knapsack.cc
@@ -576,17 +576,6 @@ namespace
     }
 }
 
-auto Knapsack::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Knapsack::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     // The two strategies draw the same inferences and share this OPB encoding;

--- a/gcs/constraints/knapsack/knapsack.hh
+++ b/gcs/constraints/knapsack/knapsack.hh
@@ -75,7 +75,6 @@ namespace gcs
         /// solutions found, or the OPB encoding.
         auto with_proof_strategy(KnapsackProofStrategy strategy) -> Knapsack &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/lex/lex.cc
+++ b/gcs/constraints/lex/lex.cc
@@ -471,17 +471,6 @@ auto LexCompareGreaterThanOrMaybeEqual::clone() const -> unique_ptr<Constraint>
     return make_unique<LexCompareGreaterThanOrMaybeEqual>(_vars_1, _vars_2, _reif_cond, _or_equal, _vars_swapped);
 }
 
-auto LexCompareGreaterThanOrMaybeEqual::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto LexCompareGreaterThanOrMaybeEqual::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _evaluated_cond = test_reification_condition(initial_state, _reif_cond);

--- a/gcs/constraints/lex/lex.hh
+++ b/gcs/constraints/lex/lex.hh
@@ -99,7 +99,6 @@ namespace gcs
         explicit LexCompareGreaterThanOrMaybeEqual(std::vector<IntegerVariableID> vars_1, std::vector<IntegerVariableID> vars_2,
             ReificationCondition reif_cond, bool or_equal, bool vars_swapped = false);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/lex/lex_smart_table.cc
+++ b/gcs/constraints/lex/lex_smart_table.cc
@@ -42,17 +42,6 @@ auto LexSmartTable::clone() const -> unique_ptr<Constraint>
     return make_unique<LexSmartTable>(_vars_1, _vars_2);
 }
 
-auto LexSmartTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto LexSmartTable::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     // Delegates entirely to the SmartTable built below; see the note on

--- a/gcs/constraints/lex/lex_smart_table.hh
+++ b/gcs/constraints/lex/lex_smart_table.hh
@@ -31,7 +31,6 @@ namespace gcs
     public:
         explicit LexSmartTable(std::vector<IntegerVariableID> vars_1, std::vector<IntegerVariableID> vars_2);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/linear/linear_equality.cc
+++ b/gcs/constraints/linear/linear_equality.cc
@@ -169,17 +169,6 @@ auto ReifiedLinearEquality::with_incremental_threshold(std::optional<std::size_t
     return *this;
 }
 
-auto ReifiedLinearEquality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ReifiedLinearEquality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _evaluated_cond = test_reification_condition(initial_state, _reif_cond);

--- a/gcs/constraints/linear/linear_equality.hh
+++ b/gcs/constraints/linear/linear_equality.hh
@@ -89,8 +89,6 @@ namespace gcs
          */
         auto with_incremental_threshold(std::optional<std::size_t> threshold) -> ReifiedLinearEquality &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
-
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -89,17 +89,6 @@ namespace gcs::innards::hints
     }
 }
 
-auto ReifiedLinearInequality::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ReifiedLinearInequality::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _evaluated_cond = test_reification_condition(initial_state, _reif_cond);

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -66,7 +66,6 @@ namespace gcs
         explicit ReifiedLinearInequality(
             WeightedSum coeff_vars, Integer value, ReificationCondition cond, std::optional<std::size_t> incremental_threshold = std::nullopt);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/logical/logical.cc
+++ b/gcs/constraints/logical/logical.cc
@@ -231,17 +231,6 @@ auto And::clone() const -> unique_ptr<Constraint>
     return make_unique<And>(_lits, _full_reif);
 }
 
-auto And::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto And::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _reif_state = initial_state.test_literal(_full_reif);
@@ -283,17 +272,6 @@ Or::Or(Literals l, const Literal & full_reif) : _lits(move(l)), _full_reif(full_
 auto Or::clone() const -> unique_ptr<Constraint>
 {
     return make_unique<Or>(_lits, _full_reif);
-}
-
-auto Or::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
 }
 
 auto Or::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool

--- a/gcs/constraints/logical/logical.hh
+++ b/gcs/constraints/logical/logical.hh
@@ -37,7 +37,6 @@ namespace gcs
 
         explicit And(innards::Literals, const innards::Literal &);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
@@ -69,7 +68,6 @@ namespace gcs
 
         explicit Or(innards::Literals, const innards::Literal &);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/mdd/mdd.cc
+++ b/gcs/constraints/mdd/mdd.cc
@@ -453,17 +453,6 @@ auto MDD::clone() const -> unique_ptr<Constraint>
     return make_unique<MDD>(_vars, _layer_transitions, _nodes_per_layer, _accepting_terminals);
 }
 
-auto MDD::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto MDD::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _bridge = make_shared<Bridge>();

--- a/gcs/constraints/mdd/mdd.hh
+++ b/gcs/constraints/mdd/mdd.hh
@@ -78,7 +78,6 @@ namespace gcs
         explicit MDD(std::vector<IntegerVariableID> vars, std::vector<std::vector<std::unordered_map<Integer, long>>> layer_transitions,
             std::vector<long> nodes_per_layer, std::vector<long> accepting_terminals);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/min_distance/min_distance.cc
+++ b/gcs/constraints/min_distance/min_distance.cc
@@ -42,17 +42,6 @@ auto MinDistance::clone() const -> unique_ptr<Constraint>
     return make_unique<MinDistance>(_x, _z, _distances, _requirements, _propagation);
 }
 
-auto MinDistance::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto MinDistance::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     const auto p = _x.size();

--- a/gcs/constraints/min_distance/min_distance.hh
+++ b/gcs/constraints/min_distance/min_distance.hh
@@ -112,7 +112,6 @@ namespace gcs
         explicit MinDistance(std::vector<IntegerVariableID> x, IntegerVariableID z, ArrayParam<Matrix> distances,
             std::optional<ArrayParam<Matrix>> requirements = std::nullopt, MinDistancePropagation propagation = MinDistancePropagation::ForwardBound);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/min_max/min_max.cc
+++ b/gcs/constraints/min_max/min_max.cc
@@ -38,17 +38,6 @@ auto ArrayMinMax::clone() const -> unique_ptr<Constraint>
     return make_unique<ArrayMinMax>(_vars, _result, _min);
 }
 
-auto ArrayMinMax::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ArrayMinMax::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     if (_vars.empty())

--- a/gcs/constraints/min_max/min_max.hh
+++ b/gcs/constraints/min_max/min_max.hh
@@ -37,7 +37,6 @@ namespace gcs
         public:
             explicit ArrayMinMax(std::vector<IntegerVariableID> vars, const IntegerVariableID result, bool min);
 
-            virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
             virtual auto clone() const -> std::unique_ptr<Constraint> override;
             [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
             [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/mini_linear_test.cc
+++ b/gcs/constraints/mini_linear_test.cc
@@ -106,30 +106,40 @@ namespace
         Integer _value;
         Mode _mode;
 
+        // The terms and the triggers, worked out by prepare() because the refined
+        // watches are stated against the initial upper bounds.
+        vector<pair<Integer, IntegerVariableID>> _terms;
+        Triggers _triggers;
+
     public:
         explicit MiniLinearGreaterEqual(WeightedSum coeff_vars, Integer value, Mode mode = Mode::RefinedAll) :
             _coeff_vars(move(coeff_vars)), _value(value), _mode(mode)
         {
         }
 
-        auto install(Propagators & propagators, State & initial_state, ProofModel * const) && -> void override
+        auto prepare(Propagators &, State & initial_state, ProofModel * const) -> bool override
         {
-            vector<pair<Integer, IntegerVariableID>> terms;
             for (const auto & [coeff, var] : _coeff_vars.terms)
-                terms.emplace_back(coeff, var);
+                _terms.emplace_back(coeff, var);
 
             // Coarse triggers on every variable's bounds. Both refined modes arm an
             // upper-bound watch (x_i < ub(x_i), entailed exactly when x_i's upper
             // bound drops) on every variable at install -- so scope and degree match
             // coarse (identical search tree), and WatchedSet then sheds the watches it
             // does not need. Payload = the variable's index into terms.
-            Triggers triggers;
             if (_mode == Mode::Coarse)
-                for (const auto & term : terms)
-                    triggers.on_bounds.push_back(term.second);
+                for (const auto & term : _terms)
+                    _triggers.on_bounds.push_back(term.second);
             else
-                for (const auto & [idx, term] : enumerate(terms))
-                    triggers.refined.emplace_back(term.second < initial_state.upper_bound(term.second), static_cast<std::uint32_t>(idx));
+                for (const auto & [idx, term] : enumerate(_terms))
+                    _triggers.refined.emplace_back(term.second < initial_state.upper_bound(term.second), static_cast<std::uint32_t>(idx));
+
+            return true;
+        }
+
+        auto install_propagators(Propagators & propagators) -> void override
+        {
+            auto terms = move(_terms);
 
             propagators.install(
                 constraint_id(),
@@ -190,7 +200,7 @@ namespace
                     }
                     return PropagatorState::Enable;
                 },
-                triggers);
+                _triggers);
         }
 
         auto clone() const -> unique_ptr<Constraint> override

--- a/gcs/constraints/multiply/multiply.cc
+++ b/gcs/constraints/multiply/multiply.cc
@@ -209,17 +209,6 @@ auto Multiply::install_propagators(Propagators & propagators) -> void
             move(_tabulation->accept), "multtab", "building GAC table for multiplication");
 }
 
-auto Multiply::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Multiply::constraint_type() const -> std::string
 {
     return "multiply";

--- a/gcs/constraints/multiply/multiply.hh
+++ b/gcs/constraints/multiply/multiply.hh
@@ -77,7 +77,6 @@ namespace gcs
         /// domains are small. Requesting an unsupported level is a compile-time error.
         auto with_consistency(MultiplyConsistency level) -> Multiply &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/n_value/n_value.cc
+++ b/gcs/constraints/n_value/n_value.cc
@@ -48,17 +48,6 @@ auto NValue::clone() const -> unique_ptr<Constraint>
     return make_unique<NValue>(_n_values, _vars);
 }
 
-auto NValue::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto NValue::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     for (const auto & var : _vars) {

--- a/gcs/constraints/n_value/n_value.hh
+++ b/gcs/constraints/n_value/n_value.hh
@@ -31,7 +31,6 @@ namespace gcs
     public:
         explicit NValue(const IntegerVariableID &, std::vector<IntegerVariableID>);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/nogoods/nogoods.cc
+++ b/gcs/constraints/nogoods/nogoods.cc
@@ -77,17 +77,6 @@ auto Nogoods::clone() const -> unique_ptr<Constraint>
     return make_unique<Nogoods>(_store, _trigger_vars, _refined);
 }
 
-auto Nogoods::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Nogoods::define_proof_model(ProofModel & model, const State &) -> void
 {
     // A nogood forbids a conjunction of literals, so its definition is the clause

--- a/gcs/constraints/nogoods/nogoods.hh
+++ b/gcs/constraints/nogoods/nogoods.hh
@@ -102,7 +102,6 @@ namespace gcs
          */
         Nogoods(std::shared_ptr<NogoodStore> store, std::vector<IntegerVariableID> trigger_vars, bool refined = false);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/parity/parity.cc
+++ b/gcs/constraints/parity/parity.cc
@@ -66,17 +66,6 @@ auto ParityOdd::clone() const -> unique_ptr<Constraint>
     return make_unique<ParityOdd>(_lits);
 }
 
-auto ParityOdd::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ParityOdd::define_proof_model(ProofModel & model, const State &) -> void
 {
     // cake_pb_cp's accumulator scheme, over the literals as cake reads them

--- a/gcs/constraints/parity/parity.hh
+++ b/gcs/constraints/parity/parity.hh
@@ -29,7 +29,6 @@ namespace gcs
 
         explicit ParityOdd(innards::Literals);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/plus_minus/minus.cc
+++ b/gcs/constraints/plus_minus/minus.cc
@@ -143,17 +143,6 @@ auto Minus::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto Minus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Minus::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     // Tabulation for GAC: enumerate the distinct underlying variables, mapping

--- a/gcs/constraints/plus_minus/minus.hh
+++ b/gcs/constraints/plus_minus/minus.hh
@@ -47,7 +47,6 @@ namespace gcs
         /// domains are small. Requesting an unsupported level is a compile-time error.
         auto with_consistency(MinusConsistency level) -> Minus &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/plus_minus/plus.cc
+++ b/gcs/constraints/plus_minus/plus.cc
@@ -133,17 +133,6 @@ auto Plus::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto Plus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Plus::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     // Tabulation for GAC: enumerate the distinct underlying variables, mapping

--- a/gcs/constraints/plus_minus/plus.hh
+++ b/gcs/constraints/plus_minus/plus.hh
@@ -55,7 +55,6 @@ namespace gcs
         /// domains are small. Requesting an unsupported level is a compile-time error.
         auto with_consistency(PlusConsistency level) -> Plus &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/power/power.cc
+++ b/gcs/constraints/power/power.cc
@@ -309,17 +309,6 @@ auto Power::install_propagators(Propagators & propagators) -> void
             move(_tabulation->accept), "powtab", "building GAC table for power");
 }
 
-auto Power::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Power::constraint_type() const -> std::string
 {
     return "power";

--- a/gcs/constraints/power/power.hh
+++ b/gcs/constraints/power/power.hh
@@ -86,7 +86,6 @@ namespace gcs
         /// domains are small. Requesting an unsupported level is a compile-time error.
         auto with_consistency(PowerConsistency level) -> Power &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/power/power_table.cc
+++ b/gcs/constraints/power/power_table.cc
@@ -28,17 +28,6 @@ auto PowerTable::clone() const -> unique_ptr<Constraint>
     return make_unique<PowerTable>(_base, _exponent, _result);
 }
 
-auto PowerTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto PowerTable::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     // Delegates entirely to a materialised Table over the reachable triples, which

--- a/gcs/constraints/power/power_table.hh
+++ b/gcs/constraints/power/power_table.hh
@@ -30,7 +30,6 @@ namespace gcs::innards
     public:
         explicit PowerTable(IntegerVariableID base, IntegerVariableID exponent, IntegerVariableID result);
 
-        virtual auto install(Propagators &, State &, ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const ProofModel * const) const -> SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/regular/regular.cc
+++ b/gcs/constraints/regular/regular.cc
@@ -514,17 +514,6 @@ auto Regular::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto Regular::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Regular::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     // The three strategies share this constraint's OPB encoding and its

--- a/gcs/constraints/regular/regular.hh
+++ b/gcs/constraints/regular/regular.hh
@@ -115,7 +115,6 @@ namespace gcs
         /// deterministic automaton (not regular-expression / NFA input).
         auto with_proof_strategy(RegularProofStrategy strategy) -> Regular &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/regular/regular_bacchus.cc
+++ b/gcs/constraints/regular/regular_bacchus.cc
@@ -257,17 +257,6 @@ auto RegularBacchus::clone() const -> unique_ptr<Constraint>
     return make_unique<RegularBacchus>(_vars, _num_states, _transitions, _final_states, _short_reasons);
 }
 
-auto RegularBacchus::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto RegularBacchus::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     _bridge = make_shared<Bridge>();

--- a/gcs/constraints/regular/regular_bacchus.hh
+++ b/gcs/constraints/regular/regular_bacchus.hh
@@ -62,7 +62,6 @@ namespace gcs
         explicit RegularBacchus(std::vector<IntegerVariableID> vars, long num_states, std::vector<std::vector<long>> transitions,
             std::vector<long> final_states, bool short_reasons = true);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/regular/regular_legacy.cc
+++ b/gcs/constraints/regular/regular_legacy.cc
@@ -438,17 +438,6 @@ auto RegularLegacy::clone() const -> unique_ptr<Constraint>
     return unique_ptr<Constraint>(new RegularLegacy(_vars, _num_states, _transitions, _final_states, _symbols, _short_reasons, _regex));
 }
 
-auto RegularLegacy::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto RegularLegacy::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     if (_regex) {

--- a/gcs/constraints/regular/regular_legacy.hh
+++ b/gcs/constraints/regular/regular_legacy.hh
@@ -74,7 +74,6 @@ namespace gcs
         /// or no argument leaves it at true.
         auto with_short_reasons(std::optional<bool> short_reasons = true) -> RegularLegacy &;
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/seq_precede_chain/seq_precede_chain.cc
+++ b/gcs/constraints/seq_precede_chain/seq_precede_chain.cc
@@ -43,17 +43,6 @@ auto SeqPrecedeChain::clone() const -> unique_ptr<Constraint>
     return make_unique<SeqPrecedeChain>(_vars);
 }
 
-auto SeqPrecedeChain::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto SeqPrecedeChain::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     // Either trivially satisfied, or delegated entirely to the ValuePrecede chain

--- a/gcs/constraints/seq_precede_chain/seq_precede_chain.hh
+++ b/gcs/constraints/seq_precede_chain/seq_precede_chain.hh
@@ -44,7 +44,6 @@ namespace gcs
          */
         explicit SeqPrecedeChain(std::vector<IntegerVariableID> vars);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/smart_table/smart_table.cc
+++ b/gcs/constraints/smart_table/smart_table.cc
@@ -776,17 +776,6 @@ auto SmartTable::clone() const -> unique_ptr<Constraint>
     return cloned;
 }
 
-auto SmartTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto SmartTable::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     // One 0/1 selector variable per tuple: allocating is a prepare() job.

--- a/gcs/constraints/smart_table/smart_table.hh
+++ b/gcs/constraints/smart_table/smart_table.hh
@@ -88,7 +88,6 @@ namespace gcs
         auto with_short_reasons(std::optional<bool> short_reasons = true) -> SmartTable &;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
 
         [[nodiscard]] static inline auto equals(const IntegerVariableID & a, const IntegerVariableID & b) -> SmartEntry
         {

--- a/gcs/constraints/sort/arg_sort.cc
+++ b/gcs/constraints/sort/arg_sort.cc
@@ -63,17 +63,6 @@ auto ArgSort::clone() const -> unique_ptr<Constraint>
     return make_unique<ArgSort>(_x, _p, _offset);
 }
 
-auto ArgSort::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ArgSort::prepare(Propagators & propagators, State & initial_state, ProofModel * const optional_model) -> bool
 {
     if (_x.size() != _p.size())

--- a/gcs/constraints/sort/arg_sort.hh
+++ b/gcs/constraints/sort/arg_sort.hh
@@ -46,7 +46,6 @@ namespace gcs
     public:
         explicit ArgSort(std::vector<IntegerVariableID> x, std::vector<IntegerVariableID> p, Integer offset = 0_i);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/sort/sort.cc
+++ b/gcs/constraints/sort/sort.cc
@@ -66,17 +66,6 @@ auto Sort::clone() const -> unique_ptr<Constraint>
     return make_unique<Sort>(_x, _y);
 }
 
-auto Sort::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Sort::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     if (_x.size() != _y.size())

--- a/gcs/constraints/sort/sort.hh
+++ b/gcs/constraints/sort/sort.hh
@@ -36,7 +36,6 @@ namespace gcs
     public:
         explicit Sort(std::vector<IntegerVariableID> x, std::vector<IntegerVariableID> y);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/table/negative_table.cc
+++ b/gcs/constraints/table/negative_table.cc
@@ -129,17 +129,6 @@ auto NegativeTable::clone() const -> unique_ptr<Constraint>
     return make_unique<NegativeTable>(_vars, ExtensionalTuples{_tuples});
 }
 
-auto NegativeTable::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto NegativeTable::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     visit(

--- a/gcs/constraints/table/negative_table.hh
+++ b/gcs/constraints/table/negative_table.hh
@@ -29,7 +29,6 @@ namespace gcs
     public:
         explicit NegativeTable(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;

--- a/gcs/constraints/table/table.cc
+++ b/gcs/constraints/table/table.cc
@@ -108,17 +108,6 @@ namespace
     }
 }
 
-auto Table::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto Table::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
 {
     visit(

--- a/gcs/constraints/table/table.hh
+++ b/gcs/constraints/table/table.hh
@@ -27,7 +27,6 @@ namespace gcs
     public:
         explicit Table(std::vector<IntegerVariableID> vars, ExtensionalTuples tuples);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;

--- a/gcs/constraints/value_precede/value_precede.cc
+++ b/gcs/constraints/value_precede/value_precede.cc
@@ -40,17 +40,6 @@ auto ValuePrecede::clone() const -> unique_ptr<Constraint>
     return make_unique<ValuePrecede>(_chain, _vars);
 }
 
-auto ValuePrecede::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
-{
-    if (! prepare(propagators, initial_state, optional_model))
-        return;
-
-    if (optional_model)
-        define_proof_model(*optional_model, initial_state);
-
-    install_propagators(propagators);
-}
-
 auto ValuePrecede::prepare(Propagators &, State &, ProofModel * const) -> bool
 {
     return _chain.size() >= 2;

--- a/gcs/constraints/value_precede/value_precede.hh
+++ b/gcs/constraints/value_precede/value_precede.hh
@@ -66,7 +66,6 @@ namespace gcs
          */
         explicit ValuePrecede(Integer s, Integer t, std::vector<IntegerVariableID> vars);
 
-        virtual auto install(innards::Propagators &, innards::State &, innards::ProofModel * const) && -> void override;
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;


### PR DESCRIPTION
The finale of the `install()` split stack (#618 → #630). All 51 `install()` overrides had become the same six lines, so the base defines that once, non-virtually, and every override is deleted.

```cpp
auto Constraint::install(Propagators & propagators, State & initial_state, ProofModel * const optional_model) && -> void
{
    if (! prepare(propagators, initial_state, optional_model))
        return;

    if (optional_model)
        define_proof_model(*optional_model, initial_state);

    install_propagators(propagators);
}
```

**Checked before deleting rather than after**: a script grouped all 51 bodies by their whitespace-normalised text and found exactly *one* distinct body, which is the one `Constraint::install()` now runs. Anything else would not have matched the deletion, and would then have failed to compile as an override — which is how the remaining odd ones out were found. Five are test or benchmark constraints that had never been split, and they are split here:

| | |
|---|---|
| `wake_cost`'s `Observer`, `slack_watch`'s `SumLeqWatched`, `tabulation_test`'s `TabulateProductForTest` | only ever installed propagators → `install_propagators()` |
| `product_justify_test`'s `ProductFragmentForTest` | its cake encoding is a `define_proof_model()`, with the encoding handles as a member |
| `mini_linear_test`'s `MiniLinearGreaterEqual` | needs a `prepare()`, because its refined watches are stated against the initial upper bounds |

## One consequence worth stating

A phase that fails to override is now a **silent no-op**, where `install()` not overriding a pure virtual was a compile error. So every `prepare` / `define_proof_model` / `install_propagators` declaration in the tree was checked to carry `override` and to match the base's signature exactly: 46 + 1 + 1 `prepare`, 48 + 1 `define_proof_model` and 48 + 5 `install_propagators` do, and the only three declarations without `override` are the base's own.

## Docs

`dev_docs/constraints.md`'s "install: the entry point" section becomes "The three install phases" — no longer a recommended shape but the only one. The phases go in the header, `install()` is not yours to write, and each phase's contract is spelled out: `prepare()` is the only one that can allocate or install a child, `define_proof_model()` sees the declared domains through a `const State &`, and returning false from `prepare()` means the other two must not run. `dev_docs/README.md` and `dev_docs/reification.md` follow.

531/531 ctest pass; OPB and `.scp` byte-identical across all 60 captured example models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVnAMyxUBCbh1a5nSqp9jD