### PR TITLE
Run the difference-logic root simplification from an initialiser

### DIFF
--- a/dev_docs/difference-logic.md
+++ b/dev_docs/difference-logic.md
@@ -277,10 +277,14 @@ Three shapes fall out of the same canonicalisation as before:
 
 The last row is a soundness obligation, not a nicety. `b -> 0 <= -1` says `!b`,
 and an implementation that quietly dropped the edge would return solutions in
-which `b` holds and the constraint is violated. It is handled in the propagator
-rather than by an initialiser (which is how the unconditional case is done),
-because the row `M·¬b >= 1` saturates directly to the unit clause `¬b`, so plain
-RUP against it suffices — and because a presolver has no initialiser available.
+which `b` holds and the constraint is violated. Both cases are handled by an
+initialiser: `!b` is a root fact that backtracking never takes back, and the row
+`M·¬b >= 1` saturates directly to the unit clause `¬b`, so plain RUP against it
+suffices. They are *different* initialisers, though — the unconditional one is
+`Propagators::install_initial_contradiction` from
+`DifferenceConstraints::install_propagators`, and the conditional one is the
+root initialiser `install_difference_propagator` installs, which the presolver
+shares.
 
 ### The reason, which is the whole soundness question
 
@@ -666,11 +670,25 @@ asserts both halves of this (something must be disabled when there is an
 unconditional edge, nothing may be when there is not).
 
 Degenerate edges — a constant operand, or the same variable at both ends — are
-also skipped, and left to the donor. This is not just tidiness: a `0 <= d` with
-`d < 0` is a root contradiction, which `DifferenceConstraints` reports with
-`install_initial_contradiction`, and **initialisers have already run** by the
-time a presolver is called. Declining to lift such an edge leaves it with the
-donor, which handles it correctly.
+also skipped, and left to the donor, because the donor handles every one of them
+and lifting would add nothing. That was checked rather than argued, since PR #658
+removed the reason this section used to give (that a `0 <= d` with `d < 0` is a
+root contradiction, and initialisers had already run by the time a presolver was
+called). With the presolver installed and the degenerate donor left to itself:
+
+| donor | what happens today |
+|---|---|
+| `x - x <= -5` | refuted in **1 recursion**, `s VERIFIED UNSATISFIABLE` |
+| `x - (x + 3) <= -5` | refuted in **1 recursion**, `s VERIFIED UNSATISFIABLE` |
+| `b -> x - x <= -5` | `!b` inferred by the donor, `s VERIFIED SATISFIABLE` |
+| `b -> x - (x + 3) <= -5` | `!b` inferred by the donor, `s VERIFIED SATISFIABLE` |
+
+So lifting them would duplicate the donor's own root inference exactly — and
+would have to do it the hard way, because the donor's row is in the *user's*
+views' bits, not the deviewed ones `DifferenceConstraints` emits, so the
+contradiction is not the bare RUP that `install_initial_contradiction` uses.
+`skipped_degenerate` therefore stays, and the count remains the way a test tells
+that these were seen and declined rather than silently missed.
 
 ### Labelling `Comparison`'s rows, and what it did to the cake chain
 
@@ -1338,32 +1356,22 @@ problem.add_presolver(DifferenceLogic{}.simplifying_at_root(false));
 Both also take `reporting_simplification_to(shared_ptr<DifferenceSimplificationStats>)`,
 which is how the tests and the example binaries tell "worked" from "did nothing".
 
-### Where it runs, and why it is not an initialiser
+### Where it runs, and why it is an initialiser
 
-It runs **inside the propagator, on its first call**. That is not where one would
-first reach for. An initialiser would be the natural home for the posted
-constraint — but a presolver runs *after* `propagators.initialise()`, so an
-initialiser it installed would never fire, and `Presolver::run` is handed a
-`State &` and a `ProofLogger *` but no inference tracker, so it cannot infer
-anything itself either. Fixing a condition is an inference. So the only place
-that works for both entry points is the propagator, and putting it there means
-one implementation and one set of proof shapes rather than two.
+It runs **from an initialiser**, installed by `install_difference_propagator`
+alongside the propagator itself, at `InitialiserPriority::Expensive`. The same
+initialiser also infers the disallowed conditions and applies the unconditional
+static bounds, in that order, because those are root facts too and the stage's
+classification of a conditional edge has to see them.
 
