### PR TITLE
Run Circuit's GAC all-different option in a lane of its own

### DIFF
--- a/examples/circuit_random/CMakeLists.txt
+++ b/examples/circuit_random/CMakeLists.txt
@@ -3,4 +3,15 @@ target_link_libraries(circuit_random PRIVATE glasgow_constraint_solver)
 
 target_link_libraries(circuit_random PRIVATE cxxopts)
 
-add_test(NAME circuit_random COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash $<TARGET_FILE:circuit_random>)
+# Circuit's all-different comes in two flavours, and until issue #642 only one of
+# them was ever run: by default Circuit writes the clique-of-not-equals encoding
+# itself, and under --gac-all-different a child AllDifferent writes it instead and
+# adds a GAC propagator. The two OPBs are meant to be identical, so what the second
+# lane buys is the other half of prepare()/define_proof_model() plus the GAC
+# propagator's own justifications appearing inside a Circuit proof.
+#
+# That last part only happens if GAC actually prunes something, which it does not at
+# the default n=3, so this lane is pinned to an instance where it does: n=6 seed 1
+# takes 11 recursions with the option on against 15 with it off.
+add_test(NAME circuit_random COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename circuit_random $<TARGET_FILE:circuit_random>)
+add_test(NAME circuit_random-gac-all-different COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename circuit_random-gac-all-different $<TARGET_FILE:circuit_random> --gac-all-different -n 6 --seed 1)

--- a/examples/circuit_random/circuit_random.cc
+++ b/examples/circuit_random/circuit_random.cc
@@ -47,7 +47,8 @@ auto create_graph_from_seed(int n, double p, unsigned int seed) -> vector<vector
     return distances;
 }
 
-Stats run_circuit_problem(int n, const vector<vector<long>> & distances, SCCOptions options, bool print_solutions, bool prove, string proof_prefix)
+Stats run_circuit_problem(
+    int n, const vector<vector<long>> & distances, SCCOptions options, bool gac_all_different, bool print_solutions, bool prove, string proof_prefix)
 {
     Problem p;
     auto x = p.create_integer_variable_vector(n, 0_i, Integer{n - 1});
@@ -59,9 +60,8 @@ Stats run_circuit_problem(int n, const vector<vector<long>> & distances, SCCOpti
             }
         }
     }
-    auto use_gac_all_different = false;
     p.post(Circuit{x}
-            .with_gac_all_different(use_gac_all_different)
+            .with_gac_all_different(gac_all_different)
             .with_prune_root(options.prune_root)
             .with_prune_skip(options.prune_skip)
             .with_fix_req(options.fix_req)
@@ -124,6 +124,7 @@ auto main(int argc, char * argv[]) -> int
                 cxxopts::value<string>()->default_value("circuit_random"))                 //
             ("print-distances", "Print the input graph used for the probllem")             //
             ("print-solutions", "Print each solution found while optimising")              //
+            ("gac-all-different", "Use a GAC all-different over the successors")           //
             ("no-prune-root", "SCC inference")                                             //
             ("no-prune-skip", "SCC inference")                                             //
             ("no-fix-req", "SCC inference")                                                //
@@ -159,6 +160,7 @@ auto main(int argc, char * argv[]) -> int
         options_vars.contains("short-reasons"),
     };
 
+    auto gac_all_different = options_vars.contains("gac-all-different");
     auto n = options_vars["n"].as<int>();
     auto seed = options_vars["seed"].as<int>();
     auto proof_prefix = options_vars["proof-files-basename"].as<string>();
@@ -184,7 +186,7 @@ auto main(int argc, char * argv[]) -> int
         }
     }
 
-    auto stats = run_circuit_problem(n, distances, options, print_solutions, prove, proof_prefix);
+    auto stats = run_circuit_problem(n, distances, options, gac_all_different, print_solutions, prove, proof_prefix);
 
     if (print_stats) {
         cout << "seed: " << seed << endl;

--- a/gcs/constraints/circuit/circuit.cc
+++ b/gcs/constraints/circuit/circuit.cc
@@ -135,6 +135,12 @@ auto Circuit::prepare(Propagators & propagators, State & initial_state, ProofMod
     // before the position encoding, as they did before.
     if (_gac_all_different) {
         AllDifferent all_diff{_succ};
+        // The child must carry this constraint's identity, as SeqPrecedeChain's does:
+        // AllDifferent keys its labelled OPB lines and its pair selectors on its id, so
+        // an unnamed child writes @c[unnamed] rows and x[unnamed] flags that two such
+        // circuits in one problem would share (issue #449). With the id set, the rows
+        // are the ones the non-GAC branch would have written anyway.
+        all_diff.set_constraint_id(constraint_id());
         std::move(all_diff).install(propagators, initial_state, model);
     }
 


### PR DESCRIPTION
Fixes #642.

`Circuit::with_gac_all_different()` selects between two install paths and two ways of getting the all-different encoding into the OPB, and nothing in the tree selected the second one — `circuit_random` pinned a local to `false` with no CLI flag to change it.

**The lane.** `circuit_random` gets a `--gac-all-different` flag, and a second ctest entry runs it under `--prove` + VeriPB. Both entries now pass `--basename` so they do not race over one set of proof files (#562).

The lane is pinned to `-n 6 --seed 1` rather than left on the default random `n=3`. At `n=3` the GAC propagator does propagate but never prunes anything the circuit propagation had not already pruned, so none of its justifications reach the proof; at `n=6` seed 1 the option takes the search from 15 recursions to 11 and the `.pbp` differs accordingly.

**What the lane found.** With the option on, the child `AllDifferent` was writing `@c[unnamed][0lt1]` rows and `x[unnamed][0_1]` selectors, because nothing gave it the parent's constraint id. Two such circuits in one problem would share those flags — the same defect `SeqPrecedeChain` was fixed for in #449. Fixed in the first commit by `all_diff.set_constraint_id(constraint_id())`.

Worth noting that VeriPB would not have caught this on its own: the names are internally consistent within a single circuit, so the proof verified both before and after. It showed up from diffing the two lanes' OPBs by hand. With the id set they are byte-identical for the same seed, which is what the option's documentation claims ("never changes the OPB encoding").

**Checks.** All 22 `circuit` ctest lanes pass, including the new one and the two `scp_chain_circuit` cases. The two changed translation units also compile clean under clang 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p