### PR TITLE
Linear inequality: fix the negated reification forms' proof rows (#644)

### DIFF
--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -411,7 +411,7 @@ if(GCS_BUILD_TESTS)
     add_view_tests(among_constraint among_test 5)
     add_view_tests(all_different_except_constraint all_different_except_test 4)
     add_view_tests(value_precede_constraint value_precede_test 5)
-    foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff ne ne_if ne_iff)
+    foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff le_not le_notif ne ne_if ne_iff)
         add_view_tests(linear_constraint_${mode} linear_test 3 ${mode})
     endforeach()
     add_view_tests(table_constraint table_test 3)
@@ -439,7 +439,7 @@ if(GCS_BUILD_TESTS)
     # stateless (a huge threshold). The threshold env is appended below (after the cap
     # block, so it doesn't clobber it) and is folded into the proof file name by the
     # test, so the two modes never collide under parallel ctest.
-    foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff ne ne_if ne_iff)
+    foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff le_not le_notif ne ne_if ne_iff)
         foreach(linmode incremental stateless)
             add_test(NAME linear_constraint_${mode}_${linmode}
                 COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_test> ${mode})
@@ -451,7 +451,7 @@ if(GCS_BUILD_TESTS)
     # reads it, so this is meaningful for the le/ge modes and their install-decided
     # reified forms. linear_test verifies each instance's proof internally, so the
     # slack path is proof-checked here too.
-    foreach(mode ge ge_if ge_iff le le_if le_iff)
+    foreach(mode ge ge_if ge_iff le le_if le_iff le_not le_notif)
         add_test(NAME linear_constraint_${mode}_slack
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:linear_test> ${mode})
     endforeach()
@@ -659,13 +659,13 @@ if(GCS_BUILD_TESTS)
     # Pin the linear incremental threshold per test variant: 0 = always incremental,
     # a huge value = always stateless, so CI exercises both linear propagation paths.
     # APPEND so the runtime-cap environment set just above is preserved.
-    foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff ne ne_if ne_iff)
+    foreach(mode eq eq_if eq_iff ge ge_if ge_iff le le_if le_iff le_not le_notif ne ne_if ne_iff)
         set_property(TEST linear_constraint_${mode}_incremental APPEND PROPERTY ENVIRONMENT "GCS_LINEAR_INCREMENTAL_THRESHOLD=0")
         set_property(TEST linear_constraint_${mode}_stateless APPEND PROPERTY ENVIRONMENT "GCS_LINEAR_INCREMENTAL_THRESHOLD=1000000")
     endforeach()
     # Force slack-based waking on (threshold 0, no covering-fraction cap) so the
     # slack path is exercised for every decided inequality direction.
-    foreach(mode ge ge_if ge_iff le le_if le_iff)
+    foreach(mode ge ge_if ge_iff le le_if le_iff le_not le_notif)
         set_property(TEST linear_constraint_${mode}_slack APPEND PROPERTY ENVIRONMENT
             "GCS_LINEAR_SLACK_WATCH_THRESHOLD=0;GCS_LINEAR_SLACK_WATCH_COVER_PERCENT=100")
     endforeach()

--- a/gcs/constraint_row_test.cc
+++ b/gcs/constraint_row_test.cc
@@ -133,11 +133,11 @@ namespace
         Problem p;
         post(p);
         p.add_presolver(CapturingPresolver<Constraint_>{&result.resolved});
