### PR TITLE
Optional tasks for Cumulative, via per-task presence Booleans (#543)

### DIFF
--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -572,6 +572,136 @@ make one derivation speak about all of them:
 Neither is implemented here. The first is the safer starting point (each lemma
 is checkable on its own); the second is smaller if it works. Whichever lands
 should measure the proof size, since that is the whole difference between them.
+## Optional tasks (issue #543)
+
+The optional-task constructor gives each task a `{0, 1}` presence
+variable, and an absent task consumes nothing. That is the *one*
+sanctioned change to the OPB in the whole #541 plan, and it is a single
+extra conjunct:
+
+```
+active_{i,t}  ⇔  before_{i,t} ∧ after_{i,t} ∧ (presences[i] = 1)
+```
+
+`C_t` keeps its shape. A `{0, 1}` variable is direct-only encoded as one
+PB literal (`i[name][b0]`, with `= 0` its negation — see
+[`variable-encodings.md`](variable-encodings.md)), so the three-way AND
+costs one term in the same two reification halves, and nothing else in
+the encoding has to know the task is optional.
+
+A task posted with the *constant* 1 as its presence keeps the two-way
+AND, and one posted with the constant 0 is dropped from the constraint
+altogether. Only constants resolve away like this: a variable that
+happens to be fixed when `prepare()` runs keeps its conjunct, because the
+OPB has to say what it means without appealing to a domain the OPB does
+not record. `cumulative_optional_test enumerate` asserts the degeneracy
+by diffing the two forms' OPB constraint lines.
+
+### Presence in reasons
+
+Presence enters a reason as an explicit `presences[i] = 1` literal per
+task known present, *not* by putting the variable in the `generic_reason`
+scope. An undecided presence has no fact to record — a task not known
+present is simply not in the profile, and staying out of it is monotone
+as the domain shrinks — and `generic_reason` would otherwise contribute
+the pair of trivial bounds `0 ≤ p ≤ 1`, which says nothing and costs an
+order atom on a variable whose whole encoding is one literal.
+
+### Presence falsification
+
+The new inference is the mirror image of an lb-push: when an undecided
+task has no start position left that fits under the profile, its presence
+is 0. The proof is the lb-push chain run over the task's *whole* domain
+with `present_j = 0` carried as an extra disjunct on every line, so each
+step reads "either `j` starts later than this, or `j` is not here at
+all". `ExtLits` generalises `emit_chain_step`'s single extension literal
+to the (at most two) disjuncts this needs.
+
+The last step drops the start-side disjunct. Its blocked time is at or
+beyond `ub(s_j)` — that is what makes it the last, since the chain stops
+when the running bound passes `ub(s_j)` — so `before_{j,t}` follows from
+the task's own upper bound in the reason, and the proof never asks for an
+order literal above the domain, which need not exist.
+
+### Why the chain is load-bearing, and what a mutation can catch
+
+The wrapping RUP (`ThenRUP::Yes`) cannot close on its own: the order
+atoms `[s_j ≥ v]` for the interior of the domain are created lazily, and
+it is the chain that creates them. The `EmitNothing` mutation is the
+control for exactly this, and VeriPB rejects it.
+
+What VeriPB will *not* reject is a mutation that merely shortens the
+chain — omitting a step, or stopping one step early. This is worth
+understanding, because it looks like a gap and is not one. Once the chain
+has narrowed `s_j` far enough, the reason context extended with
+`present_j = 1` is *contradictory*, and every subsequent RUP under it is
+vacuously valid. A shortened chain is therefore still a sound (if
+differently shaped) derivation, and VeriPB is right to accept it. This is
+the same trap as #656's contradictory micro-model, one level in: there
+the whole OPB was unsatisfiable, here it is the reason context.
+
+So the mutations that bite are the ones producing a statement that is
+*not* implied:
+
+- `WrongTask` — carry a different optional task's presence literal
+  through the chain. The pinned activity is then about a task nothing has
+  cornered, and the pin fails to RUP.
+- `ClaimOneTooFar` — fire on the twin instance where exactly one
+  placement still fits. The conclusion is wrong rather than the route to
+  it, the chain runs out of blocked times, and the wrapping RUP has
+  nothing to close on. This is the plan's "bound + 1 must fail" check for
+  this rule.
+
+The general lesson for the rest of #541: for a *conflict-shaped* rule —
+one whose content is "this assignment is impossible" — corrupting the
+route is not a test, because the destination makes every route valid.
+Corrupt the destination.
+
+### Interaction with the overload check
+
+The overload check (issue 01, above) is guarded the same way the profile
+is, and it has to be: its energy set counts each contained task's
+`length x height` as *guaranteed*, which an optional task's is not until
+its presence is fixed to 1. Counting an undecided task's energy would
+manufacture a conflict that is not there. So `propagate_cumulative`
+filters the candidate list by the same `is_present`. That one is
+load-bearing and cheap to check: remove it and the enumeration tests lose
+solutions immediately, because two optional unit-height tasks over one
+capacity-1 window carry enough combined "energy" to overload it when in
+truth both may simply be absent.
+
+The (TTOC) strengthening's pinned outside-the-window tasks are filtered
+too, and that one is *not* checkable, which is worth knowing before
+someone deletes it as untested. Pinning a task the arithmetic never
+counted would be accepted by VeriPB, not rejected: by the point the pins
+are emitted the reason context is contradictory, so every RUP under it is
+vacuously valid --- the same phenomenon as the mutation finding below,
+one rule over. The filter keeps the `pol`'s inputs matched to the
+arithmetic that decided the conflict, and it has to be argued rather than
+tested.
+
+Both then need the presence literals in the reason, which they get for
+free: `reason_with_presence()` carries every known-present task's
+literal, and the energy set is a subset of the profile's tasks. The
+eligibility resolved once in `prepare_cumulative_overload_check` is
+unchanged --- it cannot know a runtime presence, so the filtering belongs
+at the point of use.
+
+Falsifying a presence *by* an energy argument, rather than by the
+profile, is issue 09's extension and is not here.
+
+A *derived* Cumulative (issue 04) declines the whole question: it fills
+its `presence` with nullopts, and `DerivedCumulativeSpec` says the donor
+must not be optional. Deriving over an optional donor would need the
+donor's presence literals in every reason the derived constraint gives,
+which is future work --- and the presolvers of issues 06-08 are specified
+to bail out on optional Cumulatives for v1 anyway.
+
+`constraint_type()` is `cumulative_optional` for the optional form, so
+the verified-encoding chain does not silently match it against
+`cake_pb_cp`'s `cumulative` encoder, which would re-derive a strictly
+weaker set of capacity rows. cake has no optional cumulative encoder, and
+that gap is now named rather than hidden.
 
 ## Open follow-ups
 
@@ -584,6 +714,14 @@ should measure the proof size, since that is the whole difference between them.
   presolvers (#549) on the contained one.
 - **Variable lengths, heights and capacity in the energy set.** Staged
   deliberately; the extensions are sketched in #542.
+- **Conditional bounds for optional tasks.** An undecided task's start
+  bounds are never pruned, because there is no conditional-bounds store
+  and an unconditional prune would be unsound if the task turns out
+  absent. The propagation that is being left on the table is real:
+  "if present, `j` cannot start before `b`" is derivable by exactly the
+  chain above, stopped early.
+- **A `cake_pb_cp` encoder for `cumulative_optional`.** Until there is
+  one, the optional form is outside the verified-encoding chain.
 The current scaffolding (`_before_flags`, `_after_flags`,
 `_active_flags`, `_contrib_flags`, `_end`, `_capacity_lines`) is
 enough for time-table-strength reasoning over variable `d`/`r`/`b` and not

--- a/dev_docs/frontend-support-matrix.md
+++ b/dev_docs/frontend-support-matrix.md
@@ -49,6 +49,7 @@ equivalent for that frontend's vocabulary).
 | channel (inverse) | `Inverse` | ✓ | ✓ (1- and 2-list inverse; one-to-many form `s UNSUPPORTED`) | ? |
 | noOverlap (Disjunctive) | `Disjunctive` (1D, var durations) / `Disjunctive2D` (2D, var sizes)[^disj] | ✓ (1D + 2D `diffn`, var durations/sizes) | ✓ (1D + 2D, var durations/sizes) | ? |
 | cumulative | `Cumulative`[^cum] | ✓ (var s/d/r/b) | ✓ (var s/d/r/b) | ? |
+| cumulative, optional tasks | `Cumulative` presence form[^cumopt] | ✓ (`fzn_cumulative_opt`, and `fzn_disjunctive_opt` riding it) | n/a — no such form in XCSP3 | ? |
 | binPacking | `BinPacking` (per-bin GAC)[^bp] | ✓ (`fzn_bin_packing` / `_capa` / `_load`) | ✓ (signatures 1/2/3; per-bin condition list `s UNSUPPORTED`) | ? |
 | knapsack | `Knapsack` | ✓ | ✓ (basic with two `XCondition`s; not yet exercised by a test) | ? |
 | circuit | `Circuit` | ✓ | ✓ (basic; sub-circuit with size param `s UNSUPPORTED`); semantics mismatch with XCSP3 spec, see #167 | ? |
@@ -86,6 +87,28 @@ addressed.
 - [#200](https://github.com/ciaranm/glasgow-constraint-solver/issues/200) — `Knapsack`: the default per-call DP implementation is kept as the default (its proofs verify 3.6–18× faster), with an opt-in upfront-DAG variant `KnapsackUpfront` (Stage 1 checker + Stage 2 full GAC with paper-style proof scaffolding at `ProofLevel::Top`) that produces 3–6× smaller proofs. Open follow-up: factor the layered-DAG infrastructure shared with `MDD` and `BinPacking` into a common framework. See `knapsack.md`.
 
 [^cum]: Time-table propagation (mandatory-part load profile with bound pushes), now over variable origins, durations, demands, and capacity; every inference is VeriPB-certified — see [`cumulative-proof-logging.md`](cumulative-proof-logging.md). MiniZinc forwards `s`/`d`/`r`/`b` straight to `glasgow_cumulative` (constants pass through as constant variables); XCSP3 handles all four constant/variable length×height overloads and a constant- or variable-capacity `le` condition. Edge-finding / energetic reasoning remain out of scope.
+
+[^cumopt]: Optional tasks: a `{0, 1}` presence variable per task, absent tasks
+    consuming nothing, with the presences ordinary problem variables so a model
+    can maximise over them. Time-table strength on the tasks known present, plus
+    presence falsification — a task with no start position left that fits is
+    inferred absent — all VeriPB-certified; an undecided task's own start bounds
+    are deliberately not pruned (see
+    [`cumulative-proof-logging.md`](cumulative-proof-logging.md)). MiniZinc
+    redefines `fzn_cumulative_opt` to `glasgow_cumulative_opt`, splitting each
+    `var opt int` start with `occurs`/`deopt` the way the Gecode and OR-Tools
+    libraries do; `fzn_disjunctive_opt` rides the same builtin at unit demands
+    and capacity 1. `fzn_disjunctive_strict_opt` deliberately does not: strict
+    disjunctive forbids a zero-duration task from sitting inside another, and a
+    task consuming nothing for no time is invisible to a resource profile.
+    XCSP3 defines no optional-task cumulative at all — every
+    `buildConstraintCumulative` overload in the parser is
+    origins/lengths/heights[/ends] plus a condition — so there is nothing to
+    map, and the XCSP frontend records that rather than leaving it open.
+    `cake_pb_cp` has no encoder for the optional form, so it is outside the
+    verified-encoding chain; `constraint_type()` is `cumulative_optional` so
+    that gap is named rather than silently mismatched against the plain
+    encoder.
 
 [^disj]: 1D `Disjunctive`: variable starts, constant *or* variable durations, strict/non-strict; time-table specialised to heights=1, capacity=1 (variable durations fold into the pairwise ordering flags directly, with a reified zero-length escape clause in non-strict mode). 2D `Disjunctive2D` (non-overlapping rectangles, variable origins, constant or variable sizes): pairwise time-table — mandatory-box overlap is a contradiction, and a pair forced to overlap on one axis is pushed apart on the other. Both are fully proof-logged pairwise against the declarative OPB encoding ([`disjunctive-proof-logging.md`](disjunctive-proof-logging.md)); 2D adds a 4-way separation clause per pair. Outside the envelope (k-D, optional tasks): XCSP3 raises an unsupported error.
 

--- a/dev_docs/minizinc.md
+++ b/dev_docs/minizinc.md
@@ -204,6 +204,46 @@ and VeriPB alike. `minizinc-differencelogic` therefore runs with
 `-s --difference-logic` and asserts on the `%%%mzn-stat:
 differenceLogic*` counters as well.
 
+### Reachability guards and extra reference solvers
+
+Two more leading flags, both taken *before* the positional arguments:
+
+- `--fzn-pattern REGEX` (repeatable) requires the regex to match the
+  flattened model the solver was handed. This is the guard against a
+  test passing vacuously. MiniZinc's global wrappers rewrite freely —
+  `cumulative` short-circuits into a disjunctive when no two tasks can
+  coexist, `disjunctive_opt` routes to `disjunctive_strict_opt` when
+  every duration is known positive — and a rewritten model still agrees
+  with the reference solver and still verifies its proof. Nothing else
+  the harness checks can tell you the builtin never ran. Any test whose
+  point is a specific `glasgow_*` builtin wants one of these.
+- `--reference-solver NAME` (repeatable) diffs against another solver on
+  top of MiniZinc's default. Worth it where a second implementation is
+  genuinely independent: for optional-task scheduling, Gecode (the
+  default) propagates them natively while Chuffed falls back to the
+  library decomposition, so agreeing with both pins the semantics
+  against a propagator *and* against MiniZinc's own reference reading. A
+  solver that is not installed is reported and skipped rather than
+  failing, like the `veripb` check.
+
+### Optional (`var opt int`) arguments
+
+MiniZinc's optional-task predicates take `array[int] of var opt int`,
+which no `glasgow_*` builtin can accept. Split them the way the Gecode
+and OR-Tools libraries do: `occurs(s[i])` for the presence Boolean and
+`deopt(s[i])` for the underlying integer, guarding `deopt` because it is
+undefined on a value already fixed absent:
+
+```minizinc
+glasgow_cumulative_opt(
+    [ if is_fixed(si) /\ absent(fix(si)) then 0 else deopt(si) endif | si in s ],
+    d, r, [ occurs(si) | si in s ], b)
+```
+
+The presence array arrives as `array[int] of var bool`, which
+`fzn-glasgow` already presents as `{0, 1}` integer variables (see *Bool
+vs int* below), so the C++ side needs nothing special.
+
 ### Solution counts
 
 Be deliberate about how many solutions a test enumerates. The default

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -248,6 +248,7 @@ if(GCS_BUILD_TESTS)
     add_executable(cumulative_test constraints/cumulative/cumulative_test.cc)
     add_executable(cumulative_overload_test constraints/cumulative/cumulative_overload_test.cc)
     add_executable(derived_cumulative_test constraints/cumulative/derived_cumulative_test.cc)
+    add_executable(cumulative_optional_test constraints/cumulative/cumulative_optional_test.cc)
     add_executable(difference_test constraints/difference/difference_constraints_test.cc)
     add_executable(disjunctive_test constraints/disjunctive/disjunctive_test.cc)
     add_executable(disjunctive_2d_test constraints/disjunctive_2d/disjunctive_2d_test.cc)
@@ -296,7 +297,7 @@ if(GCS_BUILD_TESTS)
 
     foreach(test_target
             abs_test all_different_test all_different_except_test all_equal_test among_test at_most_one_test bin_packing_test comparison_test
-            count_test cumulative_test cumulative_overload_test derived_cumulative_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
+            count_test cumulative_test cumulative_overload_test cumulative_optional_test derived_cumulative_test difference_test disjunctive_test disjunctive_2d_test divide_modulus_test element_test equals_test bounds_global_cardinality_test gac_global_cardinality_test in_test increasing_test inverse_test knapsack_test knapsack_upfront_test lex_test linear_test linear_constant_test
             logical_test mdd_test min_distance_test min_distance_matching_test min_max_test mini_linear_test multiply_test n_value_test nogoods_test parity_test
             plus_minus_test power_test product_bounds_test product_justify_test regular_test regular_bacchus_test regular_legacy_test seq_precede_chain_test smart_table_test sort_test arg_sort_test symmetric_all_different_test
             negative_table_test table_test tabulation_test value_precede_test)
@@ -327,6 +328,20 @@ if(GCS_BUILD_TESTS)
         add_test(NAME cumulative_overload_mutation_${mutation}
             COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
                 --basename cumulative_overload_mutation_${mutation} $<TARGET_FILE:cumulative_overload_test> --mutate=${mutation})
+    endforeach()
+    # One ctest entry per mode, each writing proofs under its own basename, so a
+    # parallel run does not have two entries racing over one set of files.
+    foreach(mode enumerate falsify bijection objective)
+        add_test(NAME cumulative_optional_constraint_${mode}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_optional_test> ${mode})
+    endforeach()
+    # Presence-falsification mutation lanes, the same shape as the overload
+    # ones above: each writes a deliberately corrupted proof and passes only if
+    # veripb rejects it.
+    foreach(mutation wrong_task emit_nothing one_too_far)
+        add_test(NAME cumulative_optional_mutation_${mutation}
+            COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_expect_verify_failure.bash
+                --basename cumulative_optional_mutation_${mutation} $<TARGET_FILE:cumulative_optional_test> --mutate=${mutation})
     endforeach()
     foreach(mode basic cycles views alias reified simplify incremental random random_reified)
         add_test(NAME difference_constraint_${mode}

--- a/gcs/constraints/cumulative/cumulative.cc
+++ b/gcs/constraints/cumulative/cumulative.cc
@@ -102,6 +102,19 @@ Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<Integer> lengths
 {
 }
 
+Cumulative::Cumulative(vector<IntegerVariableID> starts, vector<IntegerVariableID> lengths, vector<IntegerVariableID> heights,
+    vector<IntegerVariableID> presences, IntegerVariableID capacity) : Cumulative(move(starts), move(lengths), move(heights), capacity)
+{
+    _presences = move(presences);
+    if (_starts.size() != _presences.size())
+        throw InvalidProblemDefinitionException{"Cumulative: starts and presences must have the same size"};
+    // A constant presence is checked here; a variable one is checked in
+    // prepare(), where its domain first becomes available.
+    for (const auto & p : _presences)
+        if (is_constant_variable(p) && const_value_of(p) != 0_i && const_value_of(p) != 1_i)
+            throw InvalidProblemDefinitionException{"Cumulative: presences must be within {0, 1}"};
+}
+
 auto Cumulative::with_rules(CumulativeRules rules) -> Cumulative &
 {
     _rules = rules;
@@ -114,11 +127,19 @@ auto Cumulative::with_proof_mutation(CumulativeProofMutation mutation) -> Cumula
     return *this;
 }
 
+auto Cumulative::with_presence_mutation(CumulativePresenceMutation mutation) -> Cumulative &
+{
+    _presence_mutation = mutation;
+    return *this;
+}
+
 auto Cumulative::clone() const -> unique_ptr<Constraint>
 {
-    auto result = make_unique<Cumulative>(_starts, _lengths, _heights, _capacity);
+    auto result = _presences.empty() ? make_unique<Cumulative>(_starts, _lengths, _heights, _capacity)
+                                     : make_unique<Cumulative>(_starts, _lengths, _heights, _presences, _capacity);
     result->with_rules(_rules);
     result->with_proof_mutation(_proof_mutation);
+    result->with_presence_mutation(_presence_mutation);
     return result;
 }
 
@@ -138,6 +159,28 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
             throw InvalidProblemDefinitionException{"Cumulative: heights must be non-negative"};
     if (! is_constant_variable(_capacity) && initial_state.lower_bound(_capacity) < 0_i)
         throw InvalidProblemDefinitionException{"Cumulative: capacity must be non-negative"};
+
+    // Resolve each task's presence to the variable that has to appear in its
+    // active flag, or nullopt when the task is unconditionally present. Only a
+    // constant argument resolves away: a *variable* presence keeps its conjunct
+    // even if it is already fixed, because the encoding has to say what it means
+    // without appealing to a domain the OPB does not record.
+    _presence.assign(n, std::nullopt);
+    for (size_t i = 0; i < n; ++i) {
+        if (_presences.empty())
+            continue;
+        const auto & p = _presences[i];
+        if (is_constant_variable(p)) {
+            if (const_value_of(p) == 1_i)
+                continue;
+        }
+        else {
+            auto [lo, hi] = initial_state.bounds(p);
+            if (lo < 0_i || hi > 1_i)
+                throw InvalidProblemDefinitionException{"Cumulative: presences must be within {0, 1}"};
+        }
+        _presence[i] = p;
+    }
 
     // Resolve snapshots used by define_proof_model and the propagator. For a
     // variable length/height, _*_vals[i] is a placeholder 0 (the propagator
@@ -168,10 +211,13 @@ auto Cumulative::prepare(Propagators &, State & initial_state, ProofModel * cons
         _capacity_val = const_value_of(_capacity);
 
     // Tasks whose length can only ever be 0, or whose height can only ever be 0,
-    // never raise the load profile.
+    // or which are constantly absent, never raise the load profile.
+    auto constantly_absent = [&](size_t i) {
+        return _presence[i].has_value() && is_constant_variable(*_presence[i]) && const_value_of(*_presence[i]) == 0_i;
+    };
     _active_tasks.reserve(n);
     for (size_t i = 0; i < n; ++i)
-        if (_length_ub[i] > 0_i && _height_ub[i] > 0_i)
+        if (_length_ub[i] > 0_i && _height_ub[i] > 0_i && ! constantly_absent(i))
             _active_tasks.push_back(i);
 
     if (_active_tasks.empty())
@@ -268,7 +314,7 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
     //   for each task i and each time point t in its possible-active range:
     //     before_{i,t}  ⇔  starts[i] ≤ t
     //     after_{i,t}   ⇔  starts[i] ≥ t − lengths[i] + 1
-    //     active_{i,t} ⇔  before_{i,t} ∧ after_{i,t}
+    //     active_{i,t} ⇔  before_{i,t} ∧ after_{i,t} [ ∧ presences[i] = 1 ]
     //   for each time point t:
     //     Σ heights[i] · active_{i,t} ≤ capacity
     _before_flags.assign(_starts.size(), {});
@@ -326,7 +372,20 @@ auto Cumulative::define_proof_model(ProofModel & model, const State &) -> void
             auto after = is_constant_variable(_lengths[i])
                 ? model.create_proof_flag_values_fully_reifying(_constraint_id, it, "ca", WPBSum{} + 1_i * _starts[i] >= t - _length_vals[i] + 1_i)
                 : model.create_proof_flag_values_fully_reifying(_constraint_id, it, "ca", WPBSum{} + 1_i * _starts[i] + 1_i * _lengths[i] >= t + 1_i);
-            auto active = model.create_proof_flag_values_fully_reifying(_constraint_id, it, "cact", WPBSum{} + 1_i * before + 1_i * after >= 2_i);
+            // active_{i,t} ⇔ before ∧ after, plus the presence conjunct for an
+            // optional task. The presence literal is the {0,1} variable's single
+            // PB atom, so the three-way AND costs one more term in the same two
+            // reification halves --- no extra flag, and nothing else in the
+            // encoding has to know whether the task is optional. An absent task
+            // fails the AND at every t, so it drops out of every capacity row,
+            // which is exactly "an absent task consumes nothing".
+            auto active_conjuncts = WPBSum{} + 1_i * before + 1_i * after;
+            auto active_arity = 2_i;
+            if (_presence[i]) {
+                active_conjuncts += 1_i * (*_presence[i] == 1_i);
+                active_arity = 3_i;
+            }
+            auto active = model.create_proof_flag_values_fully_reifying(_constraint_id, it, "cact", move(active_conjuncts) >= active_arity);
             _before_flags[i].push_back(before);
             _after_flags[i].push_back(after);
             _active_flags[i].push_back(active);
@@ -405,6 +464,14 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
     for (auto i : _active_tasks)
         if (! is_constant_variable(_lengths[i]))
             triggers.on_bounds.emplace_back(_lengths[i]);
+    // A task joins the load profile the moment its presence is fixed to 1, and
+    // leaves the falsification search the moment it is fixed to 0, so an
+    // optional task's presence has to wake the propagator as much as its start
+    // does. A {0,1} variable's only possible change is being fixed, so
+    // on_bounds and on_instantiated coincide here.
+    for (auto i : _active_tasks)
+        if (_presence[i] && ! is_constant_variable(*_presence[i]))
+            triggers.on_instantiated.emplace_back(*_presence[i]);
 
     // Per variable-duration task, the in-proof end = s + l definition lines
     // {end_ge, end_le}, filled by the initialiser and read by the propagator's
@@ -447,6 +514,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .lengths = move(_lengths),
         .heights = move(_heights),
         .capacity = _capacity,
+        .presence = move(_presence),
         .active_tasks = move(_active_tasks),
         .before_flags = move(_before_flags),
         .after_flags = move(_after_flags),
@@ -458,6 +526,7 @@ auto Cumulative::install_propagators(Propagators & propagators) -> void
         .capacity_lines = move(_capacity_lines),
         .rules = _rules,
         .proof_mutation = _proof_mutation,
+        .presence_mutation = _presence_mutation,
         .overload_tasks = move(_overload_tasks),
         .time_slot_prefix = move(_time_slot_prefix),
         .time_slot_lo = _time_slot_lo};
@@ -490,6 +559,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     const auto & capacity_lines = inputs.capacity_lines;
     const auto & rules = inputs.rules;
     const auto & mutation = inputs.proof_mutation;
+    const auto & presence = inputs.presence;
+    const auto & presence_mutation = inputs.presence_mutation;
     const auto & overload_tasks = inputs.overload_tasks;
     const auto & time_slot_prefix = inputs.time_slot_prefix;
     const auto & time_slot_lo = inputs.time_slot_lo;
@@ -517,6 +588,15 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     auto lub = [&](size_t i) { return state.upper_bound(lengths_var[i]); };
     auto l_is_var = [&](size_t i) { return ! is_constant_variable(lengths_var[i]); };
     auto s_is_var = [&](size_t i) { return ! is_constant_variable(starts[i]); };
+
+    // A task with no presence variable is always here. An optional one is here
+    // only once its presence is fixed to 1: until then it contributes nothing
+    // to the profile and nothing to the overload check's energy, and nothing
+    // may be inferred about its start, since a prune that is only valid when
+    // the task is present would be plain wrong if it turns out absent. Fixed
+    // to 0, it is gone for good and every loop below skips it.
+    auto is_present = [&](size_t i) { return ! presence[i] || state.lower_bound(*presence[i]) == 1_i; };
+    auto is_absent = [&](size_t i) { return presence[i] && state.upper_bound(*presence[i]) == 0_i; };
 
     // For a task whose start AND length are both variables, after_{i,t}
     // is reified on s_i + l_i. To pin after = 1 we first materialise the
@@ -548,6 +628,24 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             reason_vars.push_back(lengths_var[i]);
     }
 
+    // Presence enters the reason as an explicit literal per task known present,
+    // rather than by putting the variable in reason_vars: an undecided presence
+    // has no fact to record (a task not known present is simply not in the
+    // profile, and staying out of it is monotone as the domain shrinks), and
+    // generic_reason would contribute the pair of trivial bounds 0 ≤ p ≤ 1 for
+    // it, which says nothing and costs an order atom on a variable whose whole
+    // encoding is one PB literal. Every inference below reasons only about
+    // tasks known present, so this one list serves all of them --- including
+    // the overload check, whose energy set is a subset of the profile's tasks.
+    // The snapshot is taken once per call and stays accurate: the only presence
+    // this propagator ever changes is one it fixes to 0, and those were
+    // undecided, so absent from the list to begin with.
+    ReasonLiterals presence_lits;
+    for (auto i : active_tasks)
+        if (presence[i] && is_present(i))
+            presence_lits.push_back(*presence[i] == 1_i);
+    auto reason_with_presence = [&]() { return with_extra(generic_reason(reason_vars), presence_lits); };
+
     // Proof helper: pin task i's guaranteed load contribution at t and
     // return a (line, coeff) pair to feed the time-table pol. For a
     // constant height that is "active = 1" scaled by the height; for a
@@ -567,26 +665,41 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         return {contrib_line, 1_i};
     };
 
+    // The disjuncts a chain step's pins are weakened by --- what the step is out
+    // to prove. An ordinary bound push carries the one literal saying the bound
+    // has advanced; a presence falsification carries "task j is absent"
+    // alongside it, so that every line the chain lays down reads "either the
+    // bound has moved on, or the task is not there at all". At most two, so a
+    // vector costs nothing worth avoiding on a path that only runs when a proof
+    // is being written.
+    using ExtLits = vector<IntegerVariableCondition>;
+
+    auto plus_ext = [&](WPBSum sum, const ExtLits & ext, Integer coeff) -> WPBSum {
+        for (const auto & e : ext)
+            sum += coeff * e;
+        return sum;
+    };
+
     // Proof helper for the pushed task j, pinned under the EXTENDED
-    // reason {reason ∧ ¬ext_lit} (ext_lit appended as a disjunct). For a
-    // constant height it returns (active_j+ext_lit ≥ 1, h_j); for a
-    // variable height it deposits contrib_j + lb(h_j)·ext_lit ≥ lb(h_j)
-    // (vacuous when ext_lit holds, "contrib_j ≥ lb(h_j)" otherwise) and
-    // returns that line with coefficient 1.
-    auto pin_pushed = [&](const ReasonLiterals & reason, size_t j_idx, Integer t, IntegerVariableCondition ext_lit,
+    // reason {reason ∧ ¬ext} (ext appended as disjuncts). For a constant
+    // height it returns (active_j + Σext ≥ 1, h_j); for a variable height
+    // it deposits contrib_j + lb(h_j)·Σext ≥ lb(h_j) (vacuous when some ext
+    // literal holds, "contrib_j ≥ lb(h_j)" otherwise) and returns that line
+    // with coefficient 1.
+    auto pin_pushed = [&](const ReasonLiterals & reason, size_t j_idx, Integer t, const ExtLits & ext,
                           Integer s_lo_after) -> std::pair<ProofLine, Integer> {
         auto fj = (t - per_task_t_lo[j_idx]).raw_value;
-        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * before_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
-        // s_lo_after + lb(l_j) ≥ t+1 gives after_{j,t} = 1 (under ¬ext_lit
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * before_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        // s_lo_after + lb(l_j) ≥ t+1 gives after_{j,t} = 1 (under ¬ext
         // for ub-push, under the running bound for lb-push).
         materialise_after_sum(j_idx, s_lo_after);
-        logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * after_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
-        auto active_line =
-            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * active_flags[j_idx][fj] + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
+        logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{} + 1_i * after_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
+        auto active_line = logger->emit_rup_proof_line_under_reason(
+            reason, plus_ext(WPBSum{} + 1_i * active_flags[j_idx][fj], ext, 1_i) >= 1_i, ProofLevel::Temporary);
         if (! h_is_var(j_idx))
             return {active_line, hlb(j_idx)};
         auto contrib_line = logger->emit_rup_proof_line_under_reason(
-            reason, contrib_sum_of(contrib_flags[j_idx][fj]) + hlb(j_idx) * ext_lit >= hlb(j_idx), ProofLevel::Temporary);
+            reason, plus_ext(contrib_sum_of(contrib_flags[j_idx][fj]), ext, hlb(j_idx)) >= hlb(j_idx), ProofLevel::Temporary);
         return {contrib_line, 1_i};
     };
 
@@ -603,6 +716,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     bool any = false;
     Integer t_lo = 0_i, t_hi = -1_i;
     for (auto i : active_tasks) {
+        if (is_absent(i))
+            continue;
         auto [s_lo, s_hi] = state.bounds(starts[i]);
         auto lo = s_lo, hi = s_hi + lub(i) - 1_i;
         if (! any || lo < t_lo)
@@ -617,7 +732,11 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
     auto range = (t_hi - t_lo + 1_i).raw_value;
     vector<Integer> mand_load(range, 0_i);
 
+    // Only tasks known present have a mandatory part: an undecided one might
+    // not be scheduled at all, so none of its resource use is guaranteed.
     for (auto i : active_tasks) {
+        if (! is_present(i))
+            continue;
         auto lst = state.upper_bound(starts[i]);
         auto eet = state.lower_bound(starts[i]) + llb(i);
         if (lst < eet)
@@ -633,6 +752,8 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             // we'll pin to active=1 in the proof.
             vector<size_t> contributing;
             for (auto i : active_tasks) {
+                if (! is_present(i))
+                    continue;
                 auto lst = state.upper_bound(starts[i]);
                 auto eet = state.lower_bound(starts[i]) + llb(i);
                 if (lst < eet && violating_t >= lst && violating_t < eet)
@@ -656,7 +777,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 pol.emit(*logger, ProofLevel::Temporary);
             };
 
-            inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
+            inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
             return PropagatorState::DisableUntilBacktrack;
         }
 
@@ -710,10 +831,19 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
         vector<Candidate> candidates;
         candidates.reserve(overload_tasks.size());
         for (auto i : overload_tasks) {
+            // An optional task carries guaranteed energy only once it is known
+            // present. Until then it might not be scheduled at all, and
+            // counting its energy would manufacture a conflict that is not
+            // there. Its presence literal is already in the reason, put there
+            // with every other known-present task's.
+            if (! is_present(i))
+                continue;
             auto [s_lo, s_hi] = state.bounds(starts[i]);
             auto p = llb(i), h = hlb(i);
             candidates.push_back(Candidate{i, s_lo, s_hi + p, p * h, h * max(0_i, s_lo + p - s_hi)});
         }
+        // An empty candidate list leaves window_starts empty too, so the window
+        // loop below simply does not run; no early exit needed.
         sort(candidates, [](const Candidate & a, const Candidate & b) { return a.lct < b.lct; });
 
         vector<Integer> window_starts;
@@ -754,7 +884,15 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                     for (auto i : inside_tasks)
                         inside[i] = true;
                     for (auto j : active_tasks) {
-                        if (inside[j])
+                        // Exactly the tasks profile_within counted: mand_load
+                        // holds only those known present. Pinning any other
+                        // would claim load the arithmetic never used --- which
+                        // VeriPB would *accept*, since by this point the reason
+                        // context is contradictory and every RUP under it is
+                        // vacuously valid, so nothing downstream would notice.
+                        // That is exactly why it is written down here rather
+                        // than left to a test to catch.
+                        if (inside[j] || ! is_present(j))
                             continue;
                         auto lst = state.upper_bound(starts[j]);
                         auto eet = state.lower_bound(starts[j]) + llb(j);
@@ -828,8 +966,7 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                     pol.emit(*logger, ProofLevel::Temporary);
                 };
 
-                inference.contradiction(
-                    logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeOverload{owner}}, generic_reason(reason_vars));
+                inference.contradiction(logger, JustifyExplicitly{justify, ThenRUP::Yes, hints::CumulativeOverload{owner}}, reason_with_presence());
                 return PropagatorState::DisableUntilBacktrack;
             }
         }
