### PR TITLE
Presolver: strengthen a Cumulative's capacity by integrality (#547, part one)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -141,6 +141,15 @@ library. For an introduction to *using* the solver, start with the top-level
   the same strength, the clause resolution that stands in for the case split
   unit propagation cannot do, and why a satisfiable test model and an `ia`
   content check are both needed to test it.
+- [Strengthening a `Cumulative` by integrality](cumulative-strengthening.md) —
+  Schulz's pre-solving capacity rules as the `CumulativeStrengthening` presolver,
+  posting the strengthened constraint in derived mode. Covers why the largest
+  reachable load is the real capacity, why the rules are *time-table neutral* and
+  how that turns into a node-for-node soundness tripwire, the `ia` step that
+  pins every row to the declared capacity (and is the only thing that catches a
+  sound derivation of the wrong line), the deviations from the paper's statement
+  of the rules, and why the deep-gap fixture everyone quotes cannot be a
+  `Cumulative` instance.
 - [Restarts, nogoods, and dom/wdeg weighting](restarts-nogoods-weighting.md) —
   the search-side machinery from issue #315: the restart loop and its
   `SearchResult` unwind signal, `RestartSchedule`, the `ConflictObserver`

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -554,6 +554,10 @@ the capacity times its width, and that is not a multiple of three. Seven
 unit-length tasks of height three need 21 units in `[0, 3)`, which eight
 supplies and six does not.
 
+The real presolver built on that recipe is `CumulativeStrengthening` — see
+[cumulative-strengthening.md](cumulative-strengthening.md), which turns the
+invisibility above into an automated soundness tripwire rather than a caveat.
+
 ### Multi-donor, for later
 
 Issues #548 and #549 infer a Cumulative over tasks drawn from *several* donors,