-        // No .scp: s_expr() throws on the MustNotHold and NotIf comparison
-        // forms, which have no cake_pb_cp spelling --- and those are exactly the
-        // forms this has to cover, since they are the ones whose row is under
-        // the label a naive citer would build. The .opb is written either way,
-        // and the .opb is the oracle here.
+        // No .scp: s_expr() throws on the MustNotHold and NotIf forms of both
+        // families, which have no cake_pb_cp spelling --- and those are exactly
+        // the forms this has to cover, since they are the ones whose row states
+        // something other than what its label suggests. The .opb is written
+        // either way, and the .opb is the oracle here.
         ProofFileNames names{basename};
         names.s_expr_file = nullopt;
         static_cast<void>(
@@ -183,28 +183,42 @@ TEST_CASE("a linear's published role resolves to a row the .opb contains")
         p.post(LinearLessThanEqual{WeightedSum{} + 1_i * x + -1_i * y, 3_i});
         p.post(LinearLessThanEqualIf{WeightedSum{} + 1_i * y + -1_i * x, 4_i, b == 1_i});
         p.post(LinearLessThanEqualIff{WeightedSum{} + 1_i * x + 1_i * y, 12_i, b == 0_i});
+        // No derived class reaches these two, so they are posted directly.
+        p.post(ReifiedLinearInequality{WeightedSum{} + 1_i * x + 1_i * y, 4_i, reif::MustNotHold{}});
+        p.post(ReifiedLinearInequality{WeightedSum{} + 1_i * x + -1_i * y, 2_i, reif::NotIf{b == 1_i}});
     });
 
-    // Three posted, three enumerated: the enumeration is the same one the
+    // Five posted, five enumerated: the enumeration is the same one the
     // presolver uses, so a shortfall here would be a different bug.
-    REQUIRE(run.resolved.size() == 3);
+    REQUIRE(run.resolved.size() == 5);
     check_labels_against_opb(run);
 
-    // MustHold and If publish the empty role and resolve; Iff publishes nothing,
-    // because its r and f halves say the two directions of the equivalence
-    // rather than `sum <= value`.
+    // MustHold and If publish the empty role and resolve; the other three
+    // publish nothing, because none of their rows is the `sum <= value` a citer
+    // means. Iff's r and f halves say the two directions of the equivalence, and
+    // MustNotHold's and NotIf's rows both state the integer negation --- which
+    // is the thing those forms enforce, so it is the right row for them to have
+    // and the wrong one to hand a citer.
     CHECK(run.resolved[0].role == make_optional(""s));
     CHECK(run.resolved[0].label.has_value());
     CHECK(run.resolved[1].role == make_optional(""s));
     CHECK(run.resolved[1].label.has_value());
-    CHECK_FALSE(run.resolved[2].role.has_value());
-    CHECK_FALSE(run.resolved[2].label.has_value());
+    for (auto i : {2u, 3u, 4u}) {
+        CAPTURE(i);
+        CHECK_FALSE(run.resolved[i].role.has_value());
+        CHECK_FALSE(run.resolved[i].label.has_value());
+    }
 
-    // The Iff donor really did emit rows --- it published no role, which is not
-    // the same as having emitted nothing. Without this the previous check would
-    // pass just as well against a constraint that emitted no model at all.
+    // The three non-publishing donors really did emit rows --- publishing no
+    // role is not the same as having emitted nothing. Without this the previous
+    // check would pass just as well against a constraint that emitted no model
+    // at all. MustNotHold's goes out under the empty role, exactly the label a
+    // build-it-yourself citer would construct; publishing is what keeps it out
+    // of a pol.
     CHECK(opb_has_row_labelled(run.opb, "c[" + run.resolved[2].id + "][r]"));
     CHECK(opb_has_row_labelled(run.opb, "c[" + run.resolved[2].id + "][f]"));
+    CHECK(opb_has_row_labelled(run.opb, "c[" + run.resolved[3].id + "]"));
+    CHECK(opb_has_row_labelled(run.opb, "c[" + run.resolved[4].id + "][ltn]"));
 }
 
 TEST_CASE("a comparison's published role resolves to a row the .opb contains")

--- a/gcs/constraints/innards/constraints_test_utils.hh
+++ b/gcs/constraints/innards/constraints_test_utils.hh
@@ -540,9 +540,30 @@ namespace gcs::test_innards
         return branch_with(variable_order::random(p), value_order::reject_random_interval());
     }
 
