### PR TITLE
Brancher stage F: do not evict an ancestor's order literal

### DIFF
--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -844,6 +844,45 @@ win). An excluded-set constraint names many, so many are hoisted (no win, but
 correct). Retention is therefore automatic and exactly as tight as the brancher's
 backtrack constraint — there is no separate "retained set" to maintain.
 
+**But those are not the only surviving constraints, and the implementation only tracks
+some of them.** A propagator's own justification is a surviving constraint too: it is
+emitted at `ProofLevel::Current` and lives until its level is forgotten. The residency
+bookkeeping (`ge_top_pins`, and the hoists that record it) tracks references from **Top**
+lines only, so for a reference from an intermediate level there is no pin to consult, and
+`pins == nullptr` does not mean "unreferenced".
+
+`evict_order_literal` therefore adds a second, structural condition alongside the pin
+check:
+
+> Evict only a definition minted at the level the search is standing at. A definition at
+> an **ancestor** level outlives this subtree, so refuse it.
+
+This is deliberately conservative — it refuses some evictions that would have been safe,
+because the information needed to tell them apart is not kept. It was measured, on the
+ascending-eq synthetic where the window does its work, to cost **nothing**: at d250/500/1000
+the gate-0 speedups are 5.26×/8.90×/14.70× with the rule and 5.25×/8.88×/14.59× without
+(same sitting, min of 3), the proofs are 97–101 bytes *smaller* with it, and at gate 16 and
+on crystal_maze and talent they are byte-identical.
+
+What it buys is `table_layout`, which rejects at gate 0 without it: the eq-window advance
+retired `rowheight[1] >= 81`, minted at level 4, while standing at level 20, and the
+objective lower-bound row that named it —
+`totalheight>=295 \/ ~rowheight[0]>=90 \/ ~rowheight[1]>=81 \/ ~rowheight[2]>=27 \/ ~rowheight[3]>=97`,
+emitted back at level 4 — stayed live for another 239 backtracks. The atom was therefore
+not free, and its later "re-introduction" was a redundance step whose `ge81 -> 1` witness
+had to discharge that row and could not. The `-> 0` half passes, because `~ge81` satisfies
+the row trivially: **a one-sided redundance failure is the signature of a stale reference
+rather than a bad definition.**
+
+The `t` scenario in `order_evict_test` is this shape reduced, and fails both ways without
+the rule (return values first, then the proof itself).
+
+The remaining gap, unclosed and so far theoretical: a `pol` line's result names literals
+that are a function of the derivation, which we do not evaluate, so nothing can detect a
+reference from one. All 28 `PolBuilder::emit(..., ProofLevel::Top)` call sites would need
+to declare what they name for that to be checkable. The ancestor rule does not depend on
+knowing, which is why it was preferred to extending the pin bookkeeping.
+
 ## Mapping the existing heuristics
 
 Helpers make each existing `value_order::` a one-liner:

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -2062,6 +2062,26 @@ auto NamesAndIDsTracker::evict_order_literal(
         // still the safe answer.
         return false;
     }
+    else if (level < _imp->logger->proof_level()) {
+        // The definition belongs to an ANCESTOR of the subtree we are standing in, so it
+        // outlives this subtree and any line emitted between its level and here may name
+        // it. Only Top references are tracked (ge_top_pins, and the hoists that record
+        // them); for a reference at an intermediate level there is no pin to consult, so
+        // the pin check above cannot speak for one and `pins == nullptr` does not mean
+        // unreferenced. Refuse: the win forgone is one atom, and the alternative is a
+        // dangling reference VeriPB only reports much later.
+        //
+        // table_layout is what this costs nothing to protect and everything to get wrong.
+        // Its eq-window advance retired `rowheight[1] >= 81` -- definition at level 4 --
+        // while the search stood at level 20, and the objective lower-bound row
+        //   totalheight>=295 \/ ~rowheight[0]>=90 \/ ~rowheight[1]>=81 \/ ~rowheight[2]>=27 \/ ~rowheight[3]>=97
+        // emitted back at level 4 stayed live for another 239 backtracks. The atom was
+        // therefore not free, and its later re-introduction was a redundance step whose
+        // `ge81 -> 1` witness had to discharge that row and could not. (The `-> 0` half
+        // passes, because ~ge81 satisfies the row trivially -- a one-sided redundance
+        // failure is the signature of a stale reference rather than a bad definition.)
+        return false;
+    }
 
     // The immediate live neighbours to stitch over, read before v is dropped. std::map
     // iterators survive the insertions the emissions below can make, so lvl_it stays valid.

