### PR TITLE
Presolver: strengthen a Cumulative's heights, not just its capacity (#547, part two)

### DIFF
--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -142,13 +142,16 @@ library. For an introduction to *using* the solver, start with the top-level
   unit propagation cannot do, and why a satisfiable test model and an `ia`
   content check are both needed to test it.
 - [Strengthening a `Cumulative` by integrality](cumulative-strengthening.md) —
-  Schulz's pre-solving capacity rules as the `CumulativeStrengthening` presolver,
-  posting the strengthened constraint in derived mode. Covers why the largest
-  reachable load is the real capacity, why the rules are *time-table neutral* and
-  how that turns into a node-for-node soundness tripwire, the `ia` step that
-  pins every row to the declared capacity (and is the only thing that catches a
-  sound derivation of the wrong line), the deviations from the paper's statement
-  of the rules, and why the deep-gap fixture everyone quotes cannot be a
+  Schulz's pre-solving rules as the `CumulativeStrengthening` presolver, posting
+  the strengthened constraint in derived mode. Covers why the largest reachable
+  load is the real capacity, why the tasks that fill the resource on their own
+  have to be set aside from that sum and given the capacity as their height
+  instead (which is both of Schulz's height rules arriving at the same place),
+  why raising a coefficient in cutting planes is a loop rather than one
+  division, why the rules are *time-table neutral* and how that turns into a
+  node-for-node soundness tripwire, the `ia` step that pins every row to the
+  declared capacity (and is the only thing that catches a sound derivation of
+  the wrong line), and why the deep-gap fixture everyone quotes cannot be a
   `Cumulative` instance.
 - [Inferring `Disjunctive` constraints across resources](inferred-disjunctive.md) —
   the `InferredDisjunctive` presolver: conflict cliques spanning several posted

--- a/dev_docs/cumulative-strengthening.md
+++ b/dev_docs/cumulative-strengthening.md
@@ -15,15 +15,58 @@ computes
                              that is at most C )
 ```
 
-and, when `kappa < C`, posts a
+— over the tasks that can run *beside something*, which is the subtlety the whole
+thing turns on, and posts a
 [derived `Cumulative`](cumulative-proof-logging.md#derived-cumulatives-an-implied-constraint-that-adds-nothing-to-the-model)
-over the same tasks with the same heights and a capacity of `kappa`. The donor
-stays posted and the OPB is untouched: each per-time capacity row of the derived
-constraint is *proved* from the donor's row for that time point, by
-[subset-sum strengthening](subset-sum-strengthening.md).
+at a capacity of `kappa`. The donor stays posted and the OPB is untouched: each
+per-time capacity row of the derived constraint is *proved* from the donor's row
+for that time point, by [subset-sum strengthening](subset-sum-strengthening.md).
 
 The rules are Schulz's pre-solving strengthenings, recapped by Cloutier and
 Quimper (CP 2026, §2.3).
+
+## The tasks that fill the resource, and why they are set aside
+
+Call a task **full** when it cannot run beside any other task that consumes
+anything: `h_i + h_j > C` for every `j ≠ i` with `h_j > 0` whose window overlaps
+its own. Such a task occupies the resource whenever it runs, whatever its height
+says.
+
+A full task ruins the subset sum. It reaches `C` on its own, so the largest
+reachable load *is* the capacity and `kappa = C` and nothing happens — a task of
+height `C` in the model turns the capacity rule off entirely. Excluding the full
+tasks from the sum is Schulz's refinement, and it is only sound if their own
+heights come down to `kappa` as well, which is what the derived constraint does:
+
+| | capacity | full task's height | every other height |
+|---|---|---|---|
+| donor | `C` | `h_i` | `h_j` |
+| derived | `kappa` | `kappa` | `h_j` |
+
+Both of Schulz's height rules arrive at that same table. His coefficient raising
+— any `c_i` above `C − min_j c_j` can be raised to `C` — is the same set of
+tasks, since `c_i > C − min{c_j : j ≠ i, c_j > 0}` says exactly that no other
+task fits alongside; and his knapsack rule's "`c_i = C` can be reduced to
+`kappa`" is what happens to those tasks once the capacity moves. So there is one
+rule here, not two, and `CumulativeStrengtheningStats::tasks_raised` counts it.
+
+Stating it as the pairwise test rather than as the minimum is deliberate. The
+two conditions are the same, but the pairwise one is what the certificate needs
+anyway — one at-most-one per pair, off the donor's own row — and it does not
+need the empty-minimum case argued separately. Tasks whose windows cannot
+overlap are left out of the test, which is a little more than the paper claims
+and costs nothing: if they can never be active together, no row ever mentions
+both.
+
+The set is **not** computed per time point, even though fewer tasks can run at
+one time point than over the whole horizon and the set would be larger for it. A
+`Cumulative` has one height per task, not one per time point, so a task that
+only fills the resource at some of them cannot be given a raised height at all.
+
+When *every* task is full, `kappa` is a subset sum over nothing and comes out at
+zero. That is not a strengthening but a disjunctive, and the donor is declined:
+inferring those from conflict cliques is
+[`InferredDisjunctive`](cumulative-proof-logging.md)'s job.
 
 ## Why `kappa` is the right number, and why the max is the max
 
@@ -48,13 +91,27 @@ heights, so it exceeds `kappa` exactly when it exceeds `C`:
   heights, so it is at most `kappa_t ≤ kappa`.
 
 The paper says the same thing in one line — "time tabling is unaffected since any
-propagation detected after the pre-solving is detectable beforehand". The useful
-consequence is a *test*: with the energy rules off on both the donor and the
-derived constraint, the search tree with the presolver must be
+propagation detected after the pre-solving is detectable beforehand".
+
+A **raised** height needs its own argument, because the profile really is
+different: a full task contributes `kappa` to the derived profile and `h_i` to
+the donor's. What saves it is that a raised task conflicts with everything, so
+every verdict the raised height reaches is one the donor reaches too:
+
+- if a full task's compulsory part covers `t`, the derived profile there is
+  already `kappa` and pushes every other task out — and the donor pushes them
+  out too, since `h_i + h_j > C` for each of them;
+- if none does, the derived profile at `t` is a sum of unraised heights, and the
+  argument above applies to it unchanged; a full task is then pushed out of `t`
+  exactly when something else is compulsory there, which the donor also does.
+
+The useful consequence is a *test*: with the energy rules off on both the donor
+and the derived constraint, the search tree with the presolver must be
 **node-for-node identical** to the one without it. Any difference means the
 strengthening changed what the profile permits, which is the shape an unsound one
-takes, and `cumulative_strengthening_presolver` asserts it on two fixtures before
-VeriPB gets a say.
+takes, and `cumulative_strengthening_presolver` asserts it on four fixtures —
+two that only move the capacity and two that raise a height — before VeriPB gets
+a say.
 
 The same theorem, used the other way round, is why the derived constraints ship
 with **time-tabling off**: every time-table inference a derived constraint could
@@ -75,6 +132,15 @@ six, which changes no profile verdict at all, but the window then supplies
 `6 × 3 = 18` against the `21` units the tasks need, and the overload check
 refutes at the root. At a capacity of eight it supplies `24`, and the solver
 searches.
+
+The heights half has its own demonstration, and it is a fixture the capacity
+rule alone gets *nothing* on: five unit-length tasks of height three plus one of
+height eight, all able to run in `[0, 3)`, against a capacity of eight. The tall
+task reaches the capacity by itself, so `kappa` over every task is eight and the
+capacity rule declines the donor outright. Setting it aside takes `kappa` to six
+and brings its own height down with it, and the window then supplies `18`
+against the `21` those six tasks need. The donor needs `23` against a supply of
+`24`, and searches.
 
 ## What reaches the proof
 
@@ -118,34 +184,92 @@ hint"). Nothing else in the proof objects. This is
 [the third net](subset-sum-strengthening.md#testing-it) the subset-sum utility's
 own tests describe, applied at the point of use.
 
-## Two deviations from the paper's rules
+## Raising a coefficient, in cutting planes
 
-Both leave strengthening on the table; neither costs soundness or solutions.
+The capacity half is one call to the subset-sum utility. The heights half is not,
+and the reason is worth having written down, because the obvious derivation does
+not work and it is not obvious why.
 
-**The per-time knapsack set is not restricted to `c_j < C`.** The paper's `kappa`
-excludes tasks that fill the resource by themselves, which gives a smaller number
-— a task with `c_j = C` reaches `C` on its own, so including it makes `kappa = C`
-and the rule does nothing. Excluding it is only sound if those tasks' own heights
-come down to `kappa` as well, which the paper's statement duly does ("all
-consumption `c_i` such that `c_i = C`, as well as `C`, can be reduced to
-`kappa`"). That changes the derived constraint's *coefficients*, and the
-derivation for it needs at-most-one reasoning off the donor's row: if a task with
-`c_j = C` is running, nothing else is, so the row's value is `kappa` either way.
-That is the same machinery the coefficient-raising rule needs, and it is the
-remaining half of issue #547.
+The row wanted at time `t`, over the full tasks `F` present and the rest `N`, is
 
-**Coefficient raising is not implemented.** The paper's first rule — any `c_i`
-above `C − min_j c_j` can be raised to `C`, because such a task can never run
-beside another — changes heights for the same reason and needs the same
-at-most-one derivation.
+```
+    sum_{i in F} kappa·a_i  +  sum_{j in N} h_j·a_j  <=  kappa
+```
 
-A note for whoever writes that half. The paper's condition takes the minimum over
-*all* `j ∈ I`, task `i` included, which is sound but blunter than it needs to be:
-what the argument actually requires is that `i` cannot run beside any *other*
-task that consumes anything, i.e. `c_i + min{c_j : j ≠ i, c_j > 0} > C`. Issue
-#547 states it that way, and that is the version to implement — with `c_i > 0`
-guarded explicitly, since a zero-height task can always run beside anything and
-the empty-minimum case would otherwise raise it to `C`.
+It is implied by the donor's row alone. If a full task is active, everything else
+is off and the left side is exactly `kappa`; if none is, the left side is a subset
+sum of `N`'s heights that the donor keeps at most `C`, hence at most `kappa`. So
+there is a derivation to find. The route is:
+
+1. the pairwise **at-most-ones**, one per pair the full tasks are in, each
+   [off the donor's own row](../gcs/innards/proofs/am1_from_row.hh) — weaken the
+   others out, saturate, divide;
+2. the full tasks **weakened out** of the row, leaving `sum_N h_j·a_j <= C`;
+3. **subset-sum strengthening** of what is left, to `kappa_t`, then an `ia` step
+   relaxing it to the declared `kappa` if the two differ;
+4. each full task's coefficient **raised** from zero to `kappa`, in the row the
+   last one left behind.
+
+Step 3 has to happen before step 4 and not after: a raise keeps whatever right
+hand side it is given and can raise a coefficient no higher, so a row left on a
+smaller `kappa_t` would neither reach `kappa` nor pin to it.
+
+### Why step 4 is a loop
+
+Given the row `c·a_i + sum_k w_k·a_k <= R` and the at-most-ones tying `i` to each
+`k`, one `pol` raises `c` by `k` while keeping `R`: take `lambda` copies of the
+row, add each at-most-one weighted by its own `w_k`, scaled by `e`, and divide by
+`lambda + e`, with `lambda/e = (T − c − k)/k` and `T = sum_k w_k`. Every
+coefficient divides exactly; only the degree rounds, and it has `e·(T − R)` to
+round through, so the step lands back on `R` exactly when
+
+```
+    k · (T − R)  <  T − c
+```
+
+That bound is the whole of it. When the rest of the row only just overshoots the
+capacity — `T − R = 1` — one step raises all the way. When it overshoots by half,
+the steps are of size one and the raise costs a `pol` per unit of `kappa`. And no
+single `lambda`, `e`, divisor and set of weakenings does better: asking for the
+whole raise at once forces `(k − 1)·(T − R − 1) < 1`, which is why the loop is
+there and not a tidier one-shot. Hence `with_raise_budget`, which caps the lines
+this may spend on a donor; `raise_steps()` computes the same sequence for the
+budget and for the derivation, since a prediction that disagreed would decline the
+wrong donors.
+
+Two ends of the loop are not the loop:
+
+- `T <= kappa` — everything else fits alongside — needs no division at all. The
+  at-most-ones summed *are* the row, at a right hand side of `T`, which one `ia`
+  step relaxes to `kappa`. So a time point like this pays for no subset sum
+  either, and step 3 is derived lazily for that reason.
+- `T = 0` — nothing else can run at `t` — has no row to raise into and no
+  at-most-one to do it with. The claim is only that a flag is at most one, and
+  it is RUP.
+
+### What the pin catches, and what nothing catches
+
+Every step above is sound whatever it is fed, so a wrong margin, a wrong step
+size or a missing weakening all land on lines that are true and simply weaker
+than intended. The row's closing `ia` step is what rejects them, and the
+`RaiseTooFast` mutation is exactly that: one step past the bound, the degree
+rounds down instead of up, and every later step compounds it.
+
+What no proof can catch is the *set*. If a task that does not conflict with
+everything is raised anyway, the derivation runs honestly and the row it lands on
+is simply not implied by the donor — which VeriPB does reject, but only because
+the conclusion is false, not because anything about the derivation was wrong.
+`RaiseUnentitled` covers it, on the control fixture where the tallest task misses
+the pairwise test by exactly one. `recover_am1_from_row` refuses a set that does
+not overshoot the capacity outright for the same reason:
+[it cannot be caught later](../gcs/innards/proofs/am1_from_row.hh).
+
+Those at-most-ones all come off *one* donor row, which is the case where
+recovering a whole set's bound in one step beats recovering its pairs. The
+rule's own shape hides most of the win — the raise needs the individual pairwise
+lines, one per step, so they cannot simply be replaced — but a time point where
+only full tasks can run is exactly `sum_F a_i <= 1` and is one `pol`. Left for
+the proof-size pass, with #666.
 
 ## Fixtures, and one that cannot be one
 
@@ -154,14 +278,24 @@ The sharpness fixtures are checked as arithmetic against
 that has drifted makes every claim built on it a claim about something else.
 
 - **gcd path**: heights `{2, 4, 6}`, `C = 13` → `kappa = 12`, by division.
-- **dynamic programming path**: heights `{6, 10, 4}`, `C = 13` → `kappa = 10`.
+- **dynamic programming path**: heights `{2, 6, 6}`, `C = 10` → `kappa = 8`.
+- **raising**: heights `{5, 4, 2}`, `C = 6` → the five is raised to six, and the
+  capacity does not move at all; its control, heights `{4, 4, 2}`, sits exactly
+  on `C − min` and is not raised, so the whole donor is then declined.
 
-That second one is worth dwelling on, because the obvious reading gets it wrong.
-Those heights have a gcd of two, so the gcd rule offers `2·⌊13/2⌋ = 12` — but the
-largest load they can actually reach at or below thirteen is `4 + 6 = 10`, so the
-answer is ten and only the dynamic programme gets there. Rounding by the gcd is
+The second is worth dwelling on, because the obvious reading gets it wrong. Those
+heights have a gcd of two, so the gcd rule offers `2·⌊10/2⌋ = 10` — but the
+largest load they can actually reach at or below ten is `2 + 6 = 8`, so the
+answer is eight and only the dynamic programme gets there. Rounding by the gcd is
 the whole answer only when the gcd's multiples are all reachable, which
-`{2, 4, 6}` manages and `{6, 10, 4}` does not.
+`{2, 4, 6}` manages and `{2, 6, 6}` does not.
+
+The textbook version of that fixture — heights `{6, 10, 4}` against `C = 13` — is
+not one any more, and the reason is the heights half. The ten conflicts with both
+of the others, so it is full: it is set aside, `kappa` is computed over `{6, 4}`
+and comes to ten, and the derivation is a raise rather than a subset sum. A
+fixture for the dynamic programme needs every task to fit beside *something*,
+which is what `{2, 6, 6}` was chosen for.
 
 The deep gap this rule is usually illustrated with — heights `{6, 10, 15}` against
 `C = 14`, overall gcd one, answer ten — is a subset-sum fixture and **cannot be a
@@ -185,7 +319,10 @@ stop being strengthened in silence:
   row is over bit-linearised contribution flags rather than `height × active`, so
   a subset sum of the heights is not a subset sum of the row's coefficients.
 - **A height above the capacity**, as above.
-- **The dynamic-programming budget.**
+- **Every task full**, which makes `kappa` zero: a disjunctive rather than a
+  strengthening, and `InferredDisjunctive`'s to find.
+- **The dynamic-programming budget**, and separately **the raise budget** —
+  different costs in different units, so a donor can want one and not the other.
 
 ## Testing it
 
@@ -196,21 +333,37 @@ being time-table neutral — does not even change the search tree unless energy
 reasoning is on. So:
 
 1. **The stats block is a tripwire, not decoration.** Every fixture asserts the
-   presolver fired, on how many donors, by how many units of capacity, and down
-   which of the two derivations. `CumulativeStrengtheningStats::rows_by_division`
-   against `rows_by_dynamic_programming` is what stops a fixture drifting onto
-   the other path without failing anything.
-2. **Neutrality**, asserted as node-for-node equality under time-tabling alone.
-3. **The energy differential**, where the strengthening is the only thing that
-   refutes the `pack` fixture at the root.
-4. **Solution preservation** over a random corpus against brute force, with an
-   assertion that the presolver fired on some of it.
-5. **Negative controls**: a capacity that is already the largest reachable load
-   is passed over, the OPB matches a run with no presolver byte for byte, and no
-   marker comment appears in the proof at all.
-6. **Mutations**, both of which corrupt the *conclusion* rather than the route to
-   it, which is what a rule whose content is a numeric bound needs: `ClaimOneBetter`
-   claims one below the largest reachable load, and `BogusDivisor` rounds by a
-   divisor that does not divide every height. VeriPB rejects each.
+   presolver fired, on how many donors, by how many units of capacity, on how
+   many raised heights, and down which derivation.
+   `CumulativeStrengtheningStats::rows_by_division` against
+   `rows_by_dynamic_programming` is what stops a fixture drifting onto the other
+   path without failing anything, and `tasks_raised` is the only record that the
+   heights half ran at all — a raise can leave the capacity untouched, and a
+   capacity reduction can raise nothing.
+2. **The split, checked as arithmetic** before any proof, the same way `kappa`
+   is: which tasks are full, and what `kappa` over the rest comes to. The rule
+   turns on the pairwise test, and a fixture that has drifted over the boundary
+   is a fixture for the other case.
+3. **Neutrality**, asserted as node-for-node equality under time-tabling alone,
+   on fixtures that raise as well as fixtures that do not.
+4. **Two energy differentials**: the `pack` fixture, where the capacity rule is
+   the only thing that refutes at the root, and the full-task pack, where the
+   capacity rule gets nothing and only the raising refutes.
+5. **Solution preservation** over a random corpus against brute force, with
+   heights drawn against each instance's own capacity so that full tasks turn up
+   — a fixed height pool gives instances that are declined outright, and covers
+   the heights half only by accident. A second, smaller sweep runs the same
+   instances with proofs on and veripb checking every one, which is where the
+   raise arithmetic's odd corners get exercised.
+6. **Negative controls**: a capacity that is already the largest reachable load
+   is passed over, a task exactly on `C − min` is not raised, the OPB matches a
+   run with no presolver byte for byte, and no marker comment appears in the
+   proof at all.
+7. **Mutations**, each corrupting the *conclusion* rather than the route to it,
+   which is what a rule whose content is a number needs: `ClaimOneBetter` claims
+   one below the largest reachable load, `BogusDivisor` rounds by a divisor that
+   does not divide every height, `RaiseTooFast` takes one step past the bound the
+   division survives, and `RaiseUnentitled` raises a task that does not qualify.
+   VeriPB rejects each.
 
 <!-- vim: set tw=72 spell spelllang=en : -->

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.cc
@@ -2,7 +2,9 @@
 #include <gcs/constraints/cumulative.hh>
 #include <gcs/constraints/cumulative/derived_cumulative.hh>
 #include <gcs/exception.hh>
+#include <gcs/innards/proofs/am1_from_row.hh>
 #include <gcs/innards/proofs/names_and_ids_tracker.hh>
+#include <gcs/innards/proofs/pol_builder.hh>
 #include <gcs/innards/proofs/proof_error.hh>
 #include <gcs/innards/proofs/proof_logger.hh>
 #include <gcs/innards/proofs/subset_sum_strengthening.hh>
@@ -27,8 +29,10 @@ using namespace gcs::innards;
 using std::make_unique;
 using std::map;
 using std::max;
+using std::min;
 using std::move;
 using std::optional;
+using std::pair;
 using std::shared_ptr;
 using std::size_t;
 using std::to_string;
@@ -80,24 +84,65 @@ namespace
         return data;
     }
 
-    /// What the presolver worked out for one time point: the heights of the
-    /// tasks that can be running then, and the largest load they can actually
+    /// What the presolver worked out for one time point: the tasks that can be
+    /// running then, split into the ones that fill the resource on their own
+    /// and the ones that do not, and the largest load the latter can actually
     /// reach without exceeding the capacity.
     struct TimePoint
     {
         Integer t;
         vector<size_t> tasks;
         vector<Integer> heights;
+        vector<size_t> full_tasks;
         Integer kappa;
         /// Whether derive_subset_sum_strengthening() will take its two-step
         /// divisibility path here, predicted by the same test it applies. Only
         /// the other path costs anything worth budgeting for.
         bool by_division;
     };
+
+    /// The step sizes that raise one task's coefficient from zero to `kappa`,
+    /// in a row whose other coefficients total `total` and whose right hand
+    /// side is `kappa` --- one `pol` each.
+    ///
+    /// Each step is `lambda` copies of the row so far plus the at-most-ones
+    /// tying the task to the row's other terms, weighted by those terms' own
+    /// coefficients, all divided by `lambda + e`. Working out the largest step
+    /// that division survives is the whole of this: the division rounds the
+    /// degree *up*, and the margin it has to round through is `e * (total -
+    /// kappa)`, so a step of `k` lands on the right hand side again exactly
+    /// when `k * (total - kappa) < total - c`. That bound is what is being
+    /// computed here, one step at a time.
+    ///
+    /// So the cost is not uniform. A row whose other tasks only just overshoot
+    /// the capacity raises in a single step; one that overshoots by half gets
+    /// steps of one and pays a `pol` per unit of `kappa`, which is why the
+    /// caller budgets this. Predicting it is arithmetic and needs no proof, so
+    /// the budget and the derivation call the same function --- a prediction
+    /// that disagreed would decline the wrong donors.
+    [[nodiscard]] auto raise_steps(Integer total, Integer kappa) -> vector<Integer>
+    {
+        // Everything else fits alongside, so the at-most-ones alone say it:
+        // summed, they give the whole row in one `pol`, and there is no
+        // division to survive.
+        if (total <= kappa)
+            return {kappa};
+
+        auto overshoot = total - kappa;
+        vector<Integer> steps;
+        for (auto c = 0_i; c < kappa;) {
+            // ceil((total - c) / overshoot) - 1, which is at least one while
+            // `c < kappa`, so this terminates.
+            auto step = min(kappa - c, (total - c + overshoot - 1_i) / overshoot - 1_i);
+            steps.push_back(step);
+            c += step;
+        }
+        return steps;
+    }
 }
 
 CumulativeStrengthening::CumulativeStrengthening(shared_ptr<CumulativeStrengtheningStats> stats) :