+    /**
+     * Whether a proof-writing test solve should also write the .scp definition
+     * file. No for a constraint form whose s_expr() throws --- the negated
+     * reification kinds of the linear and comparison families have no
+     * cake_pb_cp spelling, so there is nothing for it to write --- and the .opb
+     * and .pbp, which are what veripb checks, are written either way.
+     */
+    enum class WriteSExprFile
+    {
+        Yes,
+        No
+    };
+
+    [[nodiscard]] inline auto proof_file_names_for_tests(const std::string & proof_name, WriteSExprFile write_s_expr_file) -> ProofFileNames
+    {
+        ProofFileNames names{proof_name};
+        if (write_s_expr_file == WriteSExprFile::No)
+            names.s_expr_file = std::nullopt;
+        return names;
+    }
+
     template <typename SolutionCallback_, typename TraceCallback_>
-    auto solve_for_tests_with_callbacks(
-        Problem & p, const std::optional<std::string> & proof_name, const SolutionCallback_ & f, const TraceCallback_ & t) -> void
+    auto solve_for_tests_with_callbacks(Problem & p, const std::optional<std::string> & proof_name, const SolutionCallback_ & f,
+        const TraceCallback_ & t, WriteSExprFile write_s_expr_file = WriteSExprFile::Yes) -> void
     {
         // Every constraint test runs with the idempotence claim checker on:
         // each honoured PropagatorState::EnableButIdempotent claim is verified
@@ -590,7 +611,7 @@ namespace gcs::test_innards
                 .trace = capped_trace,                        //
                 .branch = random_branch_with_optional_seed(p) //
             },
-            proof_name ? std::make_optional<ProofOptions>(ProofFileNames{*proof_name}) : std::nullopt);
+            proof_name ? std::make_optional<ProofOptions>(proof_file_names_for_tests(*proof_name, write_s_expr_file)) : std::nullopt);
         last_run_recursions() = stats.recursions;
     }
 
@@ -625,7 +646,8 @@ namespace gcs::test_innards
     }
 
     template <typename ResultsSet_, typename... Args_>
-    auto solve_for_tests(Problem & p, const std::optional<std::string> & proof_name, ResultsSet_ & actual, const std::tuple<Args_...> & vars) -> void
+    auto solve_for_tests(Problem & p, const std::optional<std::string> & proof_name, ResultsSet_ & actual, const std::tuple<Args_...> & vars,
+        WriteSExprFile write_s_expr_file = WriteSExprFile::Yes) -> void
     {
         solve_for_tests_with_callbacks(
             p, proof_name,
@@ -633,7 +655,7 @@ namespace gcs::test_innards
                 std::apply([&](const auto &... args) { actual.emplace(extract_from_state(s, args)...); }, vars);
                 return true;
             },
-            [&](const CurrentState &) -> bool { return true; });
+            [&](const CurrentState &) -> bool { return true; }, write_s_expr_file);
     }
 
     enum class CheckConsistency
@@ -780,7 +802,8 @@ namespace gcs::test_innards
 
     template <typename ResultsSet_, typename... AllArgs_>
     auto solve_for_tests_checking_consistency(Problem & p, const std::optional<std::string> & proof_name, const ResultsSet_ & expected,
-        ResultsSet_ & actual, const std::tuple<std::pair<AllArgs_, CheckConsistency>...> & all_vars) -> void
+        ResultsSet_ & actual, const std::tuple<std::pair<AllArgs_, CheckConsistency>...> & all_vars,
+        WriteSExprFile write_s_expr_file = WriteSExprFile::Yes) -> void
     {
         std::vector<IntegerVariableID> all_vars_as_vector;
         [&]<std::size_t... i_>(std::index_sequence<i_...>) { (add_to_all_vars(all_vars_as_vector, std::get<i_>(all_vars).first), ...); }(
@@ -846,7 +869,8 @@ namespace gcs::test_innards
                     (check_support(support[i_], s, all_vars_as_vector, std::get<i_>(all_vars).first, std::get<i_>(all_vars).second), ...);
                 }(std::index_sequence_for<AllArgs_...>());
                 return true;
-            });
+            },
+            write_s_expr_file);
     }
 
     template <typename ResultsSet_, typename... AllArgs_>

