### PR TITLE
Add dev_docs/proof-benchmarks.md: a benchmark set for proof work

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -46,6 +46,12 @@ library. For an introduction to *using* the solver, start with the top-level
   measuring the wall-time impact of a performance-sensitive change, the
   rationale for each pick, the harness pattern for comparing two builds,
   and what to capture. Use when quantifying a refactor's perf impact.
+- [Proof benchmarks](proof-benchmarks.md) — the counterpart set for when
+  the *proof* is what is being measured: proof-writing cost, proof size
+  and VeriPB checking time. Groups instances by whether they stress
+  writing or checking, records which candidates are too large to
+  proof-log at all, and lists the argument-shape traps. Use when
+  changing proof logging, scaffolding, encodings or hinting.
 - [Frontend support matrix](frontend-support-matrix.md) — single source of
   truth for which gcs propagators each frontend (MiniZinc, XCSP3, CPMpy)
   exposes, plus where the solver-side gaps are tracked. Update when adding

--- a/dev_docs/benchmarking.md
+++ b/dev_docs/benchmarking.md
@@ -10,6 +10,15 @@ The set was settled on while doing Phase 2 of issue #134. The intent is that
 future performance work re-uses it, so that results are comparable across
 PRs over time.
 
+**If the change under test is on the proof side**, use
+[proof-benchmarks.md](proof-benchmarks.md) instead: it curates a separate set
+of instances for measuring proof-writing cost, proof size and VeriPB checking
+time. The two sets are almost disjoint, because sizes that make a good solve
+benchmark are usually far too large to proof-log — `ortho_latin --size=6 --all`
+and `tsp` from the table below both write more than 4 GB of `.pbp`. The
+"Benchmarking proof-shape changes" section further down remains the methodology
+for that work; proof-benchmarks.md is the instance set to apply it to.
+
 ## What to run
 
 Eight benchmarks, picked to cover a mix of search-heavy / propagation-heavy
@@ -166,6 +175,13 @@ constraint variant, a refactor of how a propagator emits scaffolding,
 moving from per-call to upfront derivation — is a different kind of
 performance change with different signals and different traps.
 
+The rest of this section is the methodology. For the instances to apply it
+to, see [proof-benchmarks.md](proof-benchmarks.md), which curates a set sized
+so that VeriPB takes minutes rather than milliseconds, and which separates
+instances that stress proof *writing* from those that stress proof
+*checking* — the two are close to opposites, and a change that helps one
+routinely hurts the other.
+
 ### What to capture
 
 - **`solve` time** — usually goes up modestly (more proof I/O), but
@@ -263,6 +279,14 @@ instances of increasing size; `--random N` scales continuously without
 needing a data file. Enumerating all solutions (`--all`) of an
 under-clued or random instance is the proof-shape regime here, exactly
 as for `regular_random --all`.
+
+**`--random N` does not deliver that regime, though.** The generator
+builds the clues from a random picture, so the puzzle it poses is very
+nearly determined and `--all` barely searches: `--random 20 --seed 1
+--all` measures **17 recursions and 3 solutions**, which is inside the
+"tens of recursions means a no-search bench" band described two sections
+above. `--seed 3` gives 3 recursions. Use the `--dzn` instances, which
+are genuinely under-clued, and treat `--random` as a smoke test only.
 
 ### Cross-variant invariants
 

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -46,12 +46,21 @@ local SSD. `veripb` 3.0.2.
 | `freqsq6_gac` | `frequency_square 6 --all --stats --consistency gac` | enum, 53 220 | 105 825 | 44 KB | 205 MB | 0.90 s | ×2.0 | **83.6 s** |
 | `freqsq6_bc` | `frequency_square 6 --all --stats --consistency bc` | enum, 53 220 | 105 825 | 44 KB | 80 MB | 1.10 s | ×1.3 | **81.2 s** |
 | `pdisp10_tuple` | `p_dispersion --grid 10 -p 4 --variant tuple --stats` | optimal | 1 037 | 12.6 MB | 158 MB | 0.10 s | ×4.0 | **88.8 s** |
-| `mzn_hitori` | `fzn-glasgow -s -a hitori.fzn` (Challenge 2025, `h5-1.dzn`) | optimal | 113 671 | 1.2 MB | **1 000 MB** | 1.20 s | ×3.1 | **273.3 s** |
-| `mzn_seatmoving` | `fzn-glasgow -s -n 1 2018_seat-moving.fzn` | first solution | 15 610 | 3.1 MB | 629 MB | 0.40 s | ×3.8 | **122.3 s** |
+| `hitori` | `hitori --size 5 --seed 1 --quiet --stats` | optimal | 72 361 | — | 937 MB | — | — | **260.5 s** |
+| `table_layout` | `table_layout --size 15 --seed 1 --stats` | optimal | 17 768 | — | 146 MB | — | — | **102.6 s** |
+| `seat_moving` | `seat_moving --dzn sm-10-12-00.dzn --quiet --stats` | first solution | 15 610 | 2.4 MB | 645 MB | — | — | **119.5 s** |
 
 `solve` is wall time with proof logging off; `+proof` is the multiplier when it
 is on. Note how far that varies — from ×1.2 on `colour46`, whose search dominates,
-to ×9.0 on `odb_cumulative8`. One pass over group A costs about 47 minutes.
+to ×9.0 on `odb_cumulative8`. One pass over group A costs about 55 minutes.
+
+The last three rows are the native ports from issues #633–#636; they carry no
+`solve`/`+proof` column yet because they were measured after the pinned pass.
+`hitori` and `seat_moving` replaced `fzn-glasgow` entries and were validated
+against them — **recursion counts match exactly** (113 671 and 15 610), so they
+reproduce the search rather than merely the answer. `table_layout` gives `Table`
+a size where proof shape is measurable at all; `examples/tables` is 10
+recursions.
 
 `langford11` at 11.0 minutes sits just outside the nominal ceiling. It is kept
 deliberately as the largest entry; with `langford10` at 60.4 s the pair brackets
@@ -92,6 +101,7 @@ Pairs that differ in one controlled way, for attributing a difference.
 | benchmark | command | why separate |
 |---|---|---|
 | `mzn_aircraft06` | `fzn-glasgow -s -a aircraft.fzn` (Challenge 2024, `B737NG-600-06-Anon.json.dzn`) | Needs about **19 GB of veripb resident memory**. It cannot share a 30 GB machine with anything else and will exhaust a smaller one. |
+| `rcpsp20` | `rcpsp --size 20 --seed 1 --stats` | Writes a **4.1 GB `.pbp`** and verifies in 699 s — over the nominal ceiling and heavy on disk. Kept because it is the only *realistic* `Cumulative` + `Disjunctive` entry; `odb_cumulative8` covers the propagator more cheaply but is synthetic. |
 
 `mzn_aircraft06` is worth the trouble because it is the only entry where the
 checker is bound by the **model encoding** rather than the derivation: a 2.5 GB
@@ -218,6 +228,9 @@ repeated.
 | `skeleton_puzzle` at 4×3, 4×4, 5×3, 5×4, 6×3 and the default 7×5 | cap or over 1200 s at every shape tried, with `--seed` and without |
 | `random_polynomial -n 12 -d 6` | cap; `-n 10 -d 5` is 426 MB |
 | `colour` on 42-vertex (50 % density) and 60-vertex graphs | cap — but a 46-vertex graph verifies in the band; see below |
+| `rcpsp --size` 12–19 and 22–24, several seeds | either trivial (≤139 MB, under 10 s) or cap. Only `--size 20 --seed 1` lands, at 4.1 GB |
+| `seat_moving --seats` 20, 30, 60, 100 | cap in find-first mode; `--optimise` caps from 20 seats up. 16 seats is 11 MB |
+| `hitori --size` 6, 7, 8, and `--size 6 --density 0.2` | cap. `--size 5` is 937 MB, `--size 4` is 5.7 MB |
 | `order_deletion_bench --problem cumulative --size 10 --domain 500` | cap |
 | Challenge `atsp`, `triangular`, `chessboard`, `tiny-cvrp`, `table-layout` | cap or over 1200 s, despite each solving in under 12 s with proofs off |
 | `nonogram --random N --all` | no search — 17 recursions at the size `benchmarking.md` suggests |
@@ -266,20 +279,27 @@ Found the hard way, all of them producing an immediate parse error:
   proof in piloting — but that observation was made against an unseeded run and
   so compared two different instances; a seeded comparison is the way to settle
   it.
