### PR TITLE
Certified window-energy reasoning and an overload check for Cumulative (#542)

### DIFF
--- a/dev_docs/constraints.md
+++ b/dev_docs/constraints.md
@@ -852,17 +852,41 @@ GCS_PRESERVE_PROOF_FILES=all ./build/equals_test   # equals_test.0001.pbp, ...
 ```
 
 The same variable is honoured by the shell test wrappers
-(`run_test_and_verify.bash`, `run_xcsp_test.bash`, `run_minizinc_test.bash`,
-`run_fzn_json_test.bash` and `run_scp_chain.bash`), so a proof is disposed of
-the same way whether it is checked inside the test binary or by the wrapper
-around it. Those wrappers run their binary once, so there is nothing for the
-counter to disambiguate: they treat `all` the same as `1`.
+(`run_test_and_verify.bash`, `run_test_and_expect_verify_failure.bash`,
+`run_xcsp_test.bash`, `run_minizinc_test.bash`, `run_fzn_json_test.bash` and
+`run_scp_chain.bash`), so a proof is disposed of the same way whether it is
+checked inside the test binary or by the wrapper around it. Those wrappers run
+their binary once, so there is nothing for the counter to disambiguate: they
+treat `all` the same as `1`.
 
-All five get it from one `dispose_proof` in `proof_file_disposal.bash` at the
+All six get it from one `dispose_proof` in `proof_file_disposal.bash` at the
 repo root, which they source relative to their own `$0`. Changing what the
 wrappers delete — adding a sixth proof artifact, say — means changing that one
 file, and its extension list should stay in step with `proof_file_extensions`
 in `constraints_test_utils.hh`.
+
+### Mutation testing: showing a derivation is tight
+
+A proof that verifies is necessary, not sufficient. If a propagator's
+derivation has slack in it — a bound derived more weakly than claimed, a step
+that happens not to matter — then a *wrong* proof verifies too, and every
+"veripb accepted it" in the suite is saying less than it looks.
+
+The check is to break the derivation on purpose and insist that veripb
+notices. Give the constraint a test-only knob that corrupts one emitted step
+(precedent: `CumulativeProofMutation` and `Knapsack::with_proof_strategy`),
+have the test binary write that proof and stop, and register it with
+`run_test_and_expect_verify_failure.bash`, which is
+`run_test_and_verify.bash` with the verdict inverted: it passes only when
+veripb rejects.
+
+Two things make the difference between a mutation lane that tests something
+and one that does not. Mutate on an instance whose margin is *one* — corrupt a
+proof of a conflict that had three units of slack and the contradiction
+survives the corruption, so veripb accepts and the lane is green for the wrong
+reason. And check that the run being mutated really produced the inference at
+all, or the harness is checking an empty proof. If a mutation verifies anyway,
+that is a finding about the honest derivation.
 
 ## Adding a new constraint: checklist
 

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -355,14 +355,135 @@ The `pin_contributor` / `pin_pushed` helpers in
 and both push inferences share one shape across all constant/variable
 combinations.
 
+## Inference 4 — the overload check, and the window-energy lemma
+
+Time-tabling only ever looks at one time point at a time. The overload
+check (Cloutier & Quimper, CP 2026, rule `(OC')`, strengthened by the
+mandatory-part profile to their `(TTOC)`) looks at a *window*: if the
+tasks that must run entirely inside `[a, b)` carry more energy than the
+window can supply, the constraint is infeasible. It is conflict-only —
+no bound moves — and it lives behind `CumulativeRules::overload` /
+`::profile_overload`.
+
+### What the propagator computes
+
+For each pair `(a, b)` with `a` an earliest start time and `b` a latest
+completion time, let `I(a, b)` be the tasks with `est ≥ a` and
+`lct ≤ b`. The conflict condition is
+
+```
+    Σ_{i ∈ I(a,b)} p_i·h_i   +   F(a, b)   >   capacity · slots(a, b)
+```
+
+where `F(a, b)` is the mandatory-part load inside the window of the
+tasks *not* in `I(a, b)`, and `slots(a, b)` counts the time points in
+`[a, b)` that some task can occupy at all.
+
+Two things make this quadratic rather than cubic. A task in `I(a, b)`
+has its mandatory part inside the window too, so `F` is the window's
+total mandatory load minus `I(a, b)`'s — both terms then accumulate as
+`b` grows over the tasks sorted by `lct`. And `slots` comes from a
+prefix count of the per-task windows, built once in `prepare()`.
+
+`slots` rather than `b − a` because a time point no task can occupy
+supplies nothing to the window's tasks — and has no `C_t` line to cite,
+since `define_proof_model` writes one only where some task can be
+active. Counting it would claim capacity the proof cannot produce.
+
+### The window-energy lemma
+
+The proof needs, for each `i ∈ I(a, b)`, a derived line saying task `i`
+really does spend `p_i` time active inside the window:
+
+```
+    Σ_{t ∈ [a,b)} active_{i,t}  ≥  p_i .
+```
+
+That is `derive_window_energy` in
+[`gcs/constraints/innards/window_energy.hh`](../gcs/constraints/innards/window_energy.hh),
+and it is the reusable piece: issues #549 and #550 consume it, in its
+clipped form (a task only partly inside the window), so it derives the
+general bound rather than just the contained case.
+
+Per time point `t`, three `pol` lines:
+
+```
+    before_{i,t} \/ [s_i ≥ t+1]                  @v[..][cb][f]  +  Def([s_i < t+1])   , saturate
+    after_{i,t}  \/ ~[s_i ≥ t-p+1]               @v[..][ca][f]  +  Def([s_i ≥ t-p+1]) , saturate
+    active_{i,t} \/ [s_i ≥ t+1] \/ ~[s_i ≥ t-p+1]        @v[..][cact][f]  +  the two above
+```
+
+The first two are order bridges of exactly the shape
+`product_justify::add_order_bridge_hints` uses: a flag's `[f]` half and
+an order literal's defining row share the `s_i` bits, which cancel, and
+saturation turns what is left into a two-literal clause. The third adds
+`active`'s `[f]` half — the AND-gate clause
+`active \/ ¬before \/ ¬after` — whose `before` and `after` terms cancel
+against the bridges, each pair contributing a constant to the degree.
+
+Summing those over `t ∈ [a, b)` gives
+
+```
+    Σ active_{i,t}  +  Σ_{v ∈ (a, b]} [s_i ≥ v]  +  Σ_{u ∈ (a-p, b-p]} ~[s_i ≥ u]   ≥   b − a
+```
+
+and this is where the telescoping happens: every value in both ranges
+contributes `[s_i ≥ w]` and its negation, which is a constant, so it
+cancels inside the pol. What survives is `min(p, b−a)` literals at each
+end, and each is resolved against the start bounds:
+
+- `~[s_i ≥ u]` with `u ≤ lb(s_i)`: RUP `[s_i ≥ u]` under the reason —
+  the terms cancel and the degree is unchanged;
+- `[s_i ≥ v]` with `v > ub(s_i)`: RUP `[s_i < v]` under the reason —
+  likewise;
+- anything the bounds do not decide: push the literal itself onto the
+  `pol` stack (VeriPB reads a bare literal as the trivial constraint
+  `lit ≥ 0`), which cancels the term at the cost of one unit of the
+  bound.
+
+So a fully contained task yields exactly `p_i`, and a task hanging out
+of the window yields its guaranteed overlap. `window_energy_bound()`
+computes the same number without emitting anything, and the emitter
+cross-checks against it: a disagreement would otherwise only show up as
+a rejected proof much later.
+
+### The conflict
+
+One `pol`: every `C_t` for `t ∈ [a, b)` that exists, each contained
+task's window-energy line scaled by its height, and — for `(TTOC)` —
+the outside tasks' compulsory contributions via the existing
+`pin_contributor`. Each contained task's `active` terms cancel exactly
+against its terms in the capacity lines, and what is left is a
+constraint with nothing but negative coefficients on the left and a
+positive right hand side. The framework's wrapping RUP closes it.
+
+### Restrictions, and why they are only weakenings
+
+The energy set takes only tasks with a constant length and height (a
+variable height enters `C_t` as the bit-linearised `contrib`, not as
+`h·active`, so the cancellation would not be exact) and a start that is
+a plain variable with an order encoding (the bridges need order
+literals; a `{0,1}` domain is direct-only encoded, and a view's atoms
+would need deview-mode arithmetic). The whole check is skipped when the
+capacity is a variable: a `(b−a)·capacity` term would survive into the
+conflict line for the wrapping RUP to dispose of over the capacity's
+bits, which it cannot do in general.
+
+None of these lose soundness or solutions: a task the energy set will
+not take still counts through `F(a, b)`, and a check not made is a
+conflict found later.
+
 ## Open follow-ups
 
 - **Edge-finding.** A *set* of tasks blocks an interval, not a single
   task at a single time. The pol arithmetic would need to sum across
   the set; the chain idea no longer fits directly.
-- **Energetic reasoning.** Even more set-of-tasks, set-of-intervals.
-  No clean OPB witness exists in the current encoding; the proof
-  scaffold would need extra auxiliary flags.
+- **Energetic reasoning.** The window-energy lemma above is the first
+  piece of it: horizontally elastic and knapsack-augmented checking
+  (#550) build on the clipped form, and the lifted-constraint
+  presolvers (#549) on the contained one.
+- **Variable lengths, heights and capacity in the energy set.** Staged
+  deliberately; the extensions are sketched in #542.
 The current scaffolding (`_before_flags`, `_after_flags`,
 `_active_flags`, `_contrib_flags`, `_end`, `_capacity_lines`) is
 enough for time-table-strength reasoning over variable `d`/`r`/`b` and not

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(glasgow_constraint_solver
         constraints/innards/reified_state.cc
         constraints/innards/tabulation.cc
         constraints/innards/triggers.cc
+        constraints/innards/window_energy.cc
         constraints/inverse/inverse.cc
         constraints/knapsack/knapsack.cc
         constraints/knapsack/knapsack_upfront.cc
@@ -243,6 +244,7 @@ if(GCS_BUILD_TESTS)
     add_executable(comparison_test constraints/comparison/comparison_test.cc)
     add_executable(count_test constraints/count/count_test.cc)
     add_executable(cumulative_test constraints/cumulative/cumulative_test.cc)
+    add_executable(cumulative_overload_test constraints/cumulative/cumulative_overload_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
@@ -291,7 +293,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -313,6 +315,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME bounds_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:bounds_global_cardinality_test>)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
+    add_test(NAME cumulative_overload COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
     foreach(mode basic cycles views alias reified simplify incremental random random_reified)
         add_test(NAME difference_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_test> ${mode})

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -316,6 +316,14 @@ if(GCS_BUILD_TESTS)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
     add_test(NAME cumulative_overload COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
+    # Mutation lanes: each writes a deliberately corrupted proof of the
+    # sharp-margin fixture, and passes only if veripb rejects it. Distinct
+    # basenames so the lanes do not race over one set of proof files.
+    foreach(mutation energy capacity window)
+        add_test(NAME cumulative_overload_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_overload_mutation_${mutation} $<TARGET_FILE:cumulative_overload_test> --mutate=${mutation})
+    endforeach()
     foreach(mode basic cycles views alias reified simplify incremental random random_reified)
         add_test(NAME difference_constraint_${mode}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_test> ${mode})

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -107,10 +107,17 @@ auto Cumulative::with_rules(CumulativeRules rules) -> Cumulative &
     return *this;
 }
 
+auto Cumulative::with_proof_mutation(CumulativeProofMutation mutation) -> Cumulative &
+{
+    _proof_mutation = mutation;
+    return *this;
+}
+
 auto Cumulative::clone() const -> unique_ptr<Constraint>
 {
     auto result = make_unique<Cumulative>(_starts, _lengths, _heights, _capacity);
     result->with_rules(_rules);
+    result->with_proof_mutation(_proof_mutation);
     return result;
 }
 
@@ -424,8 +431,8 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         [starts = move(_starts), lengths_var = move(_lengths), heights_var = move(_heights), capacity_var = _capacity,
             active_tasks = move(_active_tasks), before_flags = move(_before_flags), after_flags = move(_after_flags),
             active_flags = move(_active_flags), contrib_flags = move(_contrib_flags), ends = move(_end), end_lines,
-            capacity_lines = move(_capacity_lines), per_task_t_lo = move(_per_task_t_lo), rules = _rules, overload_tasks = move(_overload_tasks),
-            time_slot_prefix = move(_time_slot_prefix), time_slot_lo = _time_slot_lo,
+            capacity_lines = move(_capacity_lines), per_task_t_lo = move(_per_task_t_lo), rules = _rules, mutation = _proof_mutation,
+            overload_tasks = move(_overload_tasks), time_slot_prefix = move(_time_slot_prefix), time_slot_lo = _time_slot_lo,
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // The capacity may be a variable: the load profile is infeasible
             // only when it exceeds the *largest* still-allowed capacity, so the
@@ -713,8 +720,17 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                             // lines exactly, leaving a constraint whose
                             // negative-only left hand side must reach a
                             // positive right hand side.
+                            // The mutations (tests only, see
+                            // CumulativeProofMutation) each break one step
+                            // here, and each must make VeriPB reject.
+                            auto omit_capacity_line = std::holds_alternative<cumulative_proof_mutation::OmitCapacityLine>(mutation);
+                            auto shrink_lemma_window = std::holds_alternative<cumulative_proof_mutation::ShrinkLemmaWindow>(mutation);
+                            auto overstate_energy = std::holds_alternative<cumulative_proof_mutation::OverstateWindowEnergy>(mutation);
+
                             PolBuilder pol;
                             for (Integer t = a; t < b; ++t) {
+                                if (omit_capacity_line && t == b - 1_i)
+                                    continue;
                                 auto line = capacity_lines.find(t);
                                 if (line != capacity_lines.end())
                                     pol.add(line->second);
@@ -724,10 +740,27 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                                 auto energy_line = window_energy::derive_window_energy(*logger, reason,
                                     window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i],
                                         before_flags[i], after_flags[i], active_flags[i]},
-                                    a, b, state.bounds(starts[i]), ProofLevel::Temporary);
-                                if (! energy_line || energy_line->bound != llb(i))
+                                    a, shrink_lemma_window ? b - 1_i : b, state.bounds(starts[i]), ProofLevel::Temporary);
+                                if (! energy_line) {
+                                    // Only reachable under the shrunk-window
+                                    // mutation, where a task can be left with
+                                    // nothing derivable at all.
+                                    if (shrink_lemma_window)
+                                        continue;
+                                    throw ProofError{"cumulative overload: a task in the window has no derivable energy"};
+                                }
+                                if (! shrink_lemma_window && energy_line->bound != llb(i))
                                     throw ProofError{"cumulative overload: window energy derivation is weaker than the check assumed"};
-                                pol.add(energy_line->line, hlb(i));
+
+                                auto line = energy_line->line;
+                                if (overstate_energy && i == inside_tasks.front()) {
+                                    WPBSum activity;
+                                    for (Integer t = energy_line->lo; t < energy_line->hi; ++t)
+                                        activity += 1_i * active_flags[i][static_cast<size_t>((t - per_task_t_lo[i]).raw_value)];
+                                    line = logger->emit_rup_proof_line_under_reason(
+                                        reason, move(activity) >= energy_line->bound + 1_i, ProofLevel::Temporary);
+                                }
+                                pol.add(line, hlb(i));
                             }
 
                             for (const auto & [j, t] : pins) {

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -201,6 +201,11 @@ auto Cumulative::prepare_overload_check(State & initial_state) -> void
     // before/after flags to the start's order literals. A task that is not
     // eligible is not lost to the check: whatever it must occupy still counts,
     // through the profile term of the (TTOC) strengthening.
+    //
+    // Seam for optional tasks (#543): once a task can be absent, only one
+    // whose presence is fixed true may join the energy set or the profile, and
+    // its presence literal joins the reason. Nothing here consults a presence
+    // variable yet because there is not one to consult.
     _overload_tasks.clear();
     for (auto i : _active_tasks) {
         if (! is_constant_variable(_lengths[i]) || ! is_constant_variable(_heights[i]))
@@ -712,21 +717,21 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                             logger->emit_proof_comment("cumulative overload conflict window=[" + std::to_string(a.raw_value) + "," +
                                 std::to_string(b.raw_value) + ") rule=" + (uses_profile ? "ttoc" : "oc"));
 
-                            // The capacity available across the window, plus
-                            // each contained task's window energy scaled by its
-                            // height, plus (for (TTOC)) the pinned compulsory
-                            // load of the tasks outside it. Each task's energy
-                            // terms cancel against its terms in the capacity
-                            // lines exactly, leaving a constraint whose
-                            // negative-only left hand side must reach a
-                            // positive right hand side.
-                            // The mutations (tests only, see
-                            // CumulativeProofMutation) each break one step
-                            // here, and each must make VeriPB reject.
+                            // Tests only: each of these breaks one step of what
+                            // follows, and each must make VeriPB reject the
+                            // proof. See CumulativeProofMutation.
                             auto omit_capacity_line = std::holds_alternative<cumulative_proof_mutation::OmitCapacityLine>(mutation);
                             auto shrink_lemma_window = std::holds_alternative<cumulative_proof_mutation::ShrinkLemmaWindow>(mutation);
                             auto overstate_energy = std::holds_alternative<cumulative_proof_mutation::OverstateWindowEnergy>(mutation);
 
+                            // The capacity available across the window, plus
+                            // each contained task's window energy scaled by its
+                            // height, plus (for (TTOC)) the pinned compulsory
+                            // load of the tasks outside it. Each contained
+                            // task's activity terms cancel exactly against its
+                            // terms in the capacity lines, leaving a constraint
+                            // with nothing but negative coefficients on the
+                            // left and a positive right hand side.
                             PolBuilder pol;
                             for (Integer t = a; t < b; ++t) {
                                 if (omit_capacity_line && t == b - 1_i)

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1,20 +1,24 @@
 #include <gcs/constraints/cumulative/cumulative.hh>
 #include <gcs/constraints/cumulative/hints.hh>
+#include <gcs/constraints/innards/window_energy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
 #include <gcs/innards/power.hh>
 #include <gcs/innards/proofs/bits_encoding.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
 #include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_model.hh>
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/s_expr.hh>
 #include <gcs/innards/state.hh>
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 #include <version>
@@ -30,13 +34,16 @@ using namespace gcs::innards;
 
 using std::make_shared;
 using std::make_unique;
+using std::max;
 using std::min;
 using std::move;
+using std::pair;
 using std::size_t;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
 using std::vector;
+using std::ranges::sort;
 
 #if defined(__cpp_lib_print) && defined(__cpp_lib_format)
 using std::print;
@@ -94,9 +101,17 @@ Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<Integer> lengths
 {
 }
 
+auto Cumulative::with_rules(CumulativeRules rules) -> Cumulative &
+{
+    _rules = rules;
+    return *this;
+}
+
 auto Cumulative::clone() const -> unique_ptr<Constraint>
 {
-    return make_unique<Cumulative>(_starts, _lengths, _heights, _capacity);
+    auto result = make_unique<Cumulative>(_starts, _lengths, _heights, _capacity);
+    result->with_rules(_rules);
+    return result;
 }
 
 auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * const) -> bool
@@ -163,7 +178,65 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
         _per_task_t_lo[i] = s_lo;
         _per_task_t_hi[i] = s_hi + _length_ub[i] - 1_i;
     }
+
+    if (_rules.overload)
+        prepare_overload_check(initial_state);
+
     return true;
+}
+
+auto Cumulative::prepare_overload_check(State & initial_state) -> void
+{
+    // Which tasks the window-energy lemma can speak about: a constant length
+    // and height (so the task's energy is a constant, and its load in C_t is
+    // h·active rather than the bit-linearised contrib), and a start that is a
+    // plain variable with an order encoding, since the lemma bridges the
+    // before/after flags to the start's order literals. A task that is not
+    // eligible is not lost to the check: whatever it must occupy still counts,
+    // through the profile term of the (TTOC) strengthening.
+    _overload_tasks.clear();
+    for (auto i : _active_tasks) {
+        if (! is_constant_variable(_lengths[i]) || ! is_constant_variable(_heights[i]))
+            continue;
+        if (_length_vals[i] <= 0_i || _height_vals[i] <= 0_i)
+            continue;
+        if (! std::holds_alternative<SimpleIntegerVariableID>(_starts[i]))
+            continue;
+        // A start whose domain is exactly {0, 1} is direct-only encoded, so it
+        // has no order literals for the lemma's bridges to cancel against.
+        auto [s_lo, s_hi] = initial_state.bounds(_starts[i]);
+        if (s_lo == 0_i && s_hi == 1_i)
+            continue;
+        _overload_tasks.push_back(i);
+    }
+
+    if (_overload_tasks.empty())
+        return;
+
+    // Count the time points at which some task can be active, which is exactly
+    // where define_proof_model writes a capacity line. A difference array over
+    // the per-task windows, prefix-summed, so a window's count is one
+    // subtraction.
+    Integer global_lo = _per_task_t_lo[_active_tasks.front()], global_hi = _per_task_t_hi[_active_tasks.front()];
+    for (auto i : _active_tasks) {
+        global_lo = min(global_lo, _per_task_t_lo[i]);
+        global_hi = max(global_hi, _per_task_t_hi[i]);
+    }
+
+    auto range = (global_hi - global_lo + 1_i).raw_value;
+    vector<long long> starting_or_ending(static_cast<size_t>(range) + 1, 0);
+    for (auto i : _active_tasks) {
+        ++starting_or_ending[static_cast<size_t>((_per_task_t_lo[i] - global_lo).raw_value)];
+        --starting_or_ending[static_cast<size_t>((_per_task_t_hi[i] + 1_i - global_lo).raw_value)];
+    }
+
+    _time_slot_lo = global_lo;
+    _time_slot_prefix.assign(static_cast<size_t>(range) + 1, 0_i);
+    long long covering = 0;
+    for (size_t k = 0; k < static_cast<size_t>(range); ++k) {
+        covering += starting_or_ending[k];
+        _time_slot_prefix[k + 1] = _time_slot_prefix[k] + (covering > 0 ? 1_i : 0_i);
+    }
 }
 
 auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
@@ -351,7 +424,8 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         [starts = move(_starts), lengths_var = move(_lengths), heights_var = move(_heights), capacity_var = _capacity,
             active_tasks = move(_active_tasks), before_flags = move(_before_flags), after_flags = move(_after_flags),
             active_flags = move(_active_flags), contrib_flags = move(_contrib_flags), ends = move(_end), end_lines,
-            capacity_lines = move(_capacity_lines), per_task_t_lo = move(_per_task_t_lo),
+            capacity_lines = move(_capacity_lines), per_task_t_lo = move(_per_task_t_lo), rules = _rules, overload_tasks = move(_overload_tasks),
+            time_slot_prefix = move(_time_slot_prefix), time_slot_lo = _time_slot_lo,
             owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
             // The capacity may be a variable: the load profile is infeasible
             // only when it exceeds the *largest* still-allowed capacity, so the
@@ -487,7 +561,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                         mand_load[(t - t_lo).raw_value] += hlb(i);
             }
 
-            for (auto idx = 0; idx < range; ++idx)
+            for (auto idx = 0; rules.time_table && idx < range; ++idx)
                 if (mand_load[idx] > capacity) {
                     auto violating_t = t_lo + Integer{idx};
 
@@ -521,6 +595,161 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
                     inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
                     return PropagatorState::DisableUntilBacktrack;
                 }
+
+            // Overload checking: rule (OC') of Cloutier & Quimper, CP 2026,
+            // strengthened by the mandatory-part profile to their (TTOC). If
+            // the tasks that must run entirely inside a time window carry more
+            // energy than the window can supply, the constraint is infeasible.
+            // This is conflict-only --- no bound moves --- so a bug here shows
+            // up as a missing solution, which is what the enumeration tests
+            // are the net for.
+            //
+            // The windows worth trying are [a, b) with a an earliest start and
+            // b a latest completion time. I(a, b), the tasks with est >= a and
+            // lct <= b, contribute their whole energy p·h; every other task
+            // contributes whatever of its mandatory part falls inside the
+            // window. A task in I(a, b) has its mandatory part inside the
+            // window as well, so that second term is the window's total
+            // mandatory load minus I(a, b)'s --- which makes both terms
+            // accumulate as b grows, and the whole sweep quadratic.
+            //
+            // Two restrictions, both of which only weaken the check: the
+            // capacity must be constant (a variable one would leave a
+            // (b − a)·capacity term in the conflict pol for the wrapping RUP
+            // to dispose of over the capacity's bits, which it cannot do in
+            // general), and only eligible tasks (see prepare_overload_check)
+            // may join I(a, b).
+            if (rules.overload && ! overload_tasks.empty() && is_constant_variable(capacity_var)) {
+                vector<Integer> mand_prefix(static_cast<size_t>(range) + 1, 0_i);
+                for (auto idx = 0; idx < range; ++idx)
+                    mand_prefix[static_cast<size_t>(idx) + 1] = mand_prefix[static_cast<size_t>(idx)] + mand_load[static_cast<size_t>(idx)];
+
+                // Mandatory load inside [from, to), over every task.
+                auto profile_within = [&](Integer from, Integer to) {
+                    return mand_prefix[static_cast<size_t>((to - t_lo).raw_value)] - mand_prefix[static_cast<size_t>((from - t_lo).raw_value)];
+                };
+
+                // How many time points in [from, to) some task can occupy.
+                // Anywhere else supplies nothing to this window's tasks (and
+                // has no capacity line to cite), so it is not counted.
+                auto slots_within = [&](Integer from, Integer to) {
+                    return time_slot_prefix[static_cast<size_t>((to - time_slot_lo).raw_value)] -
+                        time_slot_prefix[static_cast<size_t>((from - time_slot_lo).raw_value)];
+                };
+
+                struct Candidate
+                {
+                    size_t task;
+                    Integer est, lct, energy, mandatory;
+                };
+
+                vector<Candidate> candidates;
+                candidates.reserve(overload_tasks.size());
+                for (auto i : overload_tasks) {
+                    auto [s_lo, s_hi] = state.bounds(starts[i]);
+                    auto p = llb(i), h = hlb(i);
+                    candidates.push_back(Candidate{i, s_lo, s_hi + p, p * h, h * max(0_i, s_lo + p - s_hi)});
+                }
+                sort(candidates, [](const Candidate & a, const Candidate & b) { return a.lct < b.lct; });
+
+                vector<Integer> window_starts;
+                window_starts.reserve(candidates.size());
+                for (const auto & c : candidates)
+                    window_starts.push_back(c.est);
+                sort(window_starts);
+
+                for (size_t w = 0; w < window_starts.size(); ++w) {
+                    if (w > 0 && window_starts[w] == window_starts[w - 1])
+                        continue;
+                    auto a = window_starts[w];
+
+                    Integer energy = 0_i, inside_mandatory = 0_i;
+                    vector<size_t> inside_tasks;
+                    for (const auto & c : candidates) {
+                        if (c.est < a)
+                            continue;
+                        energy += c.energy;
+                        inside_mandatory += c.mandatory;
+                        inside_tasks.push_back(c.task);
+
+                        auto b = c.lct;
+                        auto supply = capacity * slots_within(a, b);
+                        auto outside_profile = rules.profile_overload ? profile_within(a, b) - inside_mandatory : 0_i;
+                        if (energy + outside_profile <= supply)
+                            continue;
+
+                        // (OC') on its own, or does the conflict need the
+                        // profile of the tasks outside the window?
+                        auto uses_profile = energy <= supply;
+
+                        // The (i, t) pairs whose compulsory load the proof
+                        // pins: exactly what outside_profile counted.
+                        vector<pair<size_t, Integer>> pins;
+                        if (uses_profile) {
+                            vector<bool> inside(starts.size(), false);
+                            for (auto i : inside_tasks)
+                                inside[i] = true;
+                            for (auto j : active_tasks) {
+                                if (inside[j])
+                                    continue;
+                                auto lst = state.upper_bound(starts[j]);
+                                auto eet = state.lower_bound(starts[j]) + llb(j);
+                                for (Integer t = max(lst, a); t < min(eet, b); ++t)
+                                    pins.emplace_back(j, t);
+                            }
+                        }
+
+                        auto justify = [&, a, b, inside_tasks, pins, uses_profile](const ReasonLiterals & reason) -> void {
+                            if (! logger)
+                                return;
+                            logger->emit_proof_comment("cumulative overload conflict window=[" + std::to_string(a.raw_value) + "," +
+                                std::to_string(b.raw_value) + ") rule=" + (uses_profile ? "ttoc" : "oc"));
+
+                            // The capacity available across the window, plus
+                            // each contained task's window energy scaled by its
+                            // height, plus (for (TTOC)) the pinned compulsory
+                            // load of the tasks outside it. Each task's energy
+                            // terms cancel against its terms in the capacity
+                            // lines exactly, leaving a constraint whose
+                            // negative-only left hand side must reach a
+                            // positive right hand side.
+                            PolBuilder pol;
+                            for (Integer t = a; t < b; ++t) {
+                                auto line = capacity_lines.find(t);
+                                if (line != capacity_lines.end())
+                                    pol.add(line->second);
+                            }
+
+                            for (auto i : inside_tasks) {
+                                auto energy_line = window_energy::derive_window_energy(*logger, reason,
+                                    window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i],
+                                        before_flags[i], after_flags[i], active_flags[i]},
+                                    a, b, state.bounds(starts[i]), ProofLevel::Temporary);
+                                if (! energy_line || energy_line->bound != llb(i))
+                                    throw ProofError{"cumulative overload: window energy derivation is weaker than the check assumed"};
+                                pol.add(energy_line->line, hlb(i));
+                            }
+
+                            for (const auto & [j, t] : pins) {
+                                auto [line, coeff] = pin_contributor(reason, j, t);
+                                pol.add(line, coeff);
+                            }
+
+                            pol.emit(*logger, ProofLevel::Temporary);
+                        };
+
+                        inference.contradiction(
+                            logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeOverload{owner}}, generic_reason(reason_vars));
+                        return PropagatorState::DisableUntilBacktrack;
+                    }
+                }
+            }
+
+            // The remaining work --- pushing each task's bounds away from the
+            // times where placing it would overflow the profile --- is
+            // time-table reasoning too.
+            if (! rules.time_table)
+                return PropagatorState::Enable;
 
             // One step of a bound-push proof chain: a blocked time t and the
             // tasks (≠ j) whose mandatory parts cover t. Used by both

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <map>
 #include <optional>