@@ -855,66 +992,69 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
 
     // Helper: emit (a)–(d) for one chain step.
     //
-    // `ext_lit` is the literal added to the reason in PB form (= the
+    // `ext` holds the literals added to the reason in PB form (= the
     // negation of "task j is active at t"-as-bounded-by-the-running
     // half):
-    //   lb-push:  ext_lit = (s_j ≥ t + 1)
-    //   ub-push:  ext_lit = (s_j ≤ t − l_j)
+    //   lb-push:  ext = {s_j ≥ t + 1}
+    //   ub-push:  ext = {s_j ≤ t − l_j}
+    //   falsify:  ext = {s_j ≥ t + 1, present_j = 0}, and just
+    //             {present_j = 0} on the final step
     //
-    // `emit_intermediate` deposits ext_lit as a unit under reason —
-    // needed for every step except the last (the framework's wrapping
+    // `emit_intermediate` deposits the ext disjunction as a unit clause under
+    // reason — needed for every step except the last (the framework's wrapping
     // RUP closes the final inference).
-    auto emit_chain_step = [&](size_t j_idx, Integer t, const vector<size_t> & contributing, IntegerVariableCondition ext_lit, Integer s_lo_after,
+    auto emit_chain_step = [&](size_t j_idx, Integer t, const vector<size_t> & contributing, const ExtLits & ext, Integer s_lo_after,
                                bool emit_intermediate, const ReasonLiterals & reason) -> void {
         // (a) Pin each task i ≠ j mandatory at t under the reason, and
         // (b) pin the pushed task j under the EXTENDED reason. Then
         // (c) combine all pinned load lines with C_t in one pol. After
-        // cancellation the pol is dominated by (load − capacity)·ext_lit,
-        // forcing ext_lit = 1 (the new bound) under the reason context.
+        // cancellation the pol is dominated by (load − capacity)·Σext,
+        // forcing the ext disjunction under the reason context.
         PolBuilder pol;
         pol.add(capacity_lines.at(t));
         for (auto i : contributing) {
             auto [line, coeff] = pin_contributor(reason, i, t);
             pol.add(line, coeff);
         }
-        auto [j_line, j_coeff] = pin_pushed(reason, j_idx, t, ext_lit, s_lo_after);
+        auto [j_line, j_coeff] = pin_pushed(reason, j_idx, t, ext, s_lo_after);
         pol.add(j_line, j_coeff);
         pol.emit(*logger, ProofLevel::Temporary);
 
         // (d) Deposit the running-bound advance as a fact under
         // reason for the next chain step's UP.
         if (emit_intermediate)
-            logger->emit_rup_proof_line_under_reason(reason, WPBSum{} + 1_i * ext_lit >= 1_i, ProofLevel::Temporary);
+            logger->emit_rup_proof_line_under_reason(reason, plus_ext(WPBSum{}, ext, 1_i) >= 1_i, ProofLevel::Temporary);
     };
 
     for (auto j : active_tasks) {
+        if (is_absent(j))
+            continue;
         auto [cur_lb, cur_ub] = state.bounds(starts[j]);
-        if (cur_lb == cur_ub)
+        // A fixed start leaves nothing to push, but an undecided task with a
+        // fixed start can still be shown to have nowhere to go.
+        if (cur_lb == cur_ub && is_present(j))
             continue;
 
         auto lst_j = cur_ub, eet_j = cur_lb + llb(j);
+        // Only a task known present put anything into the profile, so only that
+        // one has something to discount before asking where it could go. An
+        // undecided task's own load is not in mand_load and must not be
+        // subtracted out of it.
+        auto own_load_at = [&](Integer t) { return is_present(j) && lst_j < eet_j && t >= lst_j && t < eet_j ? hlb(j) : 0_i; };
+
         auto fits_at = [&](Integer s) -> bool {
-            for (Integer t = s; t < s + llb(j); ++t) {
-                auto load = mand_load[(t - t_lo).raw_value];
-                if (lst_j < eet_j && t >= lst_j && t < eet_j)
-                    load -= hlb(j);
-                if (load + hlb(j) > capacity)
+            for (Integer t = s; t < s + llb(j); ++t)
+                if (mand_load[(t - t_lo).raw_value] - own_load_at(t) + hlb(j) > capacity)
                     return false;
-            }
             return true;
         };
 
-        auto is_blocked_at = [&](Integer t) -> bool {
-            auto load = mand_load[(t - t_lo).raw_value];
-            if (lst_j < eet_j && t >= lst_j && t < eet_j)
-                load -= hlb(j);
-            return load + hlb(j) > capacity;
-        };
+        auto is_blocked_at = [&](Integer t) -> bool { return mand_load[(t - t_lo).raw_value] - own_load_at(t) + hlb(j) > capacity; };
 
         auto contributors_at = [&](Integer t) -> vector<size_t> {
             vector<size_t> result;
             for (auto i : active_tasks) {
-                if (i == j)
+                if (i == j || ! is_present(i))
                     continue;
                 auto lst_i = state.upper_bound(starts[i]);
                 auto eet_i = state.lower_bound(starts[i]) + llb(i);
@@ -924,16 +1064,22 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
             return result;
         };
 
-        // lb-push: find smallest s with fits_at(s), then chain
-        // through blocked t's picking the LARGEST in each step's
-        // window so the bound advances as far as possible per step.
+        // The lb-push scan, which the presence falsification also reads: find
+        // the smallest s in [cur_lb, cur_ub] with fits_at(s). If there is none,
+        // no placement at all is left for this task.
         auto new_lb = cur_lb;
         while (new_lb <= cur_ub && ! fits_at(new_lb))
             ++new_lb;
-        if (new_lb > cur_lb) {
+
+        // Build the chain of blocked times carrying the running bound from
+        // cur_lb up to `target`, picking the LARGEST blocked t in each step's
+        // window so the bound advances as far as possible per step. Every
+        // step's window contains a blocked time by construction (its running
+        // bound does not fit), so the chain always reaches `target`.
+        auto build_lb_chain = [&](Integer target) -> vector<ChainStep> {
             vector<ChainStep> chain;
             Integer running_bound = cur_lb;
-            while (running_bound < new_lb) {
+            while (running_bound < target) {
                 bool found = false;
                 for (Integer t = running_bound + llb(j) - 1_i; t >= running_bound; --t)
                     if (is_blocked_at(t)) {
@@ -945,17 +1091,80 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 if (! found)
                     break;
             }
+            return chain;
+        };
+
+        if (! is_present(j)) {
+            // Presence falsification. The task is undecided and, if it were
+            // present, has nowhere left to start: new_lb ran off the end of its
+            // domain. Replay the lb-push chain over the whole domain with "task
+            // j is absent" carried as an extra disjunct on every line, so each
+            // step says "either j starts later than this, or j is not here at
+            // all". The last step's blocked time is at or beyond cur_ub --- that
+            // is what makes it the last --- so there the start-side disjunct is
+            // dropped: j's own upper bound in the reason already puts it before
+            // that time, and asking for an order literal above the domain would
+            // be asking for one that need not exist.
+            //
+            // The ClaimOneTooFar mutation fires where exactly one placement is
+            // still open, so the conclusion is wrong rather than the route to
+            // it. The chain then stops short --- its last window has no blocked
+            // time --- and the wrapping RUP has nothing to close on, which is
+            // what VeriPB must catch.
+            if (new_lb <= cur_ub && ! (std::holds_alternative<cumulative_presence_mutation::ClaimOneTooFar>(presence_mutation) && new_lb == cur_ub))
+                continue;
+            auto chain = build_lb_chain(cur_ub + 1_i);
+            if (chain.empty())
+                continue;
+
+            auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
+                if (! logger)
+                    return;
+                // The marker a test counts to show the rule fired, and counts to
+                // zero on the twin instance where it must not.
+                logger->emit_proof_comment("cumulative optional: task " + std::to_string(j) + " cannot be placed anywhere, so it is absent");
+
+                auto steps = std::holds_alternative<cumulative_presence_mutation::EmitNothing>(presence_mutation) ? 0 : chain.size();
+                // Which task's absence the chain argues about: the one being
+                // falsified, unless the WrongTask mutation points it at some
+                // other optional task.
+                auto about = j;
+                if (std::holds_alternative<cumulative_presence_mutation::WrongTask>(presence_mutation))
+                    for (auto k : active_tasks)
+                        if (k != j && presence[k]) {
+                            about = k;
+                            break;
+                        }
+
+                for (size_t step = 0; step < steps; ++step) {
+                    auto last = step + 1 == steps;
+                    ExtLits ext;
+                    if (! last)
+                        ext.push_back(starts[j] > chain[step].t);
+                    ext.push_back(*presence[about] == 0_i);
+                    emit_chain_step(j, chain[step].t, chain[step].contributing, ext, chain[step].s_lo_after, ! last, reason);
+                }
+            };
+
+            inference.infer_equal(
+                logger, *presence[j], 0_i, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
+            continue;
+        }
+
+        // lb-push: chain through blocked t's up to the first placement that fits.
+        if (new_lb > cur_lb) {
+            auto chain = build_lb_chain(new_lb);
 
             auto justify = [&, j, chain](const ReasonLiterals & reason) -> void {
                 if (! logger)
                     return;
                 for (size_t step = 0; step < chain.size(); ++step)
-                    emit_chain_step(j, chain[step].t, chain[step].contributing, starts[j] > chain[step].t, chain[step].s_lo_after,
+                    emit_chain_step(j, chain[step].t, chain[step].contributing, ExtLits{starts[j] > chain[step].t}, chain[step].s_lo_after,
                         step + 1 < chain.size(), reason);
             };
 
             inference.infer_greater_than_or_equal(
-                logger, starts[j], new_lb, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
+                logger, starts[j], new_lb, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
         }
 
         // ub-push: mirror image. Pick SMALLEST blocked t in each
@@ -984,12 +1193,12 @@ auto gcs::innards::propagate_cumulative(const CumulativeInputs & inputs, const S
                 if (! logger)
                     return;
                 for (size_t step = 0; step < chain.size(); ++step)
-                    emit_chain_step(j, chain[step].t, chain[step].contributing, starts[j] < chain[step].t - llb(j) + 1_i, chain[step].s_lo_after,
-                        step + 1 < chain.size(), reason);
+                    emit_chain_step(j, chain[step].t, chain[step].contributing, ExtLits{starts[j] < chain[step].t - llb(j) + 1_i},
+                        chain[step].s_lo_after, step + 1 < chain.size(), reason);
             };
 
             inference.infer_less_than(
-                logger, starts[j], new_ub + 1_i, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, generic_reason(reason_vars));
+                logger, starts[j], new_ub + 1_i, JustifyExplicitly{justify, ThenRUP::Yes, hints::Cumulative{owner}}, reason_with_presence());
         }
     }
 
@@ -1009,6 +1218,11 @@ auto Cumulative::lengths() const -> const vector<IntegerVariableID> &
 auto Cumulative::heights() const -> const vector<IntegerVariableID> &
 {
     return _heights;
+}
+
+auto Cumulative::presences() const -> const vector<IntegerVariableID> &
+{
+    return _presences;
 }
 
 auto Cumulative::capacity() const -> IntegerVariableID
@@ -1044,21 +1258,37 @@ auto ConstraintProofModelData<Cumulative>::active_flag_key(size_t task, Integer 
 
 auto Cumulative::constraint_type() const -> std::string
 {
-    return "cumulative";
+    // The optional form is a different constraint, not a variant of this one:
+    // its active flags carry a third conjunct, so a verified encoder for
+    // "cumulative" would re-derive a strictly different --- and weaker --- set
+    // of capacity rows from the same s-expression. cake_pb_cp has no optional
+    // cumulative encoder today, so naming it apart is what keeps the
+    // verified-encoding chain honest about the gap rather than silently
+    // mismatching.
+    return _presences.empty() ? "cumulative" : "cumulative_optional";
 }
 
 auto Cumulative::s_expr(const ProofModel * const model) const -> SExpr
 {
     auto & tracker = model->names_and_ids_tracker();
-    vector<SExpr> starts, lengths, heights;
+    vector<SExpr> starts, lengths, heights, presences;
     for (const auto & v : _starts)
         starts.push_back(tracker.s_expr_term_of(v));
     for (const auto & l : _lengths)
         lengths.push_back(tracker.s_expr_term_of(l));
     for (const auto & h : _heights)
         heights.push_back(tracker.s_expr_term_of(h));
-    return SExpr::list({SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(starts)),
-        SExpr::list(std::move(lengths)), SExpr::list(std::move(heights)), tracker.s_expr_term_of(_capacity)});
+    for (const auto & p : _presences)
+        presences.push_back(tracker.s_expr_term_of(p));
+    vector<SExpr> terms{SExpr::atom(as_string(_constraint_id)), SExpr::atom(constraint_type()), SExpr::list(std::move(starts)),
+        SExpr::list(std::move(lengths)), SExpr::list(std::move(heights))};
+    // The presences list sits where the FlatZinc builtin puts it, between the
+    // heights and the capacity, and is absent entirely for the non-optional
+    // form so that its s-expression is unchanged.
+    if (! _presences.empty())
+        terms.push_back(SExpr::list(std::move(presences)));
+    terms.push_back(tracker.s_expr_term_of(_capacity));
+    return SExpr::list(std::move(terms));
 }
 
 template auto gcs::innards::propagate_cumulative(const CumulativeInputs &, const State &, SimpleInferenceTracker &, ProofLogger * const)

--- a/gcs/constraints/cumulative/cumulative.hh
+++ b/gcs/constraints/cumulative/cumulative.hh
@@ -91,6 +91,67 @@ namespace gcs
         cumulative_proof_mutation::OmitCapacityLine, cumulative_proof_mutation::ShrinkLemmaWindow>;
 
     /**
+     * \brief Deliberate corruptions of the presence-falsification derivation,
+     * for testing only. VeriPB must reject each of them.
+     *
+     * A proof that verifies is necessary but not sufficient, so something has
+     * to check that the derivation is doing work. What that something can be is
+     * narrower here than for a bound push, and worth understanding before
+     * adding to this list: presence falsification is a *conflict-shaped* rule,
+     * whose content is "this task cannot be here at all". Once the chain has
+     * narrowed the start domain far enough, the reason context extended with
+     * "the task is present" is contradictory, and every RUP under it is
+     * vacuously valid. A mutation that merely shortens the chain therefore
+     * produces a shorter but still *sound* derivation, and VeriPB is right to
+     * accept it. Corrupting the route is not a test; corrupt the destination.
+     *
+     * So the two that bite are \ref cumulative_presence_mutation::WrongTask,
+     * which argues about a task nothing has cornered, and \ref
+     * cumulative_presence_mutation::ClaimOneTooFar, which draws the conclusion
+     * where it is false. \ref cumulative_presence_mutation::EmitNothing is the
+     * control that says the chain is required at all.
+     *
+     * All but ClaimOneTooFar change nothing except the proof: the same
+     * presences are falsified, the same solutions reported, and the OPB is
+     * untouched. ClaimOneTooFar necessarily changes the inference, since making
+     * the conclusion wrong is the whole point of it.
+     *
+     * \ingroup Constraints
+     */
+    namespace cumulative_presence_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Carry some other optional task's presence literal through the chain,
+        /// so the derivation argues about a task that is not the one being
+        /// falsified.
+        struct WrongTask
+        {
+        };
+
+        /// Fire on an instance where exactly one placement still fits, claiming
+        /// the task is absent when it is not. The "bound + 1 must fail" check
+        /// for this rule: it corrupts the conclusion rather than the route to
+        /// it, which is what a margin of exactly one unit is there to expose.
+        struct ClaimOneTooFar
+        {
+        };
+
+        /// Emit no chain at all, leaving the inference to the framework's
+        /// wrapping RUP. Not a corruption but a control: if VeriPB accepts
+        /// this, the chain is decoration and no mutation of it can be caught.
+        struct EmitNothing
+        {
+        };
+    }
+
+    using CumulativePresenceMutation = std::variant<cumulative_presence_mutation::None, cumulative_presence_mutation::WrongTask,
+        cumulative_presence_mutation::ClaimOneTooFar, cumulative_presence_mutation::EmitNothing>;
+
+    /**
      * \brief Cumulative constraint: tasks with start times, durations, and
      * demands, sharing a resource of a given capacity. Any of the durations,
      * demands, and the capacity may be variables or constants (constants are
@@ -98,6 +159,16 @@ namespace gcs
      * demands of currently-active tasks must not exceed the capacity.
      *
      * A task <em>i</em> is active at time <em>t</em> iff
+     * <em>starts[i] &le; t &lt; starts[i] + lengths[i]</em>.
+     *
+     * Tasks may also be <em>optional</em>: the constructor taking a `presences`
+     * array gives each task a {0, 1} variable, and a task with
+     * <em>presences[i] = 0</em> is absent &mdash; it is never active, so it
+     * consumes no resource and its start time is unconstrained. The presence
+     * variables are ordinary problem variables, so a model can constrain them
+     * and optimise over them (maximising the number of scheduled tasks is the
+     * motivating use). A task <em>i</em> is then active at <em>t</em> iff
+     * <em>presences[i] = 1</em> and
      * <em>starts[i] &le; t &lt; starts[i] + lengths[i]</em>.
      *
      * Propagation is time-table consistent. For each task, the
@@ -110,6 +181,13 @@ namespace gcs
      * time point where placing it would force the load over capacity. Stronger
      * reasoning (edge-finding, energetic) is left for future work.
      *
+     * A task whose presence is still undecided is left out of the profile and
+     * out of the overload check's energy set entirely, and its own start bounds
+     * are never pruned (there is no conditional-bounds store, so a prune valid
+     * only if the task is present would be unsound). What it does get is the
+     * mirror-image inference: when no start position left in its domain fits
+     * under the profile, its presence is inferred to be 0.
+     *
      * \ingroup Constraints
      */
     class Cumulative : public Constraint
@@ -119,6 +197,10 @@ namespace gcs
         std::vector<IntegerVariableID> _lengths;
         std::vector<IntegerVariableID> _heights;
         IntegerVariableID _capacity;
+        // Per-task presence, as posted; empty for the constructors that take no
+        // presences, where every task is unconditionally present. Resolved into
+        // _presence by prepare(); this copy exists for clone() and s_expr().
+        std::vector<IntegerVariableID> _presences;
         // Snapshots resolved in prepare(). For each of lengths and heights,
         // _*_vals holds the constant value for a constant argument (and 0 for a
         // variable one, where the variable / _contrib_flags is used instead) and
@@ -133,6 +215,19 @@ namespace gcs
         std::vector<Integer> _height_vals;
         std::vector<Integer> _height_ub;
         Integer _capacity_val;
+        // Resolved in prepare(). nullopt for a task that is unconditionally
+        // present --- the non-optional constructors, or a presence argument that
+        // is the constant 1 --- which then needs no presence conjunct in its
+        // active flag and no presence literal in a reason, so it encodes and
+        // propagates exactly as it did before optional tasks existed. A task
+        // whose presence is the constant 0 is dropped from _active_tasks
+        // instead: it can never be active, so it contributes nothing to any
+        // capacity row. Only *constant* presences are resolved this way; a
+        // variable that happens to be fixed at prepare() time keeps its
+        // conjunct, because the OPB has to stand on its own and it is the OPB,
+        // not the initial State, that a checker reads.
+        std::vector<std::optional<IntegerVariableID>> _presence;
+        CumulativePresenceMutation _presence_mutation = cumulative_presence_mutation::None{};
         std::vector<std::size_t> _active_tasks;
         std::vector<Integer> _per_task_t_lo;
         std::vector<Integer> _per_task_t_hi;
@@ -191,6 +286,22 @@ namespace gcs
          */
         explicit Cumulative(std::vector<IntegerVariableID> starts, std::vector<Integer> lengths, std::vector<Integer> heights, Integer capacity);
 
+        /**
+         * \brief Optional-task form: `presences[i]` is a {0, 1} variable saying
+         * whether task <em>i</em> is scheduled at all. An absent task is never
+         * active, consumes no resource, and has an unconstrained start.
+         *
+         * Each presence must be a variable whose domain is within {0, 1}, or
+         * the constant 0 or 1. Passing the constant 1 is the same constraint as
+         * leaving the task out of the optional form entirely, and encodes
+         * identically; the constant 0 drops the task.
+         *
+         * \throws InvalidProblemDefinitionException if a presence's domain is
+         * not within {0, 1}, or if the array lengths disagree.
+         */
+        explicit Cumulative(std::vector<IntegerVariableID> starts, std::vector<IntegerVariableID> lengths, std::vector<IntegerVariableID> heights,
+            std::vector<IntegerVariableID> presences, IntegerVariableID capacity);
+
         /// Select which propagation rules are enabled (all of them, by
         /// default). Propagation strength only: the solutions found and the OPB
         /// encoding are the same whatever is selected.
@@ -201,18 +312,27 @@ namespace gcs
         /// CumulativeProofMutation.
         auto with_proof_mutation(CumulativeProofMutation mutation) -> Cumulative &;
 
+        /// Corrupt one step of the presence-falsification derivation. For tests
+        /// only, which assert that VeriPB rejects the result; see
+        /// CumulativePresenceMutation.
+        auto with_presence_mutation(CumulativePresenceMutation mutation) -> Cumulative &;
+
         /**
          * \name The arguments this constraint was posted with.
          *
-         * As posted, not as resolved: a constant length or height comes back as
-         * the ConstantIntegerVariableID it went in as. A caller wanting bounds
-         * should ask the State, which is the only thing that knows them at the
-         * point the caller is asking.
+         * As posted, not as resolved: a constant length, height or presence
+         * comes back as the ConstantIntegerVariableID it went in as. A caller
+         * wanting bounds should ask the State, which is the only thing that
+         * knows them at the point the caller is asking.
          */
         ///@{
         [[nodiscard]] auto starts() const -> const std::vector<IntegerVariableID> &;
         [[nodiscard]] auto lengths() const -> const std::vector<IntegerVariableID> &;
         [[nodiscard]] auto heights() const -> const std::vector<IntegerVariableID> &;
+        /// Empty for the non-optional constructors, which is how a caller asks
+        /// "is this an optional-task Cumulative?" --- DerivedCumulativeSpec
+        /// requires a donor for which this is empty.
+        [[nodiscard]] auto presences() const -> const std::vector<IntegerVariableID> &;
         [[nodiscard]] auto capacity() const -> IntegerVariableID;
         ///@}
 

--- a/gcs/constraints/cumulative/cumulative_optional_test.cc
+++ b/gcs/constraints/cumulative/cumulative_optional_test.cc
@@ -1,0 +1,784 @@
+#include <gcs/constraints/comparison.hh>
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/equals.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/constraints/linear.hh>
+#include <gcs/exception.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <climits>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::flush;
+using std::ifstream;
+using std::make_optional;
+using std::max;
+using std::min;
+using std::mt19937;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::tuple;
+using std::uniform_int_distribution;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::print;
+using std::println;
+#else
+using fmt::print;
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::test_innards;
+
+namespace
+{
+    // The comment the presence-falsification justification writes. Tests count
+    // it: a rule that never fires makes every other assertion about it vacuous,
+    // and a twin instance that must not fire is only checked by counting to
+    // zero. See issue #541's shared validation vocabulary.
+    const string falsification_marker = "cumulative optional: task";
+
+    // One task of an optional-Cumulative instance. A presence spec of {0, 1} is
+    // a genuine decision variable; {1, 1} and {0, 0} are the constants, which
+    // exercise the two ways prepare() resolves a presence away.
+    struct TaskSpec
+    {
+        pair<int, int> start_range;
+        int length;
+        int height;
+        pair<int, int> presence;
+    };
+
+    [[nodiscard]] auto presence_is_var(const TaskSpec & t) -> bool
+    {
+        return t.presence.first != t.presence.second;
+    }
+
+    // Solutions are (every start, then every *variable* presence in task
+    // order). A task is active at t iff it is present and its window covers t.
+    [[nodiscard]] auto make_is_satisfying(const vector<TaskSpec> & tasks, int capacity)
+    {
+        return [&tasks, capacity](const vector<int> & vals) {
+            auto n = tasks.size();
+            vector<int> present(n);
+            size_t k = n;
+            for (size_t i = 0; i < n; ++i)
+                present[i] = presence_is_var(tasks[i]) ? vals.at(k++) : tasks[i].presence.first;
+
+            int t_lo = INT_MAX, t_hi = INT_MIN;
+            for (size_t i = 0; i < n; ++i) {
+                if (! present[i] || tasks[i].length == 0 || tasks[i].height == 0)
+                    continue;
+                t_lo = min(t_lo, vals[i]);
+                t_hi = max(t_hi, vals[i] + tasks[i].length - 1);
+            }
+            for (int t = t_lo; t <= t_hi; ++t) {
+                int load = 0;
+                for (size_t i = 0; i < n; ++i)
+                    if (present[i] && vals[i] <= t && t < vals[i] + tasks[i].length)
+                        load += tasks[i].height;
+                if (load > capacity)
+                    return false;
+            }
+            return true;
+        };
+    }
+
+    [[nodiscard]] auto enumerated_ranges(const vector<TaskSpec> & tasks) -> vector<pair<int, int>>
+    {
+        vector<pair<int, int>> ranges;
+        for (const auto & t : tasks)
+            ranges.push_back(t.start_range);
+        for (const auto & t : tasks)
+            if (presence_is_var(t))
+                ranges.push_back(t.presence);
+        return ranges;
+    }
+
+    // Post the instance, returning the variables in enumeration order.
+    auto post_optional_cumulative(Problem & p, const vector<TaskSpec> & tasks, int capacity, CumulativePresenceMutation mutation)
+        -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts, presences, all_vars;
+        for (const auto & t : tasks) {
+            auto v = p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second});
+            starts.push_back(v);
+            all_vars.push_back(v);
+        }
+        for (const auto & t : tasks) {
+            if (presence_is_var(t)) {
+                auto v = p.create_integer_variable(Integer{t.presence.first}, Integer{t.presence.second});
+                presences.push_back(v);
+                all_vars.push_back(v);
+            }
+            else
+                presences.push_back(constant_variable(Integer{t.presence.first}));
+        }
+        vector<IntegerVariableID> lengths, heights;
+        for (const auto & t : tasks) {
+            lengths.push_back(constant_variable(Integer{t.length}));
+            heights.push_back(constant_variable(Integer{t.height}));
+        }
+        p.post(Cumulative{starts, lengths, heights, presences, constant_variable(Integer{capacity})}.with_presence_mutation(mutation));
+        return all_vars;
+    }
+
+    auto run_optional_test(bool proofs, const string & tag, const vector<TaskSpec> & tasks, int capacity) -> void
+    {
+        print(cerr, "cumulative optional {} n={} c={}{}", tag, tasks.size(), capacity, proofs ? " with proofs:" : ":");
+        cerr << flush;
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, make_is_satisfying(tasks, capacity), enumerated_ranges(tasks));
+        println(cerr, " expecting {} solutions", expected.size());
+
+        Problem p;
+        auto all_vars = post_optional_cumulative(p, tasks, capacity, cumulative_presence_mutation::None{});
+
+        auto proof_name = proofs ? make_optional("cumulative_optional_test_" + tag) : nullopt;
+        solve_for_tests(p, proof_name, actual, tuple{all_vars});
+        check_results(proof_name, expected, actual);
+    }
+}
+
+namespace
+{
+    // How many times `needle` appears in the proof file. The falsification
+    // marker is the only thing tests read the .pbp for; everything else about
+    // the proof is VeriPB's business.
+    [[nodiscard]] auto count_in_proof(const string & proof_name, const string & needle) -> int
+    {
+        ifstream f{proof_name + ".pbp"};
+        if (! f) {
+            println(cerr, "could not open {}.pbp to count markers", proof_name);
+            return -1;
+        }
+        int count = 0;
+        for (string line; getline(f, line);)
+            if (line.find(needle) != string::npos)
+                ++count;
+        return count;
+    }
+
+    /// What the falsification marker count must be. Note the asymmetry: "must
+    /// fire" is a claim about the root, where the fixture is arranged so the
+    /// rule triggers before any branching, and it holds whatever the search
+    /// does afterwards. "Must never fire" is a claim about every node, so it is
+    /// only assertable on a fixture where the task fits under *every* partial
+    /// assignment --- otherwise the harness's seed-derived random branching
+    /// decides whether the rule fires below the root, and the test is flaky.
+    enum class MarkerCount
+    {
+        AtLeastOne,   ///< the rule must fire
+        Never,        ///< the rule must not fire at any node
+        Unconstrained ///< firing below the root is legitimate here; see above
+    };
+
+    struct FalsificationExpectation
+    {
+        MarkerCount markers;
+        int present_ones;              ///< how many solutions have this task present
+        size_t falsified_task;         ///< index of the task under test
+        size_t falsified_var_position; ///< its position among the enumerated variables
+    };
+
+    // A falsification fixture and its twin, checked as a pair: the same
+    // enumeration check as everywhere else, plus the marker count, plus what
+    // the task's presence is allowed to be in a solution.
+    auto run_falsification_test(const string & tag, const vector<TaskSpec> & tasks, int capacity, const FalsificationExpectation & expect) -> bool
+    {
+        println(cerr, "cumulative optional falsification {} c={}", tag, capacity);
+
+        set<vector<int>> expected, actual;
+        build_expected(expected, make_is_satisfying(tasks, capacity), enumerated_ranges(tasks));
+
+        Problem p;
+        auto all_vars = post_optional_cumulative(p, tasks, capacity, cumulative_presence_mutation::None{});
+
+        auto proof_name = "cumulative_optional_falsify_" + tag;
+        solve_for_tests(p, proof_name, actual, tuple{all_vars});
+
+        auto markers = count_in_proof(proof_name, falsification_marker);
+        bool ok = true;
+        switch (expect.markers) {
+            using enum MarkerCount;
+        case AtLeastOne:
+            if (markers <= 0) {
+                println(cerr, "{}: falsification marker count is {}, expected at least one", tag, markers);
+                ok = false;
+            }
+            break;
+        case Never:
+            if (markers != 0) {
+                println(cerr, "{}: falsification marker count is {}, expected zero", tag, markers);
+                ok = false;
+            }
+            break;
+        case Unconstrained: break;
+        }
+
+        // How many solutions leave the task present, according to brute force.
+        // On a "must fire at the root" fixture, this being zero is the semantic
+        // half of the marker assertion; on a twin, its being positive is what
+        // says the rule did *not* fire at the root, whatever it did below.
+        int present_count = 0;
+        for (const auto & sol : expected)
+            if (sol.at(expect.falsified_var_position) == 1)
+                ++present_count;
+        if (present_count != expect.present_ones) {
+            println(cerr, "{}: brute force says task {} is present in {} solutions, fixture claims {}", tag, expect.falsified_task, present_count,
+                expect.present_ones);
+            ok = false;
+        }
+
+        check_results(make_optional(proof_name), expected, actual);
+        return ok;
+    }
+
+    // Write a deliberately corrupted proof of the given instance, under
+    // `proof_basename`, and leave the checking to
+    // run_test_and_expect_verify_failure.bash --- which passes only if VeriPB
+    // rejects it. A mutation that still verifies means the honest derivation
+    // had slack, which is a finding about the derivation.
+    auto write_mutated_proof(const vector<TaskSpec> & tasks, int capacity, CumulativePresenceMutation mutation, const string & proof_basename) -> void
+    {
+        set<vector<int>> actual;
+        Problem p;
+        auto all_vars = post_optional_cumulative(p, tasks, capacity, mutation);
+        // Deliberately not check_results: ClaimOneTooFar draws a wrong
+        // conclusion, so the solution set is wrong too, and that is the point.
+        solve_for_tests(p, make_optional(proof_basename), actual, tuple{all_vars});
+        println(cerr, "wrote a deliberately corrupted proof to {}.pbp", proof_basename);
+    }
+}
+
+namespace
+{
+    // The OPB's constraints, so two models can be compared line for line. The
+    // s-expression goes to the .scp, so what is left here is exactly the
+    // pseudo-Boolean model --- minus the `*` comment lines, which include the
+    // per-constraint block header naming the constraint type. That header is
+    // *meant* to differ between the two forms (they are different constraint
+    // types, and cake_pb_cp dispatches on the name), and it is the one thing
+    // here that is not part of the model.
+    [[nodiscard]] auto read_opb_constraints(const string & proof_name) -> optional<vector<string>>
+    {
+        ifstream f{proof_name + ".opb"};
+        if (! f)
+            return nullopt;
+        vector<string> lines;
+        for (string line; getline(f, line);)
+            if (! line.starts_with("*"))
+                lines.push_back(line);
+        return lines;
+    }
+
+    [[nodiscard]] auto opb_names_constraint_type(const string & proof_name, const string & type) -> bool
+    {
+        ifstream f{proof_name + ".opb"};
+        for (string line; getline(f, line);)
+            if (line.starts_with("* constraint " + type + " "))
+                return true;
+        return false;
+    }
+
+    // The optional form must degenerate structurally, not by emitting a
+    // constant-true conjunct: posting every presence as the constant 1 has to
+    // produce the same OPB as not passing presences at all. That is what keeps
+    // the non-optional constructors' encoding --- and every proof already
+    // written against it --- untouched by this feature.
+    auto check_constant_presence_encoding_is_unchanged() -> bool
+    {
+        vector<pair<int, int>> start_ranges{{0, 3}, {0, 3}, {0, 4}};
+        vector<int> lengths{2, 2, 3}, heights{1, 2, 1};
+        Integer capacity{3_i};
+
+        auto build = [&](bool optional_form, const string & proof_name) -> optional<vector<string>> {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, heights_v, presences;
+            for (auto & [lo, hi] : start_ranges)
+                starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+            for (auto l : lengths)
+                lengths_v.push_back(constant_variable(Integer{l}));
+            for (auto h : heights)
+                heights_v.push_back(constant_variable(Integer{h}));
+            for (size_t i = 0; i < starts.size(); ++i)
+                presences.push_back(constant_variable(1_i));
+
+            if (optional_form)
+                p.post(Cumulative{starts, lengths_v, heights_v, presences, constant_variable(capacity)});
+            else
+                p.post(Cumulative{starts, lengths_v, heights_v, constant_variable(capacity)});
+
+            set<vector<int>> results;
+            solve_for_tests(p, make_optional(proof_name), results, tuple{starts});
+            auto opb = read_opb_constraints(proof_name);
+            bool named_right = opb_names_constraint_type(proof_name, optional_form ? "cumulative_optional" : "cumulative");
+            dispose_of_proof_files(proof_name);
+            if (! named_right) {
+                println(cerr, "constant-presence encoding check: the {} form's OPB does not name its constraint type",
+                    optional_form ? "optional" : "plain");
+                return nullopt;
+            }
+            return opb;
+        };
+
+        // Solution-set equivalence too, over a random corpus: the OPB check
+        // above says the two models are the same pseudo-Boolean formula, and
+        // this says the two constraints propagate to the same solutions, which
+        // is the property a user of the new constructor actually relies on.
+        mt19937 rand(*get_seed());
+        for (int k = 0; k < 15; ++k) {
+            uniform_int_distribution<> n_dist(2, 3), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), ht_dist(0, 2), cap_dist(0, 3);
+            auto n = static_cast<size_t>(n_dist(rand));
+            vector<TaskSpec> tasks;
+            for (size_t i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand);
+                tasks.push_back(TaskSpec{{lo, min(lo + span_dist(rand), 3)}, len_dist(rand), ht_dist(rand), {1, 1}});
+            }
+            auto capacity = cap_dist(rand);
+
+            set<vector<int>> with_presences, without;
+            {
+                Problem p;
+                auto all_vars = post_optional_cumulative(p, tasks, capacity, cumulative_presence_mutation::None{});
+                solve_for_tests(p, nullopt, with_presences, tuple{all_vars});
+            }
+            {
+                Problem p;
+                vector<IntegerVariableID> starts, lengths_v, heights_v;
+                for (const auto & t : tasks)
+                    starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+                for (const auto & t : tasks) {
+                    lengths_v.push_back(constant_variable(Integer{t.length}));
+                    heights_v.push_back(constant_variable(Integer{t.height}));
+                }
+                p.post(Cumulative{starts, lengths_v, heights_v, constant_variable(Integer{capacity})});
+                solve_for_tests(p, nullopt, without, tuple{starts});
+            }
+            if (with_presences != without) {
+                println(cerr, "constant-presence equivalence {}: optional form has {} solutions, plain form has {}", k, with_presences.size(),
+                    without.size());
+                return false;
+            }
+        }
+
+        auto plain = build(false, "cumulative_optional_encoding_plain");
+        auto optional_form = build(true, "cumulative_optional_encoding_opt");
+        if (! plain || ! optional_form) {
+            println(cerr, "constant-presence encoding check: could not read an OPB back");
+            return false;
+        }
+        if (*plain != *optional_form) {
+            println(cerr, "constant-presence encoding check: the optional form's OPB differs from the plain form's");
+            for (size_t i = 0; i < max(plain->size(), optional_form->size()); ++i) {
+                auto a = i < plain->size() ? (*plain)[i] : "<end>";
+                auto b = i < optional_form->size() ? (*optional_form)[i] : "<end>";
+                if (a != b)
+                    println(cerr, "  line {}: plain {:?} vs optional {:?}", i + 1, a, b);
+            }
+            return false;
+        }
+        return true;
+    }
+}
+
+namespace
+{
+    // Semantic drift detector. Model the same instance two ways --- presence
+    // Booleans, and heights channelled to {0, h} --- and require the same
+    // solution count under the bijection present_i = 1 <-> h_i = h. This pins
+    // "absent consumes nothing" against a formulation that shares none of the
+    // optional-task code path, including at the zero-length and zero-height
+    // edges where "absent" and "present but weightless" look the same.
+    auto check_bijection(const string & tag, const vector<TaskSpec> & tasks, int capacity) -> bool
+    {
+        set<vector<int>> via_presence, via_height;
+
+        {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, heights_v, presences, all_vars;
+            for (const auto & t : tasks)
+                starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+            for (const auto & t : tasks) {
+                lengths_v.push_back(constant_variable(Integer{t.length}));
+                heights_v.push_back(constant_variable(Integer{t.height}));
+                presences.push_back(p.create_integer_variable(0_i, 1_i));
+            }
+            p.post(Cumulative{starts, lengths_v, heights_v, presences, constant_variable(Integer{capacity})});
+            all_vars = starts;
+            all_vars.insert(all_vars.end(), presences.begin(), presences.end());
+            solve_for_tests(p, nullopt, via_presence, tuple{all_vars});
+        }
+
+        {
+            Problem p;
+            vector<IntegerVariableID> starts, lengths_v, heights_v, presences, all_vars;
+            for (const auto & t : tasks)
+                starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+            for (const auto & t : tasks) {
+                lengths_v.push_back(constant_variable(Integer{t.length}));
+                // h_i in {0, h}, channelled to the presence Boolean. A height of
+                // 0 makes both branches the same variable, which is the honest
+                // encoding of "this task consumes nothing either way".
+                auto h = p.create_integer_variable(0_i, Integer{t.height});
+                auto present = p.create_integer_variable(0_i, 1_i);
+                p.post(LinearEquality{WeightedSum{} + 1_i * h + -Integer{t.height} * present, 0_i});
+                heights_v.push_back(h);
+                presences.push_back(present);
+            }
+            p.post(Cumulative{starts, lengths_v, heights_v, constant_variable(Integer{capacity})});
+            all_vars = starts;
+            all_vars.insert(all_vars.end(), presences.begin(), presences.end());
+            solve_for_tests(p, nullopt, via_height, tuple{all_vars});
+        }
+
+        if (via_presence != via_height) {
+            println(cerr, "bijection {}: presence model has {} solutions, variable-height model has {}", tag, via_presence.size(), via_height.size());
+            for (const auto & sol : via_presence)
+                if (! via_height.contains(sol))
+                    println(cerr, "  only in the presence model: {}", sol);
+            for (const auto & sol : via_height)
+                if (! via_presence.contains(sol))
+                    println(cerr, "  only in the variable-height model: {}", sol);
+            return false;
+        }
+        println(cerr, "bijection {}: {} solutions agree", tag, via_presence.size());
+        return true;
+    }
+}
+
+namespace
+{
+    // The motivating use case: maximise the number of scheduled tasks, with the
+    // optimum proved. This is also the only test that puts a presence variable
+    // in the objective, so it is what exercises presence literals on the
+    // objective's proof path.
+    auto check_objective(const string & tag, const vector<TaskSpec> & tasks, int capacity, int expected_optimum) -> bool
+    {
+        Problem p;
+        vector<IntegerVariableID> starts, lengths_v, heights_v, presences;
+        for (const auto & t : tasks)
+            starts.push_back(p.create_integer_variable(Integer{t.start_range.first}, Integer{t.start_range.second}));
+        for (const auto & t : tasks) {
+            lengths_v.push_back(constant_variable(Integer{t.length}));
+            heights_v.push_back(constant_variable(Integer{t.height}));
+            presences.push_back(p.create_integer_variable(0_i, 1_i));
+        }
+        p.post(Cumulative{starts, lengths_v, heights_v, presences, constant_variable(Integer{capacity})});
+
+        auto scheduled = p.create_integer_variable(0_i, Integer(static_cast<long long>(tasks.size())), "scheduled");
+        WeightedSum count;
+        for (const auto & v : presences)
+            count += 1_i * v;
+        p.post(LinearEquality{count + -1_i * scheduled, 0_i});
+        p.maximise(scheduled);
+
+        auto proof_name = "cumulative_optional_objective_" + tag;
+        optional<int> best;
+        solve_for_tests_with_callbacks(
+            p, make_optional(proof_name),
+            [&](const CurrentState & s) -> bool {
+                best = static_cast<int>(s(scheduled).raw_value);
+                return true;
+            },
+            [](const CurrentState &) -> bool { return true; });
+
+        bool ok = true;
+        if (best != make_optional(expected_optimum)) {
+            println(cerr, "objective {}: optimum is {}, expected {}", tag, best ? std::to_string(*best) : "none", expected_optimum);
+            ok = false;
+        }
+        if (! verify_proof_and_dispose(proof_name)) {
+            println(cerr, "objective {}: proof did not verify", tag);
+            ok = false;
+        }
+        else
+            println(cerr, "objective {}: optimum {} verified", tag, expected_optimum);
+        return ok;
+    }
+}
+
+namespace
+{
+    auto expect_bad_presence_throws(const char * label, pair<int, int> presence_domain) -> bool
+    {
+        Problem p;
+        auto s = p.create_integer_variable(0_i, 3_i, "s");
+        auto present = p.create_integer_variable(Integer{presence_domain.first}, Integer{presence_domain.second}, "present");
+        p.post(Cumulative{vector<IntegerVariableID>{s}, vector<IntegerVariableID>{constant_variable(2_i)},
+            vector<IntegerVariableID>{constant_variable(1_i)}, vector<IntegerVariableID>{present}, constant_variable(1_i)});
+        try {
+            solve(p, [](const CurrentState &) { return true; });
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        println(cerr, "{}: expected InvalidProblemDefinitionException", label);
+        return false;
+    }
+
+    auto expect_mismatched_sizes_throws() -> bool
+    {
+        Problem p;
+        auto s = p.create_integer_variable(0_i, 3_i, "s");
+        try {
+            p.post(Cumulative{vector<IntegerVariableID>{s}, vector<IntegerVariableID>{constant_variable(2_i)},
+                vector<IntegerVariableID>{constant_variable(1_i)}, vector<IntegerVariableID>{}, constant_variable(1_i)});
+        }
+        catch (const InvalidProblemDefinitionException &) {
+            return true;
+        }
+        println(cerr, "mismatched presence array size: expected InvalidProblemDefinitionException");
+        return false;
+    }
+}
+
+namespace
+{
+    // The sharp-margin falsification family. Three blockers with pairwise
+    // coprime heights saturate the horizon to exactly one unit below what the
+    // optional task needs, so every coefficient in the emitted derivation is
+    // load-bearing: drop any one blocker and the task fits. Task 0 is the
+    // optional one under test; the rest are present and start-fixed.
+    //
+    // The horizon is chosen so the chain runs four steps (blocked times 1, 3, 5
+    // and 7, one length apart), which is what gives the omit-a-step mutation
+    // something to omit.
+    [[nodiscard]] auto sharp_margin_tasks(int blocker_length) -> vector<TaskSpec>
+    {
+        return {
+            TaskSpec{{0, 7}, 2, 7, {0, 1}}, // the optional task under test
+            TaskSpec{{0, 0}, blocker_length, 5, {1, 1}},
+            TaskSpec{{0, 0}, blocker_length, 8, {1, 1}},
+            TaskSpec{{0, 0}, blocker_length, 11, {1, 1}},
+        };
+    }
+    constexpr int sharp_margin_capacity = 30; // 5 + 8 + 11 = 24, and 24 + 7 = 31 > 30 by exactly one
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    // Mutation lanes come in through run_test_and_expect_verify_failure.bash,
+    // which prepends its own flags, so the mutation is selected by scanning
+    // argv rather than from the positional mode. The harness runs veripb and
+    // passes only if it rejects what we write here; all this binary has to do
+    // is write the corrupted proof and exit successfully.
+    optional<CumulativePresenceMutation> mutation;
+    vector<TaskSpec> mutation_tasks;
+    string proof_basename = "cumulative_optional_mutation";
+    for (int a = 1; a < argc; ++a) {
+        string arg = argv[a];
+        // The chain argues about a different optional task than the one being
+        // falsified, so the pinned activity is not implied by anything. Needs a
+        // second optional task to point at.
+        if (arg == "--mutate=wrong_task") {
+            mutation = cumulative_presence_mutation::WrongTask{};
+            mutation_tasks = sharp_margin_tasks(9);
+            mutation_tasks.push_back(TaskSpec{{0, 7}, 2, 7, {0, 1}});
+        }
+        // The control: no chain at all. The order atoms the wrapping RUP would
+        // need are created *by* the chain, so a proof without it does not close.
+        // If this lane ever starts verifying, the chain has become decoration
+        // and the other mutations are checking nothing.
+        else if (arg == "--mutate=emit_nothing") {
+            mutation = cumulative_presence_mutation::EmitNothing{};
+            mutation_tasks = sharp_margin_tasks(9);
+        }
+        // Sharp margin: on the twin where exactly one placement still fits,
+        // falsifying anyway is a wrong inference, and the chain runs out of
+        // blocked times before it can pretend otherwise.
+        else if (arg == "--mutate=one_too_far") {
+            mutation = cumulative_presence_mutation::ClaimOneTooFar{};
+            mutation_tasks = sharp_margin_tasks(7);
+        }
+        else if (arg == "--proof-files-basename" && a + 1 < argc)
+            proof_basename = argv[++a];
+    }
+
+    if (mutation) {
+        write_mutated_proof(mutation_tasks, sharp_margin_capacity, *mutation, proof_basename);
+        return EXIT_SUCCESS;
+    }
+
+    string mode = argc >= 2 ? argv[1] : "enumerate";
+    bool ok = true;
+
+    if (mode == "enumerate") {
+        // Rejections first: a presence outside {0, 1} and a mismatched array
+        // are modelling errors, not silently-reinterpreted input.
+        ok &= expect_bad_presence_throws("presence 0..2", {0, 2});
+        ok &= expect_bad_presence_throws("presence -1..1", {-1, 1});
+        ok &= expect_mismatched_sizes_throws();
+        if (! ok)
+            return EXIT_FAILURE;
+
+        ok &= check_constant_presence_encoding_is_unchanged();
+        if (! ok)
+            return EXIT_FAILURE;
+
+        vector<pair<string, pair<vector<TaskSpec>, int>>> data{
+            // Two optional unit-height tasks, capacity 1: they may not overlap,
+            // but either or both may simply be absent, so the all-absent
+            // solution and both singletons are all in.
+            {"pair_cap1", {{{{0, 3}, 2, 1, {0, 1}}, {{0, 3}, 2, 1, {0, 1}}}, 1}},
+            // The same, capacity 2: presence never matters.
+            {"pair_cap2", {{{{0, 3}, 2, 1, {0, 1}}, {{0, 3}, 2, 1, {0, 1}}}, 2}},
+            // One mandatory task and one optional one it can block.
+            {"one_mandatory", {{{{0, 2}, 3, 2, {1, 1}}, {{0, 2}, 2, 2, {0, 1}}}, 3}},
+            // A constantly-absent task: it must drop out entirely, so its start
+            // is free and it consumes nothing even where it would not fit.
+            {"const_absent", {{{{0, 2}, 3, 5, {0, 0}}, {{0, 2}, 3, 1, {1, 1}}}, 1}},
+            // A task whose height is 0: present or absent, it is weightless.
+            {"zero_height", {{{{0, 2}, 2, 0, {0, 1}}, {{0, 2}, 2, 1, {1, 1}}}, 1}},
+            // A task whose length is 0: present or absent, it occupies nothing.
+            {"zero_length", {{{{0, 2}, 0, 3, {0, 1}}, {{0, 2}, 2, 1, {1, 1}}}, 1}},
+            // Every task optional and capacity 0: nothing with a positive height
+            // may be present at all, so the only solution set is the absent one
+            // crossed with every start.
+            {"cap_zero", {{{{0, 2}, 1, 1, {0, 1}}, {{0, 2}, 1, 1, {0, 1}}}, 0}},
+            // A task that cannot fit even alone: its presence is false at the
+            // root, with no search needed.
+            {"never_fits", {{{{0, 2}, 2, 5, {0, 1}}, {{0, 2}, 2, 1, {1, 1}}}, 3}},
+            // Three optional tasks over a tight horizon.
+            {"three_tight", {{{{0, 2}, 2, 1, {0, 1}}, {{0, 2}, 1, 1, {0, 1}}, {{0, 2}, 1, 1, {0, 1}}}, 2}},
+            // Negative starts, so the per-task windows and the flags span t < 0.
+            {"neg_start", {{{{-2, 1}, 2, 1, {0, 1}}, {{-2, 1}, 2, 1, {0, 1}}}, 1}},
+            // A fixed start on an optional task: nothing to push, but its
+            // presence can still be decided.
+            {"fixed_start", {{{{1, 1}, 2, 2, {0, 1}}, {{0, 2}, 2, 2, {1, 1}}}, 3}},
+            // The only instance here that reaches the (TTOC) strengthening
+            // with an undecided task among the outside-the-window ones. Task 0
+            // saturates the horizon without overflowing it, and is excluded
+            // from the energy set by its {0, 1} start, so it contributes only
+            // profile; task 1 has no mandatory part but cannot be placed
+            // anywhere, which the check catches only by adding that profile
+            // from outside the window; task 2 is undecided with a mandatory
+            // part overlapping it. Coverage of the path, not a tripwire: by the
+            // time the pins are emitted the reason context is contradictory, so
+            // pinning the undecided task too would verify anyway.
+            {"ttoc_undecided_outside", {{{{0, 1}, 10, 10, {1, 1}}, {{2, 6}, 4, 1, {1, 1}}, {{2, 2}, 4, 1, {0, 1}}}, 10}},
+            // Mixed constants: one always present, one always absent, one free.
+            {"mixed_consts", {{{{0, 2}, 2, 2, {1, 1}}, {{0, 2}, 2, 2, {0, 0}}, {{0, 2}, 2, 1, {0, 1}}}, 3}},
+        };
+
+        mt19937 rand(*get_seed());
+        // Random instances for breadth, all tasks optional so the presence
+        // cross-product is exercised everywhere. Kept small: enumeration is over
+        // starts times presences, so the space grows fast.
+        for (int k = 0; k < 20; ++k) {
+            uniform_int_distribution<> n_dist(2, 3), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), ht_dist(0, 2), cap_dist(0, 3), pres_dist(0, 3);
+            vector<TaskSpec> tasks;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand);
+                auto p = pres_dist(rand);
+                tasks.push_back(TaskSpec{
+                    {lo, min(lo + span_dist(rand), 3)}, len_dist(rand), ht_dist(rand), p == 0 ? pair{1, 1} : (p == 1 ? pair{0, 0} : pair{0, 1})});
+            }
+            data.emplace_back("random" + std::to_string(k), pair{tasks, cap_dist(rand)});
+        }
+
+        for (bool proofs : {false, true}) {
+            if (proofs && ! can_run_veripb())
+                continue;
+            for (const auto & [tag, instance] : data)
+                run_optional_test(proofs, tag, instance.first, instance.second);
+        }
+    }
+    else if (mode == "falsify") {
+        if (! can_run_veripb()) {
+            println(cerr, "veripb not available, skipping falsification tests");
+            return EXIT_SUCCESS;
+        }
+
+        // Sharp margin: the blockers saturate the whole horizon to one unit
+        // below what the optional task needs, so it can go nowhere, the rule
+        // fires at the root, and its presence is false in every solution.
+        ok &= run_falsification_test("sharp", sharp_margin_tasks(9), sharp_margin_capacity,
+            FalsificationExpectation{.markers = MarkerCount::AtLeastOne, .present_ones = 0, .falsified_task = 0, .falsified_var_position = 4});
+
+        // Twin, one unit the other side of the threshold: capacity 31 leaves
+        // exactly enough room. Nothing is ever blocked, at the root or below it,
+        // so this is the twin that can carry the marker-count-zero assertion,
+        // and all 8 starts stay available with the task present.
+        ok &= run_falsification_test("twin_capacity", sharp_margin_tasks(9), sharp_margin_capacity + 1,
+            FalsificationExpectation{.markers = MarkerCount::Never, .present_ones = 8, .falsified_task = 0, .falsified_var_position = 4});
+
+        // Twin, the other way: the blockers stop two time points earlier, so the
+        // tail of the horizon has room for exactly one placement --- start 7.
+        // That one surviving solution is what says the rule did not fire at the
+        // root. It legitimately *does* fire below the root, once branching has
+        // ruled that start out, so the marker count here is a function of the
+        // search seed and is not asserted on.
+        ok &= run_falsification_test("twin_window", sharp_margin_tasks(7), sharp_margin_capacity,
+            FalsificationExpectation{.markers = MarkerCount::Unconstrained, .present_ones = 1, .falsified_task = 0, .falsified_var_position = 4});
+
+        // A second optional task, so the wrong-task mutation has somewhere
+        // wrong to point. Both are falsified.
+        auto two_optional = sharp_margin_tasks(9);
+        two_optional.push_back(TaskSpec{{0, 7}, 2, 7, {0, 1}});
+        ok &= run_falsification_test("two_optional", two_optional, sharp_margin_capacity,
+            FalsificationExpectation{.markers = MarkerCount::AtLeastOne, .present_ones = 0, .falsified_task = 0, .falsified_var_position = 5});
+
+        if (! ok)
+            return EXIT_FAILURE;
+    }
+    else if (mode == "bijection") {
+        ok &= check_bijection("pair_cap1", {{{0, 3}, 2, 1, {0, 1}}, {{0, 3}, 2, 1, {0, 1}}}, 1);
+        ok &= check_bijection("three", {{{0, 2}, 2, 2, {0, 1}}, {{0, 2}, 1, 1, {0, 1}}, {{0, 2}, 2, 1, {0, 1}}}, 2);
+        ok &= check_bijection("zero_edges", {{{0, 2}, 0, 2, {0, 1}}, {{0, 2}, 2, 0, {0, 1}}, {{0, 2}, 2, 2, {0, 1}}}, 2);
+        ok &= check_bijection("cap_zero", {{{0, 2}, 1, 1, {0, 1}}, {{0, 2}, 1, 1, {0, 1}}}, 0);
+        ok &= check_bijection("neg_start", {{{-2, 1}, 2, 1, {0, 1}}, {{-2, 1}, 2, 2, {0, 1}}}, 2);
+        if (! ok)
+            return EXIT_FAILURE;
+    }
+    else if (mode == "objective") {
+        if (! can_run_veripb()) {
+            println(cerr, "veripb not available, skipping objective tests");
+            return EXIT_SUCCESS;
+        }
+        // Three unit-height tasks of length 2 over t in 0..3, capacity 1: at
+        // most two fit end to end, so the optimum is 2.
+        ok &= check_objective("pack_two", {{{0, 2}, 2, 1, {0, 1}}, {{0, 2}, 2, 1, {0, 1}}, {{0, 2}, 2, 1, {0, 1}}}, 1, 2);
+        // One task cannot fit at all, so the optimum is one short of the count.
+        ok &= check_objective("one_too_big", {{{0, 2}, 2, 5, {0, 1}}, {{0, 2}, 2, 1, {0, 1}}, {{0, 2}, 2, 1, {0, 1}}}, 2, 2);
+        if (! ok)
+            return EXIT_FAILURE;
+    }
+    else {
+        println(cerr, "unknown mode {}", mode);
+        return EXIT_FAILURE;
+    }
+
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -7,6 +7,7 @@
 #include <gcs/innards/state.hh>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -40,6 +41,11 @@ auto gcs::innards::install_derived_cumulative(
     inputs->starts = spec.starts;
     inputs->capacity = constant_variable(spec.capacity);
     inputs->rules = spec.rules;