-- **`Cumulative` and `Disjunctive` at scale** are reachable only through the
-  MiniZinc frontend, because `examples/cumulative` is a fixed five-task toy.
-  This is the most valuable gap to close.
+- **A comfortably-sized realistic `Cumulative` / `Disjunctive` instance.**
+  `examples/rcpsp` (issue #633) closed the "unreachable natively" half of this,
+  but its instances are **bimodal rather than scalable**: across `--size` 12–24
+  and three seeds, every instance was either trivial (≤139 MB, under 10 s) or
+  explosive (over 3 GB). Only `--size 20 --seed 1` lands in range, and it writes
+  4.1 GB. `odb_cumulative8` covers the propagator cheaply but synthetically.
+- **A generated `seat_moving` instance.** The port removed the dependence on an
+  unversioned flattened `.fzn`, but it still needs the Challenge `.dzn`:
+  generated instances jump from 11 MB at 16 seats to over 6 GB at 20, in both
+  find-first and `--optimise` modes.
 
 ## MiniZinc entries
 
-Three entries come through `fzn-glasgow` because nothing native reaches their
-shape: `mzn_hitori` (a realistic optimisation writing a 1 GB proof from under
-four seconds of solving), `mzn_aircraft06` (the model-encoding-bound extreme)
-and `mzn_seatmoving` (the deep find-first split search).
+One entry still comes through `fzn-glasgow`, because nothing native reaches its
+shape: `mzn_aircraft06`, the model-encoding-bound extreme. The other two — a
+realistic gigabyte-scale optimisation and the deep find-first split search — are
+now the native `hitori` and `seat_moving` examples.
 
-They carry a cost: a flattening step, `mznlib` drift between MiniZinc releases,
-and a dependence on a Challenge corpus that is not in this repository. Flatten
-once and keep the `.fzn`:
+The MiniZinc route carries a cost: a flattening step, `mznlib` drift between
+MiniZinc releases, and a dependence on a Challenge corpus that is not in this
+repository. Flatten once and keep the `.fzn`:
 
 ```shell
 minizinc --solver <glasgow.msc> -c --fzn model.fzn --no-output-ozn model.mzn data.dzn
@@ -292,15 +312,11 @@ would make the set self-contained. A port must reproduce the proof *shape* —
 `.opb` size, `.pbp` size and recursion count — against the `fzn-glasgow` run,
 not merely the answer, or it is not a substitute for the instance it replaces.
 
-Four such ports are tracked:
+Four such ports were done, as issues #633–#636 and PRs #638–#641:
+`examples/rcpsp`, `examples/hitori`, `examples/seat_moving` and
+`examples/table_layout`. Each takes a `--size`/`--seed` pair, and `hitori`,
+`seat_moving` and `table_layout` also read the original `.dzn` directly, which
+is what made the validation above possible.
 
-- **#633** — a scheduling example (`Cumulative`, `Disjunctive`, makespan). The
-  most valuable of the four: it closes the gap above rather than replacing an
-  existing entry.
-- **#634** — `hitori`, which needs only `Count` and `AllDifferentExcept`.
-- **#635** — `seat-moving`, which needs only `AllDifferent` and
-  `AllDifferentExcept`, and which removes this set's dependence on a flattened
-  `.fzn` that is not under version control.
-- **#636** — `table-layout`, which would also give `Table` a representation at
-  a size where proof shape is measurable; `examples/tables` is a 10-recursion
-  toy.
+The remaining MiniZinc dependency is `mzn_aircraft06`, whose 2.5 GB `.opb` is
+the point of the entry, and `seat_moving`'s `.dzn` — see "Known gaps".

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -31,14 +31,16 @@ runtimes on purpose and a sweep that only ran one group would be misleading.
 These verify slowly enough that a single-digit-percent change is resolvable.
 
 Measured solo, pinned to one core with ASLR off, minimum of three runs, on the
-local SSD. `veripb` 3.0.2.
+local SSD. `veripb` 3.0.2. The `rcpsp_dl21` row is a later sitting than the rest
+— see "`rcpsp`'s options" below for why — so read its verify time as a size
+guide, not as a figure to compare against the others to within a few percent.
 
 | benchmark | command | outcome | recs | `.opb` | `.pbp` | solve | +proof | verify |
 |---|---|---|--:|--:|--:|--:|--:|--:|
 | `odb_eq1000` | `order_deletion_bench --problem pairwise --size 6 --domain 1000 --window 1000 --tightness 90 --unsat --value-order smallest` | UNSAT | 49 352 | 11 KB | 37 MB | 0.10 s | ×2.0 | **139.5 s** |
 | `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT | 6 979 | 20 KB | 17 MB | 0.10 s | ×1.0 | **106.1 s** |
 | `odb_cumulative8` | `order_deletion_bench --problem cumulative --size 8 --domain 250 --window 250 --tightness 90 --unsat` | UNSAT | 33 959 | 1.9 MB | 454 MB | 0.10 s | ×9.0 | **314.7 s** |
-| `rcpsp_dl21` | `rcpsp --size 20 --seed 1 --deadline 21 --stats` | UNSAT | 42 115 | 0.3 MB | 1 247 MB | — | — | **135.8 s** |
+| `rcpsp_dl21` | `rcpsp --size 20 --seed 1 --deadline 21 --stats` | UNSAT | 42 058 | 0.3 MB | 1 242 MB | 0.30 s | ×7.0 | **139.5 s** |
 | `qap10` | `qap --size=10` | optimal | 10 985 | 3.5 MB | 504 MB | 0.20 s | ×6.0 | **283.8 s** |
 | `colour46` | `colour --file <46-vertex random graph>` | optimal | 313 109 | 0.4 MB | 736 MB | 12.31 s | ×1.2 | **347.6 s** |
 | `nqueens12` | `n_queens --size=12 --all` | enum, 14 200 | 232 163 | 0.2 MB | 208 MB | 0.50 s | ×2.2 | **219.8 s** |
@@ -119,40 +121,52 @@ Pairs that differ in one controlled way, for attributing a difference.
 | benchmark | command | why separate |
 |---|---|---|
 | `mzn_aircraft06` | `fzn-glasgow -s -a aircraft.fzn` (Challenge 2024, `B737NG-600-06-Anon.json.dzn`) | Needs about **19 GB of veripb resident memory**. It cannot share a 30 GB machine with anything else and will exhaust a smaller one. |
-| `rcpsp20_opt` | `rcpsp --size 20 --seed 1 --stats` | The makespan-optimisation form of the group A entry above: **4.1 GB `.pbp`**, 656.8 s. Superseded for routine use by `rcpsp_dl21`, which proves infeasibility at the same instance for a quarter of the proof. Keep it only when the *optimisation* proof shape is what is under test. |
+| `rcpsp20_opt` | `rcpsp --size 20 --seed 1 --stats` | The makespan-optimisation form of the group A entry above: **4.1 GB `.pbp`**, 702.7 s. Superseded for routine use by `rcpsp_dl21`, which proves infeasibility at the same instance for under a third of the proof. Keep it only when the *optimisation* proof shape is what is under test. |
 
 ### `rcpsp`'s options, and what they are worth
 
 The example grew `--variant`, `--machine`, `--unary`, `--simplify`,
-`--incremental`, `--deadline` and an RCPSP/max generalisation. **The defaults
-reproduce the original row exactly** — 171 480 recursions and a byte-identical
-4106.4 MB proof — because `--variant=decomposed` is the original linear-per-edge
-posting, `--machine=disjunctive` the `Disjunctive` global, and
-`--max-lag-density` defaults to zero and *draws no random numbers*, leaving the
-generated instance untouched. Re-check the recursion count after any future
-change to the generator: one extra random draw would move every seeded instance
-and silently stale these rows without anything failing.
+`--incremental`, `--deadline` and an RCPSP/max generalisation, and **none of
+them changed the instance**: `--variant=decomposed` is the original
+linear-per-edge posting, `--machine=disjunctive` the `Disjunctive` global, and
+`--max-lag-density` defaults to zero and *draws no random numbers*, so a seeded
+instance is untouched by the new options.
 
-Measured across the new options at `--size 20 --seed 1`:
+The search moved anyway, and not from the generator. These rows were re-measured
+against `main` at `d3c9e58b` (2026-08-07), and `--size 20 --seed 1` now takes
+**171 423** recursions where the first pass recorded 171 480; `--deadline 21` is
+**42 058** against 42 115. Both are 57 recursions shorter, and the cause is the
+`Cumulative` work merged in between, not anything in this example — every other
+row in this document still reproduces its recorded count exactly.
+
+That is the failure mode to watch for here, and nothing errors when it happens.
+Re-check the recursion counts after a change to either the generator or
+`Cumulative`: one extra random draw or one extra inference stales every seeded
+row silently.
+
+Measured across the options at `--size 20 --seed 1`:
 
 | configuration | recursions | `.pbp` | verify | outcome |
 |---|--:|--:|--:|---|
-| default (optimise) | 171 480 | 4 106 MB | 656.8 s | `BOUNDS 22 ≤ obj ≤ 22` |
-| `--variant global` | 171 480 | 4 136 MB | — | same |
-| `--variant presolved` | 171 480 | 4 125 MB | — | same |
-| `--value-order split` | 185 861 | 3 511 MB | — | same |
-| **`--deadline 21`** | 42 115 | **1 247 MB** | **135.8 s** | **UNSAT** |
-| `--deadline 21 --value-order split` | — | 1 007 MB | 111.5 s | UNSAT |
+| default (optimise) | 171 423 | 4 104 MB | 702.7 s | `BOUNDS 22 ≤ obj ≤ 22` |
+| `--variant global` | 171 423 | 4 134 MB | — | same |
+| `--variant presolved` | 171 423 | 4 118 MB | — | same |
+| `--value-order split` | 185 247 | 3 500 MB | — | same |
+| **`--deadline 21`** | 42 058 | **1 242 MB** | **139.5 s** | **UNSAT** |
+| `--deadline 21 --value-order split` | 41 507 | 996 MB | 112.3 s | UNSAT |
 | `--infeasible` | **1** | 0.1 MB | — | UNSAT at the root |
+
+The two `--deadline` rows are minimum-of-three; the 702.7 s is a single run,
+because at 4.1 GB three of them cost most of an hour to say the same thing.
 
 Three things worth knowing:
 
 - **`--deadline` is the good entry.** The optimum is 22, so `--deadline 21` asks
-  a decision question the solver has to search to refute — a quarter of the
+  a decision question the solver has to search to refute — under a third of the
   proof, a fifth of the verify time, and a *scheduling UNSAT*, which no other
   entry provides. This is why it is in group A and the optimisation form is not.
 - **The three `--variant` postings make identical search and near-identical
-  proofs** (within 0.7 %), despite posting the temporal network three completely
+  proofs** (within 0.8 %), despite posting the temporal network three completely
   different ways. That makes them a same-search control triple; it does *not*
   make `global` a route to a smaller proof.
 - **`--infeasible` refutes at the root in one recursion.** It closes a negative

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -114,7 +114,7 @@ Pairs that differ in one controlled way, for attributing a difference.
 | `knapsack_bench --instance 1` vs `--instance 1 --upfront` | **The clearest SIZE≠TIME demonstration in the set.** Identical search — 907 recursions, 454 solutions both ways — but `--upfront` writes a **5.9× smaller** proof (20.7 MB against 121.3 MB) that takes **3.5× longer** to check (7.0 s against 2.0 s). One flag, one instance, and the two axes move in opposite directions. |
 | `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | Identical search — 551 recursions, 7 solutions — through a decomposition and through the global propagator: **42.9 MB / 9.7 s against 0.8 MB / 0.7 s**. At `--grid 10` the proof-size gap widens to 91×, and at `--grid 12` the decomposition stops verifying inside 1200 s while the global takes 15 s. |
 | `langford --size=11` vs `--size=10` | Enumeration against UNSAT refutation on one model, and the pair brackets the whole target band: 662.9 s and 60.4 s. |
-| `magic_square --size=4 --all-different gac` vs `vc` | **Not** a same-search pair, despite looking like one: GAC searches 77 983 recursions against VC's 87 377. Listed so nobody mistakes it for one — `--all-different` defaults to `vc`, so comparing the default against explicit `vc` gives a spurious match. |
+| `magic_square --size=4 --all-different gac` vs `vc` | **Not** a same-search pair, despite looking like one: GAC searches 77 983 recursions against VC's 87 377, for 169 MB / 29.1 s against 164 MB / 30.1 s. Listed so nobody mistakes it for one — `--all-different` defaults to `vc`, so comparing the default against explicit `vc` gives a spurious match. |
 
 ### Group D — opt-in, needs a big machine
 
@@ -262,16 +262,42 @@ are easy to get wrong:
 
 One refinement this set adds, and it is stronger than "small proofs degrade
 worse": **a verify time measured under load cannot be corrected, only
-discarded.** Measured against solo baselines on this set, the inflation under a
-three- or four-way load ran from **1.07×** (`colour` g40, 188 MB) to **2.99×**
-(`freqsq6_gac`, 205 MB) — two proofs of similar size at opposite ends of the
-range. Proof size does not predict it. Budget for running a sweep solo end to
-end; there is no shortcut that scales a parallel pass back down.
+discarded.** Every group A and B row except the four measured after the pilot
+was verified twice, once solo and once under the pilot's three- and four-way
+load, on byte-identical proofs — all fourteen of them, sorted by inflation:
 
-A worked example of why it matters: under pilot load `freqsq6_gac` and
-`freqsq6_bc` looked 27 % apart. Solo they are **3 % apart** (83.6 s against
-81.2 s) despite the GAC proof being 2.6× larger. The entire apparent difference
-was contention.
+| row | `.pbp` | solo | loaded | inflation |
+|---|--:|--:|--:|--:|
+| `odb_cumulative8` | 454 MB | 314.7 s | 331.1 s | **1.05×** |
+| `knapsack2` | 138 MB | 2.4 s | 2.7 s | 1.13× |
+| `colour46` | 736 MB | 347.6 s | 399.2 s | 1.15× |
+| `langford10` | 101 MB | 60.4 s | 72.0 s | 1.19× |
+| `nfractions` | 146 MB | 3.2 s | 4.2 s | 1.31× |
+| `qap10` | 504 MB | 283.8 s | 378.4 s | 1.33× |
+| `langford11` | 670 MB | 662.9 s | 891.4 s | 1.34× |
+| `pdisp10_tuple` | 158 MB | 88.8 s | 125.6 s | 1.42× |
+| `nqueens12` | 208 MB | 219.8 s | 312.5 s | 1.42× |
+| `polynomial10` | 426 MB | 26.0 s | 37.5 s | 1.44× |
+| `odb_eq1000` | 37 MB | 139.5 s | 238.8 s | 1.71× |
+| `odb_split2000` | 17 MB | 106.1 s | 186.7 s | 1.76× |
+| `freqsq6_bc` | 80 MB | 81.2 s | 195.7 s | 2.41× |
+| `freqsq6_gac` | 205 MB | 83.6 s | 249.6 s | **2.99×** |
+
+The table is sorted by inflation, and the size column reads 454, 138, 736, 101,
+146, 504, 670, 158, 208, 426, 37, 17, 80, 205. There is a weak inverse tendency
+in that — rank correlation −0.41, and the smallest two proofs are eleventh and
+twelfth — but it is nowhere near strong enough to correct with. `langford10` at
+101 MB inflates 1.19× and `freqsq6_bc` at 80 MB inflates 2.41×: two proofs of
+nearly the same size, at opposite ends of the range. And on the one pair where
+everything else is held fixed, the two `frequency_square` rows, it is the
+**smaller** proof that degrades less — the opposite of the rule this is
+refining. Budget for running a sweep solo end to end; there is no shortcut that
+scales a parallel pass back down.
+
+That last pair is also the worked example of why it matters. Under pilot load
+`freqsq6_gac` and `freqsq6_bc` looked 27 % apart. Solo they are **3 % apart**
+(83.6 s against 81.2 s) despite the GAC proof being 2.6× larger. The entire
+apparent difference was contention.
 
 **On filesystems: it does not matter, and tmpfs is mildly counterproductive.**
 Measured directly — the same proof verified from the local SSD and from tmpfs,
@@ -313,7 +339,7 @@ repeated.
 | `regular_random -n 7 --all` | 172–282 MB, but **over an hour** to verify, with `--bacchus` as well as without; `-n 6` is under a second |
 | `skeleton_puzzle` at 4×3, 4×4, 5×3, 5×4, 6×3 and the default 7×5 | cap or over 1200 s at every shape tried, with `--seed` and without |
 | `random_polynomial -n 12 -d 6` | cap; `-n 10 -d 5` is 426 MB |
-| `colour` on 42-vertex (50 % density) and 60-vertex graphs | cap — but a 46-vertex graph verifies in the band; see below |
+| `colour` on 42-vertex (50 % density) and 60-vertex graphs | cap — and a 45-vertex one writes 5.6 GB without verifying inside 1200 s; a 46-vertex graph verifies in the band, see below |
 | `rcpsp --size` 12–19 and 22–24, several seeds | either trivial (≤139 MB, under 10 s) or cap. Only `--size 20 --seed 1` lands, at 4.1 GB |
 | `seat_moving --seats` 20, 30, 60, 100 | cap in find-first mode; `--optimise` caps from 20 seats up. 16 seats is 11 MB |
 | `hitori --size` 6, 7, 8, and `--size 6 --density 0.2` | cap. `--size 5` is 937 MB, `--size 4` is 5.7 MB |
@@ -326,10 +352,14 @@ repeated.
 
 Two parameters turn out not to be parameters:
 
-- **`colour` is instance-dependent, not size-monotone.** A 41-vertex graph gives
-  16 MB, a 42-vertex one 120 MB, a 46-vertex one 736 MB, and a different
-  42-vertex one blows the cap. Pick and keep an instance; do not scale the
-  vertex count and expect the proof to follow.
+- **`colour` is instance-dependent, not size-monotone.** Across a series holding
+  the edge count roughly constant (383 to 445) and varying the vertices, the
+  proof is 16 MB at 41 vertices, 120 MB at 42, 869 MB at 44, **5.6 GB** at 45 —
+  which does not verify inside 1200 s — and back down to 657 MB at 48. Three
+  more vertices for the same edge budget cut both the proof and the search by a
+  factor of eight. At a fixed 50 % density, a 42-vertex graph blows the cap
+  while the 46-vertex `colour46` verifies inside the band. Pick and keep an
+  instance; do not scale the vertex count and expect the proof to follow.
 - **`regular_random` has no usable size.** n=6 checks in 0.6 s, n=7 takes over
   1200 s, and n=9 blows the cap. `Regular` is consequently not represented at
   scale anywhere in this set — see "Known gaps".

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -1,0 +1,250 @@
+# Benchmarks for proof writing and proof checking
+
+This document curates a set of instances whose **proofs** are the object of
+measurement: how long the solver takes to write a proof, how large that proof
+is, and how long VeriPB takes to check it.
+
+It is the counterpart to [benchmarking.md](benchmarking.md), which curates a
+different set for a different purpose — *solve* speed with proof logging off.
+That document explicitly says not to put `--prove` in its numbers, and its
+instances are sized accordingly: several of them cannot be proof-logged at all
+on a development machine (see "Instances that do not fit", below). Reach for
+this document when the change under test is on the proof side — a new
+constraint's proof logging, a propagator's scaffolding, upfront versus per-call
+derivation, RUP hinting, proof-level assignment, an encoding change, or a VeriPB
+upgrade.
+
+`benchmarking.md` also has a "Benchmarking proof-shape changes" section. That
+section is the *methodology* — what to capture, the default-mode trap, how to
+pick a size. This document is the *instance set* that section never had.
+
+## What to run
+
+Build with `cmake --preset release`; binaries land in `build/`. Every command
+below is completed by `--prove --proof-files-basename <path>`.
+
+The set is grouped by what each entry is for, because the groups have different
+runtimes on purpose and a sweep that only ran one group would be misleading.
+
+### Group A — proof checking (the 1–10 minute band)
+
+These verify slowly enough that a single-digit-percent change is resolvable.
+
+| benchmark | command | outcome |
+|---|---|---|
+| `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT |
+| `odb_eq1000` | `order_deletion_bench --problem pairwise --size 6 --domain 1000 --window 1000 --tightness 90 --unsat --value-order smallest` | UNSAT |
+| `qap10` | `qap --size=10` | optimal |
+| `colour46` | `colour --file <46-vertex random graph>` | optimal |
+| `nqueens12` | `n_queens --size=12 --all` | enumeration |
+| `langford11` | `langford --size=11 --stats` | enumeration |
+| `langford10` | `langford --size=10 --stats` | UNSAT |
+| `freqsq6_gac` | `frequency_square 6 --all --stats --consistency gac` | enumeration |
+| `freqsq6_bc` | `frequency_square 6 --all --stats --consistency bc` | enumeration |
+| `pdisp10_tuple` | `p_dispersion --grid 10 -p 4 --variant tuple --stats` | optimal |
+| `mzn_hitori` | `fzn-glasgow -s -a hitori.fzn` (Challenge 2025, `h5-1.dzn`) | optimal |
+| `mzn_seatmoving` | `fzn-glasgow -s -n 1 2018_seat-moving.fzn` | first solution |
+
+### Group B — proof writing
+
+These verify in seconds but write hundreds of megabytes. They are the only
+entries that isolate emission cost, and they must not be dropped for being
+quick to check — see "The axis that matters most".
+
+| benchmark | command | outcome |
+|---|---|---|
+| `polynomial10` | `random_polynomial -n 10 -d 5 --seed 1 --stats` | optimal |
+| `knapsack2` | `knapsack_bench --instance 2 --stats` | enumeration |
+| `nfractions` | `n_fractions --unsat --stats` | UNSAT |
+
+### Group C — controls
+
+Pairs that differ in one controlled way, for attributing a difference.
+
+| pair | what it controls for |
+|---|---|
+| `magic_square --size=4 --all-different gac` vs `--all-different vc` | **Identical search** — same recursions, same solution count — with propagation count differing about 6×. Any proof-side divergence is emission, not search. |
+| `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | The same problem through a decomposition and through the global propagator. |
+| `frequency_square 6 --all --consistency gac` vs `bc` | Propagation strength on one instance (also in group A). |
+| `langford --size=11` vs `--size=10` | Enumeration against UNSAT refutation on one model. |
+
+### Group D — opt-in, needs a big machine
+
+| benchmark | command | why separate |
+|---|---|---|
+| `mzn_aircraft06` | `fzn-glasgow -s -a aircraft.fzn` (Challenge 2024, `B737NG-600-06-Anon.json.dzn`) | Needs about **19 GB of veripb resident memory**. It cannot share a 30 GB machine with anything else and will exhaust a smaller one. |
+
+`mzn_aircraft06` is worth the trouble because it is the only entry where the
+checker is bound by the **model encoding** rather than the derivation: a 2.5 GB
+`.opb` against an 8 MB `.pbp`. The largest `.opb` anything else in the set
+produces is 12.6 MB.
+
+## Why these instances
+
+Two derived ratios separate proofs far better than any qualitative label, and
+the set is chosen to span both.
+
+**Verify seconds per megabyte of `.pbp`** ranges over roughly 500× across the
+set. At one end `order_deletion_bench --domain 2000` writes 17 MB and takes
+around 110 s to check; at the other `knapsack_bench --instance 2` writes 138 MB
+and checks in under 2 s. High values mean the checker is working through long
+RUP chains over a wide resident database; low values mean it is streaming a
+large but individually-trivial derivation.
+
+**Kilobytes of `.pbp` per recursion** ranges over roughly 3000×, from under
+1 KB (`frequency_square`, `n_queens`) to about 1.3 MB (`n_fractions`). This is
+the wide-versus-deep axis: high values mean the proof is dominated by upfront
+definitional material rather than by search.
+
+Beyond those two, the set spans:
+
+- **proof outcome** — UNSAT refutation, complete enumeration, and proved
+  optimality all produce differently-shaped proofs, and a change can help one
+  and hurt another;
+- **model versus derivation** — `.opb` from a few tens of kilobytes to 2.5 GB;
+- **propagator cost** — from `n_queens`, which posts nothing but `NotEquals`, to
+  `Knapsack`, `GlobalCardinality`, `MinDistance`, `Cumulative` and chained
+  `Multiply`;
+- **realistic versus degenerate** — puzzle and MiniZinc Challenge instances
+  against random generators and the synthetic `order_deletion_bench` driver.
+
+### The axis that matters most
+
+Group A and group B are not "big" and "small". They are opposite failure modes,
+and a change that improves one commonly worsens the other — trading proof bytes
+for checking time is the normal shape of a proof-side optimisation. Measuring
+only group A rewards writing more proof to check it faster; measuring only
+group B rewards the reverse. The two groups differ by around **550×** in
+checking cost per byte, so neither substitutes for the other.
+
+## What to capture
+
+In addition to the signals listed in `benchmarking.md`'s proof-shape section:
+
+- **`.opb` bytes as well as `.pbp` bytes.** They move independently and mean
+  different things — the static model encoding against the derivation. A change
+  that grows one is not the same change as one that grows the other.
+- **The full verdict string**, not just an exit status. `s VERIFIED
+  UNSATISFIABLE`, `s VERIFIED BOUNDS x <= obj <= x` and `s VERIFIED COMPLETE
+  ENUMERATION OF n SOLUTIONS` are what say the run proved the thing it was meant
+  to prove. An exit code alone is satisfied by an unparseable proof.
+- **`recursions` and `propagations[0]`**, so a reader can see how much of the
+  proof is search and how much is initialisation, and can check that two
+  variants really did make identical decisions.
+- **veripb peak resident memory**, which tracks the resident constraint
+  database. This is *not* comparable across VeriPB's `59d948fb` "Remove mmap"
+  (merged 2026-05-28): the version string is 3.0.2 on both sides, so compare
+  build dates, not versions.
+- **Evidence that the change under test actually fired.** An optional or
+  additive proof feature satisfies solution-equivalence, an `.opb` byte-diff and
+  VeriPB by doing nothing at all. Whatever counter or diagnostic the change
+  exposes, record it per row; a timing table alone cannot tell "measured
+  neutral" from "never engaged".
+
+## Reproducibility
+
+The rules in `benchmarking.md` under "veripb timing: contention and run-to-run
+noise" apply in full, and the important ones are worth repeating because they
+are easy to get wrong:
+
+- **Time veripb runs one at a time**, on an otherwise quiet machine.
+- **Measure every row of a comparison in one contiguous sitting.** Ratios within
+  a sitting are sound; absolute times across sittings are not.
+- **Take the minimum of several runs**, not the mean.
+
+One refinement this set adds: **concurrency inflates small proofs far more than
+large ones**, so a sweep run in parallel does not merely scale — it reorders.
+Measured here against solo baselines, a 17 MB proof inflated about 1.7× under a
+four-way load while a 188 MB proof inflated about 1.07×. Extrapolating a solo
+time from a loaded one with a single correction factor is therefore wrong across
+the range of this set.
+
+**On filesystems**: on a machine with a local SSD, write the proofs wherever is
+convenient. The advice elsewhere to put timed proof I/O on tmpfs was formed
+where the alternative was network storage, and it does not transfer: disk has
+not been the bottleneck in the experiments run here. On the larger entries
+tmpfs is actively the wrong choice, because it competes with veripb for the
+same RAM — `mzn_aircraft06` wants about 19 GB resident *plus* room for a 2.5 GB
+`.opb`. Reach for tmpfs only if you have measured that your storage is slow
+enough to matter.
+
+Always cap proof output. A `ulimit -f` on the `.pbp` is the difference between a
+mis-sized run costing a minute and it filling the disk; several candidates
+below write tens of gigabytes before anyone notices.
+
+## Instances that do not fit
+
+Every entry here was measured, not guessed. `cap` means it exceeded an 8 GB
+`ulimit -f` on the `.pbp` and was killed. Recorded so the screening does not get
+repeated.
+
+| candidate | outcome |
+|---|---|
+| `ortho_latin --size=6 --all` | cap; `--size=5` is 6 MB, and there is no size in between |
+| `tsp` (fixed default instance) | cap at 4 GB, and there is no size knob |
+| `qap --size=12` | cap; `--size=11` verifies but takes over 900 s |
+| `regular_random -n 9 --all`, `-n 10 --all` | cap |
+| `regular_random -n 7 --all` | 272 MB, but over 1200 s to verify; `-n 6` is 0.6 s |
+| `skeleton_puzzle` at 4×3, 4×4, 5×4 and the default 7×5 | cap at every shape tried |
+| `random_polynomial -n 12 -d 6` | cap; `-n 10 -d 5` is 426 MB |
+| `colour` on 42-vertex (50 % density) and 60-vertex graphs | cap — but a 46-vertex graph verifies in the band; see below |
+| `order_deletion_bench --problem cumulative --size 10 --domain 500` | cap |
+| Challenge `atsp`, `triangular`, `chessboard`, `tiny-cvrp`, `table-layout` | cap or over 1200 s, despite each solving in under 12 s with proofs off |
+| `nonogram --random N --all` | no search — 17 recursions at the size `benchmarking.md` suggests |
+| `multiply_random` at any `-n` | 3 recursions and under 1 MB even at `-n 1000000000` |
+| `sudoku`, `regex`, `tables`, `auto_table`, `rostering`, `money`, `cake`, `crystal_maze`, `knapsack`, `circuit_random`, `smart_table_*` | verify in well under a second; smoke tests, not measurements |
+| `examples/cumulative` | a fixed five-task toy |
+
+Two parameters turn out not to be parameters:
+
+- **`colour` is instance-dependent, not size-monotone.** A 41-vertex graph gives
+  16 MB, a 42-vertex one 120 MB, a 46-vertex one 736 MB, and a different
+  42-vertex one blows the cap. Pick and keep an instance; do not scale the
+  vertex count and expect the proof to follow.
+- **`regular_random` has no usable size.** n=6 checks in 0.6 s, n=7 takes over
+  1200 s, and n=9 blows the cap. `Regular` is consequently not represented at
+  scale anywhere in this set — see "Known gaps".
+
+### Argument-shape traps
+
+Found the hard way, all of them producing an immediate parse error:
+
+- The `minicp_benchmarks` binaries (`n_queens`, `magic_square`, `qap`, `tsp`,
+  `magic_series`) and `bin_packing_bench` have **no `--stats`** — they print
+  statistics unconditionally and reject the flag.
+- `ortho_latin` and `magic_square` spell the encoding choice
+  `--all-different gac|vc|not-equals`, not `--gac` or `--vc`.
+- `skeleton_puzzle` refuses any non-default shape unless `--seed` is given.
+- `frequency_square` takes its size positionally, and the size must be divisible
+  by `--lambda`.
+
+## Known gaps
+
+- **`Regular` at scale**, for the reason above. `examples/nonogram` is the
+  documented structured alternative but does not search; `examples/rostering` is
+  a 23-recursion toy.
+- **`Cumulative` and `Disjunctive` at scale** are reachable only through the
+  MiniZinc frontend, because `examples/cumulative` is a fixed five-task toy.
+  This is the most valuable gap to close.
+
+## MiniZinc entries
+
+Three entries come through `fzn-glasgow` because nothing native reaches their
+shape: `mzn_hitori` (a realistic optimisation writing a 1 GB proof from under
+four seconds of solving), `mzn_aircraft06` (the model-encoding-bound extreme)
+and `mzn_seatmoving` (the deep find-first split search).
+
+They carry a cost: a flattening step, `mznlib` drift between MiniZinc releases,
+and a dependence on a Challenge corpus that is not in this repository. Flatten
+once and keep the `.fzn`:
+
+```shell
+minizinc --solver <glasgow.msc> -c --fzn model.fzn --no-output-ozn model.mzn data.dzn
+fzn-glasgow -s -a model.fzn --prove --proof-files-basename proof
+```
+
+Each of these models uses only constraints that already exist in the solver, so
+porting them to `examples/` is model-writing rather than propagator work, and
+would make the set self-contained. A port must reproduce the proof *shape* —
+`.opb` size, `.pbp` size and recursion count — against the `fzn-glasgow` run,
+not merely the answer, or it is not a substitute for the instance it replaces.

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -34,13 +34,16 @@ Measured solo, pinned to one core with ASLR off, minimum of three runs, on the
 local SSD. `veripb` 3.0.2. The `rcpsp_dl21` row is a later sitting than the rest
 — see "`rcpsp`'s options" below for why — so read its verify time as a size
 guide, not as a figure to compare against the others to within a few percent.
+It is also the one row measured seven times rather than three, and the spread
+across those seven was 139.2 s to 140.6 s: solo run-to-run noise here is about
+1 %, which is what makes the single-digit-percent claim above hold.
 
 | benchmark | command | outcome | recs | `.opb` | `.pbp` | solve | +proof | verify |
 |---|---|---|--:|--:|--:|--:|--:|--:|
 | `odb_eq1000` | `order_deletion_bench --problem pairwise --size 6 --domain 1000 --window 1000 --tightness 90 --unsat --value-order smallest` | UNSAT | 49 352 | 11 KB | 37 MB | 0.10 s | ×2.0 | **139.5 s** |
 | `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT | 6 979 | 20 KB | 17 MB | 0.10 s | ×1.0 | **106.1 s** |
 | `odb_cumulative8` | `order_deletion_bench --problem cumulative --size 8 --domain 250 --window 250 --tightness 90 --unsat` | UNSAT | 33 959 | 1.9 MB | 454 MB | 0.10 s | ×9.0 | **314.7 s** |
-| `rcpsp_dl21` | `rcpsp --size 20 --seed 1 --deadline 21 --stats` | UNSAT | 42 058 | 0.3 MB | 1 242 MB | 0.30 s | ×7.0 | **139.5 s** |
+| `rcpsp_dl21` | `rcpsp --size 20 --seed 1 --deadline 21 --stats` | UNSAT | 42 058 | 0.3 MB | 1 242 MB | 0.30 s | ×7.0 | **139.2 s** |
 | `qap10` | `qap --size=10` | optimal | 10 985 | 3.5 MB | 504 MB | 0.20 s | ×6.0 | **283.8 s** |
 | `colour46` | `colour --file <46-vertex random graph>` | optimal | 313 109 | 0.4 MB | 736 MB | 12.31 s | ×1.2 | **347.6 s** |
 | `nqueens12` | `n_queens --size=12 --all` | enum, 14 200 | 232 163 | 0.2 MB | 208 MB | 0.50 s | ×2.2 | **219.8 s** |
@@ -152,7 +155,7 @@ Measured across the options at `--size 20 --seed 1`:
 | `--variant global` | 171 423 | 4 134 MB | — | same |
 | `--variant presolved` | 171 423 | 4 118 MB | — | same |
 | `--value-order split` | 185 247 | 3 500 MB | — | same |
-| **`--deadline 21`** | 42 058 | **1 242 MB** | **139.5 s** | **UNSAT** |
+| **`--deadline 21`** | 42 058 | **1 242 MB** | **139.2 s** | **UNSAT** |
 | `--deadline 21 --value-order split` | 41 507 | 996 MB | 112.3 s | UNSAT |
 | `--infeasible` | **1** | 0.1 MB | — | UNSAT at the root |
 
@@ -326,14 +329,17 @@ below write tens of gigabytes before anyone notices.
 
 ## Instances that do not fit
 
-Every entry here was measured, not guessed. `cap` means it exceeded an 8 GB
-`ulimit -f` on the `.pbp` and was killed. Recorded so the screening does not get
-repeated.
+Every entry here was measured, not guessed. `cap` means the run blew the
+`ulimit -f` on its `.pbp` and was killed, so the figure is a floor and not a
+measurement. That limit was 8 GB for most of the screening, but earlier sittings
+ran at 3, 4 or 6 GB — `tsp` and some of the `rcpsp` and `seat_moving` rows below
+are those — so read a capped row as "out of reach", not as "exactly 8 GB".
+Recorded so the screening does not get repeated.
 
 | candidate | outcome |
 |---|---|
 | `ortho_latin --size=6 --all` | cap; `--size=5` is 6 MB, and there is no size in between |
-| `tsp` (fixed default instance) | cap at 4 GB, and there is no size knob |
+| `tsp` (fixed default instance) | cap — it passed the 4 GB limit that sitting was running, and there is no size knob |
 | `qap --size=12` | cap; `--size=11` stays under it, at 2.0 GB, but does not finish verifying inside 900 s |
 | `regular_random -n 9 --all`, `-n 10 --all` | cap |
 | `regular_random -n 7 --all` | 172–282 MB, but **over an hour** to verify, with `--bacchus` as well as without; `-n 6` is under a second |

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -30,20 +30,32 @@ runtimes on purpose and a sweep that only ran one group would be misleading.
 
 These verify slowly enough that a single-digit-percent change is resolvable.
 
-| benchmark | command | outcome |
-|---|---|---|
-| `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT |
-| `odb_eq1000` | `order_deletion_bench --problem pairwise --size 6 --domain 1000 --window 1000 --tightness 90 --unsat --value-order smallest` | UNSAT |
-| `qap10` | `qap --size=10` | optimal |
-| `colour46` | `colour --file <46-vertex random graph>` | optimal |
-| `nqueens12` | `n_queens --size=12 --all` | enumeration |
-| `langford11` | `langford --size=11 --stats` | enumeration |
-| `langford10` | `langford --size=10 --stats` | UNSAT |
-| `freqsq6_gac` | `frequency_square 6 --all --stats --consistency gac` | enumeration |
-| `freqsq6_bc` | `frequency_square 6 --all --stats --consistency bc` | enumeration |
-| `pdisp10_tuple` | `p_dispersion --grid 10 -p 4 --variant tuple --stats` | optimal |
-| `mzn_hitori` | `fzn-glasgow -s -a hitori.fzn` (Challenge 2025, `h5-1.dzn`) | optimal |
-| `mzn_seatmoving` | `fzn-glasgow -s -n 1 2018_seat-moving.fzn` | first solution |
+Measured solo, pinned to one core with ASLR off, minimum of three runs, on the
+local SSD. `veripb` 3.0.2.
+
+| benchmark | command | outcome | recs | `.opb` | `.pbp` | solve | +proof | verify |
+|---|---|---|--:|--:|--:|--:|--:|--:|
+| `odb_eq1000` | `order_deletion_bench --problem pairwise --size 6 --domain 1000 --window 1000 --tightness 90 --unsat --value-order smallest` | UNSAT | 49 352 | 11 KB | 37 MB | 0.10 s | ×2.0 | **139.5 s** |
+| `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT | 6 979 | 20 KB | 17 MB | 0.10 s | — | **~110 s** |
+| `odb_cumulative8` | `order_deletion_bench --problem cumulative --size 8 --domain 250 --window 250 --tightness 90 --unsat` | UNSAT | 33 959 | 1.9 MB | 454 MB | 0.10 s | ×9.0 | **314.7 s** |
+| `qap10` | `qap --size=10` | optimal | 10 985 | 3.5 MB | 504 MB | 0.20 s | ×6.0 | **283.8 s** |
+| `colour46` | `colour --file <46-vertex random graph>` | optimal | 313 109 | 0.4 MB | 736 MB | 12.31 s | ×1.2 | **347.6 s** |
+| `nqueens12` | `n_queens --size=12 --all` | enum, 14 200 | 232 163 | 0.2 MB | 208 MB | 0.50 s | ×2.2 | **219.8 s** |
+| `langford11` | `langford --size=11 --stats` | enum, 35 584 | 256 593 | 0.4 MB | 669 MB | 3.80 s | ×1.9 | **662.9 s** |
+| `langford10` | `langford --size=10 --stats` | UNSAT | 43 514 | 0.3 MB | 101 MB | 0.60 s | ×1.8 | **60.4 s** |
+| `freqsq6_gac` | `frequency_square 6 --all --stats --consistency gac` | enum, 53 220 | 105 825 | 44 KB | 205 MB | 0.90 s | ×2.0 | **83.6 s** |
+| `freqsq6_bc` | `frequency_square 6 --all --stats --consistency bc` | enum, 53 220 | 105 825 | 44 KB | 80 MB | 1.10 s | ×1.3 | **81.2 s** |
+| `pdisp10_tuple` | `p_dispersion --grid 10 -p 4 --variant tuple --stats` | optimal | 1 037 | 12.6 MB | 158 MB | 0.10 s | ×4.0 | **88.8 s** |
+| `mzn_hitori` | `fzn-glasgow -s -a hitori.fzn` (Challenge 2025, `h5-1.dzn`) | optimal | 113 671 | 1.2 MB | **1 000 MB** | 1.20 s | ×3.1 | **273.3 s** |
+| `mzn_seatmoving` | `fzn-glasgow -s -n 1 2018_seat-moving.fzn` | first solution | 15 610 | 3.1 MB | 629 MB | 0.40 s | ×3.8 | **122.3 s** |
+
+`solve` is wall time with proof logging off; `+proof` is the multiplier when it
+is on. Note how far that varies — from ×1.2 on `colour46`, whose search dominates,
+to ×9.0 on `odb_cumulative8`. One pass over group A costs about 47 minutes.
+
+`langford11` at 11.0 minutes sits just outside the nominal ceiling. It is kept
+deliberately as the largest entry; with `langford10` at 60.4 s the pair brackets
+the whole band from one binary, one as an enumeration and one as a refutation.
 
 ### Group B — proof writing
 
@@ -51,11 +63,16 @@ These verify in seconds but write hundreds of megabytes. They are the only
 entries that isolate emission cost, and they must not be dropped for being
 quick to check — see "The axis that matters most".
 
-| benchmark | command | outcome |
-|---|---|---|
-| `polynomial10` | `random_polynomial -n 10 -d 5 --seed 1 --stats` | optimal |
-| `knapsack2` | `knapsack_bench --instance 2 --stats` | enumeration |
-| `nfractions` | `n_fractions --unsat --stats` | UNSAT |
+| benchmark | command | outcome | recs | `.pbp` | solve | +proof | verify | s/MB |
+|---|---|---|--:|--:|--:|--:|--:|--:|
+| `polynomial10` | `random_polynomial -n 10 -d 5 --seed 1 --stats` | optimal | 1 577 | 426 MB | 0.10 s | **×13** | 26.0 s | 0.06 |
+| `nfractions` | `n_fractions --unsat --stats` | UNSAT | 112 | 146 MB | 0.10 s | ×5.0 | 3.2 s | **0.02** |
+| `knapsack2` | `knapsack_bench --instance 2 --stats` | enum, 328 | 655 | 138 MB | 0.10 s | ×9.0 | 2.4 s | **0.02** |
+
+All three check in seconds and cost between five and thirteen times the bare
+solve to write. `polynomial10` writes 426 MB from 1 577 recursions; `nfractions`
+writes 146 MB from **112**. Group A's `odb_eq1000`, by contrast, writes 37 MB
+and spends 139 s checking it. That is the whole point of keeping both groups.
 
 ### Group C — controls
 
@@ -63,11 +80,12 @@ Pairs that differ in one controlled way, for attributing a difference.
 
 | pair | what it controls for |
 |---|---|
-| `magic_square --size=4 --all-different gac` vs `--all-different vc` | **Identical search** — same recursions, same solution count — with propagation count differing about 6×. Any proof-side divergence is emission, not search. |
+| `frequency_square 6 --all --consistency gac` vs `bc` | **Identical search** — 105 825 recursions and 53 220 solutions both ways — with the GAC proof **2.6× larger** (204.6 MB against 80.2 MB) and **the same verify time** (83.6 s against 81.2 s). The cleanest same-search pair in the set, and a SIZE≠TIME case on its own. |
+| `knapsack_bench --instance 1` vs `--instance 1 --upfront` | Identical search — 907 recursions, 454 solutions — with `--upfront` writing a **5.9× smaller** proof (20.7 MB against 121.3 MB) that takes **3.5× longer** to check (7.0 s against 2.0 s). One flag, and the two axes move in opposite directions. |
 | `knapsack_bench --instance 1` vs `--instance 1 --upfront` | **The clearest SIZE≠TIME demonstration in the set.** Identical search — 907 recursions, 454 solutions both ways — but `--upfront` writes a **5.9× smaller** proof (20.7 MB against 121.3 MB) that takes **4.5× longer** to check (9.9 s against 2.2 s). One flag, one instance, and the two axes move in opposite directions. |
-| `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | The same problem through a decomposition and through the global propagator: 42.9 MB / 14.3 s against 0.8 MB / 0.8 s. At `--grid 10` the gap widens to 93× in proof size, and at `--grid 12` the decomposition stops verifying inside 1200 s while the global takes 15 s. |
-| `frequency_square 6 --all --consistency gac` vs `bc` | Propagation strength on one instance (also in group A). |
-| `langford --size=11` vs `--size=10` | Enumeration against UNSAT refutation on one model. |
+| `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | Identical search — 551 recursions, 7 solutions — through a decomposition and through the global propagator: **42.9 MB / 9.7 s against 0.8 MB / 0.7 s**. At `--grid 10` the proof-size gap widens to 93×, and at `--grid 12` the decomposition stops verifying inside 1200 s while the global takes 15 s. |
+| `langford --size=11` vs `--size=10` | Enumeration against UNSAT refutation on one model, and the pair brackets the whole target band: 662.9 s and 60.4 s. |
+| `magic_square --size=4 --all-different gac` vs `vc` | **Not** a same-search pair, despite looking like one: GAC searches 77 983 recursions against VC's 87 377. Listed so nobody mistakes it for one — `--all-different` defaults to `vc`, so comparing the default against explicit `vc` gives a spurious match. |
 
 ### Group D — opt-in, needs a big machine
 
@@ -85,17 +103,18 @@ produces is 12.6 MB.
 Two derived ratios separate proofs far better than any qualitative label, and
 the set is chosen to span both.
 
-**Verify seconds per megabyte of `.pbp`** ranges over roughly 500× across the
-set. At one end `order_deletion_bench --domain 2000` writes 17 MB and takes
-around 110 s to check; at the other `knapsack_bench --instance 2` writes 138 MB
-and checks in under 2 s. High values mean the checker is working through long
-RUP chains over a wide resident database; low values mean it is streaming a
-large but individually-trivial derivation.
+**Verify seconds per megabyte of `.pbp`** ranges over about 190× within the
+chosen set, and 1700× across everything screened. `odb_split1000` writes 6 MB
+and spends 10.2 s checking it (1.61 s/MB); `knapsack_bench --instance 2` writes
+138 MB and checks in 2.4 s (0.017 s/MB). High values mean the checker is working
+through long RUP chains over a wide resident database; low values mean it is
+streaming a large but individually-trivial derivation.
 
-**Kilobytes of `.pbp` per recursion** ranges over roughly 3000×, from under
-1 KB (`frequency_square`, `n_queens`) to about 1.3 MB (`n_fractions`). This is
-the wide-versus-deep axis: high values mean the proof is dominated by upfront
-definitional material rather than by search.
+**Kilobytes of `.pbp` per recursion** ranges over roughly 1500×, from under
+1 KB (`frequency_square`, `n_queens`, `colour46`) to 1.3 MB (`n_fractions`,
+which writes 146 MB from 112 recursions). This is the wide-versus-deep axis:
+high values mean the proof is dominated by upfront definitional material rather
+than by search.
 
 Beyond those two, the set spans:
 
@@ -115,8 +134,12 @@ Group A and group B are not "big" and "small". They are opposite failure modes,
 and a change that improves one commonly worsens the other — trading proof bytes
 for checking time is the normal shape of a proof-side optimisation. Measuring
 only group A rewards writing more proof to check it faster; measuring only
-group B rewards the reverse. The two groups differ by around **550×** in
-checking cost per byte, so neither substitutes for the other.
+group B rewards the reverse.
+
+`knapsack_bench --instance 1` versus the same instance under `--upfront` shows
+this on one binary with one flag, at **identical search**: the `--upfront` proof
+is 5.9× smaller and takes 3.5× longer to check. Whichever axis a sweep measures,
+that pair moves the other way.
 
 ## What to capture
 
@@ -153,12 +176,18 @@ are easy to get wrong:
   a sitting are sound; absolute times across sittings are not.
 - **Take the minimum of several runs**, not the mean.
 
-One refinement this set adds: **concurrency inflates small proofs far more than
-large ones**, so a sweep run in parallel does not merely scale — it reorders.
-Measured here against solo baselines, a 17 MB proof inflated about 1.7× under a
-four-way load while a 188 MB proof inflated about 1.07×. Extrapolating a solo
-time from a loaded one with a single correction factor is therefore wrong across
-the range of this set.
+One refinement this set adds, and it is stronger than "small proofs degrade
+worse": **a verify time measured under load cannot be corrected, only
+discarded.** Measured against solo baselines on this set, the inflation under a
+three- or four-way load ran from **1.07×** (`colour` g40, 188 MB) to **2.99×**
+(`freqsq6_gac`, 205 MB) — two proofs of similar size at opposite ends of the
+range. Proof size does not predict it. Budget for running a sweep solo end to
+end; there is no shortcut that scales a parallel pass back down.
+
+A worked example of why it matters: under pilot load `freqsq6_gac` and
+`freqsq6_bc` looked 27 % apart. Solo they are **3 % apart** (83.6 s against
+81.2 s) despite the GAC proof being 2.6× larger. The entire apparent difference
+was contention.
 
 **On filesystems**: on a machine with a local SSD, write the proofs wherever is
 convenient. The advice elsewhere to put timed proof I/O on tmpfs was formed

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -38,6 +38,7 @@ local SSD. `veripb` 3.0.2.
 | `odb_eq1000` | `order_deletion_bench --problem pairwise --size 6 --domain 1000 --window 1000 --tightness 90 --unsat --value-order smallest` | UNSAT | 49 352 | 11 KB | 37 MB | 0.10 s | ×2.0 | **139.5 s** |
 | `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT | 6 979 | 20 KB | 17 MB | 0.10 s | ×1.0 | **106.1 s** |
 | `odb_cumulative8` | `order_deletion_bench --problem cumulative --size 8 --domain 250 --window 250 --tightness 90 --unsat` | UNSAT | 33 959 | 1.9 MB | 454 MB | 0.10 s | ×9.0 | **314.7 s** |
+| `rcpsp_dl21` | `rcpsp --size 20 --seed 1 --deadline 21 --stats` | UNSAT | 42 115 | 0.3 MB | 1 247 MB | — | — | **135.8 s** |
 | `qap10` | `qap --size=10` | optimal | 10 985 | 3.5 MB | 504 MB | 0.20 s | ×6.0 | **283.8 s** |
 | `colour46` | `colour --file <46-vertex random graph>` | optimal | 313 109 | 0.4 MB | 736 MB | 12.31 s | ×1.2 | **347.6 s** |
 | `nqueens12` | `n_queens --size=12 --all` | enum, 14 200 | 232 163 | 0.2 MB | 208 MB | 0.50 s | ×2.2 | **219.8 s** |
@@ -101,17 +102,46 @@ Pairs that differ in one controlled way, for attributing a difference.
 | benchmark | command | why separate |
 |---|---|---|
 | `mzn_aircraft06` | `fzn-glasgow -s -a aircraft.fzn` (Challenge 2024, `B737NG-600-06-Anon.json.dzn`) | Needs about **19 GB of veripb resident memory**. It cannot share a 30 GB machine with anything else and will exhaust a smaller one. |
-| `rcpsp20` | `rcpsp --size 20 --seed 1 --stats` | Writes a **4.1 GB `.pbp`** and verifies in **656.8 s** — near the nominal ceiling and heavy on disk. Kept because it is the only *realistic* `Cumulative` + `Disjunctive` entry; `odb_cumulative8` covers the propagator more cheaply but is synthetic. |
+| `rcpsp20_opt` | `rcpsp --size 20 --seed 1 --stats` | The makespan-optimisation form of the group A entry above: **4.1 GB `.pbp`**, 656.8 s. Superseded for routine use by `rcpsp_dl21`, which proves infeasibility at the same instance for a quarter of the proof. Keep it only when the *optimisation* proof shape is what is under test. |
 
-`rcpsp` has since grown `--variant`, `--machine`, `--unary`, `--simplify`,
-`--incremental` and an RCPSP/max generalisation. **The defaults reproduce the
-row above exactly** — 171 480 recursions and a byte-identical 4106.4 MB proof —
-because `--variant=decomposed` is the original linear-per-edge posting,
-`--machine=disjunctive` the `Disjunctive` global, and `--max-lag-density`
-defaults to zero and draws no random numbers, leaving the generated instance
-untouched. No flag needs adding to the command. Worth re-checking the recursion
-count after any future change to the generator, though: a single extra random
-draw would move every seeded instance and silently stale this row.
+### `rcpsp`'s options, and what they are worth
+
+The example grew `--variant`, `--machine`, `--unary`, `--simplify`,
+`--incremental`, `--deadline` and an RCPSP/max generalisation. **The defaults
+reproduce the original row exactly** — 171 480 recursions and a byte-identical
+4106.4 MB proof — because `--variant=decomposed` is the original linear-per-edge
+posting, `--machine=disjunctive` the `Disjunctive` global, and
+`--max-lag-density` defaults to zero and *draws no random numbers*, leaving the
+generated instance untouched. Re-check the recursion count after any future
+change to the generator: one extra random draw would move every seeded instance
+and silently stale these rows without anything failing.
+
+Measured across the new options at `--size 20 --seed 1`:
+
+| configuration | recursions | `.pbp` | verify | outcome |
+|---|--:|--:|--:|---|
+| default (optimise) | 171 480 | 4 106 MB | 656.8 s | `BOUNDS 22 ≤ obj ≤ 22` |
+| `--variant global` | 171 480 | 4 136 MB | — | same |
+| `--variant presolved` | 171 480 | 4 125 MB | — | same |
+| `--value-order split` | 185 861 | 3 511 MB | — | same |
+| **`--deadline 21`** | 42 115 | **1 247 MB** | **135.8 s** | **UNSAT** |
+| `--deadline 21 --value-order split` | — | 1 007 MB | 111.5 s | UNSAT |
+| `--infeasible` | **1** | 0.1 MB | — | UNSAT at the root |
+
+Three things worth knowing:
+
+- **`--deadline` is the good entry.** The optimum is 22, so `--deadline 21` asks
+  a decision question the solver has to search to refute — a quarter of the
+  proof, a fifth of the verify time, and a *scheduling UNSAT*, which no other
+  entry provides. This is why it is in group A and the optimisation form is not.
+- **The three `--variant` postings make identical search and near-identical
+  proofs** (within 0.7 %), despite posting the temporal network three completely
+  different ways. That makes them a same-search control triple; it does *not*
+  make `global` a route to a smaller proof.
+- **`--infeasible` refutes at the root in one recursion.** It closes a negative
+  cycle the initial propagation already sees, so it is a smoke test for the
+  difference reasoning, not a search benchmark. Use `--deadline` for a searched
+  refutation.
 
 `mzn_aircraft06` is worth the trouble because it is the only entry where the
 checker is bound by the **model encoding** rather than the derivation: a 2.5 GB

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -36,7 +36,7 @@ local SSD. `veripb` 3.0.2.
 | benchmark | command | outcome | recs | `.opb` | `.pbp` | solve | +proof | verify |
 |---|---|---|--:|--:|--:|--:|--:|--:|
 | `odb_eq1000` | `order_deletion_bench --problem pairwise --size 6 --domain 1000 --window 1000 --tightness 90 --unsat --value-order smallest` | UNSAT | 49 352 | 11 KB | 37 MB | 0.10 s | ×2.0 | **139.5 s** |
-| `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT | 6 979 | 20 KB | 17 MB | 0.10 s | — | **~110 s** |
+| `odb_split2000` | `order_deletion_bench --problem pairwise --size 8 --domain 2000 --window 2000 --tightness 90 --unsat` | UNSAT | 6 979 | 20 KB | 17 MB | 0.10 s | ×1.0 | **106.1 s** |
 | `odb_cumulative8` | `order_deletion_bench --problem cumulative --size 8 --domain 250 --window 250 --tightness 90 --unsat` | UNSAT | 33 959 | 1.9 MB | 454 MB | 0.10 s | ×9.0 | **314.7 s** |
 | `qap10` | `qap --size=10` | optimal | 10 985 | 3.5 MB | 504 MB | 0.20 s | ×6.0 | **283.8 s** |
 | `colour46` | `colour --file <46-vertex random graph>` | optimal | 313 109 | 0.4 MB | 736 MB | 12.31 s | ×1.2 | **347.6 s** |
@@ -199,14 +199,22 @@ A worked example of why it matters: under pilot load `freqsq6_gac` and
 81.2 s) despite the GAC proof being 2.6× larger. The entire apparent difference
 was contention.
 
