### PR TITLE
Run the initialisers a presolver installed, rather than dropping them

### DIFF
--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -225,10 +225,17 @@ auto DifferenceConstraints::install_propagators(Propagators & propagators) -> vo
     if (_root_contradiction_posted_index) {
         // The edge's own OPB row is `0 >= something positive', so the
         // contradiction is RUP from the model with no state involved at all.
-        // Deliberately not part of install_difference_propagator: this is an
-        // initialiser, and initialisers have already run by the time a
-        // presolver builds a graph, so the presolver must instead decline to
-        // lift a degenerate edge and leave it to its own propagator.
+        // Deliberately not part of install_difference_propagator, which the
+        // difference-logic presolver shares: when this was written, an
+        // initialiser installed from a presolver was dropped, so the presolver
+        // had to decline to lift a degenerate edge and leave it to that edge's
+        // own propagator instead.
+        //
+        // Presolver-installed initialisers now run (solve.cc initialises again
+        // after each presolver), so this could move into the shared path and
+        // the presolver's decline could go with it. Not done here: both halves
+        // have to change together, and the presolver's own tests are what say
+        // whether declining is still worth its complexity.
         propagators.install_initial_contradiction("difference constraint x - x <= d with d < 0", JustifyUsingRUP{}, NoReason{});
         return;
     }

