### PR TITLE
Certified subset-sum strengthening utility (#544)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -134,6 +134,13 @@ library. For an introduction to *using* the solver, start with the top-level
   `BinPacking` Stage 3. Covers the `define_proof_model` /
   `install_initialiser` split, the paper-style reified scaffolding, the
   per-call proof chain, and the measured default-vs-opt-in trade-off.
+- [Subset-sum strengthening](subset-sum-strengthening.md) — tightening a derived
+  `Σ c_i x_i ≤ B` to the largest subset sum at most `B`, by Chvátal–Gomory
+  rounding when the coefficients share a factor and by a layered dynamic
+  programme otherwise. Covers why the two lines have the same solutions but not
+  the same strength, the clause resolution that stands in for the case split
+  unit propagation cannot do, and why a satisfiable test model and an `ia`
+  content check are both needed to test it.
 - [Restarts, nogoods, and dom/wdeg weighting](restarts-nogoods-weighting.md) —
   the search-side machinery from issue #315: the restart loop and its
   `SearchResult` unwind signal, `RestartSchedule`, the `ConflictObserver`

--- a/dev_docs/subset-sum-strengthening.md
+++ b/dev_docs/subset-sum-strengthening.md
@@ -1,0 +1,132 @@
+# Subset-sum strengthening
+
+A derived line saying
+
+```
+    Σ c_i x_i  ≤  B
+```
+
+over 0/1 terms can nearly always be tightened for free. The sum can only ever
+take a value that is a subset sum of the coefficients, so if no subset sums into
+`(B′, B]` then `Σ c_i x_i ≤ B′` holds too, where `B′` is the largest subset sum
+at most `B`. `derive_subset_sum_strengthening`
+([`gcs/innards/proofs/subset_sum_strengthening.hh`](../gcs/innards/proofs/subset_sum_strengthening.hh))
+derives that line.
+
+The two lines have the **same 0/1 solutions** — nothing lives in the gap — so
+this buys no propagation on its own. What it buys is a tighter *inequality*, and
+that matters as soon as the line is added to another one: `Σ c_i x_i ≤ B` plus
+`Σ c_i x_i ≥ B′ + 1` is perfectly consistent over the rationals, while the
+strengthened form contradicts it in one `pol` step. That is the shape all three
+consumers need — the knapsack-augmented overload check's availability bound
+(#550), Schulz's capacity reduction (#547), and single-resource lifting
+certificates (#549).
+
+## The two derivations
+
+### Divisibility, when the coefficients share a factor
+
+If `d = gcd(c_i) > 1` and `d·⌊B/d⌋` is the answer, the whole thing is
+Chvátal–Gomory rounding: divide the source line by `d`, multiply back. Two
+`pol` steps, no flags. This is the common case whenever a model's coefficients
+have a scale to them.
+
+The condition is on the gcd of **every** coefficient. `{6, 10, 15}` has pairwise
+gcds all above one and an overall gcd of one, and rounding `14` down to `12`
+would be wrong (the answer is `10`) — so a fast path keyed on anything weaker
+than the full gcd is a bug, and there is a fixture for exactly that.
+
+### Layered dynamic programming, otherwise
+
+One layer per item. Layer `k` speaks about the prefix sum `P_k = Σ_{i≤k} c_i x_i`,
+and has one state per value that prefix can reach without already exceeding `B`.
+Each state `(k, v)` gets three flags, reified at the requested `ProofLevel`:
+
+```
+    ge_{k,v}  ⇔  P_k ≥ v
+    le_{k,v}  ⇔  P_k ≤ v
+    st_{k,v}  ⇔  ge_{k,v} ∧ le_{k,v}        (the prefix sum is exactly v)
+```
+
+This is the shape [`Knapsack`'s upfront DAG](knapsack.md) uses, specialised to
+one coordinate and 0/1 items.
+
+**Transitions.** Four clauses per state, each a `pol` over two reification
+halves plus a literal axiom, saturated — the prefix-sum terms cancel exactly,
+the same cancellation the `Cumulative` window-energy bridges use:
+
+```
+    ¬ge_{k-1,u}  ∨  ge_{k,u}                    (the sum only grows)
+    ¬x_k ∨ ¬ge_{k-1,u}  ∨  ge_{k,u+c_k}         (taking the item)
+    ¬le_{k-1,u}  ∨  le_{k,u+c_k}                (the item adds at most c_k)
+    x_k  ∨ ¬le_{k-1,u}  ∨  le_{k,u}             (leaving the item)
+```
+
+From those, two state-level transitions are RUP — `¬st_{k-1,u} ∨ x_k ∨ st_{k,u}`
+and `¬st_{k-1,u} ∨ ¬x_k ∨ st_{k,u+c_k}` — and adding those two and saturating
+**resolves them on the item literal**:
+
+```
+    ¬st_{k-1,u}  ∨  st_{k,u}  ∨  st_{k,u+c_k}
+```
+
+That resolution is the load-bearing step. Unit propagation cannot case-split on
+`x_k`, and a `pol` over the weighted lines cannot either; resolving two clauses
+is how cutting planes does it, which is why the derivation goes through
+clause-shaped intermediates rather than staying with the weighted forms.
+
+**Layer at-least-ones.** `Σ_{v} st_{k,v} ≥ 1` — "the prefix sum is in one of
+these states" — is then a RUP against the previous layer's version: negating it
+falsifies every successor, each transition forces `¬st_{k-1,u}`, and the
+previous at-least-one is contradicted.
+
+**Dead states.** A prefix sum over `B` cannot be completed: the source line
+bounds the whole sum and no coefficient is negative. So states above `B` are
+never created. Instead the clause `¬st_{k-1,u} ∨ ¬x_k` is derived from the
+source line (plus a literal axiom per later item, to cancel the tail), and
+resolved into the transition, which leaves the state with only its stay branch.
+
+**Finishing.** Every state of the last layer is at most `B′` — that is what makes
+`B′` the answer — so each gives `¬st_{n,v} ∨ under`, where `under ⇔ Σ c_i x_i ≤ B′`.
+With the last at-least-one, `under` is a RUP; discharging its forward half
+against that unit is the returned line.
+
+Size is O(items × bound) flags in the worst case. In practice: six coprime
+weights against a bound of 83 — sixteen states over seven layers — is about 630
+proof lines and 50 KB. A caller working with a large bound should budget, and
+reach for this where it pays rather than everywhere.
+
+## Testing it
+
+`subset_sum_strengthening_test` makes three separate claims, because they are
+three different things:
+
+1. **The answer is right.** The bitset subset-sum is checked against brute force
+   over random weight sets — primes, near-duplicates, gcd-structured — and over
+   the hand-verified fixtures.
+2. **The derivation follows.** Each fixture is proved against a *satisfiable*
+   micro model (the source line alone), so every step has to stand on its own.
+   This is the model that catches a derivation claiming more than it proved: an
+   unsatisfiable model would make every RUP step valid and let a corrupted
+   derivation through, which is worth remembering when writing this kind of test.
+3. **The line says what the caller was told.** veripb accepting every step does
+   *not* say this: a sound step can land on something weaker than intended, and
+   a caller scaling it by a height or adding it to a capacity row would then be
+   working from a line that does not carry the bound it is supposed to. So each
+   proof also pins the returned line's content with an `ia` step, whose
+   implication check is syntactic — a weaker line does not imply the claimed one,
+   and veripb says so.
+
+Plus the end-to-end use: against a model with an extra axiom putting the sum
+above `B′`, the strengthened line and that axiom combine into a contradiction in
+one `pol`, and an `ia` against the result insists it really is one.
+
+The mutations (`SubsetSumMutation`, tests only) are each caught by exactly one
+of those nets, which is the point of keeping them separate: claiming one better
+than the largest reachable sum breaks a RUP step (net 2); skipping a layer's
+transitions leaves its at-least-one unsupported (net 2); and dividing by
+something that does not divide every coefficient is a perfectly sound proof step
+that simply does not establish the claimed bound (net 3, and nothing else would
+notice).
+
+<!-- vim: set tw=72 spell spelllang=en : -->

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(glasgow_constraint_solver
         innards/proofs/proof_only_variables.cc
         innards/proofs/scp_writer.cc
         innards/proofs/simplify_literal.cc
+        innards/proofs/subset_sum_strengthening.cc
         innards/propagators.cc
         innards/reason.cc
         innards/s_expr.cc
@@ -552,6 +553,12 @@ if(GCS_BUILD_TESTS)
     add_executable(eqvar_polarity_test innards/proofs/eqvar_polarity_test.cc)
     target_link_libraries(eqvar_polarity_test PRIVATE glasgow_constraint_solver)
     add_test(NAME eqvar_polarity_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eqvar_polarity_test>)
+
+    add_executable(subset_sum_strengthening_test innards/proofs/subset_sum_strengthening_test.cc)
+    target_link_libraries(subset_sum_strengthening_test PRIVATE glasgow_constraint_solver)
+    # Verifies (and deliberately fails to verify) its own proofs internally, so
+    # it needs no wrapper.
+    add_test(NAME subset_sum_strengthening_test COMMAND $<TARGET_FILE:subset_sum_strengthening_test>)
 
     add_executable(introduce_bits_test innards/proofs/introduce_bits_test.cc)
     target_link_libraries(introduce_bits_test PRIVATE glasgow_constraint_solver)

--- a/gcs/innards/proofs/subset_sum_strengthening.cc
+++ b/gcs/innards/proofs/subset_sum_strengthening.cc
@@ -1,0 +1,336 @@
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/simplify_literal.hh>
+#include <gcs/innards/proofs/subset_sum_strengthening.hh>
+
+#include <util/overloaded.hh>
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <numeric>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::map;
+using std::string;
+using std::to_string;
+using std::vector;
+
+namespace
+{
+    auto add_term_to(WPBSum & sum, Integer coefficient, const ProofLiteralOrFlag & term) -> void
+    {
+        overloaded{                                                      //
+            [&](const ProofLiteral & l) { sum += coefficient * l; },     //
+            [&](const ProofFlag & f) { sum += coefficient * f; },        //
+            [&](const ProofBitVariable & b) { sum += coefficient * b; }} //
+            .visit(term);
+    }
+
+    // The file-format literal for a term, so that it can be pushed onto a pol
+    // stack as a literal axiom (`x >= 0`). Constants have no literal, and an
+    // item that is always in or always out of the sum is a caller error rather
+    // than something to silently ignore.
+    auto xliteral_of(NamesAndIDsTracker & tracker, const ProofLiteralOrFlag & term) -> XLiteral
+    {
+        return overloaded{//
+            [&](const ProofLiteral & l) -> XLiteral {
+                return overloaded{                                                                                                        //
+                    [&](const VariableConditionFrom<SimpleIntegerVariableID> & c) { return tracker.xliteral_for_ensuring(c); },           //
+                    [&](const ProofVariableCondition & c) { return tracker.xliteral_for_ensuring(c); },                                   //
+                    [&](const TrueLiteral &) -> XLiteral { throw ProofError{"subset sum strengthening over a constantly true term"}; },   //
+                    [&](const FalseLiteral &) -> XLiteral { throw ProofError{"subset sum strengthening over a constantly false term"}; }} //
+                    .visit(simplify_literal(tracker, l));
+            },                                                                     //
+            [&](const ProofFlag & f) { return tracker.xliteral_for(f); },          //
+            [&](const ProofBitVariable & b) { return tracker.get_bit(b).second; }} //
+            .visit(term);
+    }
+
+    // Which sums the coefficients can reach, as a bitset: bit v is set iff some
+    // subset sums to v. mask |= mask << c per item, which is the whole
+    // algorithm.
+    auto reachable_sums(const vector<Integer> & coefficients, Integer bound) -> vector<uint64_t>
+    {
+        auto words = static_cast<size_t>(bound.raw_value / 64 + 1);
+        vector<uint64_t> mask(words, 0);
+        mask[0] = 1;
+
+        for (const auto & c : coefficients) {
+            if (c > bound)
+                continue;
+            auto shift = static_cast<size_t>(c.raw_value);
+            auto word_shift = shift / 64, bit_shift = shift % 64;
+            // Descending, so that each item is used at most once.
+            for (size_t w = words; w-- > 0;) {
+                uint64_t shifted = 0;
+                if (w >= word_shift) {
+                    shifted = mask[w - word_shift] << bit_shift;
+                    if (bit_shift != 0 && w > word_shift)
+                        shifted |= mask[w - word_shift - 1] >> (64 - bit_shift);
+                }
+                mask[w] |= shifted;
+            }
+        }
+
+        // Bits past the bound are meaningless (the shifts run off the end of
+        // the last word), so clear them rather than let a caller read one.
+        auto top = static_cast<size_t>(bound.raw_value % 64);
+        if (top != 63)
+            mask[words - 1] &= (uint64_t{1} << (top + 1)) - 1;
+
+        return mask;
+    }
+
+    auto is_reachable(const vector<uint64_t> & mask, Integer v) -> bool
+    {
+        return 0 != (mask[static_cast<size_t>(v.raw_value / 64)] & (uint64_t{1} << (v.raw_value % 64)));
+    }
+
+    // One reachable partial sum, at one layer: the flags saying the prefix sum
+    // is at least it, at most it, and (their conjunction) exactly it, with the
+    // two halves of each reification.
+    struct LayerState
+    {
+        ProofFlag at_least, at_most, exactly;
+        ProofLine at_least_forward, at_least_reverse;
+        ProofLine at_most_forward, at_most_reverse;
+        ProofLine exactly_forward;
+    };
+
+    auto make_state(ProofLogger & logger, const WPBSum & prefix, Integer value, size_t layer, ProofLevel level) -> LayerState
+    {
+        auto tag = "_" + to_string(layer) + "_" + to_string(value.raw_value);
+        auto [at_least, ge_fwd, ge_rev] = logger.create_proof_flag_reifying(prefix >= value, "ssge" + tag, level);
+        auto [at_most, le_fwd, le_rev] = logger.create_proof_flag_reifying(prefix <= value, "ssle" + tag, level);
+        auto [exactly, eq_fwd, eq_rev] = logger.create_proof_flag_reifying(WPBSum{} + 1_i * at_least + 1_i * at_most >= 2_i, "sseq" + tag, level);
+        return LayerState{at_least, at_most, exactly, ge_fwd, ge_rev, le_fwd, le_rev, eq_fwd};
+    }
+}
+
+auto gcs::innards::largest_subset_sum_at_most(const vector<Integer> & coefficients, Integer bound) -> Integer
+{
+    if (bound < 0_i)
+        throw ProofError{"subset sum strengthening needs a non-negative bound"};
+    for (const auto & c : coefficients)
+        if (c <= 0_i)
+            throw ProofError{"subset sum strengthening needs strictly positive coefficients"};
+
+    auto mask = reachable_sums(coefficients, bound);
+    for (Integer v = bound; v >= 0_i; --v)
+        if (is_reachable(mask, v))
+            return v;
+
+    throw ProofError{"subset sum strengthening: zero is always reachable"};
+}
+
+auto gcs::innards::derive_subset_sum_strengthening(ProofLogger & logger, const vector<SubsetSumItem> & items, ProofLine source, Integer bound,
+    ProofLevel level, SubsetSumMutation mutation) -> SubsetSumStrengthening
+{
+    vector<Integer> coefficients;
+    coefficients.reserve(items.size());
+    for (const auto & item : items)
+        coefficients.push_back(item.coefficient);
+
+    auto strengthened = largest_subset_sum_at_most(coefficients, bound);
+    auto claim_one_better = std::holds_alternative<subset_sum_mutation::ClaimOneBetter>(mutation);
+    auto bogus_divisor = std::holds_alternative<subset_sum_mutation::BogusDivisor>(mutation);
+    auto skip_a_layer = std::holds_alternative<subset_sum_mutation::SkipALayer>(mutation);
+
+    // Nothing to say: the bound is already a sum the coefficients can reach.
+    // Re-deriving it would be a line that says exactly what the caller already
+    // had.
+    if (strengthened == bound && ! claim_one_better && ! bogus_divisor)
+        return SubsetSumStrengthening{source, bound, false};
+
+    auto claimed = claim_one_better ? strengthened - 1_i : strengthened;
+
+    auto & tracker = logger.names_and_ids_tracker();
+
+    WPBSum total;
+    for (const auto & item : items)
+        add_term_to(total, item.coefficient, item.term);
+
+    // Divisibility: every coefficient is a multiple of d, so the sum is too,
+    // and rounding the bound down to a multiple of d loses nothing. Divide,
+    // then multiply back --- Chvatal-Gomory rounding in two pol steps.
+    auto divisor = 0_i;
+    for (const auto & c : coefficients)
+        divisor = Integer{std::gcd(divisor.raw_value, c.raw_value)};
+    if (bogus_divisor) {
+        // The smallest divisor that does *not* divide everything. Dividing by
+        // it is still a sound proof step --- division rounds --- but the line
+        // it lands on is not the one the caller is told about.
+        divisor = 2_i;
+        while (std::all_of(coefficients.begin(), coefficients.end(), [&](const Integer & c) { return c % divisor == 0_i; }))
+            ++divisor;
+    }
+
+    if (bogus_divisor || (divisor > 1_i && divisor * (bound / divisor) == claimed)) {
+        PolBuilder rounding;
+        rounding.add(source);
+        rounding.divide_by(divisor);
+        rounding.multiply_by(divisor);
+        logger.emit_proof_comment("subset sum strengthening by divisibility: " + to_string(bound.raw_value) + " to " + to_string(claimed.raw_value) +
+            ", divisor " + to_string(divisor.raw_value));
+        return SubsetSumStrengthening{rounding.emit(logger, level), claimed, true};
+    }
+
+    logger.emit_proof_comment(
+        "subset sum strengthening by dynamic programming: " + to_string(bound.raw_value) + " to " + to_string(claimed.raw_value));
+
+    // Layered dynamic programming. Layer k speaks about the prefix sum of the
+    // first k items, and has one state per value that prefix can reach without
+    // already exceeding the bound. A prefix that exceeds the bound is dead: the
+    // source line says the whole sum is at most the bound, and every remaining
+    // coefficient is non-negative, so no such prefix can be completed.
+    vector<map<Integer, LayerState>> layers;
+    WPBSum prefix;
+
+    layers.emplace_back();
+    layers.back().emplace(0_i, make_state(logger, prefix, 0_i, 0, level));
+    // Layer zero's prefix is the empty sum, so both halves are tautologies and
+    // both flags are pinned true by their own reifications: the at-least-one
+    // is a one-line RUP. Every later layer's at-least-one is a RUP against the
+    // previous one, which is why they are emitted rather than kept: unit
+    // propagation finds them in the database.
+    logger.emit_rup_proof_line(WPBSum{} + 1_i * layers.back().at(0_i).exactly >= 1_i, level);
+
+    for (size_t k = 0; k < items.size(); ++k) {
+        const auto & item = items[k];
+        auto item_literal = xliteral_of(tracker, item.term);
+        auto negated_item_literal = xliteral_of(tracker, ! item.term);
+
+        const auto & before = layers.back();
+        auto after_prefix = prefix;
+        add_term_to(after_prefix, item.coefficient, item.term);
+
+        // The states this layer can be in, and the transitions into them.
+        map<Integer, LayerState> after;
+        for (const auto & [value, state] : before) {
+            if (! after.contains(value))
+                after.emplace(value, make_state(logger, after_prefix, value, k + 1, level));
+            auto advanced = value + item.coefficient;
+            if (advanced <= bound && ! after.contains(advanced))
+                after.emplace(advanced, make_state(logger, after_prefix, advanced, k + 1, level));
+        }
+
+        // Tests only: leaving one layer's transitions out means its
+        // at-least-one has nothing to stand on.
+        auto skip_this_layer = skip_a_layer && k == items.size() / 2;
+
+        for (const auto & [value, state] : before) {
+            const auto & stay = after.at(value);
+            auto advanced = value + item.coefficient;
+
+            // Carrying the lower bound needs nothing: the prefix sum only ever
+            // grows. Carrying the upper bound needs the item to be out.
+            PolBuilder carry_at_least;
+            carry_at_least.add(state.at_least_forward).add(stay.at_least_reverse).add(item_literal, item.coefficient, tracker).saturate();
+            carry_at_least.emit(logger, level);
+
+            PolBuilder carry_at_most;
+            carry_at_most.add(state.at_most_forward).add(stay.at_most_reverse).saturate();
+            carry_at_most.emit(logger, level);
+
+            // Item out: the state stays where it was.
+            WPBSum stays;
+            stays += 1_i * ! state.exactly;
+            add_term_to(stays, 1_i, item.term);
+            stays += 1_i * stay.exactly;
+            auto stay_transition = logger.emit_rup_proof_line(move(stays) >= 1_i, level);
+
+            if (advanced <= bound) {
+                const auto & step = after.at(advanced);
+
+                // Advancing the lower bound needs the item to be in; advancing
+                // the upper bound needs nothing, since the item can add at
+                // most its coefficient.
+                PolBuilder advance_at_least;
+                advance_at_least.add(state.at_least_forward)
+                    .add(step.at_least_reverse)
+                    .add(negated_item_literal, item.coefficient, tracker)
+                    .saturate();
+                advance_at_least.emit(logger, level);
+
+                PolBuilder advance_at_most;
+                advance_at_most.add(state.at_most_forward).add(step.at_most_reverse).add(negated_item_literal, item.coefficient, tracker).saturate();
+                advance_at_most.emit(logger, level);
+
+                WPBSum steps;
+                steps += 1_i * ! state.exactly;
+                add_term_to(steps, 1_i, ! item.term);
+                steps += 1_i * step.exactly;
+                auto step_transition = logger.emit_rup_proof_line(move(steps) >= 1_i, level);
+
+                // Either way the layer moves to one of the two states:
+                // resolving the two transitions on the item literal.
+                if (! skip_this_layer) {
+                    PolBuilder resolve;
+                    resolve.add(stay_transition).add(step_transition).saturate();
+                    resolve.emit(logger, level);
+                }
+            }
+            else {
+                // Taking the item from here would put the prefix past the
+                // bound, which the source line forbids. So the item is out,
+                // and the only transition is the one that stays.
+                PolBuilder dead;
+                dead.add(state.at_least_forward).add(source);
+                for (size_t later = k + 1; later < items.size(); ++later)
+                    dead.add(xliteral_of(tracker, items[later].term), items[later].coefficient, tracker);
+                dead.add(negated_item_literal, item.coefficient, tracker).saturate();
+                dead.emit(logger, level);
+
+                WPBSum out;
+                out += 1_i * ! state.exactly;
+                add_term_to(out, 1_i, ! item.term);
+                auto item_is_out = logger.emit_rup_proof_line(move(out) >= 1_i, level);
+
+                if (! skip_this_layer) {
+                    PolBuilder resolve;
+                    resolve.add(stay_transition).add(item_is_out).saturate();
+                    resolve.emit(logger, level);
+                }
+            }
+        }
+
+        // The prefix sum is in one of this layer's states: with every
+        // transition in hand, that follows from the previous layer's version
+        // of the same statement.
+        WPBSum at_least_one;
+        for (const auto & [value, state] : after)
+            at_least_one += 1_i * state.exactly;
+        logger.emit_rup_proof_line(move(at_least_one) >= 1_i, level);
+
+        layers.push_back(move(after));
+        prefix = move(after_prefix);
+    }
+
+    // Every state of the last layer is at most the strengthened bound --- that
+    // is what makes it the strengthened bound --- so whichever one holds, the
+    // sum is under it.
+    auto [under, under_forward, under_reverse] = logger.create_proof_flag_reifying(total <= claimed, "ssunder", level);
+    for (const auto & [value, state] : layers.back()) {
+        PolBuilder dominated;
+        dominated.add(state.at_most_forward).add(under_reverse).saturate();
+        dominated.emit(logger, level);
+        logger.emit_rup_proof_line(WPBSum{} + 1_i * ! state.exactly + 1_i * under >= 1_i, level);
+    }
+
+    auto under_holds = logger.emit_rup_proof_line(WPBSum{} + 1_i * under >= 1_i, level);
+
+    // Discharge the flag: its forward half is the strengthened line, weakened
+    // by the reification coefficient, and the unit above pays exactly that
+    // coefficient back.
+    auto shape = tracker.reification_shape(total <= claimed, HalfReifyOnConjunctionOf{{under}});
+    PolBuilder discharge;
+    discharge.add(under_forward).add(under_holds, -shape.reif_coefficient);
+    return SubsetSumStrengthening{discharge.emit(logger, level), claimed, false};
+}

--- a/gcs/innards/proofs/subset_sum_strengthening.hh
+++ b/gcs/innards/proofs/subset_sum_strengthening.hh
@@ -1,0 +1,140 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_SUBSET_SUM_STRENGTHENING_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_SUBSET_SUM_STRENGTHENING_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/integer.hh>
+
+#include <variant>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief One term of a subset-sum strengthening: a strictly positive
+     * coefficient and the 0/1 term it weights.
+     *
+     * \ingroup Innards
+     */
+    struct SubsetSumItem
+    {
+        Integer coefficient;
+        ProofLiteralOrFlag term;
+    };
+
+    /**
+     * \brief Deliberate corruptions of a subset-sum strengthening, for testing
+     * only.
+     *
+     * The strengthened line is only worth having if it is tight, and a proof
+     * that verifies does not say that on its own: if the derivation has slack,
+     * a wrong bound verifies too. Each of these breaks one part of it in a way
+     * that must make VeriPB reject --- either the derivation itself, or the
+     * consumer's use of the line it returns.
+     *
+     * \ingroup Innards
+     */
+    namespace subset_sum_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim one better than the largest reachable sum. The final
+        /// domination step is then unsupported.
+        struct ClaimOneBetter
+        {
+        };
+
+        /// Leave out one layer's state transitions, so the layer's
+        /// at-least-one has nothing to stand on.
+        struct SkipALayer
+        {
+        };
+
+        /// Take the divisibility fast path with a divisor that does not divide
+        /// every coefficient. The division is still a sound proof step --- it
+        /// just does not establish the claimed bound, which shows up in the
+        /// consumer rather than here.
+        struct BogusDivisor
+        {
+        };
+    }
+
+    using SubsetSumMutation = std::variant<subset_sum_mutation::None, subset_sum_mutation::ClaimOneBetter, subset_sum_mutation::SkipALayer,
+        subset_sum_mutation::BogusDivisor>;
+
+    /**
+     * \brief What derive_subset_sum_strengthening() established.
+     *
+     * \ingroup Innards
+     */
+    struct SubsetSumStrengthening
+    {
+        /// The strengthened line, `sum of coefficient * term <= bound`. When
+        /// nothing could be strengthened this is the source line itself, not a
+        /// vacuous re-derivation of it.
+        ProofLine line;
+        /// The bound the line carries: the largest subset sum of the
+        /// coefficients that is at most the input bound.
+        Integer bound;
+        /// Whether the divisibility fast path applied.
+        bool by_division;
+    };
+
+    /**
+     * \brief The largest subset sum of `coefficients` that is at most `bound`.
+     *
+     * A word-parallel bitset subset-sum, so O(n * bound / 64). Coefficients
+     * must be strictly positive, and the bound non-negative.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto largest_subset_sum_at_most(const std::vector<Integer> & coefficients, Integer bound) -> Integer;
+
+    /**
+     * \brief Strengthen a derived line by integrality: given `source` saying
+     * `sum of coefficient * term <= bound`, derive the same sum bounded by the
+     * largest subset sum of the coefficients that is at most `bound`.
+     *
+     * The two lines have the same 0/1 solutions --- every value the sum can
+     * take is a subset sum, so no assignment lies in the gap --- but the
+     * strengthened one is a tighter inequality, which is what makes it worth
+     * deriving: it is what later cutting-planes arithmetic can use. This is the
+     * integrality argument behind a knapsack-augmented overload check's
+     * availability bound (issue #550), Schulz's capacity reduction (#547) and
+     * single-resource lifting certificates (#549).
+     *
+     * Two derivations, chosen automatically:
+     *
+     * - **Divisibility.** When `d`, the gcd of every coefficient, exceeds one
+     *   and `d * floor(bound / d)` is the answer, two pol steps do it:
+     *   divide by `d`, multiply back. This is Chvatal-Gomory rounding, and it
+     *   is what applies whenever the coefficients share a factor.
+     * - **Layered dynamic programming.** Otherwise, one layer per item, with
+     *   three reified flags per reachable partial sum (`>= v`, `<= v`, and
+     *   their conjunction), the transitions between layers derived as clauses
+     *   from the flags' own reification halves, and one at-least-one per layer
+     *   saying the partial sum is in some reachable state. The last layer's
+     *   at-least-one, whose states are all at most the answer by construction,
+     *   is what dominates the strengthened line. Size is O(n * bound) flags in
+     *   the worst case, so a caller working with a large bound should budget
+     *   for it (and reach for this only where it pays).
+     *
+     * Writes only derivations: the API has no access to a ProofModel, so it
+     * cannot add to the OPB even by mistake. `level` selects where they land
+     * --- `Temporary` inside a conflict justification, `Top` for a presolver.
+     *
+     * Degenerate cases: an empty item list gives a bound of zero; a bound that
+     * is already reachable returns the source line unchanged; a bound at least
+     * the sum of every coefficient gives that sum.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto derive_subset_sum_strengthening(ProofLogger &, const std::vector<SubsetSumItem> & items, ProofLine source, Integer bound,
+        ProofLevel level, SubsetSumMutation mutation = subset_sum_mutation::None{}) -> SubsetSumStrengthening;
+}
+
+#endif

--- a/gcs/innards/proofs/subset_sum_strengthening_test.cc
+++ b/gcs/innards/proofs/subset_sum_strengthening_test.cc
@@ -202,7 +202,13 @@ auto main(int argc, char * argv[]) -> int
         // A bound above everything: the answer is the whole sum.
         {"i", {3_i, 5_i, 11_i}, 40_i, 19_i, false},
         // A bound of zero: nothing fits.
-        {"j", {3_i, 5_i}, 0_i, 0_i, false}};
+        {"j", {3_i, 5_i}, 0_i, 0_i, false},
+        // At the scale the consumers work at: six coprime weights against a
+        // bound in the eighties, which is sixteen reachable states across
+        // seven layers. Not a stress test --- a check that the layered
+        // derivation stays a sensible size when the bound is realistic, since
+        // it is O(items x bound) flags in the worst case.
+        {"k", {29_i, 31_i, 37_i, 41_i, 43_i, 47_i}, 83_i, 80_i, false}};
 
     for (const auto & fixture : fixtures) {
         auto expected = brute_force_largest(fixture.weights, fixture.bound);

--- a/gcs/innards/proofs/subset_sum_strengthening_test.cc
+++ b/gcs/innards/proofs/subset_sum_strengthening_test.cc
@@ -1,0 +1,282 @@
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+#include <gcs/innards/proofs/subset_sum_strengthening.hh>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <string>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::string;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "subset sum strengthening test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    // The answer, from the definition: every subset, summed.
+    auto brute_force_largest(const vector<Integer> & weights, Integer bound) -> Integer
+    {
+        Integer best = 0_i;
+        for (unsigned long long subset = 0; subset < (1ull << weights.size()); ++subset) {
+            Integer sum = 0_i;
+            for (size_t i = 0; i < weights.size(); ++i)
+                if (subset & (1ull << i))
+                    sum += weights[i];
+            if (sum <= bound && sum > best)
+                best = sum;
+        }
+        return best;
+    }
+
+    auto check_algorithm(const vector<Integer> & weights, Integer bound) -> void
+    {
+        auto computed = largest_subset_sum_at_most(weights, bound);
+        auto expected = brute_force_largest(weights, bound);
+        if (computed != expected) {
+            println(cerr, "largest_subset_sum_at_most({}, {}) = {}, brute force says {}", weights, bound.raw_value, computed.raw_value,
+                expected.raw_value);
+            fail("algorithmic property");
+        }
+    }
+
+    struct Fixture
+    {
+        string name;
+        vector<Integer> weights;
+        Integer bound;
+        Integer expected;
+        bool expect_division;
+    };
+
+    // Which micro model a proof is checked against. The distinction matters:
+    // an OPB that is itself unsatisfiable makes *every* RUP step valid, so a
+    // corrupted derivation sails through one.
+    enum class Model
+    {
+        // Just the source line, so the model is satisfiable and every step of
+        // the derivation has to stand on its own.
+        SourceOnly,
+        // The source line plus an axiom putting the sum above the strengthened
+        // bound. Nothing satisfies both --- no subset sums into the gap ---
+        // but as inequalities over the rationals the two are consistent, so
+        // combining them into a contradiction takes the strengthening. This is
+        // the end-to-end demonstration that the line is usable.
+        WithContradiction
+    };
+
+    // Two things are checked about the derivation, and they are different
+    // things. veripb accepting every step says each one followed; it does not
+    // say the line that came back is the one the caller was promised, because
+    // a sound step can land somewhere weaker. So each proof also pins the
+    // line's content with an `ia` step, whose implication check is syntactic:
+    // a weaker line does not imply the claimed one and veripb says so.
+    auto check_proof(const Fixture & fixture, SubsetSumMutation mutation, Model model_kind, const string & tag, bool expect_veripb_to_accept) -> void
+    {
+        auto proof_name = "subset_sum_strengthening_" + fixture.name + "_" + tag;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+
+        vector<SubsetSumItem> items;
+        WPBSum sum;
+        for (size_t i = 0; i < fixture.weights.size(); ++i) {
+            auto flag = model.create_proof_flag("item" + std::to_string(i));
+            items.push_back(SubsetSumItem{fixture.weights[i], flag});
+            sum += fixture.weights[i] * flag;
+        }
+
+        // Labelled, because a pol step may only reference an OPB row by name:
+        // a re-derived model has a different row count.
+        auto source = model.add_labelled_constraint("source", WPBSum{sum} <= fixture.bound);
+        std::optional<ProofLine> too_big;
+        if (model_kind == Model::WithContradiction)
+            too_big = model.add_labelled_constraint("toobig", WPBSum{sum} >= fixture.expected + 1_i);
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        auto strengthening = derive_subset_sum_strengthening(logger, items, source, fixture.bound, ProofLevel::Top, mutation);
+
+        if (std::holds_alternative<subset_sum_mutation::None>(mutation)) {
+            if (strengthening.bound != fixture.expected)
+                fail(fixture.name + ": strengthened to " + std::to_string(strengthening.bound.raw_value) + ", expected " +
+                    std::to_string(fixture.expected.raw_value));
+            if (strengthening.by_division != fixture.expect_division)
+                fail(fixture.name + ": took the " + (strengthening.by_division ? "divisibility" : "dynamic programming") +
+                    " path, expected the other");
+        }
+
+        // The line must carry the bound the utility is supposed to establish,
+        // which is the fixture's, whatever a mutated run reported back.
+        logger.emit(ImpliesProofRule{strengthening.line}, WPBSum{sum} <= fixture.expected, ProofLevel::Top);
+
+        if (too_big) {
+            PolBuilder contradiction;
+            contradiction.add(strengthening.line).add(*too_big);
+            auto combined = contradiction.emit(logger, ProofLevel::Top);
+            // And that combination must really be a contradiction, rather than
+            // something the checker can refute by other means: `ia` against the
+            // pol's own line is what says so.
+            logger.emit(ImpliesProofRule{combined}, WPBSum{} >= 1_i, ProofLevel::Top);
+            logger.conclude_unsatisfiable(false);
+        }
+        else
+            logger.conclude_none();
+
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_veripb_to_accept) {
+            if (accepted)
+                fail(fixture.name + " (" + tag +
+                    "): veripb accepted a proof built from a deliberately corrupted derivation, so the honest one has slack in it");
+            else
+                fail(fixture.name + " (" + tag + "): veripb rejected an honest proof");
+        }
+        dispose_of_proof_files(proof_name);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    // Sharpness fixtures, verified by hand in the comments: each is chosen so
+    // that arithmetic which is only right by coincidence gets it wrong.
+    const vector<Fixture> fixtures{// Pairwise gcds all exceed one, but the overall gcd is one, so the
+        // divisibility path must not fire: 6 + 10 = 16 > 14, so the reachable
+        // sums under 14 are 0, 6, 10.
+        {"a", {6_i, 10_i, 15_i}, 14_i, 10_i, false},
+        // The same weights, with room for two of them: 6 + 10 = 16,
+        // 6 + 15 = 21, 10 + 15 = 25, and 6 + 10 + 15 = 31 is over. A gap of
+        // five below the bound.
+        {"b", {6_i, 10_i, 15_i}, 30_i, 25_i, false},
+        // Large coprime weights, one item's worth of room: 31 + 37 = 68 is
+        // over, so the answer is the largest single weight.
+        {"c", {31_i, 37_i, 41_i}, 67_i, 41_i, false},
+        // The same weights with four more units of room, which is enough for
+        // exactly one pair: 31 + 37 = 68, and 31 + 41 = 72 is over.
+        {"d", {31_i, 37_i, 41_i}, 71_i, 68_i, false},
+        // Every weight even, an odd bound: divisibility rounds it down by one,
+        // and that happens to be reachable (6 + 15 does not arise here).
+        {"e", {6_i, 10_i, 14_i}, 17_i, 16_i, true},
+        // Every weight a multiple of six, a bound between two multiples.
+        {"f", {6_i, 12_i, 18_i}, 29_i, 24_i, true},
+        // A single item, out of reach. One weight is its own gcd, so this is
+        // the divisibility path with a quotient of zero.
+        {"g", {7_i}, 5_i, 0_i, true},
+        // A single item, within reach but with room to spare.
+        {"h", {7_i}, 9_i, 7_i, true},
+        // A bound above everything: the answer is the whole sum.
+        {"i", {3_i, 5_i, 11_i}, 40_i, 19_i, false},
+        // A bound of zero: nothing fits.
+        {"j", {3_i, 5_i}, 0_i, 0_i, false}};
+
+    for (const auto & fixture : fixtures) {
+        auto expected = brute_force_largest(fixture.weights, fixture.bound);
+        if (expected != fixture.expected)
+            fail(fixture.name + ": the fixture's own expected value is wrong; brute force says " + std::to_string(expected.raw_value));
+        check_algorithm(fixture.weights, fixture.bound);
+    }
+
+    // The contract's degenerate cases, where the answer is the bound itself
+    // and there is nothing to derive.
+    if (largest_subset_sum_at_most({6_i, 10_i, 15_i}, 16_i) != 16_i)
+        fail("a reachable bound must come back unchanged");
+    if (largest_subset_sum_at_most({}, 12_i) != 0_i)
+        fail("an empty item list must give zero");
+    if (largest_subset_sum_at_most({3_i, 5_i, 11_i}, 19_i) != 19_i)
+        fail("a bound equal to the total must come back unchanged");
+
+    // Random weight sets against brute force. Mixtures of primes,
+    // near-duplicates and gcd-structured sets, since each hides a different
+    // kind of arithmetic slip.
+    {
+        auto seed = 1u;
+        for (int a = 1; a < argc; ++a)
+            if (string{argv[a]}.starts_with("--seed="))
+                seed = static_cast<unsigned>(std::stoul(string{argv[a]}.substr(7)));
+        println(cerr, "subset_sum_strengthening_test: random seed is {} (reproduce with --seed={})", seed, seed);
+
+        std::mt19937 rand(seed);
+        std::uniform_int_distribution<> n_dist(0, 12), weight_dist(1, 200), bound_dist(0, 400), family_dist(0, 2);
+        for (int k = 0; k < 400; ++k) {
+            vector<Integer> weights;
+            auto n = n_dist(rand);
+            auto family = family_dist(rand);
+            auto base = weight_dist(rand);
+            for (int i = 0; i < n; ++i)
+                switch (family) {
+                case 0: weights.push_back(Integer{weight_dist(rand)}); break;                                  // anything
+                case 1: weights.push_back(Integer{base + std::uniform_int_distribution<>(0, 2)(rand)}); break; // near-duplicates
+                default: weights.push_back(Integer{6 * std::uniform_int_distribution<>(1, 30)(rand)}); break;  // gcd-structured
+                }
+            check_algorithm(weights, Integer{bound_dist(rand)});
+        }
+    }
+
+    if (! can_run_veripb()) {
+        println(cerr, "veripb is not available, so the proof-level checks are skipped");
+        return EXIT_SUCCESS;
+    }
+
+    for (const auto & fixture : fixtures) {
+        // A fixture whose bound is already reachable has nothing to derive, so
+        // there is no proof to check; every fixture here is chosen otherwise.
+        println(cerr, "subset sum strengthening {}: weights {} bound {} to {}", fixture.name, fixture.weights, fixture.bound.raw_value,
+            fixture.expected.raw_value);
+        check_proof(fixture, subset_sum_mutation::None{}, Model::SourceOnly, "honest", true);
+        check_proof(fixture, subset_sum_mutation::None{}, Model::WithContradiction, "usable", true);
+    }
+
+    // Mutations. Each must be rejected: if one is not, the honest derivation
+    // was not doing the work it looks like it is doing.
+    for (const auto & fixture : fixtures) {
+        if (fixture.expected == 0_i)
+            continue; // nothing to claim one better than
+        println(cerr, "subset sum strengthening {}: mutations", fixture.name);
+        // Claiming one better makes a step of the derivation unsupported, so
+        // it is the satisfiable model that sees it.
+        check_proof(fixture, subset_sum_mutation::ClaimOneBetter{}, Model::SourceOnly, "onebetter", false);
+        // A divisor that does not divide everything still divides soundly ---
+        // the step verifies. What it does not do is establish the claimed
+        // bound, and that only shows up where the line gets used.
+        check_proof(fixture, subset_sum_mutation::BogusDivisor{}, Model::WithContradiction, "bogusdivisor", false);
+        if (! fixture.expect_division && fixture.weights.size() > 2)
+            check_proof(fixture, subset_sum_mutation::SkipALayer{}, Model::SourceOnly, "skiplayer", false);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Issue 03 of the Cumulative proof-logging plan (#541), from #544.

**Stacked on #655** (issue 01), which is where the shared mutation harness
lives. The two are otherwise independent; retarget to `main` once #655 merges.

## What it does

Given a derived line `Σ cᵢxᵢ ≤ B` over 0/1 terms, derives the same sum bounded
by `B′`, the largest subset sum of the coefficients that is at most `B`.

The two lines have the **same 0/1 solutions** — every value the sum can take is
a subset sum, so nothing lives in the gap — so this buys no propagation by
itself. What it buys is a tighter inequality: `Σ cᵢxᵢ ≤ B` together with
`Σ cᵢxᵢ ≥ B′+1` is perfectly consistent over the rationals, while the
strengthened form contradicts it in one `pol` step. That is the shape all three
consumers need (#550's availability bound, #547's capacity reduction, #549's
lifting certificates).

## Two derivations

**Divisibility.** When `d = gcd(cᵢ) > 1` and `d·⌊B/d⌋` is the answer, it is
Chvátal–Gomory rounding: divide, multiply back, two `pol` steps. The condition
is on the gcd of *every* coefficient — `{6, 10, 15}` has pairwise gcds all above
one and an overall gcd of one, and rounding 14 down to 12 would be wrong (the
answer is 10). There is a fixture for exactly that.

**Layered dynamic programming.** Otherwise, one layer per item, three reified
flags per reachable partial sum (`≥ v`, `≤ v`, and their conjunction) — the
shape `Knapsack`'s upfront DAG uses, specialised to one coordinate. Transitions
are clauses derived by `pol` from the flags' own reification halves (the
prefix-sum terms cancel; saturation leaves the clause), and the two branches —
item in, item out — are **resolved on the item literal**. That resolution is the
load-bearing step: unit propagation cannot case-split on `xₖ`, and neither can a
`pol` over the weighted forms, which is why the derivation goes through
clause-shaped intermediates. Each layer's at-least-one is then a RUP against the
previous layer's.

A partial sum already over `B` is dead — the source line bounds the whole sum
and no coefficient is negative — so those states are never created: the clause
saying the item must be out is derived from the source line and resolved into
the transition instead.

The API takes a `ProofLogger` and no `ProofModel`, so it cannot write to the OPB
even by mistake.

## Testing: three claims, three nets

Two of these came out of getting it wrong first, so they are worth stating
plainly:

1. **The answer is right** — bitset subset-sum against brute force, over random
   weight sets (primes, near-duplicates, gcd-structured) and hand-verified
   fixtures.
2. **The derivation follows** — each fixture proved against a *satisfiable*
   micro model (the source line alone), so every step stands on its own. My
   first version put the contradiction axiom in the same model; that makes the
   model unsatisfiable, which makes every RUP step valid, and a corrupted
   derivation verified happily. Worth remembering when writing this kind of test.
3. **The line says what the caller was told** — veripb accepting every step does
   *not* say this. A sound step can land somewhere weaker, and a consumer scaling
   that line by a height would be working from something it cannot support. So
   each proof pins the returned line's content with an `ia` step, whose
   implication check is syntactic.

Plus the end-to-end use: against a model with an extra axiom putting the sum
above `B′`, the strengthened line and that axiom combine into a contradiction in
one `pol`, with an `ia` insisting the result really is one.

The three mutations are each caught by exactly one net, which is why they are
kept separate: claiming one better breaks a RUP step; skipping a layer leaves
its at-least-one unsupported; dividing by something that does not divide every
coefficient is a perfectly sound step that simply does not establish the claimed
bound, and only the `ia` check notices. Writing the skip mutation also turned up
dead code — the first version collected transition lines into a vector nothing
read, so "skipping" them changed nothing and the mutation passed.

## Size

O(items × bound) flags worst case. Six coprime weights against a bound of 83 —
sixteen states over seven layers — is ~630 proof lines and 50 KB. Documented, so
callers budget rather than reach for it everywhere.

Full `ctest` (frontends on): 611/611. Built and run under clang 21. Derivation
written out in `dev_docs/subset-sum-strengthening.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p