-    _stats(move(stats)), _max_dynamic_programming_states(20000),
+    _stats(move(stats)), _max_dynamic_programming_states(20000), _max_raise_lines(5000),
     // Energy rules only: see with_rules(). A derived constraint's time-tabling
     // cannot infer anything its donor's has not, so running it is pure cost.
     _rules(CumulativeRules{.time_table = false, .overload = true, .profile_overload = true}), _mutation(cumulative_strengthening_mutation::None{})
@@ -107,6 +152,12 @@ CumulativeStrengthening::CumulativeStrengthening(shared_ptr<CumulativeStrengthen
 auto CumulativeStrengthening::with_dynamic_programming_budget(long long states) -> CumulativeStrengthening &
 {
     _max_dynamic_programming_states = states;
+    return *this;
+}
+
+auto CumulativeStrengthening::with_raise_budget(long long lines) -> CumulativeStrengthening &
+{
+    _max_raise_lines = lines;
     return *this;
 }
 
@@ -182,25 +233,67 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             continue;
         }
 
+        // Schulz's coefficient raising, as the set of tasks it applies to. A
+        // task that cannot run beside any *other* task that consumes anything
+        // occupies the resource whenever it runs, whatever its height says, so
+        // its height is really the capacity --- and, once the capacity comes
+        // down to kappa below, really kappa.
+        //
+        // Stated as the pairwise test rather than as the paper's
+        // `c_i > C - min_j c_j`, because the two are the same condition and the
+        // pairwise one is what the certificate needs anyway: it is one
+        // at-most-one per pair, each derived from the donor's own row. Tasks
+        // whose windows cannot overlap are not part of it, which is a little
+        // more than the paper claims and costs nothing --- if they can never be
+        // active together, no row ever mentions both.
+        //
+        // Deliberately *not* per time point, even though fewer tasks can run at
+        // one time point than over the whole horizon and the set would be
+        // larger for it: a Cumulative has one height per task, not one per time
+        // point, so a task that only fills the resource at some of them cannot
+        // be given a raised height at all.
+        vector<size_t> full_tasks, other_tasks;
+        for (auto i : active_tasks) {
+            auto conflicts_with_everything = std::all_of(active_tasks.begin(), active_tasks.end(),
+                [&](size_t j) { return i == j || t_hi[i] < t_lo[j] || t_hi[j] < t_lo[i] || data->heights[i] + data->heights[j] > capacity; });
+            (conflicts_with_everything ? full_tasks : other_tasks).push_back(i);
+        }
+
+        // The mutation that says the pairwise test is the load-bearing part:
+        // take the tallest task that did *not* qualify and raise it anyway.
+        // Everything downstream then runs honestly on a set that is wrong, and
+        // the row it lands on is a row the donor does not imply.
+        auto unentitled_raise = std::holds_alternative<cumulative_strengthening_mutation::RaiseUnentitled>(_mutation);
+        if (unentitled_raise && ! other_tasks.empty()) {
+            auto tallest =
+                std::max_element(other_tasks.begin(), other_tasks.end(), [&](size_t a, size_t b) { return data->heights[a] < data->heights[b]; });
+            full_tasks.push_back(*tallest);
+            other_tasks.erase(tallest);
+            std::sort(full_tasks.begin(), full_tasks.end());
+        }
+
         auto global_lo = t_lo[active_tasks.front()], global_hi = t_hi[active_tasks.front()];
         for (auto i : active_tasks) {
-            global_lo = std::min(global_lo, t_lo[i]);
+            global_lo = min(global_lo, t_lo[i]);
             global_hi = max(global_hi, t_hi[i]);
         }
 
         vector<TimePoint> time_points;
         auto kappa = 0_i;
         for (Integer t = global_lo; t <= global_hi; ++t) {
-            TimePoint point{t, {}, {}, 0_i, false};
-            for (auto i : active_tasks)
+            TimePoint point{t, {}, {}, {}, 0_i, false};
+            for (auto i : other_tasks)
                 if (t >= t_lo[i] && t <= t_hi[i]) {
                     point.tasks.push_back(i);
                     point.heights.push_back(data->heights[i]);
                 }
+            for (auto i : full_tasks)
+                if (t >= t_lo[i] && t <= t_hi[i])
+                    point.full_tasks.push_back(i);
 
             // No task can be active here, so the donor wrote no row and there is
             // nothing to derive from.
-            if (point.tasks.empty())
+            if (point.tasks.empty() && point.full_tasks.empty())
                 continue;
 
             point.kappa = largest_subset_sum_at_most(point.heights, capacity);
@@ -214,29 +307,56 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
             time_points.push_back(move(point));
         }
 
