### PR TITLE
Derived-constraint mode for Cumulative (#545)

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -473,6 +473,102 @@ None of these lose soundness or solutions: a task the energy set will
 not take still counts through `F(a, b)`, and a check not made is a
 conflict found later.
 
+## Derived Cumulatives: an implied constraint that adds nothing to the model
+
+A presolver that spots an implied `Cumulative` — a strengthened capacity, a
+lifted resource, a disjunctive clique — needs its propagator's inferences to be
+justifiable, and the obvious way to do that is the wrong one. Writing the
+implied constraint's rows into the OPB changes the statement being verified:
+VeriPB would check the proof against a model containing an assertion nobody
+proved, accept it, and mean nothing by it. The whole point of #541's plan is
+that everything inferred enters as a *derivation*.
+
+`install_derived_cumulative`
+([`derived_cumulative.hh`](../gcs/constraints/cumulative/derived_cumulative.hh))
+is the mechanism. A derived Cumulative covers a donor's tasks, with its own
+heights and capacity, and creates no flags and no rows of its own: it pins the
+donor's flags, and its per-time capacity rows are derived in the proof from the
+donor's by a recipe the caller supplies.
+
+### Reaching the donor
+
+Two halves, both following the discipline #603 set for citing another
+constraint's model output — the constraint *publishes* what is citable, and the
+tracker says whether it is there:
+
+| what | published as | resolved by |
+|---|---|---|
+| `Σ h_i·active_{i,t} ≤ C` for a time `t` | `ConstraintProofModelData<Cumulative>::capacity_row_role(t)` | `NamesAndIDsTracker::constraint_row_label` |
+| the `before` / `after` / `active` flags for `(i, t)` | `...::before_flag_key(i, t)` and friends | `NamesAndIDsTracker::find_proof_flag_values` |
+
+The flag half is new. A flag's name is a pure function of
+`(ConstraintID, values, annotation)` — the same function
+`create_proof_flag_values` applies — so the tracker can answer "did a flag go
+out under this key?" exactly as it answers the question for rows. Holding the
+returned `ProofFlag` is then the permission to cite its reification rows by
+name, as the constraint that made it does; those rows live in the `v[...]`
+namespace, which `claim_constraint_row_labels` deliberately leaves out of the
+row-label set.
+
+Reconstructing either name as a string would work and is what not to do: the
+citer would be hard-coding another constraint's naming scheme, with nothing to
+tell the constraint's author they had broken somebody.
+
+The lookup also does the windowing check for free. The donor's flags exist only
+over the windows it encoded, so a derived constraint whose tasks run longer asks
+for a key that has no flag — and declines to install, rather than inventing one
+and finding out at verification time.
+
+### Where the derivation happens
+
+Inline, in `install_derived_cumulative`, at `ProofLevel::Top` — not from an
+`install_initialiser`. Initialisers have already run by the time a presolver is
+called (`solve.cc` runs them, then the presolvers), so one installed from there
+never fires, and the propagator would spend the whole search citing rows that
+were never written. Top level is what makes the rows survive backtracking,
+which the propagator needs at every node.
+
+### The recipe
+
+```cpp
+std::function<auto(ProofLogger &, ProofLine donor_row, Integer t)->ProofLine>
+```
+
+Called once per time point with the donor's row, returning the derived one. It
+has a `ProofLogger` and no `ProofModel`, so a recipe cannot write to the OPB
+even by mistake. The two in `derived_cumulative_test` are the shapes to copy: a
+one-line `pol` that copies the donor's row, and
+[subset-sum strengthening](subset-sum-strengthening.md) over the row's own
+terms, which takes its divisibility fast path and rounds a capacity of eight
+down to six when every height is a multiple of three.
+
+That second one is worth a note, because it is easy to expect the wrong thing
+from it. Rounding the capacity down by integrality is **invisible to
+time-tabling**: a load is a sum of heights, so it clears eight exactly when it
+clears six. What it changes is the *energy* argument, where a window's supply is
+the capacity times its width, and that is not a multiple of three. Seven
+unit-length tasks of height three need 21 units in `[0, 3)`, which eight
+supplies and six does not.
+
+### Multi-donor, for later
+
+Issues #548 and #549 infer a Cumulative over tasks drawn from *several* donors,
+each with its own flag copies for the same `(task, time)` semantics. Two ways to
+make one derivation speak about all of them:
+
+1. **Bridge lemmas.** Pick one donor's flags as canonical and derive
+   `active^{(r)}_{i,t} ↔ active^{(1)}_{i,t}` per `(i, t)`, by `pol` over the two
+   reification halves — the start variable's bits cancel, exactly as in the
+   window-energy bridges above. O(tasks × times) extra Top lines per extra
+   donor, and it needs no new API: both donors' rows are citable by name.
+2. **Rewrite each donor's row.** One `pol` pass per row, over the flag-defining
+   rows directly, landing on the canonical flags without ever stating the
+   bridge.
+
+Neither is implemented here. The first is the safer starting point (each lemma
+is checkable on its own); the second is smaller if it works. Whichever lands
+should measure the proof size, since that is the whole difference between them.
+
 ## Open follow-ups
 
 - **Edge-finding.** A *set* of tasks blocks an interval, not a single

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -522,11 +522,15 @@ and finding out at verification time.
 ### Where the derivation happens
 
 Inline, in `install_derived_cumulative`, at `ProofLevel::Top` — not from an
-`install_initialiser`. Initialisers have already run by the time a presolver is
-called (`solve.cc` runs them, then the presolvers), so one installed from there
-never fires, and the propagator would spend the whole search citing rows that
-were never written. Top level is what makes the rows survive backtracking,
-which the propagator needs at every node.
+`install_initialiser`. That was originally forced: initialisers had already run
+by the time a presolver was called, so one installed from there never fired and
+the propagator spent the search citing rows that were never written. #658 fixed
+that ordering, and this stays inline anyway for a better reason — the caller is
+told whether the constraint could be set up at all, and that answer has to be
+known while not installing the propagator is still an option.
+
+Top level is what makes the rows survive backtracking, which the propagator
+needs at every node.
 
 ### The recipe
 

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(glasgow_constraint_solver
         constraints/comparison/comparison.cc
         constraints/count/count.cc
         constraints/cumulative/cumulative.cc
+        constraints/cumulative/derived_cumulative.cc
         constraints/difference/difference_constraints.cc
         constraints/difference/difference_graph.cc
         constraints/difference/difference_incremental.cc
@@ -246,6 +247,7 @@ if(GCS_BUILD_TESTS)
     add_executable(count_test constraints/count/count_test.cc)
     add_executable(cumulative_test constraints/cumulative/cumulative_test.cc)
     add_executable(cumulative_overload_test constraints/cumulative/cumulative_overload_test.cc)
+    add_executable(derived_cumulative_test constraints/cumulative/derived_cumulative_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
@@ -294,7 +296,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test derived_cumulative_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -317,6 +319,7 @@ if(GCS_BUILD_TESTS)
     add_test(NAME gac_global_cardinality_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:gac_global_cardinality_test>)
     add_test(NAME cumulative_constraint COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_test>)
     add_test(NAME cumulative_overload COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_overload_test>)
+    add_test(NAME derived_cumulative COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:derived_cumulative_test>)
     # Mutation lanes: each writes a deliberately corrupted proof of the
     # sharp-margin fixture, and passes only if veripb rejects it. Distinct
     # basenames so the lanes do not race over one set of proof files.

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -1,5 +1,6 @@
 #include <gcs/constraints/cumulative/cumulative.hh>
 #include <gcs/constraints/cumulative/hints.hh>
+#include <gcs/constraints/cumulative/propagate.hh>
 #include <gcs/constraints/innards/window_energy.hh>
 #include <gcs/exception.hh>
 #include <gcs/innards/inference_tracker.hh>
@@ -186,14 +187,22 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
         _per_task_t_hi[i] = s_hi + _length_ub[i] - 1_i;
     }
 
-    if (_rules.overload)
-        prepare_overload_check(initial_state);
+    if (_rules.overload) {
+        auto overload_data =
+            prepare_cumulative_overload_check(_starts, _lengths, _heights, _active_tasks, _per_task_t_lo, _per_task_t_hi, initial_state);
+        _overload_tasks = move(overload_data.overload_tasks);
+        _time_slot_prefix = move(overload_data.time_slot_prefix);
+        _time_slot_lo = overload_data.time_slot_lo;
+    }
 
     return true;
 }
 
-auto Cumulative::prepare_overload_check(State & initial_state) -> void
+auto gcs::innards::prepare_cumulative_overload_check(const vector<IntegerVariableID> & starts, const vector<IntegerVariableID> & lengths,
+    const vector<IntegerVariableID> & heights, const vector<size_t> & active_tasks, const vector<Integer> & per_task_t_lo,
+    const vector<Integer> & per_task_t_hi, const State & initial_state) -> CumulativeOverloadData
 {
+    CumulativeOverloadData result;
     // Which tasks the window-energy lemma can speak about: a constant length
     // and height (so the task's energy is a constant, and its load in C_t is
     // h·active rather than the bit-linearised contrib), and a start that is a
@@ -206,49 +215,51 @@ auto Cumulative::prepare_overload_check(State & initial_state) -> void
     // whose presence is fixed true may join the energy set or the profile, and
     // its presence literal joins the reason. Nothing here consults a presence
     // variable yet because there is not one to consult.
-    _overload_tasks.clear();
-    for (auto i : _active_tasks) {
-        if (! is_constant_variable(_lengths[i]) || ! is_constant_variable(_heights[i]))
+    result.overload_tasks.clear();
+    for (auto i : active_tasks) {
+        if (! is_constant_variable(lengths[i]) || ! is_constant_variable(heights[i]))
             continue;
-        if (_length_vals[i] <= 0_i || _height_vals[i] <= 0_i)
+        if (const_value_of(lengths[i]) <= 0_i || const_value_of(heights[i]) <= 0_i)
             continue;
-        if (! std::holds_alternative<SimpleIntegerVariableID>(_starts[i]))
+        if (! std::holds_alternative<SimpleIntegerVariableID>(starts[i]))
             continue;
         // A start whose domain is exactly {0, 1} is direct-only encoded, so it
         // has no order literals for the lemma's bridges to cancel against.
-        auto [s_lo, s_hi] = initial_state.bounds(_starts[i]);
+        auto [s_lo, s_hi] = initial_state.bounds(starts[i]);
         if (s_lo == 0_i && s_hi == 1_i)
             continue;
-        _overload_tasks.push_back(i);
+        result.overload_tasks.push_back(i);
     }
 
-    if (_overload_tasks.empty())
-        return;
+    if (result.overload_tasks.empty())
+        return result;
 
     // Count the time points at which some task can be active, which is exactly
     // where define_proof_model writes a capacity line. A difference array over
     // the per-task windows, prefix-summed, so a window's count is one
     // subtraction.
-    Integer global_lo = _per_task_t_lo[_active_tasks.front()], global_hi = _per_task_t_hi[_active_tasks.front()];
-    for (auto i : _active_tasks) {
-        global_lo = min(global_lo, _per_task_t_lo[i]);
-        global_hi = max(global_hi, _per_task_t_hi[i]);
+    Integer global_lo = per_task_t_lo[active_tasks.front()], global_hi = per_task_t_hi[active_tasks.front()];
+    for (auto i : active_tasks) {
+        global_lo = min(global_lo, per_task_t_lo[i]);
+        global_hi = max(global_hi, per_task_t_hi[i]);
     }
 
     auto range = (global_hi - global_lo + 1_i).raw_value;
     vector<long long> starting_or_ending(static_cast<size_t>(range) + 1, 0);
-    for (auto i : _active_tasks) {
-        ++starting_or_ending[static_cast<size_t>((_per_task_t_lo[i] - global_lo).raw_value)];
-        --starting_or_ending[static_cast<size_t>((_per_task_t_hi[i] + 1_i - global_lo).raw_value)];
+    for (auto i : active_tasks) {
+        ++starting_or_ending[static_cast<size_t>((per_task_t_lo[i] - global_lo).raw_value)];
+        --starting_or_ending[static_cast<size_t>((per_task_t_hi[i] + 1_i - global_lo).raw_value)];
     }
 
-    _time_slot_lo = global_lo;
-    _time_slot_prefix.assign(static_cast<size_t>(range) + 1, 0_i);
+    result.time_slot_lo = global_lo;
+    result.time_slot_prefix.assign(static_cast<size_t>(range) + 1, 0_i);
     long long covering = 0;
     for (size_t k = 0; k < static_cast<size_t>(range); ++k) {
         covering += starting_or_ending[k];
-        _time_slot_prefix[k + 1] = _time_slot_prefix[k] + (covering > 0 ? 1_i : 0_i);
+        result.time_slot_prefix[k + 1] = result.time_slot_prefix[k] + (covering > 0 ? 1_i : 0_i);
     }
+
+    return result;
 }
 
 auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
@@ -431,519 +442,604 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         }
     });
 
+    CumulativeInputs inputs{.owner = constraint_id(),
+        .starts = move(_starts),
+        .lengths = move(_lengths),
+        .heights = move(_heights),
+        .capacity = _capacity,
+        .active_tasks = move(_active_tasks),
+        .before_flags = move(_before_flags),
+        .after_flags = move(_after_flags),
+        .active_flags = move(_active_flags),
+        .contrib_flags = move(_contrib_flags),
+        .per_task_t_lo = move(_per_task_t_lo),
+        .ends = move(_end),
+        .end_lines = end_lines,
+        .capacity_lines = move(_capacity_lines),
+        .rules = _rules,
+        .proof_mutation = _proof_mutation,
+        .overload_tasks = move(_overload_tasks),
+        .time_slot_prefix = move(_time_slot_prefix),
+        .time_slot_lo = _time_slot_lo};
+
     propagators.install(
         constraint_id(),
-        [starts = move(_starts), lengths_var = move(_lengths), heights_var = move(_heights), capacity_var = _capacity,
-            active_tasks = move(_active_tasks), before_flags = move(_before_flags), after_flags = move(_after_flags),
-            active_flags = move(_active_flags), contrib_flags = move(_contrib_flags), ends = move(_end), end_lines,
-            capacity_lines = move(_capacity_lines), per_task_t_lo = move(_per_task_t_lo), rules = _rules, mutation = _proof_mutation,
-            overload_tasks = move(_overload_tasks), time_slot_prefix = move(_time_slot_prefix), time_slot_lo = _time_slot_lo,
-            owner = constraint_id()](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
-            // The capacity may be a variable: the load profile is infeasible
-            // only when it exceeds the *largest* still-allowed capacity, so the
-            // threshold for every overflow/blocked test is ub(capacity). When
-            // capacity is a genuine variable its bound is part of every reason.
-            auto capacity = state.upper_bound(capacity_var);
+        [inputs = move(inputs)](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            return propagate_cumulative(inputs, state, inference, logger);
+        },
+        triggers);
+}
 
-            // A height may be a variable: a task's *guaranteed* contribution to
-            // the load is its smallest still-allowed height, lb(h_i). For a
-            // constant height lb(h_i) is just its value. Variable heights' bounds
-            // are part of every reason, and the proof uses the cc flags.
-            auto hlb = [&](size_t i) { return state.lower_bound(heights_var[i]); };
-            auto h_is_var = [&](size_t i) { return ! is_constant_variable(heights_var[i]); };
+auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const State & state, auto & inference, ProofLogger * const logger)
+    -> PropagatorState
+{
+    // Named the way the propagator body has always named them, so that what
+    // follows is the same code whether a posted Cumulative or a derived one
+    // supplied the flags and lines.
+    const auto & starts = inputs.starts;
+    const auto & lengths_var = inputs.lengths;
+    const auto & heights_var = inputs.heights;
+    const auto & capacity_var = inputs.capacity;
+    const auto & active_tasks = inputs.active_tasks;
+    const auto & before_flags = inputs.before_flags;
+    const auto & after_flags = inputs.after_flags;
+    const auto & active_flags = inputs.active_flags;
+    const auto & contrib_flags = inputs.contrib_flags;
+    const auto & per_task_t_lo = inputs.per_task_t_lo;
+    const auto & end_lines = inputs.end_lines;
+    const auto & capacity_lines = inputs.capacity_lines;
+    const auto & rules = inputs.rules;
+    const auto & mutation = inputs.proof_mutation;
+    const auto & overload_tasks = inputs.overload_tasks;
+    const auto & time_slot_prefix = inputs.time_slot_prefix;
+    const auto & time_slot_lo = inputs.time_slot_lo;
+    const auto & owner = inputs.owner;
 
-            // A length may be a variable: a task's *mandatory* part and its
-            // guaranteed footprint when placed use the smallest still-allowed
-            // duration lb(l_i); the possible-active window uses ub(l_i). For a
-            // constant length both are its value. Variable-length bounds join
-            // every reason.
-            auto llb = [&](size_t i) { return state.lower_bound(lengths_var[i]); };
-            auto lub = [&](size_t i) { return state.upper_bound(lengths_var[i]); };
-            auto l_is_var = [&](size_t i) { return ! is_constant_variable(lengths_var[i]); };
-            auto s_is_var = [&](size_t i) { return ! is_constant_variable(starts[i]); };
+    // The capacity may be a variable: the load profile is infeasible
+    // only when it exceeds the *largest* still-allowed capacity, so the
+    // threshold for every overflow/blocked test is ub(capacity). When
+    // capacity is a genuine variable its bound is part of every reason.
+    auto capacity = state.upper_bound(capacity_var);
 
-            // For a task whose start AND length are both variables, after_{i,t}
-            // is reified on s_i + l_i. To pin after = 1 we first materialise the
-            // single-variable end ≥ s_lo + lb(l_i) with a pol over end's in-proof
-            // `end ≥ s + l` line plus the two operand order-literal defining lines;
-            // the after = 1 RUP is then single-variable in end, closing against the
-            // `end ≥ t+1 → after` bridge lemma the initialiser emitted (just like
-            // the constant-duration case). s_lo is the start lower bound that, with
-            // lb(l_i), reaches t+1: the chain running bound for lb-push, t−lb(l_j)+1
-            // (= ¬ext_lit) for ub-push, lb(s_i) for a mandatory task. Only needed
-            // when both operands vary (else after is already single-variable).
-            auto materialise_after_sum = [&](size_t i, Integer s_lo) -> void {
-                if (! (l_is_var(i) && s_is_var(i)))
-                    return;
-                PolBuilder sp;
-                sp.add((*end_lines)[i]->first);
-                sp.add_for_literal(logger->names_and_ids_tracker(), starts[i] >= s_lo);
-                sp.add_for_literal(logger->names_and_ids_tracker(), lengths_var[i] >= llb(i));
-                sp.emit(*logger, ProofLevel::Temporary);
-            };
+    // A height may be a variable: a task's *guaranteed* contribution to
+    // the load is its smallest still-allowed height, lb(h_i). For a
+    // constant height lb(h_i) is just its value. Variable heights' bounds
+    // are part of every reason, and the proof uses the cc flags.
+    auto hlb = [&](size_t i) { return state.lower_bound(heights_var[i]); };
+    auto h_is_var = [&](size_t i) { return ! is_constant_variable(heights_var[i]); };
 
-            vector<IntegerVariableID> reason_vars = starts;
-            if (! is_constant_variable(capacity_var))
-                reason_vars.push_back(capacity_var);
-            for (auto i : active_tasks) {
-                if (h_is_var(i))
-                    reason_vars.push_back(heights_var[i]);
-                if (l_is_var(i))
-                    reason_vars.push_back(lengths_var[i]);
-            }
+    // A length may be a variable: a task's *mandatory* part and its
+    // guaranteed footprint when placed use the smallest still-allowed
+    // duration lb(l_i); the possible-active window uses ub(l_i). For a
+    // constant length both are its value. Variable-length bounds join
+    // every reason.
+    auto llb = [&](size_t i) { return state.lower_bound(lengths_var[i]); };
+    auto lub = [&](size_t i) { return state.upper_bound(lengths_var[i]); };
+    auto l_is_var = [&](size_t i) { return ! is_constant_variable(lengths_var[i]); };
+    auto s_is_var = [&](size_t i) { return ! is_constant_variable(starts[i]); };
 
-            // Proof helper: pin task i's guaranteed load contribution at t and
-            // return a (line, coeff) pair to feed the time-table pol. For a
-            // constant height that is "active = 1" scaled by the height; for a
-            // variable height it is "contrib >= lb(h_i)" with coefficient 1
-            // (contrib is the proof-only product h_i·active in C_t). The
-            // before/after RUPs give VeriPB the units to chase active's AND-gate.
-            auto pin_contributor = [&](const ReasonLiterals & reason, size_t i, Integer t) -> std::pair<ProofLine, Integer> {
-                auto fi = (t - per_task_t_lo[i]).raw_value;
-                logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flags[i][fi] >= 1_i, ProofLevel::Temporary);
-                // A mandatory task has s_i + l_i ≥ lb(s_i) + lb(l_i) > t.
-                materialise_after_sum(i, state.lower_bound(starts[i]));
-                logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flags[i][fi] >= 1_i, ProofLevel::Temporary);
-                auto active_line =
-                    logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * active_flags[i][fi] >= 1_i, ProofLevel::Temporary);
-                if (! h_is_var(i))
-                    return {active_line, hlb(i)};
-                auto contrib_line =
-                    logger->emit_rup_proof_line_under_reason(reason, contrib_sum_of(contrib_flags[i][fi]) >= hlb(i), ProofLevel::Temporary);
-                return {contrib_line, 1_i};
-            };
+    // For a task whose start AND length are both variables, after_{i,t}
+    // is reified on s_i + l_i. To pin after = 1 we first materialise the
+    // single-variable end ≥ s_lo + lb(l_i) with a pol over end's in-proof
+    // `end ≥ s + l` line plus the two operand order-literal defining lines;
+    // the after = 1 RUP is then single-variable in end, closing against the
+    // `end ≥ t+1 → after` bridge lemma the initialiser emitted (just like
+    // the constant-duration case). s_lo is the start lower bound that, with
+    // lb(l_i), reaches t+1: the chain running bound for lb-push, t−lb(l_j)+1
+    // (= ¬ext_lit) for ub-push, lb(s_i) for a mandatory task. Only needed
+    // when both operands vary (else after is already single-variable).
+    auto materialise_after_sum = [&](size_t i, Integer s_lo) -> void {
+        if (! (l_is_var(i) && s_is_var(i)))
+            return;
+        PolBuilder sp;
+        sp.add((*end_lines)[i]->first);
+        sp.add_for_literal(logger->names_and_ids_tracker(), starts[i] >= s_lo);
+        sp.add_for_literal(logger->names_and_ids_tracker(), lengths_var[i] >= llb(i));
+        sp.emit(*logger, ProofLevel::Temporary);
+    };
 