+#include <variant>
 #include <vector>
 
 namespace gcs
@@ -41,6 +42,52 @@ namespace gcs
         /// effect unless \ref overload is also set.
         bool profile_overload = true;
     };
+
+    /**
+     * \brief Deliberate corruptions of the overload check's derivation, for
+     * testing only.
+     *
+     * A proof that verifies is necessary but not sufficient: if the honest
+     * derivation has slack in it, a wrong one verifies too, and the rule's
+     * arithmetic is then not being checked by anything. Each of these breaks
+     * one step of the emitted derivation in a way that must make VeriPB
+     * *reject* the proof; a mutation that still verifies is a finding about the
+     * honest derivation, not about the mutation.
+     *
+     * These change nothing but the proof: the same conflicts are found, the
+     * same solutions reported, and the OPB is untouched.
+     *
+     * \ingroup Constraints
+     */
+    namespace cumulative_proof_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim one more unit of activity than the window-energy lemma
+        /// derived, for the first task in the window.
+        struct OverstateWindowEnergy
+        {
+        };
+
+        /// Leave the last time point's capacity line out of the conflict's
+        /// pol, so the window appears to supply one time point less than the
+        /// energy argument was told.
+        struct OmitCapacityLine
+        {
+        };
+
+        /// Derive each task's window energy over a window one time point
+        /// short, which is honest but weaker than the conflict needs.
+        struct ShrinkLemmaWindow
+        {
+        };
+    }
+
+    using CumulativeProofMutation = std::variant<cumulative_proof_mutation::None, cumulative_proof_mutation::OverstateWindowEnergy,
+        cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow>;
 
     /**
      * \brief Cumulative constraint: tasks with start times, durations, and
@@ -89,6 +136,7 @@ namespace gcs
         std::vector<Integer> _per_task_t_lo;
         std::vector<Integer> _per_task_t_hi;
         CumulativeRules _rules;
+        CumulativeProofMutation _proof_mutation = cumulative_proof_mutation::None{};
         // Overload checking, resolved in prepare(). _overload_tasks lists the
         // tasks the window-energy lemma can speak about (constant length and
         // height, and a start whose order literals the lemma can bridge to);
@@ -148,6 +196,11 @@ namespace gcs
         /// default). Propagation strength only: the solutions found and the OPB
         /// encoding are the same whatever is selected.
         auto with_rules(CumulativeRules rules) -> Cumulative &;
+
+        /// Corrupt one step of the overload check's derivation. For tests
+        /// only, which assert that VeriPB rejects the result; see
+        /// CumulativeProofMutation.
+        auto with_proof_mutation(CumulativeProofMutation mutation) -> Cumulative &;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -15,6 +15,34 @@
 namespace gcs
 {
     /**
+     * \brief Which of Cumulative's propagation rules are enabled.
+     *
+     * All three are on by default. Turning one off weakens propagation but
+     * never changes the solutions found, and never changes the OPB encoding:
+     * these select propagation strength only, and exist so that a test can
+     * attribute an inference to the rule that made it (and so that a fixture
+     * can show a rule is load-bearing by watching the search get worse without
+     * it).
+     *
+     * \ingroup Constraints
+     */
+    struct CumulativeRules
+    {
+        /// Time-table: the mandatory-part load profile, its overflow
+        /// contradiction and the bound pushes away from blocked times.
+        bool time_table = true;
+
+        /// The overload check: a window whose fully-contained tasks carry more
+        /// energy than the window supplies is infeasible. Conflict-only.
+        bool overload = true;
+
+        /// Strengthen the overload check with the mandatory-part load of tasks
+        /// that are *not* fully contained in the window (rule (TTOC)). Has no
+        /// effect unless \ref overload is also set.
+        bool profile_overload = true;
+    };
+
+    /**
      * \brief Cumulative constraint: tasks with start times, durations, and
      * demands, sharing a resource of a given capacity. Any of the durations,
      * demands, and the capacity may be variables or constants (constants are
@@ -60,6 +88,18 @@ namespace gcs
         std::vector<std::size_t> _active_tasks;
         std::vector<Integer> _per_task_t_lo;
         std::vector<Integer> _per_task_t_hi;
+        CumulativeRules _rules;
+        // Overload checking, resolved in prepare(). _overload_tasks lists the
+        // tasks the window-energy lemma can speak about (constant length and
+        // height, and a start whose order literals the lemma can bridge to);
+        // _time_slot_prefix[t − _time_slot_lo] counts the time points strictly
+        // below t at which some task can be active, which is exactly where
+        // define_proof_model writes a per-time capacity line. A window's supply
+        // is its capacity times that count: a time point no task can occupy
+        // supplies nothing to the window's tasks and has no line to cite.
+        std::vector<std::size_t> _overload_tasks;
+        std::vector<Integer> _time_slot_prefix;
+        Integer _time_slot_lo = 0_i;
 
         // Filled in by define_proof_model; consumed by install_propagators.
         // Each [task_idx] is indexed by t − _per_task_t_lo[i].
@@ -83,6 +123,8 @@ namespace gcs
         std::vector<std::optional<innards::ProofOnlySimpleIntegerVariableID>> _end;
         std::map<Integer, innards::ProofLine> _capacity_lines; // t -> proof line for the per-t time-table constraint
 
+        auto prepare_overload_check(innards::State &) -> void;
+
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
@@ -101,6 +143,11 @@ namespace gcs
          * constructor.
          */
         explicit Cumulative(std::vector<IntegerVariableID> starts, std::vector<Integer> lengths, std::vector<Integer> heights, Integer capacity);