+    // Every task unconditionally present: a derived Cumulative over an optional
+    // donor would have to carry the donor's presence literals into its own
+    // reasons, which is future work rather than something to get wrong quietly.
+    // See DerivedCumulativeSpec, which says the donor must not be optional.
+    inputs->presence.assign(n, std::nullopt);
     for (size_t i = 0; i < n; ++i) {
         inputs->lengths.push_back(constant_variable(spec.lengths[i]));
         inputs->heights.push_back(constant_variable(spec.heights[i]));

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -38,7 +38,12 @@ namespace gcs::innards
     struct DerivedCumulativeSpec
     {
         /// The Cumulative whose flags and capacity rows this is derived from.
-        /// Its arguments come from the donor's own accessors.
+        /// Its arguments come from the donor's own accessors. The donor must
+        /// not be an optional-task Cumulative: its active flags would carry a
+        /// presence conjunct, and a derived constraint reasoning over them
+        /// would need the donor's presence literals in every reason it gives.
+        /// A caller building one of these from a donor should decline when the
+        /// donor's presences() is non-empty.
         ConstraintID donor;
 
         /// The donor's starts, in the donor's order: the flag keys are by task

--- a/gcs/constraints/cumulative/propagate.hh
+++ b/gcs/constraints/cumulative/propagate.hh
@@ -44,6 +44,13 @@ namespace gcs::innards
         std::vector<IntegerVariableID> starts, lengths, heights;
         IntegerVariableID capacity = constant_variable(0_i);
 
+        /// Sized to the task count. nullopt for a task that is unconditionally
+        /// present; otherwise the {0, 1} variable saying whether it is
+        /// scheduled at all. A derived Cumulative fills this with nullopts:
+        /// deriving over an optional donor would need the presence literals in
+        /// its own reasons, which is future work (see DerivedCumulativeSpec).
+        std::vector<std::optional<IntegerVariableID>> presence;
+
         /// The tasks that can raise the load profile at all: those whose length
         /// and height can both be non-zero.
         std::vector<std::size_t> active_tasks;
@@ -71,6 +78,7 @@ namespace gcs::innards
 
         CumulativeRules rules;
         CumulativeProofMutation proof_mutation;
+        CumulativePresenceMutation presence_mutation;
 
         /// Overload checking, resolved once (see
         /// Cumulative::prepare_overload_check). Empty when the rule is off or

--- a/minizinc/CMakeLists.txt
+++ b/minizinc/CMakeLists.txt
@@ -55,6 +55,19 @@ set_tests_properties(minizinc-cumulative-mode PROPERTIES SKIP_RETURN_CODE 66)
 add_test(NAME minizinc-cumulative-var COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativevartest true true)
 set_tests_properties(minizinc-cumulative-var PROPERTIES SKIP_RETURN_CODE 66)
 
+# Optional tasks. --fzn-pattern is the reachability guard: MiniZinc's cumulative
+# wrapper is free to rewrite the constraint into a decomposition, and if it did,
+# these tests would agree with the default solver and verify their proofs
+# without glasgow_cumulative_opt ever running.
+add_test(NAME minizinc-cumulative-opt COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_cumulative_opt --reference-solver chuffed $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativeopttest true true)
+set_tests_properties(minizinc-cumulative-opt PROPERTIES SKIP_RETURN_CODE 66)
+
+add_test(NAME minizinc-cumulative-opt-obj COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_cumulative_opt --reference-solver chuffed $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulativeoptobjtest false true)
+set_tests_properties(minizinc-cumulative-opt-obj PROPERTIES SKIP_RETURN_CODE 66)
+
+add_test(NAME minizinc-disjunctive-opt COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_minizinc_test.bash --fzn-pattern glasgow_cumulative_opt --reference-solver chuffed $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ disjunctiveopttest true true)
+set_tests_properties(minizinc-disjunctive-opt PROPERTIES SKIP_RETURN_CODE 66)
+
 # The difference-logic presolver is invisible to solution equivalence and to
 # proof verification alike, so this one also asserts on its counters: four
 # lifted edges over four nodes, and the two constraints that are not
@@ -198,6 +211,12 @@ set_tests_properties(minizinc-sets PROPERTIES SKIP_RETURN_CODE 66)
 # Empty-set set_in / set_in_reif: MiniZinc folds `x in {}` to false before it
 # reaches the solver, so these feed hand-written JSON FlatZinc to fzn-glasgow
 # directly to exercise the empty-set frontend guards.
+# Pins the glasgow_cumulative_opt signature against the solver directly, so a
+# MiniZinc version that re-routes around the builtin cannot take this coverage
+# with it. The expected solutions are the hand-countable set: 9 with both tasks
+# absent, 9 with each alone, and the 2 non-overlapping placements with both.
+add_test(NAME minizinc-cumulativeopt-fzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ cumulative_opt)
+
 add_test(NAME minizinc-emptysetin COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in)
 add_test(NAME minizinc-emptysetinreif COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/minizinc/run_fzn_json_test.bash $<TARGET_FILE:fzn-glasgow> ${CMAKE_SOURCE_DIR}/minizinc/ empty_set_in_reif)
 

--- a/minizinc/fzn_glasgow.cc
+++ b/minizinc/fzn_glasgow.cc
@@ -760,6 +760,17 @@ auto main(int argc, char * argv[]) -> int
                 const auto & capacity = arg_as_var(data, args, 3);
                 problem.post(Cumulative{starts, lengths, heights, capacity});
             }
+            else if (id == "glasgow_cumulative_opt") {
+                // Optional tasks: the presence Booleans arrive as an array of
+                // var bool, which the FlatZinc reader already presents as 0/1
+                // integer variables --- exactly what Cumulative wants.
+                const auto & starts = arg_as_array_of_var(data, args, 0);
+                const auto & lengths = arg_as_array_of_var(data, args, 1);
+                const auto & heights = arg_as_array_of_var(data, args, 2);
+                const auto & presences = arg_as_array_of_var(data, args, 3);
+                const auto & capacity = arg_as_var(data, args, 4);
+                problem.post(Cumulative{starts, lengths, heights, presences, capacity});
+            }
             else if (id == "glasgow_disjunctive" || id == "glasgow_disjunctive_strict") {
                 const auto & starts = arg_as_array_of_var(data, args, 0);
                 const auto & lengths = arg_as_array_of_var(data, args, 1);

--- a/minizinc/mznlib/fzn_cumulative_opt.mzn
+++ b/minizinc/mznlib/fzn_cumulative_opt.mzn
@@ -1,0 +1,14 @@
+predicate glasgow_cumulative_opt(array[int] of var int: s,
+    array[int] of var int: d, array[int] of var int: r,
+    array[int] of var bool: o, var int: b);
+
+% An optional start is a presence Boolean and an underlying integer, which
+% occurs/deopt split apart. deopt is undefined on a value fixed absent, so
+% guard it the way the Gecode and OR-Tools libraries do: a definitely-absent
+% task gets any start at all, since nothing constrains it.
+predicate fzn_cumulative_opt(array[int] of var opt int: s,
+    array[int] of var int: d, array[int] of var int: r,
+    var int: b) =
+    glasgow_cumulative_opt(
+        [ if is_fixed(si) /\ absent(fix(si)) then 0 else deopt(si) endif | si in s ],
+        d, r, [ occurs(si) | si in s ], b);

--- a/minizinc/mznlib/fzn_disjunctive_opt.mzn
+++ b/minizinc/mznlib/fzn_disjunctive_opt.mzn
@@ -1,0 +1,17 @@
+include "fzn_cumulative_opt.mzn";
+
+% Optional-task disjunctive is optional-task cumulative with unit demands and
+% capacity 1: at most one present task can occupy any time point. Zero-duration
+% tasks are never active under either reading, which is exactly the non-strict
+% semantics this predicate carries (disjunctive_opt routes to
+% disjunctive_strict_opt whenever every duration is known positive, so the
+% zero-duration case is the one that reaches here).
+%
+% There is deliberately no fzn_disjunctive_strict_opt redefinition: strict
+% disjunctive additionally forbids a zero-duration task from sitting inside
+% another task, and a task that consumes no resource for no time is invisible to
+% Cumulative. That one keeps the library decomposition.
+predicate fzn_disjunctive_opt(array[int] of var opt int: s,
+    array[int] of var int: d) =
+    forall(i in index_set(d)) (d[i] >= 0)
+    /\ fzn_cumulative_opt(s, d, [1 | i in index_set(d)], 1);

--- a/minizinc/run_minizinc_test.bash
+++ b/minizinc/run_minizinc_test.bash
@@ -17,10 +17,38 @@
 # verifying whether it fired or not, so only its own counters can tell the
 # difference.
 #
-# Usage: run_minizinc_test.bash <fzn-glasgow> <minizincdir> <testname> <enumeration> <doproofs>
+# A leading `--fzn-pattern REGEX` (repeatable) is an extended regex that must
+# match the *flattened* model handed to the solver. That is the guard against a
+# test passing vacuously against a library decomposition: MiniZinc's global
+# wrappers are free to rewrite a constraint into something else entirely before
+# any redefinition is consulted, and when they do, the solutions still agree and
+# the proof still verifies --- the builtin under test simply never ran.
+#
+# A leading `--reference-solver NAME` (repeatable) adds another solver to
+# differential-test against, on top of MiniZinc's default. Use it where a second
+# independent implementation is worth having: Gecode (the default) propagates
+# optional tasks natively, while Chuffed falls back to the library
+# decomposition, so agreeing with both pins the semantics against a propagator
+# and against MiniZinc's own reference reading. A named solver that is not
+# installed is reported and skipped rather than failing the test, in the same
+# spirit as the veripb check below.
+#
+# Usage: run_minizinc_test.bash [--fzn-pattern <regex>]... [--reference-solver <name>]...
+#                               <fzn-glasgow> <minizincdir>
+#                               <testname> <enumeration> <doproofs>
 #                              [<solverflags> [<requiredpattern>...]]
 
 set -euo pipefail
+
+fzn_patterns=()
+reference_solvers=()
+while [[ ${1:-} == --fzn-pattern || ${1:-} == --reference-solver ]] ; do
+    case $1 in
+        --fzn-pattern) fzn_patterns+=("$2") ;;
+        --reference-solver) reference_solvers+=("$2") ;;
+    esac
+    shift 2
+done
 
 # shellcheck source-path=SCRIPTDIR
 # shellcheck source=../proof_file_disposal.bash