-            // Proof helper for the pushed task j, pinned under the EXTENDED
-            // reason {reason ∧ ¬ext_lit} (ext_lit appended as a disjunct). For a
-            // constant height it returns (active_j+ext_lit ≥ 1, h_j); for a
-            // variable height it deposits contrib_j + lb(h_j)·ext_lit ≥ lb(h_j)
-            // (vacuous when ext_lit holds, "contrib_j ≥ lb(h_j)" otherwise) and
-            // returns that line with coefficient 1.
-            auto pin_pushed = [&](const ReasonLiterals & reason, size_t j_idx, Integer t, IntegerVariableCondition ext_lit,
-                                  Integer s_lo_after) -> std::pair<ProofLine, Integer> {
-                auto fj = (t - per_task_t_lo[j_idx]).raw_value;
-                logger->emit_rup_proof_line_under_reason(
-                    reason, WPBSum{} + 1_i * before_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
-                // s_lo_after + lb(l_j) ≥ t+1 gives after_{j,t} = 1 (under ¬ext_lit
-                // for ub-push, under the running bound for lb-push).
-                materialise_after_sum(j_idx, s_lo_after);
-                logger->emit_rup_proof_line_under_reason(
-                    reason, WPBSum{} + 1_i * after_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
-                auto active_line = logger->emit_rup_proof_line_under_reason(
-                    reason, WPBSum{} + 1_i * active_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
-                if (! h_is_var(j_idx))
-                    return {active_line, hlb(j_idx)};
-                auto contrib_line = logger->emit_rup_proof_line_under_reason(
-                    reason, contrib_sum_of(contrib_flags[j_idx][fj]) + hlb(j_idx) * ext_lit >= hlb(j_idx), ProofLevel::Temporary);
-                return {contrib_line, 1_i};
-            };
+    vector<IntegerVariableID> reason_vars = starts;
+    if (! is_constant_variable(capacity_var))
+        reason_vars.push_back(capacity_var);
+    for (auto i : active_tasks) {
+        if (h_is_var(i))
+            reason_vars.push_back(heights_var[i]);
+        if (l_is_var(i))
+            reason_vars.push_back(lengths_var[i]);
+    }
 
-            // Time-table consistency. The mandatory part of task i is the
-            // half-open interval [lst_i, eet_i) where lst_i = ub(s_i) and
-            // eet_i = lb(s_i) + l_i. Summing heights over mandatory parts
-            // gives the load profile. Each task's bounds are then pushed
-            // away from time points where placing it would force the load
-            // over capacity.
+    // Proof helper: pin task i's guaranteed load contribution at t and
+    // return a (line, coeff) pair to feed the time-table pol. For a
+    // constant height that is "active = 1" scaled by the height; for a
+    // variable height it is "contrib >= lb(h_i)" with coefficient 1
+    // (contrib is the proof-only product h_i·active in C_t). The
+    // before/after RUPs give VeriPB the units to chase active's AND-gate.
+    auto pin_contributor = [&](const ReasonLiterals & reason, size_t i, Integer t) -> std::pair<ProofLine, Integer> {
+        auto fi = (t - per_task_t_lo[i]).raw_value;
+        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flags[i][fi] >= 1_i, ProofLevel::Temporary);
+        // A mandatory task has s_i + l_i ≥ lb(s_i) + lb(l_i) > t.
+        materialise_after_sum(i, state.lower_bound(starts[i]));
+        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flags[i][fi] >= 1_i, ProofLevel::Temporary);
+        auto active_line = logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * active_flags[i][fi] >= 1_i, ProofLevel::Temporary);
+        if (! h_is_var(i))
+            return {active_line, hlb(i)};
+        auto contrib_line = logger->emit_rup_proof_line_under_reason(reason, contrib_sum_of(contrib_flags[i][fi]) >= hlb(i), ProofLevel::Temporary);
+        return {contrib_line, 1_i};
+    };
 
-            // Determine the time window we care about: the union of every
-            // task's possibly-active range. This bounds both the mandatory
-            // profile and the per-task bound search.
-            bool any = false;
-            Integer t_lo = 0_i, t_hi = -1_i;
-            for (auto i : active_tasks) {
-                auto [s_lo, s_hi] = state.bounds(starts[i]);
-                auto lo = s_lo, hi = s_hi + lub(i) - 1_i;
-                if (! any || lo < t_lo)
-                    t_lo = lo;
-                if (! any || hi > t_hi)
-                    t_hi = hi;
-                any = true;
-            }
-            if (! any)
-                return PropagatorState::DisableUntilBacktrack;
+    // Proof helper for the pushed task j, pinned under the EXTENDED
+    // reason {reason ∧ ¬ext_lit} (ext_lit appended as a disjunct). For a
+    // constant height it returns (active_j+ext_lit ≥ 1, h_j); for a
+    // variable height it deposits contrib_j + lb(h_j)·ext_lit ≥ lb(h_j)
+    // (vacuous when ext_lit holds, "contrib_j ≥ lb(h_j)" otherwise) and
+    // returns that line with coefficient 1.
+    auto pin_pushed = [&](const ReasonLiterals & reason, size_t j_idx, Integer t, IntegerVariableCondition ext_lit,
+                          Integer s_lo_after) -> std::pair<ProofLine, Integer> {
+        auto fj = (t - per_task_t_lo[j_idx]).raw_value;
+        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
+        // s_lo_after + lb(l_j) ≥ t+1 gives after_{j,t} = 1 (under ¬ext_lit
+        // for ub-push, under the running bound for lb-push).
+        materialise_after_sum(j_idx, s_lo_after);
+        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
+        auto active_line =
+            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * active_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
+        if (! h_is_var(j_idx))
+            return {active_line, hlb(j_idx)};
+        auto contrib_line = logger->emit_rup_proof_line_under_reason(
+            reason, contrib_sum_of(contrib_flags[j_idx][fj]) + hlb(j_idx) * ext_lit >= hlb(j_idx), ProofLevel::Temporary);
+        return {contrib_line, 1_i};
+    };
 
-            auto range = (t_hi - t_lo + 1_i).raw_value;
-            vector<Integer> mand_load(range, 0_i);
+    // Time-table consistency. The mandatory part of task i is the
+    // half-open interval [lst_i, eet_i) where lst_i = ub(s_i) and
+    // eet_i = lb(s_i) + l_i. Summing heights over mandatory parts
+    // gives the load profile. Each task's bounds are then pushed
+    // away from time points where placing it would force the load
+    // over capacity.
 
