### PR TITLE
Pin what a pol names, via the union over its operands (Brancher stage G)

### DIFF
--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1499,7 +1499,12 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   `magic_square --size=4 --all-different gac` rejected in the **shipped** configuration
   because of it. Fixed automatically rather than by declaration — cutting planes cannot
   invent an atom, so the union over the operands over-approximates the result. Costs a
-  `ProofLine -> named eq atoms` map, scoped to what is live. Full write-up in
+  `ProofLine -> named atoms` map, scoped to what is live. Covers **ge** thresholds too, under
+  the new `LineHoist` residency cause -- but `line_hoist` is **0 on all 24** PR #632 rows, so
+  the ge half rests on the argument and a discriminating unit test, not on an instance.
+  Pinning ge from the ordinary reference walk was tried and **reverted**: a ge threshold is a
+  chain link, so hoisting it restructures the chain and breaks RUP steps that depend on its
+  positive-level shape. Full write-up in
   [order-encoding-deletion.md](order-encoding-deletion.md), "The `pol` gap".
 
 Stages A, B, B', B'', C, D, E, F and G have all landed in sequence. Stage D was the only one

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1510,6 +1510,26 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
 Stages A, B, B', B'', C, D, E, F and G have all landed in sequence. Stage D was the only one
 gated on work outside this task (the delc mechanics), and that gate is closed.
 
+### Status: PAUSED (2026-08-03)
+
+Work on this stack is **paused**, with every stage pushed to a PR and nothing uncommitted.
+The reason is that the full PR #632 benchmark sweep did not make the case:
+
+- **Two correctness bugs found by benchmarking**, both fixed (stage F, stage G) — the stage G
+  one, `magic_square --size=4 --all-different gac`, was a rejected proof in the **shipped**
+  configuration, found on a control row expected to be an exact no-op.
+- **On real instances the feature is a no-op or worse.** 10 of 26 rows never engage at all;
+  only `qap10` (1.20×/1.28×) and the two `rcpsp` forms (~1.17×/1.20×) win; groups B and C are
+  1.00× throughout. The 3.7×–15× wins are confined to the `odb_*` synthetics built to exhibit
+  them.
+- **One severe regression**, `table_layout15` at 0.09×/0.08× — diagnosed as a VeriPB
+  unhinted-propagation issue (see order-encoding-deletion.md) rather than a cost of deletion,
+  and raised upstream.
+
+The flag-off byte-identity claim holds exactly (21/21), so carrying the stack costs nothing
+while it sits. VeriPB's forthcoming **label-groups** mechanism may offer a different route to
+the same goal, which is the other reason to stop here rather than push on.
+
 ## Implementation gates (not owner calls)
 
 Three unknowns; all are validated empirically against VeriPB, not decided by the owner.

--- a/dev_docs/brancher-design.md
+++ b/dev_docs/brancher-design.md
@@ -1486,7 +1486,23 @@ recursions / propagations / solutions unchanged mode-off vs mode-on.
   unchanged: **this is a feature for weak-propagation, large-domain search, and real
   MiniZinc-shaped models are not that.**
 
-Stages A, B, B', B'', C, D and E have all landed in sequence. Stage D was the only one
+- **Stage F — do not evict an ancestor's order literal. DONE (#645).** A definition minted
+  at a level the search has since left can still be named by a live row from that level, so
+  `evict_order_literal` refuses when `level < logger->proof_level()`. Found by rebasing onto
+  main, which made `table_layout` reachable: it rejected at gate 0 and only at gate 0.
+  Conservative by design — the information to do better is not kept — and it costs nothing
+  measurable.
+- **Stage G — pin what a `pol` names, via the union over its operands. DONE.** The
+  eq-side member of stage F's family, reached by a path stage F's rule cannot see: a `pol`
+  at Top over operands naming a windowed eq atom is a permanent reference that no walk over
+  the emitted line can detect, because a pol's literals are the derivation's result.
+  `magic_square --size=4 --all-different gac` rejected in the **shipped** configuration
+  because of it. Fixed automatically rather than by declaration — cutting planes cannot
+  invent an atom, so the union over the operands over-approximates the result. Costs a
+  `ProofLine -> named eq atoms` map, scoped to what is live. Full write-up in
+  [order-encoding-deletion.md](order-encoding-deletion.md), "The `pol` gap".
+
+Stages A, B, B', B'', C, D, E, F and G have all landed in sequence. Stage D was the only one
 gated on work outside this task (the delc mechanics), and that gate is closed.
 
 ## Implementation gates (not owner calls)

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -877,11 +877,49 @@ rather than a bad definition.**
 The `t` scenario in `order_evict_test` is this shape reduced, and fails both ways without
 the rule (return values first, then the proof itself).
 