@@ -56,6 +84,13 @@ minizinc --solver "$solver_msc" --fzn "$testname.fzn" -a \
     ${solverflags[@]+"${solverflags[@]}"} "$minizincdir/tests/$testname.mzn" | tee "$testname.glasgow.out" || exit 1
 minizinc -a "$minizincdir/tests/$testname.mzn" | tee "$testname.default.out" || exit 2
 
+for pattern in ${fzn_patterns[@]+"${fzn_patterns[@]}"} ; do
+    if ! grep -Eq -- "$pattern" "$testname.fzn" ; then
+        echo "expected flattened model matching '$pattern'; the model was rewritten before it reached the solver"
+        exit 10
+    fi
+done
+
 for pattern in ${required_patterns[@]+"${required_patterns[@]}"} ; do
     if ! grep -Eq -- "$pattern" "$testname.glasgow.out" ; then
         echo "expected output matching '$pattern', which the Glasgow run did not produce"
@@ -84,6 +119,26 @@ else
         exit 6
     fi
 fi
+
+for reference in ${reference_solvers[@]+"${reference_solvers[@]}"} ; do
+    # `--solver NAME --version` reports the *driver's* version and succeeds
+    # whatever NAME is, so ask the solver list instead. The tags in parentheses
+    # on each line are what --solver matches against.
+    if ! minizinc --solvers 2>/dev/null | grep -Fq "$reference" ; then
+        echo "reference solver $reference is not installed, skipping that comparison"
+        continue
+    fi
+    minizinc --solver "$reference" -a "$minizincdir/tests/$testname.mzn" | tee "$testname.$reference.out" || exit 11
+    if [[ "$enumeration" == "true" ]] ; then
+        grep '^ENUMSOL:' < "$testname.$reference.out" | sort > "$testname.$reference.sols" || true
+    else
+        grep '^OPTSOL:' < "$testname.$reference.out" | tail -n1 > "$testname.$reference.sols" || true
+    fi
+    if ! diff -u "$testname.glasgow.sols" "$testname.$reference.sols" ; then
+        echo "found different solutions from reference solver $reference"
+        exit 12
+    fi
+done
 
 if [[ "$doproofs" == "true" ]] && veripb --help >/dev/null ; then
     minizinc --solver "$solver_msc" -a ${solverflags[@]+"${solverflags[@]}"} "$minizincdir/tests/$testname.mzn" \