+    // Determine the time window we care about: the union of every
+    // task's possibly-active range. This bounds both the mandatory
+    // profile and the per-task bound search.
+    bool any = false;
+    Integer t_lo = 0_i, t_hi = -1_i;
+    for (auto i : active_tasks) {
+        auto [s_lo, s_hi] = state.bounds(starts[i]);
+        auto lo = s_lo, hi = s_hi + lub(i) - 1_i;
+        if (! any || lo < t_lo)
+            t_lo = lo;
+        if (! any || hi > t_hi)
+            t_hi = hi;
+        any = true;
+    }
+    if (! any)
+        return PropagatorState::DisableUntilBacktrack;
+
+    auto range = (t_hi - t_lo + 1_i).raw_value;
+    vector<Integer> mand_load(range, 0_i);
+
+    for (auto i : active_tasks) {
+        auto lst = state.upper_bound(starts[i]);
+        auto eet = state.lower_bound(starts[i]) + llb(i);
+        if (lst < eet)
+            for (Integer t = lst; t < eet; ++t)
+                mand_load[(t - t_lo).raw_value] += hlb(i);
+    }
+
+    for (auto idx = 0; rules.time_table && idx < range; ++idx)
+        if (mand_load[idx] > capacity) {
+            auto violating_t = t_lo + Integer{idx};
+
+            // Tasks whose mandatory part covers violating_t — the ones
+            // we'll pin to active=1 in the proof.
+            vector<size_t> contributing;
             for (auto i : active_tasks) {
                 auto lst = state.upper_bound(starts[i]);
                 auto eet = state.lower_bound(starts[i]) + llb(i);
-                if (lst < eet)
-                    for (Integer t = lst; t < eet; ++t)
-                        mand_load[(t - t_lo).raw_value] += hlb(i);
+                if (lst < eet && violating_t >= lst && violating_t < eet)
+                    contributing.push_back(i);
             }
 
-            for (auto idx = 0; rules.time_table && idx < range; ++idx)
-                if (mand_load[idx] > capacity) {
-                    auto violating_t = t_lo + Integer{idx};
-
-                    // Tasks whose mandatory part covers violating_t — the ones
-                    // we'll pin to active=1 in the proof.
-                    vector<size_t> contributing;
-                    for (auto i : active_tasks) {
-                        auto lst = state.upper_bound(starts[i]);
-                        auto eet = state.lower_bound(starts[i]) + llb(i);
-                        if (lst < eet && violating_t >= lst && violating_t < eet)
-                            contributing.push_back(i);
-                    }
-
-                    auto justify = [&, violating_t, contributing](const ReasonLiterals & reason) -> void {
-                        if (! logger)
-                            return;
-                        // Pin every contributing task's guaranteed load at
-                        // violating_t, then combine those lines with C_t in a
-                        // single pol. The result is unsatisfiable under the
-                        // reason context (the pinned loads already exceed
-                        // ub(capacity)), closing the framework's wrapping RUP.
-                        PolBuilder pol;
-                        pol.add(capacity_lines.at(violating_t));
-                        for (auto i : contributing) {
-                            auto [line, coeff] = pin_contributor(reason, i, violating_t);
-                            pol.add(line, coeff);
-                        }
-                        pol.emit(*logger, ProofLevel::Temporary);
-                    };
-
-                    inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
-                    return PropagatorState::DisableUntilBacktrack;
-                }
-
-            // Overload checking: rule (OC') of Cloutier & Quimper, CP 2026,
-            // strengthened by the mandatory-part profile to their (TTOC). If
-            // the tasks that must run entirely inside a time window carry more
-            // energy than the window can supply, the constraint is infeasible.
-            // This is conflict-only --- no bound moves --- so a bug here shows
-            // up as a missing solution, which is what the enumeration tests
-            // are the net for.
-            //
-            // The windows worth trying are [a, b) with a an earliest start and
-            // b a latest completion time. I(a, b), the tasks with est >= a and
-            // lct <= b, contribute their whole energy p·h; every other task
-            // contributes whatever of its mandatory part falls inside the
-            // window. A task in I(a, b) has its mandatory part inside the
-            // window as well, so that second term is the window's total
-            // mandatory load minus I(a, b)'s --- which makes both terms
-            // accumulate as b grows, and the whole sweep quadratic.
-            //
-            // Two restrictions, both of which only weaken the check: the
-            // capacity must be constant (a variable one would leave a
-            // (b − a)·capacity term in the conflict pol for the wrapping RUP
-            // to dispose of over the capacity's bits, which it cannot do in
-            // general), and only eligible tasks (see prepare_overload_check)
-            // may join I(a, b).
-            if (rules.overload && ! overload_tasks.empty() && is_constant_variable(capacity_var)) {
-                vector<Integer> mand_prefix(static_cast<size_t>(range) + 1, 0_i);
-                for (auto idx = 0; idx < range; ++idx)
-                    mand_prefix[static_cast<size_t>(idx) + 1] = mand_prefix[static_cast<size_t>(idx)] + mand_load[static_cast<size_t>(idx)];
-
-                // Mandatory load inside [from, to), over every task.
-                auto profile_within = [&](Integer from, Integer to) {
-                    return mand_prefix[static_cast<size_t>((to - t_lo).raw_value)] - mand_prefix[static_cast<size_t>((from - t_lo).raw_value)];
-                };
-
-                // How many time points in [from, to) some task can occupy.
-                // Anywhere else supplies nothing to this window's tasks (and
-                // has no capacity line to cite), so it is not counted.
-                auto slots_within = [&](Integer from, Integer to) {
-                    return time_slot_prefix[static_cast<size_t>((to - time_slot_lo).raw_value)] -
-                        time_slot_prefix[static_cast<size_t>((from - time_slot_lo).raw_value)];
-                };
-
-                struct Candidate
-                {
-                    size_t task;
-                    Integer est, lct, energy, mandatory;
-                };
-
-                vector<Candidate> candidates;
-                candidates.reserve(overload_tasks.size());
-                for (auto i : overload_tasks) {
-                    auto [s_lo, s_hi] = state.bounds(starts[i]);
-                    auto p = llb(i), h = hlb(i);
-                    candidates.push_back(Candidate{i, s_lo, s_hi + p, p * h, h * max(0_i, s_lo + p - s_hi)});
-                }
-                sort(candidates, [](const Candidate & a, const Candidate & b) { return a.lct < b.lct; });
-
-                vector<Integer> window_starts;
-                window_starts.reserve(candidates.size());
-                for (const auto & c : candidates)
-                    window_starts.push_back(c.est);
-                sort(window_starts);
-
-                for (size_t w = 0; w < window_starts.size(); ++w) {
-                    if (w > 0 && window_starts[w] == window_starts[w - 1])
-                        continue;
-                    auto a = window_starts[w];
-
-                    Integer energy = 0_i, inside_mandatory = 0_i;
-                    vector<size_t> inside_tasks;
-                    for (const auto & c : candidates) {
-                        if (c.est < a)
-                            continue;
-                        energy += c.energy;
-                        inside_mandatory += c.mandatory;
-                        inside_tasks.push_back(c.task);
-
-                        auto b = c.lct;
-                        auto supply = capacity * slots_within(a, b);
-                        auto outside_profile = rules.profile_overload ? profile_within(a, b) - inside_mandatory : 0_i;
-                        if (energy + outside_profile <= supply)
-                            continue;
-
-                        // (OC') on its own, or does the conflict need the
-                        // profile of the tasks outside the window?
-                        auto uses_profile = energy <= supply;
-
-                        // The (i, t) pairs whose compulsory load the proof
-                        // pins: exactly what outside_profile counted.
-                        vector<pair<size_t, Integer>> pins;
-                        if (uses_profile) {
-                            vector<bool> inside(starts.size(), false);
-                            for (auto i : inside_tasks)
-                                inside[i] = true;
-                            for (auto j : active_tasks) {
-                                if (inside[j])
-                                    continue;
-                                auto lst = state.upper_bound(starts[j]);
-                                auto eet = state.lower_bound(starts[j]) + llb(j);
-                                for (Integer t = max(lst, a); t < min(eet, b); ++t)
-                                    pins.emplace_back(j, t);
-                            }
-                        }
-
-                        auto justify = [&, a, b, inside_tasks, pins, uses_profile](const ReasonLiterals & reason) -> void {
-                            if (! logger)
-                                return;
-                            logger->emit_proof_comment("cumulative overload conflict window=[" + std::to_string(a.raw_value) + "," +
-                                std::to_string(b.raw_value) + ") rule=" + (uses_profile ? "ttoc" : "oc"));
-
-                            // Tests only: each of these breaks one step of what
-                            // follows, and each must make VeriPB reject the
-                            // proof. See CumulativeProofMutation.
-                            auto omit_capacity_line = std::holds_alternative<cumulative_proof_mutation::OmitCapacityLine>(mutation);
-                            auto shrink_lemma_window = std::holds_alternative<cumulative_proof_mutation::ShrinkLemmaWindow>(mutation);
-                            auto overstate_energy = std::holds_alternative<cumulative_proof_mutation::OverstateWindowEnergy>(mutation);
-
-                            // The capacity available across the window, plus
-                            // each contained task's window energy scaled by its
-                            // height, plus (for (TTOC)) the pinned compulsory
-                            // load of the tasks outside it. Each contained
-                            // task's activity terms cancel exactly against its
-                            // terms in the capacity lines, leaving a constraint
-                            // with nothing but negative coefficients on the
-                            // left and a positive right hand side.
-                            PolBuilder pol;
-                            for (Integer t = a; t < b; ++t) {
-                                if (omit_capacity_line && t == b - 1_i)
-                                    continue;
-                                auto line = capacity_lines.find(t);
-                                if (line != capacity_lines.end())
-                                    pol.add(line->second);
-                            }
-
-                            for (auto i : inside_tasks) {
-                                auto energy_line = window_energy::derive_window_energy(*logger, reason,
-                                    window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i],
-                                        before_flags[i], after_flags[i], active_flags[i]},
-                                    a, shrink_lemma_window ? b - 1_i : b, state.bounds(starts[i]), ProofLevel::Temporary);
-                                if (! energy_line) {
-                                    // Only reachable under the shrunk-window
-                                    // mutation, where a task can be left with
-                                    // nothing derivable at all.
-                                    if (shrink_lemma_window)
-                                        continue;
-                                    throw ProofError{"cumulative overload: a task in the window has no derivable energy"};
-                                }
-                                if (! shrink_lemma_window && energy_line->bound != llb(i))
-                                    throw ProofError{"cumulative overload: window energy derivation is weaker than the check assumed"};
-
-                                auto line = energy_line->line;
-                                if (overstate_energy && i == inside_tasks.front()) {
-                                    WPBSum activity;
-                                    for (Integer t = energy_line->lo; t < energy_line->hi; ++t)
-                                        activity += 1_i * active_flags[i][static_cast<size_t>((t - per_task_t_lo[i]).raw_value)];
-                                    line = logger->emit_rup_proof_line_under_reason(
-                                        reason, move(activity) >= energy_line->bound + 1_i, ProofLevel::Temporary);
-                                }
-                                pol.add(line, hlb(i));
-                            }
-
-                            for (const auto & [j, t] : pins) {
-                                auto [line, coeff] = pin_contributor(reason, j, t);
-                                pol.add(line, coeff);
-                            }
-
-                            pol.emit(*logger, ProofLevel::Temporary);
-                        };
-
-                        inference.contradiction(
-                            logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeOverload{owner}}, generic_reason(reason_vars));
-                        return PropagatorState::DisableUntilBacktrack;
-                    }
-                }
-            }
-
-            // The remaining work --- pushing each task's bounds away from the
-            // times where placing it would overflow the profile --- is
-            // time-table reasoning too.
-            if (! rules.time_table)
-                return PropagatorState::Enable;
-
-            // One step of a bound-push proof chain: a blocked time t and the
-            // tasks (≠ j) whose mandatory parts cover t. Used by both
-            // lb-push and ub-push.
-            struct ChainStep
-            {
-                Integer t;
-                vector<size_t> contributing;
-                // Start lower bound that, with lb(l_j), forces after_{j,t}=1:
-                // the running bound for lb-push, t−lb(l_j)+1 for ub-push.
-                Integer s_lo_after;
-            };
-
-            // Helper: emit (a)–(d) for one chain step.
-            //
-            // `ext_lit` is the literal added to the reason in PB form (= the
-            // negation of "task j is active at t"-as-bounded-by-the-running
-            // half):
-            //   lb-push:  ext_lit = (s_j ≥ t + 1)
-            //   ub-push:  ext_lit = (s_j ≤ t − l_j)
-            //
-            // `emit_intermediate` deposits ext_lit as a unit under reason —
-            // needed for every step except the last (the framework's wrapping
-            // RUP closes the final inference).
-            auto emit_chain_step = [&](size_t j_idx, Integer t, const vector<size_t> & contributing, IntegerVariableCondition ext_lit,
-                                       Integer s_lo_after, bool emit_intermediate, const ReasonLiterals & reason) -> void {
-                // (a) Pin each task i ≠ j mandatory at t under the reason, and
-                // (b) pin the pushed task j under the EXTENDED reason. Then
-                // (c) combine all pinned load lines with C_t in one pol. After
-                // cancellation the pol is dominated by (load − capacity)·ext_lit,
-                // forcing ext_lit = 1 (the new bound) under the reason context.
+            auto justify = [&, violating_t, contributing](const ReasonLiterals & reason) -> void {
+                if (! logger)
+                    return;
+                // Pin every contributing task's guaranteed load at
+                // violating_t, then combine those lines with C_t in a
+                // single pol. The result is unsatisfiable under the
+                // reason context (the pinned loads already exceed
+                // ub(capacity)), closing the framework's wrapping RUP.
                 PolBuilder pol;
-                pol.add(capacity_lines.at(t));
+                pol.add(capacity_lines.at(violating_t));
                 for (auto i : contributing) {
-                    auto [line, coeff] = pin_contributor(reason, i, t);
+                    auto [line, coeff] = pin_contributor(reason, i, violating_t);
                     pol.add(line, coeff);
                 }
-                auto [j_line, j_coeff] = pin_pushed(reason, j_idx, t, ext_lit, s_lo_after);
-                pol.add(j_line, j_coeff);
                 pol.emit(*logger, ProofLevel::Temporary);
-
-                // (d) Deposit the running-bound advance as a fact under
-                // reason for the next chain step's UP.
-                if (emit_intermediate)
-                    logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
             };
 
-            for (auto j : active_tasks) {
-                auto [cur_lb, cur_ub] = state.bounds(starts[j]);
-                if (cur_lb == cur_ub)
+            inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
+            return PropagatorState::DisableUntilBacktrack;
+        }
+
+    // Overload checking: rule (OC') of Cloutier & Quimper, CP 2026,
+    // strengthened by the mandatory-part profile to their (TTOC). If
+    // the tasks that must run entirely inside a time window carry more
+    // energy than the window can supply, the constraint is infeasible.
+    // This is conflict-only --- no bound moves --- so a bug here shows
+    // up as a missing solution, which is what the enumeration tests
+    // are the net for.
+    //
+    // The windows worth trying are [a, b) with a an earliest start and
+    // b a latest completion time. I(a, b), the tasks with est >= a and
+    // lct <= b, contribute their whole energy p·h; every other task
+    // contributes whatever of its mandatory part falls inside the
+    // window. A task in I(a, b) has its mandatory part inside the
+    // window as well, so that second term is the window's total
+    // mandatory load minus I(a, b)'s --- which makes both terms
+    // accumulate as b grows, and the whole sweep quadratic.
+    //
+    // Two restrictions, both of which only weaken the check: the
+    // capacity must be constant (a variable one would leave a
+    // (b − a)·capacity term in the conflict pol for the wrapping RUP
+    // to dispose of over the capacity's bits, which it cannot do in
+    // general), and only eligible tasks (see prepare_overload_check)
+    // may join I(a, b).
+    if (rules.overload && ! overload_tasks.empty() && is_constant_variable(capacity_var)) {
+        vector<Integer> mand_prefix(static_cast<size_t>(range) + 1, 0_i);
+        for (auto idx = 0; idx < range; ++idx)
+            mand_prefix[static_cast<size_t>(idx) + 1] = mand_prefix[static_cast<size_t>(idx)] + mand_load[static_cast<size_t>(idx)];
+
+        // Mandatory load inside [from, to), over every task.
+        auto profile_within = [&](Integer from, Integer to) {
+            return mand_prefix[static_cast<size_t>((to - t_lo).raw_value)] - mand_prefix[static_cast<size_t>((from - t_lo).raw_value)];
+        };
+
+        // How many time points in [from, to) some task can occupy.
+        // Anywhere else supplies nothing to this window's tasks (and
+        // has no capacity line to cite), so it is not counted.
+        auto slots_within = [&](Integer from, Integer to) {
+            return time_slot_prefix[static_cast<size_t>((to - time_slot_lo).raw_value)] -
+                time_slot_prefix[static_cast<size_t>((from - time_slot_lo).raw_value)];
+        };
+
+        struct Candidate
+        {
+            size_t task;
+            Integer est, lct, energy, mandatory;
+        };
+
+        vector<Candidate> candidates;
+        candidates.reserve(overload_tasks.size());
+        for (auto i : overload_tasks) {
+            auto [s_lo, s_hi] = state.bounds(starts[i]);
+            auto p = llb(i), h = hlb(i);
+            candidates.push_back(Candidate{i, s_lo, s_hi + p, p * h, h * max(0_i, s_lo + p - s_hi)});
+        }
+        sort(candidates, [](const Candidate & a, const Candidate & b) { return a.lct < b.lct; });
+
+        vector<Integer> window_starts;
+        window_starts.reserve(candidates.size());
+        for (const auto & c : candidates)
+            window_starts.push_back(c.est);
+        sort(window_starts);
+
+        for (size_t w = 0; w < window_starts.size(); ++w) {
+            if (w > 0 && window_starts[w] == window_starts[w - 1])
+                continue;
+            auto a = window_starts[w];
+
+            Integer energy = 0_i, inside_mandatory = 0_i;
+            vector<size_t> inside_tasks;
+            for (const auto & c : candidates) {
+                if (c.est < a)
+                    continue;
+                energy += c.energy;
+                inside_mandatory += c.mandatory;
+                inside_tasks.push_back(c.task);
+
+                auto b = c.lct;
+                auto supply = capacity * slots_within(a, b);
+                auto outside_profile = rules.profile_overload ? profile_within(a, b) - inside_mandatory : 0_i;
+                if (energy + outside_profile <= supply)
                     continue;
 
-                auto lst_j = cur_ub, eet_j = cur_lb + llb(j);
-                auto fits_at = [&](Integer s) -> bool {
-                    for (Integer t = s; t < s + llb(j); ++t) {
-                        auto load = mand_load[(t - t_lo).raw_value];
-                        if (lst_j < eet_j && t >= lst_j && t < eet_j)
-                            load -= hlb(j);
-                        if (load + hlb(j) > capacity)
-                            return false;
-                    }
-                    return true;
-                };
+                // (OC') on its own, or does the conflict need the
+                // profile of the tasks outside the window?
+                auto uses_profile = energy <= supply;
 
-                auto is_blocked_at = [&](Integer t) -> bool {
-                    auto load = mand_load[(t - t_lo).raw_value];
-                    if (lst_j < eet_j && t >= lst_j && t < eet_j)
-                        load -= hlb(j);
-                    return load + hlb(j) > capacity;
-                };
-
-                auto contributors_at = [&](Integer t) -> vector<size_t> {
-                    vector<size_t> result;
-                    for (auto i : active_tasks) {
-                        if (i == j)
+                // The (i, t) pairs whose compulsory load the proof
+                // pins: exactly what outside_profile counted.
+                vector<pair<size_t, Integer>> pins;
+                if (uses_profile) {
+                    vector<bool> inside(starts.size(), false);
+                    for (auto i : inside_tasks)
+                        inside[i] = true;
+                    for (auto j : active_tasks) {
+                        if (inside[j])
                             continue;
-                        auto lst_i = state.upper_bound(starts[i]);
-                        auto eet_i = state.lower_bound(starts[i]) + llb(i);
-                        if (lst_i < eet_i && t >= lst_i && t < eet_i)
-                            result.push_back(i);
+                        auto lst = state.upper_bound(starts[j]);
+                        auto eet = state.lower_bound(starts[j]) + llb(j);
+                        for (Integer t = max(lst, a); t < min(eet, b); ++t)
+                            pins.emplace_back(j, t);
                     }
-                    return result;
+                }
+
+                auto justify = [&, a, b, inside_tasks, pins, uses_profile](const ReasonLiterals & reason) -> void {
+                    if (! logger)
+                        return;
+                    logger->emit_proof_comment("cumulative overload conflict window=[" + std::to_string(a.raw_value) + "," +
+                        std::to_string(b.raw_value) + ") rule=" + (uses_profile ? "ttoc" : "oc"));
+
+                    // Tests only: each of these breaks one step of what
+                    // follows, and each must make VeriPB reject the
+                    // proof. See CumulativeProofMutation.
+                    auto omit_capacity_line = std::holds_alternative<cumulative_proof_mutation::OmitCapacityLine>(mutation);
+                    auto shrink_lemma_window = std::holds_alternative<cumulative_proof_mutation::ShrinkLemmaWindow>(mutation);
+                    auto overstate_energy = std::holds_alternative<cumulative_proof_mutation::OverstateWindowEnergy>(mutation);
+
+                    // The capacity available across the window, plus
+                    // each contained task's window energy scaled by its
+                    // height, plus (for (TTOC)) the pinned compulsory
+                    // load of the tasks outside it. Each contained
+                    // task's activity terms cancel exactly against its
+                    // terms in the capacity lines, leaving a constraint
+                    // with nothing but negative coefficients on the
+                    // left and a positive right hand side.
+                    PolBuilder pol;
+                    for (Integer t = a; t < b; ++t) {
+                        if (omit_capacity_line && t == b - 1_i)
+                            continue;
+                        auto line = capacity_lines.find(t);
+                        if (line != capacity_lines.end())
+                            pol.add(line->second);
+                    }
+
+                    for (auto i : inside_tasks) {
+                        auto energy_line = window_energy::derive_window_energy(*logger, reason,
+                            window_energy::ConstantLengthTask{std::get<SimpleIntegerVariableID>(starts[i]), llb(i), per_task_t_lo[i], before_flags[i],
+                                after_flags[i], active_flags[i]},
+                            a, shrink_lemma_window ? b - 1_i : b, state.bounds(starts[i]), ProofLevel::Temporary);
+                        if (! energy_line) {
+                            // Only reachable under the shrunk-window
+                            // mutation, where a task can be left with
+                            // nothing derivable at all.
+                            if (shrink_lemma_window)
+                                continue;
+                            throw ProofError{"cumulative overload: a task in the window has no derivable energy"};
+                        }
+                        if (! shrink_lemma_window && energy_line->bound != llb(i))
+                            throw ProofError{"cumulative overload: window energy derivation is weaker than the check assumed"};
+
+                        auto line = energy_line->line;
+                        if (overstate_energy && i == inside_tasks.front()) {
+                            WPBSum activity;
+                            for (Integer t = energy_line->lo; t < energy_line->hi; ++t)
+                                activity += 1_i * active_flags[i][static_cast<size_t>((t - per_task_t_lo[i]).raw_value)];
+                            line =
+                                logger->emit_rup_proof_line_under_reason(reason, move(activity) >= energy_line->bound + 1_i, ProofLevel::Temporary);
+                        }
+                        pol.add(line, hlb(i));
+                    }
+
+                    for (const auto & [j, t] : pins) {
+                        auto [line, coeff] = pin_contributor(reason, j, t);
+                        pol.add(line, coeff);
+                    }
+
+                    pol.emit(*logger, ProofLevel::Temporary);
                 };
 
-                // lb-push: find smallest s with fits_at(s), then chain
-                // through blocked t's picking the LARGEST in each step's
-                // window so the bound advances as far as possible per step.
-                auto new_lb = cur_lb;
-                while (new_lb <= cur_ub && ! fits_at(new_lb))
-                    ++new_lb;
-                if (new_lb > cur_lb) {
-                    vector<ChainStep> chain;
-                    Integer running_bound = cur_lb;
-                    while (running_bound < new_lb) {
-                        bool found = false;
-                        for (Integer t = running_bound + llb(j) - 1_i; t >= running_bound; --t)
-                            if (is_blocked_at(t)) {
-                                chain.push_back(ChainStep{t, contributors_at(t), running_bound});
-                                running_bound = t + 1_i;
-                                found = true;
-                                break;
-                            }
-                        if (! found)
-                            break;
+                inference.contradiction(
+                    logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeOverload{owner}}, generic_reason(reason_vars));
+                return PropagatorState::DisableUntilBacktrack;
+            }
+        }
+    }
+
+    // The remaining work --- pushing each task's bounds away from the
+    // times where placing it would overflow the profile --- is
+    // time-table reasoning too.
+    if (! rules.time_table)
+        return PropagatorState::Enable;
+
+    // One step of a bound-push proof chain: a blocked time t and the
+    // tasks (≠ j) whose mandatory parts cover t. Used by both
+    // lb-push and ub-push.
+    struct ChainStep
+    {
+        Integer t;
+        vector<size_t> contributing;
+        // Start lower bound that, with lb(l_j), forces after_{j,t}=1:
+        // the running bound for lb-push, t−lb(l_j)+1 for ub-push.
+        Integer s_lo_after;
+    };
+
+    // Helper: emit (a)–(d) for one chain step.
+    //
+    // `ext_lit` is the literal added to the reason in PB form (= the
+    // negation of "task j is active at t"-as-bounded-by-the-running
+    // half):
+    //   lb-push:  ext_lit = (s_j ≥ t + 1)
+    //   ub-push:  ext_lit = (s_j ≤ t − l_j)
+    //
+    // `emit_intermediate` deposits ext_lit as a unit under reason —
+    // needed for every step except the last (the framework's wrapping
+    // RUP closes the final inference).
+    auto emit_chain_step = [&](size_t j_idx, Integer t, const vector<size_t> & contributing, IntegerVariableCondition ext_lit, Integer s_lo_after,
+                               bool emit_intermediate, const ReasonLiterals & reason) -> void {
+        // (a) Pin each task i ≠ j mandatory at t under the reason, and
+        // (b) pin the pushed task j under the EXTENDED reason. Then
+        // (c) combine all pinned load lines with C_t in one pol. After
+        // cancellation the pol is dominated by (load − capacity)·ext_lit,
+        // forcing ext_lit = 1 (the new bound) under the reason context.
+        PolBuilder pol;
+        pol.add(capacity_lines.at(t));
+        for (auto i : contributing) {
+            auto [line, coeff] = pin_contributor(reason, i, t);
+            pol.add(line, coeff);
+        }
+        auto [j_line, j_coeff] = pin_pushed(reason, j_idx, t, ext_lit, s_lo_after);
+        pol.add(j_line, j_coeff);
+        pol.emit(*logger, ProofLevel::Temporary);
+
+        // (d) Deposit the running-bound advance as a fact under
+        // reason for the next chain step's UP.
+        if (emit_intermediate)
+            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
+    };
+
+    for (auto j : active_tasks) {
+        auto [cur_lb, cur_ub] = state.bounds(starts[j]);
+        if (cur_lb == cur_ub)
+            continue;
+
+        auto lst_j = cur_ub, eet_j = cur_lb + llb(j);
+        auto fits_at = [&](Integer s) -> bool {
+            for (Integer t = s; t < s + llb(j); ++t) {
+                auto load = mand_load[(t - t_lo).raw_value];
+                if (lst_j < eet_j && t >= lst_j && t < eet_j)
+                    load -= hlb(j);
+                if (load + hlb(j) > capacity)
+                    return false;
+            }
+            return true;
+        };
+
+        auto is_blocked_at = [&](Integer t) -> bool {
+            auto load = mand_load[(t - t_lo).raw_value];
+            if (lst_j < eet_j && t >= lst_j && t < eet_j)
+                load -= hlb(j);
+            return load + hlb(j) > capacity;
+        };
+
+        auto contributors_at = [&](Integer t) -> vector<size_t> {
+            vector<size_t> result;
+            for (auto i : active_tasks) {
+                if (i == j)
+                    continue;
+                auto lst_i = state.upper_bound(starts[i]);
+                auto eet_i = state.lower_bound(starts[i]) + llb(i);
+                if (lst_i < eet_i && t >= lst_i && t < eet_i)
+                    result.push_back(i);
+            }
+            return result;
+        };
+
+        // lb-push: find smallest s with fits_at(s), then chain
+        // through blocked t's picking the LARGEST in each step's
+        // window so the bound advances as far as possible per step.
+        auto new_lb = cur_lb;
+        while (new_lb <= cur_ub && ! fits_at(new_lb))
+            ++new_lb;
+        if (new_lb > cur_lb) {
+            vector<ChainStep> chain;
+            Integer running_bound = cur_lb;
+            while (running_bound < new_lb) {
+                bool found = false;
+                for (Integer t = running_bound + llb(j) - 1_i; t >= running_bound; --t)
+                    if (is_blocked_at(t)) {
+                        chain.push_back(ChainStep{t, contributors_at(t), running_bound});
+                        running_bound = t + 1_i;
+                        found = true;
+                        break;
                     }
-
-                    auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
-                        if (! logger)
-                            return;
-                        for (size_t step = 0; step < chain.size(); ++step)
-                            emit_chain_step(j, chain[step].t, chain[step].contributing, starts[j] > chain[step].t, chain[step].s_lo_after,
-                                step + 1 < chain.size(), reason);
-                    };
-
-                    inference.infer_greater_than_or_equal(
-                        logger, starts[j], new_lb, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
-                }
-
-                // ub-push: mirror image. Pick SMALLEST blocked t in each
-                // step's window so the upper bound drops the most. Each
-                // step turns a blocked t into the fact s_j ≤ t − l_j.
-                auto new_ub = cur_ub;
-                while (new_ub >= cur_lb && ! fits_at(new_ub))
-                    --new_ub;
-                if (new_ub < cur_ub) {
-                    vector<ChainStep> chain;
-                    Integer running_bound = cur_ub;
-                    while (running_bound > new_ub) {
-                        bool found = false;
-                        for (Integer t = running_bound; t <= running_bound + llb(j) - 1_i; ++t)
-                            if (is_blocked_at(t)) {
-                                chain.push_back(ChainStep{t, contributors_at(t), t - llb(j) + 1_i});
-                                running_bound = t - llb(j);
-                                found = true;
-                                break;
-                            }
-                        if (! found)
-                            break;
-                    }
-
-                    auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
-                        if (! logger)
-                            return;
-                        for (size_t step = 0; step < chain.size(); ++step)
-                            emit_chain_step(j, chain[step].t, chain[step].contributing, starts[j] < chain[step].t - llb(j) + 1_i,
-                                chain[step].s_lo_after, step + 1 < chain.size(), reason);
-                    };
-
-                    inference.infer_less_than(logger, starts[j], new_ub + 1_i, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}},
-                        generic_reason(reason_vars));
-                }
+                if (! found)
+                    break;
             }
 
-            return PropagatorState::Enable;
-        },
-        triggers);
+            auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
+                if (! logger)
+                    return;
+                for (size_t step = 0; step < chain.size(); ++step)
+                    emit_chain_step(j, chain[step].t, chain[step].contributing, starts[j] > chain[step].t, chain[step].s_lo_after,
+                        step + 1 < chain.size(), reason);
+            };
+
+            inference.infer_greater_than_or_equal(
+                logger, starts[j], new_lb, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
+        }
+
+        // ub-push: mirror image. Pick SMALLEST blocked t in each
+        // step's window so the upper bound drops the most. Each
+        // step turns a blocked t into the fact s_j ≤ t − l_j.
+        auto new_ub = cur_ub;
+        while (new_ub >= cur_lb && ! fits_at(new_ub))
+            --new_ub;
+        if (new_ub < cur_ub) {
+            vector<ChainStep> chain;
+            Integer running_bound = cur_ub;
+            while (running_bound > new_ub) {
+                bool found = false;
+                for (Integer t = running_bound; t <= running_bound + llb(j) - 1_i; ++t)
+                    if (is_blocked_at(t)) {
+                        chain.push_back(ChainStep{t, contributors_at(t), t - llb(j) + 1_i});
+                        running_bound = t - llb(j);
+                        found = true;
+                        break;
+                    }
+                if (! found)
+                    break;
+            }
+
+            auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
+                if (! logger)
+                    return;
+                for (size_t step = 0; step < chain.size(); ++step)
+                    emit_chain_step(j, chain[step].t, chain[step].contributing, starts[j] < chain[step].t - llb(j) + 1_i, chain[step].s_lo_after,
+                        step + 1 < chain.size(), reason);
+            };
+
+            inference.infer_less_than(
+                logger, starts[j], new_ub + 1_i, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
+        }
+    }
+
+    return PropagatorState::Enable;
+}
+
+auto Cumulative::starts() const -> const vector<IntegerVariableID> &
+{
+    return _starts;
+}
+
+auto Cumulative::lengths() const -> const vector<IntegerVariableID> &
+{
+    return _lengths;
+}
+
+auto Cumulative::heights() const -> const vector<IntegerVariableID> &
+{
+    return _heights;
+}
+
+auto Cumulative::capacity() const -> IntegerVariableID
+{
+    return _capacity;
+}
+
+auto ConstraintProofModelData<Cumulative>::primary_row_role(const Cumulative &) -> std::optional<string>
+{
+    return std::nullopt;
+}
+
+auto ConstraintProofModelData<Cumulative>::capacity_row_role(Integer t) -> string
+{
+    // Must stay the string define_proof_model labels the row with.
+    return "cap_" + std::to_string(t.raw_value);
+}
+
+auto ConstraintProofModelData<Cumulative>::before_flag_key(size_t task, Integer t) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(task), t.raw_value}, "cb"};
+}
+
+auto ConstraintProofModelData<Cumulative>::after_flag_key(size_t task, Integer t) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(task), t.raw_value}, "ca"};
+}
+
+auto ConstraintProofModelData<Cumulative>::active_flag_key(size_t task, Integer t) -> ProofFlagKey
+{
+    return ProofFlagKey{{static_cast<long long>(task), t.raw_value}, "cact"};
 }
 
 auto Cumulative::constraint_type() const -> std::string