-The remaining gap, unclosed and so far theoretical: a `pol` line's result names literals
-that are a function of the derivation, which we do not evaluate, so nothing can detect a
-reference from one. All 28 `PolBuilder::emit(..., ProofLevel::Top)` call sites would need
-to declare what they name for that to be checkable. The ancestor rule does not depend on
-knowing, which is why it was preferred to extending the pin bookkeeping.
+### The `pol` gap: closed for eq atoms (stage G)
+
+A `pol` line's result names literals that are a function of the derivation, which we do not
+evaluate — so for a long time nothing could detect a reference from one, and this was
+recorded here as theoretical, with no instance known to need it. **An instance is now
+known**, and it was in the shipped configuration:
+
+```
+GCS_DELETE_ORDER_ENCODING=literals magic_square --size=4 --all-different gac --prove
+  -> Proofgoal 3515 could not be autoproven  (at pbp:4310)
+```
+
+Found by the PR #632 benchmark sweep, on a group C **control** row expected to be an exact
+no-op. Constraint 3515 is all-different's Hall-set at-most-one row (`all_different/
+justify.cc:39`): a `PolBuilder` fold of fifteen pairwise clauses naming `i[_13][eq8]`,
+emitted at Top and cached across the search. The eq window evicted `eq8`'s definition
+underneath it, and the "re-introduction" at pbp:4309–4310 was not one — the atom had never
+been free. `del id 3515` before that step makes it pass, which is how the row was confirmed
+to be the sole blocker.
+
+It turned out not to need evaluating, and not to need 28 declarations either. **Cutting
+planes cannot invent an atom**: addition, multiplication, division and saturation all yield
+a constraint over a subset of the operands' variables, and the only other sources —
+`add_for_literal` and `weaken`'s flag — are handed to `PolBuilder` directly. So the union
+over the operands' recorded names over-approximates what the result names, soundly and
+automatically. `PolBuilder::emit` computes it, pins it when the line lands at Top, and
+records it against the new line so a pol over pols composes.
+
+That is why this is automatic rather than a second level argument on the emitters: a
+declaration is a second source of truth that drifts from the expression it describes, and a
+missing one is silent until deletion is enabled *and* an instance happens to hit it — which
+is exactly how this survived every green suite until a benchmark sweep tripped over it.
+
+The cost is a `ProofLine -> named eq atoms` map, which is real and worth watching: it is the
+point at which we start tracking the live contents of the proof. It is kept to what is live
+rather than to the proof — entries only for lines that name an atom, nothing recorded unless
+the window is live, and `forget_eq_atom_names_for` drops each level's entries as its lines
+are `del`'d.
+
+**Still open**: the same argument applies to *ge* atoms named through a `pol`, which are not
+tracked. Stage F's ancestor rule covers the eviction path structurally and does not depend
+on knowing what a line names, so no instance is known to need the ge side — the position
+this section recorded for the eq side until one turned up.
 
 ## Mapping the existing heuristics
 

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -1034,6 +1034,46 @@ a real use case lands.
 Each stage gates on: VeriPB accepts, and recursions/propagations/solutions are
 unchanged mode-off vs mode-on (a proof-only change must not perturb search).
 
+## The `table_layout` checking regression — diagnosed, and it is upstream's
+
+`table_layout --size 15 --seed 1` checks **11.4× slower** with the mode on (69.66 s → 797.33 s
+at gate 16; 0.08× at gate 0). It reproduced across three independent sittings, so it is not
+noise. It is **not a cost of deletion**, and there is nothing to fix here:
+
+- **All of it is before the search.** Cutting the proof at the first backtracking point:
+  pre-search **8.52 s vs 740.76 s (87×)**, while the *search* parts are comparable (~61 s vs
+  ~57 s). That is why 119 deletions cost the same as 1 870 — the cost is paid by enabling the
+  mode, not per deletion.
+- **The constraint database is identical.** At the same semantic point both hold **595 105
+  live constraints**, with the arity distribution matching in every bucket (2-term 204 735,
+  3-term 224 620, …); as sets only 12 of 595 105 differ, and as ordered sequences the dumps
+  diverge only at line 594 831. Database size, contents, arity and insertion order are all
+  ruled out.
+- **It is unhinted RUP propagation.** 83 % of runtime in `PropagationSet::propagate`;
+  `RUP[unhinted]` averages 24.9 µs against 1 849.2 µs. The +75 600 `pol` lines the mode emits
+  cost 0.7 µs each — 0.07 s in total — and every one of them derives a constraint already
+  present, which VeriPB deduplicates.
+- **Hints erase it.** Elaborated, the two check in **2.70 s vs 2.68 s**, and the "slow" proof
+  needs **5.3 % fewer** hints (19.9 M vs 21.0 M over identical 214 260 rup counts). So the
+  proof is not logically harder; the 87 × is the cost of *searching for* a path that could be
+  followed in 2.68 s.
+
+Raised with VeriPB upstream. Write-up and a self-contained reproducer (both proof pairs,
+byte-identical `.opb`, 9.4 MB) are in `~/claude/tmp/oed-bench-632/preserved-table_layout15/`
+— `FOR-VERIPB.md`, `DIAGNOSIS.md` and `table_layout15-repro.tar.zst`. Not version controlled;
+regenerate with `table_layout --size 15 --seed 1 --prove` on this branch and on main.
+
+**If a gcs-side mitigation is ever wanted**, hint the containment edges. They are emitted
+unhinted at Top by `link_immediate_containment`, they account for ~81 % of all hint volume,
+and elaboration spends ~175 steps on them where ~4 suffice (flat across parent widths 2–49,
+so the excess is not width-related). Everything the hint needs is already tracked —
+`invars_that_exist` holds both endpoints' reification lines, `chain_clauses_by_level` holds
+the chain-link lines under `Literals`, and `define_plain_invar` already hoists the relevant
+ges to Top so the path is guaranteed resident. The one addition would be an index from
+(variable, adjacent-threshold-pair) to chain-clause `ProofLine`; the existing map is
+level-major and flat, so today that lookup is a scan. Under mode `None` the chain lines are
+not recorded at all, so that config would need new bookkeeping in `emit_order_link`.
+
 ## Open questions
 
 - Backtrack-constraint expressiveness beyond bound/excluded-set/custom — deferred;

--- a/dev_docs/order-encoding-deletion.md
+++ b/dev_docs/order-encoding-deletion.md
@@ -916,10 +916,41 @@ rather than to the proof — entries only for lines that name an atom, nothing r
 the window is live, and `forget_eq_atom_names_for` drops each level's entries as its lines
 are `del`'d.
 
-**Still open**: the same argument applies to *ge* atoms named through a `pol`, which are not
-tracked. Stage F's ancestor rule covers the eviction path structurally and does not depend
-on knowing what a line names, so no instance is known to need the ge side — the position
-this section recorded for the eq side until one turned up.
+### The ge side, and where the symmetry stops
+
+The same union covers *ge* thresholds: a `pol` at Top pins the ge atoms its operands name,
+under `OrderEncodingResidencyCause::LineHoist`. Two things about it are worth recording,
+because both are easy to assume wrongly.
+
+**It fires nowhere measured.** `line_hoist` is **0 on all 24 rows** of the PR #632 set at
+gate 0 — no pol landing at Top names a live deletable ge threshold on any of them. So the
+ge half is carried on the strength of the argument and a discriminating unit test
+(`order_evict_test`, scenario `v`), not on the strength of an instance. It is defence in
+depth for a soundness property, not a measured win, and it should be read that way. Treat
+`line_hoist: 0` in the stats dump as the expected reading; a nonzero one means an instance
+has finally reached it.
+
+**Pinning ge from the ordinary reference walk does *not* work, and this was measured.** The
+obvious symmetry — extend the hoist-out rule so that any Top line naming a ge threshold pins
+it, exactly as it does for eq — **breaks proofs**:
+
+```
+comparison_test le_iff --seed=4979515          -> not implied by reverse unit propagation
+linear_constraint_le_iff_incremental (gate 0)  -> same
+```
+
+The reason is that the two atom kinds are not structurally alike. An eq atom stands alone,
+so hoisting one is a local move. A ge threshold is **a link in a chain**, and hoisting it to
+Top restructures that chain by stitching over its neighbours — so doing it at every Top line
+that happens to name a threshold pulls the chain out from under RUP steps that depend on its
+positive-level shape. The walk therefore *records* ge atoms (which is what the pol union
+reads) but does not pin them; only a pol pins, and only at pol-emit time, which is outside
+any other line's emission.
+
+So the ge coverage is exactly as wide as the pol gap, and no wider. The broader
+"any Top line naming a threshold pins it" rule remains unavailable, and stage F's ancestor
+rule is what covers the eviction path instead — which is the same conclusion stage F reached
+when the Top-pin idea was first tried against `table_layout`.
 
 ## Mapping the existing heuristics
 

--- a/gcs/innards/proofs/eq_window_test.cc
+++ b/gcs/innards/proofs/eq_window_test.cc
@@ -1,4 +1,5 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 
@@ -60,7 +61,7 @@ auto main() -> int
     // One variable per scenario, each with its own guard variable, so the scenarios cannot
     // perturb each other's chains. A guard is [0..3] rather than [0..1] so it gets the
     // ordinary bits encoding (a {0,1} variable is direct-only, and carries no order cuts).
-    SimpleIntegerVariableID x{0}, gx{1}, y{2}, gy{3}, w{4}, gw{5}, z{6}, gz{7};
+    SimpleIntegerVariableID x{0}, gx{1}, y{2}, gy{3}, w{4}, gw{5}, z{6}, gz{7}, p{8}, gp{9};
     model.set_up_integer_variable(x, 0_i, 15_i, "x", nullopt);
     model.set_up_integer_variable(gx, 0_i, 3_i, "gx", nullopt);
     model.set_up_integer_variable(y, 0_i, 15_i, "y", nullopt);
@@ -69,6 +70,8 @@ auto main() -> int
     model.set_up_integer_variable(gw, 0_i, 3_i, "gw", nullopt);
     model.set_up_integer_variable(z, 0_i, 15_i, "z", nullopt);
     model.set_up_integer_variable(gz, 0_i, 3_i, "gz", nullopt);
+    model.set_up_integer_variable(p, 0_i, 15_i, "p", nullopt);
+    model.set_up_integer_variable(gp, 0_i, 3_i, "gp", nullopt);
 
     // The guard is what makes each guess genuinely refutable, so the sibling clause the
     // window's tidy deletes is a real RUP rather than something asserted for the test:
@@ -77,6 +80,7 @@ auto main() -> int
     model.add_constraint(WPBSum{} + 8_i * gx + -1_i * x <= 0_i);
     model.add_constraint(WPBSum{} + 8_i * gw + -1_i * w <= 0_i);
     model.add_constraint(WPBSum{} + 8_i * gz + -1_i * z <= 0_i);
+    model.add_constraint(WPBSum{} + 8_i * gp + -1_i * p <= 0_i);
     // Descending: g >= 1 => var <= 7, so var == 15..8 are all refuted.
     model.add_constraint(WPBSum{} + 1_i * y + 8_i * gy <= 15_i);
 
@@ -208,6 +212,57 @@ auto main() -> int
     check(tracker.xliteral_for(z == 4_i) == z4, "z: the collapsed window's atom did not survive the forget");
     logger.emit_rup_proof_line(WPBSum{} + 1_i * (z != 4_i) + 1_i * (z >= 4_i) >= 1_i, ProofLevel::Current);
     logger.emit_rup_proof_line(WPBSum{} + 1_i * (z != 5_i) + 1_i * (z >= 5_i) >= 1_i, ProofLevel::Current);
+
+    // ---- p: a reference reached only through a `pol`'s operands ----
+    // The all-different Hall-set shape, which is what `magic_square --size=4
+    // --all-different gac` rejected on: pairwise at-most-one lines naming `p == 2` are
+    // emitted at Temporary, then folded by a PolBuilder into a line that lands at Top. The
+    // resulting constraint names `p == 2`, but nothing in the emitted `pol` text does --
+    // the literals are the arithmetic's result -- so the reference is invisible to any
+    // walk over the line, and before the operand-union rule nothing pinned the atom.
+    //
+    // The discriminating assertion is the count, not the proof: with the reference missed,
+    // the atom stays windowed and gets evicted, and only *then* does VeriPB reject. A test
+    // that checked verification alone would be reporting the symptom two steps downstream.
+    Literal outer_p{gp >= 1_i};
+    logger.enter_proof_level(2);
+    refute_sibling(outer_p, p == 2_i);
+    auto p2 = tracker.xliteral_for(p == 2_i);
+    check(tracker.live_windowed_eq_count(p) == 1, "p: the guess mint did not window the eq definition");
+
+    {
+        // Operands at Temporary, exactly as all_different/justify.cc emits them, and both
+        // genuinely RUP: `p == 2` implies `p >= 2` through the eq definition, and the guard
+        // constraint `8*gp <= p` refutes `p == 2` once `gp >= 1`. Their own level pins
+        // nothing -- it is the pol they feed that is permanent.
+        PolBuilder am1;
+        am1.add(logger.emit_rup_proof_line(WPBSum{} + 1_i * (p != 2_i) + 1_i * (p >= 2_i) >= 1_i, ProofLevel::Temporary));
+        am1.add(logger.emit_rup_proof_line(WPBSum{} + 1_i * (p != 2_i) + 1_i * (gp < 1_i) >= 1_i, ProofLevel::Temporary));
+        am1.saturate();
+        check(tracker.live_windowed_eq_count(p) == 1, "p: a Temporary operand should not pin on its own");
+        am1.emit(logger, ProofLevel::Top);
+    }
+
+    check(tracker.live_windowed_eq_count(p) == 0, "p: a Top pol over operands naming the atom did not take it out of the window");
+
+    // The window steps on regardless; the retained atom must survive both the tidy and the
+    // forget, as in scenario w.
+    logger.emit_eq_window_advance(vector<Literal>{outer_p}, p == 2_i, /*lower=*/true);
+    check(tracker.xliteral_for(p == 2_i) == p2, "p: the tidy evicted an atom a pol had pinned");
+
+    refute_sibling(outer_p, p == 3_i);
+    logger.emit_eq_window_advance(vector<Literal>{outer_p}, p == 3_i, /*lower=*/true);
+    logger.enter_proof_level(1);
+    logger.forget_proof_level(2);
+    check(tracker.xliteral_for(p == 2_i) == p2, "p: the pol-pinned atom did not survive the forget");
+    // Naming it again after the forget is the step that rejects if the ge thresholds its
+    // definition names were left deletable.
+    tracker.need_gevar(p, 2_i);
+    tracker.need_gevar(p, 3_i);
+    logger.enter_proof_level(2);
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * (p != 2_i) + 1_i * (p < 3_i) >= 1_i, ProofLevel::Current);
+    logger.enter_proof_level(1);
+    logger.forget_proof_level(2);
 
     logger.enter_proof_level(0);
     logger.conclude_none();