-        // kappa is the largest load reachable at any one time point, so it is
-        // what the capacity really is. If that is the capacity already, the
-        // donor was posted with a number the heights can reach and there is
-        // nothing here.
-        if (kappa >= capacity) {
+        // Every task fills the resource on its own, so the tasks the capacity
+        // is a subset sum *of* are none of them and kappa is zero. That is not
+        // a strengthening but a disjunctive, and inferring those from conflict
+        // cliques is what the InferredDisjunctive presolver does.
+        if (kappa <= 0_i) {
             bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
             continue;
         }
 
-        // Budget the expensive derivation. The dynamic program has a state per
+        // kappa is the largest load reachable at any one time point once the
+        // tasks that fill the resource are set aside, so it is what the
+        // capacity really is. If that is the capacity already, and no task's
+        // height changes either, the donor was posted with the numbers it
+        // deserved and there is nothing here.
+        auto raises_a_height = std::any_of(full_tasks.begin(), full_tasks.end(), [&](size_t i) { return data->heights[i] != kappa; });
+        if (kappa >= capacity && ! raises_a_height) {
+            bump(&CumulativeStrengtheningStats::declined_nothing_to_gain);
+            continue;
+        }
+
+        // Budget the expensive derivations. The dynamic program has a state per
         // reachable partial sum per item, so `items * capacity` bounds it; the
-        // divisibility path is two `pol` steps and needs no budgeting. Only
+        // divisibility path is two `pol` steps and needs no budgeting. Raising
+        // is a `pol` per step per task per time point, and how many steps a
+        // raise takes depends on how far the rest of the row overshoots. Only
         // relevant with proofs on, since with them off no derivation happens.
         if (logger) {
-            long long states = 0;
-            for (const auto & point : time_points)
+            long long states = 0, raise_lines = 0;
+            for (const auto & point : time_points) {
                 if (! point.by_division)
                     states += static_cast<long long>(point.heights.size()) * (capacity.raw_value + 1);
+
+                auto total = std::accumulate(point.heights.begin(), point.heights.end(), 0_i);
+                for (size_t taken = 0; taken < point.full_tasks.size(); ++taken) {
+                    raise_lines += static_cast<long long>(raise_steps(total, kappa).size());
+                    total += kappa;
+                }
+            }
 
             if (states > _max_dynamic_programming_states) {
                 bump(&CumulativeStrengtheningStats::declined_over_budget);
                 logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", derivation would need " +
                     to_string(states) + " dynamic programming states against a budget of " + to_string(_max_dynamic_programming_states));
+                continue;
+            }
+
+            if (raise_lines > _max_raise_lines) {
+                bump(&CumulativeStrengtheningStats::declined_over_raise_budget);
+                logger->emit_proof_comment("presolve cumulative: declining " + as_string(donor.constraint_id()) + ", raising heights would need " +
+                    to_string(raise_lines) + " proof lines against a budget of " + to_string(_max_raise_lines));
                 continue;
             }
         }
@@ -255,18 +375,25 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
         auto heights = data->heights;
         auto stats = _stats;
 
+        // The raised tasks occupy the whole of the strengthened resource, which
+        // is what the raising rule says once the capacity is kappa.
+        auto derived_heights = heights;
+        for (auto i : full_tasks)
+            derived_heights[i] = kappa;
+
         // Fixed for the whole donor, so worked out once rather than per row.
         SubsetSumMutation subset_sum_corruption = std::visit(
             overloaded{//
-                [](const cumulative_strengthening_mutation::None &) -> SubsetSumMutation { return subset_sum_mutation::None{}; },
                 [](const cumulative_strengthening_mutation::ClaimOneBetter &) -> SubsetSumMutation { return subset_sum_mutation::ClaimOneBetter{}; },
-                [](const cumulative_strengthening_mutation::BogusDivisor &) -> SubsetSumMutation { return subset_sum_mutation::BogusDivisor{}; }},
+                [](const cumulative_strengthening_mutation::BogusDivisor &) -> SubsetSumMutation { return subset_sum_mutation::BogusDivisor{}; },
+                [](const auto &) -> SubsetSumMutation { return subset_sum_mutation::None{}; }},
             _mutation);
+        auto raise_too_fast = std::holds_alternative<cumulative_strengthening_mutation::RaiseTooFast>(_mutation);
 
