### PR TITLE
Update dev_docs thesis citations to the final accepted version

### DIFF
--- a/dev_docs/arithmetic-proofs.md
+++ b/dev_docs/arithmetic-proofs.md
@@ -95,9 +95,9 @@ sign-case-conditional bound as its raw pol line plus its case literals.
   only a database-wide RUP reaches the closing conflict, so they stay
   on the default hint-free path.
 
-Inference drivers: product bounds are thesis Procedure 7.5 (per live sign
+Inference drivers: product bounds are thesis Procedure 7.6 (per live sign
 case: channel, 7.1/7.2, channel to the result, conclude); factor and
-square bounds are Procedures 7.6/7.7 — never enumerate propagator logic,
+square bounds are Procedures 7.7/7.8 — never enumerate propagator logic,
 just refute the excluded range, with the far side of that range being the
 target's *current* bound carried by the reason. The square's inner
 square-root lift is sequenced after the outer clamp so each refuted

--- a/dev_docs/range_literals_spec.md
+++ b/dev_docs/range_literals_spec.md
@@ -177,7 +177,7 @@ contradictions by 2.7/2.9, and the *backtracking* obligation (Inv2) reduces to
 leaf-conflict replays (a parent backtrack clause is RUP from its two child
 clauses), where the path's own inference clauses are live and fire over the
 vocabulary above. **A lone bound still cannot cross a bit-sum equality — the
-thesis Example 2.14 limit is real — but no replay obligation requires it once
+thesis Example 2.15 limit is real — but no replay obligation requires it once
 the vocabulary is complete.** The 2026-06 experiments that seemed to show
 otherwise were P2 gaps in disguise (Appendix B).
 
@@ -407,7 +407,7 @@ the chain stops, veripb rejects Bt, and the trace (six lines long, in W1)
 *looks like* "UP cannot thread a bound across the equality" because the
 bound-crossing steps are the next thing the stalled trail would have needed.
 That misdiagnosis cost two sessions and a theory document. The bound-crossing
-limit is real (thesis Example 2.14); it just was never the binding
+limit is real (thesis Example 2.15); it just was never the binding
 constraint.
 
 ## Appendix B — refuted designs and simplifications. Do not retry without new theory.


### PR DESCRIPTION
Matthew's thesis has been accepted and deposited as *Pseudo-Boolean Proof Logging for Constraint Propagation Algorithms* (University of Glasgow, 2026), available at <https://theses.gla.ac.uk/86049/>. We had been citing the pre-examination draft, and some numbering shifted between the two, so a few `dev_docs` citations no longer point at what they claim.

I diffed every numbered environment (theorem, lemma, corollary, proposition, example, encoding/justification procedure and subprocedure) and every equation number in chapters 2-7 of the draft against the final. Two docs needed changes:

**`dev_docs/range_literals_spec.md`** — chapter 2 gained a new `Example 2.13` ("Labels syntax"), pushing the rest down one. The bit-sum non-propagation example this doc leans on twice ("a lone bound still cannot cross a bit-sum equality") was `Example 2.14` in the draft and is **`Example 2.15`** in the final.

**`dev_docs/arithmetic-proofs.md`** — chapter 7 was restructured (it gained subsections 7.1.1-7.3.3) and a new `Justification Procedure 7.5` ("Justifying infeasible bounds for multiplication") was inserted, pushing the rest down one:

| draft | final | |
|---|---|---|
| Justification Procedure 7.5 | **7.6** | Justifying bounds on the product variable |
| Justification Procedure 7.6 | **7.7** | Justifying lower bounds on the multiplicands |
| Justification Procedure 7.7 | **7.8** | Justifying upper bounds on the multiplicands |

The Justification *Sub*procedures 7.1-7.4 that this doc cites for `channel_bound_to_magnitude`, `grid_sum_lower_bound`, `grid_sum_upper_bound` and `channel_grid_bound_to_result` kept their numbers, so those citations are untouched.

Everything else these docs reference checked out as stable: all chapter 2 and 3 theorem, lemma and corollary numbers (including `Theorem 2.7`/`2.8`/`2.9` and `Theorem 3.2`/`3.3`), all chapter 2-7 section numbers, and the chapter 3 Encoding and Justification Procedures.

Docs only — no code changes, nothing to build or test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)