+
+        /// Select which propagation rules are enabled (all of them, by
+        /// default). Propagation strength only: the solutions found and the OPB
+        /// encoding are the same whatever is selected.
+        auto with_rules(CumulativeRules rules) -> Cumulative &;
 
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;

--- a/gcs/constraints/cumulative/cumulative_overload_test.cc
+++ b/gcs/constraints/cumulative/cumulative_overload_test.cc
@@ -1,0 +1,337 @@
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <climits>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::ifstream;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // Every fixture in this file is an all-constant instance: the overload
+    // check only speaks about tasks whose length and height are constants.
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            if (inst.lengths[i] == 0 || inst.heights[i] == 0)
+                continue;
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        for (auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+
+        vector<Integer> lengths, heights;
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        for (auto h : inst.heights)
+            heights.push_back(Integer{h});
+
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules));
+        return starts;
+    }
+
+    // How many times each overload rule left its marker in a proof file. The
+    // propagator writes one comment per conflict it justifies, tagged with the
+    // rule that made it, so a test can tell "the rule fired" from "the rule
+    // was compiled in and never triggered" --- and, on a negative twin, insist
+    // that it did not fire at all.
+    struct MarkerCounts
+    {
+        size_t oc = 0, ttoc = 0;
+
+        [[nodiscard]] auto total() const -> size_t
+        {
+            return oc + ttoc;
+        }
+    };
+
+    auto count_markers(const string & proof_name) -> MarkerCounts
+    {
+        MarkerCounts counts;
+        ifstream proof{proof_name + ".pbp"};
+        if (! proof) {
+            println(cerr, "could not read {}.pbp to count overload markers", proof_name);
+            std::exit(EXIT_FAILURE);
+        }
+        string line;
+        while (getline(proof, line)) {
+            if (line.find("cumulative overload conflict") == string::npos)
+                continue;
+            if (line.find("rule=ttoc") != string::npos)
+                ++counts.ttoc;
+            else if (line.find("rule=oc") != string::npos)
+                ++counts.oc;
+        }
+        return counts;
+    }
+
+    // What one propagation at the root did: whether it refuted the instance
+    // outright, and which overload rules fired doing so. Stopping at the first
+    // search node keeps the marker counts attributable to root reasoning --- a
+    // satisfiable instance would otherwise accumulate markers from conflicts
+    // deep in the search, which says nothing about the fixture.
+    struct RootProbe
+    {
+        bool refuted = false;
+        MarkerCounts markers;
+    };
+
+    auto probe_root(const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> RootProbe
+    {
+        Problem p;
+        post(p, inst, rules);
+
+        RootProbe probe;
+        bool reached_a_node = false;
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return false; },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return false;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+        probe.refuted = ! reached_a_node;
+
+        if (proof_name) {
+            probe.markers = count_markers(*proof_name);
+            verify_proof_and_clean_up(*proof_name);
+        }
+        return probe;
+    }
+
+    // A full enumeration against brute force, with the proof verified. This is
+    // the soundness net: the overload check only ever reports conflicts, so a
+    // bug in it removes solutions.
+    auto check_enumeration(const string & what, const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> void
+    {
+        print(cerr, "cumulative overload {} starts={} lens={} hts={} c={}{}", what, inst.start_ranges, inst.lengths, inst.heights, inst.capacity,
+            proof_name ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto starts = post(p, inst, rules);
+        solve_for_tests(p, proof_name, actual, tuple{starts});
+        check_results(proof_name, expected, actual);
+    }
+
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "cumulative overload test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    // The two rules, written out from their definitions, over a fully general
+    // double loop and sharing no code with the propagator. Used to classify
+    // random instances: the propagator must refute at the root exactly when
+    // this says a window is overloaded.
+    auto oracle_says_overloaded(const Instance & inst, bool with_profile) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        for (size_t wa = 0; wa < n; ++wa)
+            for (size_t wb = 0; wb < n; ++wb) {
+                auto a = inst.start_ranges[wa].first;
+                auto b = inst.start_ranges[wb].second + inst.lengths[wb];
+                if (b <= a)
+                    continue;
+
+                long long energy = 0, profile = 0;
+                for (size_t i = 0; i < n; ++i) {
+                    if (inst.lengths[i] <= 0 || inst.heights[i] <= 0)
+                        continue;
+                    auto est = inst.start_ranges[i].first, lct = inst.start_ranges[i].second + inst.lengths[i];
+                    if (est >= a && lct <= b) {
+                        energy += static_cast<long long>(inst.lengths[i]) * inst.heights[i];
+                        continue;
+                    }
+                    if (! with_profile)
+                        continue;
+                    // the part of task i's mandatory part that lies inside the
+                    // window: [lst, eet) = [ub(s), lb(s) + p)
+                    auto lst = inst.start_ranges[i].second, eet = inst.start_ranges[i].first + inst.lengths[i];
+                    for (auto t = max(lst, a); t < min(eet, b); ++t)
+                        profile += inst.heights[i];
+                }
+
+                // Time points no task can occupy supply nothing to the window,
+                // and the propagator does not count them either.
+                long long slots = 0;
+                for (auto t = a; t < b; ++t)
+                    for (size_t i = 0; i < n; ++i)
+                        if (inst.lengths[i] > 0 && inst.heights[i] > 0 && t >= inst.start_ranges[i].first &&
+                            t <= inst.start_ranges[i].second + inst.lengths[i] - 1) {
+                            ++slots;
+                            break;
+                        }
+
+                if (energy + profile > static_cast<long long>(inst.capacity) * slots)
+                    return true;
+            }
+        return false;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    const CumulativeRules all_rules{};
+    const CumulativeRules no_overload{.time_table = true, .overload = false, .profile_overload = false};
+    const CumulativeRules no_profile{.time_table = true, .overload = true, .profile_overload = false};
+
+    auto proofs = can_run_veripb();
+
+    // F1: three unit-height tasks of length two, each free in [0, 2], sharing
+    // a resource of capacity one. Every mandatory part is empty (lst = 2 is
+    // not before eet = 2), so time-tabling sees nothing at all; but the window
+    // [0, 4) must hold 3 x 2 = 6 units of energy and supplies 1 x 4 = 4.
+    const Instance f1{{{0, 2}, {0, 2}, {0, 2}}, {2, 2, 2}, {1, 1, 1}, 1};
+
+    // F1's negative twin: the same tasks with room to spread out. The widest
+    // window [0, 8) now supplies exactly the 6 units the tasks need, so
+    // nothing is overloaded and the rule must stay silent at the root.
+    const Instance f1_twin{{{0, 6}, {0, 6}, {0, 6}}, {2, 2, 2}, {1, 1, 1}, 1};
+
+    {
+        auto with_rule = probe_root(f1, all_rules, proofs ? make_optional("cumulative_overload_f1") : nullopt);
+        if (! with_rule.refuted)
+            fail("F1: the overload check did not refute at the root");
+        if (proofs && with_rule.markers.oc != 1)
+            fail("F1: expected exactly one (OC') marker, got " + std::to_string(with_rule.markers.oc));
+        if (proofs && with_rule.markers.ttoc != 0)
+            fail("F1: (TTOC) fired where (OC') alone was enough");
+
+        auto without_rule = probe_root(f1, no_overload, nullopt);
+        if (without_rule.refuted)
+            fail("F1: time-tabling alone refuted at the root, so the fixture proves nothing");
+    }
+
+    {
+        auto with_rule = probe_root(f1_twin, all_rules, proofs ? make_optional("cumulative_overload_f1_twin") : nullopt);
+        if (with_rule.refuted)
+            fail("F1 twin: refuted at the root, but it is satisfiable");
+        if (proofs && with_rule.markers.total() != 0)
+            fail("F1 twin: the overload check claimed a conflict at the root");
+    }
+
+    // F2: (TTOC), the profile strengthening. Four length-two, height-one tasks
+    // free in [0, 2] fill the window [0, 4) exactly: energy 8 against a supply
+    // of 2 x 4, so (OC') is silent. The fifth task runs past the end of the
+    // window (est 1, lct 6), so it is not in the window's energy set at all,
+    // but its mandatory part [2, 5) puts two units of load inside the window
+    // regardless of where it starts --- and 8 + 2 > 8.
+    //
+    // Time-tabling can say nothing here: no task in the window has a mandatory
+    // part, and the fifth task's one unit of load never blocks a height-one
+    // task under a capacity of two, so no bound moves either.
+    const Instance f2{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {1, 2}}, {2, 2, 2, 2, 4}, {1, 1, 1, 1, 1}, 2};
+
+    // F2's negative twin: the same, with the straddling task moved past the
+    // window, so its mandatory part [5, 8) contributes nothing to [0, 4) and
+    // the window's demand is back to exactly its supply.
+    const Instance f2_twin{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {4, 5}}, {2, 2, 2, 2, 4}, {1, 1, 1, 1, 1}, 2};
+
+    {
+        auto with_rule = probe_root(f2, all_rules, proofs ? make_optional("cumulative_overload_f2") : nullopt);
+        if (! with_rule.refuted)
+            fail("F2: the (TTOC) strengthening did not refute at the root");
+        if (proofs && with_rule.markers.ttoc != 1)
+            fail("F2: expected exactly one (TTOC) marker, got " + std::to_string(with_rule.markers.ttoc));
+
+        auto without_profile = probe_root(f2, no_profile, nullopt);
+        if (without_profile.refuted)
+            fail("F2: (OC') alone refuted at the root, so the fixture does not test (TTOC)");
+
+        auto without_rule = probe_root(f2, no_overload, nullopt);
+        if (without_rule.refuted)
+            fail("F2: time-tabling alone refuted at the root, so the fixture proves nothing");
+    }
+
+    {
+        auto with_rule = probe_root(f2_twin, all_rules, proofs ? make_optional("cumulative_overload_f2_twin") : nullopt);
+        if (with_rule.refuted)
+            fail("F2 twin: refuted at the root, but it is satisfiable");
+        if (proofs && with_rule.markers.total() != 0)
+            fail("F2 twin: the overload check claimed a conflict at the root");
+    }
+
+    // The solutions must survive the new rule: it only ever reports conflicts,
+    // so a bug in it shows up here as a missing solution.
+    check_enumeration("f1", f1, all_rules, proofs ? make_optional("cumulative_overload_enum_f1") : nullopt);
+    check_enumeration("f1_twin", f1_twin, all_rules, proofs ? make_optional("cumulative_overload_enum_f1_twin") : nullopt);
+    check_enumeration("f2", f2, all_rules, proofs ? make_optional("cumulative_overload_enum_f2") : nullopt);
+    check_enumeration("f2_twin", f2_twin, all_rules, proofs ? make_optional("cumulative_overload_enum_f2_twin") : nullopt);
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/cumulative/cumulative_overload_test.cc
+++ b/gcs/constraints/cumulative/cumulative_overload_test.cc
@@ -3,11 +3,13 @@
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
+#include <algorithm>
 #include <climits>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <optional>