-        DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, data->lengths, heights),
+        DerivedCumulativeSpec spec{.tasks = derived_cumulative_tasks_from(donor_id, starts, data->lengths, derived_heights),
             .capacity = kappa,
             .row_donors = {donor_id},
-            .recipe = [donor_id, heights, capacity, kappa, by_time, stats, subset_sum_corruption](
+            .recipe = [donor_id, heights, capacity, kappa, by_time, stats, subset_sum_corruption, raise_too_fast, unentitled_raise](
                           ProofLogger & recipe_logger, const DerivedCumulativeRows & rows, Integer t) -> optional<ProofLine> {
                 auto point = by_time.find(t);
                 if (point == by_time.end())
@@ -280,42 +407,213 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
                         ", which cannot happen for a constraint derived over all of its tasks"};
                 auto donor_row = donor_row_at->second;
 
-                vector<SubsetSumItem> items;
-                for (auto i : point->second.tasks) {
-                    auto active = recipe_logger.names_and_ids_tracker().find_proof_flag_values(
-                        donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
+                auto & tracker = recipe_logger.names_and_ids_tracker();
+                auto flag_for = [&](size_t i) -> ProofFlag {
+                    auto active = tracker.find_proof_flag_values(donor_id, ConstraintProofModelData<Cumulative>::active_flag_key(i, t));
                     if (! active)
                         throw ProofError{"cumulative strengthening: the donor has no active flag for task " + to_string(i) + " at time " +
                             to_string(t.raw_value) + ", which install_derived_cumulative should already have declined over"};
-                    items.push_back(SubsetSumItem{heights[i], *active});
-                }
+                    return *active;
+                };
 
-                recipe_logger.emit_proof_comment(point->second.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");
+                const auto & full_here = point->second.full_tasks;
 
-                auto strengthened =
-                    derive_subset_sum_strengthening(recipe_logger, items, donor_row, capacity, ProofLevel::Top, subset_sum_corruption);
+                vector<SubsetSumItem> items;
+                for (auto i : point->second.tasks)
+                    items.push_back(SubsetSumItem{heights[i], flag_for(i)});
 
-                if (stats) {
-                    if (strengthened.by_division)
-                        ++stats->rows_by_division;
-                    else
-                        ++stats->rows_by_dynamic_programming;
-                }
-
-                // Land every row on the capacity the derived constraint was
-                // declared with, whatever this time point's own largest load
-                // was. Two things come of insisting on that rather than handing
-                // back a row that merely happens to be no weaker. The rows are
-                // then uniform, so the propagator's `pol`s cancel against a
-                // known degree; and the step is an implication check, which is
-                // syntactic, so it is the one thing that notices a derivation
-                // landing somewhere other than where it claimed --- a divisor
-                // that does not divide every height still divides *soundly*,
-                // and nothing else in the proof would object.
+                // What the derived constraint was declared to say here, which
+                // every path below closes by pinning.
                 WPBSum load;
+                for (auto i : full_here)
+                    load += kappa * flag_for(i);
                 for (const auto & item : items)
                     load += item.coefficient * std::get<ProofFlag>(item.term);
-                return recipe_logger.emit(ImpliesProofRule{strengthened.line}, move(load) <= kappa, ProofLevel::Top);
+
+                auto strengthen_to_kappa = [&](ProofLine source) -> ProofLine {
+                    recipe_logger.emit_proof_comment(point->second.by_division ? "presolve cumulative gcd" : "presolve cumulative kappa");
+                    auto strengthened =
+                        derive_subset_sum_strengthening(recipe_logger, items, source, capacity, ProofLevel::Top, subset_sum_corruption);
+                    if (stats) {
+                        if (strengthened.by_division)
+                            ++stats->rows_by_division;
+                        else
+                            ++stats->rows_by_dynamic_programming;
+                    }
+                    return strengthened.line;
+                };
+
+                // Nothing fills the resource here, so this is the capacity rule
+                // on its own and the row is the donor's, strengthened. Landing
+                // it on the declared capacity rather than on this time point's
+                // own largest load is what makes the rows uniform --- and the
+                // step is an implication check, which is syntactic, so it is
+                // the one thing that notices a derivation landing somewhere
+                // other than where it claimed: a divisor that does not divide
+                // every height still divides *soundly*, and nothing else in the
+                // proof would object.
+                if (full_here.empty())
+                    return recipe_logger.emit(ImpliesProofRule{strengthen_to_kappa(donor_row)}, move(load) <= kappa, ProofLevel::Top);
+
+                recipe_logger.emit_proof_comment("presolve cumulative amo");
+
+                // The at-most-ones, each out of the donor's own row: a raised
+                // task conflicts with everything, so every pair it is in has
+                // one. Cached, because a pair of raised tasks needs the same
+                // line from both directions.
+                map<pair<size_t, size_t>, ProofLine> at_most_ones;
+                auto at_most_one_between = [&](size_t a, size_t b) -> ProofLine {
+                    auto key = pair{min(a, b), max(a, b)};
+                    auto already = at_most_ones.find(key);
+                    if (already != at_most_ones.end())
+                        return already->second;
+
+                    vector<ProofFlag> weaken_out;
+                    for (auto i : full_here)
+                        if (i != a && i != b)
+                            weaken_out.push_back(flag_for(i));
+                    for (auto i : point->second.tasks)
+                        if (i != a && i != b)
+                            weaken_out.push_back(flag_for(i));
+
+                    // Under the unentitled-raise mutation a pair that fits has
+                    // nothing to recover, and the routine refuses. Reporting a
+                    // demand large enough to overshoot by one keeps the step
+                    // legal so that what fails is the claim the row finally
+                    // makes, which is the point of running the mutation at all
+                    // --- and lying about the demand is the more faithful lie,
+                    // since the mutation's whole content is a conflict that is
+                    // not there.
+                    auto demand_a = heights[a];
+                    if (unentitled_raise && heights[a] + heights[b] <= capacity)
+                        demand_a = capacity - heights[b] + 1_i;
+
+                    auto recovered = recover_am1_from_row(recipe_logger, donor_row, {demand_a, heights[b]}, weaken_out, capacity, ProofLevel::Top);
+                    at_most_ones.emplace(key, recovered.line);
+                    return recovered.line;
+                };
+
+                // The row the raised tasks go into, derived on demand. Only the
+                // step-by-step raise below needs it, and only when the rest of
+                // the row overshoots the capacity, so a time point where
+                // everything else fits alongside pays for no subset sum at all
+                // --- the at-most-ones are the whole argument there.
+                optional<ProofLine> row;
+                auto row_to_raise_into = [&]() -> ProofLine {
+                    if (row)
+                        return *row;
+
+                    // The raised tasks come out of the donor's row first, which
+                    // is the whole point of setting them aside: a task that
+                    // reaches the capacity on its own makes the largest
+                    // reachable load the capacity, and the subset sum then has
+                    // nothing to say.
+                    PolBuilder without_full;
+                    without_full.add(donor_row);
+                    for (auto i : full_here)
+                        without_full.weaken(flag_for(i), tracker);
+                    row = strengthen_to_kappa(without_full.emit(recipe_logger, ProofLevel::Top));
+
+                    // A time point whose own largest load is below the declared
+                    // capacity has to be relaxed up to it *before* anything is
+                    // raised into it, rather than at the end: a raise keeps
+                    // whatever right hand side it is given, and it can raise a
+                    // coefficient no higher, so a row left on the smaller one
+                    // would neither reach kappa nor pin to it.
+                    if (point->second.kappa < kappa) {
+                        WPBSum rest;
+                        for (const auto & item : items)
+                            rest += item.coefficient * std::get<ProofFlag>(item.term);
+                        row = recipe_logger.emit(ImpliesProofRule{*row}, move(rest) <= kappa, ProofLevel::Top);
+                    }
+                    return *row;
+                };
+
+                // Then the raised tasks, one at a time, each into the row the
+                // last one left behind. Ordered, so that the `pol` text depends
+                // on the fixture and not on where the heap put things.
+                map<size_t, Integer> running;
+                for (auto i : point->second.tasks)
+                    running.emplace(i, heights[i]);
+
+                for (auto task : full_here) {
+                    auto total = std::accumulate(
+                        running.begin(), running.end(), 0_i, [](Integer so_far, const auto & entry) { return so_far + entry.second; });
+
+                    if (total == 0_i) {
+                        // Nothing else can run here at all, so there is no row
+                        // to raise into and no at-most-one to do it with: the
+                        // claim is only that a flag is at most one.
+                        WPBSum alone;
+                        alone += kappa * flag_for(task);
+                        row = recipe_logger.emit_rup_proof_line(move(alone) <= kappa, ProofLevel::Top);
+                        if (stats)
+                            ++stats->raise_lines_emitted;
+                    }
+                    else if (total <= kappa) {
+                        // Everything else fits alongside, so the at-most-ones
+                        // summed are already the row --- at a right hand side
+                        // of `total`, which the implication step then relaxes
+                        // to kappa.
+                        PolBuilder summed;
+                        for (const auto & [other, weight] : running)
+                            summed.add(at_most_one_between(task, other), weight);
+                        row = summed.emit(recipe_logger, ProofLevel::Top);
+                        if (stats)
+                            ++stats->raise_lines_emitted;
+
+                        if (total < kappa) {
+                            WPBSum raised;
+                            raised += kappa * flag_for(task);
+                            for (const auto & [other, weight] : running)
+                                raised += weight * flag_for(other);
+                            row = recipe_logger.emit(ImpliesProofRule{*row}, move(raised) <= kappa, ProofLevel::Top);
+                        }
+                    }
+                    else {
+                        auto steps = raise_steps(total, kappa);
+                        auto raised_to = 0_i;
+                        for (size_t s = 0; s < steps.size(); ++s) {
+                            auto step = steps[s];
+                            if (raise_too_fast && s == 0) {
+                                // Only the first step is corrupted; the rest of
+                                // the sequence then compounds it honestly,
+                                // which is what a step-size rule getting lost
+                                // in a rearrangement would look like.
+                                if (step + 1_i > min(kappa - raised_to, total - raised_to - 1_i))
+                                    throw ProofError{"cumulative strengthening: the raise-too-fast mutation needs a raise with a step to spare, "
+                                                     "and this one does not"};
+                                step += 1_i;
+                            }
+
+                            // `lambda` copies of the row so far, plus each
+                            // at-most-one weighted by its task's coefficient in
+                            // that row, scaled so that the division comes out
+                            // whole on every term but the degree.
+                            auto rest = total - raised_to - step;
+                            auto common = Integer{std::gcd(step.raw_value, rest.raw_value)};
+                            auto e = step / common, lambda = rest / common;
+
+                            PolBuilder raise;
+                            raise.add(row_to_raise_into(), lambda);
+                            for (const auto & [other, weight] : running)
+                                raise.add(at_most_one_between(task, other), e * weight);
+                            raise.divide_by(lambda + e);
+                            row = raise.emit(recipe_logger, ProofLevel::Top);
+                            if (stats)
+                                ++stats->raise_lines_emitted;
+
+                            raised_to += step;
+                        }
+                    }
+
+                    running.emplace(task, kappa);
+                }
+
+                if (stats)
+                    ++stats->rows_with_a_raise;
+
+                return recipe_logger.emit(ImpliesProofRule{*row}, move(load) <= kappa, ProofLevel::Top);
             },
             .rules = _rules};
 
@@ -329,11 +627,14 @@ auto CumulativeStrengthening::run(Problem & problem, Propagators & propagators, 
 
         if (logger)
             logger->emit_proof_comment("presolve cumulative: strengthened " + as_string(donor_id) + " from capacity " +
-                to_string(capacity.raw_value) + " to " + to_string(kappa.raw_value));
+                to_string(capacity.raw_value) + " to " + to_string(kappa.raw_value) + ", raising " + to_string(full_tasks.size()) +
+                " heights to the capacity");
 
         bump(&CumulativeStrengtheningStats::donors_strengthened);
-        if (_stats)
+        if (_stats) {
             _stats->capacity_units_removed += capacity - kappa;
+            _stats->tasks_raised += full_tasks.size();
+        }
     }
 
     return true;
@@ -343,6 +644,7 @@ auto CumulativeStrengthening::clone() const -> unique_ptr<Presolver>
 {
     auto result = make_unique<CumulativeStrengthening>(_stats);
     result->with_dynamic_programming_budget(_max_dynamic_programming_states);
+    result->with_raise_budget(_max_raise_lines);
     result->with_rules(_rules);
     result->with_proof_mutation(_mutation);
     return result;

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening.hh
@@ -39,6 +39,12 @@ namespace gcs
         /// off each", which are different claims about the fixture.
         Integer capacity_units_removed = 0_i;
 
+        /// Tasks whose height was raised to the strengthened capacity, over
+        /// those donors: the other half of what the presolver does, and the
+        /// only record that it happened, since a raise can leave the capacity
+        /// untouched and a capacity reduction can raise nothing.
+        std::size_t tasks_raised = 0;
+
         /**
          * \name Why a donor was passed over.
          *
@@ -51,6 +57,7 @@ namespace gcs
         std::size_t declined_optional = 0;
         std::size_t declined_variable_arguments = 0;
         std::size_t declined_over_budget = 0;
+        std::size_t declined_over_raise_budget = 0;
         std::size_t declined_nothing_to_gain = 0;
         /// Declined by install_derived_cumulative itself, which is a bug rather
         /// than a restriction: the presolver derives its rows over the donor's
@@ -71,6 +78,24 @@ namespace gcs
         ///@{
         std::size_t rows_by_division = 0;
         std::size_t rows_by_dynamic_programming = 0;
+        ///@}
+
+        /**
+         * \name What the raising cost, in the proof.
+         *
+         * Zero when proofs are off. `rows_with_a_raise` counts time points
+         * whose row needed at-most-one reasoning at all; `raise_lines_emitted`
+         * counts the steps that took, which is not one per raised task --- how
+         * many a raise takes depends on how far the rest of the row overshoots
+         * the capacity, and is the sequence
+         * CumulativeStrengthening::with_raise_budget caps. It does not count
+         * the at-most-ones themselves, nor the implication steps that relax a
+         * row's right hand side, both of which are bounded by the tasks
+         * present rather than by the arithmetic.
+         */
+        ///@{
+        std::size_t rows_with_a_raise = 0;
+        std::size_t raise_lines_emitted = 0;
         ///@}
     };
 
@@ -102,10 +127,30 @@ namespace gcs
         struct BogusDivisor
         {
         };
+
+        /// Raise the tallest task that did *not* qualify for it. The pairwise
+        /// conflict test is the only thing standing between the rule and an
+        /// unsound constraint, and this is what says so: the derivation itself
+        /// runs honestly and every step of it is sound, on a set that is wrong.
+        /// Needs a fixture with a task that fails the test, which is what an
+        /// R1 control fixture is.
+        struct RaiseUnentitled
+        {
+        };
+
+        /// Take one more than the largest step the division survives, on the
+        /// first step of each raise. The step lands on a sound but weaker line,
+        /// every later step compounds it, and the row's own `ia` pin is what
+        /// rejects. Needs a raise with a step to spare, and throws rather than
+        /// passing quietly if given one that has none.
+        struct RaiseTooFast
+        {
+        };
     }
 
     using CumulativeStrengtheningMutation = std::variant<cumulative_strengthening_mutation::None, cumulative_strengthening_mutation::ClaimOneBetter,