--- a/gcs/constraints/linear/linear_inequality.cc
+++ b/gcs/constraints/linear/linear_inequality.cc
@@ -152,13 +152,19 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model, const State
     for (auto & [c, v] : _coeff_vars.terms)
         terms += c * v;
 
+    // Which slot a row goes in is the invariant install_propagators relies on:
+    // .first is the must-hold direction's row and .second the must-not-hold
+    // direction's (see the member's declaration). A form fills only the slot for
+    // a direction its dispatcher can reach, so the negated forms fill .second and
+    // leave .first empty --- putting their row in .first would leave the one
+    // direction they do run with nothing to cite.
     overloaded{
         [&](const reif::MustHold &) {
             // cake_pb_cp labels the unconditional inequality @c[<id>] (no role).
             _proof_lines = pair{model.add_labelled_constraint(constraint_id(), "", terms <= _value), nullopt};
         }, //
         [&](const reif::MustNotHold &) {
-            _proof_lines = pair{model.add_labelled_constraint(constraint_id(), "", terms >= _value + 1_i), nullopt};
+            _proof_lines = pair{nullopt, model.add_labelled_constraint(constraint_id(), "", terms >= _value + 1_i)};
         }, //
         [&](const reif::If & cond) {
             // cake_pb_cp labels the half-reified inequality @c[<id>], with no role
@@ -166,9 +172,14 @@ auto ReifiedLinearInequality::define_proof_model(ProofModel & model, const State
             _proof_lines = pair{model.add_labelled_constraint(constraint_id(), "", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
         }, //
         [&](const reif::NotIf & cond) {
+            // NotIf says cond -> the constraint must *not* hold, so the row is the
+            // integer negation under cond, exactly as MustNotHold's is
+            // unconditionally. `cond -> sum <= value` would state the opposite of
+            // what the constraint means, and is what the row said until #644.
             // s_expr throws on NotIf, so this form never reaches the cake chain and
             // the invented role is fine.
-            _proof_lines = pair{model.add_labelled_constraint(constraint_id(), "ltn", terms <= _value, HalfReifyOnConjunctionOf{cond.cond}), nullopt};
+            _proof_lines =
+                pair{nullopt, model.add_labelled_constraint(constraint_id(), "ltn", terms >= _value + 1_i, HalfReifyOnConjunctionOf{cond.cond})};
         }, //
         [&](const reif::Iff & cond) {
             // cake_pb_cp labels the iff halves r (cond -> ineq) and f (~cond -> its
@@ -198,6 +209,8 @@ auto innards::ConstraintProofModelData<ReifiedLinearInequality>::primary_row_rol
 auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> void
 {
     auto proof_lines = _proof_lines;
+    // Everything downstream cites .first, so the must-not-hold direction is handed
+    // the pair the other way round rather than being told which slot to read.
     auto proof_lines_swapped = pair{_proof_lines.second, _proof_lines.first};
 
     const auto & sanitised_cv = _sanitised;
@@ -292,7 +305,11 @@ auto ReifiedLinearInequality::install_propagators(Propagators & propagators) -> 
                 }
 
                 if (min_possible > value + modifier) {
-                    // cannot possibly hold
+                    // cannot possibly hold. The witness cites proof_lines.first, the
+                    // `sum <= value` row: only Iff and NotIf get here undecided, and of
+                    // those only Iff licenses an inference for this verdict (NotIf learns
+                    // nothing from the constraint failing), so the justification is only
+                    // ever emitted for a form that has that row.
                     return reification_verdict::MustNotHold<LinearCondJustification>{
                         .justification =
                             JustifyExplicitly{hints::LinearInequalityCond<CV>{{owner}, &state, sanitised_cv, proof_lines}, ThenRUP::Yes}, //

--- a/gcs/constraints/linear/linear_inequality.hh
+++ b/gcs/constraints/linear/linear_inequality.hh
@@ -34,6 +34,15 @@ namespace gcs
         WeightedSum _coeff_vars;
         Integer _value;
         ReificationCondition _reif_cond;
+        // The rows define_proof_model emitted, by direction rather than by order of
+        // emission: .first states `sum <= value`, which the must-hold direction cites,
+        // and .second the integer negation `sum >= value + 1`, which the must-not-hold
+        // direction cites --- each under the reification condition where there is one.
+        // A form fills only the slots for directions it can reach: If deactivates
+        // rather than enforcing the negation and NotIf deactivates rather than
+        // enforcing the inequality, so those two fill one slot each and only Iff fills
+        // both. An empty slot therefore means "this form never propagates that way",
+        // not "not logged yet"; both are empty when proofs are off.
         std::pair<std::optional<innards::ProofLine>, std::optional<innards::ProofLine>> _proof_lines;
         innards::EvaluatedReificationCondition _evaluated_cond = innards::evaluated_reif::Deactivated{};
         // Per-constraint width at/above which to use the incremental propagator; unset
@@ -137,17 +146,12 @@ namespace gcs
          * Changing which row this names is a breaking change.
          *
          * MustHold and If both use the empty role, so both come out as
-         * `@c[<id>]`. The other three publish nothing. MustNotHold's empty-role
-         * row states the integer negation and Iff's `r` / `f` halves state the
-         * two directions of the equivalence, so neither is the row a citer
-         * asking for `sum <= value` means. NotIf is excluded for a different and
-         * less comfortable reason: its `ltn` row is emitted as
-         * `cond -> sum <= value`, which is what the constraint says must *not*
-         * hold, so the row as written looks wrong rather than merely unwanted.
-         * Nothing in gcs constructs a ReifiedLinearInequality with either
-         * negated kind --- the six derived classes cover MustHold, If and Iff,
-         * and scp_reader builds only those --- so this publishes nothing rather
-         * than committing to a row that has never been exercised.
+         * `@c[<id>]`. The other three publish nothing, because none of their
+         * rows is the one a citer asking for `sum <= value` means: MustNotHold's
+         * empty-role row and NotIf's `ltn` row both state the integer negation
+         * `sum >= value + 1` (that being what those forms make the propagator
+         * enforce), and Iff's `r` / `f` halves state the two directions of the
+         * equivalence.
          *
          * A nullopt here means "no such row exists", which is different from a
          * nullopt out of NamesAndIDsTracker::constraint_row_label, where the row

--- a/gcs/constraints/linear/linear_test.cc
+++ b/gcs/constraints/linear/linear_test.cc
@@ -50,6 +50,51 @@ namespace
             return string{"_t"} + e;
         return {};
     }
+
+    // The two negated reification forms have no derived class: the six
+    // LinearLessThanEqual{,If,Iff} / LinearGreaterThanEqual{,If,Iff} spellings cover
+    // MustHold, If and Iff only, and scp_reader builds only those. Spelling them here
+    // gives them the same constructor shape as the derived classes, so the generic
+    // test functions below take them unchanged --- and gives them the coverage that
+    // being unreachable through the public API had cost them (issue #644: NotIf's OPB
+    // row stated the un-negated inequality, and both forms threw when they logged).
+    //
+    // Each is its own constraint rather than the negation of a posted one, so the
+    // satisfying predicate handed to the test functions is `>` where the positive
+    // forms pass `<=`: what these enforce, when they enforce anything, is
+    // `sum > value`.
+    struct LinearLessThanEqualNot : ReifiedLinearInequality
+    {
+        // s_expr() throws on both negated kinds --- they have no cake_pb_cp
+        // spelling --- so these instances write no .scp. The .opb and .pbp veripb
+        // checks are written as usual.
+        static constexpr auto write_s_expr_file = WriteSExprFile::No;
+
+        explicit LinearLessThanEqualNot(WeightedSum coeff_vars, Integer value) :
+            ReifiedLinearInequality(std::move(coeff_vars), value, reif::MustNotHold{})
+        {
+        }
+    };
+
+    struct LinearLessThanEqualNotIf : ReifiedLinearInequality
+    {
+        static constexpr auto write_s_expr_file = WriteSExprFile::No;
+
+        explicit LinearLessThanEqualNotIf(WeightedSum coeff_vars, Integer value, IntegerVariableCondition cond) :
+            ReifiedLinearInequality(std::move(coeff_vars), value, reif::NotIf{cond})
+        {
+        }
+    };
+
+    // Yes unless the constraint type says otherwise, which only the two above do.
+    template <typename Constraint_>
+    constexpr auto write_s_expr_file_for() -> WriteSExprFile
+    {
+        if constexpr (requires { Constraint_::write_s_expr_file; })
+            return Constraint_::write_s_expr_file;
+        else
+            return WriteSExprFile::Yes;
+    }
 }
 
 template <typename Constraint_>
@@ -89,10 +134,11 @@ auto run_linear_test(bool proofs, const string & mode, const ViewWrapConfig & vi
         proofs ? make_optional("linear_equality_test_" + mode + "_" + view_wrap_config_label(view_cfg) + threshold_proof_suffix()) : nullopt;
 
     if ((! is_same_v<Constraint_, LinearEquality>) && 1 == ineqs.size())
-        solve_for_tests_checking_consistency(
-            p, proof_name, expected, actual, tuple{pair{v1, CheckConsistency::BC}, pair{v2, CheckConsistency::BC}, pair{v3, CheckConsistency::BC}});
+        solve_for_tests_checking_consistency(p, proof_name, expected, actual,
+            tuple{pair{v1, CheckConsistency::BC}, pair{v2, CheckConsistency::BC}, pair{v3, CheckConsistency::BC}},
+            write_s_expr_file_for<Constraint_>());
     else
-        solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3});
+        solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3}, write_s_expr_file_for<Constraint_>());
 
     check_results(proof_name, expected, actual);
 }
@@ -191,9 +237,10 @@ auto run_linear_reif_test(bool full_reif, bool proofs, const string & mode, cons
             (! is_same_v<Constraint_, LinearNotEqualsIf>) && (! is_same_v<Constraint_, LinearNotEqualsIff>) && 1 == ineqs.size())
             solve_for_tests_checking_consistency(p, proof_name, expected, actual,
                 tuple{
-                    pair{v1, CheckConsistency::BC}, pair{v2, CheckConsistency::BC}, pair{v3, CheckConsistency::BC}, pair{v4, CheckConsistency::GAC}});
+                    pair{v1, CheckConsistency::BC}, pair{v2, CheckConsistency::BC}, pair{v3, CheckConsistency::BC}, pair{v4, CheckConsistency::GAC}},
+                write_s_expr_file_for<Constraint_>());
         else