-**On filesystems**: on a machine with a local SSD, write the proofs wherever is
-convenient. The advice elsewhere to put timed proof I/O on tmpfs was formed
-where the alternative was network storage, and it does not transfer: disk has
-not been the bottleneck in the experiments run here. On the larger entries
-tmpfs is actively the wrong choice, because it competes with veripb for the
-same RAM — `mzn_aircraft06` wants about 19 GB resident *plus* room for a 2.5 GB
-`.opb`. Reach for tmpfs only if you have measured that your storage is slow
-enough to matter.
+**On filesystems: it does not matter, and tmpfs is mildly counterproductive.**
+Measured directly — the same proof verified from the local SSD and from tmpfs,
+solo, pinned, minimum of three each, all in one sitting:
+
+| proof | SSD | tmpfs | difference |
+|---|--:|--:|--:|
+| `odb_split2000`, 17 MB | 110.52 s | 110.72 s | +0.2 % |
+| `pdisp10_tuple`, 151 MB | 82.26 s | 82.41 s | +0.2 % |
+| `qap10`, 481 MB | 276.05 s | 286.59 s | +3.8 % |
+
+tmpfs is never faster and is slightly *slower* at every size. So write the
+proofs wherever is convenient. The advice elsewhere to put timed proof I/O on
+tmpfs was formed where the alternative was network storage; on a machine with a
+local SSD it buys nothing, and on the larger entries it is actively the wrong
+choice because it competes with veripb for the same RAM — `mzn_aircraft06`
+wants about 19 GB resident *plus* room for a 2.5 GB `.opb`.
 
 Always cap proof output. A `ulimit -f` on the `.pbp` is the difference between a
 mis-sized run costing a minute and it filling the disk; several candidates