--- a/gcs/innards/proofs/order_evict_test.cc
+++ b/gcs/innards/proofs/order_evict_test.cc
@@ -49,12 +49,13 @@ auto main() -> int
     ProofModel model(proof_options, tracker);
 
     // One variable per scenario, so the scenarios cannot perturb each other's chains.
-    SimpleIntegerVariableID x{0}, y{1}, z{2}, w{3}, u{4};
+    SimpleIntegerVariableID x{0}, y{1}, z{2}, w{3}, u{4}, t{5};
     model.set_up_integer_variable(x, 0_i, 100_i, "x", nullopt);
     model.set_up_integer_variable(y, 0_i, 100_i, "y", nullopt);
     model.set_up_integer_variable(z, 0_i, 100_i, "z", nullopt);
     model.set_up_integer_variable(w, 0_i, 100_i, "w", nullopt);
     model.set_up_integer_variable(u, 0_i, 100_i, "u", nullopt);
+    model.set_up_integer_variable(t, 0_i, 100_i, "t", nullopt);
 
     model.finalise();
 
@@ -193,6 +194,54 @@ auto main() -> int
     tracker.need_gevar(u, 50_i);
     tracker.need_gevar(u, 60_i);
     check(tracker.evict_order_literal(u, 60_i, nullopt));
+    logger.forget_proof_level(1);
+
+    // ---- t: an ancestor's definition is not this subtree's to evict ----
+    // The window tidies from wherever the search currently stands, which is not necessarily
+    // the level that minted the atom. A definition at an ancestor level outlives this
+    // subtree, and lines emitted anywhere between that level and here may name it -- only
+    // Top references are tracked, so for those intermediate levels there is no pin to
+    // consult and "no pin" cannot be read as "unreferenced".
+    //
+    // This is table_layout's shape, reduced: it retired `rowheight[1] >= 81`, minted at
+    // level 4, from level 20, while the objective lower-bound row that named it -- emitted
+    // back at level 4 -- stayed live for another 239 backtracks. The re-introduction was
+    // then not a re-introduction at all, and its `-> 1` witness could not discharge that
+    // still-live row.
+    //
+    // The level-1 line below is what makes this discriminating rather than decorative: it is
+    // a reference that survives the level-2 subtree, so evicting either threshold at level 2
+    // strands it, and the `need_gevar` after the forget then re-emits the `red` pair the
+    // stranded line refutes.
+    //
+    // Measured by mutation, stubbing the ancestor rule out fails this test twice over: the
+    // two return-value checks below go first (which is what the harness reports, since it
+    // runs veripb only on a zero exit), and with those neutered as well the proof itself is
+    // rejected -- `Proofgoal ... could not be autoproven`, the same signature, from the same
+    // cause, as table_layout at gate 0.
+    logger.enter_proof_level(1);
+    tracker.need_gevar(t, 30_i);
+    tracker.need_gevar(t, 70_i);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (t < 70_i) + 1_i * (t >= 30_i) >= 1_i, ProofLevel::Current);
+
+    logger.enter_proof_level(2);
+    // Standing one level deeper, both thresholds belong to the ancestor: refused.
+    check(! tracker.evict_order_literal(t, 30_i, nullopt));
+    check(! tracker.evict_order_literal(t, 70_i, nullopt));
+    // A definition minted here is this subtree's own, and stays evictable -- the rule must
+    // cost the window only what it has to.
+    tracker.need_gevar(t, 50_i);
+    check(tracker.evict_order_literal(t, 50_i, nullopt));
+    logger.forget_proof_level(2);
+
+    // Still live, so no `red` pair is written here -- unless the ancestor rule let level 2
+    // take it, in which case this is the re-introduction that strands the line above.
+    tracker.need_gevar(t, 70_i);
+
+    // And a threshold this level minted, named by nothing, is still the window's to take:
+    // the rule is about ancestry, not a blanket refusal.
+    tracker.need_gevar(t, 90_i);
+    check(tracker.evict_order_literal(t, 90_i, nullopt));
     logger.forget_proof_level(1);
 
     logger.enter_proof_level(0);