+#include <random>
 #include <set>
 #include <sstream>
 #include <string>
@@ -82,7 +84,8 @@ namespace
         return true;
     }
 
-    auto post(Problem & p, const Instance & inst, CumulativeRules rules) -> vector<IntegerVariableID>
+    auto post(Problem & p, const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation = cumulative_proof_mutation::None{})
+        -> vector<IntegerVariableID>
     {
         vector<IntegerVariableID> starts;
         for (auto & [lo, hi] : inst.start_ranges)
@@ -94,7 +97,7 @@ namespace
         for (auto h : inst.heights)
             heights.push_back(Integer{h});
 
-        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules));
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(rules).with_proof_mutation(mutation));
         return starts;
     }
 
@@ -144,21 +147,33 @@ namespace
         MarkerCounts markers;
     };
 
-    auto probe_root(const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> RootProbe
+    auto solve_root_only(const Instance & inst, CumulativeRules rules, CumulativeProofMutation mutation, const optional<string> & proof_name) -> bool
     {
         Problem p;
-        post(p, inst, rules);
+        post(p, inst, rules, mutation);
 
-        RootProbe probe;
-        bool reached_a_node = false;
+        // Refuted means the root propagation reached a contradiction: neither
+        // a search node nor a solution. The solution check is not redundant --- an
+        // instance whose variables are all fixed by propagation is answered
+        // without ever branching, so no node is ever traced.
+        bool reached_a_node = false, found_a_solution = false;
         solve_with(p,
-            SolveCallbacks{.solution = [&](const CurrentState &) -> bool { return false; },
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               found_a_solution = true;
+                               return false;
+                           },
                 .trace = [&](const CurrentState &) -> bool {
                     reached_a_node = true;
                     return false;
                 }},
             proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
-        probe.refuted = ! reached_a_node;
+        return ! reached_a_node && ! found_a_solution;
+    }
+
+    auto probe_root(const Instance & inst, CumulativeRules rules, const optional<string> & proof_name) -> RootProbe
+    {
+        RootProbe probe;
+        probe.refuted = solve_root_only(inst, rules, cumulative_proof_mutation::None{}, proof_name);
 
         if (proof_name) {
             probe.markers = count_markers(*proof_name);
@@ -192,33 +207,98 @@ namespace
         std::exit(EXIT_FAILURE);
     }
 
-    // The two rules, written out from their definitions, over a fully general
-    // double loop and sharing no code with the propagator. Used to classify
-    // random instances: the propagator must refute at the root exactly when
-    // this says a window is overloaded.
+    auto read_file(const string & name) -> string
+    {
+        ifstream in{name, std::ios::binary};
+        if (! in)
+            fail("could not read " + name);
+        return string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+    }
+
+    // The OPB is the statement being verified, and nothing in the overload
+    // check may reach it: every fact it establishes is a derivation inside the
+    // proof. So the model must come out byte-identical however the rule is
+    // configured --- including under the mutations, which are proof-only too.
+    //
+    // VeriPB will happily verify a correct proof of the wrong model, so this
+    // is not a tidiness check: an inference that quietly became a model axiom
+    // would leave every proof in this file verifying and prove nothing about
+    // the solver.
+    auto check_opb_unaffected(const string & what, const Instance & inst) -> void
+    {
+        const string on = "cumulative_overload_opb_on", off = "cumulative_overload_opb_off", mutated = "cumulative_overload_opb_mutated";
+
+        solve_root_only(inst, CumulativeRules{}, cumulative_proof_mutation::None{}, on);
+        solve_root_only(
+            inst, CumulativeRules{.time_table = true, .overload = false, .profile_overload = false}, cumulative_proof_mutation::None{}, off);
+        solve_root_only(inst, CumulativeRules{}, cumulative_proof_mutation::OverstateWindowEnergy{}, mutated);
+
+        auto with_rule = read_file(on + ".opb");
+        if (with_rule != read_file(off + ".opb"))
+            fail("OPB differs with and without the overload check, on " + what);
+        if (with_rule != read_file(mutated + ".opb"))
+            fail("OPB differs under a proof mutation, on " + what);
+
+        for (const auto & name : {on, off, mutated})
+            dispose_of_proof_files(name);
+    }
+
+    // A task raises the load profile at all --- what prepare() calls an active
+    // task.
+    auto is_active(const Instance & inst, size_t i) -> bool
+    {
+        return inst.lengths[i] > 0 && inst.heights[i] > 0;
+    }
+
+    // A task the window-energy lemma can speak about, so a task the energy set
+    // may contain. Mirrors prepare_overload_check: everything here is a
+    // constant already, so all that is left is the start's encoding.
+    auto is_eligible(const Instance & inst, size_t i) -> bool
+    {
+        return is_active(inst, i) && ! (inst.start_ranges[i].first == 0 && inst.start_ranges[i].second == 1);
+    }
+
+    // The two rules, written out from their definitions over a plain double
+    // loop, sharing no code with the propagator. Used to classify random
+    // instances: with time-tabling turned off, the propagator must refute at
+    // the root exactly when this says some window is overloaded.
+    //
+    // The window candidates match the propagator's: a is an earliest start
+    // time, and b a latest completion time *of a task with est >= a*. A window
+    // whose b comes from a task starting before a has the same energy set as
+    // the shorter window ending at that set's own largest lct, and (with
+    // time-tabling on, so that no time point is loaded past the capacity)
+    // shrinking to it cannot lose more profile than supply. An empty energy
+    // set is the remaining case, and a window overloaded by profile alone is a
+    // time-table overflow.
     auto oracle_says_overloaded(const Instance & inst, bool with_profile) -> bool
     {
         auto n = inst.start_ranges.size();
-        for (size_t wa = 0; wa < n; ++wa)
+        for (size_t wa = 0; wa < n; ++wa) {
+            if (! is_eligible(inst, wa))
+                continue;
+            auto a = inst.start_ranges[wa].first;
+
             for (size_t wb = 0; wb < n; ++wb) {
-                auto a = inst.start_ranges[wa].first;
+                if (! is_eligible(inst, wb) || inst.start_ranges[wb].first < a)
+                    continue;
                 auto b = inst.start_ranges[wb].second + inst.lengths[wb];
                 if (b <= a)
                     continue;
 
                 long long energy = 0, profile = 0;
                 for (size_t i = 0; i < n; ++i) {
-                    if (inst.lengths[i] <= 0 || inst.heights[i] <= 0)
+                    if (! is_active(inst, i))
                         continue;
                     auto est = inst.start_ranges[i].first, lct = inst.start_ranges[i].second + inst.lengths[i];
-                    if (est >= a && lct <= b) {
+                    if (is_eligible(inst, i) && est >= a && lct <= b) {
                         energy += static_cast<long long>(inst.lengths[i]) * inst.heights[i];
                         continue;
                     }
                     if (! with_profile)
                         continue;
-                    // the part of task i's mandatory part that lies inside the
-                    // window: [lst, eet) = [ub(s), lb(s) + p)
+                    // the part of task i's mandatory part [lst, eet) =
+                    // [ub(s), lb(s) + p) that lies inside the window
                     auto lst = inst.start_ranges[i].second, eet = inst.start_ranges[i].first + inst.lengths[i];
                     for (auto t = max(lst, a); t < min(eet, b); ++t)
                         profile += inst.heights[i];
@@ -229,8 +309,7 @@ namespace
                 long long slots = 0;
                 for (auto t = a; t < b; ++t)
                     for (size_t i = 0; i < n; ++i)
-                        if (inst.lengths[i] > 0 && inst.heights[i] > 0 && t >= inst.start_ranges[i].first &&
-                            t <= inst.start_ranges[i].second + inst.lengths[i] - 1) {
+                        if (is_active(inst, i) && t >= inst.start_ranges[i].first && t <= inst.start_ranges[i].second + inst.lengths[i] - 1) {
                             ++slots;
                             break;
                         }
@@ -238,7 +317,51 @@ namespace
                 if (energy + profile > static_cast<long long>(inst.capacity) * slots)
                     return true;
             }
+        }
         return false;
+    }
+
+    // Sharp-margin instances: n tasks whose durations and heights are distinct
+    // primes, all free to start anywhere inside one window [0, H), with the
+    // capacity set so that the window's energy exceeds its supply by between
+    // one and three units.
+    //
+    // At a margin that small every coefficient in the emitted derivation is
+    // load-bearing: drop one capacity line, or lose one unit from one task's
+    // window energy, and the contradiction is gone. Pairwise-coprime data
+    // keeps any arithmetic that happens to be right modulo a common factor
+    // from passing by luck.
+    auto sharp_margin_instance(std::mt19937 & rand, int n, int horizon) -> optional<Instance>
+    {
+        static const vector<int> primes{29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113};
+
+        vector<int> pool = primes;
+        std::shuffle(pool.begin(), pool.end(), rand);
+        if (static_cast<size_t>(2 * n) > pool.size())
+            return nullopt;
+
+        Instance inst;
+        long long energy = 0;
+        for (int i = 0; i < n; ++i) {
+            auto length = pool.at(static_cast<size_t>(i));
+            auto height = pool.at(static_cast<size_t>(n + i));
+            if (length > horizon)
+                return nullopt;
+            inst.lengths.push_back(length);
+            inst.heights.push_back(height);
+            inst.start_ranges.emplace_back(0, horizon - length);
+            energy += static_cast<long long>(length) * height;
+        }
+
+        auto capacity = (energy - 1) / horizon;
+        if (capacity < 1)
+            return nullopt;
+        auto margin = energy - capacity * horizon;
+        if (margin < 1 || margin > 3)
+            return nullopt;
+
+        inst.capacity = static_cast<int>(capacity);
+        return inst;
     }
 }
 
@@ -249,8 +372,52 @@ auto main(int argc, char * argv[]) -> int
     const CumulativeRules all_rules{};
     const CumulativeRules no_overload{.time_table = true, .overload = false, .profile_overload = false};
     const CumulativeRules no_profile{.time_table = true, .overload = true, .profile_overload = false};
+    // Isolate the energy reasoning: with time-tabling off, the only conflict
+    // the propagator can report is an overload one.
+    const CumulativeRules only_overload{.time_table = false, .overload = true, .profile_overload = true};
 
     auto proofs = can_run_veripb();
+
+    // A sharp-margin instance: four tasks that must all run inside [0, 12),
+    // needing 5x4 + 6x3 + 5x2 + 1x1 = 49 units of energy where a capacity of
+    // four supplies 48. Every task can start early enough to have no mandatory
+    // part at all and every height fits under the capacity, so time-tabling
+    // has nothing to say --- neither a profile overflow nor a single blocked
+    // time --- which leaves the energy argument as the only way to see the
+    // conflict.
+    //
+    // The mutation runs below corrupt this instance's proof, because a margin
+    // of exactly one is what makes every step of the derivation load-bearing:
+    // one capacity line fewer, or one unit less energy from one task, and the
+    // contradiction is gone.
+    const Instance sharp{{{0, 7}, {0, 6}, {0, 7}, {0, 11}}, {5, 6, 5, 1}, {4, 3, 2, 1}, 4};
+
+    // Mutation mode: emit one deliberately corrupted proof of `sharp` and
+    // stop, for run_test_and_expect_verify_failure.bash to hand to veripb.
+    // The corruption is in the proof only, so the solve still refutes; if it
+    // ever stops doing so, the harness would be checking an empty proof.
+    {
+        optional<CumulativeProofMutation> mutation;
+        string proof_basename = "cumulative_overload_mutation";
+        for (int a = 1; a < argc; ++a) {
+            string arg = argv[a];
+            if (arg == "--mutate=energy")
+                mutation = cumulative_proof_mutation::OverstateWindowEnergy{};
+            else if (arg == "--mutate=capacity")
+                mutation = cumulative_proof_mutation::OmitCapacityLine{};
+            else if (arg == "--mutate=window")
+                mutation = cumulative_proof_mutation::ShrinkLemmaWindow{};
+            else if (arg == "--proof-files-basename" && a + 1 < argc)
+                proof_basename = argv[++a];
+        }
+
+        if (mutation) {
+            if (! solve_root_only(sharp, all_rules, *mutation, make_optional(proof_basename)))
+                fail("mutation mode: the sharp-margin instance was not refuted, so the proof is empty");
+            println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+            return EXIT_SUCCESS;
+        }
+    }
 
     // F1: three unit-height tasks of length two, each free in [0, 2], sharing
     // a resource of capacity one. Every mandatory part is empty (lst = 2 is
@@ -324,6 +491,156 @@ auto main(int argc, char * argv[]) -> int
             fail("F2 twin: refuted at the root, but it is satisfiable");
         if (proofs && with_rule.markers.total() != 0)
             fail("F2 twin: the overload check claimed a conflict at the root");
+    }
+
+    // The sharp-margin fixture itself, with time-tabling out of the way so
+    // that only the energy argument can reach the conflict.
+    {
+        auto with_rule = probe_root(sharp, only_overload, proofs ? make_optional("cumulative_overload_sharp") : nullopt);
+        if (! with_rule.refuted)
+            fail("sharp: the overload check did not refute at the root");
+        if (proofs && with_rule.markers.oc != 1)
+            fail("sharp: expected exactly one (OC') marker, got " + std::to_string(with_rule.markers.oc));
+
+        auto without_rule = probe_root(sharp, no_overload, nullopt);
+        if (without_rule.refuted)
+            fail("sharp: time-tabling alone refuted at the root, so the fixture proves nothing");
+    }
+
+    // Sharp margins at scale, over durations and heights drawn from distinct
+    // primes: the arithmetic here has no small factors to hide behind, and
+    // every window is wide enough that the derivation runs to hundreds of
+    // steps.
+    {
+        std::mt19937 rand(*get_seed());
+        int found = 0;
+        for (int attempt = 0; attempt < 4000 && found < 4; ++attempt) {
+            std::uniform_int_distribution<> horizon_dist(120, 240);
+            auto inst = sharp_margin_instance(rand, 3, horizon_dist(rand));
+            if (! inst)
+                continue;
+            ++found;
+
+            auto name = "cumulative_overload_primes_" + std::to_string(found);
+            println(cerr, "cumulative overload sharp margin lens={} hts={} c={} horizon={}", inst->lengths, inst->heights, inst->capacity,
+                inst->start_ranges[0].second + inst->lengths[0]);
+            auto probe = probe_root(*inst, only_overload, proofs ? make_optional(name) : nullopt);
+            if (! probe.refuted)
+                fail("sharp margin: the overload check did not refute at the root");
+            if (proofs && probe.markers.oc != 1)
+                fail("sharp margin: expected exactly one (OC') marker");
+        }
+        if (found == 0)
+            fail("sharp margin: the generator produced nothing to test");
+    }
+
+    // Oracle cross-check. Over a random corpus, with time-tabling off so that
+    // an overload conflict is the only conflict available, the propagator must
+    // refute at the root exactly when the from-the-definition oracle says a
+    // window is overloaded --- which catches both under- and over-firing.
+    {
+        std::mt19937 rand(*get_seed());
+        // Start domains reach below zero: a window then runs over negative
+        // time points, where the order literals the lemma bridges to are on a
+        // signed bit encoding (issue #553's shape).
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-3, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4);
+
+        size_t fired = 0, verified = 0;
+        for (int k = 0; k < 300; ++k) {
+            Instance inst;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand), span = span_dist(rand);
+                inst.start_ranges.emplace_back(lo, lo + span);
+                inst.lengths.push_back(len_dist(rand));
+                inst.heights.push_back(ht_dist(rand));
+            }
+            inst.capacity = cap_dist(rand);
+
+            auto oracle = oracle_says_overloaded(inst, true);
+            // Verify a proof for the first few conflicts, rather than all of
+            // them: the cross-check is about which instances fire, and the
+            // fixtures above are where the derivation itself is scrutinised.
+            auto name = (oracle && verified < 10) ? make_optional("cumulative_overload_oracle_" + std::to_string(verified)) : nullopt;
+            auto probe = probe_root(inst, only_overload, proofs ? name : nullopt);
+
+            if (probe.refuted != oracle) {
+                println(cerr, "oracle disagreement on starts={} lens={} hts={} c={}: oracle says {}, propagator says {}", inst.start_ranges,
+                    inst.lengths, inst.heights, inst.capacity, oracle, probe.refuted);
+                fail("oracle cross-check");
+            }
+            if (probe.refuted) {
+                ++fired;
+                if (name)
+                    ++verified;
+                if (proofs && name && probe.markers.total() != 1)
+                    fail("oracle cross-check: a refutation left no overload marker");
+            }
+
+            // The rule must not cost solutions, whatever the oracle says.
+            check_enumeration("random_" + std::to_string(k), inst, all_rules, nullopt);
+        }
+
+        if (fired == 0)
+            fail("oracle cross-check: no instance in the corpus overloaded, so nothing was compared");
+        println(cerr, "oracle cross-check: {} of 300 instances overloaded at the root", fired);
+    }
+
+    // Two tasks sharing one start variable. Each still has its own per-time
+    // flags, so each gets its own window-energy line, and the two lines cancel
+    // against their own terms in the capacity lines --- but they RUP the same
+    // order literals of the same variable along the way. Three unit-height
+    // tasks of length two in [0, 2] against a capacity of one, two of them
+    // sharing a start.
+    {
+        Problem p;
+        auto shared = p.create_integer_variable(0_i, 2_i);
+        auto other = p.create_integer_variable(0_i, 2_i);
+        vector<IntegerVariableID> starts{shared, shared, other};
+        p.post(Cumulative{starts, vector<Integer>{2_i, 2_i, 2_i}, vector<Integer>{1_i, 1_i, 1_i}, 1_i}.with_rules(only_overload));
+
+        bool reached_a_node = false, found_a_solution = false;
+        auto name = "cumulative_overload_dup";
+        solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState &) -> bool {
+                               found_a_solution = true;
+                               return false;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return false;
+                }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{name}) : nullopt);
+
+        if (reached_a_node || found_a_solution)
+            fail("dup: the overload check did not refute at the root");
+        if (proofs) {
+            if (count_markers(name).total() != 1)
+                fail("dup: expected exactly one overload marker");
+            verify_proof_and_clean_up(name);
+        }
+    }
+
+    // Nothing the overload check does may reach the model.
+    {
+        check_opb_unaffected("f1", f1);
+        check_opb_unaffected("f2", f2);
+        check_opb_unaffected("sharp", sharp);
+
+        std::mt19937 rand(*get_seed());
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(-2, 4), span_dist(0, 4), len_dist(0, 3), ht_dist(0, 3), cap_dist(0, 4);
+        for (int k = 0; k < 20; ++k) {
+            Instance inst;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand), span = span_dist(rand);
+                inst.start_ranges.emplace_back(lo, lo + span);
+                inst.lengths.push_back(len_dist(rand));
+                inst.heights.push_back(ht_dist(rand));
+            }
+            inst.capacity = cap_dist(rand);
+            check_opb_unaffected("random_" + std::to_string(k), inst);
+        }
     }
 
     // The solutions must survive the new rule: it only ever reports conflicts,