-        cumulative_strengthening_mutation::BogusDivisor>;
+        cumulative_strengthening_mutation::BogusDivisor, cumulative_strengthening_mutation::RaiseUnentitled,
+        cumulative_strengthening_mutation::RaiseTooFast>;
 
     /**
      * \brief Strengthen each posted Cumulative by integrality, posting the
@@ -121,29 +166,33 @@ namespace gcs
      *     kappa = max over t of (largest subset sum of the heights of the tasks
      *                            that can run at t, that is at most the capacity)
      *
-     * loses no solution. Schulz's two capacity rules are the two ways that
-     * quantity gets computed --- his gcd rule is the case where the heights
-     * share a factor `d`, making the answer `d * floor(C / d)`, and his knapsack
-     * rule is the general one --- and they reach the proof as the two
-     * derivations derive_subset_sum_strengthening() chooses between: two `pol`
-     * steps of Chvatal-Gomory rounding, or a layered dynamic program. Which one
-     * a row took is in CumulativeStrengtheningStats.
+     * loses no solution --- as long as the tasks that quantity is a subset sum
+     * *of* are the right ones. Schulz's two capacity rules are the two ways it
+     * gets computed --- his gcd rule is the case where the heights share a
+     * factor `d`, making the answer `d * floor(C / d)`, and his knapsack rule
+     * is the general one --- and they reach the proof as the two derivations
+     * derive_subset_sum_strengthening() chooses between: two `pol` steps of
+     * Chvatal-Gomory rounding, or a layered dynamic program. Which one a row
+     * took is in CumulativeStrengtheningStats.
      *
-     * Two deliberate deviations from the paper's statement of the rules, both
-     * documented in `dev_docs/cumulative-strengthening.md`:
+     * The right tasks are the ones that can run beside something. A task that
+     * cannot --- `c_i + c_j > C` for every other `j` that consumes anything and
+     * whose window overlaps its own --- occupies the resource whenever it runs,
+     * so it reaches `C` on its own and would make kappa the capacity and the
+     * rule do nothing. Set those aside and kappa is computed over the rest;
+     * their own heights then come down to kappa, which is what makes setting
+     * them aside sound and is Schulz's coefficient-raising rule arriving at the
+     * same place from the other direction. Both of his height rules are
+     * therefore this one step, and it is what
+     * CumulativeStrengtheningStats::tasks_raised counts.
      *
-     * - The knapsack rule's per-time set is taken over *every* task that can run
-     *   at `t`, rather than only those with `c_j < C`. Excluding the tasks that
-     *   fill the resource by themselves gives a smaller kappa, but it is then
-     *   only sound if those tasks' own heights come down to kappa as well ---
-     *   which changes the derived constraint's coefficients, and needs the
-     *   at-most-one reasoning that is issue #547's remaining half.
-     * - The coefficient-raising rule (any `c_i` above `C - min_j c_j` can be
-     *   raised to `C`) is not here at all, for the same reason: it changes
-     *   heights.
-     *
-     * Neither costs soundness or solutions; both leave strengthening on the
-     * table, which is what an unimplemented rule does.
+     * That step is where the proof gets expensive. A raised task's row has to
+     * be built out of at-most-ones taken off the donor's own row --- one per
+     * pair --- and then the task's coefficient walked up to kappa a `pol` at a
+     * time, because cutting planes cannot raise a coefficient to the right hand
+     * side in one division unless the rest of the row barely overshoots it. See
+     * with_raise_budget(), and `dev_docs/cumulative-strengthening.md` for the
+     * arithmetic.
      *
      * **Do not expect this to make anything faster on its own.** The rules are
      * time-table neutral --- a load is a sum of heights, so it clears `C`
@@ -160,6 +209,7 @@ namespace gcs
     private:
         std::shared_ptr<CumulativeStrengtheningStats> _stats;
         long long _max_dynamic_programming_states;
+        long long _max_raise_lines;
         CumulativeRules _rules;
         CumulativeStrengtheningMutation _mutation;
 
@@ -186,6 +236,25 @@ namespace gcs
          * disappear while the divisibility one keeps working.
          */
         auto with_dynamic_programming_budget(long long states) -> CumulativeStrengthening &;
+
+        /**
+         * \brief Cap the number of proof lines spent raising heights, summed
+         * over a donor's time points and raised tasks.
+         *
+         * A raise is a `pol` per step, and the number of steps depends on how
+         * far the rest of the row overshoots the capacity: a row that only just
+         * overshoots raises in one, and one that overshoots by half pays a line
+         * per unit of the strengthened capacity. So the cost is not something a
+         * caller can read off the model, and a donor whose raising would exceed
+         * this is passed over entirely and counted in
+         * CumulativeStrengtheningStats::declined_over_raise_budget.
+         *
+         * Separate from the dynamic-programming budget because the two buy
+         * different things and are counted in different units: a donor can want
+         * one and not the other, and a test setting either to zero should watch
+         * only its own half disappear.
+         */
+        auto with_raise_budget(long long lines) -> CumulativeStrengthening &;
 
         /**
          * \brief Select which propagation rules the derived constraints run.

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -689,7 +689,8 @@ auto main(int argc, char * argv[]) -> int
         // count makes them assertions about the *draw*: seed 268 raises no
         // height in sixty instances, and CI eventually meets such a seed.
         size_t fired = 0, raised = 0;
-        for (int k = 0; k < 240 && (k < 60 || 0 == raised || 0 == fired); ++k) {
+        int drawn = 0;
+        for (; drawn < 240 && (drawn < 60 || 0 == raised || 0 == fired); ++drawn) {
             Instance inst;
             inst.capacity = cap_dist(rand);
             std::uniform_int_distribution<> tall(inst.capacity / 2 + 1, inst.capacity), rest(1, inst.capacity / 2);
@@ -719,7 +720,7 @@ auto main(int argc, char * argv[]) -> int
             fail("the presolver fired on none of two hundred and forty random instances, so it checked nothing");
         if (raised == 0)
             fail("no height was raised across two hundred and forty random instances, so the heights half checked nothing");
-        println(cerr, "solution preservation: strengthened {} of 60 random instances, raising {} heights", fired, raised);
+        println(cerr, "solution preservation: strengthened {} of {} random instances, raising {} heights", fired, drawn, raised);
     }
 
     if (! proofs) {

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -1,4 +1,4 @@
-/* Schulz's capacity strengthenings, as a presolver over posted Cumulatives.
+/* Schulz's strengthenings, as a presolver over posted Cumulatives.
  *
  * What is hard to test here is not that the proofs verify --- they do that
  * whether the presolver fired or not, since a presolver that declines every
@@ -8,17 +8,21 @@
  * energy reasoning is on. Three separate nets are therefore needed:
  *
  *   - the stats block, asserting the presolver fired, on how many donors, by
- *     how much, and down which of the two derivations;
+ *     how much, on how many raised heights, and down which derivation;
  *   - an energy-rule differential, where the strengthening is the only thing
  *     that refutes at the root;
  *   - mutations, asserting VeriPB rejects a derivation that claims more than it
  *     proved.
  *
  * And the neutrality itself is a tripwire rather than a caveat: under
- * time-tabling alone the node counts must be *identical*, because a load is a
- * sum of heights and so clears the donor's capacity exactly when it clears
- * kappa. A difference would mean the strengthening had changed what the profile
- * permits, which is what an unsound one looks like.
+ * time-tabling alone the node counts must be *identical*. For the capacity that
+ * is because a load is a sum of heights and so clears the donor's capacity
+ * exactly when it clears kappa. For a *raised* height it is a separate argument
+ * --- the profile really is different --- and it holds because a raised task
+ * conflicts with everything, so any time-table verdict a raised height reaches
+ * is one the donor's own capacity reaches too. A node-count difference would
+ * mean one of those two arguments was wrong, which is what an unsound
+ * strengthening looks like.
  */
 
 #include <gcs/constraints/cumulative.hh>
@@ -126,6 +130,7 @@ namespace
         optional<CumulativeRules> derived_rules = nullopt;
         CumulativeStrengtheningMutation mutation = cumulative_strengthening_mutation::None{};
         long long budget = 20000;
+        long long raise_budget = 5000;
         shared_ptr<CumulativeStrengtheningStats> stats = nullptr;
     };
 