-Two guards make that safe:
-
-- **it runs once**, latched by a flag in the propagator's own (mutable) state;
-- **only if that first call is at the root**, tested by `state.guesses()` being
-  empty.
-
-The second is not decoration. Everything the stage concludes is *permanent* —
-edges leave the internal graph and never come back, and no part of it is trailed
-— so doing it under a decision would keep conclusions that hold only under that
-decision. That would be a completeness bug in the general case and an
-**unsoundness** in the case of an edge dropped because a conditional path implied
-it, and no proof would ever complain, because losing propagation is invisible to
-a proof. In practice the first call is always at the root (search begins by
-propagating everything, before any decision), so the guard costs nothing and
-buys the argument.
+Everything the stage concludes is *permanent* — edges leave the internal graph
+and never come back, and no part of it is trailed — so doing it under a decision
+would keep conclusions that hold only under that decision. That would be a
+completeness bug in the general case and an **unsoundness** in the case of an
+edge dropped because a conditional path implied it, and no proof would ever
+complain, because losing propagation is invisible to a proof. An initialiser is
+the root by construction, so that is a property of where the call sits rather
+than a guard it has to check.
 
 Not trailing is then justified, and by exactly the argument that puts the paper's
 own section 5.3/5.4 boundary where it is: every conclusion drawn here is a
@@ -1371,6 +1379,47 @@ statement about the *graph*, and backtracking does not change the graph. The
 stage reads no domain. The one thing that looks like a domain read — testing
 whether a condition currently holds — is a read of a fact fixed at the root and
 never undone.
+
+The stage and the propagator therefore share one `DifferenceRootGraph` (the arc
+array, the parallel condition array and the round bound) through a `shared_ptr`,
+since the stage rewrites all three and the propagator reads them afterwards. The
+propagator names them by reference at the top of each call, so nothing in the hot
+loops goes through the indirection.
+
+#### It used to be in the propagator, and what moving it changed
+
+Until PR #659 the stage ran inside the propagator on its first call, latched by a
+flag and guarded on `state.guesses()` being empty. That was forced: a presolver
+ran *after* `propagators.initialise()`, so an initialiser it installed never
+fired, and `Presolver::run` is handed a `State &` and a `ProofLogger *` but no
+inference tracker, so it cannot infer anything itself either — and fixing a
+condition is an inference. PR #658 made a presolver-installed initialiser run,
+which removed the reason.
+
+The move was measured before it was made, because the stage's role classification
+reads the state, and an initialiser runs before *any* propagation: a condition
+some other propagator would have decided at the root is undecided when an
+initialiser looks, which makes its edge a `Candidate` rather than `Base` or
+`Ignored`, and a smaller base graph simplifies less. Across every fixture in
+`difference_constraints_test`, every fixture in `difference_logic_test`, and
+`examples/rcpsp --size 14 --machine difference` over seeds 1–5 in both the
+`global` and `presolved` variants:
+
+- **solutions and recursions are identical everywhere**, and so is the `.opb`;
+- `conditions_fixed` goes **up** (rcpsp seed 4: 7 → 19), because the stage now
+  fixes conditions the donors' own propagators used to get to first. Same end
+  state, different attribution — and one that shortens the proof slightly (the
+  presolver `opb` fixture's `.pbp` goes 44807 → 44794 bytes, and rcpsp seed 4's
+  4156748 → 4155435, with `veripb` time unchanged);
+- propagation counts move by a few percent in **both** directions (rcpsp
+  presolved: seed 1 7163 → 7377, seed 3 64668 → 64661, seed 4 61467 → 64304,
+  seed 5 82697 → 82686), with the search tree unchanged in every case.
+
+The one externally visible change is that a model the stage refutes is now
+refuted in **zero** recursions rather than one, because the refutation happens
+during initialisation and no search node is ever opened.
+`run_root_refutation_test` asserts that number, and it is what would notice the
+stage moving back into the propagator.
 
 ### The four sub-steps, and which are here
 