--- a/gcs/constraints/cumulative/cumulative_overload_test.cc
+++ b/gcs/constraints/cumulative/cumulative_overload_test.cc
@@ -331,11 +331,25 @@ namespace
     // window energy, and the contradiction is gone. Pairwise-coprime data
     // keeps any arithmetic that happens to be right modulo a common factor
     // from passing by luck.
-    auto sharp_margin_instance(std::mt19937 & rand, int n, int horizon) -> optional<Instance>
+    // Degenerate data is tested separately from the coprime kind, not mixed in
+    // with it: equal heights, or heights and durations sharing a factor, make
+    // arithmetic that is only right modulo that factor look right, so a suite
+    // that mixed them could pass on the easy instances and say nothing about
+    // the hard ones.
+    enum class Data
+    {
+        Coprime,   ///< durations and heights all distinct primes
+        Equal,     ///< one height for every task
+        GcdHeavy,  ///< durations and heights all multiples of six
+        UnitHeight ///< every height one, which is where the capacity is small
+    };
+
+    auto sharp_margin_instance(std::mt19937 & rand, int n, int horizon, Data data) -> optional<Instance>
     {
         static const vector<int> primes{29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113};
+        static const vector<int> sixes{6, 12, 18, 24, 30, 36, 42, 48, 54, 60};
 
-        vector<int> pool = primes;
+        auto pool = (data == Data::GcdHeavy) ? sixes : primes;
         std::shuffle(pool.begin(), pool.end(), rand);
         if (static_cast<size_t>(2 * n) > pool.size())
             return nullopt;
@@ -344,7 +358,15 @@ namespace
         long long energy = 0;
         for (int i = 0; i < n; ++i) {
             auto length = pool.at(static_cast<size_t>(i));
-            auto height = pool.at(static_cast<size_t>(n + i));
+            auto height = [&]() {
+                switch (data) {
+                case Data::Coprime:
+                case Data::GcdHeavy: return pool.at(static_cast<size_t>(n + i));
+                case Data::Equal: return pool.at(static_cast<size_t>(n));
+                case Data::UnitHeight: return 1;
+                }
+                return 1;
+            }();
             if (length > horizon)
                 return nullopt;
             inst.lengths.push_back(length);
@@ -513,25 +535,28 @@ auto main(int argc, char * argv[]) -> int
     // steps.
     {
         std::mt19937 rand(*get_seed());
-        int found = 0;
-        for (int attempt = 0; attempt < 4000 && found < 4; ++attempt) {
-            std::uniform_int_distribution<> horizon_dist(120, 240);
-            auto inst = sharp_margin_instance(rand, 3, horizon_dist(rand));
-            if (! inst)
-                continue;
-            ++found;
+        for (auto [data, label] : {pair{Data::Coprime, "coprime"}, pair{Data::Equal, "equal_heights"}, pair{Data::GcdHeavy, "gcd_heavy"},
+                 pair{Data::UnitHeight, "unit_heights"}}) {
+            int found = 0;
+            for (int attempt = 0; attempt < 4000 && found < 3; ++attempt) {
+                std::uniform_int_distribution<> horizon_dist(120, 240);
+                auto inst = sharp_margin_instance(rand, 3, horizon_dist(rand), data);
+                if (! inst)
+                    continue;
+                ++found;
 
-            auto name = "cumulative_overload_primes_" + std::to_string(found);
-            println(cerr, "cumulative overload sharp margin lens={} hts={} c={} horizon={}", inst->lengths, inst->heights, inst->capacity,
-                inst->start_ranges[0].second + inst->lengths[0]);
-            auto probe = probe_root(*inst, only_overload, proofs ? make_optional(name) : nullopt);
-            if (! probe.refuted)
-                fail("sharp margin: the overload check did not refute at the root");
-            if (proofs && probe.markers.oc != 1)
-                fail("sharp margin: expected exactly one (OC') marker");
+                auto name = "cumulative_overload_sharp_" + string{label} + "_" + std::to_string(found);
+                println(cerr, "cumulative overload sharp margin {} lens={} hts={} c={} horizon={}", label, inst->lengths, inst->heights,
+                    inst->capacity, inst->start_ranges[0].second + inst->lengths[0]);
+                auto probe = probe_root(*inst, only_overload, proofs ? make_optional(name) : nullopt);
+                if (! probe.refuted)
+                    fail("sharp margin: the overload check did not refute at the root");
+                if (proofs && probe.markers.oc != 1)
+                    fail("sharp margin: expected exactly one (OC') marker");
+            }
+            if (found == 0)
+                fail("sharp margin: the " + string{label} + " generator produced nothing to test");
         }
-        if (found == 0)
-            fail("sharp margin: the generator produced nothing to test");
     }
 
     // Oracle cross-check. Over a random corpus, with time-tabling off so that

--- a/gcs/constraints/cumulative/hints.hh
+++ b/gcs/constraints/cumulative/hints.hh
@@ -17,6 +17,24 @@ namespace gcs::innards::hints
         ConstraintID originator;
         static constexpr std::string_view hint_name = "cumulative";
     };
+
+    /**
+     * \brief Cumulative's overload-check hint: the owning constraint, plus the
+     * `overload` subhint distinguishing an energy-based conflict from a
+     * time-table one.
+     *
+     * The two rules reach a contradiction by quite different derivations, so
+     * telling them apart matters when isolating one with
+     * AssertRatherThanJustifying. With no own hint_sexpr the hint takes the
+     * default identity-plus-subhint wire form,
+     * `(constraint_id <originator>)(subhint overload)`.
+     *
+     * \ingroup Innards
+     */
+    struct CumulativeOverload : Cumulative
+    {
+        static constexpr std::string_view subhint_name = "overload";
+    };
 }
 
 #endif

--- a/gcs/constraints/innards/window_energy.cc
+++ b/gcs/constraints/innards/window_energy.cc
@@ -1,0 +1,164 @@
+#include <gcs/constraints/innards/window_energy.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::innards::window_energy;
+
+using std::max;
+using std::min;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::size_t;
+using std::string;
+using std::vector;
+
+namespace
+{
+    // What the derivation looks like, once the requested window has been
+    // clipped to the flag range.
+    //
+    // Summing the per-time facts
+    //
+    //     active_t  \/  [s >= t + 1]  \/  ~[s >= t - p + 1]        (t in [a, b))
+    //
+    // gives a line whose order literals live in two ranges: V = (a, b] for the
+    // "starts after t" halves, and U = (a - p, b - p] for the "ends by t" ones.
+    // Every value in V n U contributes both [s >= w] and ~[s >= w] to that sum,
+    // which is the constant 1, so those cancel inside the pol and the survivors
+    // are the P = min(p, b - a) literals of each kind below.
+    //
+    // What is left is resolved against the start bounds: a `keep` value is one
+    // the bounds decide the right way (so a unit RUP under the reason cancels
+    // it for free), and a `lose` value one they do not (so the literal axiom
+    // cancels it at the cost of one unit of the bound).
+    struct Shape
+    {
+        Integer a, b;       // the clipped window, half-open
+        Integer u_lo, u_hi; // U \ V = [u_lo, u_hi], the "ends by t" survivors
+        Integer v_lo, v_hi; // V \ U = [v_lo, v_hi], the "starts after t" survivors
+        Integer p;          // the task's length
+        Integer bound;      // what the derivation establishes
+        [[nodiscard]] auto empty() const -> bool
+        {
+            return b <= a;
+        }
+    };
+
+    auto shape_of(Integer length, Integer flags_t_lo, size_t flags_size, Integer lo, Integer hi, pair<Integer, Integer> start_bounds) -> Shape
+    {
+        auto a = max(lo, flags_t_lo), b = min(hi, flags_t_lo + Integer(static_cast<long long>(flags_size)));
+        if (b <= a || length <= 0_i)
+            return Shape{a, a, 0_i, -1_i, 0_i, -1_i, length, 0_i};
+
+        auto p = length;
+        // |U \ V| = |V \ U| = min(p, b - a): the shift between the two ranges,
+        // capped by the window width.
+        auto count = min(p, b - a);
+        auto u_lo = a - p + 1_i, u_hi = min(a, b - p);
+        auto v_lo = max(a, b - p) + 1_i, v_hi = b;
+
+        auto [start_lb, start_ub] = start_bounds;
+        // How many of each kind the bounds decide our way. clamp to [0, count]:
+        // the bounds may reach past the end of the range in either direction.
+        auto kept_u = min(max(0_i, start_lb - u_lo + 1_i), count);
+        auto lost_v = min(max(0_i, start_ub - v_lo + 1_i), count);
+
+        return Shape{a, b, u_lo, u_hi, v_lo, v_hi, p, kept_u - lost_v};
+    }
+}
+
+auto gcs::innards::window_energy::window_energy_bound(
+    Integer length, Integer flags_t_lo, size_t flags_size, Integer lo, Integer hi, pair<Integer, Integer> start_bounds) -> Integer
+{
+    return shape_of(length, flags_t_lo, flags_size, lo, hi, start_bounds).bound;
+}
+
+auto gcs::innards::window_energy::derive_window_energy(ProofLogger & logger, const ReasonLiterals & reason, const ConstantLengthTask & task,
+    Integer lo, Integer hi, pair<Integer, Integer> start_bounds, ProofLevel level) -> optional<WindowEnergy>
+{
+    auto shape = shape_of(task.length, task.flags_t_lo, task.active.size(), lo, hi, start_bounds);
+    if (shape.empty() || shape.bound <= 0_i)
+        return nullopt;
+
+    auto & tracker = logger.names_and_ids_tracker();
+    IntegerVariableID start = task.start;
+
+    // Step 1, three pol lines per time point, ending in
+    //     active_t  \/  [s >= t + 1]  \/  ~[s >= t - p + 1] .
+    // The first two bridge a flag to an order literal of s, in the same way
+    // product_justify's order bridges do: the flag's [f] half and the order
+    // literal's defining row share the s bits, which cancel exactly, leaving a
+    // two-literal clause after saturation. The third adds active's [f] half,
+    // the AND-gate clause active \/ ~before \/ ~after, whose before and after
+    // terms then cancel against the two bridges.
+    vector<ProofLine> per_time;
+    per_time.reserve(static_cast<size_t>((shape.b - shape.a).raw_value));
+    for (Integer t = shape.a; t < shape.b; ++t) {
+        auto idx = static_cast<size_t>((t - task.flags_t_lo).raw_value);
+
+        PolBuilder before_bridge;
+        before_bridge.add(ProofLineLabel{tracker.name_of(task.before[idx]) + "[f]"});
+        before_bridge.add_for_literal(tracker, start < t + 1_i);
+        before_bridge.saturate();
+        auto before_clause = before_bridge.emit(logger, level);
+
+        PolBuilder after_bridge;
+        after_bridge.add(ProofLineLabel{tracker.name_of(task.after[idx]) + "[f]"});
+        after_bridge.add_for_literal(tracker, start >= t - shape.p + 1_i);
+        after_bridge.saturate();
+        auto after_clause = after_bridge.emit(logger, level);
+
+        PolBuilder step;
+        step.add(ProofLineLabel{tracker.name_of(task.active[idx]) + "[f]"});
+        step.add(before_clause);
+        step.add(after_clause);
+        per_time.push_back(step.emit(logger, level));
+    }
+
+    // Step 2, one pol summing them, into which the order literals telescope.
+    PolBuilder sum;
+    for (const auto & line : per_time)
+        sum.add(line);
+
+    // The "ends by t" survivors. [s >= u] holds under the reason when
+    // u <= lb(s), and a unit RUP of it cancels the ~[s >= u] term for free;
+    // otherwise the literal axiom [s >= u] >= 0 cancels it at the cost of one.
+    auto kept_u = 0_i;
+    for (Integer u = shape.u_lo; u <= shape.u_hi; ++u) {
+        if (u <= start_bounds.first) {
+            sum.add(logger.emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (start >= u) >= 1_i, level));
+            ++kept_u;
+        }
+        else
+            sum.add(tracker.xliteral_for_ensuring(task.start >= u), tracker);
+    }
+
+    // The "starts after t" survivors, mirror image: ~[s >= v] holds under the
+    // reason when v > ub(s).
+    auto lost_v = 0_i;
+    for (Integer v = shape.v_lo; v <= shape.v_hi; ++v) {
+        if (v > start_bounds.second)
+            sum.add(logger.emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * (start < v) >= 1_i, level));
+        else {
+            sum.add(! tracker.xliteral_for_ensuring(task.start >= v), tracker);
+            ++lost_v;
+        }
+    }
+
+    // The bound the emission just built must be the one shape_of predicted:
+    // the caller scales this line by a height and expects a specific total, so
+    // a disagreement here would surface only as a rejected proof much later.
+    if (kept_u - lost_v != shape.bound)
+        throw ProofError{"window energy derivation and its predicted bound disagree"};
+
+    return WindowEnergy{sum.emit(logger, level), shape.bound, shape.a, shape.b};
+}