--- a/gcs/innards/proofs/names_and_ids_tracker-fwd.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker-fwd.hh
@@ -11,19 +11,36 @@ namespace gcs::innards
 {
     class NamesAndIDsTracker;
 
+    enum class EqualsOrGreaterEqual
+    {
+        Equals,
+        GreaterEqual
+    };
+
     /**
-     * An `id == v` eq atom named by a proof line, and the set of them a line names.
+     * A deletable order-encoding atom named by a proof line: `id == v` or `id >= v`.
      *
      * Lives in the -fwd header because PolBuilder needs the type to accumulate a union
      * across its operands, and cannot include the tracker proper (the tracker includes
      * PolBuilder).
+     */
+    struct NamedAtom
+    {
+        SimpleIntegerVariableID id;
+        Integer value;
+        EqualsOrGreaterEqual kind;
+
+        [[nodiscard]] auto operator==(const NamedAtom &) const -> bool = default;
+    };
+
+    /**
+     * The set of atoms one line names.
      *
      * A vector rather than a set because these are tiny -- a handful of atoms per line at
      * most -- so a linear dedup beats any node-based container, and the whole point of the
      * structure is to stay cheap enough to carry per line.
      */
-    using NamedEqAtom = std::pair<SimpleIntegerVariableID, Integer>;
-    using NamedEqAtoms = std::vector<NamedEqAtom>;
+    using NamedAtoms = std::vector<NamedAtom>;
 }
 
 #endif

--- a/gcs/innards/proofs/names_and_ids_tracker-fwd.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker-fwd.hh
@@ -1,9 +1,29 @@
 #ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_VARIABLE_CONSTRAINTS_TRACKER_FWD_HH
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_VARIABLE_CONSTRAINTS_TRACKER_FWD_HH
 
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <utility>
+#include <vector>
+
 namespace gcs::innards
 {
     class NamesAndIDsTracker;
+
+    /**
+     * An `id == v` eq atom named by a proof line, and the set of them a line names.
+     *
+     * Lives in the -fwd header because PolBuilder needs the type to accumulate a union
+     * across its operands, and cannot include the tracker proper (the tracker includes
+     * PolBuilder).
+     *
+     * A vector rather than a set because these are tiny -- a handful of atoms per line at
+     * most -- so a linear dedup beats any node-based container, and the whole point of the
+     * structure is to stay cheap enough to carry per line.
+     */
+    using NamedEqAtom = std::pair<SimpleIntegerVariableID, Integer>;
+    using NamedEqAtoms = std::vector<NamedEqAtom>;
 }
 
 #endif

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -395,9 +395,9 @@ struct NamesAndIDsTracker::Imp
     // What each emitted proof line names, for lines that name any eq atom at all --- the
     // only way a `pol` can find out what citing an operand would name, since its own
     // literals are a derivation result rather than text. Entries exist only for lines that
-    // name something, and forget_eq_atom_names_for drops them as the lines are del'd, so
+    // name something, and forget_atom_names_for drops them as the lines are del'd, so
     // this tracks what is live in the proof rather than the proof.
-    unordered_map<long long, NamedEqAtoms> eq_atoms_by_line;
+    unordered_map<long long, NamedAtoms> atoms_by_line;
     // Set by a NamesAndIDsTracker::WindowedEqScope, for the duration of one guess mint in
     // the branch layer: the eq atom need_direct_encoding_for is about to define belongs to
     // a frontier, and wants a deletable (Current) definition rather than a permanent one.
@@ -2254,41 +2254,41 @@ auto NamesAndIDsTracker::note_permanent_eq_reference(const SimpleIntegerVariable
     hoist_eq_to_top(id, v);
 }
 
-auto NamesAndIDsTracker::note_line_names_eq_atoms(ProofLineNumber line, NamedEqAtoms atoms) -> void
+auto NamesAndIDsTracker::note_line_names_atoms(ProofLineNumber line, NamedAtoms atoms) -> void
 {
     if (atoms.empty())
         return;
-    _imp->eq_atoms_by_line.insert_or_assign(line.number, move(atoms));
+    _imp->atoms_by_line.insert_or_assign(line.number, move(atoms));
 }
 
-auto NamesAndIDsTracker::eq_atoms_named_by(const ProofLine & line) const -> const NamedEqAtoms *
+auto NamesAndIDsTracker::atoms_named_by(const ProofLine & line) const -> const NamedAtoms *
 {
     // A labelled line is a model row, which is permanent and never windowed, so it can
     // name nothing the window could evict.
     const auto * n = get_if<ProofLineNumber>(&line);
     if (! n)
         return nullptr;
-    auto it = _imp->eq_atoms_by_line.find(n->number);
-    return it == _imp->eq_atoms_by_line.end() ? nullptr : &it->second;
+    auto it = _imp->atoms_by_line.find(n->number);
+    return it == _imp->atoms_by_line.end() ? nullptr : &it->second;
 }
 
-auto NamesAndIDsTracker::forget_eq_atom_names_for(const IntervalSet<long long> & lines) -> void
+auto NamesAndIDsTracker::forget_atom_names_for(const IntervalSet<long long> & lines) -> void
 {
-    if (_imp->eq_atoms_by_line.empty())
+    if (_imp->atoms_by_line.empty())
         return;
 
     // Iterate the intervals rather than the map: a level's deletions are contiguous runs,
     // and the map is (by design) far smaller than the run it covers, so probing per line
     // would be quadratic in the wrong direction on a long-lived level. Erasing over the
     // smaller of the two is what keeps this off the profile.
-    if (_imp->eq_atoms_by_line.size() <= 64) {
-        erase_if(_imp->eq_atoms_by_line, [&](const auto & entry) { return lines.contains(entry.first); });
+    if (_imp->atoms_by_line.size() <= 64) {
+        erase_if(_imp->atoms_by_line, [&](const auto & entry) { return lines.contains(entry.first); });
         return;
     }
 
     for (const auto & [l, u] : lines.each_interval())
         for (auto n = l; n <= u; ++n)
-            _imp->eq_atoms_by_line.erase(n);
+            _imp->atoms_by_line.erase(n);
 }
 
 auto NamesAndIDsTracker::evict_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> bool
@@ -2488,7 +2488,9 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
         }
         bool any_hoist_pin = false, any_gate = false;
         for (const auto & [v, cause] : vs) {
-            if (cause && (*cause == Cause::EqHoist || *cause == Cause::InvarHoist || *cause == Cause::NogoodHoist || *cause == Cause::SoliHoist))
+            if (cause &&
+                (*cause == Cause::EqHoist || *cause == Cause::InvarHoist || *cause == Cause::NogoodHoist || *cause == Cause::SoliHoist ||
+                    *cause == Cause::LineHoist))
                 any_hoist_pin = true;
             if (cause && *cause == Cause::GateResident)
                 any_gate = true;
@@ -2513,8 +2515,9 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     long long boundary = get(by_cause, Cause::Boundary), model_time = get(by_cause, Cause::ModelTime);
     long long gate_resident = get(by_cause, Cause::GateResident);
     long long frontier_exempt = get(by_cause, Cause::FrontierExempt);
+    long long line_h = get(by_cause, Cause::LineHoist);
     long long would_free = view_pin + aux_pin;
-    long long would_not_free = eq_h + invar_h + nogood_h + soli_h;
+    long long would_not_free = eq_h + invar_h + nogood_h + soli_h + line_h;
     long long structural = boundary + model_time;
 
     stringstream o;
@@ -2530,11 +2533,17 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     emit(format("  step-3-WOULD-free (view_pin + aux_pin): {} ({:.1f}%)", would_free, pct(would_free)));
     emit(format("      view_pin:     {} ({:.1f}%)", view_pin, pct(view_pin)));
     emit(format("      aux_pin:      {} ({:.1f}%)", aux_pin, pct(aux_pin)));
-    emit(format("  step-3-would-NOT-free (eq + invar + nogood + soli hoist): {} ({:.1f}%)", would_not_free, pct(would_not_free)));
+    emit(format("  step-3-would-NOT-free (eq + invar + nogood + soli + line hoist): {} ({:.1f}%)", would_not_free, pct(would_not_free)));
     emit(format("      eq_hoist:     {} ({:.1f}%)", eq_h, pct(eq_h)));
     emit(format("      invar_hoist:  {} ({:.1f}%)", invar_h, pct(invar_h)));
     emit(format("      nogood_hoist: {} ({:.1f}%)", nogood_h, pct(nogood_h)));
     emit(format("      soli_hoist:   {} ({:.1f}%)", soli_h, pct(soli_h)));
+    // A ge atom pinned because an emitted Top line names it, found by the generic reference
+    // walk or by the union over a pol's operands. Broken out rather than folded into the
+    // others because it is the only cause that can fire from a `pol`, whose literals nothing
+    // else can see -- so if this reads 0 on a model with Hall-set reasoning, the union is
+    // not working.
+    emit(format("      line_hoist:   {} ({:.1f}%)", line_h, pct(line_h)));
     emit(format("  structural (boundary + model_time): {} ({:.1f}%)", structural, pct(structural)));
     emit(format("      boundary:     {} ({:.1f}%)", boundary, pct(boundary)));
     emit(format("      model_time:   {} ({:.1f}%)", model_time, pct(model_time)));
@@ -2547,14 +2556,15 @@ auto NamesAndIDsTracker::dump_order_encoding_stats() const -> void
     emit(format("  stitches (forget-path): {}", _imp->stats_stitches));
     emit(format("  reintroductions: {}", _imp->stats_reintroductions));
     emit(format("  duplicate-Top-stitches: {}", _imp->stats_dup_top_stitches));
-    emit(format("  hoists: eq={} invar={} nogood={} soli={} guess={}", get(_imp->stats_hoist_events, Cause::EqHoist),
+    emit(format("  hoists: eq={} invar={} nogood={} soli={} guess={} line={}", get(_imp->stats_hoist_events, Cause::EqHoist),
         get(_imp->stats_hoist_events, Cause::InvarHoist), get(_imp->stats_hoist_events, Cause::NogoodHoist),
-        get(_imp->stats_hoist_events, Cause::SoliHoist), get(_imp->stats_hoist_events, Cause::GuessHoist)));
+        get(_imp->stats_hoist_events, Cause::SoliHoist), get(_imp->stats_hoist_events, Cause::GuessHoist),
+        get(_imp->stats_hoist_events, Cause::LineHoist)));
     emit("variables by class:");
     emit(format("  fully-resident-by-view: {}", n_view));
     emit(format("  fully-resident-by-aux:  {}", n_aux));
     emit(format("  fully-resident-by-exemption: {}", n_exempt));
-    emit(format("  mixed (some eq/invar/nogood/soli-hoisted resident): {}", n_mixed));
+    emit(format("  mixed (some eq/invar/nogood/soli/line-hoisted resident): {}", n_mixed));
     emit(format("  gate-held (no hoist pins, some ge below min_chain gate): {}", n_gate_held));
     emit(format("  fully-deletable (no hoist pins): {}", n_deletable));
 

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -11,6 +11,7 @@
 #include <gcs/innards/proofs/proof_only_variables.hh>
 #include <gcs/innards/proofs/simplify_literal.hh>
 #include <gcs/innards/variable_id_utils.hh>
+#include <gcs/interval_set.hh>
 
 #include <algorithm>
 #include <cstdlib>
@@ -42,9 +43,11 @@ using namespace gcs;
 using namespace gcs::innards;
 
 using std::any_of;
+using std::erase_if;
 using std::fstream;
 using std::function;
 using std::generator;
+using std::get_if;
 using std::ios;
 using std::ios_base;
 using std::list;
@@ -389,6 +392,12 @@ struct NamesAndIDsTracker::Imp
     // reason (a level-0 entry would be a permanent def).
     map<SimpleIntegerVariableID, map<Integer, int>> live_eq_literals;
     map<int, vector<pair<SimpleIntegerVariableID, Integer>>> eq_literals_by_level;
+    // What each emitted proof line names, for lines that name any eq atom at all --- the
+    // only way a `pol` can find out what citing an operand would name, since its own
+    // literals are a derivation result rather than text. Entries exist only for lines that
+    // name something, and forget_eq_atom_names_for drops them as the lines are del'd, so
+    // this tracks what is live in the proof rather than the proof.
+    unordered_map<long long, NamedEqAtoms> eq_atoms_by_line;
     // Set by a NamesAndIDsTracker::WindowedEqScope, for the duration of one guess mint in
     // the branch layer: the eq atom need_direct_encoding_for is about to define belongs to
     // a frontier, and wants a deletable (Current) definition rather than a permanent one.
@@ -2243,6 +2252,43 @@ auto NamesAndIDsTracker::note_permanent_eq_reference(const SimpleIntegerVariable
         return;
 
     hoist_eq_to_top(id, v);
+}
+
+auto NamesAndIDsTracker::note_line_names_eq_atoms(ProofLineNumber line, NamedEqAtoms atoms) -> void
+{
+    if (atoms.empty())
+        return;
+    _imp->eq_atoms_by_line.insert_or_assign(line.number, move(atoms));
+}
+
+auto NamesAndIDsTracker::eq_atoms_named_by(const ProofLine & line) const -> const NamedEqAtoms *
+{
+    // A labelled line is a model row, which is permanent and never windowed, so it can
+    // name nothing the window could evict.
+    const auto * n = get_if<ProofLineNumber>(&line);
+    if (! n)
+        return nullptr;
+    auto it = _imp->eq_atoms_by_line.find(n->number);
+    return it == _imp->eq_atoms_by_line.end() ? nullptr : &it->second;
+}
+
+auto NamesAndIDsTracker::forget_eq_atom_names_for(const IntervalSet<long long> & lines) -> void
+{
+    if (_imp->eq_atoms_by_line.empty())
+        return;
+
+    // Iterate the intervals rather than the map: a level's deletions are contiguous runs,
+    // and the map is (by design) far smaller than the run it covers, so probing per line
+    // would be quadratic in the wrong direction on a long-lived level. Erasing over the
+    // smaller of the two is what keeps this off the profile.
+    if (_imp->eq_atoms_by_line.size() <= 64) {
+        erase_if(_imp->eq_atoms_by_line, [&](const auto & entry) { return lines.contains(entry.first); });
+        return;
+    }
+
+    for (const auto & [l, u] : lines.each_interval())
+        for (auto n = l; n <= u; ++n)
+            _imp->eq_atoms_by_line.erase(n);
 }
 
 auto NamesAndIDsTracker::evict_eq_literal(const SimpleIntegerVariableID & id, Integer v) -> bool

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -55,12 +55,6 @@ namespace gcs::innards
         return XLiteral{lit.id, ! lit.negated};
     }
 