--- a/gcs/constraints/difference/difference_constraints.cc
+++ b/gcs/constraints/difference/difference_constraints.cc
@@ -225,17 +225,19 @@ auto DifferenceConstraints::install_propagators(Propagators & propagators) -> vo
     if (_root_contradiction_posted_index) {
         // The edge's own OPB row is `0 >= something positive', so the
         // contradiction is RUP from the model with no state involved at all.
-        // Deliberately not part of install_difference_propagator, which the
-        // difference-logic presolver shares: when this was written, an
-        // initialiser installed from a presolver was dropped, so the presolver
-        // had to decline to lift a degenerate edge and leave it to that edge's
-        // own propagator instead.
         //
-        // Presolver-installed initialisers now run (solve.cc initialises again
-        // after each presolver), so this could move into the shared path and
-        // the presolver's decline could go with it. Not done here: both halves
-        // have to change together, and the presolver's own tests are what say
-        // whether declining is still worth its complexity.
+        // Deliberately not part of install_difference_propagator, which the
+        // difference-logic presolver shares, and this is now a statement about
+        // the presolver rather than about initialisers. Nothing would reach it
+        // from there: a degenerate donor is one the presolver declines, and it
+        // declines because lifting would only duplicate what the donor's own
+        // propagator already does. Measured rather than assumed --- with the
+        // presolver installed and the donor left to itself, an unconditional
+        // `x - (x + c) <= d' that canonicalises to `0 <= d' with `d < 0' is
+        // refuted in one recursion and the proof verifies, with and without a
+        // view offset, and the half-reified counterpart's `!cond' likewise. So
+        // this is DifferenceConstraints' own row and its own contradiction, and
+        // it belongs where the edges it came from were posted.
         propagators.install_initial_contradiction("difference constraint x - x <= d with d < 0", JustifyUsingRUP{}, NoReason{});
         return;
     }

--- a/gcs/constraints/difference/difference_constraints_test.cc
+++ b/gcs/constraints/difference/difference_constraints_test.cc
@@ -816,6 +816,12 @@ namespace
     // round --- the second fix is the contradiction, and never gets counted,
     // which is also why the counters are published by a destructor rather than
     // at the end of the stage.
+    //
+    // "Before search starts" is meant exactly: the stage runs from an
+    // initialiser, so this refutes in *zero* recursions, and that number is what
+    // this fixture pins. It is the one externally visible consequence of where
+    // the stage lives, and so the one thing that would notice it moving back
+    // into the propagator, where it would refute in one.
     auto run_root_refutation_test() -> void
     {
         print(cerr, "difference root refutation:");
@@ -854,9 +860,13 @@ namespace
             throw UnexpectedException{"difference root refutation: the simplification stage recorded " + to_string(on.conditions_fixed) +
                 " conditions fixed, expected exactly 1: both polarities of the ordering Boolean close a cycle against the maximum time lag, the "
                 "first is inferred and the second is the contradiction, which unwinds before it can be counted"};
-        if (1 != on_recursions)
-            throw UnexpectedException{"difference root refutation: with simplification the model must be refuted at the root, in " +
-                to_string(on_recursions) + " recursions rather than 1"};
+        if (0 != on_recursions)
+            throw UnexpectedException{"difference root refutation: with simplification the model must be refuted during initialisation, before "
+                                      "search is entered at all, and instead took " +
+                to_string(on_recursions) +
+                " recursions. The stage runs from an initialiser: a refutation from one is reported by solve() "
+                "without a search node ever being opened, and anything else means the stage has moved back into the "
+                "propagator"};
         if (off_recursions <= on_recursions)
             throw UnexpectedException{"difference root refutation: without simplification the solver is supposed to have to search, and it took " +
                 to_string(off_recursions) + " recursions"};

--- a/gcs/constraints/difference/difference_graph.cc
+++ b/gcs/constraints/difference/difference_graph.cc
@@ -16,6 +16,7 @@
 #include <any>
 #include <chrono>
 #include <cstdlib>
+#include <memory>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -87,6 +88,17 @@ namespace
         Integer value;
     };
 
+    // The graph the propagator actually walks: the hot arc array, the parallel
+    // condition array, and the number of relaxation rounds a simple path can
+    // need. The root simplification stage rewrites all three, so it and the
+    // propagator share one of these rather than each holding a copy.
+    struct DifferenceRootGraph
+    {
+        vector<DifferenceArc> arcs;
+        vector<optional<IntegerVariableCondition>> arc_conditions;
+        size_t round_bound;
+    };
+
     // Everything the incremental propagator remembers between calls.
     //
     // None of it is copied by the engine: the one thing that *is* trailed is a
@@ -148,13 +160,16 @@ namespace
     };
 
     // The root simplification stage, which is the paper's Algorithm 4