@@ -964,3 +1060,9 @@ auto Cumulative::s_expr(const ProofModel * const model) const -> SExpr
     return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(starts)),
         SExpr::list(std::move(lengths)), SExpr::list(std::move(heights)), tracker.s_expr_term_of(_capacity)});
 }
+
+template auto gcs::innards::propagate_cumulative(const CumulativeInputs &, const State &, SimpleInferenceTracker &, ProofLogger * const)
+    -> PropagatorState;
+
+template auto gcs::innards::propagate_cumulative(const CumulativeInputs &, const State &, EagerProofLoggingInferenceTracker &, ProofLogger * const)
+    -> PropagatorState;

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_CUMULATIVE_HH
 
 #include <gcs/constraint.hh>
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/proof_only_variables-fwd.hh>
 #include <gcs/integer.hh>
@@ -171,8 +172,6 @@ namespace gcs
         std::vector<std::optional<innards::ProofOnlySimpleIntegerVariableID>> _end;
         std::map<Integer, innards::ProofLine> _capacity_lines; // t -> proof line for the per-t time-table constraint
 
-        auto prepare_overload_check(innards::State &) -> void;
-
         virtual auto prepare(innards::Propagators &, innards::State &, innards::ProofModel * const) -> bool override;
         virtual auto define_proof_model(innards::ProofModel &, const innards::State &) -> void override;
         virtual auto install_propagators(innards::Propagators &) -> void override;