--- a/minizinc/tests/cumulativeoptobjtest.mzn
+++ b/minizinc/tests/cumulativeoptobjtest.mzn
@@ -1,0 +1,22 @@
+include "globals.mzn";
+
+% The motivating use for optional tasks: schedule as many as possible. Four
+% tasks of length 2 and unit demand share a capacity-1 resource over t in 0..5,
+% so at most three fit end to end and the fourth must be dropped.
+%
+% One constraint per model file, per the test conventions: independent
+% constraints in one model multiply the search space for no extra coverage.
+array[1..4] of int: lengths = [2, 2, 2, 2];
+array[1..4] of int: heights = [1, 1, 1, 1];
+int: capacity = 1;
+
+array[1..4] of var opt 0..4: s;
+
+constraint cumulative(s, lengths, heights, capacity);
+
+var 0..4: scheduled;
+constraint scheduled = sum(i in 1..4) (bool2int(occurs(s[i])));
+
+solve maximize scheduled;
+
+output ["OPTSOL: " ++ show(scheduled)];

--- a/minizinc/tests/cumulativeopttest.mzn
+++ b/minizinc/tests/cumulativeopttest.mzn
@@ -1,0 +1,20 @@
+include "globals.mzn";
+
+% Three optional tasks on a single resource of capacity 2. Heights are chosen so
+% that pairs CAN coexist: otherwise MiniZinc's cumulative wrapper short-circuits
+% into a disjunctive on the starts and never calls fzn_cumulative_opt (the
+% ctest registration also greps the flattened model for the builtin, so a
+% rewrite is caught rather than passing vacuously).
+%
+% Task 3 demands the whole resource for longer than the horizon allows once
+% either other task is scheduled, so the interesting solutions are the ones
+% where it is absent.
+array[1..3] of int: lengths = [2, 2, 3];
+array[1..3] of int: heights = [1, 1, 2];
+int: capacity = 2;
+
+array[1..3] of var opt 0..3: s;
+
+constraint cumulative(s, lengths, heights, capacity);
+
+output ["ENUMSOL: " ++ show(s)];