@@ -144,7 +149,7 @@ namespace
         p.post(Cumulative{starts, lengths, heights, Integer{inst.capacity}}.with_rules(setup.rules));
         if (setup.presolve) {
             auto presolver = CumulativeStrengthening{setup.stats};
-            presolver.with_dynamic_programming_budget(setup.budget).with_proof_mutation(setup.mutation);
+            presolver.with_dynamic_programming_budget(setup.budget).with_raise_budget(setup.raise_budget).with_proof_mutation(setup.mutation);
             if (setup.derived_rules)
                 presolver.with_rules(*setup.derived_rules);
             p.add_presolver(presolver);
@@ -251,6 +256,46 @@ namespace
             fail(what + ": the derivation takes the " + (by_division ? "divisibility" : "dynamic programming") +
                 " path, not the one the fixture is for");
     }
+
+    /// The same discipline for the split: which tasks the presolver will raise
+    /// to the capacity, and what kappa the rest of them come to. Asserted as
+    /// arithmetic first, because the whole rule turns on the pairwise test and
+    /// a fixture that has drifted over the boundary --- `c_i = C - min` rather
+    /// than one above it --- is a fixture for the other case entirely.
+    ///
+    /// Every fixture here has tasks whose windows all overlap, so the overlap
+    /// half of the presolver's test is not repeated.
+    auto check_split(const string & what, const vector<int> & heights, int capacity, const vector<size_t> & expected_raised, int expected_kappa)
+        -> void
+    {
+        vector<size_t> raised;
+        vector<Integer> rest;
+        for (size_t i = 0; i < heights.size(); ++i) {
+            bool conflicts_with_everything = true;
+            for (size_t j = 0; j < heights.size(); ++j)
+                if (i != j && heights[i] + heights[j] <= capacity)
+                    conflicts_with_everything = false;
+            if (conflicts_with_everything)
+                raised.push_back(i);
+            else
+                rest.push_back(Integer{heights[i]});
+        }
+
+        auto as_text = [](const vector<size_t> & positions) {
+            string text;
+            for (auto p : positions)
+                text += (text.empty() ? "" : ", ") + std::to_string(p);
+            return "{" + text + "}";
+        };
+        if (raised != expected_raised)
+            fail(what + ": the tasks that fill the resource on their own are " + as_text(raised) + ", not the " + as_text(expected_raised) +
+                " the fixture claims");
+
+        auto kappa = largest_subset_sum_at_most(rest, Integer{capacity});
+        if (kappa != Integer{expected_kappa})
+            fail(what + ": kappa over the rest is " + std::to_string(kappa.raw_value) + ", not the " + std::to_string(expected_kappa) +
+                " the fixture claims");
+    }
 }
 
 auto main(int argc, char * argv[]) -> int
@@ -280,6 +325,17 @@ auto main(int argc, char * argv[]) -> int
     // below is a viable version of.
     check_kappa("deep gap, as arithmetic", {6, 10, 15}, 14, 10, false);
 
+    // And the split the heights half turns on, checked the same way. The R1
+    // sharpness fixture is barely over the line --- five is one above
+    // `C - min = 4` --- and its control sits exactly on it, which is the case
+    // the rule must *not* fire for.
+    check_split("R1 fixture", {5, 4, 2}, 6, {0}, 6);
+    check_split("R1 control", {4, 4, 2}, 6, {}, 6);
+    check_split("full-task pack fixture", {8, 3, 3, 3, 3, 3}, 8, {0}, 6);
+    check_split("knapsack raise fixture", {1, 3, 4, 6}, 6, {3}, 5);
+    check_split("gcd pack fixture", {3, 3, 3, 3, 3, 3, 3}, 8, {}, 6);
+    check_split("deep gap fixture", {2, 6, 6}, 10, {}, 8);
+
     // The value demonstration. Seven unit-length tasks of height three, all
     // able to run in [0, 3), against a capacity of eight. Every load is a
     // multiple of three, so the capacity is really six --- and that is invisible
@@ -306,6 +362,8 @@ auto main(int argc, char * argv[]) -> int
             fail("pack fixture: strengthened " + std::to_string(stats->donors_strengthened) + " donors, not one");
         if (stats->capacity_units_removed != 2_i)
             fail("pack fixture: took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off the capacity, not the two 8 to 6 is");
+        if (stats->tasks_raised != 0)
+            fail("pack fixture: a height was raised, so the fixture is not testing the capacity rule on its own");
         if (proofs && stats->rows_by_dynamic_programming != 0)
             fail("pack fixture: a row took the dynamic programming path, so the fixture is not testing the gcd rule");
         if (proofs && stats->rows_by_division == 0)
@@ -327,12 +385,28 @@ auto main(int argc, char * argv[]) -> int
 
     const Instance searchy{{{0, 5}, {0, 5}, {0, 5}, {0, 5}}, {2, 2, 3, 3}, {2, 2, 2, 4}, 7};
 
-    // Heights {6, 10, 4} against a capacity of thirteen: the gcd is two, so
-    // Schulz's gcd rule offers twelve, but 4 + 6 = 10 is the largest load that
-    // can actually be reached, and only the dynamic programming gets there.
-    const Instance deep_gap{{{0, 3}, {0, 3}, {0, 3}}, {2, 2, 2}, {6, 10, 4}, 13};
+    // Heights {2, 6, 6} against a capacity of ten: the gcd is two, so Schulz's
+    // gcd rule offers ten, but 2 + 6 = 8 is the largest load that can actually
+    // be reached, and only the dynamic programming gets there. No task fills
+    // the resource on its own --- 2 + 6 fits --- so nothing is raised and this
+    // is the capacity rule alone.
+    const Instance deep_gap{{{0, 3}, {0, 3}, {0, 3}}, {2, 2, 2}, {2, 6, 6}, 10};
 
-    for (const auto & [what, inst] : {pair<string, Instance>{"searchy", searchy}, pair<string, Instance>{"deep gap", deep_gap}}) {
+    // Heights {1, 3, 4, 6} against a capacity of six. The six conflicts with
+    // everything, so it is raised; kappa over the remaining {1, 3, 4} is five,
+    // which the gcd cannot reach. Both halves of the rule, in one fixture, and
+    // the raise takes four `pol` steps because {1, 3, 4} overshoots five by
+    // three.
+    const Instance knapsack_raise{{{0, 3}, {0, 3}, {0, 3}, {0, 3}}, {2, 2, 2, 2}, {1, 3, 4, 6}, 6};
+
+    // Heights {5, 4, 2} against a capacity of six: the issue's R1 fixture,
+    // where five is one above `C - min` and is raised to the capacity, and
+    // where the capacity itself does not move at all. So the only thing the
+    // presolver does here is raise a height.
+    const Instance r1{{{0, 3}, {0, 3}, {0, 3}}, {2, 2, 2}, {5, 4, 2}, 6};
+
+    for (const auto & [what, inst] : {pair<string, Instance>{"searchy", searchy}, pair<string, Instance>{"deep gap", deep_gap},
+             pair<string, Instance>{"knapsack raise", knapsack_raise}, pair<string, Instance>{"R1", r1}}) {
         auto stats = make_shared<CumulativeStrengtheningStats>();
 
         auto without = solve_it(inst, Setup{.presolve = false, .rules = tt_only}, nullopt);
@@ -345,7 +419,8 @@ auto main(int argc, char * argv[]) -> int
         if (without.recursions != with.recursions)
             fail(what + " neutrality: " + std::to_string(with.recursions) + " nodes against " + std::to_string(without.recursions) +
                 " --- the strengthening is not time-table neutral, which means it is not sound");
-        println(cerr, "{} neutrality: {} nodes either way, capacity down by {}", what, with.recursions, stats->capacity_units_removed.raw_value);
+        println(cerr, "{} neutrality: {} nodes either way, capacity down by {}, {} heights raised", what, with.recursions,
+            stats->capacity_units_removed.raw_value, stats->tasks_raised);
     }
 
     // The deep-gap fixture is the one that exercises the dynamic programming.
@@ -362,13 +437,136 @@ auto main(int argc, char * argv[]) -> int
         // backtracked would not notice if they had landed at any other level.
         if (outcome.recursions < 5)
             fail("deep gap fixture: the instance did not search, so it soaked nothing");
-        if (stats->capacity_units_removed != 3_i)
-            fail("deep gap fixture: took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off, not the three 13 to 10 is");
+        if (stats->capacity_units_removed != 2_i)
+            fail("deep gap fixture: took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off, not the two 10 to 8 is");
+        if (stats->tasks_raised != 0)
+            fail("deep gap fixture: a height was raised, so the fixture is not testing the capacity rule on its own");
         if (proofs && stats->rows_by_division != 0)
             fail("deep gap fixture: a row took the divisibility path, so the fixture is not testing the knapsack rule");
         if (proofs && stats->rows_by_dynamic_programming == 0)
             fail("deep gap fixture: no row took the dynamic programming path");
         println(cerr, "deep gap fixture: {} rows by dynamic programming", stats->rows_by_dynamic_programming);
+    }
+
+    // The heights half, and what it buys. Five unit-length tasks of height
+    // three plus one that fills the resource, all able to run in [0, 3),
+    // against a capacity of eight.
+    //
+    // The capacity rule alone gets nothing here: the tall task reaches eight
+    // on its own, so the largest reachable load *is* the capacity. Setting it
+    // aside takes kappa to six, and its own height comes down to six with it,
+    // which is what makes the energy sums come apart --- the window supplies
+    // twenty-four at a capacity of eight, covering the twenty-three the tasks
+    // need, and eighteen at six against the twenty-one they then need.
+    const Instance full_task_pack{{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}}, {1, 1, 1, 1, 1, 1}, {8, 3, 3, 3, 3, 3}, 8};
+
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+
+        auto donor_only = solve_it(full_task_pack, Setup{.presolve = false}, nullopt);
+        if (donor_only.refuted_at_root)
+            fail("full-task pack: the donor alone refuted at the root, so the fixture proves nothing");
+
+        // And the capacity rule on its own does not get there either, which is
+        // the claim that makes this a fixture for the heights half rather than
+        // another version of the pack one. Checked by arithmetic rather than by
+        // a toggle: kappa over *every* task is the capacity, so the presolver
+        // that stops at the capacity rule declines the donor outright.
+        vector<Integer> every_height{8_i, 3_i, 3_i, 3_i, 3_i, 3_i};
+        if (largest_subset_sum_at_most(every_height, 8_i) != 8_i)
+            fail("full-task pack: the capacity rule alone would have strengthened this, so the fixture is not about raising");
+
+        auto strengthened =
+            solve_it(full_task_pack, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_full_task_pack") : nullopt);
+        if (! strengthened.refuted_at_root)
+            fail("full-task pack: the strengthened constraint did not refute at the root");
+        if (! strengthened.solutions.empty())
+            fail("full-task pack: the instance is unsatisfiable but solutions were reported");
+
+        if (stats->tasks_raised != 1)
+            fail("full-task pack: raised " + std::to_string(stats->tasks_raised) + " heights, not the one");
+        if (stats->capacity_units_removed != 2_i)
+            fail(
+                "full-task pack: took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off the capacity, not the two 8 to 6 is");
+        if (proofs && stats->rows_with_a_raise == 0)
+            fail("full-task pack: no row needed at-most-one reasoning, so nothing was raised in the proof");
+        println(cerr, "full-task pack: refuted at the root, {} rows raised over {} pol steps", stats->rows_with_a_raise, stats->raise_lines_emitted);
+    }
+
+    // The R1 fixture and its control, as the issue states them. Five is one
+    // above `C - min = 4` and is raised; four is exactly on it and is not, and
+    // since nothing else moves either the whole donor is then declined.
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+        auto outcome = solve_it(r1, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_r1") : nullopt);
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(r1, starts); }, r1.start_ranges);
+        if (expected != outcome.solutions)
+            fail("R1 fixture: solutions do not match brute force");
+        if (stats->tasks_raised != 1)
+            fail("R1 fixture: raised " + std::to_string(stats->tasks_raised) + " heights, not the one");
+        if (stats->capacity_units_removed != 0_i)
+            fail("R1 fixture: the capacity moved, so the fixture is not testing raising on its own");
+        println(cerr, "R1 fixture: one height raised to the capacity, which did not move");
+    }
+
+    const Instance r1_control{{{0, 3}, {0, 3}, {0, 3}}, {2, 2, 2}, {4, 4, 2}, 6};
+
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+        auto outcome = solve_it(r1_control, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_r1_control") : nullopt);
+
+        if (stats->donors_strengthened != 0)
+            fail("R1 control: a task whose height is exactly `C - min` was raised");
+        if (stats->declined_nothing_to_gain != 1)
+            fail("R1 control: the donor was passed over for the wrong reason");
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(r1_control, starts); }, r1_control.start_ranges);
+        if (expected != outcome.solutions)
+            fail("R1 control: solutions do not match brute force");
+    }
+
+    // Two tasks raised in the same row, which is a different shape again: the
+    // second one is raised into the row the first one left behind, so its own
+    // at-most-ones have to include the one tying it to a task whose coefficient
+    // is already the capacity rather than its posted height.
+    const Instance two_full{{{0, 3}, {0, 3}, {0, 3}, {0, 3}}, {2, 2, 2, 2}, {7, 7, 3, 3}, 8};
+
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+        auto outcome = solve_it(two_full, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_two_full") : nullopt);
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(two_full, starts); }, two_full.start_ranges);
+        if (expected != outcome.solutions)
+            fail("two-raised fixture: solutions do not match brute force");
+        if (stats->tasks_raised != 2)
+            fail("two-raised fixture: raised " + std::to_string(stats->tasks_raised) + " heights, not the two");
+        if (stats->capacity_units_removed != 2_i)
+            fail("two-raised fixture: took " + std::to_string(stats->capacity_units_removed.raw_value) + " units off the capacity, not the two");
+        println(cerr, "two-raised fixture: {} pol steps over {} raised rows", stats->raise_lines_emitted, stats->rows_with_a_raise);
+    }
+
+    // Both halves at once, over a raise that takes several steps.
+    {
+        auto stats = make_shared<CumulativeStrengtheningStats>();
+        auto outcome = solve_it(knapsack_raise, Setup{.stats = stats}, proofs ? make_optional("cumulative_strengthening_knapsack_raise") : nullopt);
+
+        set<vector<int>> expected;
+        build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(knapsack_raise, starts); }, knapsack_raise.start_ranges);
+        if (expected != outcome.solutions)
+            fail("knapsack raise fixture: solutions do not match brute force");
+        if (stats->tasks_raised != 1 || stats->capacity_units_removed != 1_i)
+            fail("knapsack raise fixture: raised " + std::to_string(stats->tasks_raised) + " heights and took " +
+                std::to_string(stats->capacity_units_removed.raw_value) + " off the capacity, wanting one of each");
+        if (proofs && stats->rows_by_dynamic_programming == 0)
+            fail("knapsack raise fixture: no row took the dynamic programming path, so it is not exercising both halves");
+        if (proofs && stats->raise_lines_emitted <= stats->rows_with_a_raise)
+            fail("knapsack raise fixture: " + std::to_string(stats->raise_lines_emitted) + " pol steps over " +
+                std::to_string(stats->rows_with_a_raise) + " rows, so no raise took more than one step");
+        println(cerr, "knapsack raise fixture: {} pol steps over {} raised rows", stats->raise_lines_emitted, stats->rows_with_a_raise);
     }
 
     // The negative control. A capacity the heights can reach exactly is already