-    enum class EqualsOrGreaterEqual
-    {
-        Equals,
-        GreaterEqual
-    };
-
     /**
      * Why a real variable's proof-time `ge` order literal is resident (for
      * GuessHoist, transiently resident at a positive backtrack level), under
@@ -97,7 +91,9 @@ namespace gcs::innards
         InvarHoist,     ///< hoisted to Top from an interval-partition atom's Top def (define_plain_invar).
         NogoodHoist,    ///< hoisted to Top by emit_learned_nogood.
         SoliHoist,      ///< hoisted to Top by the objective-improvement hoist in ProofLogger::solution.
-        GuessHoist      ///< hoisted to a positive backtrack level by ProofLogger::backtrack (transient; never a Top cause).
+        GuessHoist,     ///< hoisted to a positive backtrack level by ProofLogger::backtrack (transient; never a Top cause).
+        LineHoist       ///< hoisted to Top because an emitted Top line names it, found by the generic reference walk
+                        ///< (an inequality's own terms, or the union over a pol's operands).
     };
 
     /**
@@ -603,19 +599,19 @@ namespace gcs::innards
          * nothing" and the map stays proportional to the eq-naming lines rather than to the
          * proof. Recorded only while the eq window is live; a no-op otherwise.
          */
-        auto note_line_names_eq_atoms(ProofLineNumber line, NamedEqAtoms atoms) -> void;
+        auto note_line_names_atoms(ProofLineNumber line, NamedAtoms atoms) -> void;
 
         /**
          * The eq atoms \p line names, or nullptr if it names none (or predates tracking).
          */
-        [[nodiscard]] auto eq_atoms_named_by(const ProofLine & line) const -> const NamedEqAtoms *;
+        [[nodiscard]] auto atoms_named_by(const ProofLine & line) const -> const NamedAtoms *;
 
         /**
          * Drop the naming records for every line in \p lines, which forget_proof_level is
          * about to `del`. Without this the map would grow with the proof rather than with
          * what is live in it.
          */
-        auto forget_eq_atom_names_for(const IntervalSet<long long> & lines) -> void;
+        auto forget_atom_names_for(const IntervalSet<long long> & lines) -> void;
 
         /**
          * The eq mirror of evict_order_literal: take real variable \p id's live windowed

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -12,6 +12,7 @@
 #include <gcs/innards/proofs/reification.hh>
 #include <gcs/innards/reason.hh>
 #include <gcs/innards/s_expr.hh>
+#include <gcs/interval_set-fwd.hh>
 #include <gcs/proof.hh>
 #include <gcs/reification.hh>
 #include <gcs/variable_condition.hh>
@@ -578,6 +579,43 @@ namespace gcs::innards
          * windowed definition, every eq atom outside a window being permanent already.
          */
         auto note_permanent_eq_reference(const SimpleIntegerVariableID & id, Integer v) -> void;