--- a/gcs/constraints/innards/window_energy.hh
+++ b/gcs/constraints/innards/window_energy.hh
@@ -1,0 +1,103 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_WINDOW_ENERGY_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_INNARDS_WINDOW_ENERGY_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/reason.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace gcs::innards::window_energy
+{
+    /**
+     * \brief A task, as the window-energy lemma sees it: a start variable with a
+     * constant duration, plus the per-time proof flags a time-table encoding
+     * gives it.
+     *
+     * The three flag vectors are indexed by <code>t - flags_t_lo</code>, and
+     * must be fully reified (so that both their <code>[r]</code> and
+     * <code>[f]</code> halves are citable by label) as
+     *
+     * <ul>
+     * <li><code>before[t] &hArr; start &le; t</code></li>
+     * <li><code>after[t] &hArr; start &ge; t - length + 1</code></li>
+     * <li><code>active[t] &hArr; before[t] &and; after[t]</code></li>
+     * </ul>
+     *
+     * which is exactly what <code>Cumulative::define_proof_model</code> emits.
+     *
+     * The flag range must cover every time at which the task can be active
+     * (i.e. <code>[lb(start), ub(start) + length - 1]</code> at the time the
+     * flags were created): the lemma clips its window to the flag range, and
+     * that clipping is only energy-preserving because the task is inactive
+     * outside it.
+     */
+    struct ConstantLengthTask
+    {
+        SimpleIntegerVariableID start;
+        Integer length;
+        Integer flags_t_lo;
+        const std::vector<ProofFlag> & before;
+        const std::vector<ProofFlag> & after;
+        const std::vector<ProofFlag> & active;
+    };
+
+    /**
+     * \brief What derive_window_energy() proved.
+     */
+    struct WindowEnergy
+    {
+        /// The derived line: <code>sum of active[t] for t in [lo, hi) &ge; bound</code>.
+        ProofLine line;
+        /// The bound the line establishes. Always at least 1 when a line exists.
+        Integer bound;
+        /// The window the sum actually runs over: the requested window clipped
+        /// to the task's flag range.
+        Integer lo, hi;
+    };
+
+    /**
+     * \brief How much activity a window-energy derivation over this window
+     * would establish, without emitting anything.
+     *
+     * This is the minimum, over every start position still allowed by
+     * <code>start_bounds</code>, of the overlap between the task's execution
+     * interval and the window --- i.e. the strongest bound the lemma can
+     * certify. Callers use it to decide whether a window is worth an emission,
+     * and tests use it as the oracle the emitted claim must match.
+     */
+    [[nodiscard]] auto window_energy_bound(
+        Integer length, Integer flags_t_lo, std::size_t flags_size, Integer lo, Integer hi, std::pair<Integer, Integer> start_bounds) -> Integer;
+
+    /**
+     * \brief Derive a lower bound on a task's activity inside a time window.
+     *
+     * Under the reason context (which must entail <code>start_bounds</code>),
+     * derives
+     *
+     * <blockquote>
+     * sum of <code>active[t]</code> for <code>t</code> in the window &ge; bound
+     * </blockquote>
+     *
+     * in O(window width) proof steps, and returns the line. The derivation is
+     * three steps per time point --- two saturated two-line pols bridging
+     * <code>before</code> / <code>after</code> to the start variable's order
+     * literals, and one combining them with the <code>active</code> AND-gate
+     * --- followed by one pol summing them, into which the order literals
+     * telescope: the sum's <code>start</code> terms cancel exactly, in the
+     * same way the <code>end</code> bridge lemma's operand bits do.
+     *
+     * Returns nullopt when the window is empty after clipping, or when the
+     * bound would be zero or less (there is nothing to say, and callers must
+     * not cite a line that was never emitted).
+     */
+    [[nodiscard]] auto derive_window_energy(ProofLogger &, const ReasonLiterals &, const ConstantLengthTask &, Integer lo, Integer hi,
+        std::pair<Integer, Integer> start_bounds, ProofLevel) -> std::optional<WindowEnergy>;
+}
+
+#endif

