### PR TITLE
Cross-check the inferred cliques against Sidorov's Pack bounds

### DIFF
--- a/dev_docs/inferred-disjunctive.md
+++ b/dev_docs/inferred-disjunctive.md
@@ -98,6 +98,13 @@ resources.
 - **Neutrality**, as node-for-node equality under time-tabling alone.
 - **Budgets**, on a two-disjoint-edges fixture where the drops are real rather
   than an artefact of there being no candidates.
+- **The capacity bound itself**, asserted as six on the differential fixture —
+  which is also *why* it refutes, three length-two tasks needing six units of a
+  five-unit horizon — and as zero where nothing was posted, so a stale bound
+  cannot masquerade as a derived one.
+- **End to end from a file**, as the `rcpsp_dzn_inferred` example test:
+  `examples/rcpsp/sample.dzn` is built so each conflicting pair is witnessed by a
+  different resource, and its proof is VeriPB-checked like every other example.
 - **Mutations**, on a fixture carrying a *camouflage* task — a fourth task on a
   capacity-two resource where every pairwise demand sums to exactly two, so it is
   compatible with everything by exactly one unit. Honestly it stays out of the
@@ -113,11 +120,46 @@ resources.
   which is what a conflict-shaped derivation requires: the route is where it
   forgives everything.
 
+## The Pack / Pack-d cross-check
+
+Sidorov's §5.1 says "no less than twelve of the instances in Pack and Pack-d
+collections can be closed immediately by using one of the lifted cumulative
+constraints, with the capacities varying between one and three". Twenty of those
+lifted constraints have capacity one, which is what this presolver infers, and
+for those his capacity bound `L = sum_i d_i pi_i / pi_0` collapses to the
+clique's total duration — `InferredDisjunctiveStats::largest_capacity_bound`.
+
+The instances are the MiniZinc benchmarks' `rcpsp/data_pack` and
+`rcpsp/data_pack_d`, read with `--dzn`. On all twenty capacity-one targets this
+presolver reports **exactly the bound the paper does**, under his own budgets
+(`N_cover = 100`, `N_out = 5`, the defaults here):
+
+| collection | instances | `L` reproduced |
+|---|---|---|
+| Pack | 4, 5, 8, 9, 11, 13, 16, 23, 28, 29 | 10 / 10 |
+| Pack-d | 8, 9, 12, 15, 16, 17, 18, 20, 24, 43 | 10 / 10 |
+
+Eleven of the twenty have `L` equal to the best known makespan, so the bound
+closes the instance with no search at all.
+
+Two things about the comparison are worth writing down, because both are easy to
+get wrong and neither is visible from the paper:
+
+- His logs record the bound **unrounded** — the rational `sum_i d_i w_i / r` to
+  three decimal places, not its ceiling. Capacity-one rows are integral either
+  way, so a naive comparison looks right and then fails on every non-unit
+  capacity. His own reporting script compares the unrounded value, which is why
+  the paper's counts are conservative: twenty Pack/Pack-d instances close on that
+  comparison and thirty-six close with the ceiling.
+- The standard `rcpsp.mzn` posts redundant pairwise non-overlap constraints for
+  conflicting pairs. His preprocessor does not, and neither does `--dzn`: they
+  are a modelling choice of that file rather than part of the instance, and
+  posting them would hand the presolver conflicts it is supposed to find.
+
 ## Not done
 