### PR DESCRIPTION
Found by rebasing the #612 stack onto current main: `table_layout` — one of main's new examples — is **rejected by VeriPB** under `GCS_DELETE_ORDER_ENCODING=literals` with `GCS_DELETE_ORDER_ENCODING_MIN_CHAIN=0`.

Flag off verifies, and the **shipped gate of 16 verifies**; only the research "gate-off ceiling" fails. So this is not a default-path bug, but it is a real hole in the rule the whole feature rests on.

## What went wrong

The deletion rule is *delete a literal only when no surviving constraint names it*. The bookkeeping that enforces it (`ge_top_pins`, and the hoists that record it) tracks references from **Top** lines only — the five hoist causes name a fixed set of emission sites. A propagator's own justification is a sixth: emitted at `ProofLevel::Current`, live until its level is forgotten.

`table_layout` minimises objective `totalheight = Σ rowheight[i]`. At level 4 the linear propagator derived, permanently enough to survive **239 backtracks**:

```
totalheight>=295 \/ ~rowheight[0]>=90 \/ ~rowheight[1]>=81 \/ ~rowheight[2]>=27 \/ ~rowheight[3]>=97
```

(295 = 90+81+27+97). The eq-window advance then retired `rowheight[1] >= 81` — definition at level 4 — while the search stood at **level 20**, with `pins == 0`. The atom was not free, so its later re-introduction was a redundance step that had to discharge that still-live row:

- witness `ge81 -> 0` — **passes**, `~ge81` satisfies the row trivially
- witness `ge81 -> 1` — **fails**, the row reduces to a claim that does not follow

A one-sided redundance failure is the signature of a stale reference rather than a bad definition.

## The fix

Refuse structurally what the pin check cannot speak for: **evict only a definition minted at the level the search is standing at, never an ancestor's.** Conservative by design — it refuses some evictions that would have been safe, because the information to tell them apart is not kept.

## What it costs: nothing measurable

Ascending-eq synthetic, one sitting, min of 3, gate 0:

| domain | speedup without the rule | with the rule | proof size delta |
|---|---|---|---|
| 250 | 5.25× | **5.26×** | −97 B |
| 500 | 8.88× | **8.90×** | −98 B |
| 1000 | 14.59× | **14.70×** | −101 B |

At gate 16, and on crystal_maze and talent, the proofs are **byte-identical**. The proofs are marginally *smaller* with the rule, because a refused eviction also avoids its stitch and re-introduction lines.

## Validation

- **618/618** ctest with frontends on, in all three configurations (flag off, `literals`, `literals` at gate 0)
- **30/30** deterministic examples still byte-identical to main with the flag off
- **30/30** examples verify at gate 0, `table_layout` included — previously 29/30
- New `t` scenario in `order_evict_test`. Stubbing the rule out fails it twice over: the return-value checks first, and with those neutered the proof itself, with the same `could not be autoproven` signature

## Still open

A `pol` result's literals are a function of the derivation, which gcs does not evaluate, so a reference from one is undetectable. Closing that would need all **28** `PolBuilder::emit(..., ProofLevel::Top)` call sites to declare what they name. This rule does not depend on knowing, which is why it was preferred to extending the pin bookkeeping. No instance is currently known to need it.

Part of #612. Not for merge ahead of the rest of the stack.