--- a/minizinc/tests/disjunctiveopttest.mzn
+++ b/minizinc/tests/disjunctiveopttest.mzn
@@ -1,0 +1,15 @@
+include "globals.mzn";
+
+% Optional-task disjunctive, routed through glasgow_cumulative_opt with unit
+% demands and capacity 1. A zero-duration task is in the array on purpose: it is
+% what stops disjunctive_opt short-circuiting into disjunctive_strict_opt (which
+% it does whenever every duration is known positive), so this is the path the
+% redefinition actually covers --- and the non-strict semantics, under which a
+% zero-duration task may sit anywhere, including inside another task.
+array[1..3] of int: durations = [2, 2, 0];
+
+array[1..3] of var opt 0..3: s;
+
+constraint disjunctive(s, durations);
+
+output ["ENUMSOL: " ++ show(s)];

--- a/minizinc/tests/json/cumulative_opt.expected
+++ b/minizinc/tests/json/cumulative_opt.expected
@@ -1,0 +1,146 @@
+s1 = 0;
+s2 = 0;
+o1 = false;
+o2 = false;
+----------
+s1 = 0;
+s2 = 1;
+o1 = false;
+o2 = false;
+----------
+s1 = 0;
+s2 = 2;
+o1 = false;
+o2 = false;
+----------
+s1 = 1;
+s2 = 0;
+o1 = false;
+o2 = false;
+----------
+s1 = 1;
+s2 = 1;
+o1 = false;
+o2 = false;
+----------
+s1 = 1;
+s2 = 2;
+o1 = false;
+o2 = false;
+----------
+s1 = 2;
+s2 = 0;
+o1 = false;
+o2 = false;
+----------
+s1 = 2;
+s2 = 1;
+o1 = false;
+o2 = false;
+----------
+s1 = 2;
+s2 = 2;
+o1 = false;
+o2 = false;
+----------
+s1 = 0;
+s2 = 0;
+o1 = false;
+o2 = true;
+----------
+s1 = 0;
+s2 = 1;
+o1 = false;
+o2 = true;
+----------
+s1 = 0;
+s2 = 2;
+o1 = false;
+o2 = true;
+----------
+s1 = 1;
+s2 = 0;
+o1 = false;
+o2 = true;
+----------
+s1 = 1;
+s2 = 1;
+o1 = false;
+o2 = true;
+----------
+s1 = 1;
+s2 = 2;
+o1 = false;
+o2 = true;
+----------
+s1 = 2;
+s2 = 0;
+o1 = false;
+o2 = true;
+----------
+s1 = 2;
+s2 = 1;
+o1 = false;
+o2 = true;
+----------
+s1 = 2;
+s2 = 2;
+o1 = false;
+o2 = true;
+----------
+s1 = 0;
+s2 = 0;
+o1 = true;
+o2 = false;
+----------
+s1 = 0;
+s2 = 1;
+o1 = true;
+o2 = false;
+----------
+s1 = 0;
+s2 = 2;
+o1 = true;
+o2 = false;
+----------
+s1 = 1;
+s2 = 0;
+o1 = true;
+o2 = false;
+----------
+s1 = 1;
+s2 = 1;
+o1 = true;
+o2 = false;
+----------
+s1 = 1;
+s2 = 2;
+o1 = true;
+o2 = false;
+----------
+s1 = 2;
+s2 = 0;
+o1 = true;
+o2 = false;
+----------
+s1 = 2;
+s2 = 1;
+o1 = true;
+o2 = false;
+----------
+s1 = 2;
+s2 = 2;
+o1 = true;
+o2 = false;
+----------
+s1 = 0;
+s2 = 2;
+o1 = true;
+o2 = true;
+----------
+s1 = 2;
+s2 = 0;
+o1 = true;
+o2 = true;
+----------
+==========