@@ -202,9 +201,74 @@ namespace gcs
         /// CumulativeProofMutation.
         auto with_proof_mutation(CumulativeProofMutation mutation) -> Cumulative &;
 
+        /**
+         * \name The arguments this constraint was posted with.
+         *
+         * As posted, not as resolved: a constant length or height comes back as
+         * the ConstantIntegerVariableID it went in as. A caller wanting bounds
+         * should ask the State, which is the only thing that knows them at the
+         * point the caller is asking.
+         */
+        ///@{
+        [[nodiscard]] auto starts() const -> const std::vector<IntegerVariableID> &;
+        [[nodiscard]] auto lengths() const -> const std::vector<IntegerVariableID> &;
+        [[nodiscard]] auto heights() const -> const std::vector<IntegerVariableID> &;
+        [[nodiscard]] auto capacity() const -> IntegerVariableID;
+        ///@}
+
         virtual auto clone() const -> std::unique_ptr<Constraint> override;
         [[nodiscard]] virtual auto s_expr(const innards::ProofModel * const) const -> innards::SExpr override;
         [[nodiscard]] virtual auto constraint_type() const -> std::string override;
+    };
+
+    /**
+     * \brief What Cumulative publishes for other proof steps to build on: its
+     * per-time capacity rows, and the keys of its per-(task, time) flags.
+     *
+     * Public API, in the sense #603 established: a derived Cumulative
+     * (install_derived_cumulative) builds `pol`s on the capacity rows and pins
+     * the flags, so changing what these name is a breaking change. cake_pb_cp
+     * re-derives the same names, so it is a cross-tool break rather than merely
+     * an internal one.
+     *
+     * Unlike a comparison or a linear inequality, there is no single primary
+     * row to publish --- the capacity rows are a family, one per time point ---
+     * so primary_row_role is honestly nullopt and \ref capacity_row_role is
+     * what a citer wants.
+     */
+    template <>
+    struct innards::ConstraintProofModelData<Cumulative>
+    {
+        /**
+         * \brief Always nullopt: a Cumulative's rows are a per-time family, and
+         * no one of them is the row a citer could mean.
+         */
+        [[nodiscard]] static auto primary_row_role(const Cumulative &) -> std::optional<std::string>;
+
+        /**
+         * \brief The role of the row saying the load at time `t` is within the
+         * capacity: `Σ heights[i]·active[i,t] ≤ capacity`.
+         *
+         * A row exists for each time point some task can occupy; ask
+         * NamesAndIDsTracker::constraint_row_label whether this one did.
+         */
+        [[nodiscard]] static auto capacity_row_role(Integer t) -> std::string;
+
+        /**
+         * \name The keys of the per-(task, time) flags.
+         *
+         * `before` is `start[i] <= t`, `after` is `start[i] + length[i] > t`,
+         * and `active` is their conjunction. Ask
+         * NamesAndIDsTracker::find_proof_flag_values for the flag: a key
+         * outside the task's possible-active window has none, which is how a
+         * citer discovers it is asking about a window the constraint did not
+         * encode.
+         */
+        ///@{
+        [[nodiscard]] static auto before_flag_key(std::size_t task, Integer t) -> innards::ProofFlagKey;
+        [[nodiscard]] static auto after_flag_key(std::size_t task, Integer t) -> innards::ProofFlagKey;
+        [[nodiscard]] static auto active_flag_key(std::size_t task, Integer t) -> innards::ProofFlagKey;
+        ///@}
     };
 }
 

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -131,10 +131,14 @@ auto gcs::innards::install_derived_cumulative(
     // can reach the OPB.
     //
     // Not through an install_initialiser, even though that is where a posted
-    // constraint would do its once-only proof work: initialisers have already
-    // run by the time a presolver is called (solve.cc runs them, then the
-    // presolvers), so one installed from here would never fire and the
-    // propagator would cite rows that were never written.
+    // constraint would do its once-only proof work. That used to be forced ---
+    // initialisers had already run by the time a presolver was called, so one
+    // installed from here never fired and the propagator cited rows that were
+    // never written --- and #658 has since fixed the ordering. It stays inline
+    // anyway, for a better reason: the caller is told whether this constraint
+    // could be set up, and that answer has to be known now, while there is
+    // still the option of not installing a propagator whose inferences could
+    // not be justified.
     if (logger) {
         logger->emit_proof_comment("derived cumulative: " + to_string(donor_rows.size()) + " capacity rows from " + as_string(spec.donor));
         for (const auto & [t, donor_row] : donor_rows)

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -1,0 +1,156 @@
+#include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/constraints/cumulative/propagate.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/propagators.hh>
+#include <gcs/innards/state.hh>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_shared;
+using std::move;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::vector;
+
+auto gcs::innards::install_derived_cumulative(
+    Propagators & propagators, const State & initial_state, ProofLogger * const logger, DerivedCumulativeSpec spec) -> bool
+{
+    auto n = spec.starts.size();
+    if (n != spec.lengths.size() || n != spec.heights.size())
+        throw InvalidProblemDefinitionException{"derived Cumulative: starts, lengths, heights must have the same size"};
+    if (spec.capacity < 0_i)
+        throw InvalidProblemDefinitionException{"derived Cumulative: capacity must be non-negative"};
+    for (size_t i = 0; i < n; ++i)
+        if (spec.lengths[i] < 0_i || spec.heights[i] < 0_i)
+            throw InvalidProblemDefinitionException{"derived Cumulative: lengths and heights must be non-negative"};
+    if (! spec.recipe)
+        throw InvalidProblemDefinitionException{"derived Cumulative: no recipe for deriving the capacity rows"};
+
+    auto inputs = make_shared<CumulativeInputs>();
+    inputs->owner = CurrentlyUnnamedConstraint{};
+    inputs->starts = spec.starts;
+    inputs->capacity = constant_variable(spec.capacity);
+    inputs->rules = spec.rules;
+    for (size_t i = 0; i < n; ++i) {
+        inputs->lengths.push_back(constant_variable(spec.lengths[i]));
+        inputs->heights.push_back(constant_variable(spec.heights[i]));
+    }
+
+    // The same windowing a posted Cumulative resolves in prepare(): a task can
+    // be active from its earliest start to its latest finish, and one whose
+    // length or height is zero never raises the profile at all.
+    inputs->per_task_t_lo.assign(n, 0_i);
+    vector<Integer> per_task_t_hi(n, 0_i);
+    for (size_t i = 0; i < n; ++i) {
+        if (spec.lengths[i] <= 0_i || spec.heights[i] <= 0_i)
+            continue;
+        inputs->active_tasks.push_back(i);
+        auto [s_lo, s_hi] = initial_state.bounds(spec.starts[i]);
+        inputs->per_task_t_lo[i] = s_lo;
+        per_task_t_hi[i] = s_hi + spec.lengths[i] - 1_i;
+    }
+
+    if (inputs->active_tasks.empty())
+        return false;
+
+    if (spec.rules.overload) {
+        auto overload_data = prepare_cumulative_overload_check(
+            inputs->starts, inputs->lengths, inputs->heights, inputs->active_tasks, inputs->per_task_t_lo, per_task_t_hi, initial_state);
+        inputs->overload_tasks = move(overload_data.overload_tasks);
+        inputs->time_slot_prefix = move(overload_data.time_slot_prefix);
+        inputs->time_slot_lo = overload_data.time_slot_lo;
+    }
+
+    // The donor's rows, to derive from. Resolved before anything is installed:
+    // a derived constraint that cannot cite its donor must not be installed at
+    // all, since its propagator would then be drawing inferences it has no way
+    // to justify.
+    vector<std::pair<Integer, ProofLine>> donor_rows;
+    if (logger) {
+        auto & tracker = logger->names_and_ids_tracker();
+
+        inputs->before_flags.assign(n, {});
+        inputs->after_flags.assign(n, {});
+        inputs->active_flags.assign(n, {});
+        inputs->contrib_flags.assign(n, {});
+        inputs->ends.assign(n, std::nullopt);
+        inputs->end_lines = make_shared<vector<std::optional<std::pair<ProofLine, ProofLine>>>>(n);
+
+        for (auto i : inputs->active_tasks)
+            for (Integer t = inputs->per_task_t_lo[i]; t <= per_task_t_hi[i]; ++t) {
+                auto before = tracker.find_proof_flag_values(spec.donor, ConstraintProofModelData<Cumulative>::before_flag_key(i, t));
+                auto after = tracker.find_proof_flag_values(spec.donor, ConstraintProofModelData<Cumulative>::after_flag_key(i, t));
+                auto active = tracker.find_proof_flag_values(spec.donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+                // Missing means the donor never encoded this (task, time): it
+                // was not installed, or it windowed the task differently. Either
+                // way there is nothing to pin, so decline rather than guess.
+                if (! before || ! after || ! active)
+                    return false;
+                inputs->before_flags[i].push_back(*before);
+                inputs->after_flags[i].push_back(*after);
+                inputs->active_flags[i].push_back(*active);
+            }
+
+        // One donor row per time point some task can occupy, which is exactly
+        // where the donor wrote one.
+        Integer global_lo = inputs->per_task_t_lo[inputs->active_tasks.front()], global_hi = per_task_t_hi[inputs->active_tasks.front()];
+        for (auto i : inputs->active_tasks) {
+            global_lo = std::min(global_lo, inputs->per_task_t_lo[i]);
+            global_hi = std::max(global_hi, per_task_t_hi[i]);
+        }
+
+        for (Integer t = global_lo; t <= global_hi; ++t) {
+            bool covered = false;
+            for (auto i : inputs->active_tasks)
+                if (t >= inputs->per_task_t_lo[i] && t <= per_task_t_hi[i]) {
+                    covered = true;
+                    break;
+                }
+            if (! covered)
+                continue;
+
+            auto row = tracker.constraint_row_label(spec.donor, ConstraintProofModelData<Cumulative>::capacity_row_role(t));
+            if (! row)
+                return false;
+            donor_rows.emplace_back(t, *row);
+        }
+    }
+
+    // Derive this constraint's own rows, here and now, at the top of the
+    // proof: they must outlive every backtrack, since the propagator cites them
+    // at every node. Nothing on this path reaches a ProofModel, so nothing here
+    // can reach the OPB.
+    //
+    // Not through an install_initialiser, even though that is where a posted
+    // constraint would do its once-only proof work: initialisers have already
+    // run by the time a presolver is called (solve.cc runs them, then the
+    // presolvers), so one installed from here would never fire and the
+    // propagator would cite rows that were never written.
+    if (logger) {
+        logger->emit_proof_comment("derived cumulative: " + to_string(donor_rows.size()) + " capacity rows from " + as_string(spec.donor));
+        for (const auto & [t, donor_row] : donor_rows)
+            inputs->capacity_lines.emplace(t, spec.recipe(*logger, donor_row, t));
+    }
+
+    Triggers triggers;
+    for (auto i : inputs->active_tasks)
+        triggers.on_bounds.emplace_back(spec.starts[i]);
+
+    propagators.install(
+        inputs->owner,
+        [inputs](const State & state, auto & inference, ProofLogger * const logger) -> PropagatorState {
+            return propagate_cumulative(*inputs, state, inference, logger);
+        },
+        triggers);
+
+    return true;
+}

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -1,0 +1,95 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_DERIVED_CUMULATIVE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_DERIVED_CUMULATIVE_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/state-fwd.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <functional>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief A Cumulative whose proof semantics are *derived* rather than
+     * asserted: it adds no rows to the OPB, and establishes its per-time
+     * capacity rows inside the proof instead, from a donor Cumulative's.
+     *
+     * This is what lets a presolver add an implied Cumulative without touching
+     * the model. The model is the statement being verified, so a presolver that
+     * wrote its inference into the OPB would be changing that statement rather
+     * than proving anything about it --- VeriPB would verify the result and it
+     * would mean nothing.
+     *
+     * The derived constraint covers the donor's tasks, with its own heights and
+     * capacity. It creates no flags: it pins the donor's, found through the keys
+     * ConstraintProofModelData<Cumulative> publishes, which is also what checks
+     * that the two agree about the tasks' possible-active windows --- a key
+     * outside the window the donor encoded has no flag, and this declines rather
+     * than inventing one.
+     *
+     * \ingroup Innards
+     */
+    struct DerivedCumulativeSpec
+    {
+        /// The Cumulative whose flags and capacity rows this is derived from.
+        /// Its arguments come from the donor's own accessors.
+        ConstraintID donor;
+
+        /// The donor's starts, in the donor's order: the flag keys are by task
+        /// position, so these must be the donor's tasks and nothing else.
+        std::vector<IntegerVariableID> starts;
+
+        /// Constant by type, which is the v1 restriction made structural: a
+        /// variable height enters the donor's capacity row as a bit-linearised
+        /// contribution rather than as `height x active`, and the derived row
+        /// would have to speak about those bits too.
+        std::vector<Integer> lengths, heights;
+        Integer capacity;
+
+        /**
+         * \brief How the derived row for time `t` comes off the donor's.
+         *
+         * Called once per time point, at ProofLevel::Top, with the donor's row
+         * for `t`; returns the derived row, which must say
+         * `Σ heights[i]·active[i,t] ≤ capacity` over the donor's flags. Anything
+         * else and the propagator's `pol`s will not cancel, which VeriPB will
+         * say so about.
+         *
+         * A recipe is a derivation, never an axiom: it has a ProofLogger and no
+         * ProofModel, so it cannot write to the OPB even by mistake.
+         */
+        std::function<auto(ProofLogger &, ProofLine donor_row, Integer t)->ProofLine> recipe;
+
+        /// Which propagation rules the derived constraint runs. The default is
+        /// all of them: it gets the same time-tabling and overload checking a
+        /// posted Cumulative does, over the donor's flags.
+        CumulativeRules rules;
+    };
+
+    /**
+     * \brief Install a derived Cumulative's propagator.
+     *
+     * For a presolver to call, in the shape auto_table and the difference-logic
+     * presolver already use: there is no constraint to post, because posting is
+     * what writes to the OPB.
+     *
+     * Returns false when the derived constraint could not be set up --- proofs
+     * are on but the donor's flags or rows are not where its published keys say,
+     * which means the donor was never installed, or the windows disagree. That
+     * is a decline, not a failure: the caller should not install a propagator
+     * whose inferences it cannot justify. With proofs off there is nothing to
+     * cite and nothing to decline, and the propagator installs unconditionally,
+     * so the same inferences are drawn either way.
+     *
+     * \ingroup Innards
+     */
+    auto install_derived_cumulative(Propagators &, const State & initial_state, ProofLogger * const, DerivedCumulativeSpec) -> bool;
+}
+
+#endif

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -1,0 +1,481 @@
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/subset_sum_strengthening.hh>
+#include <gcs/presolver.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <climits>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::ifstream;
+using std::make_optional;
+using std::make_unique;
+using std::max;
+using std::min;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::tuple;
+using std::unique_ptr;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "derived cumulative test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    auto constant_value_of(const IntegerVariableID & v) -> Integer
+    {
+        return std::get<ConstantIntegerVariableID>(v).const_value;
+    }
+
+    /**
+     * What the demo presolver derives from each Cumulative it finds.
+     */
+    enum class Demo
+    {
+        /// C'_t := C_t, copied by a one-line pol. The derived propagator must
+        /// then behave exactly like the donor's, which is what makes this the
+        /// test of the plumbing rather than of any reasoning.
+        Duplicate,
+        /// C'_t strengthened by integrality: every height is a multiple of d,
+        /// so the load at any time is too, and a capacity that is not gets
+        /// rounded down. Uses the subset-sum utility, which takes its
+        /// divisibility fast path here.
+        Strengthened,
+        /// Strengthened, but claiming one unit lower than the derivation
+        /// supports. VeriPB must reject.
+        ClaimOneLower,
+        /// A derived constraint whose tasks run longer than the donor's, so it
+        /// asks about (task, time) pairs the donor never encoded. The install
+        /// must decline.
+        BeyondDonorWindow
+    };
+
+    struct DerivedDemoPresolver : Presolver
+    {
+        Demo demo;
+        // Set by run(), read by the test: whether anything was installed.
+        std::shared_ptr<bool> installed = std::make_shared<bool>(false);
+
+        explicit DerivedDemoPresolver(Demo d) : demo(d)
+        {
+        }
+
+        [[nodiscard]] auto run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool override
+        {
+            for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
+                vector<Integer> lengths, heights;
+                for (const auto & l : donor.lengths())
+                    lengths.push_back(constant_value_of(l));
+                for (const auto & h : donor.heights())
+                    heights.push_back(constant_value_of(h));
+                auto capacity = constant_value_of(donor.capacity());
+
+                // Over the tasks that can raise the profile: a zero height is
+                // not a multiple of anything useful, and a task that never
+                // loads has no term in the row to divide.
+                auto divisor = 0_i;
+                for (size_t i = 0; i < heights.size(); ++i)
+                    if (lengths[i] > 0_i && heights[i] > 0_i)
+                        divisor = Integer{std::gcd(divisor.raw_value, heights[i].raw_value)};
+
+                DerivedCumulativeSpec spec{.donor = donor.constraint_id(),
+                    .starts = donor.starts(),
+                    .lengths = lengths,
+                    .heights = heights,
+                    .capacity = capacity,
+                    .recipe = {},
+                    .rules = CumulativeRules{}};
+
+                switch (demo) {
+                case Demo::Duplicate:
+                    spec.recipe = [](ProofLogger & logger, ProofLine donor_row, Integer) -> ProofLine {
+                        PolBuilder copy;
+                        copy.add(donor_row);
+                        return copy.emit(logger, ProofLevel::Top);
+                    };
+                    break;
+
+                case Demo::Strengthened:
+                case Demo::ClaimOneLower: {
+                    if (divisor <= 1_i)
+                        continue; // nothing to round: the derivation would be the duplicate one
+                    spec.capacity = divisor * (capacity / divisor);
+                    if (demo == Demo::ClaimOneLower)
+                        spec.capacity -= 1_i;
+
+                    // The items the donor's row for t is over: one per task
+                    // that can be active then, weighted by its height. Looked
+                    // up through the same published keys install_derived_-
+                    // cumulative uses, which is the presolver's half of the
+                    // contract.
+                    auto starts = donor.starts();
+                    auto donor_id = donor.constraint_id();
+                    auto claim_one_lower = (demo == Demo::ClaimOneLower);
+                    spec.recipe = [starts, heights, lengths, capacity, donor_id, claim_one_lower, &state](
+                                      ProofLogger & logger, ProofLine donor_row, Integer t) -> ProofLine {
+                        vector<SubsetSumItem> items;
+                        for (size_t i = 0; i < starts.size(); ++i) {
+                            if (lengths[i] <= 0_i || heights[i] <= 0_i)
+                                continue;
+                            auto active = logger.names_and_ids_tracker().find_proof_flag_values(
+                                donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+                            if (active)
+                                items.push_back(SubsetSumItem{heights[i], *active});
+                        }
+
+                        auto strengthened = derive_subset_sum_strengthening(logger, items, donor_row, capacity, ProofLevel::Top);
+                        if (! claim_one_lower)
+                            return strengthened.line;
+
+                        // Claim a capacity the derivation does not support: the
+                        // RUP has no way to reach it, so veripb says no.
+                        WPBSum load;
+                        for (const auto & item : items)
+                            load += item.coefficient * std::get<ProofFlag>(item.term);
+                        return logger.emit_rup_proof_line(move(load) <= strengthened.bound - 1_i, ProofLevel::Top);
+                    };
+                } break;
+
+                case Demo::BeyondDonorWindow:
+                    // One unit longer than the donor's tasks, so the derived
+                    // constraint's last time point is one the donor never
+                    // encoded a flag for.
+                    for (auto & l : spec.lengths)
+                        l += 1_i;
+                    spec.recipe = [](ProofLogger & logger, ProofLine donor_row, Integer) -> ProofLine {
+                        PolBuilder copy;
+                        copy.add(donor_row);
+                        return copy.emit(logger, ProofLevel::Top);
+                    };
+                    break;
+                }
+
+                *installed = install_derived_cumulative(propagators, state, logger, move(spec));
+            }
+            return true;
+        }
+
+        [[nodiscard]] auto clone() const -> unique_ptr<Presolver> override
+        {
+            auto result = make_unique<DerivedDemoPresolver>(demo);
+            result->installed = installed;
+            return result;
+        }
+    };
+
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            if (inst.lengths[i] == 0 || inst.heights[i] == 0)
+                continue;
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    auto post(Problem & p, const Instance & inst, optional<Demo> demo) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        for (auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+
+        vector<Integer> lengths, heights;
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        for (auto h : inst.heights)
+            heights.push_back(Integer{h});
+
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}});
+        if (demo)
+            p.add_presolver(DerivedDemoPresolver{*demo});
+        return starts;
+    }
+
+    struct Outcome
+    {
+        set<vector<int>> solutions;
+        unsigned long long recursions = 0;
+        bool refuted_at_root = false;
+    };
+
+    auto solve_it(const Instance & inst, optional<Demo> demo, const optional<string> & proof_name) -> Outcome
+    {
+        Problem p;
+        auto starts = post(p, inst, demo);
+
+        Outcome outcome;
+        bool reached_a_node = false, found_a_solution = false;
+        auto stats = solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               found_a_solution = true;
+                               vector<int> solution;
+                               for (const auto & v : starts)
+                                   solution.push_back(s(v).raw_value);
+                               outcome.solutions.insert(move(solution));
+                               return true;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return true;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+
+        outcome.recursions = stats.recursions;
+        outcome.refuted_at_root = ! reached_a_node && ! found_a_solution;
+
+        if (proof_name)
+            verify_proof_and_clean_up(*proof_name);
+        return outcome;
+    }
+
+    auto read_file(const string & name) -> string
+    {
+        ifstream in{name, std::ios::binary};
+        if (! in)
+            fail("could not read " + name);
+        return string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+    }
+
+    // The headline check. A derived constraint's whole reason to exist is that
+    // a presolver can add an implied constraint without touching the model:
+    // the OPB is the statement being verified, so a presolver that wrote into
+    // it would be changing the statement rather than proving anything about it,
+    // and every proof in this file would verify and mean nothing.
+    auto check_opb_unaffected(const string & what, const Instance & inst, Demo demo) -> void
+    {
+        const string with = "derived_cumulative_opb_with", without = "derived_cumulative_opb_without";
+
+        // A trace callback that stops at once: the model is written before the
+        // search, and this is about the model.
+        auto write_model_only = [&](const string & name, optional<Demo> d) {
+            Problem p;
+            post(p, inst, d);
+            solve_with(
+                p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, make_optional<ProofOptions>(ProofFileNames{name}));
+        };
+
+        write_model_only(with, make_optional(demo));
+        write_model_only(without, nullopt);
+
+        if (read_file(with + ".opb") != read_file(without + ".opb"))
+            fail("the derived constraint changed the OPB, on " + what);
+
+        for (const auto & name : {with, without})
+            dispose_of_proof_files(name);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+    auto proofs = can_run_veripb();
+
+    // Demo one: a verbatim duplicate. Two tasks that cannot overlap under a
+    // capacity of one, so there is real propagation to compare.
+    const Instance duplicate_instance{{{0, 4}, {0, 4}, {0, 4}}, {2, 2, 3}, {1, 1, 1}, 1};
+
+    {
+        auto donor_only = solve_it(duplicate_instance, nullopt, nullopt);
+        auto with_derived =
+            solve_it(duplicate_instance, make_optional(Demo::Duplicate), proofs ? make_optional("derived_cumulative_duplicate") : nullopt);
+
+        if (donor_only.solutions != with_derived.solutions)
+            fail("duplicate demo: the solution set changed");
+        if (donor_only.recursions != with_derived.recursions)
+            fail("duplicate demo: the search changed, so the copy is not behaving like the donor (" + std::to_string(donor_only.recursions) +
+                " nodes against " + std::to_string(with_derived.recursions) + ")");
+
+        set<vector<int>> expected;
+        build_expected(
+            expected, [&](const vector<int> & starts) { return is_satisfying(duplicate_instance, starts); }, duplicate_instance.start_ranges);
+        if (expected != with_derived.solutions)
+            fail("duplicate demo: solutions do not match brute force");
+    }
+
+    // Demo two: strengthening by integrality. Every height is a multiple of
+    // three, so the load at any time is a multiple of three, and a capacity of
+    // eight is really a capacity of six.
+    //
+    // That difference is invisible to time-tabling --- a load is a sum of
+    // heights, so it clears eight exactly when it clears six --- and shows up
+    // only in the energy argument, where the window's supply is capacity times
+    // its width and *that* is not a multiple of three. Seven unit-length tasks
+    // of height three need 21 units of energy in [0, 3), which a capacity of
+    // eight supplies (24) and a capacity of six does not (18). So the donor
+    // alone has nothing to say at the root, and the derived constraint refutes
+    // it there.
+    const Instance strengthened_instance{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, {1, 1, 1, 1, 1, 1, 1}, {3, 3, 3, 3, 3, 3, 3}, 8};
+
+    {
+        auto donor_only = solve_it(strengthened_instance, nullopt, nullopt);
+        if (donor_only.refuted_at_root)
+            fail("strengthened demo: the donor alone refuted at the root, so the fixture proves nothing");
+
+        auto with_derived =
+            solve_it(strengthened_instance, make_optional(Demo::Strengthened), proofs ? make_optional("derived_cumulative_strengthened") : nullopt);
+        if (! with_derived.refuted_at_root)
+            fail("strengthened demo: the derived constraint did not refute at the root");
+        if (! with_derived.solutions.empty())
+            fail("strengthened demo: the instance is unsatisfiable but solutions were reported");
+    }
+
+    // Nothing above may have reached the OPB.
+    check_opb_unaffected("duplicate", duplicate_instance, Demo::Duplicate);
+    check_opb_unaffected("strengthened", strengthened_instance, Demo::Strengthened);
+
+    // A derived constraint is implied, so it must not cost solutions. Random
+    // instances, against brute force, with the duplicate recipe (which keeps
+    // the propagation identical) and the strengthening one (which does not).
+    {
+        std::mt19937 rand(*get_seed());
+        std::uniform_int_distribution<> n_dist(2, 3), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), ht_dist(0, 2), cap_dist(1, 4);
+
+        for (int k = 0; k < 60; ++k) {
+            Instance inst;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand), span = span_dist(rand);
+                inst.start_ranges.emplace_back(lo, lo + span);
+                inst.lengths.push_back(len_dist(rand));
+                // Heights in multiples of two, so the strengthening has
+                // something to round.
+                inst.heights.push_back(2 * ht_dist(rand));
+            }
+            inst.capacity = cap_dist(rand);
+
+            set<vector<int>> expected;
+            build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+
+            for (auto demo : {Demo::Duplicate, Demo::Strengthened}) {
+                auto outcome = solve_it(inst, make_optional(demo), nullopt);
+                if (outcome.solutions != expected) {
+                    println(cerr, "starts={} lens={} hts={} c={}", inst.start_ranges, inst.lengths, inst.heights, inst.capacity);
+                    fail("a derived constraint removed solutions");
+                }
+            }
+        }
+    }
+
+    // A derived constraint that asks about a (task, time) the donor never
+    // encoded must be declined, not guessed at.
+    {
+        Problem p;
+        post(p, duplicate_instance, make_optional(Demo::BeyondDonorWindow));
+        // The presolver's own record of what happened: with proofs on there is
+        // nothing to cite past the donor's window, so nothing is installed.
+        auto presolver = DerivedDemoPresolver{Demo::BeyondDonorWindow};
+        auto installed = presolver.installed;
+        Problem p2;
+        auto starts = post(p2, duplicate_instance, nullopt);
+        p2.add_presolver(presolver);
+        solve_with(p2, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }},
+            proofs ? make_optional<ProofOptions>(ProofFileNames{"derived_cumulative_beyond_window"}) : nullopt);
+        if (proofs) {
+            if (*installed)
+                fail("a derived constraint reaching past the donor's windows was installed anyway");
+            dispose_of_proof_files("derived_cumulative_beyond_window");
+        }
+    }
+
+    if (! proofs) {
+        println(cerr, "veripb is not available, so the proof-level checks are skipped");
+        return EXIT_SUCCESS;
+    }
+
+    // Claiming a capacity the derivation does not support must be rejected.
+    {
+        Problem p;
+        post(p, strengthened_instance, make_optional(Demo::ClaimOneLower));
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return true; }},
+            make_optional<ProofOptions>(ProofFileNames{"derived_cumulative_one_lower"}));
+
+        if (run_veripb("derived_cumulative_one_lower.opb", "derived_cumulative_one_lower.pbp"))
+            fail("veripb accepted a derived capacity one lower than the derivation supports");
+        println(cerr, "veripb rejected the one-lower capacity, as expected");
+        dispose_of_proof_files("derived_cumulative_one_lower");
+    }
+
+    // Backtracking soak: the derived rows are emitted once, at the top of the
+    // proof, and cited at every node. A search that backtracks deeply would
+    // find them gone if they had been emitted at any other level.
+    {
+        const Instance soak{{{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {2, 2, 3, 3}, {2, 2, 2, 4}, 6};
+        auto outcome = solve_it(soak, make_optional(Demo::Strengthened), make_optional("derived_cumulative_soak"));
+        println(cerr, "backtracking soak: {} solutions over {} nodes", outcome.solutions.size(), outcome.recursions);
+        if (outcome.recursions < 5)
+            fail("backtracking soak: the instance did not search, so it soaked nothing");
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(soak, starts); }, soak.start_ranges);
+        if (expected != outcome.solutions)
+            fail("backtracking soak: solutions do not match brute force");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -239,7 +239,7 @@ namespace
         return true;
     }
 