+
+        /**
+         * Record that proof line \p line names exactly these eq atoms, so that a later
+         * `pol` citing it can find out what citing it would name.
+         *
+         * The problem this exists to solve: an inequality emitter can see its own literals
+         * and hand them to note_permanent_eq_reference, but a `pol` line's literals are the
+         * *result* of a cutting-planes derivation, which gcs never evaluates. A `pol` at Top
+         * over operands naming `x == v` is a permanent reference to `x == v` that is
+         * invisible in the emitted text, so nothing pinned it and the window evicted it
+         * anyway --- `magic_square --size=4 --all-different gac` rejects for exactly this
+         * reason (the all-different Hall-set at-most-one row, justify.cc).
+         *
+         * Cutting planes cannot invent an atom: addition, multiplication, division and
+         * saturation all yield a constraint over a subset of the operands' variables, and
+         * the only other sources (`add(XLiteral)`, `add_for_literal`, `weaken`) are handed
+         * to PolBuilder directly. So the union over a pol's operands, plus whatever it was
+         * given literally, over-approximates what the result names --- soundly, and with no
+         * declaration for anyone to forget.
+         *
+         * Only lines that name at least one atom get an entry, so absence means "names
+         * nothing" and the map stays proportional to the eq-naming lines rather than to the
+         * proof. Recorded only while the eq window is live; a no-op otherwise.
+         */
+        auto note_line_names_eq_atoms(ProofLineNumber line, NamedEqAtoms atoms) -> void;
+
+        /**
+         * The eq atoms \p line names, or nullptr if it names none (or predates tracking).
+         */
+        [[nodiscard]] auto eq_atoms_named_by(const ProofLine & line) const -> const NamedEqAtoms *;
+
+        /**
+         * Drop the naming records for every line in \p lines, which forget_proof_level is
+         * about to `del`. Without this the map would grow with the proof rather than with
+         * what is live in it.
+         */
+        auto forget_eq_atom_names_for(const IntervalSet<long long> & lines) -> void;
 
         /**
          * The eq mirror of evict_order_literal: take real variable \p id's live windowed

--- a/gcs/innards/proofs/order_evict_test.cc
+++ b/gcs/innards/proofs/order_evict_test.cc
@@ -1,4 +1,5 @@
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 
@@ -49,13 +50,14 @@ auto main() -> int
     ProofModel model(proof_options, tracker);
 
     // One variable per scenario, so the scenarios cannot perturb each other's chains.
-    SimpleIntegerVariableID x{0}, y{1}, z{2}, w{3}, u{4}, t{5};
+    SimpleIntegerVariableID x{0}, y{1}, z{2}, w{3}, u{4}, t{5}, v{6};
     model.set_up_integer_variable(x, 0_i, 100_i, "x", nullopt);
     model.set_up_integer_variable(y, 0_i, 100_i, "y", nullopt);
     model.set_up_integer_variable(z, 0_i, 100_i, "z", nullopt);
     model.set_up_integer_variable(w, 0_i, 100_i, "w", nullopt);
     model.set_up_integer_variable(u, 0_i, 100_i, "u", nullopt);
     model.set_up_integer_variable(t, 0_i, 100_i, "t", nullopt);
+    model.set_up_integer_variable(v, 0_i, 100_i, "v", nullopt);
 
     model.finalise();
 
@@ -242,6 +244,38 @@ auto main() -> int
     // the rule is about ancestry, not a blanket refusal.
     tracker.need_gevar(t, 90_i);
     check(tracker.evict_order_literal(t, 90_i, nullopt));
+    logger.forget_proof_level(1);
+
+    // ---- v: a ge threshold pinned only through a pol's operands ----
+    // The ge half of the union rule. A `pol` landing at Top over an operand naming
+    // `v >= 30` is a permanent reference to that threshold, but nothing in the emitted pol
+    // text names it -- the literals are the arithmetic's result -- so before the operand
+    // union nothing pinned it and the window was free to take it.
+    //
+    // Asserted through the Top-pin bookkeeping rather than through the proof, because that
+    // is where the difference shows immediately: an unpinned threshold at a positive level
+    // is evictable with no cause at all, and a pinned one is evictable only against its
+    // sole cause. Checking the proof instead would only fail once something later named the
+    // evicted atom.
+    logger.enter_proof_level(1);
+    tracker.need_gevar(v, 30_i);
+    check(tracker.order_literal_is_live(v, 30_i));
+    // Deletable right now: this level minted it and nothing names it.
+    check(tracker.evict_order_literal(v, 30_i, nullopt));
+    tracker.need_gevar(v, 30_i);
+
+    {
+        PolBuilder pol;
+        pol.add(logger.emit_rup_proof_line(WPBSum{} + 1_i * (v < 30_i) + 1_i * (v >= 30_i) >= 1_i, ProofLevel::Temporary));
+        pol.emit(logger, ProofLevel::Top);
+    }
+
+    // The Top pol pinned it: a no-cause eviction is now refused, and LineHoist is the cause
+    // that owns the pin. Both halves matter -- the first is what fails without the union,
+    // the second is what fails if the pin is recorded against the wrong cause.
+    check(! tracker.evict_order_literal(v, 30_i, nullopt));
+    check(! tracker.evict_order_literal(v, 30_i, Cause::SoliHoist));
+    check(tracker.evict_order_literal(v, 30_i, Cause::LineHoist));
     logger.forget_proof_level(1);
 
     logger.enter_proof_level(0);

--- a/gcs/innards/proofs/pol_builder.cc
+++ b/gcs/innards/proofs/pol_builder.cc
@@ -9,6 +9,7 @@
 using std::nullopt;
 using std::optional;
 using std::string;
+using std::vector;
 using std::visit;
 using std::ranges::contains;
 
@@ -91,15 +92,29 @@ auto PolBuilder::note_literal_pushed(const IntegerVariableCondition & lit) -> vo
 {
     // The other way an atom enters a pol: pushed as a literal rather than reached through
     // an operand's names. `add(XLiteral)` cannot be caught here -- an XLiteral is already a
-    // proof name with no condition to read back -- but every eq atom a caller means to push
+    // proof name with no condition to read back -- but every atom a caller means to push
     // arrives through add_for_literal, which still has the condition.
-    if (lit.op != VariableConditionOperator::Equal && lit.op != VariableConditionOperator::NotEqual)
+    const auto * sid = std::get_if<SimpleIntegerVariableID>(&lit.var);
+    if (! sid)
         return;
-    if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&lit.var)) {
-        NamedEqAtom atom{*sid, lit.value};
-        if (! contains(_named_eq_atoms, atom))
-            _named_eq_atoms.push_back(atom);
+
+    optional<EqualsOrGreaterEqual> kind;
+    switch (lit.op) {
+        using enum VariableConditionOperator;
+    case Equal:
+    case NotEqual: kind = EqualsOrGreaterEqual::Equals; break;
+    // ge(v) is named by `X >= v` and by `X < v` (its negation); `X <= v` / `X > v` are
+    // lowered to Less(v+1) / GreaterEqual(v+1), so the threshold is the value either way.
+    case GreaterEqual:
+    case Less: kind = EqualsOrGreaterEqual::GreaterEqual; break;
+    default: break;
     }
+    if (! kind)
+        return;
+
+    NamedAtom atom{*sid, lit.value, *kind};
+    if (! contains(_named_atoms, atom))
+        _named_atoms.push_back(atom);
 }
 
 auto PolBuilder::add_for_literal(NamesAndIDsTracker & tracker, const IntegerVariableCondition & lit) -> PolBuilder &
@@ -202,27 +217,42 @@ auto PolBuilder::emit(ProofLogger & logger, ProofLevel level) -> ProofLine
     //
     // Over-approximating costs only a pin that was not strictly required; under-approximating
     // costs a rejected proof, so erring this way is the whole point.
-    NamedEqAtoms named;
-    if (logger.eq_window_active()) {
+    //
+    // Gated on bound_advances_active() rather than eq_window_active(): ge definitions are
+    // deletable under Literals whether or not the eq window was asked for, so gating the ge
+    // half on the window would miss every reference in the shipped configuration.
+    NamedAtoms named;
+    if (logger.bound_advances_active()) {
         const auto & tracker = logger.names_and_ids_tracker();
-        auto note = [&](const NamedEqAtom & atom) {
+        auto note = [&](const NamedAtom & atom) {
             if (! contains(named, atom))
                 named.push_back(atom);
         };
         for (const auto & [offset, line] : _refs)
-            if (const auto * from_operand = tracker.eq_atoms_named_by(line))
+            if (const auto * from_operand = tracker.atoms_named_by(line))
                 for (const auto & atom : *from_operand)
                     note(atom);
-        for (const auto & atom : _named_eq_atoms)
+        for (const auto & atom : _named_atoms)
             note(atom);
 
         // A pol landing at Top is a permanent reference to everything it names, so pin
         // before the line is written -- hoisting emits lines of its own, and they have to
         // precede the citing line. Rendering must therefore happen after this, or the
         // relative operand offsets would be computed against a stale line counter.
-        if (level == ProofLevel::Top)
-            for (const auto & [id, v] : named)
-                logger.names_and_ids_tracker().note_permanent_eq_reference(id, v);
+        if (level == ProofLevel::Top) {
+            // ge references go through the existing hoist path: it owns the Top-pin counting
+            // that evict_order_literal's precondition reads, and hoisting is the action a
+            // permanent reference requires. One call, so all its emissions stay together.
+            vector<Literal> ge_references;
+            for (const auto & atom : named) {
+                if (atom.kind == EqualsOrGreaterEqual::Equals)
+                    logger.names_and_ids_tracker().note_permanent_eq_reference(atom.id, atom.value);
+                else
+                    ge_references.push_back(Literal{atom.id >= atom.value});
+            }
+            if (! ge_references.empty())
+                logger.names_and_ids_tracker().hoist_live_order_literals_toward_level(ge_references, 0, OrderEncodingResidencyCause::LineHoist);
+        }
     }
 
     auto result = logger.emit_proof_line(render(logger.get_current_proof_line().number), level, nullopt, named);
@@ -234,6 +264,6 @@ auto PolBuilder::clear() -> void
 {
     _text.clear();
     _refs.clear();
-    _named_eq_atoms.clear();
+    _named_atoms.clear();
     _empty = true;
 }

--- a/gcs/innards/proofs/pol_builder.cc
+++ b/gcs/innards/proofs/pol_builder.cc
@@ -6,9 +6,11 @@
 
 #include <util/overloaded.hh>
 
+using std::nullopt;
 using std::optional;
 using std::string;
 using std::visit;
+using std::ranges::contains;
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -85,8 +87,24 @@ auto PolBuilder::add(const XLiteral & lit, Integer coeff, const NamesAndIDsTrack
     return *this;
 }
 
+auto PolBuilder::note_literal_pushed(const IntegerVariableCondition & lit) -> void
+{
+    // The other way an atom enters a pol: pushed as a literal rather than reached through
+    // an operand's names. `add(XLiteral)` cannot be caught here -- an XLiteral is already a
+    // proof name with no condition to read back -- but every eq atom a caller means to push
+    // arrives through add_for_literal, which still has the condition.
+    if (lit.op != VariableConditionOperator::Equal && lit.op != VariableConditionOperator::NotEqual)
+        return;
+    if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&lit.var)) {
+        NamedEqAtom atom{*sid, lit.value};
+        if (! contains(_named_eq_atoms, atom))
+            _named_eq_atoms.push_back(atom);
+    }
+}
+
 auto PolBuilder::add_for_literal(NamesAndIDsTracker & tracker, const IntegerVariableCondition & lit) -> PolBuilder &
 {
+    note_literal_pushed(lit);
     visit(overloaded{
               [&](const ProofLine & l) { add(l); },        //
               [&](const XLiteral & x) { add(x, tracker); } //
@@ -97,6 +115,7 @@ auto PolBuilder::add_for_literal(NamesAndIDsTracker & tracker, const IntegerVari
 
 auto PolBuilder::add_for_literal(NamesAndIDsTracker & tracker, const IntegerVariableCondition & lit, Integer coeff) -> PolBuilder &
 {
+    note_literal_pushed(lit);
     visit(overloaded{
               [&](const ProofLine & l) { add(l, coeff); },        //
               [&](const XLiteral & x) { add(x, coeff, tracker); } //
@@ -167,7 +186,46 @@ auto PolBuilder::str() const -> string
 
 auto PolBuilder::emit(ProofLogger & logger, ProofLevel level) -> ProofLine
 {
-    auto result = logger.emit_proof_line(render(logger.get_current_proof_line().number), level);
+    // What does the constraint this pol derives actually name? The text cannot say: it is
+    // reverse-polish over *references*, and the result's literals fall out of the
+    // arithmetic. gcs never evaluates that arithmetic, so before this the answer was
+    // "nobody knows", and a Top pol over operands naming a windowed eq atom was an
+    // invisible permanent reference to it -- which is why
+    // `magic_square --size=4 --all-different gac` rejected under the window, at the
+    // all-different Hall-set at-most-one row.
+    //
+    // It does not need evaluating. Cutting planes cannot invent an atom: addition,
+    // multiplication, division and saturation all yield a constraint over a subset of the
+    // operands' variables. So the union over the operands' recorded names, plus whatever
+    // was pushed as a literal rather than a reference, over-approximates the result --
+    // soundly, automatically, and with nothing for a caller to declare or forget.
+    //
+    // Over-approximating costs only a pin that was not strictly required; under-approximating
+    // costs a rejected proof, so erring this way is the whole point.
+    NamedEqAtoms named;
+    if (logger.eq_window_active()) {
+        const auto & tracker = logger.names_and_ids_tracker();
+        auto note = [&](const NamedEqAtom & atom) {
+            if (! contains(named, atom))
+                named.push_back(atom);
+        };
+        for (const auto & [offset, line] : _refs)
+            if (const auto * from_operand = tracker.eq_atoms_named_by(line))
+                for (const auto & atom : *from_operand)
+                    note(atom);
+        for (const auto & atom : _named_eq_atoms)
+            note(atom);
+
+        // A pol landing at Top is a permanent reference to everything it names, so pin
+        // before the line is written -- hoisting emits lines of its own, and they have to
+        // precede the citing line. Rendering must therefore happen after this, or the
+        // relative operand offsets would be computed against a stale line counter.
+        if (level == ProofLevel::Top)
+            for (const auto & [id, v] : named)
+                logger.names_and_ids_tracker().note_permanent_eq_reference(id, v);
+    }
+
+    auto result = logger.emit_proof_line(render(logger.get_current_proof_line().number), level, nullopt, named);
     clear();
     return result;
 }
@@ -176,5 +234,6 @@ auto PolBuilder::clear() -> void
 {
     _text.clear();
     _refs.clear();
+    _named_eq_atoms.clear();
     _empty = true;
 }

--- a/gcs/innards/proofs/pol_builder.hh
+++ b/gcs/innards/proofs/pol_builder.hh
@@ -79,7 +79,7 @@ namespace gcs::innards
         std::vector<std::pair<std::size_t, ProofLine>> _refs;
         // Eq atoms pushed as literals rather than reached through an operand's names --- the
         // one source of atoms that the operand union cannot see. See emit().
-        NamedEqAtoms _named_eq_atoms;
+        NamedAtoms _named_atoms;
         bool _empty = true;
         const NamesAndIDsTracker * _deview_tracker = nullptr;
 

--- a/gcs/innards/proofs/pol_builder.hh
+++ b/gcs/innards/proofs/pol_builder.hh
@@ -77,10 +77,15 @@ namespace gcs::innards
         // logger's current line.
         std::string _text;
         std::vector<std::pair<std::size_t, ProofLine>> _refs;
+        // Eq atoms pushed as literals rather than reached through an operand's names --- the
+        // one source of atoms that the operand union cannot see. See emit().
+        NamedEqAtoms _named_eq_atoms;
         bool _empty = true;
         const NamesAndIDsTracker * _deview_tracker = nullptr;
 
         auto separator_if_not_first() -> void;
+
+        auto note_literal_pushed(const IntegerVariableCondition & lit) -> void;
 
         // Render to "pol ... ;". With current_max set, constraint references are
         // emitted as relative indices; without, absolutely.

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -59,6 +59,7 @@ using std::tuple;
 using std::variant;
 using std::vector;
 using std::visit;
+using std::ranges::contains;
 
 using namespace gcs;
 using namespace gcs::innards;
@@ -553,7 +554,7 @@ auto ProofLogger::eq_window_active() const -> bool
     return _imp->eq_window && bound_advances_active();
 }
 
-auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> void
+auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> NamedEqAtoms
 {
     // The eq-atom window's hoist-out rule, applied generally rather than site by site: a
     // line about to land at ProofLevel::Top that names a windowed eq atom is a PERMANENT
@@ -571,9 +572,14 @@ auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoB
     // otherwise: eq_window_active() is false unless order-encoding deletion is on (which it
     // is not by default), and the tracker's own guard returns immediately when no variable
     // is currently windowed.
-    if (level != ProofLevel::Top || ! eq_window_active())
-        return;
+    // The walk runs at every level, not only Top, because what it collects is also what a
+    // later `pol` needs in order to know what citing this line would name -- and pol
+    // operands are routinely Temporary (all-different's pairwise at-most-ones are). Only
+    // the pinning below is Top-only.
+    if (! eq_window_active())
+        return {};
 
+    NamedEqAtoms named;
     for (const auto & term : ineq.lhs.terms) {
         const auto * lit = std::get_if<ProofLiteral>(&term.variable);
         if (! lit)
@@ -584,9 +590,15 @@ auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoB
         const auto * ivc = std::get_if<IntegerVariableCondition>(cond);
         if (! ivc || (ivc->op != VariableConditionOperator::Equal && ivc->op != VariableConditionOperator::NotEqual))
             continue;
-        if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&ivc->var))
-            names_and_ids_tracker().note_permanent_eq_reference(*sid, ivc->value);
+        if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&ivc->var)) {
+            if (level == ProofLevel::Top)
+                names_and_ids_tracker().note_permanent_eq_reference(*sid, ivc->value);
+            NamedEqAtom atom{*sid, ivc->value};
+            if (! contains(named, atom))
+                named.push_back(atom);
+        }
     }
+    return named;
 }
 
 namespace
@@ -856,14 +868,14 @@ auto ProofLogger::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & 
     return names_and_ids_tracker().reify(ineq, half_reif);
 }
 
-auto ProofLogger::emit_proof_line(const string & s, ProofLevel level, const optional<ProofLineLabel> & label) -> ProofLine
+auto ProofLogger::emit_proof_line(const string & s, ProofLevel level, const optional<ProofLineLabel> & label, const NamedEqAtoms & names) -> ProofLine
 {
     log_stacktrace();
     write_indent();
     if (label)
         _imp->proof << *label << ' ';
     _imp->proof << s << '\n';
-    auto result = record_proof_line(advance_proof_line_number(), level);
+    auto result = record_proof_line(advance_proof_line_number(), level, names);
     return result;
 }
 
@@ -876,7 +888,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
     const std::optional<AssertionAnnotation> & assertion_hint, const std::optional<ProofLineLabel> & label) -> ProofLine
 {
     log_stacktrace();
-    note_top_eq_references(ineq, level);
+    auto named_eq_atoms = note_top_eq_references(ineq, level);
 
     LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
     auto & rule_line = lease.buffer();
@@ -926,7 +938,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
     }
         .visit(rule);
 
-    auto line = emit_proof_line(rule_line, level, label);
+    auto line = emit_proof_line(rule_line, level, label, named_eq_atoms);
     // Note: no automatic deview-derivation here. Runtime RUP/red emissions
     // happen many times per propagator inference and per-call deview
     // derivation explodes proof size on tests with many view-using
@@ -940,7 +952,7 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     const ReasonLiterals & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
     log_stacktrace();
-    note_top_eq_references(ineq, level);
+    auto named_eq_atoms = note_top_eq_references(ineq, level);
 
     LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
     auto & rule_line = lease.buffer();
@@ -994,7 +1006,7 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     }
         .visit(rule);
 
-    auto line = emit_proof_line(rule_line, level);
+    auto line = emit_proof_line(rule_line, level, nullopt, named_eq_atoms);
     // Note: see comment in `emit()` about why no auto-deview-derivation.
     return line;
 }
@@ -1068,6 +1080,11 @@ auto ProofLogger::forget_proof_level(int depth) -> void
             _imp->proof << "del id " << rel(u) << ";\n";
         }
     }
+    // Drop the naming records for the lines just del'd, before `lines` is cleared and they
+    // become unrecoverable. Without this the map would grow with the proof rather than with
+    // what is live in it, which on a long search is the difference between bounded and not.
+    names_and_ids_tracker().forget_eq_atom_names_for(lines);
+
     lines.clear();
 
     // Keep the tracker's live order-encoding structures in sync with the deletions just
@@ -1178,13 +1195,18 @@ auto ProofLogger::start_proof(const ProofModel & model) -> void
     _imp->proof_line.number += model.number_of_constraints().number;
 }
 
-auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level) -> ProofLineNumber
+auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level, const NamedEqAtoms & names) -> ProofLineNumber
 {
     switch (level) {
     case ProofLevel::Top: _imp->proof_lines_by_level.at(0).insert_at_end(line.number); break;
     case ProofLevel::Current: _imp->proof_lines_by_level.at(_imp->active_proof_level).insert_at_end(line.number); break;
     case ProofLevel::Temporary: _imp->proof_lines_by_level.at(_imp->active_proof_level + 1).insert_at_end(line.number); break;
     }
+
+    // Empty for nearly every line, and unconditionally empty when the window is not live,
+    // so this costs a branch on the common path.
+    if (! names.empty())
+        names_and_ids_tracker().note_line_names_eq_atoms(line, names);
 
     return line;
 }
@@ -1244,6 +1266,12 @@ auto ProofLogger::emit_red_proof_line(const SumLessThanEqual<Weighted<PseudoBool
     const std::vector<std::pair<ProofLiteralOrFlag, ProofLiteralOrFlag>> & witness, ProofLevel level,
     const std::optional<std::map<ProofGoal, Subproof>> & subproofs) -> ProofLine
 {
+    // This funnel renders a sum at a caller-chosen level exactly as the two reifying `red`
+    // emitters do, but was not on the hoist-out rule's list of call sites. A plain `red` at
+    // Top naming a windowed eq atom is as permanent a reference as a reifying one, and its
+    // names are as citable by a later `pol`, so it belongs here too.
+    auto named_eq_atoms = note_top_eq_references(ineq, level);
+
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
 
     log_stacktrace();
@@ -1260,7 +1288,7 @@ auto ProofLogger::emit_red_proof_line(const SumLessThanEqual<Weighted<PseudoBool
     else
         _imp->proof << ";\n";
 
-    return record_proof_line(advance_proof_line_number(), level);
+    return record_proof_line(advance_proof_line_number(), level, named_eq_atoms);
 }
 
 auto ProofLogger::introduce_bits_of(
@@ -1400,7 +1428,7 @@ auto ProofLogger::emit_red_proof_lines_forward_reifying(const SumLessThanEqual<W
     ProofLevel level, const optional<map<ProofGoal, Subproof>> & subproofs) -> ProofLine
 {
     log_stacktrace();
-    note_top_eq_references(ineq, level);
+    auto named_eq_atoms = note_top_eq_references(ineq, level);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     write_indent();
@@ -1412,14 +1440,14 @@ auto ProofLogger::emit_red_proof_lines_forward_reifying(const SumLessThanEqual<W
     else
         _imp->proof << ";\n";
 
-    return record_proof_line(advance_proof_line_number(), level);
+    return record_proof_line(advance_proof_line_number(), level, named_eq_atoms);
 }
 
 auto ProofLogger::emit_red_proof_lines_reverse_reifying(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLiteralOrFlag reif,
     ProofLevel level, const optional<map<ProofGoal, Subproof>> & subproofs) -> ProofLine
 {
     log_stacktrace();
-    note_top_eq_references(ineq, level);
+    auto named_eq_atoms = note_top_eq_references(ineq, level);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     auto negated_ineq = ineq.lhs >= ineq.rhs + 1_i;
@@ -1431,7 +1459,7 @@ auto ProofLogger::emit_red_proof_lines_reverse_reifying(const SumLessThanEqual<W
         emit_subproofs(subproofs.value());
     else
         _imp->proof << ";\n";
-    return record_proof_line(advance_proof_line_number(), level);
+    return record_proof_line(advance_proof_line_number(), level, named_eq_atoms);
 }
 
 auto ProofLogger::emit_red_proof_lines_reifying(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLiteralOrFlag reif, ProofLevel level)

--- a/gcs/innards/proofs/proof_logger.cc
+++ b/gcs/innards/proofs/proof_logger.cc
@@ -554,7 +554,7 @@ auto ProofLogger::eq_window_active() const -> bool
     return _imp->eq_window && bound_advances_active();
 }
 
-auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> NamedEqAtoms
+auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> NamedAtoms
 {
     // The eq-atom window's hoist-out rule, applied generally rather than site by site: a
     // line about to land at ProofLevel::Top that names a windowed eq atom is a PERMANENT
@@ -576,10 +576,38 @@ auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoB
     // later `pol` needs in order to know what citing this line would name -- and pol
     // operands are routinely Temporary (all-different's pairwise at-most-ones are). Only
     // the pinning below is Top-only.
-    if (! eq_window_active())
+    //
+    // Gated on bound_advances_active() rather than eq_window_active(): ge definitions are
+    // deletable under Literals whether or not the eq window was asked for, so gating the ge
+    // half on the window would miss every reference in the shipped configuration. The eq
+    // half stays effectively window-gated regardless, because note_permanent_eq_reference
+    // returns immediately when nothing is windowed.
+    if (! bound_advances_active())
         return {};
 
-    NamedEqAtoms named;
+    NamedAtoms named;
+    auto note = [&](const NamedAtom & atom) {
+        if (! contains(named, atom))
+            named.push_back(atom);
+    };
+
+    // ge atoms are RECORDED but deliberately not pinned here, which is where the two sides
+    // stop being symmetric.
+    //
+    // An eq atom stands alone, so hoisting one is local. A ge threshold is a link in a
+    // chain, and hoisting it to Top *restructures that chain* by stitching over its
+    // neighbours. Doing that at every Top line that happens to name a ge threshold breaks
+    // RUP steps that depend on the chain's positive-level shape -- measured:
+    // `comparison_constraint_le_iff` (`comparison_test le_iff --seed=4979515`) and
+    // `linear_constraint_le_iff_incremental` both reject at gate 0 with "not implied by
+    // reverse unit propagation" when the ge half pins here.
+    //
+    // Recording still has to happen, at every level, because it is what a later `pol`
+    // unions over -- and a pol that lands at Top *does* pin the ge atoms it finds, which is
+    // safe because it happens at pol-emit time rather than inside another line's emission.
+    // So the pol gap is covered for ge; the broader "any Top line naming a ge threshold
+    // pins it" rule is not, and stage F's ancestor rule is what covers the eviction path
+    // instead.
     for (const auto & term : ineq.lhs.terms) {
         const auto * lit = std::get_if<ProofLiteral>(&term.variable);
         if (! lit)
@@ -588,16 +616,29 @@ auto ProofLogger::note_top_eq_references(const SumLessThanEqual<Weighted<PseudoB
         if (! cond)
             continue;
         const auto * ivc = std::get_if<IntegerVariableCondition>(cond);
-        if (! ivc || (ivc->op != VariableConditionOperator::Equal && ivc->op != VariableConditionOperator::NotEqual))
+        if (! ivc)
             continue;
-        if (const auto * sid = std::get_if<SimpleIntegerVariableID>(&ivc->var)) {
+        const auto * sid = std::get_if<SimpleIntegerVariableID>(&ivc->var);
+        if (! sid)
+            continue;
+
+        switch (ivc->op) {
+            using enum VariableConditionOperator;
+        case Equal:
+        case NotEqual:
             if (level == ProofLevel::Top)
                 names_and_ids_tracker().note_permanent_eq_reference(*sid, ivc->value);
-            NamedEqAtom atom{*sid, ivc->value};
-            if (! contains(named, atom))
-                named.push_back(atom);
+            note(NamedAtom{*sid, ivc->value, EqualsOrGreaterEqual::Equals});
+            break;
+        // ge(v) is named by `X >= v` and by `X < v` (its negation); `X <= v` / `X > v` are
+        // lowered to Less(v+1) / GreaterEqual(v+1), so the threshold is the value either
+        // way. Mirrors hoist_live_order_literals_toward_level's own reading.
+        case GreaterEqual:
+        case Less: note(NamedAtom{*sid, ivc->value, EqualsOrGreaterEqual::GreaterEqual}); break;
+        default: break;
         }
     }
+
     return named;
 }
 
@@ -868,7 +909,7 @@ auto ProofLogger::reify(const WPBSumLE & ineq, const HalfReifyOnConjunctionOf & 
     return names_and_ids_tracker().reify(ineq, half_reif);
 }
 
-auto ProofLogger::emit_proof_line(const string & s, ProofLevel level, const optional<ProofLineLabel> & label, const NamedEqAtoms & names) -> ProofLine
+auto ProofLogger::emit_proof_line(const string & s, ProofLevel level, const optional<ProofLineLabel> & label, const NamedAtoms & names) -> ProofLine
 {
     log_stacktrace();
     write_indent();
@@ -888,7 +929,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
     const std::optional<AssertionAnnotation> & assertion_hint, const std::optional<ProofLineLabel> & label) -> ProofLine
 {
     log_stacktrace();
-    auto named_eq_atoms = note_top_eq_references(ineq, level);
+    auto named_atoms = note_top_eq_references(ineq, level);
 
     LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
     auto & rule_line = lease.buffer();
@@ -938,7 +979,7 @@ auto ProofLogger::emit(const ProofRule & rule, const SumLessThanEqual<Weighted<P
     }
         .visit(rule);
 
-    auto line = emit_proof_line(rule_line, level, label, named_eq_atoms);
+    auto line = emit_proof_line(rule_line, level, label, named_atoms);
     // Note: no automatic deview-derivation here. Runtime RUP/red emissions
     // happen many times per propagator inference and per-call deview
     // derivation explodes proof size on tests with many view-using
@@ -952,7 +993,7 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     const ReasonLiterals & reason, const std::optional<AssertionAnnotation> & assertion_hint) -> ProofLine
 {
     log_stacktrace();
-    auto named_eq_atoms = note_top_eq_references(ineq, level);
+    auto named_atoms = note_top_eq_references(ineq, level);
 
     LineBufferLease lease{_imp->line_buffers, _imp->line_buffer_depth};
     auto & rule_line = lease.buffer();
@@ -1006,7 +1047,7 @@ auto ProofLogger::emit_under_reason(const ProofRule & rule, const SumLessThanEqu
     }
         .visit(rule);
 
-    auto line = emit_proof_line(rule_line, level, nullopt, named_eq_atoms);
+    auto line = emit_proof_line(rule_line, level, nullopt, named_atoms);
     // Note: see comment in `emit()` about why no auto-deview-derivation.
     return line;
 }
@@ -1083,7 +1124,7 @@ auto ProofLogger::forget_proof_level(int depth) -> void
     // Drop the naming records for the lines just del'd, before `lines` is cleared and they
     // become unrecoverable. Without this the map would grow with the proof rather than with
     // what is live in it, which on a long search is the difference between bounded and not.
-    names_and_ids_tracker().forget_eq_atom_names_for(lines);
+    names_and_ids_tracker().forget_atom_names_for(lines);
 
     lines.clear();
 
@@ -1195,7 +1236,7 @@ auto ProofLogger::start_proof(const ProofModel & model) -> void
     _imp->proof_line.number += model.number_of_constraints().number;
 }
 
-auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level, const NamedEqAtoms & names) -> ProofLineNumber
+auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level, const NamedAtoms & names) -> ProofLineNumber
 {
     switch (level) {
     case ProofLevel::Top: _imp->proof_lines_by_level.at(0).insert_at_end(line.number); break;
@@ -1206,7 +1247,7 @@ auto ProofLogger::record_proof_line(ProofLineNumber line, ProofLevel level, cons
     // Empty for nearly every line, and unconditionally empty when the window is not live,
     // so this costs a branch on the common path.
     if (! names.empty())
-        names_and_ids_tracker().note_line_names_eq_atoms(line, names);
+        names_and_ids_tracker().note_line_names_atoms(line, names);
 
     return line;
 }
@@ -1270,7 +1311,7 @@ auto ProofLogger::emit_red_proof_line(const SumLessThanEqual<Weighted<PseudoBool
     // emitters do, but was not on the hoist-out rule's list of call sites. A plain `red` at
     // Top naming a windowed eq atom is as permanent a reference as a reifying one, and its
     // names are as citable by a later `pol`, so it belongs here too.
-    auto named_eq_atoms = note_top_eq_references(ineq, level);
+    auto named_atoms = note_top_eq_references(ineq, level);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
 
@@ -1288,7 +1329,7 @@ auto ProofLogger::emit_red_proof_line(const SumLessThanEqual<Weighted<PseudoBool
     else
         _imp->proof << ";\n";
 
-    return record_proof_line(advance_proof_line_number(), level, named_eq_atoms);
+    return record_proof_line(advance_proof_line_number(), level, named_atoms);
 }
 
 auto ProofLogger::introduce_bits_of(
@@ -1428,7 +1469,7 @@ auto ProofLogger::emit_red_proof_lines_forward_reifying(const SumLessThanEqual<W
     ProofLevel level, const optional<map<ProofGoal, Subproof>> & subproofs) -> ProofLine
 {
     log_stacktrace();
-    auto named_eq_atoms = note_top_eq_references(ineq, level);
+    auto named_atoms = note_top_eq_references(ineq, level);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     write_indent();
@@ -1440,14 +1481,14 @@ auto ProofLogger::emit_red_proof_lines_forward_reifying(const SumLessThanEqual<W
     else
         _imp->proof << ";\n";
 
-    return record_proof_line(advance_proof_line_number(), level, named_eq_atoms);
+    return record_proof_line(advance_proof_line_number(), level, named_atoms);
 }
 
 auto ProofLogger::emit_red_proof_lines_reverse_reifying(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLiteralOrFlag reif,
     ProofLevel level, const optional<map<ProofGoal, Subproof>> & subproofs) -> ProofLine
 {
     log_stacktrace();
-    auto named_eq_atoms = note_top_eq_references(ineq, level);
+    auto named_atoms = note_top_eq_references(ineq, level);
 
     names_and_ids_tracker().need_all_proof_names_in(ineq.lhs);
     auto negated_ineq = ineq.lhs >= ineq.rhs + 1_i;
@@ -1459,7 +1500,7 @@ auto ProofLogger::emit_red_proof_lines_reverse_reifying(const SumLessThanEqual<W
         emit_subproofs(subproofs.value());
     else
         _imp->proof << ";\n";
-    return record_proof_line(advance_proof_line_number(), level, named_eq_atoms);
+    return record_proof_line(advance_proof_line_number(), level, named_atoms);
 }
 
 auto ProofLogger::emit_red_proof_lines_reifying(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLiteralOrFlag reif, ProofLevel level)

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -55,7 +55,7 @@ namespace gcs::innards
         // evict: stored against the line so that a later `pol` citing it can discover what
         // citing it would name. Empty for the overwhelming majority of lines, and always
         // empty unless the window is live.
-        auto record_proof_line(ProofLineNumber line, ProofLevel level, const NamedEqAtoms & names = {}) -> ProofLineNumber;
+        auto record_proof_line(ProofLineNumber line, ProofLevel level, const NamedAtoms & names = {}) -> ProofLineNumber;
 
         auto end_proof() -> void;
 
@@ -75,7 +75,7 @@ namespace gcs::innards
         // that names an eq atom can still be cited by a `pol` that lands at Top --- which
         // is exactly how all-different's Hall-set row referenced an atom nothing had
         // pinned. Only the *pinning* is Top-only; the *recording* cannot be.
-        auto note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> NamedEqAtoms;
+        auto note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> NamedAtoms;
 
         // Record the incumbent an improving solution has just left resident, and take the
         // one it supersedes back out of the proof: `delc` its improvement constraint, `del`
@@ -436,7 +436,7 @@ namespace gcs::innards
          * --- it is how PolBuilder hands over the union it computed over its operands.
          */
         auto emit_proof_line(const std::string &, ProofLevel level, const std::optional<ProofLineLabel> & label = std::nullopt,
-            const NamedEqAtoms & names = {}) -> ProofLine;
+            const NamedAtoms & names = {}) -> ProofLine;
 
         /**
          * Emit a proof step, with a specified rule. An optional label is written as a

--- a/gcs/innards/proofs/proof_logger.hh
+++ b/gcs/innards/proofs/proof_logger.hh
@@ -51,7 +51,11 @@ namespace gcs::innards
 
         auto advance_proof_line_number() -> ProofLineNumber;
 
-        auto record_proof_line(ProofLineNumber line, ProofLevel level) -> ProofLineNumber;
+        // `names` is what the line being recorded names, for the eq atoms the window can
+        // evict: stored against the line so that a later `pol` citing it can discover what
+        // citing it would name. Empty for the overwhelming majority of lines, and always
+        // empty unless the window is live.
+        auto record_proof_line(ProofLineNumber line, ProofLevel level, const NamedEqAtoms & names = {}) -> ProofLineNumber;
 
         auto end_proof() -> void;
 
@@ -63,9 +67,15 @@ namespace gcs::innards
         // ProofLevel::Top that names a windowed eq atom is a permanent reference to it, so
         // the atom (and the ge thresholds its definition names) has to become permanent
         // before the line is written. Called from every emission funnel that renders a sum
-        // at a caller-chosen level; a no-op unless eq_window_active() and the line is at
-        // Top. See dev_docs/brancher-design.md, "The hoist-out rule".
-        auto note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> void;
+        // at a caller-chosen level; a no-op unless eq_window_active().
+        // See dev_docs/brancher-design.md, "The hoist-out rule".
+        //
+        // Returns what the line names, which the caller passes to record_proof_line. The
+        // walk now runs at *every* level rather than only Top, because a Temporary line
+        // that names an eq atom can still be cited by a `pol` that lands at Top --- which
+        // is exactly how all-different's Hall-set row referenced an atom nothing had
+        // pinned. Only the *pinning* is Top-only; the *recording* cannot be.
+        auto note_top_eq_references(const SumLessThanEqual<Weighted<PseudoBooleanTerm>> & ineq, ProofLevel level) -> NamedEqAtoms;
 
         // Record the incumbent an improving solution has just left resident, and take the
         // one it supersedes back out of the proof: `delc` its improvement constraint, `del`
@@ -420,8 +430,13 @@ namespace gcs::innards
          * Emit the specified text as a proof line. An optional label is written as a
          * leading `@<label>` (legal before any rule -- pol, rup, red, ia, ...), binding
          * the label to the constraint the line produces, as an OPB `@label` does.
+         *
+         * `names` is what the emitted line names, for the eq atoms the window can evict.
+         * The text is already rendered by the time it gets here, so this cannot be derived
+         * --- it is how PolBuilder hands over the union it computed over its operands.
          */