--- a/dev_docs/cumulative-strengthening.md
+++ b/dev_docs/cumulative-strengthening.md
@@ -1,0 +1,216 @@
+# Strengthening a `Cumulative` by integrality
+
+A capacity is worth more than it says. The load on the resource at any one time
+is a sum of the heights of the tasks running then, so it can only ever take a
+value that is a *subset sum* of those heights — and a capacity that is not
+itself such a value has room in it that nothing can use.
+
+`CumulativeStrengthening`
+([`gcs/presolvers/cumulative_strengthening.hh`](../gcs/presolvers/cumulative_strengthening.hh))
+is the presolver that takes that room away. For each posted `Cumulative` it
+computes
+
+```
+    kappa = max over t of  ( largest subset sum of { h_i : task i can run at t }
+                             that is at most C )
+```
+
+and, when `kappa < C`, posts a
+[derived `Cumulative`](cumulative-proof-logging.md#derived-cumulatives-an-implied-constraint-that-adds-nothing-to-the-model)
+over the same tasks with the same heights and a capacity of `kappa`. The donor
+stays posted and the OPB is untouched: each per-time capacity row of the derived
+constraint is *proved* from the donor's row for that time point, by
+[subset-sum strengthening](subset-sum-strengthening.md).
+
+The rules are Schulz's pre-solving strengthenings, recapped by Cloutier and
+Quimper (CP 2026, §2.3).
+
+## Why `kappa` is the right number, and why the max is the max
+
+At a time point `t` the load is a subset sum of `{h_i : i can run at t}`. Any
+feasible assignment keeps it at most `C`, so it is at most `kappa_t`, the largest
+such subset sum that does not exceed `C`. Since `kappa_t ≤ kappa` for every `t`,
+the single capacity `kappa` holds everywhere, which is what lets one derived
+constraint — with one capacity — carry the whole strengthening.
+
+Taking the *maximum* over time points is the weakest of the per-time bounds, and
+that is not a concession: a derived `Cumulative` has one capacity, and the
+strongest single number that is valid at every time point is exactly the largest
+of them.
+
+## Time-table neutrality is a tripwire, not a caveat
+
+The strengthening cannot change a time-table verdict. A profile value is a sum of
+heights, so it exceeds `kappa` exactly when it exceeds `C`:
+
+- if a load exceeds `C` it exceeds `kappa`, since `kappa < C`;
+- if a load is at most `C`, it is a subset sum at most `C` of that time point's
+  heights, so it is at most `kappa_t ≤ kappa`.
+
+The paper says the same thing in one line — "time tabling is unaffected since any
+propagation detected after the pre-solving is detectable beforehand". The useful
+consequence is a *test*: with the energy rules off on both the donor and the
+derived constraint, the search tree with the presolver must be
+**node-for-node identical** to the one without it. Any difference means the
+strengthening changed what the profile permits, which is the shape an unsound one
+takes, and `cumulative_strengthening_presolver` asserts it on two fixtures before
+VeriPB gets a say.
+
+The same theorem, used the other way round, is why the derived constraints ship
+with **time-tabling off**: every time-table inference a derived constraint could
+draw is one the donor draws already, at every node, so running it is pure cost.
+`with_rules` turns it back on, and the neutrality test has to, because with it off
+the comparison would pass without `kappa` having been used for anything. (This is
+the issue's "measure propagation redundancy" question, answered by proof rather
+than by measurement. Retiring the *donor's* propagators is the other half of it,
+and remains a separate follow-up: the donor's rows are the semantic anchor and
+its time-tabling is the only thing drawing those inferences at all.)
+
+So do not expect this presolver to make anything faster on its own. The benefit
+arrives with energy reasoning, where a window's supply is the capacity times its
+width, and *that* is not a sum of heights. The `pack` fixture is the
+demonstration: seven unit-length tasks of height three, all able to run in
+`[0, 3)`, against a capacity of eight. The strengthening takes the capacity to
+six, which changes no profile verdict at all, but the window then supplies
+`6 × 3 = 18` against the `21` units the tasks need, and the overload check
+refutes at the root. At a capacity of eight it supplies `24`, and the solver
+searches.
+
+## What reaches the proof
+
+Schulz states two capacity rules, and they arrive in the proof as the two
+derivations `derive_subset_sum_strengthening` chooses between:
+
+| rule | when it applies | derivation |
+|---|---|---|
+| gcd rounding | the heights share a factor `d` and `d·⌊C/d⌋` is the largest reachable load | two `pol` steps of Chvátal–Gomory rounding |
+| knapsack capacity reduction | otherwise | the layered dynamic programme |
+
+The presolver does not choose between them — the utility picks whichever reaches
+the true largest subset sum, which is always at least as strong as rounding, and
+reports which it took in `SubsetSumStrengthening::by_division`. What the
+presolver does is *predict* the choice, using the same test, so that it can
+budget: the dynamic programme costs three flags per state and a state per
+reachable partial sum per item, per time point, and a donor whose derivation
+would exceed `with_dynamic_programming_budget` is passed over entirely rather
+than producing a great deal of proof for a strengthening worth one unit. The
+rounding path is two `pol` steps and is not budgeted. `CumulativeStrengtheningStats`
+counts rows both ways, and the budget fixture asserts the prediction agrees with
+the choice — if it did not, the budget would decline the wrong donors.
+
+### Every row lands on the declared capacity
+
+A time point whose own `kappa_t` is below `kappa` yields a *stronger* row than
+the derived constraint declared. The recipe does not hand that back. It closes
+with an `ia` step against `Σ h_i·active_{i,t} ≤ kappa`, which is an implication
+check and therefore syntactic.
+
+Two things come of insisting on that. The rows are uniform, so the propagator's
+`pol`s cancel against a known degree rather than against whatever each time point
+happened to prove. And — the reason it is worth a line per time point — it is the
+only thing in the proof that notices a derivation landing somewhere other than
+where it claimed. A divisor that does not divide every height still divides
+*soundly*; VeriPB accepts every step of that derivation and the resulting line is
+true, it is simply not the line the derived constraint was told it had. The
+`BogusDivisor` mutation is exactly that, and the `ia` step is what rejects it
+("expected constraint is not syntactically implied by the constraint at the
+hint"). Nothing else in the proof objects. This is
+[the third net](subset-sum-strengthening.md#testing-it) the subset-sum utility's
+own tests describe, applied at the point of use.
+
+## Two deviations from the paper's rules
+
+Both leave strengthening on the table; neither costs soundness or solutions.
+
+**The per-time knapsack set is not restricted to `c_j < C`.** The paper's `kappa`
+excludes tasks that fill the resource by themselves, which gives a smaller number
+— a task with `c_j = C` reaches `C` on its own, so including it makes `kappa = C`
+and the rule does nothing. Excluding it is only sound if those tasks' own heights
+come down to `kappa` as well, which the paper's statement duly does ("all
+consumption `c_i` such that `c_i = C`, as well as `C`, can be reduced to
+`kappa`"). That changes the derived constraint's *coefficients*, and the
+derivation for it needs at-most-one reasoning off the donor's row: if a task with
+`c_j = C` is running, nothing else is, so the row's value is `kappa` either way.
+That is the same machinery the coefficient-raising rule needs, and it is the
+remaining half of issue #547.
+
+**Coefficient raising is not implemented.** The paper's first rule — any `c_i`
+above `C − min_j c_j` can be raised to `C`, because such a task can never run
+beside another — changes heights for the same reason and needs the same
+at-most-one derivation.
+
+A note for whoever writes that half. The paper's condition takes the minimum over
+*all* `j ∈ I`, task `i` included, which is sound but blunter than it needs to be:
+what the argument actually requires is that `i` cannot run beside any *other*
+task that consumes anything, i.e. `c_i + min{c_j : j ≠ i, c_j > 0} > C`. Issue
+#547 states it that way, and that is the version to implement — with `c_i > 0`
+guarded explicitly, since a zero-height task can always run beside anything and
+the empty-minimum case would otherwise raise it to `C`.
+
+## Fixtures, and one that cannot be one
+
+The sharpness fixtures are checked as arithmetic against
+`largest_subset_sum_at_most` *before* any proof is involved, because a fixture
+that has drifted makes every claim built on it a claim about something else.
+
+- **gcd path**: heights `{2, 4, 6}`, `C = 13` → `kappa = 12`, by division.
+- **dynamic programming path**: heights `{6, 10, 4}`, `C = 13` → `kappa = 10`.
+
+That second one is worth dwelling on, because the obvious reading gets it wrong.
+Those heights have a gcd of two, so the gcd rule offers `2·⌊13/2⌋ = 12` — but the
+largest load they can actually reach at or below thirteen is `4 + 6 = 10`, so the
+answer is ten and only the dynamic programme gets there. Rounding by the gcd is
+the whole answer only when the gcd's multiples are all reachable, which
+`{2, 4, 6}` manages and `{6, 10, 4}` does not.
+
+The deep gap this rule is usually illustrated with — heights `{6, 10, 15}` against
+`C = 14`, overall gcd one, answer ten — is a subset-sum fixture and **cannot be a
+`Cumulative` fixture**: a task of height fifteen under a capacity of fourteen can
+never run at all, so the constraint is infeasible before any strengthening is
+considered. The presolver declines a donor with a height above the capacity for
+that reason, and the test keeps the arithmetic assertion without pretending it is
+an instance.
+
+## Restrictions
+
+Each is declined rather than worked around, and counted in
+`CumulativeStrengtheningStats` so that a model drifting into one does not simply
+stop being strengthened in silence:
+
+- **Optional tasks.** A derived `Cumulative` over an optional donor would need
+  the donor's presence literals in every reason it gives; `DerivedCumulativeSpec`
+  says the donor's `presences()` must be empty. This is the v1 bail-out issues
+  #547–#549 are all specified to take.
+- **Variable lengths, heights or capacity.** With a variable height the donor's
+  row is over bit-linearised contribution flags rather than `height × active`, so
+  a subset sum of the heights is not a subset sum of the row's coefficients.
+- **A height above the capacity**, as above.
+- **The dynamic-programming budget.**
+
+## Testing it
+
+`cumulative_strengthening_presolver` is built out of the observation that almost
+every check a presolver normally faces is passed just as well by a presolver that
+declined every donor. It writes nothing to the OPB, removes no solution, and —
+being time-table neutral — does not even change the search tree unless energy
+reasoning is on. So:
+
+1. **The stats block is a tripwire, not decoration.** Every fixture asserts the
+   presolver fired, on how many donors, by how many units of capacity, and down
+   which of the two derivations. `CumulativeStrengtheningStats::rows_by_division`
+   against `rows_by_dynamic_programming` is what stops a fixture drifting onto
+   the other path without failing anything.
+2. **Neutrality**, asserted as node-for-node equality under time-tabling alone.
+3. **The energy differential**, where the strengthening is the only thing that
+   refutes the `pack` fixture at the root.
+4. **Solution preservation** over a random corpus against brute force, with an
+   assertion that the presolver fired on some of it.
+5. **Negative controls**: a capacity that is already the largest reachable load
+   is passed over, the OPB matches a run with no presolver byte for byte, and no
+   marker comment appears in the proof at all.
+6. **Mutations**, both of which corrupt the *conclusion* rather than the route to
+   it, which is what a rule whose content is a numeric bound needs: `ClaimOneBetter`
+   claims one below the largest reachable load, and `BogusDivisor` rounds by a
+   divisor that does not divide every height. VeriPB rejects each.
+
+<!-- vim: set tw=72 spell spelllang=en : -->

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(glasgow_constraint_solver
         innards/state.cc
         innards/variable_id_utils.cc
         presolvers/auto_table/auto_table.cc
+        presolvers/cumulative_strengthening/cumulative_strengthening.cc
         presolvers/difference_logic/difference_logic.cc
 )
 
@@ -194,6 +195,11 @@ if(GCS_BUILD_TESTS)
     endforeach()
     add_test(NAME difference_logic_presolver_proofs
         COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_logic_presolver_test> proofs)
+
+    add_executable(cumulative_strengthening_presolver_test presolvers/cumulative_strengthening/cumulative_strengthening_test.cc)
+    target_link_libraries(cumulative_strengthening_presolver_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME cumulative_strengthening_presolver
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:cumulative_strengthening_presolver_test>)
 
     add_executable(constraint_enumeration_test constraint_enumeration_test.cc)
     target_link_libraries(constraint_enumeration_test PRIVATE glasgow_constraint_solver Catch2::Catch2WithMain)

--- a/gcs/presolvers/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening.hh
@@ -1,0 +1,6 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_CUMULATIVE_STRENGTHENING_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_CUMULATIVE_STRENGTHENING_HH
+
+#include <gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh>
+
+#endif

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -1,0 +1,343 @@
+#include <gcs/constraint_id.hh>
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/subset_sum_strengthening.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh>
+#include <gcs/problem.hh>
+#include <util/overloaded.hh>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_unique;
+using std::map;
+using std::max;
+using std::move;
+using std::optional;
+using std::shared_ptr;
+using std::size_t;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+namespace
+{
+    /// The donor's arguments, once every one of them has been confirmed
+    /// constant. A variable length, height or capacity is a v1 restriction:
+    /// with a variable height the donor's row is over bit-linearised
+    /// contribution flags rather than `height * active`, so a subset sum of the
+    /// heights is not what the row's coefficients are.
+    struct ConstantTaskData
+    {
+        vector<Integer> lengths, heights;
+        Integer capacity;
+    };
+
+    [[nodiscard]] auto constant_task_data(const Cumulative & donor) -> optional<ConstantTaskData>
+    {
+        ConstantTaskData data{{}, {}, 0_i};
+
+        auto value_of = [](const IntegerVariableID & v) -> optional<Integer> {
+            if (! is_constant_variable(v))
+                return std::nullopt;
+            return std::get<ConstantIntegerVariableID>(v).const_value;
+        };
+
+        auto capacity = value_of(donor.capacity());
+        if (! capacity)
+            return std::nullopt;
+        data.capacity = *capacity;
+
+        for (const auto & l : donor.lengths()) {
+            auto length = value_of(l);
+            if (! length)
+                return std::nullopt;
+            data.lengths.push_back(*length);
+        }
+
+        for (const auto & h : donor.heights()) {
+            auto height = value_of(h);
+            if (! height)
+                return std::nullopt;
+            data.heights.push_back(*height);
+        }
+
+        return data;
+    }
+
+    /// What the presolver worked out for one time point: the heights of the
+    /// tasks that can be running then, and the largest load they can actually
+    /// reach without exceeding the capacity.
+    struct TimePoint
+    {
+        Integer t;
+        vector<size_t> tasks;
+        vector<Integer> heights;
+        Integer kappa;
+        /// Whether derive_subset_sum_strengthening() will take its two-step
+        /// divisibility path here, predicted by the same test it applies. Only
+        /// the other path costs anything worth budgeting for.
+        bool by_division;
+    };
+}
+
+CumulativeStrengthening::CumulativeStrengthening(shared_ptr<CumulativeStrengtheningStats> stats) :
+    _stats(move(stats)), _max_dynamic_programming_states(20000),
+    // Energy rules only: see with_rules(). A derived constraint's time-tabling
+    // cannot infer anything its donor's has not, so running it is pure cost.
+    _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(cumulative_strengthening_mutation::None{})
+{
+}
+
+auto CumulativeStrengthening::with_dynamic_programming_budget(long long states) -> CumulativeStrengthening &
+{
+    _max_dynamic_programming_states = states;
+    return *this;
+}
+
+auto CumulativeStrengthening::with_rules(CumulativeRules rules) -> CumulativeStrengthening &
+{
+    _rules = rules;
+    return *this;
+}
+
+auto CumulativeStrengthening::with_proof_mutation(CumulativeStrengtheningMutation mutation) -> CumulativeStrengthening &
+{
+    _mutation = mutation;
+    return *this;
+}
+
+auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool
+{
+    auto bump = [&](size_t CumulativeStrengtheningStats::* field) {
+        if (_stats)
+            ++((*_stats).*field);
+    };
+
+    for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
+        bump(&CumulativeStrengtheningStats::donors_seen);
+
+        // A derived Cumulative over an optional donor would need the donor's
+        // presence literals in every reason it gives, which DerivedCumulativeSpec
+        // says it does not have. Loudly, because a model that turned optional
+        // would otherwise just quietly stop being strengthened.
+        if (! donor.presences().empty()) {
+            bump(&CumulativeStrengtheningStats::declined_optional);
+            if (logger)
+                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", optional tasks");
+            continue;
+        }
+
+        auto data = constant_task_data(donor);
+        if (! data) {
+            bump(&CumulativeStrengtheningStats::declined_variable_arguments);
+            if (logger)
+                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", non-constant arguments");
+            continue;
+        }
+
+        const auto & starts = donor.starts();
+        auto n = starts.size();
+        auto capacity = data->capacity;
+
+        // The same windowing install_derived_cumulative resolves, and the same
+        // windowing the donor encoded: a task can be active from its earliest
+        // start to its latest finish. This is the paper's `t in [est_j, lct_j)`.
+        vector<Integer> t_lo(n, 0_i), t_hi(n, 0_i);
+        vector<size_t> active_tasks;
+        for (size_t i = 0; i < n; ++i) {
+            if (data->lengths[i] <= 0_i || data->heights[i] <= 0_i)
+                continue;
+            active_tasks.push_back(i);
+            auto [s_lo, s_hi] = state.bounds(starts[i]);
+            t_lo[i] = s_lo;
+            t_hi[i] = s_hi + data->lengths[i] - 1_i;
+        }
+
+        if (active_tasks.empty()) {
+            bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
+            continue;
+        }
+
+        // A height above the capacity means the donor is infeasible on its own,
+        // which is the donor's business to detect and not something to build a
+        // subset sum over.
+        if (std::any_of(active_tasks.begin(), active_tasks.end(), [&](size_t i) { return data->heights[i] > capacity; })) {
+            bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
+            continue;
+        }
+
+        auto global_lo = t_lo[active_tasks.front()], global_hi = t_hi[active_tasks.front()];
+        for (auto i : active_tasks) {
+            global_lo = std::min(global_lo, t_lo[i]);
+            global_hi = max(global_hi, t_hi[i]);
+        }
+
+        vector<TimePoint> time_points;
+        auto kappa = 0_i;
+        for (Integer t = global_lo; t <= global_hi; ++t) {
+            TimePoint point{t, {}, {}, 0_i, false};
+            for (auto i : active_tasks)
+                if (t >= t_lo[i] && t <= t_hi[i]) {
+                    point.tasks.push_back(i);
+                    point.heights.push_back(data->heights[i]);
+                }
+
+            // No task can be active here, so the donor wrote no row and there is
+            // nothing to derive from.
+            if (point.tasks.empty())
+                continue;
+
+            point.kappa = largest_subset_sum_at_most(point.heights, capacity);
+
+            auto divisor = 0_i;
+            for (const auto & h : point.heights)
+                divisor = Integer{std::gcd(divisor.raw_value, h.raw_value)};
+            point.by_division = (divisor > 1_i && divisor * (capacity / divisor) == point.kappa);
+
+            kappa = max(kappa, point.kappa);
+            time_points.push_back(move(point));
+        }
+
+        // kappa is the largest load reachable at any one time point, so it is
+        // what the capacity really is. If that is the capacity already, the
+        // donor was posted with a number the heights can reach and there is
+        // nothing here.
+        if (kappa >= capacity) {
+            bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
+            continue;
+        }
+
+        // Budget the expensive derivation. The dynamic program has a state per
+        // reachable partial sum per item, so `items * capacity` bounds it; the
+        // divisibility path is two `pol` steps and needs no budgeting. Only
+        // relevant with proofs on, since with them off no derivation happens.
+        if (logger) {
+            long long states = 0;
+            for (const auto & point : time_points)
+                if (! point.by_division)
+                    states += static_cast<long long>(point.heights.size()) * (capacity.raw_value + 1);
+
+            if (states > _max_dynamic_programming_states) {
+                bump(&CumulativeStrengtheningStats::declined_over_budget);
+                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", derivation would need " +
+                    to_string(states) + " dynamic programming states against a budget of " + to_string(_max_dynamic_programming_states));
+                continue;
+            }
+        }
+
+        // The recipe needs to find, for each time point, the same tasks and the
+        // same flags that the donor's row for that time point is over --- so
+        // that the subset sum it strengthens is a subset sum of exactly that
+        // row's coefficients. By value: the recipe is called before this
+        // iteration ends today, but a capture that only works because of that
+        // is one refactor away from being a use-after-free nobody sees.
+        map<Integer, TimePoint> by_time;
+        for (auto & point : time_points)
+            by_time.emplace(point.t, move(point));
+
+        auto donor_id = donor.constraint_id();
+        auto heights = data->heights;
+        auto stats = _stats;
+
+        // Fixed for the whole donor, so worked out once rather than per row.
+        SubsetSumMutation subset_sum_corruption = std::visit(
+            overloaded{//
+                [](const cumulative_strengthening_mutation::None &) -> SubsetSumMutation { return subset_sum_mutation::None{}; },
+                [](const cumulative_strengthening_mutation::ClaimOneBetter &) -> SubsetSumMutation { return subset_sum_mutation::ClaimOneBetter{}; },
+                [](const cumulative_strengthening_mutation::BogusDivisor &) -> SubsetSumMutation { return subset_sum_mutation::BogusDivisor{}; }},
+            _mutation);
+
+        DerivedCumulativeSpec spec{.donor = donor_id,
+            .starts = starts,
+            .lengths = data->lengths,
+            .heights = heights,
+            .capacity = kappa,
+            .recipe = [donor_id, heights, capacity, kappa, by_time, stats, subset_sum_corruption](
+                          ProofLogger & recipe_logger, ProofLine donor_row, Integer t) -> ProofLine {
+                auto point = by_time.find(t);
+                if (point == by_time.end())
+                    throw ProofError{"cumulative strengthening: no time point worked out for " + to_string(t.raw_value)};
+
+                vector<SubsetSumItem> items;
+                for (auto i : point->second.tasks) {
+                    auto active = recipe_logger.names_and_ids_tracker().find_proof_flag_values(
+                        donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+                    if (! active)
+                        throw ProofError{"cumulative strengthening: the donor has no active flag for task " + to_string(i) + " at time " +
+                            to_string(t.raw_value) + ", which install_derived_cumulative should already have declined over"};
+                    items.push_back(SubsetSumItem{heights[i], *active});
+                }
+
+                recipe_logger.emit_proof_comment(point->second.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");
+
+                auto strengthened =
+                    derive_subset_sum_strengthening(recipe_logger, items, donor_row, capacity, ProofLevel::Top, subset_sum_corruption);
+
+                if (stats) {
+                    if (strengthened.by_division)
+                        ++stats->rows_by_division;
+                    else
+                        ++stats->rows_by_dynamic_programming;
+                }
+
+                // Land every row on the capacity the derived constraint was
+                // declared with, whatever this time point's own largest load
+                // was. Two things come of insisting on that rather than handing
+                // back a row that merely happens to be no weaker. The rows are
+                // then uniform, so the propagator's `pol`s cancel against a
+                // known degree; and the step is an implication check, which is
+                // syntactic, so it is the one thing that notices a derivation
+                // landing somewhere other than where it claimed --- a divisor
+                // that does not divide every height still divides *soundly*,
+                // and nothing else in the proof would object.
+                WPBSum load;
+                for (const auto & item : items)
+                    load += item.coefficient * std::get<ProofFlag>(item.term);
+                return recipe_logger.emit(ImpliesProofRule{strengthened.line}, move(load) <= kappa, ProofLevel::Top);
+            },
+            .rules = _rules};
+
+        // After the install rather than before it: a decline writes nothing at
+        // all, and a proof saying a constraint was strengthened when it was not
+        // is worse than one saying nothing.
+        if (! install_derived_cumulative(propagators, state, logger, move(spec))) {
+            bump(&CumulativeStrengtheningStats::declined_by_install);
+            continue;
+        }
+
+        if (logger)
+            logger->emit_proof_comment("presolve cumulative: strengthened " + as_string(donor_id) + " from capacity " +
+                to_string(capacity.raw_value) + " to " + to_string(kappa.raw_value));
+
+        bump(&CumulativeStrengtheningStats::donors_strengthened);
+        if (_stats)
+            _stats->capacity_units_removed += capacity - kappa;
+    }
+
+    return true;
+}
+
+auto CumulativeStrengthening::clone() const -> unique_ptr<Presolver>
+{
+    auto result = make_unique<CumulativeStrengthening>(_stats);
+    result->with_dynamic_programming_budget(_max_dynamic_programming_states);
+    result->with_rules(_rules);
+    result->with_proof_mutation(_mutation);
+    return result;
+}

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -1,0 +1,215 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_CUMULATIVE_STRENGTHENING_CUMULATIVE_STRENGTHENING_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_CUMULATIVE_STRENGTHENING_CUMULATIVE_STRENGTHENING_HH
+
+#include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/integer.hh>
+#include <gcs/presolver.hh>
+
+#include <cstddef>
+#include <memory>
+#include <variant>
+
+namespace gcs
+{
+    /**
+     * \brief What the Cumulative strengthening presolver did, filled in when it
+     * runs.
+     *
+     * The presolver is invisible from the outside by construction: it writes
+     * nothing to the OPB, removes no solution, and --- because the rules it
+     * applies are time-table neutral --- does not even change the search tree
+     * unless energy reasoning is switched on. So every check that a presolver
+     * normally has to pass is passed just as well by a presolver that did
+     * nothing at all, and the counts below are how a test tells the two apart.
+     * \sa CumulativeStrengthening
+     *
+     * \ingroup Presolvers
+     */
+    struct CumulativeStrengtheningStats
+    {
+        /// Posted Cumulatives the presolver looked at.
+        std::size_t donors_seen = 0;
+
+        /// Donors it posted a strengthened, derived Cumulative for: the number
+        /// that matters.
+        std::size_t donors_strengthened = 0;
+
+        /// Summed `capacity - kappa` over those donors. Distinguishes "fired on
+        /// three constraints" from "fired on three constraints and took a unit
+        /// off each", which are different claims about the fixture.
+        Integer capacity_units_removed = 0_i;
+
+        /**
+         * \name Why a donor was passed over.
+         *
+         * Broken out because they mean different things to a caller: the first
+         * two are the v1 restrictions, the third is a proof-size budget that a
+         * caller may want to raise, and the last is the honest and common
+         * answer that the capacity was already the largest reachable load.
+         */
+        ///@{
+        std::size_t declined_optional = 0;
+        std::size_t declined_variable_arguments = 0;
+        std::size_t declined_over_budget = 0;
+        std::size_t declined_nothing_to_gain = 0;
+        /// Declined by install_derived_cumulative itself, which is a bug rather
+        /// than a restriction: the presolver derives its rows over the donor's
+        /// own windows, so the flags it asks for should always be there.
+        std::size_t declined_by_install = 0;
+        ///@}
+
+        /**
+         * \name Which derivation each per-time capacity row took.
+         *
+         * Zero when proofs are off, since there are no rows to derive. The
+         * split is the difference between Schulz's gcd rule and his knapsack
+         * rule as they reach the proof --- see CumulativeStrengthening --- and
+         * a fixture that means to exercise one of them has to assert which it
+         * got, because the arithmetic picks whichever is stronger and a fixture
+         * can drift onto the other path without failing anything else.
+         */
+        ///@{
+        std::size_t rows_by_division = 0;
+        std::size_t rows_by_dynamic_programming = 0;
+        ///@}
+    };
+
+    /**
+     * \brief Deliberate corruptions of the strengthening derivation, for
+     * testing only. VeriPB must reject each of them.
+     *
+     * \ingroup Presolvers
+     */
+    namespace cumulative_strengthening_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim a capacity one below the largest load the heights can reach.
+        /// The "bound + 1 must fail" check for this rule: it corrupts the
+        /// conclusion rather than the route to it.
+        struct ClaimOneBetter
+        {
+        };
+
+        /// Take the divisibility fast path with a divisor that does not divide
+        /// every height. Dividing is a sound proof step whatever the divisor,
+        /// so this produces a perfectly valid line that simply is not the one
+        /// the derived constraint was told it had --- which nothing catches
+        /// except the `ia` step pinning each row's content.
+        struct BogusDivisor
+        {
+        };
+    }
+
+    using CumulativeStrengtheningMutation = std::variant<cumulative_strengthening_mutation::None, cumulative_strengthening_mutation::ClaimOneBetter,
+        cumulative_strengthening_mutation::BogusDivisor>;
+
+    /**
+     * \brief Strengthen each posted Cumulative by integrality, posting the
+     * strengthened version as a *derived* constraint whose per-time capacity
+     * rows are proved from the donor's.
+     *
+     * The rules are Schulz's pre-solving strengthenings, as recapped by
+     * Cloutier and Quimper (CP 2026, section 2.3). The load at a time point is a
+     * sum of the heights of the tasks running then, so it can only ever take a
+     * value that is a subset sum of those heights; a capacity that is not itself
+     * such a value is therefore worth more than it says. Reducing it to
+     *
+     *     kappa = max over t of (largest subset sum of the heights of the tasks
+     *                            that can run at t, that is at most the capacity)
+     *
+     * loses no solution. Schulz's two capacity rules are the two ways that
+     * quantity gets computed --- his gcd rule is the case where the heights
+     * share a factor `d`, making the answer `d * floor(C / d)`, and his knapsack
+     * rule is the general one --- and they reach the proof as the two
+     * derivations derive_subset_sum_strengthening() chooses between: two `pol`
+     * steps of Chvatal-Gomory rounding, or a layered dynamic program. Which one
+     * a row took is in CumulativeStrengtheningStats.
+     *
+     * Two deliberate deviations from the paper's statement of the rules, both
+     * documented in `dev_docs/cumulative-strengthening.md`:
+     *
+     * - The knapsack rule's per-time set is taken over *every* task that can run
+     *   at `t`, rather than only those with `c_j < C`. Excluding the tasks that
+     *   fill the resource by themselves gives a smaller kappa, but it is then
+     *   only sound if those tasks' own heights come down to kappa as well ---
+     *   which changes the derived constraint's coefficients, and needs the
+     *   at-most-one reasoning that is issue #547's remaining half.
+     * - The coefficient-raising rule (any `c_i` above `C - min_j c_j` can be
+     *   raised to `C`) is not here at all, for the same reason: it changes
+     *   heights.
+     *
+     * Neither costs soundness or solutions; both leave strengthening on the
+     * table, which is what an unimplemented rule does.
+     *
+     * **Do not expect this to make anything faster on its own.** The rules are
+     * time-table neutral --- a load is a sum of heights, so it clears `C`
+     * exactly when it clears kappa --- which the paper says outright and which
+     * the tests assert as a tripwire, since a search-tree difference under
+     * time-tabling alone would mean the strengthening was unsound. The benefit
+     * arrives with energy reasoning, where a window's supply is the capacity
+     * times its width and that is not a sum of heights.
+     *
+     * \ingroup Presolvers
+     */
+    class CumulativeStrengthening : public Presolver
+    {
+    private:
+        std::shared_ptr<CumulativeStrengtheningStats> _stats;
+        long long _max_dynamic_programming_states;
+        CumulativeRules _rules;
+        CumulativeStrengtheningMutation _mutation;
+
+    public:
+        /**
+         * \brief Construct the presolver, optionally sharing a stats block that
+         * outlives the copy Problem takes.
+         */
+        explicit CumulativeStrengthening(std::shared_ptr<CumulativeStrengtheningStats> stats = nullptr);
+
+        /**
+         * \brief Cap the size of the dynamic-programming derivation, summed over
+         * a donor's time points, in states.
+         *
+         * The layered dynamic program costs three flags per state and a handful
+         * of lines per transition, so a donor with a large capacity and a long
+         * horizon can produce a great deal of proof for a strengthening worth
+         * one unit. A donor whose derivation would exceed this is passed over
+         * entirely and counted in CumulativeStrengtheningStats::declined_over_budget;
+         * the divisibility path is not budgeted, being two `pol` steps a row.
+         *
+         * The default is meant to be left alone. It exists as a knob so that a
+         * test can set it to zero and watch the dynamic-programming path
+         * disappear while the divisibility one keeps working.
+         */
+        auto with_dynamic_programming_budget(long long states) -> CumulativeStrengthening &;
+
+        /**
+         * \brief Select which propagation rules the derived constraints run.
+         *
+         * The default is the energy rules only, because time-tabling a derived
+         * constraint is provably wasted work: neutrality says a load exceeds
+         * kappa exactly when it exceeds the donor's capacity, so every
+         * time-table inference the derived constraint could draw is one the
+         * donor draws already, at every node. That is the same theorem the
+         * tests check, used the other way round.
+         *
+         * Which is why a test asserting the neutrality has to turn time-tabling
+         * back *on* here: with the derived constraint's time-tabling off, the
+         * comparison would pass without kappa having been used for anything.
+         */
+        auto with_rules(CumulativeRules rules) -> CumulativeStrengthening &;
+
+        /// Corrupt one step of the emitted derivation. For tests only, which
+        /// assert that VeriPB rejects the result.
+        auto with_proof_mutation(CumulativeStrengtheningMutation mutation) -> CumulativeStrengthening &;
+
+        [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
+        [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;
+    };
+}
+
+#endif

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -1,0 +1,568 @@
+/* Schulz's capacity strengthenings, as a presolver over posted Cumulatives.
+ *
+ * What is hard to test here is not that the proofs verify --- they do that
+ * whether the presolver fired or not, since a presolver that declines every
+ * donor writes nothing and leaves a perfectly good proof behind. Nor is a
+ * solution-equivalence check enough, for the same reason. Worse, the rules are
+ * *time-table neutral* by design, so even the search tree is unchanged unless
+ * energy reasoning is on. Three separate nets are therefore needed:
+ *
+ *   - the stats block, asserting the presolver fired, on how many donors, by
+ *     how much, and down which of the two derivations;
+ *   - an energy-rule differential, where the strengthening is the only thing
+ *     that refutes at the root;
+ *   - mutations, asserting VeriPB rejects a derivation that claims more than it
+ *     proved.
+ *
+ * And the neutrality itself is a tripwire rather than a caveat: under
+ * time-tabling alone the node counts must be *identical*, because a load is a
+ * sum of heights and so clears the donor's capacity exactly when it clears
+ * kappa. A difference would mean the strengthening had changed what the profile
+ * permits, which is what an unsound one looks like.
+ */
+
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/innards/proofs/subset_sum_strengthening.hh>
+#include <gcs/presolvers/cumulative_strengthening.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <climits>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::ifstream;
+using std::make_optional;
+using std::make_shared;
+using std::max;
+using std::min;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::pair;
+using std::set;
+using std::shared_ptr;
+using std::string;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "cumulative strengthening test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    struct Instance
+    {
+        vector<pair<int, int>> start_ranges;
+        vector<int> lengths;
+        vector<int> heights;
+        int capacity;
+    };
+
+    auto is_satisfying(const Instance & inst, const vector<int> & starts) -> bool
+    {
+        auto n = inst.start_ranges.size();
+        int t_lo = INT_MAX, t_hi = INT_MIN;
+        for (size_t i = 0; i < n; ++i) {
+            if (inst.lengths[i] == 0 || inst.heights[i] == 0)
+                continue;
+            t_lo = min(t_lo, starts[i]);
+            t_hi = max(t_hi, starts[i] + inst.lengths[i] - 1);
+        }
+        for (int t = t_lo; t <= t_hi; ++t) {
+            int load = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (starts[i] <= t && t < starts[i] + inst.lengths[i])
+                    load += inst.heights[i];
+            if (load > inst.capacity)
+                return false;
+        }
+        return true;
+    }
+
+    /// How a solve was set up: whether the presolver ran, with which rules on
+    /// both sides, and with what corruption.
+    struct Setup
+    {
+        bool presolve = true;
+        CumulativeRules rules = CumulativeRules{};
+        /// What the derived constraints run. Left alone, the presolver's own
+        /// default applies --- energy rules only --- which is what every fixture
+        /// but the neutrality one wants, since that default is the thing being
+        /// shipped.
+        optional<CumulativeRules> derived_rules = nullopt;
+        CumulativeStrengtheningMutation mutation = cumulative_strengthening_mutation::None{};
+        long long budget = 20000;
+        shared_ptr<CumulativeStrengtheningStats> stats = nullptr;
+    };
+
+    auto post(Problem & p, const Instance & inst, const Setup & setup) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        for (auto & [lo, hi] : inst.start_ranges)
+            starts.push_back(p.create_integer_variable(Integer{lo}, Integer{hi}));
+
+        vector<Integer> lengths, heights;
+        for (auto l : inst.lengths)
+            lengths.push_back(Integer{l});
+        for (auto h : inst.heights)
+            heights.push_back(Integer{h});
+
+        p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(setup.rules));
+        if (setup.presolve) {
+            auto presolver = CumulativeStrengthening{setup.stats};
+            presolver.with_dynamic_programming_budget(setup.budget).with_proof_mutation(setup.mutation);
+            if (setup.derived_rules)
+                presolver.with_rules(*setup.derived_rules);
+            p.add_presolver(presolver);
+        }
+        return starts;
+    }
+
+    struct Outcome
+    {
+        set<vector<int>> solutions;
+        unsigned long long recursions = 0;
+        bool refuted_at_root = false;
+    };
+
+    auto solve_it(const Instance & inst, const Setup & setup, const optional<string> & proof_name, bool verify = true) -> Outcome
+    {
+        Problem p;
+        auto starts = post(p, inst, setup);
+
+        Outcome outcome;
+        bool reached_a_node = false, found_a_solution = false;
+        auto stats = solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               found_a_solution = true;
+                               vector<int> solution;
+                               for (const auto & v : starts)
+                                   solution.push_back(s(v).raw_value);
+                               outcome.solutions.insert(move(solution));
+                               return true;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return true;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+
+        outcome.recursions = stats.recursions;
+        outcome.refuted_at_root = ! reached_a_node && ! found_a_solution;
+
+        if (proof_name && verify)
+            verify_proof_and_clean_up(*proof_name);
+        return outcome;
+    }
+
+    auto read_file(const string & name) -> string
+    {
+        ifstream in{name, std::ios::binary};
+        if (! in)
+            fail("could not read " + name);
+        return string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+    }
+
+    auto count_occurrences(const string & haystack, const string & needle) -> size_t
+    {
+        size_t count = 0;
+        for (auto at = haystack.find(needle); at != string::npos; at = haystack.find(needle, at + needle.size()))
+            ++count;
+        return count;
+    }
+
+    /// The blanket rule of the whole plan: an inferred constraint is a
+    /// derivation, never a model axiom. A presolver that wrote its inference
+    /// into the OPB would be changing the statement being verified, and every
+    /// proof in this file would verify and mean nothing.
+    auto check_opb_unaffected(const string & what, const Instance & inst) -> void
+    {
+        const string with = "cumulative_strengthening_opb_with", without = "cumulative_strengthening_opb_without";
+
+        auto write_model_only = [&](const string & name, bool presolve) {
+            Problem p;
+            post(p, inst, Setup{.presolve = presolve});
+            solve_with(
+                p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, make_optional<ProofOptions>(ProofFileNames{name}));
+        };
+
+        write_model_only(with, true);
+        write_model_only(without, false);
+
+        if (read_file(with + ".opb") != read_file(without + ".opb"))
+            fail("the presolver changed the OPB, on " + what);
+
+        for (const auto & name : {with, without})
+            dispose_of_proof_files(name);
+    }
+
+    /// Assert the arithmetic against a hand-computed answer before any proof is
+    /// involved. If largest_subset_sum_at_most() and the fixture disagree, the
+    /// fixture has drifted and every claim built on it is about something else.
+    auto check_kappa(const string & what, const vector<int> & heights, int capacity, int expected_kappa, bool expected_by_division) -> void
+    {
+        vector<Integer> hs;
+        for (auto h : heights)
+            hs.push_back(Integer{h});
+
+        auto kappa = largest_subset_sum_at_most(hs, Integer{capacity});
+        if (kappa != Integer{expected_kappa})
+            fail(what + ": kappa is " + std::to_string(kappa.raw_value) + ", not the " + std::to_string(expected_kappa) + " the fixture claims");
+
+        auto divisor = 0_i;
+        for (const auto & h : hs)
+            divisor = Integer{std::gcd(divisor.raw_value, h.raw_value)};
+        auto by_division = (divisor > 1_i && divisor * (Integer{capacity} / divisor) == kappa);
+        if (by_division != expected_by_division)
+            fail(what + ": the derivation takes the " + (by_division ? "divisibility" : "dynamic programming") +
+                " path, not the one the fixture is for");
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+    auto proofs = can_run_veripb();
+
+    // The sharpness fixtures, checked as arithmetic first.
+    //
+    // The divisibility one has to be chosen with care, and the obvious candidate
+    // is not one: heights {6, 10, 4} against a capacity of 13 have a gcd of two,
+    // so Schulz's gcd rule gives 2 * floor(13 / 2) = 12 --- but the largest load
+    // those heights can actually reach at or below 13 is 4 + 6 = 10, so the
+    // strengthening is to ten and it is the dynamic programming that gets there.
+    // Rounding by the gcd is only the whole answer when the gcd's multiples are
+    // all reachable, which {2, 4, 6} manages and {6, 10, 4} does not.
+    check_kappa("gcd fixture", {2, 4, 6}, 13, 12, true);
+    check_kappa("deep gap fixture", {6, 10, 4}, 13, 10, false);
+    check_kappa("nothing to gain fixture", {1, 2, 4}, 7, 7, false);
+
+    // The deep gap this rule is famous for --- heights {6, 10, 15} against a
+    // capacity of 14, where the overall gcd is one so no rounding reaches the
+    // answer of ten --- is a subset-sum fixture and cannot be a Cumulative one:
+    // a task of height fifteen under a capacity of fourteen can never run, so
+    // the constraint is infeasible before any strengthening is considered. The
+    // arithmetic is still worth pinning here, since it is what the instance
+    // below is a viable version of.
+    check_kappa("deep gap, as arithmetic", {6, 10, 15}, 14, 10, false);
+
+    // The value demonstration. Seven unit-length tasks of height three, all
+    // able to run in [0, 3), against a capacity of eight. Every load is a
+    // multiple of three, so the capacity is really six --- and that is invisible
+    // to time-tabling, since a load clears eight exactly when it clears six. It
+    // shows up in the energy argument, where the window [0, 3) supplies capacity
+    // times width: twenty-four at a capacity of eight, which covers the twenty-
+    // one units the tasks need, and eighteen at six, which does not.
+    const Instance pack{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, {1, 1, 1, 1, 1, 1, 1}, {3, 3, 3, 3, 3, 3, 3}, 8};
+
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+
+        auto donor_only = solve_it(pack, Setup{.presolve = false}, nullopt);
+        if (donor_only.refuted_at_root)
+            fail("pack fixture: the donor alone refuted at the root, so the fixture proves nothing");
+
+        auto strengthened = solve_it(pack, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_pack") : nullopt);
+        if (! strengthened.refuted_at_root)
+            fail("pack fixture: the strengthened constraint did not refute at the root");
+        if (! strengthened.solutions.empty())
+            fail("pack fixture: the instance is unsatisfiable but solutions were reported");
+
+        if (stats->donors_strengthened != 1)
+            fail("pack fixture: strengthened " + std::to_string(stats->donors_strengthened) + " donors, not one");
+        if (stats->capacity_units_removed != 2_i)
+            fail("pack fixture: took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off the capacity, not the two 8 to 6 is");
+        if (proofs && stats->rows_by_dynamic_programming != 0)
+            fail("pack fixture: a row took the dynamic programming path, so the fixture is not testing the gcd rule");
+        if (proofs && stats->rows_by_division == 0)
+            fail("pack fixture: no row took the divisibility path");
+        println(cerr, "pack fixture: refuted at the root, {} rows by division", stats->rows_by_division);
+    }
+
+    // Time-table neutrality, the tripwire. With the energy rules off on both the
+    // donor and the derived constraint, the strengthening must be invisible: the
+    // same solutions over exactly the same number of nodes. Anything else means
+    // it changed what the profile permits.
+    //
+    // The derived constraint's rules have to be set explicitly here, and to
+    // time-tabling: the presolver ships with time-tabling *off*, on the strength
+    // of this very theorem, so leaving the default in place would compare a
+    // donor against a donor plus a propagator that does nothing, and kappa would
+    // never be used for anything.
+    const CumulativeRules tt_only{.time_table = true, .overload = false, .profile_overload = false};
+
+    const Instance searchy{{{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {2, 2, 3, 3}, {2, 2, 2, 4}, 7};
+
+    // Heights {6, 10, 4} against a capacity of thirteen: the gcd is two, so
+    // Schulz's gcd rule offers twelve, but 4 + 6 = 10 is the largest load that
+    // can actually be reached, and only the dynamic programming gets there.
+    const Instance deep_gap{{{0, 3}, {0, 3}, {0, 3}}, {2, 2, 2}, {6, 10, 4}, 13};
+
+    for (const auto & [what, inst] : {pair<string, Instance>{"searchy", searchy}, pair<string, Instance>{"deep gap", deep_gap}}) {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+
+        auto without = solve_it(inst, Setup{.presolve = false, .rules = tt_only}, nullopt);
+        auto with = solve_it(inst, Setup{.rules = tt_only, .derived_rules = make_optional(tt_only), .stats = stats}, nullopt);
+
+        if (stats->donors_strengthened != 1)
+            fail(what + " neutrality: the presolver did not fire, so the comparison is vacuous");
+        if (without.solutions != with.solutions)
+            fail(what + " neutrality: the solution set changed");
+        if (without.recursions != with.recursions)
+            fail(what + " neutrality: " + std::to_string(with.recursions) + " nodes against " + std::to_string(without.recursions) +
+                " --- the strengthening is not time-table neutral, which means it is not sound");
+        println(cerr, "{} neutrality: {} nodes either way, capacity down by {}", what, with.recursions, stats->capacity_units_removed.raw_value);
+    }
+
+    // The deep-gap fixture is the one that exercises the dynamic programming.
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+        auto outcome = solve_it(deep_gap, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_deep_gap") : nullopt);
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(deep_gap, starts); }, deep_gap.start_ranges);
+        if (expected != outcome.solutions)
+            fail("deep gap fixture: solutions do not match brute force");
+        // Doubles as the backtracking soak: the derived rows are emitted once,
+        // at the top of the proof, and cited at every node. A search that never
+        // backtracked would not notice if they had landed at any other level.
+        if (outcome.recursions < 5)
+            fail("deep gap fixture: the instance did not search, so it soaked nothing");
+        if (stats->capacity_units_removed != 3_i)
+            fail("deep gap fixture: took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off, not the three 13 to 10 is");
+        if (proofs && stats->rows_by_division != 0)
+            fail("deep gap fixture: a row took the divisibility path, so the fixture is not testing the knapsack rule");
+        if (proofs && stats->rows_by_dynamic_programming == 0)
+            fail("deep gap fixture: no row took the dynamic programming path");
+        println(cerr, "deep gap fixture: {} rows by dynamic programming", stats->rows_by_dynamic_programming);
+    }
+
+    // The negative control. A capacity the heights can reach exactly is already
+    // the largest reachable load, so there is nothing to strengthen and nothing
+    // may be posted --- and, since a declined donor writes no comment, the OPB
+    // and the proof both come out as they would with no presolver at all.
+    const Instance nothing_to_gain{{{0, 3}, {0, 3}, {0, 3}}, {2, 2, 2}, {1, 2, 4}, 7};
+
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+        auto outcome = solve_it(nothing_to_gain, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_control") : nullopt);
+
+        if (stats->donors_seen != 1)
+            fail("negative control: the presolver did not see the donor at all");
+        if (stats->donors_strengthened != 0)
+            fail("negative control: the presolver strengthened a capacity that was already the largest reachable load");
+        if (stats->declined_nothing_to_gain != 1)
+            fail("negative control: the donor was passed over for the wrong reason");
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(nothing_to_gain, starts); }, nothing_to_gain.start_ranges);
+        if (expected != outcome.solutions)
+            fail("negative control: solutions do not match brute force");
+    }
+
+    // v1 restrictions, each declined loudly rather than quietly mis-derived.
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts, presences;
+        for (int i = 0; i < 3; ++i) {
+            starts.push_back(p.create_integer_variable(0_i, 3_i));
+            presences.push_back(p.create_integer_variable(0_i, 1_i));
+        }
+        vector<IntegerVariableID> lengths{constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)},
+            heights{constant_variable(6_i), constant_variable(10_i), constant_variable(15_i)};
+        p.post(Cumulative{starts, lengths, heights, presences, constant_variable(14_i)});
+        p.add_presolver(CumulativeStrengthening{stats});
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, nullopt);
+
+        if (stats->declined_optional != 1)
+            fail("an optional-task donor was not declined");
+        if (stats->donors_strengthened != 0)
+            fail("an optional-task donor was strengthened anyway");
+    }
+
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < 3; ++i)
+            starts.push_back(p.create_integer_variable(0_i, 3_i));
+        auto varying_height = p.create_integer_variable(1_i, 6_i);
+        vector<IntegerVariableID> lengths{constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)},
+            heights{varying_height, constant_variable(10_i), constant_variable(15_i)};
+        p.post(Cumulative{starts, lengths, heights, constant_variable(14_i)});
+        p.add_presolver(CumulativeStrengthening{stats});
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, nullopt);
+
+        if (stats->declined_variable_arguments != 1)
+            fail("a variable-height donor was not declined");
+        if (stats->donors_strengthened != 0)
+            fail("a variable-height donor was strengthened anyway");
+    }
+
+    // The budget. Set to zero, the dynamic programming path is unaffordable and
+    // its donor is passed over --- while the divisibility path, which is two pol
+    // steps and not budgeted, keeps working. This is also the check that the
+    // budget is predicted from the same test the derivation applies: if the
+    // prediction disagreed, the pack fixture would be declined too.
+    if (proofs) {
+        auto gap_stats = make_shared<CumulativeStrengtheningStats>();
+        solve_it(deep_gap, Setup{.budget = 0, .stats = gap_stats}, make_optional("cumulative_strengthening_budget_gap"));
+        if (gap_stats->declined_over_budget != 1)
+            fail("a zero budget did not stop the dynamic programming derivation");
+
+        auto pack_stats = make_shared<CumulativeStrengtheningStats>();
+        solve_it(pack, Setup{.budget = 0, .stats = pack_stats}, make_optional("cumulative_strengthening_budget_pack"));
+        if (pack_stats->donors_strengthened != 1)
+            fail("a zero budget stopped the divisibility derivation, which it does not pay for");
+    }
+
+    // Nothing above may have reached the OPB.
+    check_opb_unaffected("pack", pack);
+    check_opb_unaffected("deep gap", deep_gap);
+
+    // Solution preservation, the defining property of a presolve strengthening.
+    // Random instances against brute force, with heights drawn so that both
+    // derivations get a turn.
+    {
+        std::mt19937 rand(*get_seed());
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), cap_dist(2, 12);
+        const vector<int> height_pool{1, 2, 3, 4, 5, 6, 10, 15};
+        std::uniform_int_distribution<> height_dist(0, static_cast<int>(height_pool.size()) - 1);
+
+        size_t fired = 0;
+        for (int k = 0; k < 60; ++k) {
+            Instance inst;
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand), span = span_dist(rand);
+                inst.start_ranges.emplace_back(lo, lo + span);
+                inst.lengths.push_back(len_dist(rand));
+                inst.heights.push_back(height_pool[height_dist(rand)]);
+            }
+            inst.capacity = cap_dist(rand);
+
+            set<vector<int>> expected;
+            build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+
+            auto stats = make_shared<CumulativeStrengtheningStats>();
+            auto outcome = solve_it(inst, Setup{.stats = stats}, nullopt);
+            if (outcome.solutions != expected) {
+                println(cerr, "starts={} lens={} hts={} c={}", inst.start_ranges, inst.lengths, inst.heights, inst.capacity);
+                fail("the strengthening removed solutions");
+            }
+            fired += stats->donors_strengthened;
+        }
+
+        if (fired == 0)
+            fail("the presolver fired on none of the random corpus, so it checked nothing");
+        println(cerr, "solution preservation: strengthened {} of 60 random instances", fired);
+    }
+
+    if (! proofs) {
+        println(cerr, "veripb is not available, so the proof-level checks are skipped");
+        return EXIT_SUCCESS;
+    }
+
+    // Mutations. Both corrupt the *conclusion* rather than the route to it,
+    // which is what a rule whose content is a numeric bound needs: claiming one
+    // better than the largest reachable load, and rounding by a divisor that
+    // does not divide every height. The second is worth keeping even though it
+    // is a perfectly sound proof step --- it lands on a line that is not the one
+    // the derived constraint was told it had, and only the `ia` step pinning
+    // each row's content notices that.
+    for (const auto & [what, mutation] :
+        {pair<string, CumulativeStrengtheningMutation>{"one better", cumulative_strengthening_mutation::ClaimOneBetter{}},
+            pair<string, CumulativeStrengtheningMutation>{"bogus divisor", cumulative_strengthening_mutation::BogusDivisor{}}}) {
+        const string name = "cumulative_strengthening_mutation";
+        solve_it(pack, Setup{.mutation = mutation}, make_optional(name), false);
+
+        if (run_veripb(name + ".opb", name + ".pbp"))
+            fail("veripb accepted the " + what + " mutation");
+        println(cerr, "veripb rejected the {} mutation, as expected", what);
+        dispose_of_proof_files(name);
+    }
+
+    // The markers, counted. The pack fixture takes the divisibility path at
+    // every time point and the deep-gap one the dynamic programming path at
+    // every time point, so each fixture must show one marker and not the other.
+    {
+        for (const auto & [what, inst, wanted, unwanted] :
+            {std::tuple<string, Instance, string, string>{"pack", pack, "presolve cumulative gcd", "presolve cumulative kappa"},
+                std::tuple<string, Instance, string, string>{"deep gap", deep_gap, "presolve cumulative kappa", "presolve cumulative gcd"}}) {
+            const string name = "cumulative_strengthening_markers";
+            // Unverified here, because verifying is what deletes the file this
+            // needs to read; veripb still gets its turn, below.
+            solve_it(inst, Setup{}, make_optional(name), false);
+
+            auto proof = read_file(name + ".pbp");
+            if (! run_veripb(name + ".opb", name + ".pbp"))
+                fail(what + " markers: veripb rejected the proof");
+            if (0 == count_occurrences(proof, wanted))
+                fail(what + " markers: no `" + wanted + "` in the proof, so the rule did not fire where the fixture says");
+            if (0 != count_occurrences(proof, unwanted))
+                fail(what + " markers: `" + unwanted + "` in the proof, so the fixture is exercising the other derivation");
+            println(cerr, "{} markers: {} occurrences of `{}`", what, count_occurrences(proof, wanted), wanted);
+            dispose_of_proof_files(name);
+        }
+    }
+
+    // A declined donor writes nothing at all, so its proof is the one a run with
+    // no presolver produces.
+    {
+        const string with = "cumulative_strengthening_control_with", without = "cumulative_strengthening_control_without";
+        solve_it(nothing_to_gain, Setup{}, make_optional(with), false);
+        solve_it(nothing_to_gain, Setup{.presolve = false}, make_optional(without), false);
+        if (! run_veripb(with + ".opb", with + ".pbp"))
+            fail("negative control: veripb rejected the proof");
+
+        auto proof = read_file(with + ".pbp");
+        for (const auto & marker : {"presolve cumulative gcd", "presolve cumulative kappa", "presolve cumulative:"})
+            if (0 != count_occurrences(proof, marker))
+                fail(string{"negative control: `"} + marker + "` in the proof of a donor that was passed over");
+
+        if (read_file(with + ".opb") != read_file(without + ".opb"))
+            fail("negative control: the OPB differs from a run with no presolver");
+
+        for (const auto & name : {with, without})
+            dispose_of_proof_files(name);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
First half of issue #547 (Schulz's single-Cumulative strengthening), and the
first real consumer of #656's subset-sum utility and #657's derived-constraint
mode. Stacked on #660; the base retargets to `main` once the stack lands.

## What it does

The load on a resource at any one time is a sum of the heights of the tasks
running then, so it can only take a value that is a *subset sum* of those
heights. A capacity that is not itself such a value has room in it that nothing
can use.

`CumulativeStrengthening` takes that room away. For each posted `Cumulative` it
computes

```
kappa = max over t of ( largest subset sum of { h_i : task i can run at t }
                        that is at most C )
```

and, when `kappa < C`, posts a **derived** `Cumulative` over the same tasks with
a capacity of `kappa`. The donor stays posted and the OPB is untouched: each
per-time capacity row is proved from the donor's row by
`derive_subset_sum_strengthening`.

Schulz's two capacity rules are just the two derivations that utility chooses
between — gcd rounding is Chvátal–Gomory division, the knapsack rule is the
layered dynamic programme. The presolver does not choose; it *predicts* the
choice, with the same test the utility applies, so that it can budget the
expensive path. `CumulativeStrengtheningStats` counts rows both ways, and the
budget fixture asserts the prediction agrees with the choice.

## Time-table neutrality is a tripwire, not a caveat

The strengthening cannot change a time-table verdict: a load exceeding `C`
exceeds `kappa` since `kappa < C`, and a load at most `C` is a subset sum at most
`C` of that time point's heights, hence at most `kappa`. The paper says as much
in one line.

So the test asserts node-for-node identical search trees under time-tabling
alone. A difference there would mean the strengthening had changed what the
profile permits, which is the shape an unsound one takes — and it catches that
before VeriPB is consulted.

The same theorem, used the other way round, is why the derived constraints ship
with **time-tabling off**: every time-table inference a derived constraint could
draw, the donor draws already. That is the issue's "measure propagation
redundancy" question answered by proof rather than measurement. (Retiring the
*donor's* propagators remains the separate follow-up the issue asks for.)

The benefit is all in the energy rules. Seven unit-length tasks of height three
in `[0, 3)` under a capacity of eight: the window supplies 24 against the 21 the
tasks need, so the solver searches. At a capacity of six it supplies 18, and the
overload check refutes at the root.

## Every row lands on the declared capacity

A time point whose own `kappa_t` is below `kappa` yields a stronger row than the
constraint declared. The recipe does not hand that back — it closes with an `ia`
step against `Σ h_i·active_{i,t} ≤ kappa`.

That keeps the rows uniform, and it is the **only** thing in the proof that
notices a derivation landing somewhere other than where it claimed. A divisor
that does not divide every height still divides *soundly*; VeriPB accepts every
step and the line is true, it is simply not the line the derived constraint was
told it had. That is exactly the `BogusDivisor` mutation, and the `ia` step is
what rejects it (`expected constraint is not syntactically implied by the
constraint at the hint`). Nothing else objects.

## Two deviations from the paper, and one fixture that cannot be one

Documented in `dev_docs/cumulative-strengthening.md`:

- **The per-time knapsack set is not restricted to `c_j < C`.** Excluding the
  tasks that fill the resource by themselves gives a smaller `kappa`, but is only
  sound if those tasks' heights come down to `kappa` too — which changes
  *coefficients*, and needs at-most-one reasoning off the donor's row.
- **Coefficient raising is not implemented**, for the same reason.

Both are the remaining half of #547. A note for whoever writes it: the paper's
condition for raising takes the minimum over all `j ∈ I`, task `i` included,
which is sound but blunter than needed — #547's own statement (`j ≠ i`,
`c_j > 0`) is the sharp one, and wants a `c_i > 0` guard for the empty-minimum
case.