-    // (its section 5.2) run to the fixpoint of its section 5.3. Once, on
-    // the first call, and only if that call is at the root --- which it
-    // always is, since search begins by propagating everything before
-    // any decision is made, but the guard is not decoration: everything
-    // below is *permanent*, so doing it below a decision would keep
-    // conclusions that only held under that decision, and no proof would
-    // ever complain because losing propagation is invisible to a proof.
+    // (its section 5.2) run to the fixpoint of its section 5.3. Called
+    // from an initialiser, which is the only place it can go: everything
+    // below is *permanent* and none of it is trailed, so running it
+    // under a decision would keep conclusions that hold only under that
+    // decision --- a completeness bug in general, and an unsoundness for
+    // an edge dropped because a conditional path implied it, and no
+    // proof would ever complain, because losing propagation is invisible
+    // to a proof. An initialiser is the root by construction, so that is
+    // a property of where the call sits rather than a guard it has to
+    // check.
     //
     // Three of the paper's four sub-steps are here. Redundant-edge
     // removal and node removal are decisions about what to propagate,
@@ -172,7 +187,7 @@ namespace
     template <typename Inference_>
     auto run_difference_root_simplification(const State & state, Inference_ & inference, ProofLogger * const logger, size_t number_of_nodes,
         vector<DifferenceArc> & arcs, vector<optional<IntegerVariableCondition>> & arc_conditions, const vector<ProofLine> & edge_lines,
-        const DifferenceSimplificationOptions & simplify, size_t & round_bound, bool at_root) -> void
+        const DifferenceSimplificationOptions & simplify, size_t & round_bound) -> void
     {
         auto n = number_of_nodes;
         auto m = arcs.size();
@@ -196,7 +211,7 @@ namespace
             if (condition_of(e))
                 ++stats.conditional_edges;
 
-        if (simplify.enabled && at_root && ! arcs.empty()) {
+        if (simplify.enabled && ! arcs.empty()) {
             stats.ran = true;
 
             vector<DifferenceSimplifyEdge> simplify_edges;
@@ -399,6 +414,33 @@ namespace
             auto live_count = static_cast<size_t>(count(live, true));
             stats.isolated_nodes_removed = n - live_count;
             round_bound = live_count;
+        }
+    }
+
+    // An edge with a constant operand is a plain bound on the other operand,
+    // and once applied it is just part of the state that the relaxation passes
+    // seed from. An unconditional one is a root fact and is applied by the
+    // initialiser; a conditional one applies from the moment its condition
+    // holds, which is why the propagator runs this too. Idempotent either way:
+    // a bound already in the state is skipped, and applying one moves the
+    // state, which is exactly what puts the node into Vl on the call that does
+    // it.
+    template <typename Inference_>
+    auto apply_difference_static_bounds(const State & state, Inference_ & inference, ProofLogger * const logger,
+        const vector<SimpleIntegerVariableID> & nodes, const vector<DifferenceStaticBound> & static_bounds) -> void
+    {
+        for (const auto & sb : static_bounds) {
+            if (sb.cond && LiteralIs::DefinitelyTrue != state.test_literal(*sb.cond))
+                continue;
+            Reason why = sb.cond ? Reason{ExplicitReason{ReasonLiterals{{*sb.cond}}}} : Reason{NoReason{}};
+            if (sb.is_lower) {
+                if (state.lower_bound(nodes[sb.node]) < sb.value)
+                    inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, why);
+            }
+            else {
+                if (state.upper_bound(nodes[sb.node]) > sb.value)
+                    inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, why);
+            }
         }
     }
 