-    auto post(Problem & p, const Instance & inst, optional<Demo> demo) -> vector<IntegerVariableID>
+    auto post(Problem & p, const Instance & inst, optional<Demo> demo, CumulativeRules donor_rules = CumulativeRules{}) -> vector<IntegerVariableID>
     {
         vector<IntegerVariableID> starts;
         for (auto & [lo, hi] : inst.start_ranges)
@@ -251,7 +251,7 @@ namespace
         for (auto h : inst.heights)
             heights.push_back(Integer{h});
 
-        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}});
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(donor_rules));
         if (demo)
             p.add_presolver(DerivedDemoPresolver{*demo});
         return starts;
@@ -264,10 +264,11 @@ namespace
         bool refuted_at_root = false;
     };
 
-    auto solve_it(const Instance & inst, optional<Demo> demo, const optional<string> & proof_name) -> Outcome
+    auto solve_it(const Instance & inst, optional<Demo> demo, const optional<string> & proof_name, CumulativeRules donor_rules = CumulativeRules{})
+        -> Outcome
     {
         Problem p;
-        auto starts = post(p, inst, demo);
+        auto starts = post(p, inst, demo, donor_rules);
 
         Outcome outcome;
         bool reached_a_node = false, found_a_solution = false;
@@ -383,6 +384,30 @@ auto main(int argc, char * argv[]) -> int
             fail("strengthened demo: the derived constraint did not refute at the root");
         if (! with_derived.solutions.empty())
             fail("strengthened demo: the instance is unsatisfiable but solutions were reported");
+    }
+
+    // The derived propagator has to be the one doing the work, not a
+    // bystander watching the donor do it. With the donor's own rules turned off
+    // it infers nothing at all, so every inference in this solve --- and every
+    // justification --- comes from the derived constraint, over the donor's
+    // flags and its own derived rows.
+    {
+        const CumulativeRules silent{.time_table = false, .overload = false, .profile_overload = false};
+
+        auto donor_silent = solve_it(duplicate_instance, nullopt, nullopt, silent);
+        auto derived_working =
+            solve_it(duplicate_instance, make_optional(Demo::Duplicate), proofs ? make_optional("derived_cumulative_carrying") : nullopt, silent);
+
+        set<vector<int>> expected;
+        build_expected(
+            expected, [&](const vector<int> & starts) { return is_satisfying(duplicate_instance, starts); }, duplicate_instance.start_ranges);
+        if (derived_working.solutions != expected)
+            fail("carrying demo: solutions do not match brute force with the donor silent");
+        if (derived_working.recursions >= donor_silent.recursions)
+            fail("carrying demo: the derived constraint pruned nothing (" + std::to_string(derived_working.recursions) + " nodes against " +
+                std::to_string(donor_silent.recursions) + " with nothing propagating), so its proof path is untested");
+        println(cerr, "derived propagator carrying alone: {} nodes against {} with nothing propagating", derived_working.recursions,
+            donor_silent.recursions);
     }
 
     // Nothing above may have reached the OPB.

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -1,0 +1,123 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_PROPAGATE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_CONSTRAINTS_CUMULATIVE_PROPAGATE_HH
+
+#include <gcs/constraint_id.hh>
+#include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+#include <gcs/innards/propagators-fwd.hh>
+#include <gcs/innards/state-fwd.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/integer.hh>
+#include <gcs/variable_id.hh>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Everything Cumulative's propagator reads: the task data, the
+     * per-time proof flags it pins, and the per-time capacity lines it builds
+     * its `pol`s on.
+     *
+     * Hoisted out of the propagator's closure so that a *derived* Cumulative
+     * (see install_derived_cumulative) can run the same algorithm over the same
+     * flags with different capacity lines. Nothing here says where the flags
+     * and lines came from --- a posted constraint fills them in from its own
+     * define_proof_model, a derived one from its donor's --- which is exactly
+     * the separation that lets the second exist without writing to the OPB.
+     *
+     * The proof-side members are all empty when proofs are off.
+     *
+     * \ingroup Innards
+     */
+    struct CumulativeInputs
+    {
+        /// The constraint whose identity inferences are attributed to.
+        ConstraintID owner = CurrentlyUnnamedConstraint{};
+
+        std::vector<IntegerVariableID> starts, lengths, heights;
+        IntegerVariableID capacity = constant_variable(0_i);
+
+        /// The tasks that can raise the load profile at all: those whose length
+        /// and height can both be non-zero.
+        std::vector<std::size_t> active_tasks;
+
+        /// Indexed by `t - per_task_t_lo[i]`, over the task's possible-active
+        /// window. A derived Cumulative points these at its donor's flags, so
+        /// the windows must be the donor's too.
+        std::vector<std::vector<ProofFlag>> before_flags, after_flags, active_flags;
+        /// Per (variable-height task, t, bit), the linearised load
+        /// contribution. Empty for a constant height, and empty throughout for
+        /// a derived Cumulative, which takes constant heights only.
+        std::vector<std::vector<std::vector<ProofFlag>>> contrib_flags;
+        std::vector<Integer> per_task_t_lo;
+
+        /// The proof-only `end = start + length` proxy for a task whose start
+        /// and length both vary, and the `{end >= s + l, end <= s + l}` lines
+        /// its initialiser cached. Shared, so the cache survives across calls.
+        std::vector<std::optional<ProofOnlySimpleIntegerVariableID>> ends;
+        std::shared_ptr<std::vector<std::optional<std::pair<ProofLine, ProofLine>>>> end_lines;
+
+        /// t -> the row saying the load at t is within the capacity. A posted
+        /// constraint's are OPB rows; a derived constraint's are derived from
+        /// its donor's, in the proof.
+        std::map<Integer, ProofLine> capacity_lines;
+
+        CumulativeRules rules;
+        CumulativeProofMutation proof_mutation;
+
+        /// Overload checking, resolved once (see
+        /// Cumulative::prepare_overload_check). Empty when the rule is off or
+        /// no task is eligible.
+        std::vector<std::size_t> overload_tasks;
+        std::vector<Integer> time_slot_prefix;
+        Integer time_slot_lo = 0_i;
+    };
+
+    /**
+     * \brief What the overload check needs resolving once, before the search
+     * starts: which tasks its window-energy lemma can speak about, and where a
+     * capacity row exists to be cited.
+     *
+     * \ingroup Innards
+     */
+    struct CumulativeOverloadData
+    {
+        std::vector<std::size_t> overload_tasks;
+        std::vector<Integer> time_slot_prefix;
+        Integer time_slot_lo = 0_i;
+    };
+
+    /**
+     * \brief Resolve CumulativeOverloadData from a constraint's posted
+     * arguments and the initial state.
+     *
+     * Shared by a posted Cumulative and a derived one, so that a derived
+     * constraint gets the same energy reasoning over its donor's flags rather
+     * than a second implementation of the eligibility rules.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto prepare_cumulative_overload_check(const std::vector<IntegerVariableID> & starts,
+        const std::vector<IntegerVariableID> & lengths, const std::vector<IntegerVariableID> & heights, const std::vector<std::size_t> & active_tasks,
+        const std::vector<Integer> & per_task_t_lo, const std::vector<Integer> & per_task_t_hi, const State & initial_state)
+        -> CumulativeOverloadData;
+
+    /**
+     * \brief Time-table propagation and overload checking for Cumulative.
+     *
+     * Instantiated for both inference trackers; see the bottom of
+     * cumulative.cc.
+     *
+     * \ingroup Innards
+     */
+    auto propagate_cumulative(const CumulativeInputs &, const State &, auto & inference_tracker, ProofLogger * const logger) -> PropagatorState;
+}
+
+#endif