Two corrections to the issue's fixtures, both found by asserting the arithmetic
before building anything on it:

- The R2 fixture `{6, 10, 4}`, `C = 13` does **not** give 12. The gcd is two, so
  rounding offers `2·⌊13/2⌋ = 12`, but the largest reachable load is `4 + 6 = 10`
  — so the answer is ten and the *dynamic programme* gets there, not the gcd
  rule. It makes an excellent knapsack-rule fixture; `{2, 4, 6}`, `C = 13` → 12
  is the gcd one.
- The R3 fixture `{6, 10, 15}`, `C = 14` → 10 cannot be a `Cumulative` instance
  at all: a task of height fifteen under a capacity of fourteen can never run, so
  the constraint is infeasible before any strengthening. Kept as an arithmetic
  assertion, with the presolver declining such a donor.

## Validation

- **Neutrality**: node-for-node equality under time-tabling alone, on two
  fixtures, with the stats block asserting the presolver actually fired first.
- **Energy differential**: the pack fixture refutes at the root only with the
  presolver, and the donor alone is asserted *not* to.
- **Sharpness**, checked as arithmetic against `largest_subset_sum_at_most`
  before any proof exists, and asserted down to which derivation each takes.
- **Solution preservation** over 60 random instances against brute force, with
  an assertion that the presolver fired on some of them (13–29 across seeds 1–7).
- **Negative control**: a capacity already equal to the largest reachable load is
  passed over, the OPB matches a no-presolver run byte for byte, and no marker
  comment reaches the proof.
- **Restrictions**: optional-task and variable-argument donors declined, each
  counted separately so a model drifting into one does not quietly stop being
  strengthened.
- **Mutations**: `ClaimOneBetter` and `BogusDivisor`, both rejected by VeriPB.
  Both corrupt the *conclusion* rather than the route to it, which is what #660
  established a rule of this shape needs.
- **OPB byte-diff** on two fixtures; distinct proof file names throughout.
- Backtracking soak on the deep-gap fixture, since the rows are emitted once at
  `ProofLevel::Top` and cited at every node.

Full `ctest` green (624/624, `GCS_TEST_CAP_DEFAULTS=OFF`); GCC and clang both
warning-free on the new files; the new test clean under ASan/UBSan (sanitizers
confirmed present in `flags.make`, per #597).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p