### PR TITLE
Inferred Disjunctive constraints from cross-resource conflict cliques (#548)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -150,6 +150,14 @@ library. For an introduction to *using* the solver, start with the top-level
   sound derivation of the wrong line), the deviations from the paper's statement
   of the rules, and why the deep-gap fixture everyone quotes cannot be a
   `Cumulative` instance.
+- [Inferring `Disjunctive` constraints across resources](inferred-disjunctive.md) —
+  the `InferredDisjunctive` presolver: conflict cliques spanning several posted
+  Cumulatives, posted in derived mode. Covers why the cross-resource case is an
+  inference no single Cumulative can make, the three-piece certificate (pairwise
+  at-most-one out of a witnessing row, flag bridge, clique merge), why two-task
+  cliques are never worth posting, the camouflage fixture the mutations need, and
+  the measured proof size — which is the thing to fix before pointing this at a
+  real instance.
 - [Restarts, nogoods, and dom/wdeg weighting](restarts-nogoods-weighting.md) —
   the search-side machinery from issue #315: the restart loop and its
   `SearchResult` unwind signal, `RestartSchedule`, the `ConflictObserver`

--- a/dev_docs/cumulative-proof-logging.md
+++ b/dev_docs/cumulative-proof-logging.md
@@ -558,24 +558,52 @@ The real presolver built on that recipe is `CumulativeStrengthening` — see
 [cumulative-strengthening.md](cumulative-strengthening.md), which turns the
 invisibility above into an automated soundness tripwire rather than a caveat.
 
-### Multi-donor, for later
+### Multi-donor
 
 Issues #548 and #549 infer a Cumulative over tasks drawn from *several* donors,
-each with its own flag copies for the same `(task, time)` semantics. Two ways to
-make one derivation speak about all of them:
+each with its own flag copies for the same `(task, time)` semantics. Two things
+make that work, and both are now here.
 
-1. **Bridge lemmas.** Pick one donor's flags as canonical and derive
-   `active^{(r)}_{i,t} ↔ active^{(1)}_{i,t}` per `(i, t)`, by `pol` over the two
-   reification halves — the start variable's bits cancel, exactly as in the
-   window-energy bridges above. O(tasks × times) extra Top lines per extra
-   donor, and it needs no new API: both donors' rows are citable by name.
-2. **Rewrite each donor's row.** One `pol` pass per row, over the flag-defining
-   rows directly, landing on the canonical flags without ever stating the
-   bridge.
+**The spec is per task.** `DerivedCumulativeTask` names the donor and the
+position within it for each task separately, so a constraint whose members come
+from different donors needs nothing special — `derived_cumulative_tasks_from`
+builds the all-of-one-donor case, which is still the common one. `row_donors`
+is separate from the tasks' donors, because a pairwise conflict is witnessed by
+whichever resource cannot hold both tasks, and that need not be where either
+task's flags are taken from. The recipe is handed the rows those donors wrote
+for that time point, by donor, and may return nullopt to decline a time point it
+cannot derive — which declines the whole constraint, since the propagator cites
+a row at every time it covers.
 
-Neither is implemented here. The first is the safer starting point (each lemma
-is checkable on its own); the second is smaller if it works. Whichever lands
-should measure the proof size, since that is the whole difference between them.
+**The bridge is one `pol`.** `derive_flag_bridge`
+([`flag_bridge.hh`](../gcs/innards/proofs/flag_bridge.hh)) turns one donor's
+flag into another's. A fully reified flag emits `g → ineq` under `[r]` and
+`ineq → g` under `[f]`; adding one flag's `[r]` to another's `[f]` puts the two
+inequalities in with opposite signs, so their terms cancel — every bit of every
+variable they mention — and saturation leaves the two-literal clause. The
+sketch this replaces assumed order literals and bit reasoning would be needed;
+they are not.
+
+`active ⇔ before ∧ after` needs one more step, since two `active` flags are
+reified over *different* flags and so do not cancel against each other.
+`derive_conjunction_flag_bridge` bridges the conjuncts first, after which each
+appears with both signs and drops out. Three `pol`s per `(task, time, donor
+pair)`.
+
+What the derivation needs is not that the conditions match but that the
+constants leave something behind: for `e ≤ p` and `e ≤ q` the sum has degree
+`q − p + 1`, so it goes through exactly when the implication is true. Identical
+conditions are the case this is for; a weaker target also works, a stronger one
+correctly does not.
+
+Two traps, both guarded. The halves are labelled from the flag's **full PB
+rendering**, not `name_of`, whose plain-flag form is the bare stem — the
+window-energy bridges get away with `name_of` only because `Cumulative`'s flags
+are values-named. And a negated flag has no halves of its own, so bridging one
+is refused rather than silently naming the positive flag's rows.
+
+Proof size is the thing to watch: the bridges are O(tasks × times) Top lines per
+extra donor, and at `Top` none of them ever dies.
 ## Optional tasks (issue #543)
 
 The optional-task constructor gives each task a `{0, 1}` presence

--- a/dev_docs/inferred-disjunctive.md
+++ b/dev_docs/inferred-disjunctive.md
@@ -1,0 +1,124 @@
+# Inferring `Disjunctive` constraints across resources
+
+Two tasks conflict when *some* resource cannot hold both at once. A set of tasks
+conflicting pairwise can have at most one of them running at any time — and when
+different pairs of that set conflict on *different* resources, that is an
+inference no single posted `Cumulative` can make.
+
+`InferredDisjunctive`
+([`gcs/presolvers/inferred_disjunctive.hh`](../gcs/presolvers/inferred_disjunctive.hh))
+finds those sets and posts each as a capacity-one derived `Cumulative`. It is the
+first stage of Sidorov (CP 2026), restricted to capacity one and unit
+coefficients — which is what keeps every certificate polynomial, and where his
+own data says most of the value is. The general lifted case is issue #549.
+
+## What it does
+
+Tasks are identified by **start variable**, so the same task on two resources is
+one node of the conflict graph. Each candidate pair is grown into a maximal
+clique taking longest-duration first (the unit-coefficient reading of Sidorov's
+lifting order), cliques are ranked by total duration, and anything subsumed by an
+accepted clique or smaller than three members is dropped.
+
+Three is the floor because a two-task "clique" is just a conflicting pair, which
+the resource witnessing it already rules out — posting one adds a propagator that
+cannot infer anything new.
+
+Both budgets (`N_cover`, `N_out` in the paper) count what they drop.
+A budget that quietly swallowed every candidate is indistinguishable, from the
+outside, from a conflict graph with nothing in it.
+
+## Time-table neutrality, again
+
+As with [capacity strengthening](cumulative-strengthening.md), the inference
+cannot change a time-table verdict: a conflicting pair is already kept apart by
+whichever resource witnesses it, so the inferred constraint's profile reasoning
+is redundant. It therefore ships with **time-tabling off**, and the test asserts
+node-for-node equality with it turned back on.
+
+What is new is the *energy* argument over the whole clique. Three pairwise
+incompatible tasks of length two need six units of a five-slot window, and no
+single resource's capacity row says that. The fixture family refutes exactly
+there.
+
+## The certificate
+
+Per time point, over the clique members whose window covers it:
+
+1. **The pairwise at-most-one**, out of its witnessing resource's capacity row:
+   weaken every other task away, saturate, divide by the margin
+   `c_u + c_v - C`. No side condition on `c_u, c_v <= C` is needed — saturation
+   caps both coefficients at the margin and the division rounds them back to one.
+   A pair summing to *exactly* the capacity has margin zero and correctly yields
+   nothing.
+2. **The bridge**, where the witness is not where a task's flags live — which is
+   the normal case, since a clique's pairs are witnessed by different resources.
+   `derive_conjunction_flag_bridge` carries it across, cached per
+   `(task, resource)` rather than per pair. The carry *continues the same `pol`*
+   as step 1 rather than starting another: the bridges go on the stack, each
+   cancelling its task's term, and one saturation clears up after all of it.
+3. **The merge**, `derive_clique_from_amos`, whose pinned output *is* the
+   unit-height capacity-one row the derived constraint needs. No separate step
+   is required to turn one into the other.
+
+Nothing reaches the OPB; the byte-diff test enforces it.
+
+## Proof size
+
+Measured on the three-task family over five time points: **251 lines, 11 KB, 139
+`pol` steps** — about 28 `pol` per time point for a three-clique.
+
+The shape is `O(k²)` pair derivations plus `O(k)` bridges plus `O(k)` merge steps,
+**per time point**, so the whole thing is multiplied by the horizon. At eight
+members and a horizon of a thousand that is order 10⁵ lines per clique, and every
+one of them is emitted at `ProofLevel::Top`, where it never dies and taxes every
+later unhinted RUP — the `table_layout15` pathology.
+
+Only the pinned per-time row needs to outlive the recipe. Deriving the
+intermediates at `Temporary` and forgetting them after each row, or inlining a
+whole time point into a single `pol` so they never enter the checker's database
+at all, is the fix. Neither is done yet, and it is the first thing to do before
+this is pointed at a real instance.
+
+## Testing it
+
+The fixture family is built so that no single donor could make the inference: k
+tasks, k resources, pair `(i, j)` conflicting only on resource `(i + j) mod k`,
+every resource posted over all k starts with zero demand for non-members. A root
+refutation there cannot be one of the donors doing the work, and
+`bridges_derived` being non-zero says the certificate genuinely spanned
+resources.
+
+- **The differential**: three tasks of length two into five time points — root
+  refutation with the presolver, search without, proof verified.
+- **The sharp twin**: one more unit of horizon, satisfiable, all six solutions
+  matching brute force. An inferred constraint has to be harmless where it is not
+  decisive.
+- **Solution preservation** at three shapes, against brute force.
+- **Neutrality**, as node-for-node equality under time-tabling alone.
+- **Budgets**, on a two-disjoint-edges fixture where the drops are real rather
+  than an artefact of there being no candidates.
+- **Mutations**, on a fixture carrying a *camouflage* task — a fourth task on a
+  capacity-two resource where every pairwise demand sums to exactly two, so it is
+  compatible with everything by exactly one unit. Honestly it stays out of the
+  clique; the mutations force the issue:
+
+  | mutation | what it corrupts |
+  |---|---|
+  | `ClaimRhsZero` | claims no member may run at all |
+  | `BridgeWrongTask` | bridges a task onto the *other* task's flags, so the at-most-one is about a task nothing cornered |
+  | `IncludeNonConflicting` | grows the clique with the camouflage task, inventing the conflict record — exactly where an off-by-one in the conflict test lands |
+
+  VeriPB rejects each. All three corrupt the *conclusion* rather than the route,
+  which is what a conflict-shaped derivation requires: the route is where it
+  forgives everything.
+
+## Not done
+
+- Sidorov's Pack/Pack_d cross-check (his §5.1, instance lists in the zenodo
+  logs), which would say whether the cliques found here match the ones his
+  capacity-bound metric reports.
+- Budget-robustness sweeps on larger instances.
+- The proof-size work above.
+
+<!-- vim: set tw=72 spell spelllang=en : -->

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -121,6 +121,7 @@ add_library(glasgow_constraint_solver
         presolvers/auto_table/auto_table.cc
         presolvers/cumulative_strengthening/cumulative_strengthening.cc
         presolvers/difference_logic/difference_logic.cc
+        presolvers/inferred_disjunctive/inferred_disjunctive.cc
 )
 
 # The repo root contains both gcs/ and util/, so it must be on the include path.
@@ -197,6 +198,11 @@ if(GCS_BUILD_TESTS)
     endforeach()
     add_test(NAME difference_logic_presolver_proofs
         COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:difference_logic_presolver_test> proofs)