@@ -1146,73 +1188,91 @@ auto gcs::innards::install_difference_propagator(Propagators & propagators, Stat
     // between the backtrack and that call.
     auto trail_mark_handle = initial_state.add_constraint_state(size_t{0});
 
-    // The root simplification stage mutates `arcs`, `arc_conditions` and
-    // `round_bound` in place, once, on the first call --- hence the `mutable`
-    // below. It is safe without trailing for the same reason the paper's section
-    // 5.3 boundary is where it is: the stage runs only at the root, before any
-    // decision, and every conclusion it draws (this edge is implied by a path of
-    // unconditional or root-fixed edges; this node has no edges left) is a
-    // statement about the *graph*, which no amount of backtracking changes.
-    // Nothing there reads a domain. The incremental machinery below is `mutable`
-    // for a different reason, and one the paper is explicit about: the potential
+    // The arc arrays and the round bound are shared between the root
+    // initialiser and the propagator, because the simplification stage rewrites
+    // them: it drops edges the propagator will never need to look at again, and
+    // shrinks the number of relaxation rounds a pass can need. Shared rather
+    // than handed over because the propagator is installed here and the stage
+    // runs later, and rather than copied because there is exactly one owner of
+    // the post-simplification graph. The propagator names them by reference at
+    // the top of each call, so nothing in the hot loops goes through the
+    // indirection.
+    //
+    // Not trailing any of it is safe for the same reason the paper's section 5.3
+    // boundary is where it is: every conclusion the stage draws (this edge is
+    // implied by a path of unconditional or root-fixed edges; this node has no
+    // edges left) is a statement about the *graph*, which no amount of
+    // backtracking changes. The incremental machinery below is `mutable` for a
+    // different reason, and one the paper is explicit about: the potential
     // function survives backtracking by design.
-    propagators.install(
-        constraint_id,
-        [nodes = move(graph.nodes), arcs = move(arcs), arc_conditions = move(arc_conditions), static_bounds = move(graph.static_bounds),
-            disallowed_conditions = move(graph.disallowed_conditions), edge_lines = move(graph.edge_lines), simplify = move(simplify),
-            incremental = move(incremental), memory = DifferencePropagatorMemory{}, trail_mark_handle, simplification_pending = true,
-            round_bound = number_of_nodes](const State & state, auto & inference, ProofLogger * const logger) mutable -> PropagatorState {
-            auto n = nodes.size();
-            auto m = arcs.size();
+    auto root_graph = std::make_shared<DifferenceRootGraph>(move(arcs), move(arc_conditions), number_of_nodes);
 
+    // Everything that is a root fact goes in an initialiser, which is where root
+    // work belongs and, since PR #658, is available to a presolver-installed
+    // constraint as well as a posted one. Ordering inside it is the ordering the
+    // stage needs: the conditions it classifies must already have had everything
+    // said about them that this system has to say.
+    //
+    // Expensive priority, not because anything here is definitional --- nothing
+    // in it writes OPB content --- but because the stage's classification of a
+    // conditional edge reads the state, so the later it runs the more it knows.
+    propagators.install_initialiser(
+        [nodes = graph.nodes, static_bounds = graph.static_bounds, disallowed_conditions = move(graph.disallowed_conditions),
+            edge_lines = graph.edge_lines, simplify = move(simplify), root_graph,
+            number_of_nodes](const State & state, auto & inference, ProofLogger * const logger) {
             // A half-reified edge whose condition says `cond -> 0 <= d' with
             // d < 0 says `!cond', and saying so is a soundness obligation, not a
             // nicety: dropping the edge would licence solutions in which cond
             // holds and the constraint is violated. The row is `M.~cond >= -d'
             // with -d >= 1, which is the unit clause `~cond' after saturation,
             // so plain RUP against it suffices and nothing in the state is
-            // involved. (Unconditionally this is a root contradiction instead;
-            // see DifferenceConstraints::install_propagators.)
+            // involved. Said once, because it is a root fact that backtracking
+            // never takes back. (Unconditionally this is a root contradiction
+            // instead; see DifferenceConstraints::install_propagators.)
             for (const auto & dc : disallowed_conditions)
                 if (LiteralIs::DefinitelyFalse != state.test_literal(dc.cond))
                     inference.infer(logger, ! dc.cond, JustifyUsingRUP{}, NoReason{});
 
-            // Static bounds next: an edge with a constant operand is a plain
-            // bound on the other operand, and once applied it is just part of
-            // the state that the passes below seed from. An unconditional one
-            // never changes, so after the first call it is a no-op; a
-            // conditional one applies from the moment its condition holds, and
-            // cites it. Nothing about it needs trailing or gating: a bound it
-            // applies moves the state, and moving the state is exactly what puts
-            // the node into Vl on this very call.
-            for (const auto & sb : static_bounds) {
-                if (sb.cond && LiteralIs::DefinitelyTrue != state.test_literal(*sb.cond))
-                    continue;
-                Reason why = sb.cond ? Reason{ExplicitReason{ReasonLiterals{{*sb.cond}}}} : Reason{NoReason{}};
-                if (sb.is_lower) {
-                    if (state.lower_bound(nodes[sb.node]) < sb.value)
-                        inference.infer_greater_than_or_equal(logger, nodes[sb.node], sb.value, JustifyUsingRUP{}, why);
-                }
-                else {
-                    if (state.upper_bound(nodes[sb.node]) > sb.value)
-                        inference.infer_less_than(logger, nodes[sb.node], sb.value + 1_i, JustifyUsingRUP{}, why);
-                }
-            }
+            apply_difference_static_bounds(state, inference, logger, nodes, static_bounds);
 
-            auto first_call = simplification_pending;
+            run_difference_root_simplification(state, inference, logger, number_of_nodes, root_graph->arcs, root_graph->arc_conditions, edge_lines,
+                simplify, root_graph->round_bound);
+        },
+        InitialiserPriority::Expensive);
+
+    propagators.install(
+        constraint_id,
+        [nodes = move(graph.nodes), static_bounds = move(graph.static_bounds), edge_lines = move(graph.edge_lines), incremental = move(incremental),
+            memory = DifferencePropagatorMemory{}, trail_mark_handle, first_call_pending = true,
+            root_graph](const State & state, auto & inference, ProofLogger * const logger) mutable -> PropagatorState {
+            auto & arcs = root_graph->arcs;
+            auto & arc_conditions = root_graph->arc_conditions;
+            auto & round_bound = root_graph->round_bound;
+
+            auto n = nodes.size();
+            auto m = arcs.size();
+
+            // A conditional static bound applies from the moment its condition
+            // holds, so unlike the unconditional ones the initialiser dealt
+            // with, these have to be retested on every call.
+            apply_difference_static_bounds(state, inference, logger, nodes, static_bounds);
+
+            auto first_call = first_call_pending;
+            first_call_pending = false;
+
+            // The incremental machinery's own root requirement, which is not the
+            // stage's: what it builds on its first call --- the adjacency, the
+            // potential function, the Do arrays --- is never reset, so a first
+            // call below a decision would leave it holding values that only that
+            // decision justifies. Search propagates everything before it guesses
+            // anything, so this cannot happen; say so rather than assume it.
+            // Only asked on the call that would be misled by the answer.
             bool at_root = true;
-
-            if (first_call) {
-                simplification_pending = false;
-
+            if (first_call)
                 for ([[maybe_unused]] const auto & guess : state.guesses()) {
                     at_root = false;
                     break;
                 }
-
-                run_difference_root_simplification(state, inference, logger, n, arcs, arc_conditions, edge_lines, simplify, round_bound, at_root);
-                m = arcs.size();
-            }
 
             // Which edges are in the graph *for this call*. A half-reified edge
             // participates exactly while its condition currently holds; the

--- a/gcs/constraints/difference/difference_graph.hh
+++ b/gcs/constraints/difference/difference_graph.hh
@@ -178,15 +178,19 @@ namespace gcs::innards
      * A no-op if the system has no edges, static bounds or disallowed
      * conditions. Detecting a root-level contradiction (an *unconditional* edge
      * saying `0 <= d` with `d < 0`) is *not* this function's job --- see
-     * DifferenceConstraints::install_propagators, which handles it with an
-     * initialiser, a door that has closed by the time a presolver runs. The
-     * half-reified counterpart *is* handled here, as a
-     * DifferenceDisallowedCondition, precisely because it needs no initialiser.
+     * DifferenceConstraints::install_propagators, which handles it directly, and
+     * which is the only caller that can produce one. The half-reified
+     * counterpart, a DifferenceDisallowedCondition, *is* handled here.
      *
-     * The root simplification stage lives here too, for the same reason: it must
-     * infer, and a presolver has no way to. It runs inside the propagator, on its
-     * first call, guarded on that call being at the root --- which is where every
-     * propagator's first call is, since search starts by propagating everything.
+     * Two propagator-like things are installed, not one: an initialiser for
+     * everything that is a root fact --- the disallowed conditions, the
+     * unconditional static bounds, and the root simplification stage --- and the
+     * propagator itself. The split is what the stage requires rather than a
+     * tidying: it rewrites the internal graph permanently and trails none of it,
+     * so it may only run where no decision has been made, and an initialiser is
+     * that place by construction. (Before PR #658 it could not go there, because
+     * an initialiser installed by a presolver was dropped, so it ran inside the
+     * propagator behind a `state.guesses()` guard instead.)
      *
      * The \c State is needed at install time for one thing only: a trailed
      * constraint state holding the length of the incremental machinery's undo

--- a/gcs/constraints/difference/difference_simplify.hh
+++ b/gcs/constraints/difference/difference_simplify.hh
@@ -25,8 +25,8 @@ namespace gcs
      */
     struct DifferenceSimplificationStats
     {
-        /// True if the stage actually ran. It runs once, on the propagator's
-        /// first call, and only if that call is at the root (see
+        /// True if the stage actually ran. It runs once, from an initialiser,
+        /// which is the root by construction (see
         /// `dev_docs/difference-logic.md`).
         bool ran = false;
 

--- a/gcs/presolvers/difference_logic/difference_logic.cc
+++ b/gcs/presolvers/difference_logic/difference_logic.cc
@@ -172,11 +172,15 @@ auto DifferenceLogic::run(Problem & problem, Propagators & propagators, State & 
         // A constant operand makes this a plain bound, which the donor's own
         // propagator applies once and which adds nothing to the graph; and
         // aliasing says 0 <= d, which is vacuous, or else a root contradiction
-        // (unconditionally, needing an initialiser --- and initialisers have
-        // already run by the time a presolver is called) or a fact about the
-        // condition (half-reified). Leave all of them to the donor, which
-        // handles them. Checked before node_index is called, so a skipped edge
-        // never leaves an isolated node behind to be triggered on.
+        // (unconditionally) or a fact about the condition (half-reified). Leave
+        // all of them to the donor, which handles them --- measured, not
+        // assumed: with this presolver installed, an unconditional degenerate
+        // donor is refuted in one recursion with a verifying proof, with and
+        // without a view offset, and a half-reified one's `!cond' is inferred
+        // by its own propagator. Lifting would duplicate that and nothing more,
+        // and would have to cite the donor's row in the *user's* views' bits to
+        // do it. Checked before node_index is called, so a skipped edge never
+        // leaves an isolated node behind to be triggered on.
         if (! left->variable || ! right->variable || *left->variable == *right->variable) {
             ++stats.skipped_degenerate;
             return false;

--- a/gcs/presolvers/difference_logic/difference_logic.hh
+++ b/gcs/presolvers/difference_logic/difference_logic.hh
@@ -99,9 +99,9 @@ namespace gcs
 
         /// An edge that canonicalises to `0 <= d` (both operands the same
         /// variable, or both constants), or to a plain bound on one variable
-        /// (one constant operand). Nothing is gained by lifting these and the
-        /// `d < 0` case would need an initialiser, a door that has closed by
-        /// the time a presolver runs, so they are left to their own propagator.
+        /// (one constant operand). Nothing is gained by lifting these --- the
+        /// donor's own propagator refutes the `d < 0` case at the root, or
+        /// applies the bound, or infers `!cond` --- so they are left to it.
         std::size_t skipped_degenerate = 0;
 
         /// A donor of the right shape whose primary OPB row cannot be cited: it
@@ -215,15 +215,15 @@ namespace gcs
          * On by default, matching DifferenceConstraints, and for the same
          * reason: the paper's section 6.3 measures the simplification stage as
          * most of the difference-logic win. It is exactly the same code and the
-         * same proof shapes from either entry point --- it runs inside the shared
-         * propagator, on its first call.
+         * same proof shapes from either entry point --- it runs from an
+         * initialiser installed alongside the shared propagator, so a model
+         * this presolver builds a graph for can be refuted before search is
+         * entered at all.
          *
-         * That placement was originally forced: a presolver ran after
+         * That was not always possible: a presolver ran after
          * propagators.initialise(), so an initialiser installed from one was
-         * dropped, leaving nowhere else to do root work that infers. Presolver-
-         * installed initialisers now run (solve.cc initialises again after each
-         * presolver), so the stage could move; it has not been tried, and there
-         * is no reason to think it would change what the stage does.
+         * dropped, and the stage ran inside the propagator instead. PR #658
+         * fixed the ordering and the stage moved.
          */
         auto simplifying_at_root(bool = true) -> DifferenceLogic &;
 


### PR DESCRIPTION
Stacked on #658.

#658 said the two difference-logic workarounds were "untried rather than
impossible". I tried both. One goes, one stays, and the one that stays now has a
measured reason rather than a stale one.

## The root simplification stage: moved

It ran **inside the propagator, on its first call**, latched by a flag and
guarded on `state.guesses()` being empty. That was forced, not chosen: a
presolver ran after `propagators.initialise()`, so an initialiser it installed
never fired, and `Presolver::run` gets a `State &` and a `ProofLogger *` but no
inference tracker — and fixing a condition is an inference. #658 removed that.

The stage is root-only work by construction. It rewrites the propagator's
internal graph permanently and trails none of it, so running it under a decision
would keep conclusions that hold only under that decision — a completeness bug in
general, and an **unsoundness** for an edge dropped because a conditional path
implied it, which no proof would ever complain about. An initialiser is the root,
so that stops being a guard and becomes a property of where the call sits.

The disallowed conditions and the unconditional static bounds go with it. Both
are root facts, and the ordering between them and the stage matters: the stage
classifies a conditional edge by reading the state, so everything this system has
to say about a condition has to have been said first. The propagator keeps the
static-bound loop, because a conditional bound applies from the moment its
condition holds; the two now share one `apply_difference_static_bounds`.

The stage and the propagator share one `DifferenceRootGraph` through a
`shared_ptr` — the arc array, the parallel condition array and the round bound,
all three of which the stage rewrites. The propagator names them by reference at
the top of each call, so the hot loops are untouched.

## What moving it changed

Measured before it was made, because an initialiser runs before *any*
propagation: a condition another propagator would have decided at the root is
undecided when an initialiser looks, which makes its edge a `Candidate` rather
than `Base` or `Ignored`, and a smaller base graph simplifies less. Across every
fixture in `difference_constraints_test`, every fixture in
`difference_logic_test`, and `examples/rcpsp --size 14 --machine difference` over
seeds 1–5 in both the `global` and `presolved` variants:

| | |
|---|---|
| solutions, recursions | **identical everywhere** |
| `.opb` | identical |
| `.pbp` | marginally smaller (presolver `opb` fixture 44807 → 44794 bytes; rcpsp seed 4 4156748 → 4155435), `veripb` time unchanged |
| `conditions_fixed` | **up** — rcpsp seed 4, 7 → 19 |
| propagations | ±few %, both directions (rcpsp presolved: seed 1 7163 → 7377, seed 3 64668 → 64661, seed 4 61467 → 64304, seed 5 82697 → 82686) |
| `difference_chain -n 640` | unchanged, interleaved: global 0.25 s both, presolved 0.51 s both, propagation counts equal |

`conditions_fixed` going up is the interesting one, and it is not more work: the
stage now gets to conditions the donors' own propagators used to reach first.
Same end state, different attribution — and the attribution that makes the proof
slightly shorter, since the stage's `pol` + saturate replaces the donor's RUP.

The one externally visible change: a model the stage refutes is refuted in
**zero** recursions rather than one, because no search node is opened at all.
`run_root_refutation_test` now pins that number, and it is what would notice the
stage moving back into the propagator.

## The degenerate-edge contradiction: stays

`DifferenceConstraints` keeps its `install_initial_contradiction` out of the
shared install path, and the presolver keeps declining to lift a degenerate
donor. Post-#658 that is a statement about the presolver, not about initialisers:
nothing would reach the shared path from there, because lifting would only
duplicate what the donor's own propagator already does.

Checked rather than argued. With the presolver installed and the degenerate donor
left to itself:

| donor | today |
|---|---|
| `x - x <= -5` | refuted in 1 recursion, `s VERIFIED UNSATISFIABLE` |
| `x - (x + 3) <= -5` | refuted in 1 recursion, `s VERIFIED UNSATISFIABLE` |
| `b -> x - x <= -5` | `!b` inferred by the donor, `s VERIFIED SATISFIABLE` |
| `b -> x - (x + 3) <= -5` | `!b` inferred by the donor, `s VERIFIED SATISFIABLE` |

And lifting would have to do it the hard way: the donor's row is in the *user's*
views' bits, not the deviewed ones `DifferenceConstraints` emits, so the
contradiction is not the bare RUP `install_initial_contradiction` uses.
`skipped_degenerate` stays, and stays counted, so a test can still tell "seen and
declined" from "silently missed".

## Checking

Full `ctest` (frontends on): 606/606 under GCC 15.2, 497/497 under clang 21.
`clang-format` 21 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)