--- a/gcs/innards/propagators.cc
+++ b/gcs/innards/propagators.cc
@@ -155,6 +155,11 @@ struct Propagators::Imp : RefinedWatchSink
 {
     vector<PropagationFunction> propagation_functions;
     std::array<vector<InitialisationFunction>, number_of_initialiser_priorities> initialisation_functions_by_priority;
+    // How many of each bucket initialise() has already run. A presolver can
+    // install a constraint after the first round, and that constraint's
+    // initialiser has to run like any other: the next round picks up from here,
+    // so nothing runs twice and nothing is left behind.
+    std::array<std::size_t, number_of_initialiser_priorities> initialisers_already_run{};
 
     // Every propagation function's index appears exactly once in queue, and lookup[id] always tells
     // us where that position is. The ready-to-propagate items are [enqueued_begin, enqueued_end);
@@ -528,23 +533,43 @@ auto Propagators::install_initialiser(InitialisationFunction && f, InitialiserPr
     _imp->initialisation_functions_by_priority[to_underlying(priority)].emplace_back(move(f));
 }
 
-auto Propagators::initialise(State & state, ProofLogger * const logger) const -> bool
+auto Propagators::initialise(State & state, ProofLogger * const logger) -> bool
 {
-    for (auto & bucket : _imp->initialisation_functions_by_priority) {
-        for (auto & f : bucket) {
-            try {
-                // As in propagate(): with no logger, run the lean tracker.
-                if (logger) {
-                    EagerProofLoggingInferenceTracker inf(state);
-                    f(state, inf, logger);
+    // Sweep the buckets in priority order until every one has been run to its
+    // end. The repeat matters because running an initialiser can install more
+    // of them --- including into a bucket this sweep has already passed --- and
+    // an initialiser that never runs is a silent hole in a proof rather than a
+    // visible failure.
+    //
+    // Priority ordering holds within a round, which is all it can: an
+    // initialiser installed after an earlier-priority one has already run
+    // cannot be made to precede it.
+    bool anything_left = true;
+    while (anything_left) {
+        anything_left = false;
+
+        for (std::size_t priority = 0; priority < number_of_initialiser_priorities; ++priority) {
+            // By index, and re-reading the size: the bucket can grow underneath
+            // this loop.
+            while (_imp->initialisers_already_run[priority] < _imp->initialisation_functions_by_priority[priority].size()) {
+                auto & f = _imp->initialisation_functions_by_priority[priority][_imp->initialisers_already_run[priority]];
+                ++_imp->initialisers_already_run[priority];
+                anything_left = true;
+
+                try {
+                    // As in propagate(): with no logger, run the lean tracker.
+                    if (logger) {
+                        EagerProofLoggingInferenceTracker inf(state);
+                        f(state, inf, logger);
+                    }
+                    else {
+                        SimpleInferenceTracker inf(state);
+                        f(state, inf, logger);
+                    }
                 }
-                else {
-                    SimpleInferenceTracker inf(state);
-                    f(state, inf, logger);
+                catch (const TrackedPropagationFailed &) {
+                    return false;
                 }
-            }
-            catch (const TrackedPropagationFailed &) {
-                return false;
             }
         }
     }

--- a/gcs/innards/propagators.hh
+++ b/gcs/innards/propagators.hh
@@ -506,10 +506,18 @@ namespace gcs::innards
         auto disable_propagators_for_constraints(std::span<const ConstraintID> constraint_ids) -> std::size_t;
 
         /**
-         * Install an initialiser, which will be called once just before search
+         * Install an initialiser, which will be called once before search
          * starts. Initialisers run in priority order
          * (\c SimpleDefinition before \c Cheap before \c Expensive); within
          * the same priority they run in registration order.
+         *
+         * A Presolver may install one too, and it will run after that presolver
+         * returns rather than being silently dropped --- which is what a
+         * constraint installed by a presolver needs, since a constraint that
+         * introduces a proof-only variable does that work in an initialiser.
+         * Priorities then order only what that round installed: an initialiser
+         * registered after an earlier-priority one has already run cannot be
+         * made to precede it.
          */
         auto install_initialiser(InitialisationFunction &&, InitialiserPriority priority = InitialiserPriority::SimpleDefinition) -> void;
 
@@ -554,9 +562,19 @@ namespace gcs::innards
             -> bool;
 
         /**
-         * Call every initialiser, or until a contradiction is reached.
+         * \brief Call every initialiser that has not run yet, or run until a
+         * contradiction is reached.
+         *
+         * Called once before search starts, and again after each Presolver: a
+         * presolver can install a constraint, and a constraint can install an
+         * initialiser, so there is a second (and third, ...) round to run. Each
+         * call picks up where the last one left off, so an initialiser runs
+         * exactly once however many rounds there are.
+         *
+         * Returns false if an initialiser reached a contradiction, meaning the
+         * problem is unsatisfiable.
          */
-        [[nodiscard]] auto initialise(State &, ProofLogger * const) const -> bool;
+        [[nodiscard]] auto initialise(State &, ProofLogger * const) -> bool;
 
         ///@}
 

--- a/gcs/presolvers/difference_logic/difference_logic.hh
+++ b/gcs/presolvers/difference_logic/difference_logic.hh
@@ -216,9 +216,14 @@ namespace gcs
          * reason: the paper's section 6.3 measures the simplification stage as
          * most of the difference-logic win. It is exactly the same code and the
          * same proof shapes from either entry point --- it runs inside the shared
-         * propagator, on its first call, precisely because a presolver runs after
-         * propagators.initialise() and so has no initialiser available and no way
-         * to infer anything itself.
+         * propagator, on its first call.
+         *
+         * That placement was originally forced: a presolver ran after
+         * propagators.initialise(), so an initialiser installed from one was
+         * dropped, leaving nowhere else to do root work that infers. Presolver-
+         * installed initialisers now run (solve.cc initialises again after each
+         * presolver), so the stage could move; it has not been tried, and there
+         * is no reason to think it would change what the stage does.
          */
         auto simplifying_at_root(bool = true) -> DifferenceLogic &;
 

--- a/gcs/solve.cc
+++ b/gcs/solve.cc
@@ -349,6 +349,19 @@ auto gcs::solve_with(
                 presolve_success = false;
                 break;
             }
+
+            // Whatever that presolver installed gets initialised before the
+            // next one looks at the problem. A presolver can install a
+            // constraint, and a constraint can install an initialiser --- that
+            // is where one introduces a proof-only variable, for instance ---
+            // so without this the constraint would be propagating against
+            // definitions that were never written, which shows up as a
+            // rejected proof at best. initialise() picks up where it left off,
+            // so the first round's initialisers do not run again.
+            if (! propagators.initialise(state, optional_proof ? optional_proof->logger() : nullptr)) {
+                presolve_success = false;
+                break;
+            }
         }
     }
 

--- a/gcs/solve_test.cc
+++ b/gcs/solve_test.cc
@@ -5,6 +5,7 @@
 #include <gcs/constraints/innards/constraints_test_utils.hh>
 #include <gcs/constraints/plus.hh>
 #include <gcs/expression.hh>
+#include <gcs/presolver.hh>
 #include <gcs/presolvers/auto_table.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.cc>
@@ -12,6 +13,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdlib>
+#include <memory>
 #include <optional>
 #include <set>
 #include <tuple>
@@ -407,5 +409,163 @@ TEST_CASE("Solve unsat optimisation presolving")
         ProofOptions{proof_name});
 
     CHECK(! found_solution);
+    CHECK(verify_proof_and_dispose(proof_name));
+}
+
+namespace
+{
+    // A presolver that installs initialisers, to pin that they run: a presolver
+    // may install a constraint, and a constraint does its once-only work ---
+    // introducing a proof-only variable, say --- in an initialiser. Before
+    // this, one installed from a presolver was dropped without a word, because
+    // solve() had already run the initialisers by the time presolvers were
+    // called.
+    struct InitialiserInstallingPresolver : Presolver
+    {
+        std::shared_ptr<unsigned> ran;
+        std::shared_ptr<unsigned> ran_before_next_presolver;
+        bool contradict = false;
+        bool install_another = false;
+
+        [[nodiscard]] auto run(Problem &, innards::Propagators & propagators, innards::State &, innards::ProofLogger * const) -> bool override
+        {
+            propagators.install_initialiser([ran = ran, contradict = contradict, install_another = install_another, &propagators](
+                                                const innards::State &, auto & inference, innards::ProofLogger * const logger) -> void {
+                ++*ran;
+                if (logger)
+                    logger->emit_proof_comment("initialiser installed by a presolver");
+                if (install_another)
+                    propagators.install_initialiser([ran = ran](const innards::State &, auto &, innards::ProofLogger * const) -> void { ++*ran; },
+                        innards::InitialiserPriority::SimpleDefinition);
+                if (contradict)
+                    inference.contradiction(logger, JustifyUsingRUP{}, NoReason{});
+            });
+            return true;
+        }
+
+        [[nodiscard]] auto clone() const -> std::unique_ptr<Presolver> override
+        {
+            return std::make_unique<InitialiserInstallingPresolver>(*this);
+        }
+    };
+
+    // Runs second, and records what the first one's initialiser had done by
+    // then.
+    struct ObservingPresolver : Presolver
+    {
+        std::shared_ptr<unsigned> ran;
+        std::shared_ptr<unsigned> observed;
+
+        [[nodiscard]] auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override
+        {
+            *observed = *ran;
+            return true;
+        }
+
+        [[nodiscard]] auto clone() const -> std::unique_ptr<Presolver> override
+        {
+            return std::make_unique<ObservingPresolver>(*this);
+        }
+    };
+}
+
+TEST_CASE("An initialiser installed by a presolver runs")
+{
+    const auto proof_name = "solve_test_presolver_initialiser";
+    auto ran = std::make_shared<unsigned>(0);
+
+    Problem p;
+    auto v = p.create_integer_variable(0_i, 3_i);
+    p.post(WeightedSum{} + 1_i * v >= 0_i);
+
+    InitialiserInstallingPresolver presolver;
+    presolver.ran = ran;
+    p.add_presolver(presolver);
+
+    unsigned solutions = 0;
+    solve(
+        p,
+        [&](const CurrentState &) -> bool {
+            ++solutions;
+            return true;
+        },
+        ProofOptions{proof_name});
+
+    CHECK(*ran == 1); // exactly once: not dropped, and not re-run per node
+    CHECK(solutions == 4);
+    CHECK(verify_proof_and_dispose(proof_name)); // and what it wrote is part of a verifiable proof
+}
+
+TEST_CASE("A presolver's initialiser runs before the next presolver")
+{
+    auto ran = std::make_shared<unsigned>(0);
+    auto observed = std::make_shared<unsigned>(0);
+
+    Problem p;
+    auto v = p.create_integer_variable(0_i, 3_i);
+    p.post(WeightedSum{} + 1_i * v >= 0_i);
+
+    InitialiserInstallingPresolver first;
+    first.ran = ran;
+    p.add_presolver(first);
+
+    ObservingPresolver second;
+    second.ran = ran;
+    second.observed = observed;
+    p.add_presolver(second);
+
+    solve(p, [&](const CurrentState &) -> bool { return true; });
+
+    CHECK(*observed == 1); // the second presolver saw a fully initialised problem
+}
+
+TEST_CASE("An initialiser installed by an initialiser runs")
+{
+    auto ran = std::make_shared<unsigned>(0);
+
+    Problem p;
+    auto v = p.create_integer_variable(0_i, 3_i);
+    p.post(WeightedSum{} + 1_i * v >= 0_i);
+
+    InitialiserInstallingPresolver presolver;
+    presolver.ran = ran;
+    presolver.install_another = true;
+    p.add_presolver(presolver);
+
+    solve(p, [&](const CurrentState &) -> bool { return true; });
+
+    CHECK(*ran == 2); // the one the presolver installed, and the one that installed
+}
+
+TEST_CASE("A presolver's initialiser can report unsatisfiability")
+{
+    const auto proof_name = "solve_test_presolver_initialiser_contradiction";
+    auto ran = std::make_shared<unsigned>(0);
+
+    // Genuinely unsatisfiable, so the contradiction the initialiser raises is
+    // one reverse unit propagation can reach: two constraints that are each
+    // fine on their own, so nothing detects it before the presolver runs.
+    Problem p;
+    auto a = p.create_integer_variable(0_i, 3_i);
+    auto b = p.create_integer_variable(0_i, 3_i);
+    p.post(WeightedSum{} + 1_i * a + 1_i * b >= 5_i);
+    p.post(WeightedSum{} + 1_i * a + 1_i * b <= 1_i);
+
+    InitialiserInstallingPresolver presolver;
+    presolver.ran = ran;
+    presolver.contradict = true;
+    p.add_presolver(presolver);
+
+    bool found_solution = false;
+    solve(
+        p,
+        [&](const CurrentState &) -> bool {
+            found_solution = true;
+            return false;
+        },
+        ProofOptions{proof_name});
+
+    CHECK(*ran == 1);
+    CHECK(! found_solution); // a contradiction there ends the solve, rather than being lost
     CHECK(verify_proof_and_dispose(proof_name));
 }


### PR DESCRIPTION
`solve()` ran every initialiser and *then* ran the presolvers, so an initialiser
installed by a presolver was silently never called.

That is a trap rather than a limitation. A presolver may install a constraint,
and a constraint does its once-only proof work in an initialiser — that is where
one introduces a proof-only variable (`introduce_bits_of`), or pins a
definitional bound. Installed from a presolver, that work never happens, and the
constraint spends the search propagating against definitions that were never
written. Nothing says so at the time: it surfaces as a rejected proof, or as a
crash citing a row that does not exist, a long way from the cause.

## Why fix it rather than document it again

Three places had already worked around it, each in its own way:

- `DifferenceConstraints` keeps its degenerate-edge contradiction *out* of the
  install path it shares with the difference-logic presolver — "initialisers
  have already run by the time a presolver builds a graph, so the presolver must
  instead decline to lift a degenerate edge".
- The difference-logic presolver's root simplification runs inside the
  propagator on its first call, "precisely because a presolver runs after
  `propagators.initialise()` and so has no initialiser available and no way to
  infer anything itself".
- A derived `Cumulative` (#657) derives its rows inline for the same reason —
  which is where I hit this, as a `map::at` crash.

Three workarounds for one missing behaviour is the point at which the behaviour
is the bug.

## The change

`Propagators::initialise` picks up where it left off, and `solve()` calls it
again after each presolver. So whatever a presolver installed is initialised
before the next presolver looks at the problem, an initialiser runs exactly once
however many rounds there are, and a contradiction raised by one ends the solve
like any other.

Two smaller things fall out:

- **An initialiser installed by an initialiser now runs**, in the same call.
  Previously that was a range-`for` over a vector being appended to — undefined
  behaviour rather than a policy. The loop is index-based and re-reads the size,
  and sweeps the priority buckets until none has anything left.
- **Priority ordering is now documented as holding within a round**, which is
  all it can: an initialiser installed after an earlier-priority one has already
  run cannot be made to precede it.

## Checking

Four cases in `solve_test.cc`, three of them proof-verified:

| case | pins |
|---|---|
| an initialiser installed by a presolver runs | it fires exactly once, and what it wrote is part of a verifiable proof |
| ... and runs before the next presolver | a second presolver observes it as already done |
| an initialiser installed by an initialiser runs | the growth case, in one call |
| a contradiction from one reports unsatisfiability | the solve ends, and the proof of *that* verifies |

The last one needed a genuinely unsatisfiable model — two constraints each
satisfiable alone, so nothing detects it before the presolver runs — because a
contradiction that nothing implies is one veripb is right to reject, and the
first version of the test learned that the hard way.

Full `ctest` (frontends on): 606/606. Built and run under clang 21.

## Not changed

The two difference-logic workarounds. Their comments now say the ordering has
been lifted and that moving them is untried rather than impossible; actually
moving either means moving both halves (the constraint's initialiser *and* the
presolver's decline) together, and their own tests are what should say whether
that is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p