--- a/run_test_and_expect_verify_failure.bash
+++ b/run_test_and_expect_verify_failure.bash
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Usage: run_test_and_expect_verify_failure.bash [--basename NAME] PROGRAM [ARGS...]
+#
+# The inverse of run_test_and_verify.bash: runs PROGRAM with --prove, then
+# checks that veripb *rejects* the resulting proof.
+#
+# This is for mutation testing. A propagator whose derivation has slack in it
+# writes proofs that verify even when one step is deliberately corrupted --- so
+# "veripb accepts" on its own says little about whether the honest derivation
+# is load-bearing. A test binary run under this harness emits a knowingly wrong
+# proof (see e.g. CumulativeProofMutation), and the run passes only if veripb
+# says no. If veripb accepts, the honest derivation was slack, and that is a
+# finding about the propagator, not about the harness.
+#
+# PROGRAM must still exit successfully: this checks the proof, not the program,
+# and a crash or a failed assertion is a test failure like any other. As in
+# run_test_and_verify.bash, pass --basename when several ctest entries share one
+# binary, so they do not race over one set of proof files (issue #562); PROGRAM
+# must accept --proof-files-basename for the override to work.
+#
+# The proof files are always disposed of on success (i.e. on rejection), since
+# they are exactly the ones we expected to be bad; they are kept when veripb
+# unexpectedly accepts, which is when there is something to look at. Set
+# GCS_PRESERVE_PROOF_FILES to keep them either way.
+
+set -u
+
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=proof_file_disposal.bash
+. "$(dirname "$0")/proof_file_disposal.bash"
+
+basename_override=
+if [[ ${1:-} == --basename ]] ; then
+    basename_override=$2
+    shift 2
+fi
+
+prog=$1
+shift
+
+progname=$(basename "$prog")
+progname=${progname%.exe}
+
+proofname=${basename_override:-$progname}
+
+export PATH=$HOME/.cargo/bin:$PATH
+
+if [[ -n $basename_override ]] ; then
+    "$prog" --prove --proof-files-basename "$proofname" "$@" || exit 1
+else
+    "$prog" --prove "$@" || exit 1
+fi
+
+if veripb "${proofname}.opb" "${proofname}.pbp" ; then
+    echo "veripb accepted ${proofname}.pbp, but this proof was deliberately corrupted:" >&2
+    echo "the honest derivation it was made from has slack in it." >&2
+    exit 1
+fi
+
+echo "veripb rejected ${proofname}.pbp, as expected"
+dispose_proof "$proofname"