-            solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3, v4});
+            solve_for_tests(p, proof_name, actual, tuple{v1, v2, v3, v4}, write_s_expr_file_for<Constraint_>());
 
         check_results(proof_name, expected, actual);
     }
@@ -311,7 +358,8 @@ auto main(int argc, char * argv[]) -> int
     }
     // Keep in sync with the if-chain below and the matching foreach(mode ...) in
     // gcs/CMakeLists.txt.
-    const vector<string> all_modes = {"eq", "eq_if", "eq_iff", "ne", "ne_if", "ne_iff", "le", "le_if", "le_iff", "ge", "ge_if", "ge_iff"};
+    const vector<string> all_modes = {
+        "eq", "eq_if", "eq_iff", "ne", "ne_if", "ne_iff", "le", "le_if", "le_iff", "le_not", "le_notif", "ge", "ge_if", "ge_iff"};
     const vector<string> modes = requested_mode.empty() ? all_modes : vector<string>{requested_mode};
 
     auto view_cfg = parse_view_wrap_config_from_argv(argc, argv);
@@ -418,6 +466,13 @@ auto main(int argc, char * argv[]) -> int
                 else if (mode == "le_iff") {
                     run_linear_reif_test<LinearLessThanEqualIff>(
                         true, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a <= b; });