-- Sidorov's Pack/Pack_d cross-check (his §5.1, instance lists in the zenodo
-  logs), which would say whether the cliques found here match the ones his
-  capacity-bound metric reports.
+- The general lifted case, capacity above one with non-unit coefficients, which
+  is where the remaining sixteen of his thirty-six closures live (issue #549).
 - Budget-robustness sweeps on larger instances.
 - The proof-size work above.
 

--- a/examples/dzn.hh
+++ b/examples/dzn.hh
@@ -1,0 +1,262 @@
+#ifndef GLASGOW_CONSTRAINT_SOLVER_GUARD_EXAMPLES_DZN_HH
+#define GLASGOW_CONSTRAINT_SOLVER_GUARD_EXAMPLES_DZN_HH
+
+// A small reader for MiniZinc `.dzn` data files, shared by the example
+// programs. Header-only; not part of the library API.
+//
+// This handles the fragment of dzn the examples' data files actually use: a
+// sequence of `name = value;` statements, `%` line comments, integer scalars,
+// integer arrays in one and two dimensions, and arrays of integer sets. It is
+// not a MiniZinc parser and does not try to be --- there are no expressions, no
+// floats, no strings, no enums and no output items.
+//
+// Four examples (table_layout, seat_moving, nonogram, hitori) still carry their
+// own readers, written before this existed and diverged in what they accept.
+// Issue #664 tracks migrating them onto this; new examples should start here.
+
+#include <cctype>
+#include <cstddef>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace dzn
+{
+    /// A parsed data file: the raw text of each `name = value` statement,
+    /// comments removed, keyed by name. Values are left unparsed because what a
+    /// value means depends on the model, not on the file.
+    class Data
+    {
+    private:
+        std::string _path;
+        std::map<std::string, std::string> _values;
+
+        [[nodiscard]] auto _raw(const std::string & name) const -> const std::string &
+        {
+            auto i = _values.find(name);
+            if (i == _values.end())
+                throw std::runtime_error{"'" + _path + "' does not define '" + name + "'"};
+            return i->second;
+        }
+
+        [[noreturn]] auto _bad(const std::string & name, const std::string & why) const -> void
+        {
+            throw std::runtime_error{"'" + _path + "': " + name + " " + why};
+        }
+
+    public:
+        Data(std::string path, std::map<std::string, std::string> values) : _path(std::move(path)), _values(std::move(values))
+        {
+        }
+
+        [[nodiscard]] auto path() const -> const std::string &
+        {
+            return _path;
+        }
+
+        [[nodiscard]] auto contains(const std::string & name) const -> bool
+        {
+            return _values.contains(name);
+        }
+
+        /// An integer scalar.
+        [[nodiscard]] auto integer(const std::string & name) const -> long long
+        {
+            const auto & text = _raw(name);
+            std::istringstream in{text};
+            long long value = 0;
+            if (! (in >> value))
+                _bad(name, "is not an integer: '" + text + "'");
+            std::string trailing;
+            if (in >> trailing)
+                _bad(name, "has trailing text after the integer: '" + text + "'");
+            return value;
+        }
+
+        /// A one-dimensional integer array. The `array1d(...)`, `array2d(...)`
+        /// and `array3d(...)` wrappers are accepted and their index-set
+        /// arguments ignored, so a wrapped array is read flat; use matrix() when
+        /// the shape matters.
+        [[nodiscard]] auto integers(const std::string & name) const -> std::vector<long long>
+        {
+            const auto & text = _raw(name);
+            auto open = text.find('[');
+            auto close = text.rfind(']');
+            if (open == std::string::npos || close == std::string::npos || close < open)
+                _bad(name, "is not an array: '" + text + "'");
+
+            auto body = text.substr(open + 1, close - open - 1);
+            // A 2-D literal is `[| a, b | c, d |]`; read flat, the row
+            // separators are just more whitespace.
+            for (auto & c : body)
+                if (c == '|')
+                    c = ' ';
+
+            std::vector<long long> result;
+            std::istringstream in{body};
+            std::string item;
+            while (std::getline(in, item, ',')) {
+                std::istringstream one{item};
+                long long value = 0;
+                if (! (one >> value)) {
+                    if (item.find_first_not_of(" \t\r\n") == std::string::npos)
+                        continue;
+                    _bad(name, "has a non-integer entry: '" + item + "'");
+                }
+                result.push_back(value);
+            }
+            return result;
+        }
+
+        /// A two-dimensional integer array written `[| a, b | c, d |]`, as
+        /// `rows` rows of equal length. The row count is taken from the `|`
+        /// separators rather than supplied, so a ragged literal is an error
+        /// rather than a silent reshape.
+        [[nodiscard]] auto matrix(const std::string & name) const -> std::vector<std::vector<long long>>
+        {
+            const auto & text = _raw(name);
+            auto open = text.find('[');
+            auto close = text.rfind(']');
+            if (open == std::string::npos || close == std::string::npos || close < open)
+                _bad(name, "is not an array: '" + text + "'");
+
+            auto body = text.substr(open + 1, close - open - 1);
+            auto first = body.find_first_not_of(" \t\r\n");
+            if (first == std::string::npos || body[first] != '|')
+                _bad(name, "is not a two-dimensional array literal: '" + text + "'");
+
+            std::vector<std::vector<long long>> rows;
+            std::istringstream in{body};
+            std::string row;
+            // The literal both opens and closes with '|', so splitting on it
+            // gives an empty piece at each end; both are skipped as blank.
+            while (std::getline(in, row, '|')) {
+                if (row.find_first_not_of(" \t\r\n") == std::string::npos)
+                    continue;
+                std::vector<long long> entries;
+                std::istringstream cells{row};
+                std::string item;
+                while (std::getline(cells, item, ',')) {
+                    std::istringstream one{item};
+                    long long value = 0;
+                    if (! (one >> value)) {
+                        if (item.find_first_not_of(" \t\r\n") == std::string::npos)
+                            continue;
+                        _bad(name, "has a non-integer entry: '" + item + "'");
+                    }
+                    entries.push_back(value);
+                }
+                rows.push_back(std::move(entries));
+            }
+
+            for (const auto & r : rows)
+                if (r.size() != rows.front().size())
+                    _bad(name, "has rows of differing lengths");
+            return rows;
+        }
+
+        /// An array of integer sets, `[ {1, 2}, {}, {3} ]`. Each set comes back
+        /// in the order written; nothing is sorted or deduplicated, because a
+        /// model that cares can do either and one that does not should not pay
+        /// for it.
+        [[nodiscard]] auto sets(const std::string & name) const -> std::vector<std::vector<long long>>
+        {
+            const auto & text = _raw(name);
+            auto open = text.find('[');
+            auto close = text.rfind(']');
+            if (open == std::string::npos || close == std::string::npos || close < open)
+                _bad(name, "is not an array: '" + text + "'");
+
+            std::vector<std::vector<long long>> result;
+            auto body = text.substr(open + 1, close - open - 1);
+            std::size_t at = 0;
+            while (true) {
+                auto brace = body.find('{', at);
+                if (brace == std::string::npos)
+                    break;
+                auto end = body.find('}', brace);
+                if (end == std::string::npos)
+                    _bad(name, "has a set that is never closed");
+
+                std::vector<long long> members;
+                std::istringstream in{body.substr(brace + 1, end - brace - 1)};
+                std::string item;
+                while (std::getline(in, item, ',')) {
+                    std::istringstream one{item};
+                    long long value = 0;
+                    if (! (one >> value)) {
+                        if (item.find_first_not_of(" \t\r\n") == std::string::npos)
+                            continue;
+                        _bad(name, "has a non-integer set member: '" + item + "'");
+                    }
+                    members.push_back(value);
+                }
+                result.push_back(std::move(members));
+                at = end + 1;
+            }
+
+            // Anything outside the braces other than separators means this is
+            // not an array of sets, and reading it as one would quietly drop it.
+            for (std::size_t i = 0, brace_depth = 0; i != body.size(); ++i) {
+                if (body[i] == '{')
+                    ++brace_depth;
+                else if (body[i] == '}')
+                    --brace_depth;
+                else if (0 == brace_depth && ',' != body[i] && ! std::isspace(static_cast<unsigned char>(body[i])))
+                    _bad(name, "is not an array of sets: '" + text + "'");
+            }
+            return result;
+        }
+    };
+
+    /// Read a `.dzn` file. Line comments are stripped, then the text is split
+    /// into `name = value;` statements. A statement without an `=` is ignored
+    /// rather than rejected, so a data file carrying an `output` item or a
+    /// bare `;` still reads.
+    [[nodiscard]] inline auto read(const std::string & path) -> Data
+    {
+        std::ifstream infile{path};
+        if (! infile)
+            throw std::runtime_error{"cannot read '" + path + "'"};
+
+        std::string text, line;
+        while (std::getline(infile, line)) {
+            auto comment = line.find('%');
+            text += (comment == std::string::npos ? line : line.substr(0, comment));
+            text += '\n';
+        }
+
+        auto trim = [](const std::string & s) -> std::string {
+            auto first = s.find_first_not_of(" \t\r\n");
+            if (first == std::string::npos)
+                return {};
+            return s.substr(first, s.find_last_not_of(" \t\r\n") - first + 1);
+        };
+
+        std::map<std::string, std::string> values;
+        std::size_t pos = 0;
+        while (true) {
+            auto end = text.find(';', pos);
+            if (end == std::string::npos)
+                break;
+            auto statement = text.substr(pos, end - pos);
+            pos = end + 1;
+
+            auto eq = statement.find('=');
+            if (eq == std::string::npos)
+                continue;
+            auto name = trim(statement.substr(0, eq));
+            if (name.empty())
+                continue;
+            if (! values.emplace(name, trim(statement.substr(eq + 1))).second)
+                throw std::runtime_error{"'" + path + "' defines '" + name + "' twice"};
+        }
+
+        return Data{path, std::move(values)};
+    }
+}
+
+#endif

--- a/examples/rcpsp/CMakeLists.txt
+++ b/examples/rcpsp/CMakeLists.txt
@@ -41,6 +41,22 @@ add_test(NAME rcpsp_infeasible COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_
 add_test(NAME rcpsp_sch COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_sch
     $<TARGET_FILE:rcpsp> --file ${CMAKE_CURRENT_SOURCE_DIR}/sample.sch)
 
+# The plain-RCPSP .dzn reader, which is a different format entirely: a demand
+# matrix and finish-to-start successor sets rather than a token stream of
+# start-to-start arcs.
+add_test(NAME rcpsp_dzn COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_dzn
+    $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn)
+
+# The same instance with the InferredDisjunctive presolver, whose derived
+# capacity-one Cumulative is proved rather than asserted --- so this is the
+# end-to-end proof check for that certificate on a model read from a file, as
+# opposed to the presolver's own fixtures. sample.dzn is built so that each
+# conflicting pair is witnessed by a different resource, which is the case no
+# single posted Cumulative can reach; the presolver reports a capacity bound of
+# 6, and the optimum is 6.
+add_test(NAME rcpsp_dzn_inferred COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_dzn_inferred
+    $<TARGET_FILE:rcpsp> --dzn ${CMAKE_CURRENT_SOURCE_DIR}/sample.dzn --infer-disjunctive)
+
 # Enumeration rather than optimisation, so this one reaches the COMPLETE
 # ENUMERATION conclusion, which none of the others do.
 add_test(NAME rcpsp_all COMMAND ${GCS_BASH} ${CMAKE_SOURCE_DIR}/run_test_and_verify.bash --basename rcpsp_all

--- a/examples/rcpsp/rcpsp.cc
+++ b/examples/rcpsp/rcpsp.cc
@@ -79,6 +79,7 @@
 #include <gcs/constraints/disjunctive.hh>
 #include <gcs/constraints/linear.hh>
 #include <gcs/presolvers/difference_logic.hh>
+#include <gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh>
 #include <gcs/problem.hh>
 #include <gcs/search_heuristics.hh>
 #include <gcs/solve.hh>
@@ -87,6 +88,7 @@
 #include <examples/rcpsp/rcpsp_instance.hh>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
@@ -282,16 +284,31 @@ auto main(int argc, char * argv[]) -> int
             ("max-demand", "Largest demand a task can place on a resource, zero meaning it does not use it", //
                 cxxopts::value<int>()->default_value("3"))                                                   //
             ("density",
-                "Probability of a precedence between two tasks close together in the topological " //
-                "order",                                                                           //
-                cxxopts::value<double>()->default_value("0.3"))                                    //
-            ("machine-fraction", "Probability that a task also needs the unary machine",           //
-                cxxopts::value<double>()->default_value("0.35"))                                   //
-            ("print-instance", "Print the generated instance before solving")                      //
-            ("file",                                                                               //
-                "Read a single-mode RCPSP/max instance from PATH, in ProGen/max .sch format (the " //
-                "UBO, CD and SM sets), instead of generating one",                                 //
-                cxxopts::value<string>())                                                          //
+                "Probability of a precedence between two tasks close together in the topological "       //
+                "order",                                                                                 //
+                cxxopts::value<double>()->default_value("0.3"))                                          //
+            ("machine-fraction", "Probability that a task also needs the unary machine",                 //
+                cxxopts::value<double>()->default_value("0.35"))                                         //
+            ("print-instance", "Print the generated instance before solving")                            //
+            ("infer-disjunctive",                                                                        //
+                "Run the InferredDisjunctive presolver, which looks for cliques of tasks that no "       //
+                "single resource can hold pairwise and posts each as a derived capacity-one Cumulative", //
+                cxxopts::value<bool>()->default_value("false"))                                          //
+            ("infer-disjunctive-candidates",                                                             //
+                "Cap how many candidate pairs the clique search grows (Sidorov's N_cover)",              //
+                cxxopts::value<std::size_t>()->default_value("100"))                                     //
+            ("infer-disjunctive-posted",                                                                 //
+                "Cap how many cliques are posted (Sidorov's N_out)",                                     //
+                cxxopts::value<std::size_t>()->default_value("5"))                                       //
+            ("file",                                                                                     //
+                "Read a single-mode RCPSP/max instance from PATH, in ProGen/max .sch format (the "       //
+                "UBO, CD and SM sets), instead of generating one",                                       //
+                cxxopts::value<string>())                                                                //
+            ("dzn",                                                                                      //
+                "Read a plain RCPSP instance from PATH, in the MiniZinc data format that goes with "     //
+                "rcpsp.mzn (the Pack, Pack_d, PSPLib, la_x, ksd15_d and bl sets), instead of "           //
+                "generating one",                                                                        //
+                cxxopts::value<string>())                                                                //
             ("max-lag-density",
                 "Probability that a pair joined by a precedence path also gets a maximum time " //
                 "lag, which is what turns this into an RCPSP/max instance. Zero, the default, " //
@@ -382,8 +399,12 @@ auto main(int argc, char * argv[]) -> int
 
     rcpsp::Instance instance;
     try {
+        if (options_vars.contains("file") && options_vars.contains("dzn"))
+            throw std::runtime_error{"--file and --dzn both name an instance; give only one"};
         if (options_vars.contains("file"))
             instance = rcpsp::read_file(options_vars["file"].as<string>());
+        else if (options_vars.contains("dzn"))
+            instance = rcpsp::read_dzn_file(options_vars["dzn"].as<string>());
         else {
             rcpsp::GeneratorOptions gen_opts;
             gen_opts.n_tasks = options_vars["size"].as<int>();
@@ -638,6 +659,15 @@ auto main(int argc, char * argv[]) -> int
                 }
     }
 
+    // Added after every Cumulative above, because what it has to work with is
+    // the set of posted resources: it looks for pairs of tasks that some
+    // resource cannot hold together, and grows those into cliques.
+    auto disjunctive_stats = std::make_shared<InferredDisjunctiveStats>();
+    auto infer_disjunctive = options_vars["infer-disjunctive"].as<bool>();
+    if (infer_disjunctive)
+        problem.add_presolver(InferredDisjunctive{disjunctive_stats}.with_budgets(
+            options_vars["infer-disjunctive-candidates"].as<std::size_t>(), options_vars["infer-disjunctive-posted"].as<std::size_t>()));
+
     auto all = options_vars.contains("all");
 
     // A deadline that the horizon already enforces needs nothing more; one
@@ -717,6 +747,15 @@ auto main(int argc, char * argv[]) -> int
     if (*variant == Variant::Presolved) {
         println("presolver_edges_lifted: {}", presolver_stats->edges_lifted);
         println("presolver_nodes: {}", presolver_stats->nodes);
+    }
+    if (infer_disjunctive) {
+        println("inferred_disjunctive_conflicting_pairs: {}", disjunctive_stats->conflicting_pairs);
+        println("inferred_disjunctive_cross_donor_pairs: {}", disjunctive_stats->cross_donor_pairs);
+        println("inferred_disjunctive_cliques_found: {}", disjunctive_stats->cliques_found);
+        println("inferred_disjunctive_cliques_posted: {}", disjunctive_stats->cliques_posted);
+        println("inferred_disjunctive_clique_members_posted: {}", disjunctive_stats->clique_members_posted);
+        // Sidorov's L: a makespan lower bound that needs no search to believe.
+        println("inferred_disjunctive_capacity_bound: {}", disjunctive_stats->largest_capacity_bound.raw_value);
     }
     if (*variant != Variant::Decomposed) {
         println("simplify: {}", simplify_name);

--- a/examples/rcpsp/rcpsp_instance.hh
+++ b/examples/rcpsp/rcpsp_instance.hh
@@ -29,6 +29,8 @@
 // this example is part of the proof benchmark set (issues #632, #633), and the
 // default instance family, horizon and posting order have to stay put.
 
+#include <examples/dzn.hh>
+
 #include <gcs/integer.hh>
 
 #include <algorithm>
@@ -623,6 +625,92 @@ namespace rcpsp
         if (! in)
             throw std::runtime_error{"could not open instance file: " + path};
         return read_sch_stream(in, "file " + path);
+    }
+
+    /// Read a plain RCPSP instance in the MiniZinc data format that goes with
+    /// the standard `rcpsp.mzn` model, as distributed in the MiniZinc
+    /// benchmarks: the Pack, Pack_d, PSPLib (j30/j60/j120), la_x, ksd15_d and
+    /// bl collections.
+    ///
+    /// The file defines `n_res`, the capacities `rc`, `n_tasks`, the durations
+    /// `d`, the demands `rr` as a `[Res, Tasks]` matrix, and the successors
+    /// `suc` as an array of sets of one-based task indices. RCPSP/max data files
+    /// name the same things `rcap`, `dur` and `dcons` instead and carry time
+    /// lags rather than precedences; those are a different format and belong in
+    /// read_sch_stream, not here.
+    ///
+    /// This is plain RCPSP, so the instance comes back with no time lags, no
+    /// machine tasks and no pinned source: `suc` is finish-to-start throughout.
+    ///
+    /// \warning Only the resource and precedence structure is read. The
+    /// redundant pairwise non-overlap constraints that `rcpsp.mzn` itself posts
+    /// are deliberately **not** reproduced --- they are a modelling choice of
+    /// that file, not part of the instance, and posting them changes what a
+    /// presolver looking for cross-resource conflicts has left to find.
+    [[nodiscard]] inline auto read_dzn_file(const std::string & path) -> Instance
+    {
+        auto data = dzn::read(path);
+
+        Instance inst;
+        inst.n_tasks = static_cast<int>(data.integer("n_tasks"));
+        auto n_res = static_cast<std::size_t>(data.integer("n_res"));
+        if (inst.n_tasks < 1)
+            throw std::runtime_error{"'" + path + "' has no tasks"};
+
+        for (auto & c : data.integers("rc"))
+            inst.capacities.push_back(gcs::Integer{c});
+        if (inst.capacities.size() != n_res)
+            throw std::runtime_error{
+                "'" + path + "' gives " + std::to_string(inst.capacities.size()) + " capacities for " + std::to_string(n_res) + " resources"};
+
+        for (auto & p : data.integers("d")) {
+            if (p < 1)
+                throw std::runtime_error{
+                    "'" + path + "' has a task of duration " + std::to_string(p) + "; this model needs every duration to be at least one"};
+            inst.durations.push_back(gcs::Integer{p});
+        }
+        if (static_cast<int>(inst.durations.size()) != inst.n_tasks)
+            throw std::runtime_error{
+                "'" + path + "' gives " + std::to_string(inst.durations.size()) + " durations for " + std::to_string(inst.n_tasks) + " tasks"};
+
+        auto rr = data.matrix("rr");
+        if (rr.size() != n_res)
+            throw std::runtime_error{"'" + path + "' gives demands for " + std::to_string(rr.size()) + " resources, not " + std::to_string(n_res)};
+        inst.demands.assign(n_res, std::vector<gcs::Integer>(static_cast<std::size_t>(inst.n_tasks), gcs::Integer{0}));
+        for (std::size_t r = 0; r != n_res; ++r) {
+            if (static_cast<int>(rr[r].size()) != inst.n_tasks)
+                throw std::runtime_error{"'" + path + "' gives " + std::to_string(rr[r].size()) + " demands for resource " + std::to_string(r) +
+                    ", not " + std::to_string(inst.n_tasks)};
+            for (int i = 0; i != inst.n_tasks; ++i) {
+                if (rr[r][static_cast<std::size_t>(i)] < 0)
+                    throw std::runtime_error{"'" + path + "' has a negative demand"};
+                inst.demands[r][static_cast<std::size_t>(i)] = gcs::Integer{rr[r][static_cast<std::size_t>(i)]};
+            }
+        }
+
+        // `suc` is one-based, and every collection in the MiniZinc benchmarks
+        // lists it in topological order. earliest_starts(), tails() and
+        // longest_paths() all walk the tasks in index order and rely on that, so
+        // a file that broke it would give silently wrong bounds rather than an
+        // error --- hence the check rather than a sort.
+        auto suc = data.sets("suc");
+        if (static_cast<int>(suc.size()) != inst.n_tasks)
+            throw std::runtime_error{
+                "'" + path + "' gives successors for " + std::to_string(suc.size()) + " tasks, not " + std::to_string(inst.n_tasks)};
+        for (int i = 0; i != inst.n_tasks; ++i)
+            for (auto & one_based : suc[static_cast<std::size_t>(i)]) {
+                auto j = static_cast<int>(one_based) - 1;
+                if (j < 0 || j >= inst.n_tasks)
+                    throw std::runtime_error{"'" + path + "' has a precedence to a nonexistent task"};
+                if (j <= i)
+                    throw std::runtime_error{"'" + path + "' lists task " + std::to_string(one_based) + " as a successor of task " +
+                        std::to_string(i + 1) + ", so the tasks are not in topological order; this reader needs them to be"};
+                inst.precedences.emplace_back(i, j);
+            }
+
+        inst.description = "dzn " + path + " n=" + std::to_string(inst.n_tasks) + " resources=" + std::to_string(n_res) +
+            " precedences=" + std::to_string(inst.precedences.size());
+        return inst;
     }
 }
 

--- a/examples/rcpsp/sample.dzn
+++ b/examples/rcpsp/sample.dzn
@@ -1,0 +1,31 @@
+% A small plain-RCPSP instance in the MiniZinc data format that goes with the
+% standard rcpsp.mzn, for the --dzn reader. Written by hand rather than taken
+% from a benchmark set, so it is small enough to prove quickly and there is no
+% licence question about redistributing it.
+%
+% Tasks 1, 2 and 3 are pairwise incompatible, but each pair is witnessed by a
+% *different* resource: (1,3) by resource 1, (2,3) by resource 2, (1,2) by
+% resource 3. No single resource sees more than one of the three pairs, so no
+% single Cumulative can tell that all three must be serialised --- only the
+% clique across all of them says so. That is exactly the cross-resource shape
+% the InferredDisjunctive presolver is for, and --infer-disjunctive on this file
+% derives a capacity bound of 6, which is also the optimal makespan.
+%
+% Task 4 uses a resource without conflicting with anything, and is a successor
+% of task 1, so `suc` is not uniformly empty and the demand matrix has a row
+% that is not part of any conflict.
+
+n_res = 3;
+rc = [ 10, 10, 10 ];
+
+n_tasks = 4;
+d = [ 2, 2, 2, 1 ];
+
+rr = [| 6, 0, 6, 1
+      | 0, 6, 6, 0
+      | 6, 6, 0, 1 |];
+
+suc = [ { 4 },
+        {  },
+        {  },
+        {  } ];

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.cc
@@ -354,17 +354,22 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
 
     bump(&InferredDisjunctiveStats::cliques_found, found.size());
 
-    // Rank by the capacity-bound metric, which at unit coefficients is just the
-    // total duration the clique must serialise, and drop any clique contained
-    // in one already accepted.
+    // The capacity bound a clique carries: its members run one after another, so
+    // the schedule cannot finish before their durations summed. This is
+    // Sidorov's L at unit coefficients, it is what the cliques are ranked by,
+    // and it is what InferredDisjunctiveStats reports --- one function, so the
+    // number a test compares against a published bound is the number the
+    // ranking actually used.
+    auto capacity_bound = [&](const vector<size_t> & c) {
+        auto sum = 0_i;
+        for (auto i : c)
+            sum += tasks[i].length;
+        return sum;
+    };
+
+    // Rank by that, and drop any clique contained in one already accepted.
     std::sort(found.begin(), found.end(), [&](const vector<size_t> & a, const vector<size_t> & b) {
-        auto total = [&](const vector<size_t> & c) {
-            auto sum = 0_i;
-            for (auto i : c)
-                sum += tasks[i].length;
-            return sum;
-        };
-        auto ta = total(a), tb = total(b);
+        auto ta = capacity_bound(a), tb = capacity_bound(b);
         if (ta != tb)
             return ta > tb;
         return a < b;
@@ -541,8 +546,12 @@ auto InferredDisjunctive::run(Problem & problem, Propagators & propagators, Stat
 
         bump(&InferredDisjunctiveStats::cliques_posted);
         bump(&InferredDisjunctiveStats::clique_members_posted, clique.size());
+        auto bound = capacity_bound(clique);
+        if (_stats && bound > _stats->largest_capacity_bound)
+            _stats->largest_capacity_bound = bound;
         if (logger)
-            logger->emit_proof_comment("presolve disjunctive: inferred a clique of " + to_string(clique.size()) + " tasks");
+            logger->emit_proof_comment(
+                "presolve disjunctive: inferred a clique of " + to_string(clique.size()) + " tasks, total duration " + to_string(bound.raw_value));
     }
 
     // How much of this genuinely spanned resources, which is what says a

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive.hh
@@ -95,6 +95,23 @@ namespace gcs
         /// three of two.
         std::size_t clique_members_posted = 0;
 
+        /**
+         * \brief The largest capacity bound over the posted cliques: Sidorov's
+         * `L`, and a lower bound on the makespan.
+         *
+         * A capacity-one Cumulative over a set of tasks says they must run one
+         * after another, so the schedule cannot finish before their durations
+         * summed. Sidorov reports this as `L = sum_i d_i pi_i / pi_0`; at the
+         * unit coefficients this presolver deals in, `pi_0` is one and it is
+         * just the clique's total duration --- which is already the metric the
+         * cliques are ranked by, so this is that ranking's winning score.
+         *
+         * It is the number to compare against a published bound, and the only
+         * output of this presolver that is meaningful without running a search.
+         * Zero when nothing was posted.
+         */
+        Integer largest_capacity_bound{0};
+
         /// Flag bridges emitted, one per (task, time) that had to be carried
         /// from a witnessing resource to the one holding the task's flags.
         std::size_t bridges_derived = 0;

--- a/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
+++ b/gcs/presolvers/inferred_disjunctive/inferred_disjunctive_test.cc
@@ -222,6 +222,15 @@ auto main(int argc, char * argv[]) -> int
             fail("posted " + to_string(stats->cliques_posted) + " cliques, not the one the family contains");
         if (stats->clique_members_posted != 3)
             fail("the posted clique had " + to_string(stats->clique_members_posted) + " members, not three");
+        // Sidorov's L, and the whole reason this fixture is unsatisfiable:
+        // three tasks of length two must run one after another, so they need
+        // six units, and the horizon supplies five. Asserting it here rather
+        // than just the clique's size is what makes the reported bound a
+        // checked number rather than an incidental one --- it is the number
+        // the Pack / Pack-d cross-check compares against the paper.
+        if (stats->largest_capacity_bound != 6_i)
+            fail("reported a capacity bound of " + to_string(stats->largest_capacity_bound.raw_value) +
+                ", not the six units three length-two tasks must serialise into");
         if (stats->cross_donor_pairs == 0)
             fail("no pair needed bridging, so the fixture is not exercising the cross-resource case");
         if (proofs && stats->bridges_derived == 0)
@@ -292,6 +301,10 @@ auto main(int argc, char * argv[]) -> int
             fail("a zero candidate budget still posted a clique");
         if (stats->dropped_over_budget == 0)
             fail("a zero candidate budget dropped candidates without counting them");
+        // Nothing posted has to mean no bound claimed: a stale capacity bound
+        // would be a lower bound nobody derived.
+        if (stats->largest_capacity_bound != 0_i)
+            fail("posted no clique but still reported a capacity bound of " + to_string(stats->largest_capacity_bound.raw_value));
     }
 
     // Two resources, each forbidding one pair, with no conflict between the


### PR DESCRIPTION
Closes #548. Its last substantive item is validation 5, "discover a clique on a
Pack/Pack_d instance with a capacity-bound value `L` matching what the paper
reports", which is what this does. Stacked on #663.

## The result

On **all twenty** capacity-one Pack and Pack-d targets, `InferredDisjunctive`
reports **exactly** the capacity bound Sidorov reports, under his own budgets
(`N_cover = 100`, `N_out = 5`, which are the defaults here):

| collection | instances | `L` reproduced |
|---|---|---|
| Pack | 4, 5, 8, 9, 11, 13, 16, 23, 28, 29 | 10 / 10 |
| Pack-d | 8, 9, 12, 15, 16, 17, 18, 20, 24, 43 | 10 / 10 |

Eleven of the twenty have `L` equal to the best known makespan, so the bound
closes the instance with no search at all.

This is a pass/fail check rather than a search-quality judgement: before running
anything I re-verified all 83 of the paper's Pack/Pack-d lifted constraints
against the instance data (83 valid, 0 invalid), and asserted that each of the
twenty capacity-one supports really is a disjunctive clique — every coefficient
one, every pair genuinely conflicting on some resource, `L` equal to the
members' total duration. So the presolver is being asked to rediscover a clique
that provably exists.

## What is here

**`examples/dzn.hh`**, a shared `.dzn` reader. Four examples already have their
own — table_layout, seat_moving, nonogram, hitori — and the comment stripper is
byte-identical in three of them. They have also quietly diverged on what dzn they
accept: hitori handles `[| a, b | c, d |]`, table_layout silently mis-parses it;
table_layout handles `array3d(...)` and nobody else does; none of them read a set
literal, which is what `suc` is. Rather than add a fifth copy, this is the
fragment they all need in one place. **Nothing is migrated onto it here** —
#664 is that follow-up, since doing it in this PR would turn a cross-check into
an examples-wide refactor.

**`rcpsp --dzn`**, reading plain RCPSP in the format that goes with the standard
`rcpsp.mzn`. Note it deliberately does *not* reproduce that file's redundant
pairwise non-overlap constraints: they are a modelling choice of the file rather
than part of the instance, and posting them would hand the presolver the
conflicts it is supposed to find. Sidorov's preprocessor does not post them
either, so this matches what he ran.

**`InferredDisjunctiveStats::largest_capacity_bound`**, which is Sidorov's `L`.
The clique ranking already computed it, so that computation is hoisted into one
function used by both the ranking and the statistic — the number a test compares
against a published bound is then necessarily the number the ranking used.

## Two things worth knowing about the comparison

Both are easy to get wrong and neither is visible from the paper; both are now in
`dev_docs/inferred-disjunctive.md`.

- **His logs record the bound unrounded** — the rational `sum_i d_i w_i / r` to
  three decimal places, not its ceiling. Capacity-one rows are integral either
  way, so a naive comparison looks correct and then fails on every non-unit
  capacity. His own reporting script compares the unrounded value, which is why
  the paper's counts are conservative: 20 Pack/Pack-d instances close on that
  comparison, 36 with the ceiling.
- **There is no Pack/Pack-d table in the paper.** The claim is one sentence in
  §5.1. Appendix A is all RCPSP/max because his reporting script filters
  `problem == 'max'` before writing every report.

## Testing

- The capacity bound asserted on the differential fixture as six — which is
  *why* it refutes, three length-two tasks needing six units of a five-unit
  horizon — and as zero where nothing was posted, so a stale bound cannot pose
  as a derived one.
- `rcpsp_dzn` and `rcpsp_dzn_inferred`, end to end and VeriPB-checked, over a
  hand-written `examples/rcpsp/sample.dzn` built so each conflicting pair is
  witnessed by a different resource. Hand-written rather than vendored from the
  benchmark set, so there is no redistribution question.
- 629/629 ctest with `GCS_TEST_CAP_DEFAULTS=OFF`; clean under clang; the reader
  and the presolver clean under ASan/UBSan on both the fixture and a real Pack
  instance.

The acquired data, the reproduction scripts and the sweep live outside the repo
in `~/claude/tmp/sidorov-548`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173hT2hFo3MyGRBon8SHt2p