--- a/minizinc/tests/json/cumulative_opt.fzn
+++ b/minizinc/tests/json/cumulative_opt.fzn
@@ -1,0 +1,20 @@
+{
+    "variables": {
+        "s1": { "type": "int", "domain": [[0, 2]] },
+        "s2": { "type": "int", "domain": [[0, 2]] },
+        "o1": { "type": "bool" },
+        "o2": { "type": "bool" }
+    },
+    "arrays": {
+        "starts": { "a": ["s1", "s2"] },
+        "durations": { "a": [2, 2] },
+        "demands": { "a": [1, 1] },
+        "presences": { "a": ["o1", "o2"] }
+    },
+    "constraints": [
+        { "id": "glasgow_cumulative_opt", "args": ["starts", "durations", "demands", "presences", 1] }
+    ],
+    "output": ["s1", "s2", "o1", "o2"],
+    "solve": { "method": "satisfy" },
+    "version": "1.0"
+}

--- a/xcsp/xcsp_glasgow_constraint_solver.cc
+++ b/xcsp/xcsp_glasgow_constraint_solver.cc
@@ -618,6 +618,13 @@ namespace
             return result;
         }
 
+        // XCSP3 has no optional-task cumulative, so Cumulative's presence-taking
+        // constructor has no callback to hang off here. Every
+        // buildConstraintCumulative overload the parser declares
+        // (XCSP3CoreCallbacks.h) is origins/lengths/heights, optionally with
+        // ends, plus a condition --- there is no presence, occurrence or
+        // absence argument anywhere in the format. Recorded so nobody goes
+        // looking twice; if XCSP3 ever grows an optional form, wire it then.
         auto buildConstraintCumulative(string, vector<XVariable *> & origins, vector<int> & lengths, vector<int> & heights, XCondition & cond)
             -> void override
         {


### PR DESCRIPTION
Closes #543. Part of the Cumulative proof-logging plan, #541 — issue 02, the
last of the plan's independent issues.

**Restacked onto #657**, so the four merge in sequence: #655 → #656 → #657 →
#660. It was off `main` before; the conflict against the stack was mostly #657's
re-indentation of the propagator body (17 hunks, ~1045 lines, of which
`-X ignore-all-space` showed only ~156 were real), but there was one genuinely
semantic interaction, below.

Optional tasks: each task gets a `{0, 1}` presence variable, and an absent task
consumes no resource. The presences are ordinary problem variables, so a model
can constrain and optimise over them — maximising the number of scheduled tasks
is the motivating use, and is one of the tests.

## The survey, first

The issue asked for one before committing to a design; it confirms the design in
the issue body, with one correction.

| | how optional tasks are modelled |
|---|---|
| MiniZinc stdlib | `fzn_cumulative_opt(array of var opt int: s, d, r, b)`; the time decomposition is `occurs(s[i]) /\ s[i] <= t < s[i] + d[i]` — a presence Boolean conjoined into the activity indicator, exactly the encoding below |
| Gecode | `gecode_schedule_cumulative_optional(starts, durations, usages, m, capacity)` — presences a separate `array of var bool`, and it *requires* fixed durations/usages/capacity, else falls back to the decomposition |
| OR-Tools CP-SAT | `ortools_cumulative_opt(o, s, d, r, b)` — same split, presence array first |
| Chuffed | no `fzn_cumulative_opt` override at all; uses the library decomposition |
| XCSP3 | **no such constraint.** All eight `buildConstraintCumulative` overloads in the in-tree parser are origins/lengths/heights\[/ends\] plus a condition, and the word "optional" does not appear in `XCSP3CoreCallbacks.h` at all |

Both solver libraries split an optional start the same way — `occurs(s[i])` for
the presence and `deopt(s[i])` for the integer, with a guard because `deopt` is
undefined on a value fixed absent — so the FlatZinc wiring here follows them
verbatim.

The correction: the issue suggested `presences` as the *fourth* builtin
argument. That is what is implemented (`glasgow_cumulative_opt(s, d, r, o, b)`),
which matches Gecode's ordering rather than OR-Tools'; noting it because the
signature is now pinned by a FlatZinc-level test.

## The encoding — the one sanctioned OPB change in #541

```
active_{i,t}  ⇔  before_{i,t} ∧ after_{i,t} ∧ (presences[i] = 1)
```

`C_t` keeps its shape. A `{0, 1}` variable is direct-only encoded as a single PB
literal, so the three-way AND costs one term in the same two reification halves
— no extra flag, and nothing else in the encoding has to know a task is
optional.

The non-optional constructors are byte-identical to before: a task with no
presence keeps the two-way AND, a presence that is the *constant* 1 degenerates
to it structurally, and a constant 0 drops the task. Only constants resolve away
— a variable that happens to be fixed when `prepare()` runs keeps its conjunct,
because the OPB has to stand on its own and it is the OPB, not the initial
State, that a checker reads.

`constraint_type()` is `cumulative_optional` for the optional form. cake_pb_cp
has no encoder for it, and naming it apart is what stops the verified-encoding
chain silently matching it against the plain `cumulative` encoder, which would
re-derive a strictly weaker set of capacity rows.

## The one semantic interaction with #655

#541 flagged this and #655 left an explicit seam for it: *"once a task can be
absent, only one whose presence is fixed true may join the energy set or the
profile, and its presence literal joins the reason."* This PR takes that seam.

The overload check counts each contained task's `length × height` as
**guaranteed** energy, which an optional task's is not until its presence is
fixed to 1. Counting an undecided task's energy manufactures a conflict that is
not there — and it is easy to hit: two optional unit-height tasks over one
capacity-1 window have enough combined energy to "overload" it, when in truth
both may simply be absent. So `propagate_cumulative` filters the candidate list
by the same `is_present` as the profile, and filters the (TTOC) strengthening's
pinned outside-the-window tasks too — those have to be exactly the tasks
`mand_load` counted, or the `pol` claims load the arithmetic never used and the
pin is not derivable anyway.

Both get their presence literals for free: `reason_with_presence()` carries
every known-present task's literal, and the energy set is a subset of the
profile's tasks. The eligibility resolved once in
`prepare_cumulative_overload_check` is unchanged — it cannot know a runtime
presence, so the filtering belongs at the point of use.

A **derived** Cumulative (#657) declines the question rather than getting it
subtly wrong: it fills its `presence` with nullopts, and `DerivedCumulativeSpec`
now documents that the donor must not be optional. Deriving over an optional
donor would need the donor's presence literals in every reason the derived
constraint gives. #543 already specifies that the #547–#548 presolvers bail out
on optional Cumulatives for v1, so nothing is blocked by this.

## Propagation and the new inference

Presence fixed true is exactly today's behaviour; fixed false excludes the task;
undecided contributes nothing to the profile and its own start bounds are never
pruned (there is no conditional-bounds store, so a prune valid only if the task
is present would be unsound). What an undecided task does get is the mirror
image: when no start position left in its domain fits under the profile, its
presence is inferred to be 0.

The proof is the lb-push chain run over the whole domain with `present_j = 0`
carried as an extra disjunct on every line, so each step reads "either `j`
starts later than this, or `j` is not here at all". The last step drops the
start-side disjunct: its blocked time is at or beyond `ub(s_j)` — that is what
makes it the last — so `before` follows from the task's own upper bound in the
reason, and the proof never asks for an order literal above the domain, which
need not exist.

Presence enters a reason as an explicit `presences[i] = 1` literal per task
known present, not by putting the variable in the `generic_reason` scope: an
undecided presence has no fact to record, and `generic_reason` would otherwise
contribute the pair of trivial bounds `0 ≤ p ≤ 1`, which says nothing and costs
an order atom on a variable whose whole encoding is one literal.

One deviation from the issue's sketch: it asked for `pin_contributor` to
additionally RUP `present_i ≥ 1` when pinning `active_{i,t}`. That turns out to
be unnecessary — the presence literal is already a unit in the reason context,
so the `active` RUP closes against the three-way AND's `[f]` half without it,
and `pin_contributor` is unchanged. The `EmitNothing` control is what says this
is not simply going unchecked.

## What the mutation testing found

Worth reading, because it changes what a mutation knob can be for a
conflict-shaped rule, and #541 has more of those coming (issues 06–09).

The plan asked for three mutations: falsify the wrong task, omit a blocked-time
step, end the chain one time point early. **The last two verify.** That is not a
bug in them and not slack in the honest derivation — it is a property of the
rule. Once the chain has narrowed the start domain far enough, the reason
context extended with "the task is present" is *contradictory*, so every
subsequent RUP under it is vacuously valid. A shortened chain is a shorter but
still sound derivation, and VeriPB is right to accept it. Same trap as #656's
contradictory micro-model, one level in: there the whole OPB was unsatisfiable,
here it is the reason context.

So the mutations that survive are the ones producing a statement that is not
implied, and the shipped set is:

- `WrongTask` — carry a different optional task's presence literal through the
  chain, so the pinned activity is about a task nothing has cornered. Rejected
  at the first pin.
- `ClaimOneTooFar` — fire on the twin where exactly one placement still fits.
  This corrupts the *conclusion* rather than the route to it, which is what a
  margin of exactly one unit is there to expose, and is this rule's "bound + 1
  must fail". Rejected.
- `EmitNothing` — the control. Emit no chain and leave it to the framework's
  wrapping RUP. Rejected, because the order atoms that RUP would need are
  created *by* the chain — so the chain is load-bearing, not decoration, and the
  two mutations above are checking something real.

The general lesson, written up in `dev_docs/cumulative-proof-logging.md`: for a
rule whose content is "this assignment is impossible", corrupting the route is
not a test, because the destination makes every route valid. Corrupt the
destination.

One more finding worth flagging: the first version of the negative-twin
assertion required a marker count of zero on the widened-window instance. That
is wrong, and seed-flaky — the rule legitimately fires *below* the root there,
once branching has ruled out the one surviving placement, and the harness
branches with a seed-derived random heuristic. The marker-count-zero assertion
now sits on the capacity twin, where nothing is blocked at any node; the
window twin asserts the surviving `present = 1` solution instead, which is the
real content of "it did not fire at the root".

## Validation

`cumulative_optional_test`, four modes plus three mutation lanes, each with its
own proof basenames:

- `enumerate` — presence domains rejected outside `{0, 1}`, mismatched array
  sizes rejected; the constant-presence OPB diff and a 15-instance random
  solution-set equivalence against the plain form; then 12 fixed plus 20 random
  instances enumerated against brute force over (starts × presences) with proofs
  — all-optional, all-absent, constantly-absent, zero-length, zero-height,
  capacity 0, never-fits, fixed starts, negative starts, mixed constants.
- `falsify` — the sharp-margin family: three blockers with pairwise coprime
  heights (5, 8, 11) saturating the horizon to exactly one unit below what the
  optional task (height 7, capacity 30) needs, so every blocker is load-bearing.
  Marker counts, both twins, and the brute-force presence counts.
- three mutation lanes under `run_test_and_expect_verify_failure.bash` — the
  same harness and the same shape as #655's overload mutations, now that it
  exists in the same stack (this was in-process before the restack).
- `bijection` — five instances posted both ways (presence Booleans, and heights
  channelled to `{0, h}`) with equal solution sets under the bijection,
  including the zero-length and zero-height edges where "absent" and "present
  but weightless" look the same.
- `objective` — maximise Σ present, optimum verified by VeriPB.

Frontends:

- `minizinc-cumulative-opt`, `-opt-obj`, `minizinc-disjunctive-opt` — differential
  against Gecode (MiniZinc's default) *and* Chuffed, with proofs.
- `minizinc-cumulativeopt-fzn` — pins the builtin signature against the solver
  directly, expected solutions hand-countable (9 both-absent + 9 + 9 singletons
  + 2 non-overlapping = 29).

Two additions to `run_minizinc_test.bash`, both leading optional flags, both
used by the tests above:

- `--fzn-pattern REGEX` — requires the regex to match the *flattened* model.
  This is the reachability guard the issue asked for, and it is not theoretical:
  MiniZinc's `cumulative` wrapper short-circuits into a disjunctive when no two
  tasks can coexist, and a rewritten model still agrees with the reference
  solver and still verifies its proof. Nothing else the harness checks can tell
  you the builtin never ran. Verified to bite by pointing it at a pattern that
  is not there.
- `--reference-solver NAME` — an extra differential solver. Gecode propagates
  optional tasks natively while Chuffed falls back to the library
  decomposition, so agreeing with both pins the semantics against a propagator
  and against MiniZinc's own reference reading. A solver that is not installed
  is reported and skipped, like the `veripb` check; the CI MiniZinc bundle
  ships Chuffed, so it runs there.

`fzn_disjunctive_opt` rides the same builtin at unit demands and capacity 1.
`fzn_disjunctive_strict_opt` deliberately does not: strict disjunctive forbids a
zero-duration task from sitting inside another, and a task consuming nothing for
no time is invisible to a resource profile. That one keeps the library
decomposition.

XCSP3 gets a comment in the frontend recording that the format has no
optional-task cumulative, so nobody goes looking twice; its existing cumulative
tests are untouched.

## Checked

Full `ctest` green **on the restacked branch**, GCC release with
`-DGCS_TEST_CAP_DEFAULTS=OFF` so the enumeration checks are complete rather than
capped. The pre-restack version was additionally checked under clang 21 Debug
and the Sanitize preset across several seeds; the restack changed the
propagator's surroundings, not its logic, so CI's Sanitize and clang lanes are
the check on that.

## Not in this PR

- Conditional bound pruning of undecided tasks ("if present, `j` cannot start
  before `b`"), which needs a conditional-bounds store. The propagation being
  left on the table is real, and noted as a follow-up in the dev doc.
- Falsifying a presence by an *energy* argument rather than by the profile —
  that is #550, and it is why the overload check here only declines to count
  absent tasks rather than reasoning about them.
- A derived Cumulative over an optional donor.
- A cake_pb_cp encoder for the optional form, so it is outside the
  verified-encoding chain for now.
- Falsifying a presence *by* an energy argument — that is #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p