+                }
+                else if (mode == "le_not") {
+                    run_linear_test<LinearLessThanEqualNot>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a > b; });
+                }
+                else if (mode == "le_notif") {
+                    run_linear_reif_test<LinearLessThanEqualNotIf>(
+                        false, proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a > b; });
                 }
                 else if (mode == "ge") {
                     run_linear_test<LinearGreaterThanEqual>(proofs, mode, view_cfg, r1, r2, r3, constraints, [&](int a, int b) { return a >= b; });


### PR DESCRIPTION
Fixes #644.

`ReifiedLinearInequality`'s `reif::MustNotHold` and `reif::NotIf` were both
broken in the proof path. Neither is constructible through the public API — the
six derived classes and `scp_reader` cover `MustHold`, `If` and `Iff` only — so
this was latent, and the propagator side was correct throughout.

## What was wrong

**The `NotIf` row stated the inequality it is supposed to negate.**
`NotIf{cond}` means *if `cond` holds, the constraint must not hold*, which
`reified_state.cc` resolves to `evaluated_reif::MustNotHold` when `cond` is
true. `MustNotHold` encodes that as the integer negation; `NotIf` emitted
`cond -> sum <= value`, the same row the positive `If` form emits. For
`x, y ∈ 0..3`, `b ∈ 0..1`, `NotIf(b == 1): x + y <= 2` the row said `x + y <= 2`
whenever `b` was 1 — exactly the opposite of the constraint. It now states the
negation under the condition, as `comparison.cc`'s `NotIf` branch already did.

**Both forms threw `bad optional access` when they propagated.** The
must-not-hold direction reads `pair{_proof_lines.second, _proof_lines.first}
.first`, i.e. the *second* slot — and that direction is precisely the one those
two forms reach — but both filled the first slot and left the second empty.

## What changed

The slots are per direction, not per order of emission: `.first` is the
must-hold direction's `sum <= value` row and `.second` the must-not-hold
direction's `sum >= value + 1`. The negated forms' single row moves to
`.second`, and the member now documents the invariant, since the asymmetry is
easy to reintroduce.

Nothing changes for `MustHold`, `If` or `Iff`. `NotIf` keeps its invented `ltn`
role: `s_expr()` throws on both negated forms, so they have no `.scp` spelling
and never reach the cake chain. `primary_row_role` still publishes nothing for
either, but now for the reason `MustNotHold`'s already did — the row states the
negation, not the `sum <= value` a citer means — rather than because it said
something wrong. That matters for #598, which lifts these donors: the row now
says the right thing, so the question there is only whether a citer wants the
negation.

## Tests

`linear_test` gains `le_not` and `le_notif` modes over the existing data set,
running in the incremental, stateless and slack-waking lanes and verifying every
instance's proof, with BC checked on the terms and GAC on `le_notif`'s condition
variable. `constraint_row_test` posts the two kinds too, so the published-role
contract is checked over all five reification kinds rather than three.

Both modes catch the throw against pre-fix code. `le_notif` also catches the
wrong row on its own: with the slot fixed and the row left un-negated, veripb
rejects the `pol` as not RUP-derivable. The condition-forcing direction is
covered as well — `justify_cond` fires 37 times across the mode's instances.

The two forms have no `.scp` spelling, so asking for the file aborts the solve
before veripb sees the `.opb`; the test utilities gain a `WriteSExprFile`
argument, defaulted to `Yes`, which only these two modes set.

## Checks

- `ctest` 605/605 on GCC 15 with XCSP and MiniZinc on and `GCS_TEST_CAP_DEFAULTS=OFF`.
- clang 21 builds the changed translation units clean; both new modes pass there too.
- clang-format 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p