### PR DESCRIPTION
Issue 01 of the Cumulative proof-logging plan (#541), from #542.

Adds the overload check — Cloutier & Quimper's (OC'), strengthened by the
mandatory-part profile to their (TTOC) — to `Cumulative`, as a conflict-only
rule sitting between time-tabling's overflow scan and its bound pushes. The
propagation it adds is the small part; the deliverable is the **window-energy
lemma** underneath it, which issues #549 and #550 consume.

## The lemma

`gcs/constraints/innards/window_energy.{hh,cc}` derives, for a constant-length
task under a reason that bounds its start,

```
    Σ_{t ∈ [a,b)} active_{i,t}  ≥  the task's guaranteed activity in the window
```

in three `pol` lines per time point plus one summing `pol`. Per time point:

```
    before_t \/ [s ≥ t+1]                      cb[f] + Def([s < t+1]),   saturate
    after_t  \/ ~[s ≥ t-p+1]                   ca[f] + Def([s ≥ t-p+1]), saturate
    active_t \/ [s ≥ t+1] \/ ~[s ≥ t-p+1]      cact[f] + the two above
```

The first two are order bridges of the shape `product_justify` already uses —
the flag's `[f]` half and the order literal's defining row share the start's
bits, which cancel, and saturation leaves a two-literal clause. Summing over
the window telescopes the order literals: every value appearing in both ranges
contributes a literal and its negation, so it cancels inside the `pol`, and the
`min(p, b−a)` survivors at each end are resolved against the start bounds —
a unit RUP under the reason where the bounds decide them, and a bare literal
axiom (`lit ≥ 0`) where they do not, at a cost of one unit of the bound. That
last part is what makes the clipped form work, which is what #549/#550 need.

No new OPB content: everything is a derivation at `ProofLevel::Temporary`
inside the conflict's justification, citing flag definitions the time-table
encoding already writes.

## Scope, staged as #542 asks

Constants only for now: a task joins a window's energy set when its length and
height are constants and its start is a plain variable with an order encoding,
and the whole check is skipped when the capacity is a variable (a
`(b−a)·capacity` term would survive into the conflict line for the wrapping RUP
to dispose of over the capacity's bits, which it cannot do in general). None of
these lose solutions: an excluded task still counts through the profile term.
The seam where optional tasks (#543) will restrict the energy set is marked.

## Validation

The rule fires **nowhere** in the existing cumulative corpus, so that suite
being green said nothing about it. `cumulative_overload_test` is where the
claims are made:

- **Differential fixtures with negative twins.** F1: (OC') fires, time-tabling
  is silent. F2: (TTOC) is needed and (OC') is not enough. Each asserts the
  marker-comment count in the `.pbp`, so "fired" is distinguished from
  "compiled in", and each twin — one step the other side of the threshold —
  asserts it did not fire at all.
- **An oracle cross-check.** The two rules written out from their definitions
  over a plain double loop, sharing no code with the propagator. Over 300
  random instances (including negative start times, so windows run over signed
  encodings), with time-tabling off so an overload conflict is the only
  conflict available, the propagator refutes at the root exactly when the
  oracle says a window is overloaded. This is what caught a bug in my own
  probe, incidentally.
- **Sharp margins.** Hand-written and generated instances whose energy exceeds
  their supply by exactly one, over durations and heights drawn from distinct
  primes. Degenerate data (equal heights, gcd-heavy, unit heights) is generated
  and asserted separately, so a pass on the friendly arithmetic cannot be
  mistaken for a pass on the hard kind.
- **Mutation lanes.** `CumulativeProofMutation` (tests only) breaks one step —
  overstate one task's window energy by one, omit a capacity line, shrink the
  lemma's window — and `run_test_and_expect_verify_failure.bash`, the inverse
  of `run_test_and_verify.bash`, passes only if veripb rejects. All three are
  rejected at the sharp margin, so the honest derivation has no slack. The
  script is introduced here for the rest of #541 to reuse.
- **OPB byte-diff.** The model is identical with the rule on, off, and mutated,
  over a corpus. Checked against `main` by hand as well: all twenty `.opb` and
  `.scp` files `cumulative_test` writes are byte-identical.
- **Enumeration against brute force** throughout (the soundness net for a
  conflict-only rule), plus a shared-start-variable case.

Full `ctest` (frontends on): 610/610. Also built and run under clang 21.

## Not here

Variable lengths/heights/capacity in the energy set, edge-finding, bound
adjustment from energy reasoning, and explanation minimisation. The derivation
is written out in `dev_docs/cumulative-proof-logging.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p