@@ -224,7 +232,7 @@ repeated.
 | `tsp` (fixed default instance) | cap at 4 GB, and there is no size knob |
 | `qap --size=12` | cap; `--size=11` verifies but takes over 900 s |
 | `regular_random -n 9 --all`, `-n 10 --all` | cap |
-| `regular_random -n 7 --all` | over 1200 s to verify; `-n 6` is under a second. Note the `--seed` trap below — these were unseeded, so they are not one instance scaled |
+| `regular_random -n 7 --all` | 172–282 MB, but **over an hour** to verify, with `--bacchus` as well as without; `-n 6` is under a second |
 | `skeleton_puzzle` at 4×3, 4×4, 5×3, 5×4, 6×3 and the default 7×5 | cap or over 1200 s at every shape tried, with `--seed` and without |
 | `random_polynomial -n 12 -d 6` | cap; `-n 10 -d 5` is 426 MB |
 | `colour` on 42-vertex (50 % density) and 60-vertex graphs | cap — but a 46-vertex graph verifies in the band; see below |
@@ -271,14 +279,16 @@ Found the hard way, all of them producing an immediate parse error:
 
 ## Known gaps
 
-- **`Regular` at scale.** `regular_random --all` has no comfortable size: n=6
-  checks in well under a second, n=7 takes many minutes, and n=9 exceeds an 8 GB
-  proof cap. `examples/nonogram` is the documented structured alternative but
-  does not search, and `examples/rostering` is a 23-recursion toy. The
-  `--bacchus` strategy may bring n=7 into range — it produced a far smaller
-  proof in piloting — but that observation was made against an unseeded run and
-  so compared two different instances; a seeded comparison is the way to settle
-  it.
+- **`Regular` at scale, and this one looks closed rather than open.**
+  `regular_random --all` has no usable size: n=6 checks in well under a second,
+  n=9 exceeds an 8 GB proof cap, and n=7 sits in between in size but not in
+  checking cost. Measured seeded, `-n 7 --all --seed 1` under `--bacchus` writes
+  a 172 MB proof that **exceeds an hour** to verify — about 21 s/MB, the worst
+  cost-per-byte of any derivation-bound proof here. So the smaller-proof strategy
+  does not rescue it. `examples/nonogram` is the documented structured
+  alternative but does not search (17 recursions), and `examples/rostering` is a
+  23-recursion toy. Representing `Regular` at a measurable size probably needs a
+  cheaper proof strategy rather than a better instance.
 - **A comfortably-sized realistic `Cumulative` / `Disjunctive` instance.**
   `examples/rcpsp` (issue #633) closed the "unreachable natively" half of this,
   but its instances are **bimodal rather than scalable**: across `--size` 12–24

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -101,7 +101,17 @@ Pairs that differ in one controlled way, for attributing a difference.
 | benchmark | command | why separate |
 |---|---|---|
 | `mzn_aircraft06` | `fzn-glasgow -s -a aircraft.fzn` (Challenge 2024, `B737NG-600-06-Anon.json.dzn`) | Needs about **19 GB of veripb resident memory**. It cannot share a 30 GB machine with anything else and will exhaust a smaller one. |
-| `rcpsp20` | `rcpsp --size 20 --seed 1 --stats` | Writes a **4.1 GB `.pbp`** and verifies in 699 s — over the nominal ceiling and heavy on disk. Kept because it is the only *realistic* `Cumulative` + `Disjunctive` entry; `odb_cumulative8` covers the propagator more cheaply but is synthetic. |
+| `rcpsp20` | `rcpsp --size 20 --seed 1 --stats` | Writes a **4.1 GB `.pbp`** and verifies in **656.8 s** — near the nominal ceiling and heavy on disk. Kept because it is the only *realistic* `Cumulative` + `Disjunctive` entry; `odb_cumulative8` covers the propagator more cheaply but is synthetic. |
+
+`rcpsp` has since grown `--variant`, `--machine`, `--unary`, `--simplify`,
+`--incremental` and an RCPSP/max generalisation. **The defaults reproduce the
+row above exactly** — 171 480 recursions and a byte-identical 4106.4 MB proof —
+because `--variant=decomposed` is the original linear-per-edge posting,
+`--machine=disjunctive` the `Disjunctive` global, and `--max-lag-density`
+defaults to zero and draws no random numbers, leaving the generated instance
+untouched. No flag needs adding to the command. Worth re-checking the recursion
+count after any future change to the generator, though: a single extra random
+draw would move every seeded instance and silently stale this row.
 
 `mzn_aircraft06` is worth the trouble because it is the only entry where the
 checker is bound by the **model encoding** rather than the derivation: a 2.5 GB

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -47,21 +47,39 @@ local SSD. `veripb` 3.0.2.
 | `freqsq6_gac` | `frequency_square 6 --all --stats --consistency gac` | enum, 53 220 | 105 825 | 44 KB | 205 MB | 0.90 s | ×2.0 | **83.6 s** |
 | `freqsq6_bc` | `frequency_square 6 --all --stats --consistency bc` | enum, 53 220 | 105 825 | 44 KB | 80 MB | 1.10 s | ×1.3 | **81.2 s** |
 | `pdisp10_tuple` | `p_dispersion --grid 10 -p 4 --variant tuple --stats` | optimal | 1 037 | 12.6 MB | 158 MB | 0.10 s | ×4.0 | **88.8 s** |
-| `hitori` | `hitori --size 5 --seed 1 --quiet --stats` | optimal | 72 361 | — | 937 MB | — | — | **260.5 s** |
-| `table_layout` | `table_layout --size 15 --seed 1 --stats` | optimal | 17 768 | — | 146 MB | — | — | **102.6 s** |
+| `hitori` | `hitori --size 5 --seed 1 --quiet --stats` | optimal | 72 361 | 1.0 MB | 937 MB | — | — | **260.5 s** |
+| `table_layout` | `table_layout --size 15 --seed 1 --stats` | optimal | 17 768 | 1.8 MB | 146 MB | — | — | **102.6 s** |
 | `seat_moving` | `seat_moving --dzn sm-10-12-00.dzn --quiet --stats` | first solution | 15 610 | 2.4 MB | 645 MB | — | — | **119.5 s** |
 
 `solve` is wall time with proof logging off; `+proof` is the multiplier when it
 is on. Note how far that varies — from ×1.2 on `colour46`, whose search dominates,
-to ×9.0 on `odb_cumulative8`. One pass over group A costs about 55 minutes.
+to ×9.0 on `odb_cumulative8`. One pass over group A costs about 50 minutes.
 
-The last three rows are the native ports from issues #633–#636; they carry no
-`solve`/`+proof` column yet because they were measured after the pinned pass.
+The three `odb_*` rows drive `order_deletion_bench`, which is **not on `main`**:
+it is added by the order-encoding-deletion branch. They are kept because they
+are the set's only synthetic knob on domain size and branching order, and
+because `odb_split2000` holds the expensive end of the cost-per-byte range
+below; skip them where that binary is not built.
+
+The last three rows are three of the four native ports from issues #633–#636 —
+the fourth is `rcpsp`, which is `rcpsp_dl21` above — and they carry no
+`solve`/`+proof` column because they were measured after the pinned pass.
 `hitori` and `seat_moving` replaced `fzn-glasgow` entries and were validated
-against them — **recursion counts match exactly** (113 671 and 15 610), so they
-reproduce the search rather than merely the answer. `table_layout` gives `Table`
-a size where proof shape is measurable at all; `examples/tables` is 10
-recursions.
+against them on the *same* instance, read through `--dzn`: **recursion counts
+match exactly**, 113 671 for `hitori --dzn h5-1.dzn` against the flattened
+`hitori.fzn`, and 15 610 for `seat_moving --dzn sm-10-12-00.dzn`. The ports
+reproduce the search, not merely the answer.
+
+Only one of those two rows is that validated run, and it is worth being clear
+which. `seat_moving` above **is** the `--dzn` run, because generated
+`seat_moving` instances are still unusable (see "Known gaps"). `hitori` above is
+**not**: it is the self-contained generated instance, `--size 5 --seed 1`, whose
+72 361 recursions are a different and smaller search than the 113 671 of the
+Challenge puzzle the port was validated against. Prefer it for exactly that
+reason — it needs no external data.
+
+`table_layout` gives `Table` a size where proof shape is measurable at all;
+`examples/tables` is 10 recursions.
 
 `langford11` at 11.0 minutes sits just outside the nominal ceiling. It is kept
 deliberately as the largest entry; with `langford10` at 60.4 s the pair brackets
@@ -91,9 +109,8 @@ Pairs that differ in one controlled way, for attributing a difference.
 | pair | what it controls for |
 |---|---|
 | `frequency_square 6 --all --consistency gac` vs `bc` | **Identical search** — 105 825 recursions and 53 220 solutions both ways — with the GAC proof **2.6× larger** (204.6 MB against 80.2 MB) and **the same verify time** (83.6 s against 81.2 s). The cleanest same-search pair in the set, and a SIZE≠TIME case on its own. |
-| `knapsack_bench --instance 1` vs `--instance 1 --upfront` | Identical search — 907 recursions, 454 solutions — with `--upfront` writing a **5.9× smaller** proof (20.7 MB against 121.3 MB) that takes **3.5× longer** to check (7.0 s against 2.0 s). One flag, and the two axes move in opposite directions. |
-| `knapsack_bench --instance 1` vs `--instance 1 --upfront` | **The clearest SIZE≠TIME demonstration in the set.** Identical search — 907 recursions, 454 solutions both ways — but `--upfront` writes a **5.9× smaller** proof (20.7 MB against 121.3 MB) that takes **4.5× longer** to check (9.9 s against 2.2 s). One flag, one instance, and the two axes move in opposite directions. |
-| `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | Identical search — 551 recursions, 7 solutions — through a decomposition and through the global propagator: **42.9 MB / 9.7 s against 0.8 MB / 0.7 s**. At `--grid 10` the proof-size gap widens to 93×, and at `--grid 12` the decomposition stops verifying inside 1200 s while the global takes 15 s. |
+| `knapsack_bench --instance 1` vs `--instance 1 --upfront` | **The clearest SIZE≠TIME demonstration in the set.** Identical search — 907 recursions, 454 solutions both ways — but `--upfront` writes a **5.9× smaller** proof (20.7 MB against 121.3 MB) that takes **3.5× longer** to check (7.0 s against 2.0 s). One flag, one instance, and the two axes move in opposite directions. |
+| `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | Identical search — 551 recursions, 7 solutions — through a decomposition and through the global propagator: **42.9 MB / 9.7 s against 0.8 MB / 0.7 s**. At `--grid 10` the proof-size gap widens to 91×, and at `--grid 12` the decomposition stops verifying inside 1200 s while the global takes 15 s. |
 | `langford --size=11` vs `--size=10` | Enumeration against UNSAT refutation on one model, and the pair brackets the whole target band: 662.9 s and 60.4 s. |
 | `magic_square --size=4 --all-different gac` vs `vc` | **Not** a same-search pair, despite looking like one: GAC searches 77 983 recursions against VC's 87 377. Listed so nobody mistakes it for one — `--all-different` defaults to `vc`, so comparing the default against explicit `vc` gives a spurious match. |
 
@@ -153,25 +170,28 @@ produces is 12.6 MB.
 Two derived ratios separate proofs far better than any qualitative label, and
 the set is chosen to span both.
 
-**Verify seconds per megabyte of `.pbp`** ranges over about 190× within the
-chosen set, and 1700× across everything screened. `odb_split1000` writes 6 MB
-and spends 10.2 s checking it (1.61 s/MB); `knapsack_bench --instance 2` writes
-138 MB and checks in 2.4 s (0.017 s/MB). High values mean the checker is working
-through long RUP chains over a wide resident database; low values mean it is
-streaming a large but individually-trivial derivation.
+**Verify seconds per megabyte of `.pbp`** ranges over about **360×** within the
+chosen set: `odb_split2000` writes 17 MB and spends 106.1 s checking it
+(6.2 s/MB), while `knapsack_bench --instance 2` writes 138 MB and checks in
+2.4 s (0.017 s/MB). Across everything screened it is wider still — over 1200×,
+since the `regular_random` candidates exceed 21 s/MB (see "Known gaps"). High
+values mean the checker is working through long RUP chains over a wide resident
+database; low values mean it is streaming a large but individually-trivial
+derivation.
 
-**Kilobytes of `.pbp` per recursion** ranges over roughly 1500×, from under
-1 KB (`frequency_square`, `n_queens`, `colour46`) to 1.3 MB (`n_fractions`,
-which writes 146 MB from 112 recursions). This is the wide-versus-deep axis:
-high values mean the proof is dominated by upfront definitional material rather
-than by search.
+**Kilobytes of `.pbp` per recursion** ranges over roughly **1700×**, from about
+0.8 KB (`odb_eq1000`, `freqsq6_bc`, `nqueens12`) to 1.3 MB (`nfractions`, which
+writes 146 MB from 112 recursions). This is the wide-versus-deep axis: high
+values mean the proof is dominated by upfront definitional material rather than
+by search. Note that it separates the two `frequency_square` rows, which are the
+same search: 0.8 KB under BC against 1.9 KB under GAC.
 
 Beyond those two, the set spans:
 
 - **proof outcome** — UNSAT refutation, complete enumeration, and proved
   optimality all produce differently-shaped proofs, and a change can help one
   and hurt another;
-- **model versus derivation** — `.opb` from a few tens of kilobytes to 2.5 GB;
+- **model versus derivation** — `.opb` from about ten kilobytes to 2.5 GB;
 - **propagator cost** — from `n_queens`, which posts nothing but `NotEquals`, to
   `Knapsack`, `GlobalCardinality`, `MinDistance`, `Cumulative` and chained
   `Multiply`;
@@ -246,8 +266,12 @@ solo, pinned, minimum of three each, all in one sitting:
 | proof | SSD | tmpfs | difference |
 |---|--:|--:|--:|
 | `odb_split2000`, 17 MB | 110.52 s | 110.72 s | +0.2 % |
-| `pdisp10_tuple`, 151 MB | 82.26 s | 82.41 s | +0.2 % |
-| `qap10`, 481 MB | 276.05 s | 286.59 s | +3.8 % |
+| `pdisp10_tuple`, 158 MB | 82.26 s | 82.41 s | +0.2 % |
+| `qap10`, 504 MB | 276.05 s | 286.59 s | +3.8 % |
+
+These six numbers are their own sitting, so read only along the rows: the
+absolute times are not the group A ones and are not meant to be, by the rule
+directly above.
 
 tmpfs is never faster and is slightly *slower* at every size. So write the
 proofs wherever is convenient. The advice elsewhere to put timed proof I/O on
@@ -270,7 +294,7 @@ repeated.
 |---|---|
 | `ortho_latin --size=6 --all` | cap; `--size=5` is 6 MB, and there is no size in between |
 | `tsp` (fixed default instance) | cap at 4 GB, and there is no size knob |
-| `qap --size=12` | cap; `--size=11` verifies but takes over 900 s |
+| `qap --size=12` | cap; `--size=11` stays under it, at 2.0 GB, but does not finish verifying inside 900 s |
 | `regular_random -n 9 --all`, `-n 10 --all` | cap |
 | `regular_random -n 7 --all` | 172–282 MB, but **over an hour** to verify, with `--bacchus` as well as without; `-n 6` is under a second |
 | `skeleton_puzzle` at 4×3, 4×4, 5×3, 5×4, 6×3 and the default 7×5 | cap or over 1200 s at every shape tried, with `--seed` and without |
@@ -282,7 +306,7 @@ repeated.
 | `order_deletion_bench --problem cumulative --size 10 --domain 500` | cap |
 | Challenge `atsp`, `triangular`, `chessboard`, `tiny-cvrp`, `table-layout` | cap or over 1200 s, despite each solving in under 12 s with proofs off |
 | `nonogram --random N --all` | no search — 17 recursions at the size `benchmarking.md` suggests |
-| `multiply_random` at any `-n` | 3 recursions and under 1 MB even at `-n 1000000000` |
+| `multiply_random` at any `-n` | 3 recursions and about 1 MB even at `-n 1000000000` |
 | `sudoku`, `regex`, `tables`, `auto_table`, `rostering`, `money`, `cake`, `crystal_maze`, `knapsack`, `circuit_random`, `smart_table_*` | verify in well under a second; smoke tests, not measurements |
 | `examples/cumulative` | a fixed five-task toy |
 
@@ -358,9 +382,23 @@ fzn-glasgow -s -a model.fzn --prove --proof-files-basename proof
 
 Each of these models uses only constraints that already exist in the solver, so
 porting them to `examples/` is model-writing rather than propagator work, and
-would make the set self-contained. A port must reproduce the proof *shape* —
-`.opb` size, `.pbp` size and recursion count — against the `fzn-glasgow` run,
-not merely the answer, or it is not a substitute for the instance it replaces.
+would make the set self-contained. The bar for a port is that it reproduces the
+**search** — identical recursion counts against the `fzn-glasgow` run on the
+same instance, not merely the same answer. Anything weaker is not a substitute
+for the instance it replaces.
+
+Proof and model *sizes* do not come out equal, and should not be expected to:
+the flattened model posts a different set of constraints, so the encoding
+differs even where the search does not.
+
+| instance | native `--dzn` | via `fzn-glasgow` |
+|---|--:|--:|
+| `hitori` h5-1 | 1.0 MB `.opb`, 815 MB `.pbp` | 1.2 MB, 1 000 MB |
+| `seat_moving` sm-10-12-00 | 2.4 MB `.opb`, 645 MB `.pbp` | 3.1 MB, 629 MB |
+
+Both ports write a smaller `.opb`; the `.pbp` falls 19 % for `hitori` and rises
+2 % for `seat_moving`. The recursion counts are exact matches either way, which
+is the part that had to hold.
 
 Four such ports were done, as issues #633–#636 and PRs #638–#641:
 `examples/rcpsp`, `examples/hitori`, `examples/seat_moving` and

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -248,3 +248,16 @@ porting them to `examples/` is model-writing rather than propagator work, and
 would make the set self-contained. A port must reproduce the proof *shape* —
 `.opb` size, `.pbp` size and recursion count — against the `fzn-glasgow` run,
 not merely the answer, or it is not a substitute for the instance it replaces.
+
+Four such ports are tracked:
+
+- **#633** — a scheduling example (`Cumulative`, `Disjunctive`, makespan). The
+  most valuable of the four: it closes the gap above rather than replacing an
+  existing entry.
+- **#634** — `hitori`, which needs only `Count` and `AllDifferentExcept`.
+- **#635** — `seat-moving`, which needs only `AllDifferent` and
+  `AllDifferentExcept`, and which removes this set's dependence on a flattened
+  `.fzn` that is not under version control.
+- **#636** — `table-layout`, which would also give `Table` a representation at
+  a size where proof shape is measurable; `examples/tables` is a 10-recursion
+  toy.

--- a/dev_docs/proof-benchmarks.md
+++ b/dev_docs/proof-benchmarks.md
@@ -64,7 +64,8 @@ Pairs that differ in one controlled way, for attributing a difference.
 | pair | what it controls for |
 |---|---|
 | `magic_square --size=4 --all-different gac` vs `--all-different vc` | **Identical search** — same recursions, same solution count — with propagation count differing about 6×. Any proof-side divergence is emission, not search. |
-| `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | The same problem through a decomposition and through the global propagator. |
+| `knapsack_bench --instance 1` vs `--instance 1 --upfront` | **The clearest SIZE≠TIME demonstration in the set.** Identical search — 907 recursions, 454 solutions both ways — but `--upfront` writes a **5.9× smaller** proof (20.7 MB against 121.3 MB) that takes **4.5× longer** to check (9.9 s against 2.2 s). One flag, one instance, and the two axes move in opposite directions. |
+| `p_dispersion --grid 8 -p 4 --variant tuple` vs `--variant min-distance-ps` | The same problem through a decomposition and through the global propagator: 42.9 MB / 14.3 s against 0.8 MB / 0.8 s. At `--grid 10` the gap widens to 93× in proof size, and at `--grid 12` the decomposition stops verifying inside 1200 s while the global takes 15 s. |
 | `frequency_square 6 --all --consistency gac` vs `bc` | Propagation strength on one instance (also in group A). |
 | `langford --size=11` vs `--size=10` | Enumeration against UNSAT refutation on one model. |
 
@@ -184,8 +185,8 @@ repeated.
 | `tsp` (fixed default instance) | cap at 4 GB, and there is no size knob |
 | `qap --size=12` | cap; `--size=11` verifies but takes over 900 s |
 | `regular_random -n 9 --all`, `-n 10 --all` | cap |
-| `regular_random -n 7 --all` | 272 MB, but over 1200 s to verify; `-n 6` is 0.6 s |
-| `skeleton_puzzle` at 4×3, 4×4, 5×4 and the default 7×5 | cap at every shape tried |
+| `regular_random -n 7 --all` | over 1200 s to verify; `-n 6` is under a second. Note the `--seed` trap below — these were unseeded, so they are not one instance scaled |
+| `skeleton_puzzle` at 4×3, 4×4, 5×3, 5×4, 6×3 and the default 7×5 | cap or over 1200 s at every shape tried, with `--seed` and without |
 | `random_polynomial -n 12 -d 6` | cap; `-n 10 -d 5` is 426 MB |
 | `colour` on 42-vertex (50 % density) and 60-vertex graphs | cap — but a 46-vertex graph verifies in the band; see below |
 | `order_deletion_bench --problem cumulative --size 10 --domain 500` | cap |
@@ -217,12 +218,25 @@ Found the hard way, all of them producing an immediate parse error:
 - `skeleton_puzzle` refuses any non-default shape unless `--seed` is given.
 - `frequency_square` takes its size positionally, and the size must be divisible
   by `--lambda`.
+- **`--seed` defaults to `-1`, meaning a fresh random instance every run**, in
+  `regular_random`, `circuit_random`, `multiply_random`, `random_polynomial` and
+  `smart_table_random`. Three consecutive `regular_random -n 6 --all` runs give
+  32 664, 28 881 and 21 116 recursions — three different problems. Any use of
+  these binaries in a benchmark **must** pass an explicit `--seed`, and any two
+  numbers being compared must share it. This is easy to miss because the runs
+  succeed and the numbers look plausible; it silently turns a strategy
+  comparison into a comparison of unrelated instances.
 
 ## Known gaps
 
-- **`Regular` at scale**, for the reason above. `examples/nonogram` is the
-  documented structured alternative but does not search; `examples/rostering` is
-  a 23-recursion toy.
+- **`Regular` at scale.** `regular_random --all` has no comfortable size: n=6
+  checks in well under a second, n=7 takes many minutes, and n=9 exceeds an 8 GB
+  proof cap. `examples/nonogram` is the documented structured alternative but
+  does not search, and `examples/rostering` is a 23-recursion toy. The
+  `--bacchus` strategy may bring n=7 into range — it produced a far smaller
+  proof in piloting — but that observation was made against an unseeded run and
+  so compared two different instances; a seeded comparison is the way to settle
+  it.
 - **`Cumulative` and `Disjunctive` at scale** are reachable only through the
   MiniZinc frontend, because `examples/cumulative` is a fixed five-task toy.
   This is the most valuable gap to close.


### PR DESCRIPTION
`benchmarking.md` curates instances for *solve* speed and says explicitly not to put `--prove` in its numbers. There has been no counterpart set for when the proof itself is what is being measured, so proof-logging work has been sized ad hoc.

The two sets turn out to be almost disjoint. Sizes that make a good solve benchmark are usually far too large to proof-log: `ortho_latin --size=6 --all` and `tsp`, both in the solve table, each write over 4 GB of `.pbp`.

## Why grouped by failure mode rather than size

The set separates instances that stress proof **checking** from those that stress proof **writing**. These are close to opposites, and trading proof bytes for checking time is the normal shape of a proof-side optimisation, so a change that helps one group routinely hurts the other:

| extreme | proof | verify | cost per byte |
|---|--:|--:|--:|
| `odb_split2000` | 17 MB | 106.1 s | 6.2 s/MB |
| `knapsack_bench --instance 2` | 138 MB | 2.4 s | 0.017 s/MB |

That is a **360×** spread, and it widens past 1200× across everything screened. Measuring only the first rewards writing more proof to check it faster; measuring only the second rewards the reverse.

A third corner, reachable only through the MiniZinc frontend, is the checker being bound by the *model* rather than the derivation: `aircraft-disassembly` writes a **2.5 GB `.opb`** against an 8 MB `.pbp`. It is listed separately because it needs about 19 GB of veripb resident memory.

## What was screened out

Most of the work was rejection, and the document records it so the screening does not get repeated: instances too large to proof-log at all, and two parameters that turn out not to be parameters —

- **`colour` is instance-dependent, not size-monotone.** 41 vertices gives 16 MB, 42 gives 120 MB, 46 gives 736 MB, and a different 42-vertex graph blows an 8 GB cap.
- **`regular_random` has no usable size.** n=6 checks in 0.6 s, n=7 takes over 1200 s, n=9 exceeds the cap. `Regular` is consequently unrepresented at scale, which is noted as a known gap.

Plus the argument-shape traps that produce an immediate parse error: the `minicp_benchmarks` binaries and `bin_packing_bench` reject `--stats`; `ortho_latin`/`magic_square` spell it `--all-different gac|vc|not-equals`; `skeleton_puzzle` needs `--seed` for any non-default shape; `frequency_square` takes its size positionally and divisible by `--lambda`.

## Corrections to benchmarking.md

- Cross-referenced in both directions, and from the `dev_docs` index.
- `nonogram --random 20 --seed 1 --all` is recommended there as the structured `Regular` instance. Measured, it is **17 recursions and 3 solutions** — inside the "tens of recursions means a no-search bench" band that same document defines two sections earlier. The generator builds clues from a random picture, so the puzzle is nearly determined. Now says to use the `--dzn` instances instead.
- Notes that concurrency inflates small proofs far more than large ones (2.99× for a 205 MB proof against 1.07× for a 188 MB one under the same load), so a single correction factor cannot be used to extrapolate solo times across this set's range.
- The "put timed proof I/O on tmpfs" advice is not carried over: it was formed where the alternative was network storage, and on the larger entries tmpfs competes with veripb for the same RAM.

## Since the pre-merge check

The three inconsistencies flagged in review are settled against the retained solo pass, not by picking a side:

1. **The duplicated `knapsack --upfront` row.** The 4.5× version was the pilot-load measurement, left behind when the solo pass replaced the figures. The solo numbers are 7.00 s against 2.00 s — 3.5×, which is what "the axis that matters most" already quoted. One row now.
2. **`hitori`'s recursion count.** The two numbers are two different instances. The group A row is the *generated* `--size 5 --seed 1` at 72 361 recursions; the port validation was against `fzn-glasgow` on the Challenge puzzle read through `--dzn`, at 113 671. Both re-run on current main, both reproduce. The document now says which is which and why the row is the generated one.
3. **`odb_split1000`.** Rewritten against `odb_split2000`, which is tabulated. The spread within the set is 360×, and the across-everything figure now follows from `regular_random`'s 21 s/MB, at over 1200×.

The `.pbp`-per-recursion range had the same defect and is fixed with it: `colour46` is 2.4 KB per recursion, not under 1 KB. The tmpfs table was in `du -h` mebibytes against decimal megabytes everywhere else, which is the `481`/`504` discrepancy; converted, and it now says those three times are their own sitting. Two further measured claims did not match the data — `qap --size=11` does not verify in over 900 s, it fails to finish inside 900 s; `multiply_random` at `-n 1000000000` writes 1.02 MB, not under 1 MB.

## The rcpsp rows are re-measured

Checking the above meant re-running every recursion count in the document against `main` at `d3c9e58b`. All of them reproduce exactly **except `rcpsp`'s**, which are 57 recursions shorter in both forms — 171 480 → 171 423 and 42 115 → 42 058. Nothing in `examples/rcpsp` changed; it is the `Cumulative` work merged since the first pass, strengthening the initial propagation. Sizes and verify times for those rows are re-measured accordingly (`rcpsp_dl21` is now 1 242 MB and 139.5 s), and the deadline row gains the `solve`/`+proof` columns it was missing.

That is the trap the section already warned about, arriving from the direction it did not name: the warning was about the generator drawing one more random number, but a propagator getting one inference stronger stales the same rows just as silently, and nothing errors either way. The document now says both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiXjJTM4G1dMjbr45wGb12