-        auto emit_proof_line(const std::string &, ProofLevel level, const std::optional<ProofLineLabel> & label = std::nullopt) -> ProofLine;
+        auto emit_proof_line(const std::string &, ProofLevel level, const std::optional<ProofLineLabel> & label = std::nullopt,
+            const NamedEqAtoms & names = {}) -> ProofLine;
 
         /**
          * Emit a proof step, with a specified rule. An optional label is written as a


### PR DESCRIPTION
Closes the `pol`-reference gap that `dev_docs/order-encoding-deletion.md` recorded as
theoretical. It is not theoretical, and the instance is in the **shipped** configuration.

## The bug

```
GCS_DELETE_ORDER_ENCODING=literals magic_square --size=4 --all-different gac --prove
  -> Proofgoal 3515 could not be autoproven  (at pbp:4310)
```

`main` verifies this in 28.7 s. With the feature on it is **rejected in 0.10 s** — same
search (77 983 recursions), proof only **228 bytes** larger. Found by the PR #632 benchmark
sweep, on a **group C control row** that was expected to be an exact no-op.

A `pol` line's literals are the *result* of a cutting-planes derivation, which gcs never
evaluates. So a `pol` landing at Top over operands naming a windowed eq atom is a permanent
reference nothing can see — the hoist-out rule walks an emitted sum's terms, and a pol has
no terms to walk. The window evicted the atom anyway, and the "re-introduction" at
pbp:4309–4310 was not one: the atom had never been free.

Constraint 3515 is all-different's Hall-set at-most-one row (`all_different/justify.cc:39`),
a `PolBuilder` fold of fifteen pairwise clauses naming `i[_13][eq8]`. Inserting
`del id 3515` before the failing step makes it pass, confirming it as the sole blocker.

It is the eq-side member of the family stage F (#645) fixed on the ge side, reached by a
path stage F's rule cannot see — `evictions` is **0** in every config here, so
`evict_order_literal`'s ancestor guard never runs.

## The fix, and why it is automatic

**Cutting planes cannot invent an atom.** Addition, multiplication, division and saturation
all yield a constraint over a subset of the operands' variables, and the only other sources
(`add_for_literal`, `weaken`'s flag) are handed to `PolBuilder` directly. So the union over
the operands' recorded names over-approximates what the result names — soundly, with
nothing for a caller to declare or forget. `PolBuilder::emit` computes it, pins it when the
line lands at Top, and records it against the new line so a pol over pols composes.

That is why this is not a second level argument on the emitters, which was the other option
considered: a declaration is a second source of truth that drifts from the expression it
describes, and a missing one is silent until deletion is enabled *and* an instance hits it —
exactly how this survived every green suite until a benchmark sweep tripped over it. It
would also have missed this bug entirely, since the offending site is a `PolBuilder::emit`
and not an `emit_rup_proof_line`.

## What it costs

A `ProofLine -> named eq atoms` map — the point at which we start tracking the live contents
of the proof, and the part worth watching. Scoped to what is live, not to the proof: entries
only for lines that name an atom, nothing recorded unless the window is live, and
`forget_eq_atom_names_for` drops each level's entries as its lines are `del`'d.

Also brings `emit_red_proof_line` onto the hoist-out rule — it renders a sum at a
caller-chosen level exactly as the two reifying `red` emitters do, and was the one such
funnel not on the list.

## Validation

- `magic_square --size=4 --all-different gac` **verifies** at gate 16 and gate 0
- **505/505** ctest, flag off / `literals` / `literals` + `MIN_CHAIN=0`
- **21/21 byte-identical to main with the flag off** — carrying this still costs nothing
- **Must-fail control**: with the union rule disabled, `eq_window_test` fails on the named
  invariant (`p: a Top pol over operands naming the atom did not take it out of the
  window`), not merely on the downstream VeriPB rejection
- A verdict-only pass over the whole PR #632 row set at gate 16 and gate 0 is still running;
  I will post the result

The new `eq_window_test` scenario `p` asserts the **pin**, not the proof: with the reference
missed the atom stays windowed and is evicted, and VeriPB only objects two steps later.

Per the #612 stack policy this is **not for merge without an explicit go-ahead**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p