@@ -451,32 +649,52 @@ auto main(int argc, char * argv[]) -> int
         solve_it(pack, Setup{.budget = 0, .stats = pack_stats}, make_optional("cumulative_strengthening_budget_pack"));
         if (pack_stats->donors_strengthened != 1)
             fail("a zero budget stopped the divisibility derivation, which it does not pay for");
+
+        // And the raising budget, which is a separate knob because it is a
+        // separate cost in different units. Zero stops the fixture that raises
+        // and leaves the two that do not alone.
+        auto raise_stats = make_shared<CumulativeStrengtheningStats>();
+        solve_it(knapsack_raise, Setup{.raise_budget = 0, .stats = raise_stats}, make_optional("cumulative_strengthening_budget_raise"));
+        if (raise_stats->declined_over_raise_budget != 1)
+            fail("a zero raise budget did not stop the raising derivation");
+
+        auto unraised_stats = make_shared<CumulativeStrengtheningStats>();
+        solve_it(pack, Setup{.raise_budget = 0, .stats = unraised_stats}, make_optional("cumulative_strengthening_budget_unraised"));
+        if (unraised_stats->donors_strengthened != 1)
+            fail("a zero raise budget stopped a donor with nothing to raise");
     }
 
     // Nothing above may have reached the OPB.
     check_opb_unaffected("pack", pack);
     check_opb_unaffected("deep gap", deep_gap);
+    check_opb_unaffected("knapsack raise", knapsack_raise);
+    check_opb_unaffected("two raised", two_full);
+    check_opb_unaffected("full-task pack", full_task_pack);
 
     // Solution preservation, the defining property of a presolve strengthening.
-    // Random instances against brute force, with heights drawn so that both
-    // derivations get a turn.
+    // Random instances against brute force, with heights drawn against each
+    // instance's own capacity rather than from a fixed pool. Two reasons, both
+    // about what the corpus actually covers: a height above the capacity means
+    // the donor is declined outright and the instance tests nothing, and a task
+    // over half the capacity is what conflicts with everything, so drawing one
+    // deliberately is how the heights half gets a turn at all.
     {
         std::mt19937 rand(*get_seed());
-        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), cap_dist(2, 12);
-        const vector<int> height_pool{1, 2, 3, 4, 5, 6, 10, 15};
-        std::uniform_int_distribution<> height_dist(0, static_cast<int>(height_pool.size()) - 1);
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), cap_dist(4, 12), tall_dist(0, 2);
 
-        size_t fired = 0;
+        size_t fired = 0, raised = 0;
         for (int k = 0; k < 60; ++k) {
             Instance inst;
+            inst.capacity = cap_dist(rand);
+            std::uniform_int_distribution<> tall(inst.capacity / 2 + 1, inst.capacity), rest(1, inst.capacity / 2);
+
             auto n = n_dist(rand);
             for (int i = 0; i < n; ++i) {
                 auto lo = lo_dist(rand), span = span_dist(rand);
                 inst.start_ranges.emplace_back(lo, lo + span);
                 inst.lengths.push_back(len_dist(rand));
-                inst.heights.push_back(height_pool[height_dist(rand)]);
+                inst.heights.push_back(0 == tall_dist(rand) ? tall(rand) : rest(rand));
             }
-            inst.capacity = cap_dist(rand);
 
             set<vector<int>> expected;
             build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
@@ -488,16 +706,61 @@ auto main(int argc, char * argv[]) -> int
                 fail("the strengthening removed solutions");
             }
             fired += stats->donors_strengthened;
+            raised += stats->tasks_raised;
         }
 
         if (fired == 0)
             fail("the presolver fired on none of the random corpus, so it checked nothing");
-        println(cerr, "solution preservation: strengthened {} of 60 random instances", fired);
+        if (raised == 0)
+            fail("the presolver raised no height across the random corpus, so the heights half checked nothing");
+        println(cerr, "solution preservation: strengthened {} of 60 random instances, raising {} heights", fired, raised);
     }
 
     if (! proofs) {
         println(cerr, "veripb is not available, so the proof-level checks are skipped");
         return EXIT_SUCCESS;
+    }
+
+    // The raise arithmetic has more cases than a fixture set reaches evenly: a
+    // raise into a row with nothing else in it, one into a row everything fits
+    // alongside, one that takes several steps, and a time point whose own
+    // largest load is below the declared capacity and has to be relaxed up to
+    // it first. So the corpus gets a second turn with proofs on, where every
+    // one of them is checked by veripb rather than by inspection.
+    {
+        std::mt19937 rand(*get_seed());
+        std::uniform_int_distribution<> n_dist(2, 4), lo_dist(0, 3), span_dist(0, 3), len_dist(1, 3), cap_dist(4, 10), tall_dist(0, 1);
+
+        size_t raised = 0, rows = 0;
+        for (int k = 0; k < 25; ++k) {
+            Instance inst;
+            inst.capacity = cap_dist(rand);
+            std::uniform_int_distribution<> tall(inst.capacity / 2 + 1, inst.capacity), rest(1, inst.capacity / 2);
+
+            auto n = n_dist(rand);
+            for (int i = 0; i < n; ++i) {
+                auto lo = lo_dist(rand), span = span_dist(rand);
+                inst.start_ranges.emplace_back(lo, lo + span);
+                inst.lengths.push_back(len_dist(rand));
+                inst.heights.push_back(0 == tall_dist(rand) ? tall(rand) : rest(rand));
+            }
+
+            set<vector<int>> expected;
+            build_expected(expected, [&](const vector<int> & starts) { return is_satisfying(inst, starts); }, inst.start_ranges);
+
+            auto stats = make_shared<CumulativeStrengtheningStats>();
+            auto outcome = solve_it(inst, Setup{.stats = stats}, make_optional("cumulative_strengthening_sweep"));
+            if (outcome.solutions != expected) {
+                println(cerr, "starts={} lens={} hts={} c={}", inst.start_ranges, inst.lengths, inst.heights, inst.capacity);
+                fail("the verified sweep lost solutions");
+            }
+            raised += stats->tasks_raised;
+            rows += stats->rows_with_a_raise;
+        }
+
+        if (raised == 0)
+            fail("the verified sweep raised nothing, so veripb checked no raising");
+        println(cerr, "verified sweep: {} heights raised over {} rows, every proof checked", raised, rows);
     }
 
     // Mutations. Both corrupt the *conclusion* rather than the route to it,
@@ -507,11 +770,25 @@ auto main(int argc, char * argv[]) -> int
     // is a perfectly sound proof step --- it lands on a line that is not the one
     // the derived constraint was told it had, and only the `ia` step pinning
     // each row's content notices that.