+
+    add_executable(inferred_disjunctive_presolver_test presolvers/inferred_disjunctive/inferred_disjunctive_test.cc)
+    target_link_libraries(inferred_disjunctive_presolver_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME inferred_disjunctive_presolver
+        COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_only.bash $<TARGET_FILE:inferred_disjunctive_presolver_test>)
 
     add_executable(cumulative_strengthening_presolver_test presolvers/cumulative_strengthening/cumulative_strengthening_test.cc)
     target_link_libraries(cumulative_strengthening_presolver_test PRIVATE glasgow_constraint_solver)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(glasgow_constraint_solver
         innards/proofs/clique_from_amos.cc
         innards/proofs/constraint_proof_model_data.cc
         innards/proofs/emit_inequality_to.cc
+        innards/proofs/flag_bridge.cc
         innards/proofs/names_and_ids_tracker.cc
         innards/proofs/pol_builder.cc
         innards/proofs/proof_error.cc
@@ -578,6 +579,10 @@ if(GCS_BUILD_TESTS)
     add_executable(eqvar_polarity_test innards/proofs/eqvar_polarity_test.cc)
     target_link_libraries(eqvar_polarity_test PRIVATE glasgow_constraint_solver)
     add_test(NAME eqvar_polarity_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eqvar_polarity_test>)
+
+    add_executable(flag_bridge_test innards/proofs/flag_bridge_test.cc)
+    target_link_libraries(flag_bridge_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME flag_bridge_test COMMAND $<TARGET_FILE:flag_bridge_test>)
 
     add_executable(clique_from_amos_test innards/proofs/clique_from_amos_test.cc)
     target_link_libraries(clique_from_amos_test PRIVATE glasgow_constraint_solver)

--- a/gcs/CMakeLists.txt
+++ b/gcs/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(glasgow_constraint_solver
         innards/literal.cc
         innards/power.cc
         innards/proofs/bits_encoding.cc
+        innards/proofs/clique_from_amos.cc
         innards/proofs/constraint_proof_model_data.cc
         innards/proofs/emit_inequality_to.cc
         innards/proofs/names_and_ids_tracker.cc
@@ -577,6 +578,10 @@ if(GCS_BUILD_TESTS)
     add_executable(eqvar_polarity_test innards/proofs/eqvar_polarity_test.cc)
     target_link_libraries(eqvar_polarity_test PRIVATE glasgow_constraint_solver)
     add_test(NAME eqvar_polarity_test COMMAND ${GCS_BASH} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test_and_verify.bash $<TARGET_FILE:eqvar_polarity_test>)
+
+    add_executable(clique_from_amos_test innards/proofs/clique_from_amos_test.cc)
+    target_link_libraries(clique_from_amos_test PRIVATE glasgow_constraint_solver)
+    add_test(NAME clique_from_amos_test COMMAND $<TARGET_FILE:clique_from_amos_test>)
 
     add_executable(subset_sum_strengthening_test innards/proofs/subset_sum_strengthening_test.cc)
     target_link_libraries(subset_sum_strengthening_test PRIVATE glasgow_constraint_solver)

--- a/gcs/constraints/cumulative/derived_cumulative.cc
+++ b/gcs/constraints/cumulative/derived_cumulative.cc
@@ -6,6 +6,7 @@
 #include <gcs/innards/propagators.hh>
 #include <gcs/innards/state.hh>
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
@@ -22,33 +23,44 @@ using std::string;
 using std::to_string;
 using std::vector;
 
+auto gcs::innards::derived_cumulative_tasks_from(const ConstraintID & donor, const vector<IntegerVariableID> & starts,
+    const vector<Integer> & lengths, const vector<Integer> & heights) -> vector<DerivedCumulativeTask>
+{
+    if (starts.size() != lengths.size() || starts.size() != heights.size())
+        throw InvalidProblemDefinitionException{"derived Cumulative: starts, lengths, heights must have the same size"};
+
+    vector<DerivedCumulativeTask> tasks;
+    tasks.reserve(starts.size());
+    for (size_t i = 0; i < starts.size(); ++i)
+        tasks.push_back(DerivedCumulativeTask{donor, i, starts[i], lengths[i], heights[i]});
+    return tasks;
+}
+
 auto gcs::innards::install_derived_cumulative(
     Propagators & propagators, const State & initial_state, ProofLogger * const logger, DerivedCumulativeSpec spec) -> bool
 {
-    auto n = spec.starts.size();
-    if (n != spec.lengths.size() || n != spec.heights.size())
-        throw InvalidProblemDefinitionException{"derived Cumulative: starts, lengths, heights must have the same size"};
+    auto n = spec.tasks.size();
     if (spec.capacity < 0_i)
         throw InvalidProblemDefinitionException{"derived Cumulative: capacity must be non-negative"};
-    for (size_t i = 0; i < n; ++i)
-        if (spec.lengths[i] < 0_i || spec.heights[i] < 0_i)
+    for (const auto & task : spec.tasks)
+        if (task.length < 0_i || task.height < 0_i)
             throw InvalidProblemDefinitionException{"derived Cumulative: lengths and heights must be non-negative"};
     if (! spec.recipe)
         throw InvalidProblemDefinitionException{"derived Cumulative: no recipe for deriving the capacity rows"};
 
     auto inputs = make_shared<CumulativeInputs>();
     inputs->owner = CurrentlyUnnamedConstraint{};
-    inputs->starts = spec.starts;
     inputs->capacity = constant_variable(spec.capacity);
     inputs->rules = spec.rules;
     // Every task unconditionally present: a derived Cumulative over an optional
-    // donor would have to carry the donor's presence literals into its own
+    // donor would have to carry that donor's presence literals into its own
     // reasons, which is future work rather than something to get wrong quietly.
-    // See DerivedCumulativeSpec, which says the donor must not be optional.
+    // See DerivedCumulativeSpec, which says no donor may be optional.
     inputs->presence.assign(n, std::nullopt);
-    for (size_t i = 0; i < n; ++i) {
-        inputs->lengths.push_back(constant_variable(spec.lengths[i]));
-        inputs->heights.push_back(constant_variable(spec.heights[i]));
+    for (const auto & task : spec.tasks) {
+        inputs->starts.push_back(task.start);
+        inputs->lengths.push_back(constant_variable(task.length));
+        inputs->heights.push_back(constant_variable(task.height));
     }
 
     // The same windowing a posted Cumulative resolves in prepare(): a task can
@@ -57,12 +69,12 @@ auto gcs::innards::install_derived_cumulative(
     inputs->per_task_t_lo.assign(n, 0_i);
     vector<Integer> per_task_t_hi(n, 0_i);
     for (size_t i = 0; i < n; ++i) {
-        if (spec.lengths[i] <= 0_i || spec.heights[i] <= 0_i)
+        if (spec.tasks[i].length <= 0_i || spec.tasks[i].height <= 0_i)
             continue;
         inputs->active_tasks.push_back(i);
-        auto [s_lo, s_hi] = initial_state.bounds(spec.starts[i]);
+        auto [s_lo, s_hi] = initial_state.bounds(spec.tasks[i].start);
         inputs->per_task_t_lo[i] = s_lo;
-        per_task_t_hi[i] = s_hi + spec.lengths[i] - 1_i;
+        per_task_t_hi[i] = s_hi + spec.tasks[i].length - 1_i;
     }
 
     if (inputs->active_tasks.empty())
@@ -76,11 +88,11 @@ auto gcs::innards::install_derived_cumulative(
         inputs->time_slot_lo = overload_data.time_slot_lo;
     }
 
-    // The donor's rows, to derive from. Resolved before anything is installed:
-    // a derived constraint that cannot cite its donor must not be installed at
-    // all, since its propagator would then be drawing inferences it has no way
-    // to justify.
-    vector<std::pair<Integer, ProofLine>> donor_rows;
+    // The donors' rows, to derive from. Resolved before anything is installed:
+    // a derived constraint that cannot cite what it needs must not be installed
+    // at all, since its propagator would then be drawing inferences it has no
+    // way to justify.
+    vector<std::pair<Integer, DerivedCumulativeRows>> rows_by_time;
     if (logger) {
         auto & tracker = logger->names_and_ids_tracker();
 
@@ -91,12 +103,14 @@ auto gcs::innards::install_derived_cumulative(
         inputs->ends.assign(n, std::nullopt);
         inputs->end_lines = make_shared<vector<std::optional<std::pair<ProofLine, ProofLine>>>>(n);
 
-        for (auto i : inputs->active_tasks)
+        for (auto i : inputs->active_tasks) {
+            const auto & task = spec.tasks[i];
+            auto position = task.position;
             for (Integer t = inputs->per_task_t_lo[i]; t <= per_task_t_hi[i]; ++t) {
-                auto before = tracker.find_proof_flag_values(spec.donor, ConstraintProofModelData<Cumulative>::before_flag_key(i, t));
-                auto after = tracker.find_proof_flag_values(spec.donor, ConstraintProofModelData<Cumulative>::after_flag_key(i, t));
-                auto active = tracker.find_proof_flag_values(spec.donor, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
-                // Missing means the donor never encoded this (task, time): it
+                auto before = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
+                auto after = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
+                auto active = tracker.find_proof_flag_values(task.donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
+                // Missing means that donor never encoded this (task, time): it
                 // was not installed, or it windowed the task differently. Either
                 // way there is nothing to pin, so decline rather than guess.
                 if (! before || ! after || ! active)
@@ -105,9 +119,12 @@ auto gcs::innards::install_derived_cumulative(
                 inputs->after_flags[i].push_back(*after);
                 inputs->active_flags[i].push_back(*active);
             }
+        }
 
-        // One donor row per time point some task can occupy, which is exactly
-        // where the donor wrote one.
+        // One entry per time point some task of *this* constraint can occupy,
+        // carrying whichever of the row donors wrote a row there. A donor with
+        // nothing at that time is simply absent: the recipe is what knows
+        // whether it needed it.
         Integer global_lo = inputs->per_task_t_lo[inputs->active_tasks.front()], global_hi = per_task_t_hi[inputs->active_tasks.front()];
         for (auto i : inputs->active_tasks) {
             global_lo = std::min(global_lo, inputs->per_task_t_lo[i]);
@@ -124,10 +141,11 @@ auto gcs::innards::install_derived_cumulative(
             if (! covered)
                 continue;
 
-            auto row = tracker.constraint_row_label(spec.donor, ConstraintProofModelData<Cumulative>::capacity_row_role(t));
-            if (! row)
-                return false;
-            donor_rows.emplace_back(t, *row);
+            DerivedCumulativeRows rows;
+            for (const auto & donor : spec.row_donors)
+                if (auto row = tracker.constraint_row_label(donor, ConstraintProofModelData<Cumulative>::capacity_row_role(t)))
+                    rows.emplace(donor, *row);
+            rows_by_time.emplace_back(t, move(rows));
         }
     }
 
@@ -146,14 +164,19 @@ auto gcs::innards::install_derived_cumulative(
     // still the option of not installing a propagator whose inferences could
     // not be justified.
     if (logger) {
-        logger->emit_proof_comment("derived cumulative: " + to_string(donor_rows.size()) + " capacity rows from " + as_string(spec.donor));
-        for (const auto & [t, donor_row] : donor_rows)
-            inputs->capacity_lines.emplace(t, spec.recipe(*logger, donor_row, t));
+        logger->emit_proof_comment(
+            "derived cumulative: " + to_string(rows_by_time.size()) + " capacity rows over " + to_string(spec.row_donors.size()) + " donors");
+        for (const auto & [t, rows] : rows_by_time) {
+            auto derived = spec.recipe(*logger, rows, t);
+            if (! derived)
+                return false;
+            inputs->capacity_lines.emplace(t, *derived);
+        }
     }
 
     Triggers triggers;
     for (auto i : inputs->active_tasks)
-        triggers.on_bounds.emplace_back(spec.starts[i]);
+        triggers.on_bounds.emplace_back(spec.tasks[i].start);
 
     propagators.install(
         inputs->owner,

--- a/gcs/constraints/cumulative/derived_cumulative.hh
+++ b/gcs/constraints/cumulative/derived_cumulative.hh
@@ -10,15 +10,68 @@
 #include <gcs/integer.hh>
 #include <gcs/variable_id.hh>
 
+#include <cstddef>
 #include <functional>
+#include <map>
+#include <optional>
 #include <vector>
 
 namespace gcs::innards
 {
     /**
+     * \brief One task of a derived Cumulative, and where its activity flags are
+     * to be found.
+     *
+     * A derived constraint creates no flags of its own, so every task has to
+     * point at a posted Cumulative that already encoded it: `donor` says which,
+     * and `position` says which of that donor's tasks it is, since the flag keys
+     * ConstraintProofModelData publishes are by task position.
+     *
+     * Tasks may name *different* donors. That is what an inferred constraint
+     * over several resources needs --- a clique whose members conflict pairwise
+     * on different resources has no single donor covering all of it --- and it
+     * is the caller's job to make sure the flags it points at mean the same
+     * thing as the ones its rows are derived from, which
+     * derive_conjunction_flag_bridge exists to establish.
+     *
+     * \ingroup Innards
+     */
+    struct DerivedCumulativeTask
+    {
+        /// The posted Cumulative whose flags express this task's activity.
+        ConstraintID donor;
+
+        /// This task's index within that donor's own task list.
+        std::size_t position;
+
+        /// The start variable, which must be the one the donor was posted with
+        /// at `position`: the flags are reified on it, so a different variable
+        /// would silently mean something else.
+        IntegerVariableID start;
+
+        /// Constant by type, which is the v1 restriction made structural: a
+        /// variable height enters a donor's capacity row as a bit-linearised
+        /// contribution rather than as `height x active`, and a derived row
+        /// would have to speak about those bits too.
+        Integer length, height;
+    };
+
+    /**
+     * \brief The donors' capacity rows for one time point, by donor, as handed
+     * to a recipe.
+     *
+     * Only donors that wrote a row for that time point appear: a donor whose own
+     * tasks cannot be active then has nothing there to cite, which is a fact
+     * about the donor and not an error.
+     *
+     * \ingroup Innards
+     */
+    using DerivedCumulativeRows = std::map<ConstraintID, ProofLine>;
+
+    /**
      * \brief A Cumulative whose proof semantics are *derived* rather than
      * asserted: it adds no rows to the OPB, and establishes its per-time
-     * capacity rows inside the proof instead, from a donor Cumulative's.
+     * capacity rows inside the proof instead, from posted Cumulatives'.
      *
      * This is what lets a presolver add an implied Cumulative without touching
      * the model. The model is the statement being verified, so a presolver that
@@ -26,56 +79,60 @@ namespace gcs::innards
      * than proving anything about it --- VeriPB would verify the result and it
      * would mean nothing.
      *
-     * The derived constraint covers the donor's tasks, with its own heights and
-     * capacity. It creates no flags: it pins the donor's, found through the keys
-     * ConstraintProofModelData<Cumulative> publishes, which is also what checks
-     * that the two agree about the tasks' possible-active windows --- a key
-     * outside the window the donor encoded has no flag, and this declines rather
-     * than inventing one.
-     *
      * \ingroup Innards
      */
     struct DerivedCumulativeSpec
     {
-        /// The Cumulative whose flags and capacity rows this is derived from.
-        /// Its arguments come from the donor's own accessors. The donor must
-        /// not be an optional-task Cumulative: its active flags would carry a
-        /// presence conjunct, and a derived constraint reasoning over them
-        /// would need the donor's presence literals in every reason it gives.
-        /// A caller building one of these from a donor should decline when the
-        /// donor's presences() is non-empty.
-        ConstraintID donor;
+        /// The derived constraint's tasks, each pointing at the donor that
+        /// encoded it. No donor may be an optional-task Cumulative: its active
+        /// flags would carry a presence conjunct, and a derived constraint
+        /// reasoning over them would need that donor's presence literals in
+        /// every reason it gives. A caller building one of these should decline
+        /// when a donor's presences() is non-empty.
+        std::vector<DerivedCumulativeTask> tasks;
 
-        /// The donor's starts, in the donor's order: the flag keys are by task
-        /// position, so these must be the donor's tasks and nothing else.
-        std::vector<IntegerVariableID> starts;
-
-        /// Constant by type, which is the v1 restriction made structural: a
-        /// variable height enters the donor's capacity row as a bit-linearised
-        /// contribution rather than as `height x active`, and the derived row
-        /// would have to speak about those bits too.
-        std::vector<Integer> lengths, heights;
         Integer capacity;
 
+        /// The donors whose per-time capacity rows the recipe wants to build
+        /// on. Usually the same donors the tasks name, but not necessarily ---
+        /// a pairwise conflict is witnessed by whichever resource cannot hold
+        /// both tasks, which need not be where either task's flags are taken
+        /// from.
+        std::vector<ConstraintID> row_donors;
+
         /**
-         * \brief How the derived row for time `t` comes off the donor's.
+         * \brief How the derived row for time `t` is established.
          *
-         * Called once per time point, at ProofLevel::Top, with the donor's row
-         * for `t`; returns the derived row, which must say
-         * `Σ heights[i]·active[i,t] ≤ capacity` over the donor's flags. Anything
-         * else and the propagator's `pol`s will not cancel, which VeriPB will
-         * say so about.
+         * Called once per time point, at ProofLevel::Top, with the rows those
+         * of \ref row_donors that have one wrote for `t`; returns the derived
+         * row, which must say `Σ heights[i]·active[i,t] ≤ capacity` over the
+         * flags \ref tasks point at. Anything else and the propagator's `pol`s
+         * will not cancel, which VeriPB will say so about.
+         *
+         * Returning nullopt means this time point cannot be derived, and the
+         * whole constraint is then declined: a derived Cumulative needs a row
+         * everywhere its propagator will cite one, so there is no useful
+         * halfway house.
          *
          * A recipe is a derivation, never an axiom: it has a ProofLogger and no
          * ProofModel, so it cannot write to the OPB even by mistake.
          */
-        std::function<auto(ProofLogger &, ProofLine donor_row, Integer t)->ProofLine> recipe;
+        std::function<auto(ProofLogger &, const DerivedCumulativeRows &, Integer t)->std::optional<ProofLine>> recipe;
 
         /// Which propagation rules the derived constraint runs. The default is
         /// all of them: it gets the same time-tabling and overload checking a
-        /// posted Cumulative does, over the donor's flags.
+        /// posted Cumulative does, over the donors' flags.
         CumulativeRules rules;
     };
+
+    /**
+     * \brief Build the task list for the common case of a derived Cumulative
+     * over all of one donor's tasks, in the donor's order.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto derived_cumulative_tasks_from(const ConstraintID & donor, const std::vector<IntegerVariableID> & starts,
+        const std::vector<Integer> & lengths, const std::vector<Integer> & heights) -> std::vector<DerivedCumulativeTask>;
 
     /**
      * \brief Install a derived Cumulative's propagator.
@@ -85,12 +142,12 @@ namespace gcs::innards
      * what writes to the OPB.
      *
      * Returns false when the derived constraint could not be set up --- proofs
-     * are on but the donor's flags or rows are not where its published keys say,
-     * which means the donor was never installed, or the windows disagree. That
-     * is a decline, not a failure: the caller should not install a propagator
-     * whose inferences it cannot justify. With proofs off there is nothing to
-     * cite and nothing to decline, and the propagator installs unconditionally,
-     * so the same inferences are drawn either way.
+     * are on but a donor's flags are not where its published keys say, which
+     * means the donor was never installed or the windows disagree, or the recipe
+     * declined a time point. That is a decline, not a failure: the caller should
+     * not install a propagator whose inferences it cannot justify. With proofs
+     * off there is nothing to cite and nothing to decline, and the propagator
+     * installs unconditionally, so the same inferences are drawn either way.
      *
      * \ingroup Innards
      */

--- a/gcs/constraints/cumulative/derived_cumulative_test.cc
+++ b/gcs/constraints/cumulative/derived_cumulative_test.cc
@@ -125,19 +125,27 @@ namespace
                     if (lengths[i] > 0_i && heights[i] > 0_i)
                         divisor = Integer{std::gcd(divisor.raw_value, heights[i].raw_value)};
 
-                DerivedCumulativeSpec spec{.donor = donor.constraint_id(),
-                    .starts = donor.starts(),
-                    .lengths = lengths,
-                    .heights = heights,
+                auto donor_id = donor.constraint_id();
+                DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, donor.starts(), lengths, heights),
                     .capacity = capacity,
+                    .row_donors = {donor_id},
                     .recipe = {},
                     .rules = CumulativeRules{}};
 
+                // Every demo here derives from the one donor it was built over,
+                // so each pulls that donor's row out of the map it is handed.
+                auto row_of = [donor_id](const DerivedCumulativeRows & rows) -> ProofLine {
+                    auto at = rows.find(donor_id);
+                    if (at == rows.end())
+                        fail("the donor had no capacity row where the derived constraint has one");
+                    return at->second;
+                };
+
                 switch (demo) {
                 case Demo::Duplicate:
-                    spec.recipe = [](ProofLogger & logger, ProofLine donor_row, Integer) -> ProofLine {
+                    spec.recipe = [row_of](ProofLogger & logger, const DerivedCumulativeRows & rows, Integer) -> optional<ProofLine> {
                         PolBuilder copy;
-                        copy.add(donor_row);
+                        copy.add(row_of(rows));
                         return copy.emit(logger, ProofLevel::Top);
                     };
                     break;
@@ -156,10 +164,10 @@ namespace
                     // cumulative uses, which is the presolver's half of the
                     // contract.
                     auto starts = donor.starts();
-                    auto donor_id = donor.constraint_id();
                     auto claim_one_lower = (demo == Demo::ClaimOneLower);
-                    spec.recipe = [starts, heights, lengths, capacity, donor_id, claim_one_lower, &state](
-                                      ProofLogger & logger, ProofLine donor_row, Integer t) -> ProofLine {
+                    spec.recipe = [starts, heights, lengths, capacity, donor_id, claim_one_lower, row_of, &state](
+                                      ProofLogger & logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
+                        auto donor_row = row_of(rows);
                         vector<SubsetSumItem> items;
                         for (size_t i = 0; i < starts.size(); ++i) {
                             if (lengths[i] <= 0_i || heights[i] <= 0_i)
@@ -187,11 +195,11 @@ namespace
                     // One unit longer than the donor's tasks, so the derived
                     // constraint's last time point is one the donor never
                     // encoded a flag for.
-                    for (auto & l : spec.lengths)
-                        l += 1_i;
-                    spec.recipe = [](ProofLogger & logger, ProofLine donor_row, Integer) -> ProofLine {
+                    for (auto & task : spec.tasks)
+                        task.length += 1_i;
+                    spec.recipe = [row_of](ProofLogger & logger, const DerivedCumulativeRows & rows, Integer) -> optional<ProofLine> {
                         PolBuilder copy;
-                        copy.add(donor_row);
+                        copy.add(row_of(rows));
                         return copy.emit(logger, ProofLevel::Top);
                     };
                     break;

--- a/gcs/innards/proofs/clique_from_amos.cc
+++ b/gcs/innards/proofs/clique_from_amos.cc
@@ -1,0 +1,101 @@
+#include <gcs/innards/proofs/clique_from_amos.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/pseudo_boolean.hh>
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::move;
+using std::size_t;
+using std::to_string;
+using std::vector;
+
+auto gcs::innards::derive_clique_from_amos(ProofLogger & logger, const vector<ProofLiteralOrFlag> & members,
+    const vector<vector<ProofLine>> & at_most_ones, ProofLevel level, CliqueMutation mutation) -> ProofLine
+{
+    auto k = members.size();
+    if (k < 2)
+        throw ProofError{"a clique needs at least two members, not " + to_string(k)};
+    if (at_most_ones.size() != k)
+        throw ProofError{"clique derivation: " + to_string(k) + " members but " + to_string(at_most_ones.size()) + " rows of at-most-ones"};
+    for (size_t j = 0; j < k; ++j)
+        if (at_most_ones[j].size() != j)
+            throw ProofError{"clique derivation: member " + to_string(j) + " has " + to_string(at_most_ones[j].size()) +
+                " at-most-ones, needing one per earlier member (" + to_string(j) + ")"};
+
+    auto drop_one = std::holds_alternative<clique_mutation::DropAnAtMostOne>(mutation);
+    auto claim_one_more = std::holds_alternative<clique_mutation::ClaimOneMore>(mutation);
+    auto skip_final_division = std::holds_alternative<clique_mutation::SkipFinalDivision>(mutation);
+    if ((drop_one || skip_final_division) && k < 3)
+        throw ProofError{"clique derivation: this mutation needs a merge to corrupt, so at least three members"};
+
+    logger.emit_proof_comment("clique at-most-one over " + to_string(k) + " members");
+
+    // The base case is not a derivation: the at-most-one for the first pair
+    // already is the clique inequality for those two.
+    auto current = at_most_ones[1][0];
+
+    if (std::holds_alternative<clique_mutation::NaiveOneShot>(mutation)) {
+        // Everything at once. Each member appears in `k - 1` pairs, so this
+        // sums to `(k-1) * sum ~a_p >= k(k-1)/2`, and the division lands on
+        // `ceil(k/2)` --- the answer for two and three members, and short of
+        // `k - 1` for every larger clique.
+        PolBuilder naive;
+        for (size_t j = 1; j < k; ++j)
+            for (size_t i = 0; i < j; ++i)
+                naive.add(at_most_ones[j][i]);
+        if (k > 2)
+            naive.divide_by(Integer{static_cast<long long>(k) - 1});
+        current = naive.emit(logger, level);
+    }
+
+    // Then one member at a time. At the top of each pass `current` says
+    // `sum_{i<m} ~a_i >= m - 1` over the first `m`, and the pass extends it to
+    // `m + 1`.
+    for (size_t m = 2; ! std::holds_alternative<clique_mutation::NaiveOneShot>(mutation) && m < k; ++m) {
+        PolBuilder merge;
+
+        // The `m` at-most-ones tying the new member to the ones already in.
+        // Summed, they say `m*~a_m + sum_{i<m} ~a_i >= m`, which on its own is
+        // far too weak --- it permits every earlier member being active.
+        // Dropped from the *first* merge rather than the last, so that the
+        // resulting weakness has every later pass to propagate through: if
+        // anything downstream were quietly repairing it, this is the version
+        // that would show it.
+        for (size_t i = 0; i < m; ++i) {
+            if (drop_one && m == 2 && i == 0)
+                continue;
+            merge.add(at_most_ones[m][i]);
+        }
+
+        // What fixes that is `m - 1` copies of the clique so far, which
+        // contributes `(m-1)^2` to the degree while raising the earlier
+        // members' coefficients to `m`, matching the new member's.
+        merge.add(current, Integer{static_cast<long long>(m) - 1});
+
+        // `m + (m-1)^2 = m(m-1) + 1`, so the division rounds the degree up to
+        // exactly `m`. One short of that and it would round down to `m - 1`
+        // and the induction would not advance.
+        if (! (skip_final_division && m == k - 1))
+            merge.divide_by(Integer{static_cast<long long>(m)});
+        current = merge.emit(logger, level);
+    }
+
+    // Pin what came back. Every step above is sound whatever was fed into it,
+    // so a merge that lost an input, or was scaled wrongly, lands on a weaker
+    // line and the proof sails on --- this is the step that says the line is
+    // the one that was asked for. Syntactic, so a weaker line does not pass.
+    WPBSum clique;
+    for (const auto & member : members)
+        add_term_to(clique, 1_i, member);
+
+    return logger.emit(ImpliesProofRule{current}, move(clique) <= (claim_one_more ? 0_i : 1_i), level);
+}

--- a/gcs/innards/proofs/clique_from_amos.hh
+++ b/gcs/innards/proofs/clique_from_amos.hh
@@ -1,0 +1,136 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_CLIQUE_FROM_AMOS_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_CLIQUE_FROM_AMOS_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+
+#include <variant>
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Deliberate corruptions of a clique derivation, for testing only.
+     *
+     * \ingroup Innards
+     */
+    namespace clique_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Leave one at-most-one out of the final merge. Note what this does
+        /// and does not do: the `pol` still lands on a perfectly *sound* line,
+        /// just a weaker one, so nothing rejects until the returned line's
+        /// content is pinned. Needs at least three members to have a merge to
+        /// corrupt.
+        struct DropAnAtMostOne
+        {
+        };
+
+        /// Claim the members are all inactive rather than at most one active
+        /// --- the "bound + 1 must fail" check for a rule whose content is a
+        /// number.
+        struct ClaimOneMore
+        {
+        };
+
+        /// Sum every at-most-one at once and divide by `k - 1`, instead of the
+        /// induction. Not a corruption so much as the derivation everyone tries
+        /// first: it is *correct* for two and three members and wrong from four
+        /// on, where it lands on `ceil(k/2)` instead of `k - 1`. Keeping it
+        /// runnable is what stops the induction looking like unnecessary
+        /// ceremony.
+        struct NaiveOneShot
+        {
+        };
+
+        /// Leave the division off the last merge. The line is then *stronger*
+        /// than the clique inequality rather than weaker --- and the pin
+        /// rejects it anyway, because an implication check is syntactic and
+        /// cannot see an equivalence that needs dividing to spot. Kept because
+        /// that is a surprising property to be relying on, and is what a future
+        /// rearrangement of this arithmetic is most likely to break. Needs at
+        /// least three members.
+        struct SkipFinalDivision
+        {
+        };
+    }
+
+    using CliqueMutation = std::variant<clique_mutation::None, clique_mutation::DropAnAtMostOne, clique_mutation::ClaimOneMore,
+        clique_mutation::NaiveOneShot, clique_mutation::SkipFinalDivision>;
+
+    /**
+     * \brief Merge the pairwise at-most-ones of a clique into the clique
+     * inequality: given `~a_p + ~a_q >= 1` for every pair, derive
+     * `sum over members of a_p <= 1`.
+     *
+     * Cutting planes can do this, but not in one step. Summing all `k(k-1)/2`
+     * at-most-ones gives `(k-1) * sum ~a_p >= k(k-1)/2`, and dividing by `k-1`
+     * gives `sum ~a_p >= ceil(k/2)` --- which is the answer for `k` of two or
+     * three and wrong from four on. So the derivation is the classic induction,
+     * growing the clique one member at a time: with the inequality for the
+     * first `m` members in hand, add the `m` at-most-ones tying member `m` to
+     * them, plus `m - 1` copies of the inequality so far, and divide by `m`:
+     *
+     *     m*~a_m + sum_{i<m} ~a_i                >= m            (the m pairs)
+     *             (m-1) * sum_{i<m} ~a_i         >= (m-1)^2      (m-1 copies)
+     *     ------------------------------------------------------------------
+     *     m * ( ~a_m + sum_{i<m} ~a_i )          >= m + (m-1)^2
+     *
+     * and since `m + (m-1)^2 = m(m-1) + 1`, dividing by `m` rounds the degree up
+     * to exactly `m`, which is the inequality for `m + 1` members. That spare
+     * `+1` is the whole margin --- one less and the division would round down to
+     * `m - 1` and the induction would not advance. It is why this works where
+     * summing everything at once does not.
+     *
+     * `at_most_ones[j]` holds `j` lines, one per pair `(i, j)` with `i < j`,
+     * indexed by `i` --- the lower triangle, in the order the induction consumes
+     * it. Each must really be the at-most-one for that pair; nothing here can
+     * check that, and a line that is something else will simply produce a
+     * different result.
+     *
+     * The returned line is pinned to `sum a_p <= 1` with an `ia` step before it
+     * comes back, and that step is not decoration. Dropping an input, or
+     * mis-scaling a merge, leaves the `pol` on a weaker but still sound line
+     * that VeriPB is right to accept --- so without the pin there is no
+     * mutation of this derivation that can be caught, and the caller has no
+     * guarantee that what it got says what it wanted.
+     *
+     * The pin is also stricter than "weaker fails". An implication check is
+     * syntactic, so it rejects a line that is *equivalent* to the target but
+     * differently shaped, and even one that is strictly stronger: leaving the
+     * division off the last merge gives `m*(sum ~a) >= m(m-1)+1`, which implies
+     * the clique inequality mathematically and does not pin
+     * (\ref clique_mutation::SkipFinalDivision covers it). The final division
+     * is therefore load-bearing twice over, and any rearrangement of this
+     * arithmetic that changes the shape of the last line will break the pin
+     * even if it stays sound. On the other hand the pin *normalises*: `ia`
+     * enters the target as a new line and that is what comes back, so a caller
+     * always receives the literal-exact clique inequality.
+     *
+     * Two things it cannot check, which are the caller's to get right: that
+     * `members` are pairwise distinct (a repeat becomes a coefficient-two term
+     * and means something else entirely), and that each line really is the
+     * at-most-one for its pair rather than some other line that happens to
+     * carry the arithmetic.
+     *
+     * Every intermediate is emitted at `level`. Only the returned line needs to
+     * outlive the call, so a caller replaying this across a scheduling horizon
+     * should think about deriving the intermediates at `ProofLevel::Temporary`
+     * and forgetting them: `k^2/2` permanently-live constraints per time point
+     * is a tax on every later unhinted RUP in the proof.
+     *
+     * Writes only derivations: no ProofModel is reachable from here, so nothing
+     * can add to the OPB.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto derive_clique_from_amos(ProofLogger &, const std::vector<ProofLiteralOrFlag> & members,
+        const std::vector<std::vector<ProofLine>> & at_most_ones, ProofLevel, CliqueMutation mutation = clique_mutation::None{}) -> ProofLine;
+}
+
+#endif

--- a/gcs/innards/proofs/clique_from_amos_test.cc
+++ b/gcs/innards/proofs/clique_from_amos_test.cc
@@ -1,0 +1,359 @@
+/* Merging pairwise at-most-ones into a clique inequality.
+ *
+ * Nothing here goes near a Cumulative. The routine's whole job is the cutting-
+ * planes arithmetic, so it is tested on a micro model of `k` fresh flags whose
+ * only constraints are the pairwise at-most-ones --- and that model is
+ * *satisfiable* (everything false satisfies every at-most-one), which matters:
+ * against an unsatisfiable one every RUP step is vacuously valid and a
+ * corrupted derivation would sail through, which is the trap #656 walked into.
+ *
+ * The three claims made here are separate:
+ *
+ *   1. the derivation follows, for cliques of two to twelve;
+ *   2. the line that comes back is the clique inequality and not something
+ *      weaker --- which nothing but the `ia` pin can say, because every step of
+ *      a corrupted merge is still individually sound;
+ *   3. the induction is necessary, which the NaiveOneShot mutation shows by
+ *      being accepted for two and three members and rejected from four on.
+ */
+
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/innards/proofs/clique_from_amos.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::move;
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "clique from amos test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    enum class Model
+    {
+        /// The at-most-ones alone: satisfiable, so every step has to stand up
+        /// on its own.
+        Plain,
+        /// Plus an axiom forcing two members active, which the clique
+        /// inequality must contradict.
+        WithTwoActive
+    };
+
+    auto check(size_t k, CliqueMutation mutation, Model model_kind, const string & tag, bool expect_veripb_to_accept) -> void
+    {
+        auto proof_name = "clique_from_amos_" + to_string(k) + "_" + tag;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+
+        vector<ProofFlag> flags;
+        vector<ProofLiteralOrFlag> members;
+        for (size_t i = 0; i < k; ++i) {
+            auto flag = model.create_proof_flag("member" + to_string(i));
+            flags.push_back(flag);
+            members.push_back(flag);
+        }
+
+        // The lower triangle, in the order the induction consumes it. Labelled,
+        // because a pol step may only reference an OPB row by name.
+        vector<vector<ProofLine>> at_most_ones(k);
+        for (size_t j = 1; j < k; ++j)
+            for (size_t i = 0; i < j; ++i) {
+                WPBSum pair;
+                pair += 1_i * flags[i];
+                pair += 1_i * flags[j];
+                at_most_ones[j].push_back(model.add_labelled_constraint("amo" + to_string(i) + "x" + to_string(j), move(pair) <= 1_i));
+            }
+
+        std::optional<ProofLine> two_active;
+        if (model_kind == Model::WithTwoActive) {
+            WPBSum both;
+            both += 1_i * flags[0];
+            both += 1_i * flags[1];
+            two_active = model.add_labelled_constraint("bothactive", move(both) >= 2_i);
+        }
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        auto clique = derive_clique_from_amos(logger, members, at_most_ones, ProofLevel::Top, mutation);
+
+        if (two_active) {
+            // The clique inequality says at most one is active and the axiom
+            // says two are, so one pol closes it --- and `ia` against the
+            // result insists that it really is a contradiction rather than
+            // something the checker refuted by other means.
+            PolBuilder contradiction;
+            contradiction.add(clique).add(*two_active);
+            auto combined = contradiction.emit(logger, ProofLevel::Top);
+            logger.emit(ImpliesProofRule{combined}, WPBSum{} >= 1_i, ProofLevel::Top);
+            logger.conclude_unsatisfiable(false);
+        }
+        else
+            logger.conclude_none();
+
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_veripb_to_accept) {
+            if (accepted)
+                fail("k=" + to_string(k) + " (" + tag +
+                    "): veripb accepted a proof built from a deliberately corrupted derivation, so the honest one has slack in it");
+            else
+                fail("k=" + to_string(k) + " (" + tag + "): veripb rejected an honest proof");
+        }
+        dispose_of_proof_files(proof_name);
+    }
+
+    /* The at-most-ones this routine consumes have to come from somewhere, and
+     * for #548 they come from a resource constraint `sum c_i x_i <= C`: two
+     * tasks whose demands together exceed the capacity cannot both run. The
+     * recipe is weaken the others out, saturate, divide by the margin.
+     *
+     * Checked here rather than argued, because two things about it are only
+     * decidable by running it: whether the derivation needs `c_u, c_v <= C`
+     * (the arithmetic suggests not, since division rounds coefficients up), and
+     * whether a pair that fits *exactly* is correctly refused.
+     */
+    auto check_pair_at_most_one(
+        const string & name, const vector<Integer> & demands, Integer capacity, size_t u, size_t v, bool expect_veripb_to_accept) -> void
+    {
+        auto proof_name = "clique_from_amos_pair_" + name;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+
+        vector<ProofFlag> flags;
+        WPBSum load;
+        for (size_t i = 0; i < demands.size(); ++i) {
+            flags.push_back(model.create_proof_flag("task" + to_string(i)));
+            load += demands[i] * flags[i];
+        }
+        auto resource = model.add_labelled_constraint("resource", WPBSum{load} <= capacity);
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        // Weakening drops a term and takes its coefficient off the degree, so
+        // what is left after dropping everything but the pair is exactly the
+        // margin by which the two overshoot.
+        auto margin = demands[u] + demands[v] - capacity;
+        PolBuilder pair;
+        pair.add(resource);
+        for (size_t i = 0; i < demands.size(); ++i)
+            if (i != u && i != v)
+                pair.weaken(flags[i], tracker);
+        pair.saturate();
+        // A pair that fits exactly has a margin of zero and no at-most-one to
+        // derive. Dividing by one keeps the step legal so that the claim below
+        // is what fails, which is the point of running the case at all.
+        pair.divide_by(margin > 0_i ? margin : 1_i);
+        auto derived = pair.emit(logger, ProofLevel::Top);
+
+        WPBSum both;
+        both += 1_i * flags[u];
+        both += 1_i * flags[v];
+        logger.emit(ImpliesProofRule{derived}, move(both) <= 1_i, ProofLevel::Top);
+        logger.conclude_none();
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_veripb_to_accept)
+            fail("pair at-most-one (" + name + "): veripb " + (accepted ? "accepted" : "rejected") + " it, expecting the opposite");
+        dispose_of_proof_files(proof_name);
+    }
+
+    /* When several members of a clique draw their conflicts from the SAME
+     * resource row, the pairwise at-most-ones are not the cheapest premises to
+     * work from --- the row itself is stronger than the edges it implies, and
+     * the same weaken/saturate/divide chain lands on the whole sub-clique
+     * inequality in one step, skipping both the pairwise derivations and the
+     * induction over them.
+     *
+     * With `Delta = sum_{K} c_i - C` and `d = min(c_max, Delta)`, dividing
+     * gives `sum_{K} ~a_i >= ceil(Delta / d)`, which is `|K| - 1` exactly when
+     * `Delta > d * (|K| - 2)`. Recorded here as a checked fact rather than an
+     * argument, because it is what should decide how #548's certificate is
+     * built and it is worth knowing where the condition stops holding.
+     *
+     * The same chain with a smaller `ceil(Delta / d)` is a *cardinality* cut
+     * --- `sum a_i <= |K| - ceil(Delta/d)` --- which is valid for sets with no
+     * conflicting pair at all, and which the pairwise machinery cannot see.
+     */
+    auto check_row_gives_clique(
+        const string & name, const vector<Integer> & demands, Integer capacity, Integer expected_at_most, bool expect_veripb_to_accept) -> void
+    {
+        auto proof_name = "clique_from_amos_row_" + name;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+
+        vector<ProofFlag> flags;
+        WPBSum load, all;
+        auto total = 0_i, largest = 0_i;
+        for (size_t i = 0; i < demands.size(); ++i) {
+            flags.push_back(model.create_proof_flag("task" + to_string(i)));
+            load += demands[i] * flags[i];
+            all += 1_i * flags[i];
+            total += demands[i];
+            largest = largest > demands[i] ? largest : demands[i];
+        }
+        auto resource = model.add_labelled_constraint("resource", WPBSum{load} <= capacity);
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        auto delta = total - capacity;
+        auto divisor = largest < delta ? largest : delta;
+        PolBuilder chain;
+        chain.add(resource).saturate().divide_by(divisor);
+        auto derived = chain.emit(logger, ProofLevel::Top);
+
+        logger.emit(ImpliesProofRule{derived}, move(all) <= expected_at_most, ProofLevel::Top);
+        logger.conclude_none();
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_veripb_to_accept)
+            fail("row-to-clique (" + name + "): veripb " + (accepted ? "accepted" : "rejected") + " it, expecting the opposite");
+        dispose_of_proof_files(proof_name);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    if (! can_run_veripb()) {
+        println(cerr, "veripb is not available, and this test is entirely about what it accepts");
+        return EXIT_SUCCESS;
+    }
+
+    // The derivation follows, over the whole range the callers will use. Twelve
+    // is where #548 expects to stop caring: the merge is O(k^2) additions per
+    // time point, so a clique is not something to be casual about.
+    for (size_t k = 2; k <= 12; ++k)
+        check(k, clique_mutation::None{}, Model::Plain, "honest", true);
+    println(cerr, "cliques of 2 to 12 members: derived and verified");
+
+    // And it means what it says: two members active contradicts it.
+    for (size_t k : {2, 3, 5, 8})
+        check(k, clique_mutation::None{}, Model::WithTwoActive, "contradiction", true);
+    println(cerr, "the clique inequality contradicts two active members");
+
+    // Dropping an input from the last merge. Worth being clear about what this
+    // catches: the merge itself stays sound, and lands on a weaker line that
+    // VeriPB would be right to accept. It is the `ia` pin that rejects, which
+    // is the only reason this mutation is a test at all.
+    for (size_t k : {3, 4, 7})
+        check(k, clique_mutation::DropAnAtMostOne{}, Model::Plain, "dropped", false);
+    println(cerr, "veripb rejected a merge missing an at-most-one, as expected");
+
+    // Claiming no member may be active at all.
+    for (size_t k : {2, 3, 6})
+        check(k, clique_mutation::ClaimOneMore{}, Model::Plain, "onemore", false);
+    println(cerr, "veripb rejected the one-stronger claim, as expected");
+
+    // The induction is necessary, and here is where. Summing every at-most-one
+    // and dividing once gives `ceil(k/2)`, which is `k - 1` exactly while
+    // `k <= 3`. So the naive derivation is *accepted* for two and three members
+    // and rejected from four on --- if this boundary ever moves, the argument
+    // for the induction has changed and the comment explaining it is wrong.
+    for (size_t k : {2, 3})
+        check(k, clique_mutation::NaiveOneShot{}, Model::Plain, "naive", true);
+    for (size_t k : {4, 5, 9})
+        check(k, clique_mutation::NaiveOneShot{}, Model::Plain, "naive", false);
+    println(cerr, "the one-shot merge works to three members and fails from four, as the induction's premise says");
+
+    // Where the at-most-ones come from: weaken, saturate, divide by the margin.
+    check_pair_at_most_one("plain", {6_i, 7_i, 3_i, 2_i}, 10_i, 0, 1, true);
+    // Margin of exactly one, with nothing else in the row to hide behind.
+    check_pair_at_most_one("margin_one", {6_i, 5_i}, 10_i, 0, 1, true);
+    // A demand *above* the capacity. The task can never run at all, so the
+    // at-most-one is a weak thing to say about it --- but the derivation does
+    // not care, because saturation caps both coefficients at the margin and the
+    // division rounds them back up to one. This is the case #548 expects to
+    // need a `c_j <= C` side condition for, and it does not: the condition
+    // belongs to clique *discovery*, where a task that can never run would
+    // otherwise pad every clique it touches.
+    check_pair_at_most_one("over_capacity", {1_i, 12_i, 4_i}, 10_i, 0, 1, true);
+    check_pair_at_most_one("both_full", {10_i, 10_i, 1_i}, 10_i, 0, 1, true);
+    // And the camouflage case: a pair summing to *exactly* the capacity fits,
+    // so there is no at-most-one, and veripb says so. An off-by-one in the
+    // conflict test lands here.
+    check_pair_at_most_one("fits_exactly", {6_i, 4_i, 3_i}, 10_i, 0, 1, false);
+    println(cerr, "pair at-most-ones: derived over the capacity, and refused for a pair that fits exactly");
+
+    // Leaving the division off the last merge gives a line that is *stronger*
+    // than the clique inequality, and the pin rejects it regardless, because an
+    // implication check cannot see an equivalence that needs dividing. Not a
+    // corruption to be defended against so much as a property being relied on:
+    // it says the final division is load-bearing for the pin and not only for
+    // the induction.
+    for (size_t k : {3, 5})
+        check(k, clique_mutation::SkipFinalDivision{}, Model::Plain, "nodivide", false);
+    println(cerr, "veripb rejected an undivided --- and strictly stronger --- last merge, as expected");
+
+    // The same chain applied to a whole resource row at once, which is what
+    // #548 should be doing wherever a row covers three or more clique members.
+    check_row_gives_clique("four_sixes", {6_i, 6_i, 6_i, 6_i}, 10_i, 1_i, true);
+    check_row_gives_clique("two_sixes_a_nine", {6_i, 6_i, 9_i}, 10_i, 1_i, true);
+    // Unbalanced demands push `d` up until the condition fails: Delta = 17 is
+    // not more than d(|K| - 2) = 18, so the one-shot lands on `<= 2` and the
+    // clique inequality has to be reached the long way round.
+    check_row_gives_clique("unbalanced", {9_i, 6_i, 6_i, 6_i}, 10_i, 1_i, false);
+    check_row_gives_clique("unbalanced_weaker", {9_i, 6_i, 6_i, 6_i}, 10_i, 2_i, true);
+    // And with no conflicting pair at all --- 4 + 4 fits under 10 --- the same
+    // chain still yields a cardinality cut, which nothing built out of pairwise
+    // at-most-ones could ever produce.
+    check_row_gives_clique("no_conflicting_pair", {4_i, 4_i, 4_i}, 10_i, 2_i, true);
+    println(cerr, "a shared resource row gives its sub-clique in one step, and a cardinality cut where no pair conflicts");
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/innards/proofs/flag_bridge.cc
+++ b/gcs/innards/proofs/flag_bridge.cc
@@ -1,0 +1,91 @@
+#include <gcs/innards/proofs/flag_bridge.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::size_t;
+using std::string;
+using std::to_string;
+using std::vector;
+
+namespace
+{
+    // A fully reified flag's two halves, under the labels ProofModel gives
+    // them: `[r]` is `flag -> ineq` and `[f]` is `ineq -> flag`. The names read
+    // backwards, which is ProofModel's doing and not worth diverging from here.
+    //
+    // Built from the flag's full PB rendering rather than from name_of, which
+    // for a flag made from a plain stem returns just that stem and would name
+    // the wrong row --- or none. ProofModel labels these halves the same way,
+    // and says so where it does it.
+    [[nodiscard]] auto label_base(const NamesAndIDsTracker & tracker, const ProofFlag & flag) -> string
+    {
+        if (! flag.positive)
+            throw ProofError{"flag bridge: bridging a negated flag, whose reification halves are labelled under the positive one"};
+        return tracker.pb_file_string_for(flag);
+    }
+
+    [[nodiscard]] auto implies_condition(const NamesAndIDsTracker & tracker, const ProofFlag & flag) -> ProofLineLabel
+    {
+        return ProofLineLabel{label_base(tracker, flag) + "[r]"};
+    }
+
+    [[nodiscard]] auto implied_by_condition(const NamesAndIDsTracker & tracker, const ProofFlag & flag) -> ProofLineLabel
+    {
+        return ProofLineLabel{label_base(tracker, flag) + "[f]"};
+    }
+}
+
+auto gcs::innards::derive_flag_bridge(ProofLogger & logger, const ProofFlag & from, const ProofFlag & to, ProofLevel level) -> ProofLine
+{
+    auto & tracker = logger.names_and_ids_tracker();
+
+    // `from -> ineq` plus `ineq -> to`. The inequality goes in once with each
+    // sign, so all of it cancels --- however many variables and bits it
+    // mentions --- and saturation turns the remainder into the clause.
+    PolBuilder bridge;
+    bridge.add(implies_condition(tracker, from));
+    bridge.add(implied_by_condition(tracker, to));
+    bridge.saturate();
+    return bridge.emit(logger, level);
+}
+
+auto gcs::innards::derive_conjunction_flag_bridge(ProofLogger & logger, const ProofFlag & from, const vector<ProofFlag> & from_conjuncts,
+    const ProofFlag & to, const vector<ProofFlag> & to_conjuncts, ProofLevel level) -> ProofLine
+{
+    if (from_conjuncts.size() != to_conjuncts.size())
+        throw ProofError{"conjunction bridge: " + to_string(from_conjuncts.size()) + " conjuncts on one side and " + to_string(to_conjuncts.size()) +
+            " on the other, so they cannot correspond"};
+    if (from_conjuncts.empty())
+        throw ProofError{"conjunction bridge: no conjuncts to bridge"};
+
+    auto & tracker = logger.names_and_ids_tracker();
+
+    // Bridge the conjuncts first: those *are* reified on the same inequality as
+    // each other, one pol apiece.
+    vector<ProofLine> conjunct_bridges;
+    conjunct_bridges.reserve(from_conjuncts.size());
+    for (size_t i = 0; i < from_conjuncts.size(); ++i)
+        conjunct_bridges.push_back(derive_flag_bridge(logger, from_conjuncts[i], to_conjuncts[i], level));
+
+    // Then every conjunct appears once positively (out of `from`'s [r] half,
+    // which says all of them hold) and once negatively (out of `to`'s [f] half,
+    // which says one of them fails), with the bridges carrying each across.
+    // They all cancel, and saturation clears the multiplicities the
+    // conjunction's arity leaves behind.
+    PolBuilder combine;
+    combine.add(implies_condition(tracker, from));
+    for (const auto & bridge : conjunct_bridges)
+        combine.add(bridge);
+    combine.add(implied_by_condition(tracker, to));
+    combine.saturate();
+    return combine.emit(logger, level);
+}

--- a/gcs/innards/proofs/flag_bridge.hh
+++ b/gcs/innards/proofs/flag_bridge.hh
@@ -1,0 +1,67 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_FLAG_BRIDGE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_INNARDS_PROOFS_FLAG_BRIDGE_HH
+
+#include <gcs/innards/proofs/proof_line.hh>
+#include <gcs/innards/proofs/proof_logger-fwd.hh>
+#include <gcs/innards/proofs/proof_only_variables.hh>
+
+#include <vector>
+
+namespace gcs::innards
+{
+    /**
+     * \brief Derive `from -> to`, as the line `~from + to >= 1`, for two flags
+     * fully reified on inequalities over the same terms.
+     *
+     * One `pol`, and it is worth seeing why it is only one. A fully reified flag
+     * emits `g -> ineq` under `[r]` and `ineq -> g` under `[f]`. Adding `from`'s
+     * `[r]` to `to`'s `[f]` puts the two inequalities in with opposite signs, so
+     * their terms cancel --- including all the bits of any integer variable they
+     * mention --- and what is left after saturation is the two-literal clause.
+     * No order literals, no bit reasoning, no dependence on what the conditions
+     * actually say.
+     *
+     * What it does depend on is the terms cancelling and the constants leaving
+     * something behind: for `from <-> (e <= p)` and `to <-> (e <= q)` over the
+     * same expression `e`, the sum has degree `q - p + 1`, so the derivation
+     * goes through exactly when `q >= p` --- which is exactly when the
+     * implication is true. Identical conditions are the case this exists for,
+     * and give a degree of one; a `to` whose condition is strictly weaker also
+     * works, and a stronger one correctly does not.
+     *
+     * There is no way for this to derive something false, since every step is a
+     * `pol`. What a caller has to check is that the line it got back says what
+     * it wanted --- pin it, as everything else in this directory does.
+     *
+     * This is what lets one constraint's proof speak about another's flags ---
+     * the multi-donor bridging sketched in the derived-Cumulative writeup, and
+     * what an inferred constraint over tasks drawn from several resources needs
+     * before it can say anything about them at all.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto derive_flag_bridge(ProofLogger &, const ProofFlag & from, const ProofFlag & to, ProofLevel) -> ProofLine;
+
+    /**
+     * \brief As derive_flag_bridge, for two flags each fully reified
+     * as the *conjunction* of some other flags: derive `from -> to`, given that
+     * the conjuncts correspond in order and each corresponding pair is reified
+     * on the same inequality.
+     *
+     * The conjuncts cannot be bridged by the one-`pol` trick directly, because
+     * `from` and `to` are reified on conditions that mention *different* flags
+     * and so do not cancel. What does work is bridging each conjunct --- those
+     * do reify the same inequality --- and then adding `from`'s `[r]` half, the
+     * conjunct bridges, and `to`'s `[f]` half: each conjunct then appears with
+     * both signs and drops out, leaving `~from + to` after saturation.
+     *
+     * This is `Cumulative`'s `active <-> before /\ after` exactly, which is what
+     * it exists for.
+     *
+     * \ingroup Innards
+     */
+    [[nodiscard]] auto derive_conjunction_flag_bridge(ProofLogger &, const ProofFlag & from, const std::vector<ProofFlag> & from_conjuncts,
+        const ProofFlag & to, const std::vector<ProofFlag> & to_conjuncts, ProofLevel) -> ProofLine;
+}
+
+#endif

--- a/gcs/innards/proofs/flag_bridge_test.cc
+++ b/gcs/innards/proofs/flag_bridge_test.cc
@@ -1,0 +1,171 @@
+/* Bridging one constraint's flags to another's.
+ *
+ * The whole point is that this costs one `pol` and knows nothing about what the
+ * flags mean: two flags fully reified on the same inequality cancel it away
+ * between them. So the tests are micro models with a couple of integer
+ * variables and flags reified over them, and what is checked is that veripb
+ * accepts the bridge, that the bridge really does force what it claims, and
+ * that flags reified on *different* conditions are not bridgeable --- which is
+ * the failure mode, since nothing in the API can tell the two cases apart.
+ */
+
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/innards/proofs/flag_bridge.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/proof_model.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::move;
+using std::string;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "flag bridge test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    /* Two flags reified on `start <= t`, as two separate constraints would
+     * write them, bridged. `shift` offsets the second flag's condition, so a
+     * positive shift makes the target weaker (and the implication true) and a
+     * negative one makes it stronger (and the implication false).
+     */
+    auto check_same_condition(const string & name, Integer t, Integer shift, bool expect_veripb_to_accept) -> void
+    {
+        auto proof_name = "flag_bridge_same_" + name;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+
+        SimpleIntegerVariableID start{0};
+        model.set_up_integer_variable(start, 0_i, 10_i, "start", std::nullopt);
+        auto from = model.create_proof_flag_fully_reifying("from", WPBSum{} + 1_i * start <= t);
+        auto to = model.create_proof_flag_fully_reifying("to", WPBSum{} + 1_i * start <= t + shift);
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        auto bridge = derive_flag_bridge(logger, from, to, ProofLevel::Top);
+
+        // And it says what it is for: `from` implies `to`. Pinned, because a
+        // pol that landed somewhere weaker would otherwise pass unnoticed ---
+        // the same reason every other derivation in this directory pins.
+        logger.emit(ImpliesProofRule{bridge}, WPBSum{} + 1_i * ! from + 1_i * to >= 1_i, ProofLevel::Top);
+        logger.conclude_none();
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_veripb_to_accept)
+            fail("same-condition bridge (" + name + "): veripb " + (accepted ? "accepted" : "rejected") + " it, expecting the opposite");
+        dispose_of_proof_files(proof_name);
+    }
+
+    /* Cumulative's shape: `active <-> before /\ after`, written twice over the
+     * same start variable as two posted constraints would, and bridged. This is
+     * the one an inferred constraint over several resources actually needs.
+     */
+    auto check_conjunction(const string & name, Integer length, Integer other_length, bool expect_veripb_to_accept) -> void
+    {
+        auto proof_name = "flag_bridge_conj_" + name;
+        ProofOptions proof_options{proof_name};
+        NamesAndIDsTracker tracker(proof_options);
+        ProofModel model(proof_options, tracker);
+
+        const auto t = 4_i;
+        SimpleIntegerVariableID start{0};
+        model.set_up_integer_variable(start, 0_i, 10_i, "start", std::nullopt);
+
+        auto make = [&](const string & side, Integer p) {
+            auto before = model.create_proof_flag_fully_reifying(side + "before", WPBSum{} + 1_i * start <= t);
+            auto after = model.create_proof_flag_fully_reifying(side + "after", WPBSum{} + -1_i * start <= -(t - p + 1_i));
+            auto active = model.create_proof_flag_fully_reifying(side + "active", WPBSum{} + -1_i * before + -1_i * after <= -2_i);
+            return std::tuple{before, after, active};
+        };
+
+        auto [from_before, from_after, from_active] = make("from", length);
+        auto [to_before, to_after, to_active] = make("to", other_length);
+        model.finalise();
+
+        ProofLogger logger(proof_options, tracker);
+        tracker.switch_from_model_to_proof(&logger);
+        logger.start_proof(model);
+        tracker.emit_delayed_proof_steps();
+
+        auto bridge =
+            derive_conjunction_flag_bridge(logger, from_active, {from_before, from_after}, to_active, {to_before, to_after}, ProofLevel::Top);
+
+        logger.emit(ImpliesProofRule{bridge}, WPBSum{} + 1_i * ! from_active + 1_i * to_active >= 1_i, ProofLevel::Top);
+        logger.conclude_none();
+        tracker.finalise();
+
+        auto accepted = run_veripb(proof_name + ".opb", proof_name + ".pbp");
+        if (accepted != expect_veripb_to_accept)
+            fail("conjunction bridge (" + name + "): veripb " + (accepted ? "accepted" : "rejected") + " it, expecting the opposite");
+        dispose_of_proof_files(proof_name);
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+
+    if (! can_run_veripb()) {
+        println(cerr, "veripb is not available, and this test is entirely about what it accepts");
+        return EXIT_SUCCESS;
+    }
+
+    check_same_condition("identical", 4_i, 0_i, true);
+    // A `to` reified one unit *weaker* bridges too, and should: `start <= 4`
+    // really does imply `start <= 5`. Worth pinning down, because it says the
+    // routine is not doing a syntactic equality check on the conditions --- it
+    // is doing the arithmetic, and the arithmetic is what decides.
+    check_same_condition("weaker_target", 4_i, 1_i, true);
+    // One unit *stronger* is a false implication, and the cancellation leaves
+    // nothing to saturate into a clause. This is the direction a caller can get
+    // wrong, and nothing but running it says so.
+    check_same_condition("stronger_target", 4_i, -1_i, false);
+    println(cerr, "flag bridges: derived where the implication holds, refused where it does not");
+
+    check_conjunction("identical", 3_i, 3_i, true);
+    // Two resources cannot disagree about a task's duration, but if the caller
+    // ever pairs up the wrong tasks that is what it looks like from here: `to`'s
+    // `after` is then the stronger condition and the conjunct bridge fails.
+    check_conjunction("shorter_target", 3_i, 2_i, false);
+    println(cerr, "conjunction bridges: derived for matching conjuncts, refused for mismatched ones");
+
+    return EXIT_SUCCESS;
+}

--- a/gcs/innards/proofs/pseudo_boolean.hh
+++ b/gcs/innards/proofs/pseudo_boolean.hh
@@ -4,6 +4,8 @@
 #include <gcs/expression.hh>
 #include <gcs/innards/proofs/proof_only_variables.hh>
 
+#include <util/overloaded.hh>
+
 namespace gcs::innards
 {
     /**
@@ -20,6 +22,26 @@ namespace gcs::innards
     using WPBSumLE = SumLessThanEqual<Weighted<PseudoBooleanTerm>>;
 
     using WPBSumEq = SumEquals<Weighted<PseudoBooleanTerm>>;
+
+    /**
+     * \brief Add `coefficient * term` to a sum, over the three things a
+     * ProofLiteralOrFlag can be.
+     *
+     * Every alternative of ProofLiteralOrFlag is also one of
+     * PseudoBooleanTerm, so this only widens --- but widening a variant is a
+     * visit rather than a conversion, and it is worth writing once rather than
+     * once per caller that takes its terms in the narrower type.
+     *
+     * \ingroup Innards
+     */
+    inline auto add_term_to(WPBSum & sum, Integer coefficient, const ProofLiteralOrFlag & term) -> void
+    {
+        overloaded{                                                      //
+            [&](const ProofLiteral & l) { sum += coefficient * l; },     //
+            [&](const ProofFlag & f) { sum += coefficient * f; },        //
+            [&](const ProofBitVariable & b) { sum += coefficient * b; }} //
+            .visit(term);
+    }
 }
 
 #endif

--- a/gcs/innards/proofs/subset_sum_strengthening.cc
+++ b/gcs/innards/proofs/subset_sum_strengthening.cc
@@ -24,15 +24,6 @@ using std::vector;
 
 namespace
 {
-    auto add_term_to(WPBSum & sum, Integer coefficient, const ProofLiteralOrFlag & term) -> void
-    {
-        overloaded{                                                      //
-            [&](const ProofLiteral & l) { sum += coefficient * l; },     //
-            [&](const ProofFlag & f) { sum += coefficient * f; },        //
-            [&](const ProofBitVariable & b) { sum += coefficient * b; }} //
-            .visit(term);
-    }
-
     // The file-format literal for a term, so that it can be pushed onto a pol
     // stack as a literal axiom (`x >= 0`). Constants have no literal, and an
     // item that is always in or always out of the sum is a caller error rather

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -263,16 +263,22 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                 [](const cumulative_strengthening_mutation::BogusDivisor &) -> SubsetSumMutation { return subset_sum_mutation::BogusDivisor{}; }},
             _mutation);
 
-        DerivedCumulativeSpec spec{.donor = donor_id,
-            .starts = starts,
-            .lengths = data->lengths,
-            .heights = heights,
+        DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, data->lengths, heights),
             .capacity = kappa,
+            .row_donors = {donor_id},
             .recipe = [donor_id, heights, capacity, kappa, by_time, stats, subset_sum_corruption](
-                          ProofLogger & recipe_logger, ProofLine donor_row, Integer t) -> ProofLine {
+                          ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
                 auto point = by_time.find(t);
                 if (point == by_time.end())
                     throw ProofError{"cumulative strengthening: no time point worked out for " + to_string(t.raw_value)};
+
+                // The donor is the only row source, and it wrote a row wherever
+                // this constraint has one, since they cover the same tasks.
+                auto donor_row_at = rows.find(donor_id);
+                if (donor_row_at == rows.end())
+                    throw ProofError{"cumulative strengthening: the donor has no capacity row at time " + to_string(t.raw_value) +
+                        ", which cannot happen for a constraint derived over all of its tasks"};
+                auto donor_row = donor_row_at->second;
 
                 vector<SubsetSumItem> items;
                 for (auto i : point->second.tasks) {

--- a/gcs/presolvers/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive.hh
@@ -1,0 +1,6 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INFERRED_DISJUNCTIVE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INFERRED_DISJUNCTIVE_HH
+
+#include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
+
+#endif

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -102,8 +102,14 @@ InferredDisjunctive::InferredDisjunctive(shared_ptr<InferredDisjunctiveStats> st
     _stats(move(stats)), _max_candidates(100), _max_posted(5), _min_clique_size(3),
     // Energy only: a conflicting pair is already kept apart by the resource
     // that witnesses it, so an inferred constraint's time-tabling is redundant.
-    _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true})
+    _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(inferred_disjunctive_mutation::None{})
 {
+}
+
+auto InferredDisjunctive::with_proof_mutation(InferredDisjunctiveMutation mutation) -> InferredDisjunctive &
+{
+    _mutation = mutation;
+    return *this;
 }
 
 auto InferredDisjunctive::with_budgets(size_t max_candidates, size_t max_posted) -> InferredDisjunctive &
@@ -131,6 +137,10 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         if (_stats)
             (*_stats).*field += by;
     };
+
+    auto claim_rhs_zero = std::holds_alternative<inferred_disjunctive_mutation::ClaimRhsZero>(_mutation);
+    auto bridge_wrong_task = std::holds_alternative<inferred_disjunctive_mutation::BridgeWrongTask>(_mutation);
+    auto include_non_conflicting = std::holds_alternative<inferred_disjunctive_mutation::IncludeNonConflicting>(_mutation);
 
     // Collect the tasks, keyed by start variable so that the same task on two
     // resources is one node of the conflict graph.
@@ -297,6 +307,51 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         found.push_back(move(clique));
     }
 
+    // The camouflage mutation: extend one clique with a task that is
+    // *compatible* with its members, inventing the conflict record the
+    // certificate would need. A pair whose demands sum to exactly the capacity
+    // looks like a conflict to an off-by-one and is not one, and the
+    // at-most-one for it cannot be derived --- which is what has to be caught.
+    if (include_non_conflicting && ! found.empty()) {
+        auto & clique = found.front();
+        for (size_t w = 0; w < tasks.size(); ++w) {
+            if (std::find(clique.begin(), clique.end(), w) != clique.end())
+                continue;
+
+            // Every member has to at least share a resource with it, or there
+            // would be no row to build a bogus at-most-one on.
+            vector<pair<size_t, Conflict>> invented;
+            bool usable = true;
+            for (auto member : clique) {
+                if (conflict[member][w]) {
+                    invented.emplace_back(member, *conflict[member][w]);
+                    continue;
+                }
+                optional<Conflict> shared;
+                for (const auto & aw : tasks[w].appearances)
+                    for (const auto & am : tasks[member].appearances)
+                        if (aw.donor == am.donor && ! shared)
+                            shared = Conflict{aw.donor, am.position, aw.position, 1_i};
+                if (! shared) {
+                    usable = false;
+                    break;
+                }
+                invented.emplace_back(member, *shared);
+            }
+            if (! usable)
+                continue;
+
+            for (const auto & [member, c] : invented)
+                if (! conflict[member][w]) {
+                    conflict[member][w] = c;
+                    conflict[w][member] = Conflict{c.witness, c.witness_position_v, c.witness_position_u, c.margin};
+                }
+            clique.push_back(w);
+            std::sort(clique.begin(), clique.end());
+            break;
+        }
+    }
+
     bump(&InferredDisjunctiveStats::cliques_found, found.size());
 
     // Rank by the capacity-bound metric, which at unit coefficients is just the
@@ -359,7 +414,7 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
         DerivedCumulativeSpec spec{.tasks = derived_tasks,
             .capacity = 1_i,
             .row_donors = vector<ConstraintID>{row_donors.begin(), row_donors.end()},
-            .recipe = [members, task_data, conflicts, resource_size, stats](
+            .recipe = [members, task_data, conflicts, resource_size, stats, claim_rhs_zero, bridge_wrong_task](
                           ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
                 auto & tracker = recipe_logger.names_and_ids_tracker();
 
@@ -453,23 +508,29 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
                         pair_amo.saturate();
                         pair_amo.divide_by(c.margin);
 
-                        auto bridged_u = bridge_to(here[a], c.witness, c.witness_position_u);
+                        // Bridging a task onto the *other* task's flags leaves
+                        // its own term uncancelled, so what is merged is not the
+                        // at-most-one for this pair at all.
+                        // Carrying the at-most-one onto this constraint's own
+                        // flags continues the same `pol` rather than starting
+                        // another: the bridges just go on the stack, each
+                        // cancelling its task's term and leaving the other, and
+                        // one saturation clears up after all of it. A line per
+                        // pair per time point saved, which over a horizon is the
+                        // difference worth having.
+                        auto bridged_u = bridge_to(here[a], c.witness, bridge_wrong_task ? c.witness_position_v : c.witness_position_u);
                         auto bridged_v = bridge_to(here[b], c.witness, c.witness_position_v);
-                        if (bridged_u || bridged_v) {
-                            PolBuilder carry;
-                            carry.add(pair_amo.emit(recipe_logger, ProofLevel::Top));
-                            if (bridged_u)
-                                carry.add(*bridged_u);
-                            if (bridged_v)
-                                carry.add(*bridged_v);
-                            carry.saturate();
-                            at_most_ones[b].push_back(carry.emit(recipe_logger, ProofLevel::Top));
-                        }
-                        else
-                            at_most_ones[b].push_back(pair_amo.emit(recipe_logger, ProofLevel::Top));
+                        if (bridged_u)
+                            pair_amo.add(*bridged_u);
+                        if (bridged_v)
+                            pair_amo.add(*bridged_v);
+                        if (bridged_u || bridged_v)
+                            pair_amo.saturate();
+                        at_most_ones[b].push_back(pair_amo.emit(recipe_logger, ProofLevel::Top));
                     }
 
-                return derive_clique_from_amos(recipe_logger, flags, at_most_ones, ProofLevel::Top);
+                return derive_clique_from_amos(recipe_logger, flags, at_most_ones, ProofLevel::Top,
+                    claim_rhs_zero ? CliqueMutation{clique_mutation::ClaimOneMore{}} : CliqueMutation{clique_mutation::None{}});
             },
             .rules = _rules};
 
@@ -502,5 +563,6 @@ auto InferredDisjunctive::clone() const -> unique_ptr<Presolver>
     result->with_budgets(_max_candidates, _max_posted);
     result->with_minimum_clique_size(_min_clique_size);
     result->with_rules(_rules);
+    result->with_proof_mutation(_mutation);
     return result;
 }

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -1,0 +1,506 @@
+#include <gcs/constraint_id.hh>
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/cumulative/derived_cumulative.hh>
+#include <gcs/exception.hh>
+#include <gcs/innards/proofs/clique_from_amos.hh>
+#include <gcs/innards/proofs/flag_bridge.hh>
+#include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
+#include <gcs/innards/proofs/proof_error.hh>
+#include <gcs/innards/proofs/proof_logger.hh>
+#include <gcs/innards/proofs/pseudo_boolean.hh>
+#include <gcs/innards/state.hh>
+#include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
+#include <gcs/problem.hh>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gcs;
+using namespace gcs::innards;
+
+using std::make_unique;
+using std::map;
+using std::move;
+using std::optional;
+using std::pair;
+using std::set;
+using std::shared_ptr;
+using std::size_t;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+namespace
+{
+    /// One appearance of a task on a resource: which donor, where in it, and
+    /// what it demands there.
+    struct Appearance
+    {
+        ConstraintID donor;
+        size_t position;
+        Integer height;
+    };
+
+    /// A task, as the conflict graph sees it. Identified by its start variable,
+    /// which is what makes two donors' entries the same task.
+    struct Task
+    {
+        IntegerVariableID start;
+        Integer length;
+        Integer t_lo, t_hi;
+        vector<Appearance> appearances;
+    };
+
+    /// A resource, once confirmed usable.
+    struct Resource
+    {
+        ConstraintID id;
+        Integer capacity;
+        /// How many tasks it was posted over, which is how far a weakening
+        /// sweep has to go: positions with no flags are simply skipped.
+        size_t size;
+    };
+
+    /// Why a pair conflicts: the resource that cannot hold both, and the margin
+    /// by which it cannot.
+    struct Conflict
+    {
+        ConstraintID witness;
+        size_t witness_position_u, witness_position_v;
+        Integer margin;
+    };
+
+    [[nodiscard]] auto constant_value_of(const IntegerVariableID & v) -> optional<Integer>
+    {
+        if (! is_constant_variable(v))
+            return std::nullopt;
+        return std::get<ConstantIntegerVariableID>(v).const_value;
+    }
+
+    /// The flags a task's activity is expressed in, on one resource, at one
+    /// time. Absent when that resource never encoded the pair.
+    [[nodiscard]] auto flags_for(const NamesAndIDsTracker & tracker, const ConstraintID & donor, size_t position, Integer t)
+        -> optional<std::tuple<ProofFlag, ProofFlag, ProofFlag>>
+    {
+        auto before = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::before_flag_key(position, t));
+        auto after = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::after_flag_key(position, t));
+        auto active = tracker.find_proof_flag_values(donor, ConstraintProofModelData<Cumulative>::active_flag_key(position, t));
+        if (! before || ! after || ! active)
+            return std::nullopt;
+        return std::tuple{*before, *after, *active};
+    }
+}
+
+InferredDisjunctive::InferredDisjunctive(shared_ptr<InferredDisjunctiveStats> stats) :
+    _stats(move(stats)), _max_candidates(100), _max_posted(5), _min_clique_size(3),
+    // Energy only: a conflicting pair is already kept apart by the resource
+    // that witnesses it, so an inferred constraint's time-tabling is redundant.
+    _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true})
+{
+}
+
+auto InferredDisjunctive::with_budgets(size_t max_candidates, size_t max_posted) -> InferredDisjunctive &
+{
+    _max_candidates = max_candidates;
+    _max_posted = max_posted;
+    return *this;
+}
+
+auto InferredDisjunctive::with_minimum_clique_size(size_t size) -> InferredDisjunctive &
+{
+    _min_clique_size = size;
+    return *this;
+}
+
+auto InferredDisjunctive::with_rules(CumulativeRules rules) -> InferredDisjunctive &
+{
+    _rules = rules;
+    return *this;
+}
+
+auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, State & state, ProofLogger * const logger) -> bool
+{
+    auto bump = [&](size_t InferredDisjunctiveStats::* field, size_t by = 1) {
+        if (_stats)
+            (*_stats).*field += by;
+    };
+
+    // Collect the tasks, keyed by start variable so that the same task on two
+    // resources is one node of the conflict graph.
+    vector<Task> tasks;
+    map<IntegerVariableID, size_t> task_of_start;
+    vector<Resource> resources;
+
+    for (const auto & donor : problem.each_constraint_of_type<Cumulative>()) {
+        bump(&InferredDisjunctiveStats::donors_seen);
+
+        if (! donor.presences().empty()) {
+            bump(&InferredDisjunctiveStats::declined_optional);
+            if (logger)
+                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", optional tasks");
+            continue;
+        }
+
+        auto capacity = constant_value_of(donor.capacity());
+        if (! capacity) {
+            bump(&InferredDisjunctiveStats::declined_variable_arguments);
+            if (logger)
+                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", variable capacity");
+            continue;
+        }
+
+        vector<Integer> lengths, heights;
+        bool constant = true;
+        for (const auto & l : donor.lengths()) {
+            auto value = constant_value_of(l);
+            constant = constant && value.has_value();
+            lengths.push_back(value.value_or(0_i));
+        }
+        for (const auto & h : donor.heights()) {
+            auto value = constant_value_of(h);
+            constant = constant && value.has_value();
+            heights.push_back(value.value_or(0_i));
+        }
+        if (! constant) {
+            bump(&InferredDisjunctiveStats::declined_variable_arguments);
+            if (logger)
+                logger->emit_proof_comment("presolve disjunctive: declining " + as_string(donor.constraint_id()) + ", variable lengths or heights");
+            continue;
+        }
+
+        const auto & starts = donor.starts();
+        resources.push_back(Resource{donor.constraint_id(), *capacity, starts.size()});
+
+        for (size_t i = 0; i < starts.size(); ++i) {
+            // A task that cannot load this resource has no flags on it, so it
+            // is not reachable through it even if it is listed.
+            if (lengths[i] <= 0_i || heights[i] <= 0_i)
+                continue;
+
+            auto found = task_of_start.find(starts[i]);
+            if (found == task_of_start.end()) {
+                auto [s_lo, s_hi] = state.bounds(starts[i]);
+                found = task_of_start.emplace(starts[i], tasks.size()).first;
+                tasks.push_back(Task{starts[i], lengths[i], s_lo, s_hi + lengths[i] - 1_i, {}});
+            }
+            else if (tasks[found->second].length != lengths[i]) {
+                // Two resources disagreeing about a duration is not something
+                // to average over: the flags would reify different conditions
+                // and no bridge between them exists.
+                continue;
+            }
+
+            tasks[found->second].appearances.push_back(Appearance{donor.constraint_id(), i, heights[i]});
+        }
+    }
+
+    bump(&InferredDisjunctiveStats::tasks, tasks.size());
+    if (tasks.size() < _min_clique_size)
+        return true;
+
+    // The conflict graph. A pair conflicts if some one resource cannot hold
+    // both; the first such resource found is the witness the certificate will
+    // use, since any of them proves the same at-most-one.
+    map<ConstraintID, Integer> capacity_of;
+    map<ConstraintID, size_t> resource_size;
+    for (const auto & resource : resources) {
+        capacity_of.emplace(resource.id, resource.capacity);
+        resource_size.emplace(resource.id, resource.size);
+    }
+
+    vector<vector<optional<Conflict>>> conflict(tasks.size(), vector<optional<Conflict>>(tasks.size()));
+    vector<pair<size_t, size_t>> candidate_pairs;
+    for (size_t u = 0; u < tasks.size(); ++u)
+        for (size_t v = u + 1; v < tasks.size(); ++v) {
+            for (const auto & au : tasks[u].appearances) {
+                for (const auto & av : tasks[v].appearances) {
+                    if (au.donor != av.donor)
+                        continue;
+                    auto capacity = capacity_of.at(au.donor);
+                    if (au.height + av.height <= capacity)
+                        continue;
+                    conflict[u][v] = conflict[v][u] = Conflict{au.donor, au.position, av.position, au.height + av.height - capacity};
+                    break;
+                }
+                if (conflict[u][v])
+                    break;
+            }
+
+            if (conflict[u][v]) {
+                bump(&InferredDisjunctiveStats::conflicting_pairs);
+                candidate_pairs.emplace_back(u, v);
+            }
+        }
+
+    if (candidate_pairs.empty())
+        return true;
+
+    // Grow each candidate pair into a maximal clique, taking the longest task
+    // first --- the unit-coefficient reading of Sidorov's lifting order, and
+    // the one that maximises the energy the resulting constraint can argue
+    // about.
+    auto grow = [&](size_t u, size_t v) -> vector<size_t> {
+        vector<size_t> clique{u, v};
+        vector<size_t> candidates;
+        for (size_t w = 0; w < tasks.size(); ++w)
+            if (w != u && w != v && conflict[u][w] && conflict[v][w])
+                candidates.push_back(w);
+
+        std::sort(candidates.begin(), candidates.end(), [&](size_t a, size_t b) {
+            if (tasks[a].length != tasks[b].length)
+                return tasks[a].length > tasks[b].length;
+            return a < b;
+        });
+
+        for (auto w : candidates) {
+            bool joins = true;
+            for (auto member : clique)
+                if (! conflict[member][w]) {
+                    joins = false;
+                    break;
+                }
+            if (joins)
+                clique.push_back(w);
+        }
+
+        std::sort(clique.begin(), clique.end());
+        return clique;
+    };
+
+    vector<vector<size_t>> found;
+    set<vector<size_t>> seen;
+    size_t considered = 0;
+    for (const auto & [u, v] : candidate_pairs) {
+        if (considered >= _max_candidates) {
+            bump(&InferredDisjunctiveStats::dropped_over_budget, candidate_pairs.size() - considered);
+            if (logger)
+                logger->emit_proof_comment("presolve disjunctive: " + to_string(candidate_pairs.size() - considered) +
+                    " candidate pairs left ungrown, against a budget of " + to_string(_max_candidates));
+            break;
+        }
+        ++considered;
+
+        auto clique = grow(u, v);
+        if (clique.size() < _min_clique_size) {
+            bump(&InferredDisjunctiveStats::dropped_too_small);
+            continue;
+        }
+        if (! seen.insert(clique).second)
+            continue;
+        found.push_back(move(clique));
+    }
+
+    bump(&InferredDisjunctiveStats::cliques_found, found.size());
+
+    // Rank by the capacity-bound metric, which at unit coefficients is just the
+    // total duration the clique must serialise, and drop any clique contained
+    // in one already accepted.
+    std::sort(found.begin(), found.end(), [&](const vector<size_t> & a, const vector<size_t> & b) {
+        auto total = [&](const vector<size_t> & c) {
+            auto sum = 0_i;
+            for (auto i : c)
+                sum += tasks[i].length;
+            return sum;
+        };
+        auto ta = total(a), tb = total(b);
+        if (ta != tb)
+            return ta > tb;
+        return a < b;
+    });
+
+    vector<vector<size_t>> accepted;
+    for (auto & clique : found) {
+        if (accepted.size() >= _max_posted) {
+            bump(&InferredDisjunctiveStats::dropped_over_budget);
+            if (logger)
+                logger->emit_proof_comment("presolve disjunctive: a clique beyond the output budget of " + to_string(_max_posted) + " was dropped");
+            continue;
+        }
+
+        bool subsumed = false;
+        for (const auto & already : accepted)
+            if (std::includes(already.begin(), already.end(), clique.begin(), clique.end())) {
+                subsumed = true;
+                break;
+            }
+        if (subsumed) {
+            bump(&InferredDisjunctiveStats::dropped_subset);
+            continue;
+        }
+
+        accepted.push_back(move(clique));
+    }
+
+    for (const auto & clique : accepted) {
+        // Each member's flags come from its first appearance; the certificate
+        // bridges a pair's witness across to those where they differ.
+        vector<DerivedCumulativeTask> derived_tasks;
+        set<ConstraintID> row_donors;
+        for (auto i : clique) {
+            const auto & home = tasks[i].appearances.front();
+            derived_tasks.push_back(DerivedCumulativeTask{home.donor, home.position, tasks[i].start, tasks[i].length, 1_i});
+        }
+        for (size_t a = 0; a < clique.size(); ++a)
+            for (size_t b = a + 1; b < clique.size(); ++b)
+                row_donors.insert(conflict[clique[a]][clique[b]]->witness);
+
+        auto members = clique;
+        auto task_data = tasks;
+        auto conflicts = conflict;
+        auto stats = _stats;
+
+        DerivedCumulativeSpec spec{.tasks = derived_tasks,
+            .capacity = 1_i,
+            .row_donors = vector<ConstraintID>{row_donors.begin(), row_donors.end()},
+            .recipe = [members, task_data, conflicts, resource_size, stats](
+                          ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
+                auto & tracker = recipe_logger.names_and_ids_tracker();
+
+                // Only the members that can be running at t appear in this time
+                // point's inequality; the donors windowed them all the same way,
+                // so this is the same set their flags exist for.
+                vector<size_t> here;
+                for (auto i : members)
+                    if (t >= task_data[i].t_lo && t <= task_data[i].t_hi)
+                        here.push_back(i);
+
+                vector<ProofLiteralOrFlag> flags;
+                for (auto i : here) {
+                    const auto & home = task_data[i].appearances.front();
+                    auto found = flags_for(tracker, home.donor, home.position, t);
+                    if (! found)
+                        return std::nullopt;
+                    flags.push_back(std::get<2>(*found));
+                }
+
+                WPBSum at_most_one;
+                for (const auto & flag : flags)
+                    add_term_to(at_most_one, 1_i, flag);
+
+                // One member here means the row says a single flag is at most
+                // one, which is true of any 0/1 and needs no derivation.
+                if (here.size() < 2)
+                    return recipe_logger.emit_rup_proof_line(move(at_most_one) <= 1_i, ProofLevel::Top);
+
+                recipe_logger.emit_proof_comment("presolve disjunctive clique at time " + to_string(t.raw_value));
+
+                // Bridges, once per (member, witnessing resource) rather than
+                // once per pair: several pairs of a clique often share a witness.
+                map<pair<size_t, ConstraintID>, ProofLine> bridges;
+                auto bridge_to = [&](size_t i, const ConstraintID & witness, size_t witness_position) -> optional<ProofLine> {
+                    const auto & home = task_data[i].appearances.front();
+                    if (home.donor == witness)
+                        return std::nullopt; // already there, nothing to carry
+
+                    auto key = pair{i, witness};
+                    auto already = bridges.find(key);
+                    if (already != bridges.end())
+                        return already->second;
+
+                    auto from = flags_for(tracker, home.donor, home.position, t);
+                    auto to = flags_for(tracker, witness, witness_position, t);
+                    if (! from || ! to)
+                        throw ProofError{"inferred disjunctive: a resource that witnesses a conflict at time " + to_string(t.raw_value) +
+                            " has no flags for one of the tasks it is about"};
+
+                    auto line = derive_conjunction_flag_bridge(recipe_logger, std::get<2>(*from), {std::get<0>(*from), std::get<1>(*from)},
+                        std::get<2>(*to), {std::get<0>(*to), std::get<1>(*to)}, ProofLevel::Top);
+                    if (stats)
+                        ++stats->bridges_derived;
+                    bridges.emplace(key, line);
+                    return line;
+                };
+
+                // The pairwise at-most-ones, each out of its witness's capacity
+                // row: weaken every other task out, saturate, divide by the
+                // margin. Then carry it onto the flags this constraint is
+                // expressed in.
+                vector<vector<ProofLine>> at_most_ones(here.size());
+                for (size_t b = 1; b < here.size(); ++b)
+                    for (size_t a = 0; a < b; ++a) {
+                        const auto & c = *conflicts[here[a]][here[b]];
+                        auto row = rows.find(c.witness);
+                        if (row == rows.end())
+                            return std::nullopt;
+
+                        auto u_flags = flags_for(tracker, c.witness, c.witness_position_u, t);
+                        auto v_flags = flags_for(tracker, c.witness, c.witness_position_v, t);
+                        if (! u_flags || ! v_flags)
+                            return std::nullopt;
+
+                        // Everything else on that resource that could be running
+                        // now has to come out of the row first. Over every
+                        // position, not up to the first one without flags: a
+                        // task that demands nothing of this resource has no
+                        // term in the row and no flags either, and stopping
+                        // there would leave the later tasks' terms in.
+                        PolBuilder pair_amo;
+                        pair_amo.add(row->second);
+                        for (size_t other = 0; other < resource_size.at(c.witness); ++other) {
+                            if (other == c.witness_position_u || other == c.witness_position_v)
+                                continue;
+                            auto other_flags = flags_for(tracker, c.witness, other, t);
+                            if (other_flags)
+                                pair_amo.weaken(std::get<2>(*other_flags), tracker);
+                        }
+                        pair_amo.saturate();
+                        pair_amo.divide_by(c.margin);
+
+                        auto bridged_u = bridge_to(here[a], c.witness, c.witness_position_u);
+                        auto bridged_v = bridge_to(here[b], c.witness, c.witness_position_v);
+                        if (bridged_u || bridged_v) {
+                            PolBuilder carry;
+                            carry.add(pair_amo.emit(recipe_logger, ProofLevel::Top));
+                            if (bridged_u)
+                                carry.add(*bridged_u);
+                            if (bridged_v)
+                                carry.add(*bridged_v);
+                            carry.saturate();
+                            at_most_ones[b].push_back(carry.emit(recipe_logger, ProofLevel::Top));
+                        }
+                        else
+                            at_most_ones[b].push_back(pair_amo.emit(recipe_logger, ProofLevel::Top));
+                    }
+
+                return derive_clique_from_amos(recipe_logger, flags, at_most_ones, ProofLevel::Top);
+            },
+            .rules = _rules};
+
+        if (! install_derived_cumulative(propagators, state, logger, move(spec))) {
+            bump(&InferredDisjunctiveStats::declined_by_install);
+            continue;
+        }
+
+        bump(&InferredDisjunctiveStats::cliques_posted);
+        bump(&InferredDisjunctiveStats::clique_members_posted, clique.size());
+        if (logger)
+            logger->emit_proof_comment("presolve disjunctive: inferred a clique of " + to_string(clique.size()) + " tasks");
+    }
+
+    // How much of this genuinely spanned resources, which is what says a
+    // fixture is exercising the cross-resource case rather than something a
+    // single Cumulative could have found.
+    for (const auto & [u, v] : candidate_pairs) {
+        const auto & c = *conflict[u][v];
+        if (tasks[u].appearances.front().donor != c.witness || tasks[v].appearances.front().donor != c.witness)
+            bump(&InferredDisjunctiveStats::cross_donor_pairs);
+    }
+
+    return true;
+}
+
+auto InferredDisjunctive::clone() const -> unique_ptr<Presolver>
+{
+    auto result = make_unique<InferredDisjunctive>(_stats);
+    result->with_budgets(_max_candidates, _max_posted);
+    result->with_minimum_clique_size(_min_clique_size);
+    result->with_rules(_rules);
+    return result;
+}

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -7,9 +7,53 @@
 
 #include <cstddef>
 #include <memory>
+#include <variant>
 
 namespace gcs
 {
+    /**
+     * \brief Deliberate corruptions of the assembled per-time certificate, for
+     * testing only. VeriPB must reject each of them.
+     *
+     * The pieces this is built from each have their own mutations, and those
+     * cover the pieces. What is left for these is the *assembly*: whether the
+     * at-most-ones being merged really are about the tasks the clique claims,
+     * whether the conclusion is the one the arithmetic supports, and whether a
+     * pair that merely looks like a conflict can be smuggled in. Each of these
+     * corrupts the conclusion rather than the route to it, since the route is
+     * where a conflict-shaped derivation forgives everything.
+     *
+     * \ingroup Presolvers
+     */
+    namespace inferred_disjunctive_mutation
+    {
+        /// Emit the honest derivation.
+        struct None
+        {
+        };
+
+        /// Claim no member may run at all, rather than at most one.
+        struct ClaimRhsZero
+        {
+        };
+
+        /// Bridge one task's flags onto the *other* task's, so the at-most-one
+        /// being merged is about a task the derivation never cornered.
+        struct BridgeWrongTask
+        {
+        };
+
+        /// Grow a clique with a task that does not conflict with its members ---
+        /// the camouflage case, where a pair's demands sum to exactly the
+        /// capacity and so are compatible by one unit. An off-by-one in the
+        /// conflict test lands exactly here.
+        struct IncludeNonConflicting
+        {
+        };
+    }
+
+    using InferredDisjunctiveMutation = std::variant<inferred_disjunctive_mutation::None, inferred_disjunctive_mutation::ClaimRhsZero,
+        inferred_disjunctive_mutation::BridgeWrongTask, inferred_disjunctive_mutation::IncludeNonConflicting>;
     /**
      * \brief What the inferred-Disjunctive presolver did, filled in when it
      * runs.
@@ -110,6 +154,7 @@ namespace gcs
         std::size_t _max_posted;
         std::size_t _min_clique_size;
         CumulativeRules _rules;
+        InferredDisjunctiveMutation _mutation;
 
     public:
         explicit InferredDisjunctive(std::shared_ptr<InferredDisjunctiveStats> stats = nullptr);
@@ -144,6 +189,11 @@ namespace gcs
          * redundancy has to turn time-tabling back on.
          */
         auto with_rules(CumulativeRules rules) -> InferredDisjunctive &;
+
+        /// Corrupt one step of the assembled certificate. For tests only, which
+        /// assert that VeriPB rejects the result; see
+        /// InferredDisjunctiveMutation.
+        auto with_proof_mutation(InferredDisjunctiveMutation mutation) -> InferredDisjunctive &;
 
         [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
         [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -1,0 +1,153 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INFERRED_DISJUNCTIVE_INFERRED_DISJUNCTIVE_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_GCS_PRESOLVERS_INFERRED_DISJUNCTIVE_INFERRED_DISJUNCTIVE_HH
+
+#include <gcs/constraints/cumulative/cumulative.hh>
+#include <gcs/integer.hh>
+#include <gcs/presolver.hh>
+
+#include <cstddef>
+#include <memory>
+
+namespace gcs
+{
+    /**
+     * \brief What the inferred-Disjunctive presolver did, filled in when it
+     * runs.
+     *
+     * A presolver that found nothing writes nothing, removes no solution and
+     * leaves every proof verifying, so the counts are what a test has to assert
+     * on to tell "working" from "no-op". The drop counters matter as much as the
+     * find ones: a budget that silently swallowed every candidate looks exactly
+     * like a conflict graph with no cliques in it.
+     *
+     * \ingroup Presolvers
+     */
+    struct InferredDisjunctiveStats
+    {
+        /// Posted Cumulatives the presolver looked at.
+        std::size_t donors_seen = 0;
+
+        /// Distinct tasks across all of them, identified by start variable.
+        std::size_t tasks = 0;
+
+        /// Pairs of tasks that some resource cannot hold together.
+        std::size_t conflicting_pairs = 0;
+
+        /// Of those, the pairs whose conflict is witnessed only by a resource
+        /// that does not contain both tasks' flags --- meaning the inference
+        /// genuinely spans donors and needed bridging. Zero here on a
+        /// single-resource model is the honest answer, and it is also how a
+        /// test says a fixture is not exercising what it claims to.
+        std::size_t cross_donor_pairs = 0;
+
+        /// Maximal cliques the search produced, before ranking and budgeting.
+        std::size_t cliques_found = 0;
+
+        /// Cliques actually posted as derived Cumulatives: the number that
+        /// matters.
+        std::size_t cliques_posted = 0;
+
+        /// Summed sizes of those, so a test can tell one clique of six from
+        /// three of two.
+        std::size_t clique_members_posted = 0;
+
+        /// Flag bridges emitted, one per (task, time) that had to be carried
+        /// from a witnessing resource to the one holding the task's flags.
+        std::size_t bridges_derived = 0;
+
+        /**
+         * \name Why a candidate or a donor was passed over.
+         */
+        ///@{
+        std::size_t declined_optional = 0;
+        std::size_t declined_variable_arguments = 0;
+        std::size_t dropped_too_small = 0;
+        std::size_t dropped_subset = 0;
+        std::size_t dropped_over_budget = 0;
+        std::size_t declined_by_install = 0;
+        ///@}
+    };
+
+    /**
+     * \brief Infer `Disjunctive` constraints --- capacity-one Cumulatives ---
+     * from cliques in the conflict graph across all posted Cumulatives, and post
+     * them in derived mode.
+     *
+     * Two tasks conflict if *some* resource cannot hold both at once, i.e. their
+     * demands on it sum to more than its capacity. A set of tasks conflicting
+     * pairwise can have at most one of them running at any time, whatever
+     * resources the individual conflicts came from --- and when different pairs
+     * conflict on different resources, that is an inference no single posted
+     * Cumulative can make, which is the whole point.
+     *
+     * This is the first stage of Sidorov (CP 2026), restricted to what his own
+     * data says carries most of the value: capacity one, unit coefficients. It
+     * keeps every certificate polynomial. The general lifted case is issue #549.
+     *
+     * Nothing reaches the OPB. Each clique is posted as a derived Cumulative
+     * whose per-time rows are *proved*: the pairwise at-most-ones come out of a
+     * witnessing resource's capacity row by weakening, saturating and dividing
+     * by the margin; where the pair's witness is not where a task's flags live,
+     * derive_conjunction_flag_bridge carries it across; and
+     * derive_clique_from_amos merges them into the clique inequality, which is
+     * exactly a unit-height capacity-one row.
+     *
+     * **Expect no speedup from time-tabling.** A pair that conflicts is already
+     * kept apart by whichever resource witnesses it, so the inferred
+     * constraint's profile reasoning is redundant --- and it ships with
+     * time-tabling off for that reason, exactly as CumulativeStrengthening does.
+     * What is new is the *energy* argument over the clique: three pairwise
+     * incompatible tasks of length three need nine units of a window that
+     * supplies its width, which no single resource's capacity row says.
+     *
+     * \ingroup Presolvers
+     */
+    class InferredDisjunctive : public Presolver
+    {
+    private:
+        std::shared_ptr<InferredDisjunctiveStats> _stats;
+        std::size_t _max_candidates;
+        std::size_t _max_posted;
+        std::size_t _min_clique_size;
+        CumulativeRules _rules;
+
+    public:
+        explicit InferredDisjunctive(std::shared_ptr<InferredDisjunctiveStats> stats = nullptr);
+
+        /**
+         * \brief Cap how many candidate pairs are grown into cliques, and how
+         * many of the results are posted.
+         *
+         * Sidorov's `N_cover` and `N_out`. The conflict graph can be dense, and
+         * both the clique search and the per-time certificates cost real time
+         * and real proof, so neither is allowed to run away. Every drop is
+         * counted, because a budget that quietly swallowed everything is
+         * indistinguishable from a model with nothing to find.
+         */
+        auto with_budgets(std::size_t max_candidates, std::size_t max_posted) -> InferredDisjunctive &;
+
+        /**
+         * \brief The smallest clique worth posting; three by default.
+         *
+         * A two-task "clique" is just a conflicting pair, which the resource
+         * that witnesses it already rules out --- so posting one adds a
+         * propagator that cannot infer anything new. Three is where the energy
+         * argument starts to say something.
+         */
+        auto with_minimum_clique_size(std::size_t size) -> InferredDisjunctive &;
+
+        /**
+         * \brief Select which propagation rules the inferred constraints run.
+         *
+         * Energy only, by default, since their time-tabling is redundant with
+         * the resources the conflicts came from. A test asserting that
+         * redundancy has to turn time-tabling back on.
+         */
+        auto with_rules(CumulativeRules rules) -> InferredDisjunctive &;
+
+        [[nodiscard]] virtual auto run(Problem &, innards::Propagators &, innards::State &, innards::ProofLogger * const) -> bool override;
+        [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Presolver> override;
+    };
+}
+
+#endif

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -16,7 +16,7 @@
 
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/innards/constraints_test_utils.hh>
-#include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
+#include <gcs/presolvers/inferred_disjunctive.hh>
 #include <gcs/problem.hh>
 #include <gcs/solve.hh>
 
@@ -77,6 +77,7 @@ namespace
         optional<CumulativeRules> inferred_rules = nullopt;
         std::size_t min_clique_size = 3;
         std::size_t max_candidates = 100, max_posted = 5;
+        InferredDisjunctiveMutation mutation = inferred_disjunctive_mutation::None{};
         shared_ptr<InferredDisjunctiveStats> stats = nullptr;
     };
 
@@ -362,6 +363,66 @@ auto main(int argc, char * argv[]) -> int
         for (const auto & name : {with, without})
             dispose_of_proof_files(name);
         println(cerr, "the OPB is untouched");
+    }
+
+    /* Mutations of the assembled certificate.
+     *
+     * The pieces have their own, and those cover the pieces. What is left is
+     * the assembly, and it needs a fixture with a *camouflage* task: a fourth
+     * task on a resource of capacity two, where every pairwise demand sums to
+     * exactly two. Compatible, but only just --- which is what an off-by-one in
+     * the conflict test would get wrong, and what IncludeNonConflicting forces.
+     */
+    {
+        auto camouflage = [](Problem & p, const Setup & setup) {
+            vector<IntegerVariableID> starts;
+            for (int i = 0; i < 4; ++i)
+                starts.push_back(p.create_integer_variable(0_i, 3_i, "s" + to_string(i)));
+
+            const vector<Integer> lengths(4, 2_i);
+            // The three-task cross-resource family, over the first three.
+            p.post(Cumulative{starts, lengths, vector<Integer>{0_i, 1_i, 1_i, 0_i}, 1_i});
+            p.post(Cumulative{starts, lengths, vector<Integer>{1_i, 1_i, 0_i, 0_i}, 1_i});
+            p.post(Cumulative{starts, lengths, vector<Integer>{1_i, 0_i, 1_i, 0_i}, 1_i});
+            // And a resource all four share, where any two of them fit exactly.
+            p.post(Cumulative{starts, lengths, vector<Integer>{1_i, 1_i, 1_i, 1_i}, 2_i});
+
+            auto presolver = InferredDisjunctive{setup.stats};
+            presolver.with_proof_mutation(setup.mutation);
+            p.add_presolver(presolver);
+            return starts;
+        };
+
+        // Honestly, task three joins no clique: it is compatible with every
+        // one of the others, by exactly one unit.
+        {
+            auto stats = make_shared<InferredDisjunctiveStats>();
+            Problem p;
+            camouflage(p, Setup{.stats = stats});
+            solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }},
+                make_optional<ProofOptions>(ProofFileNames{"inferred_disjunctive_camouflage"}));
+            if (stats->cliques_posted != 1 || stats->clique_members_posted != 3)
+                fail("camouflage: posted " + to_string(stats->cliques_posted) + " cliques over " + to_string(stats->clique_members_posted) +
+                    " members, not the one clique of three");
+            verify_proof_and_clean_up("inferred_disjunctive_camouflage");
+            println(cerr, "camouflage: the compatible task stayed out of the clique, and the proof verifies");
+        }
+
+        for (const auto & [what, mutation] :
+            {std::pair<string, InferredDisjunctiveMutation>{"rhs zero", inferred_disjunctive_mutation::ClaimRhsZero{}},
+                std::pair<string, InferredDisjunctiveMutation>{"wrong task bridged", inferred_disjunctive_mutation::BridgeWrongTask{}},
+                std::pair<string, InferredDisjunctiveMutation>{"non-conflicting member", inferred_disjunctive_mutation::IncludeNonConflicting{}}}) {
+            const string name = "inferred_disjunctive_mutation";
+            Problem p;
+            camouflage(p, Setup{.mutation = mutation});
+            solve_with(
+                p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return true; }}, make_optional<ProofOptions>(ProofFileNames{name}));
+
+            if (run_veripb(name + ".opb", name + ".pbp"))
+                fail("veripb accepted the " + what + " mutation, so the honest certificate has slack in it");
+            println(cerr, "veripb rejected the {} mutation, as expected", what);
+            dispose_of_proof_files(name);
+        }
     }
 
     // And the markers say the clique derivation actually ran, per time point.

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -1,0 +1,383 @@
+/* Inferring Disjunctive constraints from cliques in the cross-resource conflict
+ * graph.
+ *
+ * The fixture family is the one the issue asks for, and it is built so that no
+ * single posted Cumulative can make the inference: k tasks and k resources,
+ * with the pair (i, j) conflicting only on resource (i + j) mod k. Every
+ * resource sees exactly one conflicting pair, so the clique exists only in the
+ * union of them --- which is what makes a root refutation here evidence of
+ * something, rather than evidence that one of the donors was enough.
+ *
+ * The sharp twin is the same instance with one more unit of horizon, where the
+ * tasks fit exactly. That has to stay satisfiable with the presolver on, and to
+ * report the same solutions as brute force, since an inferred constraint that
+ * quietly removed one would otherwise look like a success.
+ */
+
+#include <gcs/constraints/cumulative.hh>
+#include <gcs/constraints/innards/constraints_test_utils.hh>
+#include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
+#include <gcs/problem.hh>
+#include <gcs/solve.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include <version>
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+#include <print>
+#else
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#endif
+
+using std::cerr;
+using std::ifstream;
+using std::make_optional;
+using std::make_shared;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::set;
+using std::shared_ptr;
+using std::string;
+using std::to_string;
+using std::vector;
+
+#if defined(__cpp_lib_print) && defined(__cpp_lib_format)
+using std::println;
+#else
+using fmt::println;
+#endif
+
+using namespace gcs;
+using namespace gcs::innards;
+using namespace gcs::test_innards;
+
+namespace
+{
+    auto fail(const string & message) -> void
+    {
+        println(cerr, "inferred disjunctive test failure: {}", message);
+        std::exit(EXIT_FAILURE);
+    }
+
+    struct Setup
+    {
+        bool presolve = true;
+        CumulativeRules rules = CumulativeRules{};
+        optional<CumulativeRules> inferred_rules = nullopt;
+        std::size_t min_clique_size = 3;
+        std::size_t max_candidates = 100, max_posted = 5;
+        shared_ptr<InferredDisjunctiveStats> stats = nullptr;
+    };
+
+    /* k tasks of length p, and k resources of capacity one. Resource r carries
+     * demand one for exactly the two tasks i, j with (i + j) mod k == r, and
+     * zero for everyone else --- so it forbids that one pair overlapping and
+     * says nothing about any other.
+     *
+     * Every resource is posted over all k starts, so a task keeps the same
+     * position everywhere, and the zero demands drop it out of that resource's
+     * flags exactly as a real model's would.
+     */
+    auto post_family(Problem & p, int k, int length, int horizon, const Setup & setup) -> vector<IntegerVariableID>
+    {
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < k; ++i)
+            starts.push_back(p.create_integer_variable(0_i, Integer{horizon - length}, "s" + to_string(i)));
+
+        vector<Integer> lengths(static_cast<size_t>(k), Integer{length});
+        for (int r = 0; r < k; ++r) {
+            vector<Integer> heights(static_cast<size_t>(k), 0_i);
+            for (int i = 0; i < k; ++i)
+                for (int j = i + 1; j < k; ++j)
+                    if ((i + j) % k == r) {
+                        heights[static_cast<size_t>(i)] = 1_i;
+                        heights[static_cast<size_t>(j)] = 1_i;
+                    }
+            p.post(Cumulative{starts, lengths, heights, 1_i}.with_rules(setup.rules));
+        }
+
+        if (setup.presolve) {
+            auto presolver = InferredDisjunctive{setup.stats};
+            presolver.with_budgets(setup.max_candidates, setup.max_posted).with_minimum_clique_size(setup.min_clique_size);
+            if (setup.inferred_rules)
+                presolver.with_rules(*setup.inferred_rules);
+            p.add_presolver(presolver);
+        }
+        return starts;
+    }
+
+    struct Outcome
+    {
+        set<vector<int>> solutions;
+        unsigned long long recursions = 0;
+        bool refuted_at_root = false;
+    };
+
+    auto solve_family(int k, int length, int horizon, const Setup & setup, const optional<string> & proof_name, bool verify = true) -> Outcome
+    {
+        Problem p;
+        auto starts = post_family(p, k, length, horizon, setup);
+
+        Outcome outcome;
+        bool reached_a_node = false, found_a_solution = false;
+        auto stats = solve_with(p,
+            SolveCallbacks{.solution = [&](const CurrentState & s) -> bool {
+                               found_a_solution = true;
+                               vector<int> solution;
+                               for (const auto & v : starts)
+                                   solution.push_back(s(v).raw_value);
+                               outcome.solutions.insert(move(solution));
+                               return true;
+                           },
+                .trace = [&](const CurrentState &) -> bool {
+                    reached_a_node = true;
+                    return true;
+                }},
+            proof_name ? make_optional<ProofOptions>(ProofFileNames{*proof_name}) : nullopt);
+
+        outcome.recursions = stats.recursions;
+        outcome.refuted_at_root = ! reached_a_node && ! found_a_solution;
+
+        if (proof_name && verify)
+            verify_proof_and_clean_up(*proof_name);
+        return outcome;
+    }
+
+    /// Brute force over the same family: every start assignment where no two
+    /// tasks sharing a resource overlap.
+    auto expected_solutions(int k, int length, int horizon) -> set<vector<int>>
+    {
+        set<vector<int>> expected;
+        vector<int> current(static_cast<size_t>(k), 0);
+        auto ok = [&]() {
+            for (int i = 0; i < k; ++i)
+                for (int j = i + 1; j < k; ++j)
+                    if (current[static_cast<size_t>(i)] < current[static_cast<size_t>(j)] + length &&
+                        current[static_cast<size_t>(j)] < current[static_cast<size_t>(i)] + length)
+                        return false;
+            return true;
+        };
+        auto recurse = [&](auto && self, int at) -> void {
+            if (at == k) {
+                if (ok())
+                    expected.insert(current);
+                return;
+            }
+            for (int s = 0; s <= horizon - length; ++s) {
+                current[static_cast<size_t>(at)] = s;
+                self(self, at + 1);
+            }
+        };
+        recurse(recurse, 0);
+        return expected;
+    }
+
+    auto read_file(const string & name) -> string
+    {
+        ifstream in{name, std::ios::binary};
+        if (! in)
+            fail("could not read " + name);
+        return string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+    }
+
+    auto count_occurrences(const string & haystack, const string & needle) -> size_t
+    {
+        size_t count = 0;
+        for (auto at = haystack.find(needle); at != string::npos; at = haystack.find(needle, at + needle.size()))
+            ++count;
+        return count;
+    }
+}
+
+auto main(int argc, char * argv[]) -> int
+{
+    establish_and_announce_seed(argc, argv);
+    auto proofs = can_run_veripb();
+
+    // Three tasks of length two, pairwise incompatible, into five time points.
+    // Six units of work and five slots, so it cannot be done --- but only the
+    // clique says so, since each resource on its own sees one pair.
+    {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+
+        auto donors_only = solve_family(3, 2, 5, Setup{.presolve = false}, nullopt);
+        if (donors_only.refuted_at_root)
+            fail("the donors alone refuted at the root, so the fixture proves nothing");
+
+        auto inferred = solve_family(3, 2, 5, Setup{.stats = stats}, proofs ? make_optional("inferred_disjunctive_unsat") : nullopt);
+
+        if (stats->cliques_posted != 1)
+            fail("posted " + to_string(stats->cliques_posted) + " cliques, not the one the family contains");
+        if (stats->clique_members_posted != 3)
+            fail("the posted clique had " + to_string(stats->clique_members_posted) + " members, not three");
+        if (stats->cross_donor_pairs == 0)
+            fail("no pair needed bridging, so the fixture is not exercising the cross-resource case");
+        if (proofs && stats->bridges_derived == 0)
+            fail("no flag bridge was derived, so the certificate is not spanning resources");
+        if (! inferred.refuted_at_root)
+            fail("the inferred constraint did not refute at the root");
+        if (! inferred.solutions.empty())
+            fail("the instance is unsatisfiable but solutions were reported");
+
+        println(cerr, "cross-resource clique: refuted at the root against {} nodes without it, {} bridges", donors_only.recursions,
+            stats->bridges_derived);
+    }
+
+    // The sharp twin: one more unit of horizon and the three tasks fit exactly.
+    // Still satisfiable, still every solution, and the clique is still posted
+    // --- an inferred constraint has to be harmless where it is not decisive.
+    {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+        auto inferred = solve_family(3, 2, 6, Setup{.stats = stats}, proofs ? make_optional("inferred_disjunctive_sat") : nullopt);
+
+        if (stats->cliques_posted != 1)
+            fail("sharp twin: the clique was not posted, so the comparison is vacuous");
+        auto expected = expected_solutions(3, 2, 6);
+        if (expected.empty())
+            fail("sharp twin: the fixture has no solutions, so it is not the twin it claims to be");
+        if (inferred.solutions != expected)
+            fail("sharp twin: solutions do not match brute force, so the inferred constraint removed some");
+        println(cerr, "sharp twin: {} solutions, matching brute force", inferred.solutions.size());
+    }
+
+    // Solution preservation over the family, at several shapes.
+    for (auto [k, length, horizon] : {std::tuple{3, 2, 7}, std::tuple{3, 1, 4}, std::tuple{4, 1, 5}}) {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+        auto inferred = solve_family(k, length, horizon, Setup{.stats = stats}, nullopt);
+        auto expected = expected_solutions(k, length, horizon);
+        if (inferred.solutions != expected)
+            fail("k=" + to_string(k) + " length=" + to_string(length) + " horizon=" + to_string(horizon) + ": solutions do not match brute force");
+    }
+    println(cerr, "solution preservation: three shapes match brute force");
+
+    // The inference is time-table neutral, for the same reason
+    // CumulativeStrengthening's is: a conflicting pair is already kept apart by
+    // whichever resource witnesses it, so the inferred constraint's profile
+    // reasoning cannot say anything new. With the energy rules off everywhere,
+    // the node counts must be identical.
+    {
+        const CumulativeRules tt_only{.time_table = true, .overload = false, .profile_overload = false};
+        auto stats = make_shared<InferredDisjunctiveStats>();
+
+        auto without = solve_family(3, 2, 6, Setup{.presolve = false, .rules = tt_only}, nullopt);
+        auto with = solve_family(3, 2, 6, Setup{.rules = tt_only, .inferred_rules = make_optional(tt_only), .stats = stats}, nullopt);
+
+        if (stats->cliques_posted != 1)
+            fail("neutrality: nothing was posted, so the comparison is vacuous");
+        if (without.solutions != with.solutions)
+            fail("neutrality: the solution set changed");
+        if (without.recursions != with.recursions)
+            fail("neutrality: " + to_string(with.recursions) + " nodes against " + to_string(without.recursions) +
+                " --- the inferred constraint changed what time-tabling permits, which means it is not implied");
+        println(cerr, "neutrality: {} nodes either way", with.recursions);
+    }
+
+    // Budgets, and that they are counted rather than silent.
+    {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+        solve_family(3, 2, 6, Setup{.max_candidates = 0, .stats = stats}, nullopt);
+        if (stats->cliques_posted != 0)
+            fail("a zero candidate budget still posted a clique");
+        if (stats->dropped_over_budget == 0)
+            fail("a zero candidate budget dropped candidates without counting them");
+    }
+
+    // Two resources, each forbidding one pair, with no conflict between the
+    // pairs: the conflict graph is two disjoint edges and every maximal clique
+    // has two members. Nothing worth posting --- a pair is already kept apart by
+    // the resource that witnesses it --- but the drops have to be counted, or
+    // "found nothing" and "dropped everything" look the same.
+    {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+        Problem p;
+        vector<IntegerVariableID> starts;
+        for (int i = 0; i < 4; ++i)
+            starts.push_back(p.create_integer_variable(0_i, 4_i));
+
+        const vector<Integer> lengths(4, 2_i);
+        p.post(Cumulative{starts, lengths, vector<Integer>{1_i, 1_i, 0_i, 0_i}, 1_i});
+        p.post(Cumulative{starts, lengths, vector<Integer>{0_i, 0_i, 1_i, 1_i}, 1_i});
+        p.add_presolver(InferredDisjunctive{stats});
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, nullopt);
+
+        if (stats->conflicting_pairs != 2)
+            fail("disjoint pairs: found " + to_string(stats->conflicting_pairs) + " conflicting pairs, not the two there are");
+        if (stats->cliques_posted != 0)
+            fail("disjoint pairs: a two-task clique was posted, which cannot infer anything the resource has not");
+        if (stats->dropped_too_small != 2)
+            fail("disjoint pairs: " + to_string(stats->dropped_too_small) + " undersized cliques counted, not the two dropped");
+    }
+    println(cerr, "budgets: candidate cap and minimum size both bite, and both are counted");
+
+    // An optional-task donor is declined loudly rather than mis-derived.
+    {
+        auto stats = make_shared<InferredDisjunctiveStats>();
+        Problem p;
+        vector<IntegerVariableID> starts, presences;
+        for (int i = 0; i < 3; ++i) {
+            starts.push_back(p.create_integer_variable(0_i, 3_i));
+            presences.push_back(p.create_integer_variable(0_i, 1_i));
+        }
+        vector<IntegerVariableID> lengths{constant_variable(2_i), constant_variable(2_i), constant_variable(2_i)},
+            heights{constant_variable(1_i), constant_variable(1_i), constant_variable(1_i)};
+        p.post(Cumulative{starts, lengths, heights, presences, constant_variable(1_i)});
+        p.add_presolver(InferredDisjunctive{stats});
+        solve_with(p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, nullopt);
+
+        if (stats->declined_optional != 1)
+            fail("an optional-task donor was not declined");
+        if (stats->cliques_posted != 0)
+            fail("an optional-task donor was used anyway");
+    }
+    println(cerr, "an optional-task donor is declined");
+
+    if (! proofs) {
+        println(cerr, "veripb is not available, so the proof-level checks are skipped");
+        return EXIT_SUCCESS;
+    }
+
+    // Nothing may have reached the OPB: the whole plan turns on an inferred
+    // constraint being a derivation rather than a model axiom.
+    {
+        const string with = "inferred_disjunctive_opb_with", without = "inferred_disjunctive_opb_without";
+        for (const auto & [name, presolve] : {std::pair{with, true}, std::pair{without, false}}) {
+            Problem p;
+            post_family(p, 3, 2, 6, Setup{.presolve = presolve});
+            solve_with(
+                p, SolveCallbacks{.trace = [](const CurrentState &) -> bool { return false; }}, make_optional<ProofOptions>(ProofFileNames{name}));
+        }
+        if (read_file(with + ".opb") != read_file(without + ".opb"))
+            fail("the inferred constraint changed the OPB");
+        for (const auto & name : {with, without})
+            dispose_of_proof_files(name);
+        println(cerr, "the OPB is untouched");
+    }
+
+    // And the markers say the clique derivation actually ran, per time point.
+    {
+        const string name = "inferred_disjunctive_markers";
+        solve_family(3, 2, 5, Setup{}, make_optional(name), false);
+        if (! run_veripb(name + ".opb", name + ".pbp"))
+            fail("markers: veripb rejected the proof");
+        auto proof = read_file(name + ".pbp");
+        if (0 == count_occurrences(proof, "presolve disjunctive: inferred a clique"))
+            fail("markers: no clique was recorded as inferred");
+        if (0 == count_occurrences(proof, "presolve disjunctive clique at time"))
+            fail("markers: no per-time clique derivation in the proof");
+        println(cerr, "markers: {} per-time clique derivations", count_occurrences(proof, "presolve disjunctive clique at time"));
+        dispose_of_proof_files(name);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The cutting-planes core of #548 (Sidorov stage 1), as a standalone utility with
no Cumulative anywhere near it. Stacked on #661; both retarget to `main` as the
#541 stack lands.

Given `~a_p + ~a_q >= 1` for every pair of a clique, derive `sum a_p <= 1`.

## The derivation, and why not the obvious one

Summing all `k(k-1)/2` at-most-ones gives `(k-1) * sum ~a_p >= k(k-1)/2`;
dividing by `k-1` lands on `ceil(k/2)`. That is `k-1` for two and three members
and short of it from four on. So the merge is the induction: with the inequality
for the first `m` members in hand,

```
    m*~a_m + sum_{i<m} ~a_i             >= m          the m pairs
            (m-1) * sum_{i<m} ~a_i      >= (m-1)^2    m-1 copies of the current
    ---------------------------------------------------------------------------
    m * ( ~a_m + sum_{i<m} ~a_i )       >= m + (m-1)^2
```

and `m + (m-1)^2 = m(m-1) + 1`, so dividing by `m` rounds the degree up to
exactly `m`. **That spare `+1` is the entire margin** — one less and the division
rounds down to `m-1` and the induction does not advance.

The one-shot version is kept as a runnable mutation rather than described in a
comment, because it is *accepted* for k=2,3 and *rejected* from k=4 — so the
argument for the induction is pinned to a boundary a test watches, and if that
boundary ever moves the comment explaining it is wrong.

## The `ia` pin is what makes any mutation a test

Every step of the merge is sound whatever was fed into it. Drop an input and the
`pol` lands on a **weaker but still true** line, which VeriPB is right to accept
— so without pinning the result there is no corruption of this derivation that
can be detected. Same lesson as #660's shortened chain and #661's bogus divisor.

It turns out to be stricter than "weaker fails", which is worth knowing
deliberately: leaving the division off the last merge gives
`m*(sum ~a) >= m(m-1)+1`, which is mathematically **stronger** than the clique
inequality — and it is rejected too, because a syntactic implication check cannot
see an equivalence that needs dividing to spot. The final division is therefore
load-bearing twice, and any future rearrangement of this arithmetic breaks the
pin even while staying sound. That has a mutation of its own so it cannot rot
quietly.

The pin also *normalises*: `ia` enters the target as a new line and that is what
comes back, so a caller always receives the literal-exact clique inequality.

## Where the at-most-ones come from, checked here because only running it settles it

`#548` specifies a `c_j <= C` side condition on the pair derivation. **It is not
needed.** Weaken the other terms out of a resource row, saturate, divide by the
margin `D = c_u + c_v - C`: saturation caps both coefficients at `D` and the
division rounds them back up to one, whatever they were. Verified with
`c_v = 12` against `C = 10`. The condition belongs to clique *discovery*, where a
task that can never run would otherwise pad every clique it touches.

A pair summing to **exactly** the capacity is correctly refused — that is where
an off-by-one in the conflict test lands, and it is #548's camouflage-task case.

## A shortcut the caller should know about before it is built

Where one row covers three or more clique members, the pairwise at-most-ones are
not the cheapest premises: weakening the row down to that set and dividing by
`d = min(c_max, Delta)`, with `Delta = sum_K c_i - C`, reaches the **whole
sub-clique inequality in one step** whenever `Delta > d(|K| - 2)`. Verified:

| demands | C | result |
|---|---|---|
| `{6,6,6,6}` | 10 | `sum a <= 1` in one pol (Delta 14 > 12) |
| `{6,6,9}` | 10 | `sum a <= 1` in one pol (Delta 11 > 9) |
| `{9,6,6,6}` | 10 | fails at `<= 1` (Delta 17 not > 18), succeeds at `<= 2` |
| `{4,4,4}` | 10 | `sum a <= 2` — and **no pair conflicts at all** |

Since most conflicting pairs in a real instance share a resource, that replaces
up to `(k_r choose 2)` pair derivations and their weaken chains with one step.
The last row is a cardinality cut the pairwise machinery is structurally blind
to. Neither belongs in *this* routine, which works from at-most-ones by
construction — they are recorded as checked facts for #548 and #549 to build on.

## For the caller, in the header

- Every intermediate is emitted at the caller's level. Only the returned line
  needs to outlive the call, so replaying this across a horizon at `Top` leaves
  `k^2/2` permanently-live constraints per time point, taxing every later
  unhinted RUP (the `table_layout15` pathology). Deriving intermediates at
  `Temporary` and forgetting them, or inlining into a single `pol`, is the fix,
  and it is #548's to make.
- Two things the pin cannot check, both the caller's to get right: that
  `members` are pairwise distinct (a repeat becomes a coefficient-two term and
  means something else), and that each line really is the at-most-one for its
  pair.
- `PolBuilder::weaken` renders the flag verbatim, so a negative-polarity
  `ProofFlag` would emit `~name w`, which VeriPB's weakening rule rejects. Not
  reachable from here; a trap for #548's row-weakening.

## Validation

`clique_from_amos_test`, on a **satisfiable** micro model (per #656 — against an
unsatisfiable one every RUP is vacuously valid):

- the induction verifies for k = 2..12;
- the result contradicts an axiom forcing two members active, `ia`-confirmed as
  a genuine contradiction;
- `DropAnAtMostOne` (from the *first* merge, so the weakness propagates through
  every later pass) — rejected;
- `ClaimOneMore` — rejected;
- `SkipFinalDivision` — rejected, though strictly stronger;
- `NaiveOneShot` — accepted at k=2,3 and rejected at k=4,5,9;
- the pair recipe over/under/at capacity, and the row shortcut table above.

Full ctest green (625/625, `GCS_TEST_CAP_DEFAULTS=OFF`); GCC and clang
warning-free; clean under ASan/UBSan.

`add_term_to` moves to `pseudo_boolean.hh`, having acquired a second user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p