--- a/gcs/innards/proofs/constraint_proof_model_data.hh
+++ b/gcs/innards/proofs/constraint_proof_model_data.hh
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace gcs::innards
 {
@@ -44,6 +45,32 @@ namespace gcs::innards
      */
     template <typename Constraint_>
     struct ConstraintProofModelData;
+
+    /**
+     * \brief The key a constraint created one of its proof flags under: the
+     * value list and optional annotation it passed to
+     * NamesAndIDsTracker::create_proof_flag_values.
+     *
+     * The flag-side counterpart of a published row role, and published the same
+     * way and for the same reason. A flag's name is a pure function of
+     * `(ConstraintID, values, annotation)`, so a caller that knows the key can
+     * find the flag whatever clone created it --- but a caller that *builds*
+     * that name itself is hard-coding another constraint's naming scheme, which
+     * is what ConstraintProofModelData exists to stop.
+     *
+     * Holding the resulting ProofFlag is then the permission to cite its
+     * reification rows by name, exactly as the constraint that made it does:
+     * those rows live in the `v[...]` namespace rather than `c[id][role]`, so
+     * constraint_row_label deliberately does not cover them.
+     *
+     * \ingroup Innards
+     * \sa NamesAndIDsTracker::find_proof_flag_values
+     */
+    struct ProofFlagKey
+    {
+        std::vector<long long> values;
+        std::optional<std::string> annotation;
+    };
 
     /**
      * \brief NamesAndIDsTracker::constraint_row_label, reached through a

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -149,6 +149,14 @@ struct NamesAndIDsTracker::Imp
     // it needs no synchronisation under the intended one-OPB, N-thread model.
     set<string> emitted_constraint_row_labels;
 
+    // Every flag created under a ConstraintID-keyed name, so that a caller
+    // holding the key can find it (find_proof_flag_values). Filled by
+    // make_proof_flag_named, which is the funnel for exactly those namespaces:
+    // an f[index][stem] flag is anonymous and has no key. Same write-only
+    // during model definition, read-only afterwards story as
+    // emitted_constraint_row_labels, and for the same reason.
+    map<string, optional<ProofFlag>> constraint_keyed_flags;
+
     unordered_map<SimpleOrProofOnlyIntegerVariableID, ProofLine, HashSimpleOrProofOnlyVariable> variable_at_least_one_constraints;
     // Indexed by variable index (variables are allocated with sequential
     // indices, so these stay dense), one per id kind.
@@ -1613,6 +1621,27 @@ auto NamesAndIDsTracker::constraint_row_label(const ConstraintID & id, const str
     return ProofLineLabel{label};
 }
 
+auto NamesAndIDsTracker::find_proof_flag_values(const ConstraintID & id, const ProofFlagKey & key) const -> optional<ProofFlag>
+{
+    // Built the same way create_proof_flag_values builds it, because it has to
+    // be the same string: that is what makes this a pure function of
+    // (id, values, annotation) rather than a lookup into per-solve state.
+    string name = "v[" + as_string(id) + "][";
+    for (size_t k = 0; k < key.values.size(); ++k) {
+        if (k != 0)
+            name += "_";
+        name += to_string(key.values[k]);
+    }
+    name += "]";
+    if (key.annotation)
+        name += "[" + *key.annotation + "]";
+
+    auto found = _imp->constraint_keyed_flags.find(name);
+    if (found == _imp->constraint_keyed_flags.end())
+        return nullopt;
+    return found->second;
+}
+
 auto NamesAndIDsTracker::create_proof_flag(const string & name) -> ProofFlag
 {
     ProofFlag result{allocate_flag_index(), true};
@@ -1693,6 +1722,15 @@ auto NamesAndIDsTracker::make_proof_flag_named(const string & full_name) -> Proo
     auto flagvar = allocate_flag_xliteral(result, full_name);
     _imp->flags.emplace(result, flagvar);
     _imp->flags.emplace(! result, ! flagvar);
+    // Indexed so that find_proof_flag_values can answer for it. A repeat is a
+    // name collision in the PB file --- two flags rendering as one variable ---
+    // so it is a bug in whichever namer produced it rather than something to
+    // resolve here, but this is not the place to be strict about it: the
+    // ambiguity that matters is a *lookup* that could name either, so record
+    // the first and let a repeat poison the entry.
+    auto [where, inserted] = _imp->constraint_keyed_flags.emplace(full_name, result);
+    if (! inserted)
+        where->second = nullopt; // poisoned: a lookup could name either, so it names neither
     return result;
 }
 

--- a/gcs/innards/proofs/names_and_ids_tracker.cc
+++ b/gcs/innards/proofs/names_and_ids_tracker.cc
@@ -134,6 +134,40 @@ namespace
             return hash_combine(flag.positive ? 5 : 6, flag.index);
         }
     };
+
+    // The cake-style bracketed flag name `<kind>[id][n1_n2..][annotation?]`:
+    // the number list joined by '_', the optional annotation in its own
+    // brackets, mirroring cake_pb_cp's format_flag (cp_to_ilpScript.sml).
+    // `kind` is cake's rendering class -- 'x' where the numbers are array
+    // positions, 'v' where they are domain values. See #354.
+    //
+    // Shared rather than written out at each caller because
+    // find_proof_flag_values has to rebuild *exactly* the string
+    // create_proof_flag_values built: that is what makes the lookup a pure
+    // function of (id, values, annotation) rather than a read of per-solve
+    // state. One builder is what keeps "the same string" a fact rather than an
+    // intention.
+    //
+    // Negative numbers render as `-N`, matching cake's format_int_list and the
+    // solver's own eq/ge literals (i[X][eq-N]). VeriPB allows '-' in variable
+    // names and in @labels alike (VeriPB-dev #191), so this is legal in the
+    // labelled flag definitions too, and byte-matches cake over negative
+    // domains.
+    [[nodiscard]] auto bracketed_flag_name(char kind, const ConstraintID & id, const vector<long long> & numbers, const optional<string> & annotation)
+        -> string
+    {
+        string name{kind};
+        name += "[" + as_string(id) + "][";
+        for (size_t k = 0; k < numbers.size(); ++k) {
+            if (k != 0)
+                name += "_";
+            name += to_string(numbers[k]);
+        }
+        name += "]";
+        if (annotation)
+            name += "[" + *annotation + "]";
+        return name;
+    }
 }
 
 struct NamesAndIDsTracker::Imp
@@ -1623,20 +1657,10 @@ auto NamesAndIDsTracker::constraint_row_label(const ConstraintID & id, const str
 
 auto NamesAndIDsTracker::find_proof_flag_values(const ConstraintID & id, const ProofFlagKey & key) const -> optional<ProofFlag>
 {
-    // Built the same way create_proof_flag_values builds it, because it has to
-    // be the same string: that is what makes this a pure function of
+    // Built by the same helper create_proof_flag_values builds with, because it
+    // has to be the same string: that is what makes this a pure function of
     // (id, values, annotation) rather than a lookup into per-solve state.
-    string name = "v[" + as_string(id) + "][";
-    for (size_t k = 0; k < key.values.size(); ++k) {
-        if (k != 0)
-            name += "_";
-        name += to_string(key.values[k]);
-    }
-    name += "]";
-    if (key.annotation)
-        name += "[" + *key.annotation + "]";
-
-    auto found = _imp->constraint_keyed_flags.find(name);
+    auto found = _imp->constraint_keyed_flags.find(bracketed_flag_name('v', id, key.values, key.annotation));
     if (found == _imp->constraint_keyed_flags.end())
         return nullopt;
     return found->second;
@@ -1655,19 +1679,10 @@ auto NamesAndIDsTracker::create_proof_flag(const string & name) -> ProofFlag
 auto NamesAndIDsTracker::create_proof_flag(const ConstraintID & id, const vector<long long> & indices, const optional<string> & annotation)
     -> ProofFlag
 {
-    // Mirror cake_pb_cp's Indices flag rendering (cp_to_ilpScript.sml format_flag):
-    // x[id][i1_i2..][annotation?] -- the index list joined by '_', the optional
-    // annotation in its own brackets.
-    string name = "x[" + as_string(id) + "][";
-    for (size_t k = 0; k < indices.size(); ++k) {
-        if (k != 0)
-            name += "_";
-        name += to_string(indices[k]);
-    }
-    name += "]";
-    if (annotation)
-        name += "[" + *annotation + "]";
-    return make_proof_flag_named(name);
+    // cake_pb_cp's Indices flag rendering: x[id][i1_i2..][annotation?]. The
+    // numbers are array positions, in contrast to the domain values of the
+    // v[...] overload.
+    return make_proof_flag_named(bracketed_flag_name('x', id, indices, annotation));
 }
 
 auto NamesAndIDsTracker::create_proof_flag(const ConstraintID & id, const string & annotation) -> ProofFlag
@@ -1682,26 +1697,11 @@ auto NamesAndIDsTracker::create_proof_flag(const ConstraintID & id, const string
 auto NamesAndIDsTracker::create_proof_flag_values(const ConstraintID & id, const vector<long long> & values, const optional<string> & annotation)
     -> ProofFlag
 {
-    // Mirror cake_pb_cp's Values flag rendering (cp_to_ilpScript.sml format_flag):
-    // v[id][v1_v2..][annotation?] -- the value list joined by '_', the optional
-    // annotation in its own brackets. The values are domain values, in contrast
-    // to the array positions of the x[...] overload; nvalue's per-value
-    // occurrence flag is create_proof_flag_values(id, {v}) -> v[id][v]. See #354.
-    string name = "v[" + as_string(id) + "][";
-    for (size_t k = 0; k < values.size(); ++k) {
-        if (k != 0)
-            name += "_";
-        // Negative values are rendered `-N`, matching cake's format_int_list and
-        // the solver's eq/ge literals (i[X][eq-N]). VeriPB allows '-' in both
-        // variable names and @labels (VeriPB-dev #191), so this is legal in the
-        // labelled flag definitions too and byte-matches cake over negative
-        // domains.
-        name += to_string(values[k]);
-    }
-    name += "]";
-    if (annotation)
-        name += "[" + *annotation + "]";
-    return make_proof_flag_named(name);
+    // cake_pb_cp's Values flag rendering: v[id][v1_v2..][annotation?]. The
+    // numbers are domain values, in contrast to the array positions of the
+    // x[...] overload; nvalue's per-value occurrence flag is
+    // create_proof_flag_values(id, {v}) -> v[id][v]. See #354.
+    return make_proof_flag_named(bracketed_flag_name('v', id, values, annotation));
 }
 
 auto NamesAndIDsTracker::create_proof_flag_for_constant(Integer k, const string & atom) -> ProofFlag

--- a/gcs/innards/proofs/names_and_ids_tracker.hh
+++ b/gcs/innards/proofs/names_and_ids_tracker.hh
@@ -2,6 +2,7 @@
 #define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PROOFS_PROOF_VARIABLE_CONSTRAINTS_TRACKER_HH
 
 #include <gcs/constraint_id.hh>
+#include <gcs/innards/proofs/constraint_proof_model_data.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker-fwd.hh>
 #include <gcs/innards/proofs/proof_line.hh>
 #include <gcs/innards/proofs/proof_logger-fwd.hh>
@@ -534,6 +535,34 @@ namespace gcs::innards
          * constraint's naming scheme.
          */
         [[nodiscard]] auto constraint_row_label(const ConstraintID & id, const std::string & role) const -> std::optional<ProofLineLabel>;
+
+        /**
+         * \brief The flag a constraint created under this key, if it created
+         * one.
+         *
+         * The flag-side counterpart of \ref constraint_row_label, and the same
+         * shape of answer: "may I cite this?", not "what does it say". A flag's
+         * name is a pure function of `(id, values, annotation)` --- the same
+         * function \ref create_proof_flag_values applies --- so this finds the
+         * flag whichever clone of the constraint created it, and stores nothing
+         * a solve depends on beyond the name index the flags already need.
+         *
+         * nullopt means no flag went out under that key: the constraint was
+         * never installed, or proofs are off, or the key names a
+         * (task, time) pair outside the window the constraint encoded. All of
+         * those mean the same thing to a caller --- there is nothing to cite,
+         * so do not do the thing that would need citing.
+         *
+         * Pair it with innards::ConstraintProofModelData, which is how a
+         * constraint publishes the *keys* it uses; building one here instead
+         * would be guessing at another constraint's naming scheme.
+         *
+         * Only the ConstraintID-keyed flag namespaces are indexed, matching
+         * what \ref claim_constraint_row_labels covers on the row side: an
+         * `f[index][stem]` flag is anonymous by construction and has no key to
+         * look up.
+         */
+        [[nodiscard]] auto find_proof_flag_values(const ConstraintID & id, const ProofFlagKey & key) const -> std::optional<ProofFlag>;
 
         /**
          * Create a proof flag with a new identifier, named `f[index][stem]`.


### PR DESCRIPTION
Issue 04 of the Cumulative proof-logging plan (#541), from #545.

**Stacked on #656** → #655. The strengthening demo is the subset-sum utility's
first real consumer, which is why it sits on top of that one; retarget as each
merges.

## What it is

A derived Cumulative covers a donor's tasks with its own heights and capacity,
and **adds nothing to the OPB**: its per-time capacity rows are derived inside
the proof from the donor's, by a recipe the caller supplies. That is what lets
issues #547–#549 add implied Cumulatives without touching the model — the model
is the statement being verified, so a presolver writing its inference into the
OPB would be changing that statement rather than proving anything about it, and
VeriPB would verify the result and it would mean nothing.

## The API, and its relationship to #603

This is the part worth reviewing. #603 established the discipline for citing
another constraint's model output: the constraint *publishes* what is citable,
the tracker says whether it is there, and nobody reconstructs a name as a
string. A derived Cumulative needs two things from its donor, and only one of
them was already covered:

| what | published as | resolved by |
|---|---|---|
| `Σ hᵢ·activeᵢₜ ≤ C` for a time `t` | `ConstraintProofModelData<Cumulative>::capacity_row_role(t)` | `constraint_row_label` — **#603, unchanged** |
| the `before`/`after`/`active` flags for `(i, t)` | `...::before_flag_key(i, t)` and friends | `find_proof_flag_values` — **new** |

The flag half is the same idea one step further. A flag's name is a pure
function of `(ConstraintID, values, annotation)` — the same function
`create_proof_flag_values` applies — so the tracker can answer "did a flag go
out under this key?" exactly as it answers the question for rows. Holding the
returned `ProofFlag` is then the permission to cite its reification rows by
name, as the constraint that made it does; those live in the `v[...]` namespace,
which `claim_constraint_row_labels` deliberately excludes. The index is
`make_proof_flag_named`'s, so it covers exactly the ConstraintID-keyed
namespaces, and a repeated name poisons its entry rather than letting a lookup
name either of two flags.

Two things fall out of doing it this way. The installed clone preserves the
original's `ConstraintID` (problem.cc:211, explicitly so labels match), so a
presolver enumerating stored constraints resolves the same keys the clone
created. And the lookup **is** the windowing check the issue asks for: a key
outside the window the donor encoded has no flag, so a derived constraint whose
tasks run longer declines to install rather than inventing one.

## Shape

`install_derived_cumulative(propagators, state, logger, spec)` — a free function
for a presolver, in the shape `auto_table` and the difference-logic presolver
already use. There is no constraint to post, because posting is what writes rows.

It derives its rows **inline**, not from an `install_initialiser`: initialisers
have already run by the time a presolver is called (`solve.cc` runs them at 343,
presolvers at 347), so one installed from there never fires and the propagator
spends the search citing rows that were never written. That cost me a
`map::at` crash before I found it, and it is now a comment where somebody else
will need it.

The propagator body moves out of `install_propagators` into
`propagate_cumulative` over an explicit `CumulativeInputs`, so the derived form
runs the same algorithm — time-tabling *and* the overload check — over the
donor's flags with its own rows. Behaviour-preserving: existing tests pass
unchanged, and the OPB is byte-identical to main.

## The recipe

```cpp
std::function<auto(ProofLogger &, ProofLine donor_row, Integer t)->ProofLine>
```

A `ProofLogger` and no `ProofModel`, so a recipe cannot write to the OPB even by
mistake. The two demos are a copying `pol`, and subset-sum strengthening (#656)
over the row's own terms.

That second one is worth knowing the shape of: rounding a capacity of eight down
to six when every height is a multiple of three is **invisible to
time-tabling** — a load is a sum of heights, so it clears eight exactly when it
clears six. It bites in the *energy* argument, where a window's supply is
capacity times width and that is not a multiple of three. Seven unit tasks of
height three need 21 units in `[0, 3)`, which eight supplies and six does not.
My first fixture got this wrong and the test told me.

## Checking

- **OPB byte-diff**, the headline: identical with and without the derived
  constraint, across the demo corpus. Checked against `main` by hand as well —
  all twenty `.opb` and `.scp` files `cumulative_test` writes are unchanged
  across this whole stack.
- **The derived propagator is the one doing the work.** With the donor's own
  rules turned off it infers nothing, so every inference and every justification
  comes from the derived constraint: 6 nodes against 156 with nothing
  propagating, proof verified. Without this the donor could have been doing all
  the pruning while the derived propagator's proof path never ran.
- Duplicate demo: solutions *and node counts* identical to donor-only.
- Strengthened demo: root refutation with, search without.
- Reaching past the donor's windows: declined.
- A recipe claiming one lower than it derived: rejected by veripb.
- Enumeration against brute force (a derived constraint is implied, so it must
  not cost solutions), and a 947-node backtracking soak, which would catch rows
  emitted at any level that does not survive backtracking.

Full `ctest` (frontends on): 612/612. Built and run under clang 21.

## Multi-donor

Not implemented — #548/#549 need it, and the two candidate mechanisms (per-(i,t)
bridge lemmas versus rewriting each donor's row over canonical flags) are
written up in `dev_docs/cumulative-proof-logging.md` with what would decide
between them. Neither needs new API: both donors' rows are citable by name
already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p