-    for (const auto & [what, mutation] :
-        {pair<string, CumulativeStrengtheningMutation>{"one better", cumulative_strengthening_mutation::ClaimOneBetter{}},
-            pair<string, CumulativeStrengtheningMutation>{"bogus divisor", cumulative_strengthening_mutation::BogusDivisor{}}}) {
+    for (const auto & [what, inst, mutation] :
+        {std::tuple<string, Instance, CumulativeStrengtheningMutation>{"one better", pack, cumulative_strengthening_mutation::ClaimOneBetter{}},
+            std::tuple<string, Instance, CumulativeStrengtheningMutation>{"bogus divisor", pack, cumulative_strengthening_mutation::BogusDivisor{}},
+            // The pairwise conflict test is the only thing standing between the
+            // heights rule and an unsound constraint, and this is what says so.
+            // Run on the control fixture, where the tallest task misses the
+            // test by exactly one: raising it anyway claims that a task of
+            // height four cannot run beside one of height two under a capacity
+            // of six, which it plainly can.
+            std::tuple<string, Instance, CumulativeStrengtheningMutation>{
+                "unentitled raise", r1_control, cumulative_strengthening_mutation::RaiseUnentitled{}},
+            // And the step-size rule, which is the arithmetic a rearrangement
+            // of this derivation is most likely to lose: one step too far and
+            // the division rounds the degree down instead of up, leaving a
+            // sound but weaker line that only the row's own pin objects to.
+            std::tuple<string, Instance, CumulativeStrengtheningMutation>{
+                "raise too fast", knapsack_raise, cumulative_strengthening_mutation::RaiseTooFast{}}}) {
         const string name = "cumulative_strengthening_mutation";
-        solve_it(pack, Setup{.mutation = mutation}, make_optional(name), false);
+        solve_it(inst, Setup{.mutation = mutation}, make_optional(name), false);
 
         if (run_veripb(name + ".opb", name + ".pbp"))
             fail("veripb accepted the " + what + " mutation");
@@ -525,7 +802,12 @@ auto main(int argc, char * argv[]) -> int
     {
         for (const auto & [what, inst, wanted, unwanted] :
             {std::tuple<string, Instance, string, string>{"pack", pack, "presolve cumulative gcd", "presolve cumulative kappa"},
-                std::tuple<string, Instance, string, string>{"deep gap", deep_gap, "presolve cumulative kappa", "presolve cumulative gcd"}}) {
+                std::tuple<string, Instance, string, string>{"deep gap", deep_gap, "presolve cumulative kappa", "presolve cumulative gcd"},
+                // A raised row is marked as such, and a fixture with nothing to
+                // raise must not be: the marker is how a reader tells which of
+                // the two rules a row came from.
+                std::tuple<string, Instance, string, string>{"knapsack raise", knapsack_raise, "presolve cumulative amo", ""},
+                std::tuple<string, Instance, string, string>{"pack, unraised", pack, "presolve cumulative gcd", "presolve cumulative amo"}}) {
             const string name = "cumulative_strengthening_markers";
             // Unverified here, because verifying is what deletes the file this
             // needs to read; veripb still gets its turn, below.
@@ -536,7 +818,7 @@ auto main(int argc, char * argv[]) -> int
                 fail(what + " markers: veripb rejected the proof");
             if (0 == count_occurrences(proof, wanted))
                 fail(what + " markers: no `" + wanted + "` in the proof, so the rule did not fire where the fixture says");
-            if (0 != count_occurrences(proof, unwanted))
+            if (! unwanted.empty() && 0 != count_occurrences(proof, unwanted))
                 fail(what + " markers: `" + unwanted + "` in the proof, so the fixture is exercising the other derivation");
             println(cerr, "{} markers: {} occurrences of `{}`", what, count_occurrences(proof, wanted), wanted);
             dispose_of_proof_files(name);
@@ -553,7 +835,7 @@ auto main(int argc, char * argv[]) -> int
             fail("negative control: veripb rejected the proof");
 
         auto proof = read_file(with + ".pbp");
-        for (const auto & marker : {"presolve cumulative gcd", "presolve cumulative kappa", "presolve cumulative:"})
+        for (const auto & marker : {"presolve cumulative gcd", "presolve cumulative kappa", "presolve cumulative amo", "presolve cumulative:"})
             if (0 != count_occurrences(proof, marker))
                 fail(string{"negative control: `"} + marker + "` in the proof of a donor that was passed over");
 

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -682,8 +682,14 @@ auto main(int argc, char * argv[]) -> int
         std::mt19937 rand(*get_seed());
         std::uniform_int_distribution<> n_dist(2, 4), lo_dist(0, 3), span_dist(0, 3), len_dist(0, 3), cap_dist(4, 12), tall_dist(0, 2);
 
+        // Sixty instances, and then more until the heights half has had a turn.
+        // Both assertions below are of the "it actually fired" kind, which is
+        // the only sort with any power over a presolver --- doing nothing
+        // preserves every solution and verifies every proof --- but a fixed
+        // count makes them assertions about the *draw*: seed 268 raises no
+        // height in sixty instances, and CI eventually meets such a seed.
         size_t fired = 0, raised = 0;
-        for (int k = 0; k < 60; ++k) {
+        for (int k = 0; k < 240 && (k < 60 || 0 == raised || 0 == fired); ++k) {
             Instance inst;
             inst.capacity = cap_dist(rand);
             std::uniform_int_distribution<> tall(inst.capacity / 2 + 1, inst.capacity), rest(1, inst.capacity / 2);
@@ -710,9 +716,9 @@ auto main(int argc, char * argv[]) -> int
         }
 
         if (fired == 0)
-            fail("the presolver fired on none of the random corpus, so it checked nothing");
+            fail("the presolver fired on none of two hundred and forty random instances, so it checked nothing");
         if (raised == 0)
-            fail("the presolver raised no height across the random corpus, so the heights half checked nothing");
+            fail("no height was raised across two hundred and forty random instances, so the heights half checked nothing");
         println(cerr, "solution preservation: strengthened {} of 60 random instances, raising {} heights", fired, raised);
     }
 

--- a/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
+++ b/gcs/presolvers/cumulative_strengthening/cumulative_strengthening_test.cc
@@ -731,8 +731,13 @@ auto main(int argc, char * argv[]) -> int
         std::mt19937 rand(*get_seed());
         std::uniform_int_distribution<> n_dist(2, 4), lo_dist(0, 3), span_dist(0, 3), len_dist(1, 3), cap_dist(4, 10), tall_dist(0, 1);
 
+        // Twenty-five instances, and then more until one of them has had
+        // something to raise. About one seed in fifty draws twenty-five that do
+        // not, and an assertion failing then would be saying something about the
+        // draw rather than about the presolver --- while dropping the assertion
+        // would let a sweep that certified no raising at all pass quietly.
         size_t raised = 0, rows = 0;
-        for (int k = 0; k < 25; ++k) {
+        for (int k = 0; k < 100 && (k < 25 || 0 == raised); ++k) {
             Instance inst;
             inst.capacity = cap_dist(rand);
             std::uniform_int_distribution<> tall(inst.capacity / 2 + 1, inst.capacity), rest(1, inst.capacity / 2);
@@ -759,7 +764,7 @@ auto main(int argc, char * argv[]) -> int
         }
 
         if (raised == 0)
-            fail("the verified sweep raised nothing, so veripb checked no raising");
+            fail("a hundred swept instances raised nothing, so veripb checked no raising");
         println(cerr, "verified sweep: {} heights raised over {} rows, every proof checked", raised, rows);
     }
 


### PR DESCRIPTION
Closes #547. Stacked on #667, which is where the at-most-one recovery this needs now lives.

Part one (#661) took the capacity down to `kappa`, the largest load the heights
can actually reach. This does the other half: the tasks that fill the resource
on their own are set aside from that sum, and their own heights come down to
`kappa` with it.

### One rule, not two

A task that cannot run beside any other task that consumes anything —
`h_i + h_j > C` for every overlapping `j` — occupies the resource whenever it
runs, whatever its height says. Such a task also **turns the capacity rule off**:
it reaches `C` by itself, so the largest reachable load *is* the capacity and
part one declines the donor outright.

Both of Schulz's height rules land on the same table. Coefficient raising (`c_i`
above `C − min_j c_j` goes to `C`) picks out exactly that set of tasks, and the
knapsack rule's "`c_i = C` can be reduced to `kappa`" is what happens to them
once the capacity moves.

| | capacity | full task | every other task |
|---|---|---|---|
| donor | `C` | `h_i` | `h_j` |
| derived | `kappa` | `kappa` | `h_j` |

Stated as the pairwise test rather than as the minimum: the two conditions are
the same, and the pairwise one is what the certificate needs anyway. Tasks whose
windows cannot overlap are left out, which is slightly more than the paper claims
and costs nothing. The set is deliberately not per time point — a `Cumulative`
has one height per task.

### The value

New fixture: five unit tasks of height three plus one of height eight, all able
to run in `[0, 3)`, capacity eight. `kappa` over every task is eight, so part one
declines. Setting the tall task aside takes `kappa` to six and its own height
with it, and the window then supplies 18 against the 21 those six tasks need —
root refutation. The donor needs 23 against a supply of 24, and searches.

### Raising a coefficient is a loop

The at-most-ones all come off *one* donor row, which is the case where #667's
`recover_am1_from_row` can bound a whole set in one step rather than pair by
pair. The rule's shape hides most of that win — a raise consumes the individual
pairwise lines, one per step, so they cannot simply be replaced — but a time
point where only full tasks can run is exactly `sum_F a_i <= 1` and could be one
`pol` instead of a RUP plus `|F|-1` sums. Left for the proof-size pass with
#666, since it changes bytes and wants measuring.

Cutting planes cannot raise a coefficient to the right hand side in one
division. Asking for the whole raise at once forces `(k−1)(T−R−1) < 1`, so each
step is `lambda` copies of the row so far plus the pairwise at-most-ones weighted
by their own coefficients, divided by `lambda + e`, with the step size bounded by
`k·(T − R) < T − c` — the margin the degree has to round through. A row whose
other tasks only just overshoot the capacity raises in one step; one that
overshoots by half pays a `pol` per unit of `kappa`. Hence `with_raise_budget()`,
predicted by the same function the derivation walks.

Two ends of that are not the loop: everything fitting alongside needs no division
at all (the at-most-ones summed *are* the row, relaxed by one `ia`), and nothing
else being able to run at all is a RUP.

### Testing

Time-table neutrality still holds, and now needs a second argument, since a
raised height really does change the profile: a raised task conflicts with
everything, so every verdict its height reaches is one the donor's capacity
reaches too. Asserted node-for-node on four fixtures, two of which raise.

Two new mutations, because the halves fail differently:

- **`RaiseTooFast`** takes one step past the bound. The step is sound and
  weaker, every later step compounds it, and only the row's `ia` pin objects.
- **`RaiseUnentitled`** raises a task that misses the pairwise test by one. The
  derivation then runs honestly and lands on a row the donor does not imply —
  the one mistake here that no care in the arithmetic could have caught.

The random corpus draws heights against each instance's own capacity now: a
fixed pool mostly produced donors declined for a height above the capacity, and
covered raising only by accident. It gets a second, smaller pass with proofs on
and veripb checking every one, which is where the raise arithmetic's corners get
exercised.

Fixture note: **`{6, 10, 4}` under `C = 13` is no longer a dynamic-programming
fixture.** The ten conflicts with both others, so it is now raised and `kappa`
over `{6, 4}` needs no subset sum. `{2, 6, 6}` under `C = 10` takes over as the
case where the gcd's multiples are not all reachable.

630/630 ctest, GCC and clang, ASan+UBSan clean on the touched tests.
